### PR TITLE
Update `puma` Gem to 5.6.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,8 +126,8 @@ gem 'open_uri_redirections', require: false
 gem 'gctools', github: 'wjordan/gctools', ref: 'ruby-2.5'
 # Optimizes copy-on-write memory usage with GC before web-application fork.
 gem 'nakayoshi_fork'
-# Ref: https://github.com/puma/puma/pull/1646
-gem 'puma', github: 'wjordan/puma', branch: 'debugging'
+
+gem 'puma', '~> 5.0'
 gem 'puma_worker_killer'
 gem 'raindrops'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,13 +106,6 @@ GIT
       omniauth-oauth2 (~> 1.4)
 
 GIT
-  remote: https://github.com/wjordan/puma.git
-  revision: 29a576120b30c34db7706c062ddf9a046723789f
-  branch: debugging
-  specs:
-    puma (3.12.0)
-
-GIT
   remote: https://github.com/wjordan/sprockets.git
   revision: 35caa45a78b739362b7db087b141f89e27d107c7
   ref: concurrent_asset_bundle_3.x
@@ -651,9 +644,11 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.0.1)
-    puma_worker_killer (0.1.0)
+    puma (5.6.5)
+      nio4r (~> 2.0)
+    puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)
-      puma (>= 2.7, < 4)
+      puma (>= 2.7)
     pusher (1.3.1)
       httpclient (~> 2.7)
       multi_json (~> 1.0)
@@ -674,8 +669,6 @@ GEM
     rack-openid (1.3.1)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
-    rack-parser (0.7.0)
-      rack
     rack-protection (2.2.3)
       rack
     rack-ssl-enforcer (0.2.9)
@@ -1026,7 +1019,7 @@ DEPENDENCIES
   pg
   phantomjs (~> 1.9.7.1)
   pry (~> 0.14.0)
-  puma!
+  puma (~> 5.0)
   puma_worker_killer
   pusher (~> 1.3.1)
   rack-cache

--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -39,9 +39,3 @@ unless DCDO.get('oobgc_middleware_disabled', false)
   require 'gctools/oobgc'
   out_of_band {GC::OOB.run}
 end
-
-# Log thread backtraces and GC stats from all worker processes every second when enabled.
-plugin :log_stats
-LogStats.threshold = -> {DCDO.get('logStatsDashboard', nil)}
-filter_gems = %w(puma sinatra actionview activesupport honeybadger newrelic rack)
-LogStats.backtrace_filter = ->(bt) {CDO.filter_backtrace(bt, filter_gems: filter_gems)}

--- a/pegasus/config/puma.rb
+++ b/pegasus/config/puma.rb
@@ -38,9 +38,3 @@ unless DCDO.get('oobgc_middleware_disabled', false)
   require 'gctools/oobgc'
   out_of_band {GC::OOB.run}
 end
-
-# Log thread backtraces and GC stats from all worker processes every second when enabled.
-plugin :log_stats
-LogStats.threshold = -> {DCDO.get('logStatsPegasus', nil)}
-filter_gems = %w(puma sinatra actionview activesupport honeybadger newrelic rack)
-LogStats.backtrace_filter = ->(bt) {CDO.filter_backtrace(bt, filter_gems: filter_gems)}


### PR DESCRIPTION
Also switch back to mainline. Target 5.x for compatibility with Ruby 3.

This should be a relatively safe upgrade, despite taking us through two major versions. The main breaking change in 4.x was the switch to `nio4r` for I/O management, and in 5.x it was removal of support for plugins and versions of Ruby that we do not use.

From what I can tell, we maintained a custom branch for two reasons: one was to provide the `log_stats` plugin we were using for some performance monitoring. We don't use this data anywhere and don't need to keep collecting it, so the simple solution is to remove the monitoring logic.

The other reason was to implement some performance fixes. Specifically, [we add some logic to attempt to balance incoming requests between worker threads in a more informed way](https://github.com/puma/puma/pull/1646). According to Will's notes, we were getting some performance improvements out of this. Puma 5.6.5 does not include our custom logic, but does include [this alternative](https://github.com/puma/puma/pull/2079) authored by the folks at GitLab which instructs busy worker threads to be less eager to pick up new jobs, thereby allowing the jobs to be distributed to other workers. According to some of Will's notes in that PR, we did also get performance improvements from this change but it's not clear to me how much or how they compare to the other set of improvements.

Ultimately, my proposal at this point is that we simply apply this update and see what the performance implications are. It should be straightforward to revert if we're unhappy with the effects.

## Links

- https://github.com/puma/puma/blob/master/5.0-Upgrade.md#welcome-to-puma-5-spoony-bard
- https://github.com/puma/puma/releases/tag/v4.0.0
- https://github.com/puma/puma/releases/tag/v5.0.0
- https://github.com/puma/puma/releases/tag/v5.6.5

## Testing story

For correctness testing, I tested locally and on an adhoc that loading the site works fine both on Ruby 2.7 and 3.0.

For performance testing, we plan to rely on post-merge monitoring.

## Deployment strategy

Because this is a low-level dependency with a lot of potential performance implications, we plan to deploy this in a standalone deploy after our main deploy with a closed pipeline and a revert prepped.