### PR TITLE
Added test for already deployed InfoToolTip

### DIFF
--- a/apps/test/unit/lib/ui/InfoHelpTipTest.js
+++ b/apps/test/unit/lib/ui/InfoHelpTipTest.js
@@ -1,0 +1,31 @@
+/** @file Test InfoHelpTip component */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import InfoHelpTip from '@cdo/apps/lib/ui/InfoHelpTip';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import ReactTooltip from 'react-tooltip';
+
+// "it renders" test that checks for FontAwesome and ReactTooltip
+
+describe('InfoHelpTip', () => {
+  const DEFAULT_PROPS = {
+    id: 'test-id',
+    content: 'test content',
+  };
+
+  it('renders FontAwesome', () => {
+    const wrapper = shallow(<InfoHelpTip {...DEFAULT_PROPS} />);
+    expect(wrapper.find(FontAwesome)).to.have.lengthOf(1);
+    expect(wrapper.find(FontAwesome).props().icon).to.equal('info-circle');
+  });
+
+  it('renders ReactTooltip', () => {
+    const wrapper = shallow(<InfoHelpTip {...DEFAULT_PROPS} />);
+    expect(wrapper.find(ReactTooltip)).to.have.lengthOf(1);
+    expect(wrapper.find(ReactTooltip).props().id).to.equal('test-id');
+    expect(wrapper.find(ReactTooltip).children().text()).to.equal(
+      'test content'
+    );
+  });
+});


### PR DESCRIPTION
This creates a test file for a newly created component (InfoToolTip).   This task was part of clean-up work for the new-section-setup page.

## Testing strategy

- I ran this test on my machine and it passed. 
