### PR TITLE
Self-paced PL page post-launch updates

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -164,6 +164,7 @@ a.link-button {
 // (not homepage or campaign pages)
 .hero-banner-basic {
   position: relative;
+  overflow: hidden;
 
   .text-wrapper {
     position: relative;

--- a/pegasus/sites.v3/code.org/public/educate/professional-development-online.haml
+++ b/pegasus/sites.v3/code.org/public/educate/professional-development-online.haml
@@ -111,7 +111,7 @@ theme: responsive_full_width
             =hoc_s(:curriculum_name_csp)
           %p
             %strong=hoc_s(:module_label_duration)
-            =hoc_s(:module_duration_35_hrs)
+            =hoc_s(:module_duration_3_hrs)
           %p
             %strong=hoc_s(:module_label_prerequisites)
             =hoc_s(:module_prerequisites_none)


### PR DESCRIPTION
Fixing a couple things post-launch on https://code.org/educate/professional-development-online:
- The duration of "Teaching Computer Science Principles" should be 3 hours. It is listed as 35 hours.
- On mobile landscape the hero banner image was overflowing creating a scroll

**Jira ticket:** [ACQ-599?](https://codedotorg.atlassian.net/browse/ACQ-599?atlOrigin=eyJpIjoiZTliYjQyYjgyZDY2NDVkNzkxMzczNmExNjg5NmY2NTUiLCJwIjoiaiJ9)

----

### Before
<img width="250" alt="Screenshot 2023-05-17 at 10 30 15 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/a4c5d05a-7805-473a-ac0c-e7aa0f51d540">

### After
<img width="250" alt="Screenshot 2023-05-17 at 10 30 05 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/08ac63c1-7a21-4826-ad94-287dd1fd9297">

----

### Before
https://github.com/code-dot-org/code-dot-org/assets/9256643/0cc4c9c7-d56e-4802-9311-95e1c936a747

### After
https://github.com/code-dot-org/code-dot-org/assets/9256643/9c9032e4-8f44-41e0-9d41-cca8be343e02



