### PR TITLE
Make Checkbox Dropdowns accessible with screenreaders

### DIFF
--- a/apps/src/templates/CheckboxDropdown.jsx
+++ b/apps/src/templates/CheckboxDropdown.jsx
@@ -19,6 +19,8 @@ const CheckboxDropdown = ({
       type="button"
       className="selectbox"
       data-toggle="dropdown"
+      aria-haspopup={true}
+      aria-label={`${name} filter dropdown`}
     >
       {checkedOptions.length > 0 && (
         <FontAwesome
@@ -30,8 +32,8 @@ const CheckboxDropdown = ({
       {label}
       <FontAwesome id={'chevron-down-icon'} icon={'chevron-down'} />
     </button>
-    <ul className="dropdown-menu">
-      <form>
+    <form className="dropdown-menu">
+      <ul className={style.dropdownCheckboxUL}>
         {Object.keys(allOptions).map(optionKey => (
           <li key={optionKey} className="checkbox form-group">
             <input
@@ -63,8 +65,8 @@ const CheckboxDropdown = ({
         >
           {i18n.clearAll()}
         </button>
-      </form>
-    </ul>
+      </ul>
+    </form>
   </div>
 );
 CheckboxDropdown.propTypes = {

--- a/apps/src/templates/checkbox-dropdown.module.scss
+++ b/apps/src/templates/checkbox-dropdown.module.scss
@@ -1,3 +1,9 @@
+.dropdownCheckboxUL {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
 .affectAllButton {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Currently, there are some inconsistencies between what the screen reader is reading out for filter checkbox dropdowns and what is actually present on the Curriculum Catalog page. For example, it currently reads out that a given checkbox dropdown has 0 list items (when in fact each list item should be mapped to a dropdown option); it also does not verbally state that the button is a pop-up button that expands out into a menu.

This PR ensures baseline consistency between what the screenreader says and the checkbox dropdown's behavior:
- States that the button is a popup button (i.e. clicking it expands out some sort of dropdown or popup)
- Adds more specific aria labels to denote the checkbox dropdown buttons as "[filter name] filter dropdown"
- Correct number of options is read out (all of which are selectable, including the 'Select all' and 'Clear all' buttons in each filter)
- When hovering over an option, the name is read out as well as whether its associated checkbox is checked or not
- When none of the dropdowns are expanded, it only takes one tab to go from one dropdown to the next (previously, there were cases where it would take 2 sometimes)

### Demo of tab-navigating through checkbox dropdowns with screen-reader on (sound on)
https://github.com/code-dot-org/code-dot-org/assets/56283563/d471b4c7-6f85-44b5-b864-8de0e1b3fa6b

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-569&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and drone build.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
