### PR TITLE
Return 'nil' for course offering duration with no latest published version

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -213,6 +213,7 @@ class CourseOffering < ApplicationRecord
   end
 
   def duration
+    return nil unless latest_published_version
     co_units = latest_published_version.units
     co_duration_in_minutes = co_units.sum(&:duration_in_minutes)
     DURATION_LABEL_TO_MINUTES_CAP.keys.find {|dur| co_duration_in_minutes <= DURATION_LABEL_TO_MINUTES_CAP[dur]}

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -571,6 +571,14 @@ class CourseOfferingTest < ActiveSupport::TestCase
     Unit.clear_cache
   end
 
+  test 'duration returns nil if latest_published_version does not exist' do
+    unit = create(:script, family_name: 'test-duration', version_year: '1997', is_course: true, published_state: 'in_development')
+    co = CourseOffering.add_course_offering(unit)
+
+    assert_nil co.latest_published_version
+    assert_nil co.duration
+  end
+
   test 'duration returns label associated with sum of units duration' do
     # Create a unit with multiple lessons, each with a different number of lesson activities.
     unit = create(:script, family_name: 'test-duration', version_year: '1997', is_course: true, published_state: 'stable')


### PR DESCRIPTION
We use a course offering's `latest_published_version` to calculate an offering's duration for the catalog. This PR ensures we have a valid `latest_published_version` before calculating duration to avoid errors (if there is no valid latest published version, returns `nil`).

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-598&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and adding a unit test.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
