### PR TITLE
Add Amplitude event for visiting the self-paced PL marketing page

### DIFF
--- a/pegasus/helpers/analytics_constants.rb
+++ b/pegasus/helpers/analytics_constants.rb
@@ -22,6 +22,7 @@ module AnalyticsConstants
     MIDDLE_AND_HIGH_SCHOOL_PL_PAGE_VISITED_EVENT =
       'Middle And High School Professional Learning Page Visited'.freeze,
     PICK_PL_PAGE_VISITED_EVENT = 'Pick Your Professional Learning Page Visited'.freeze,
+    SELF_PACED_PL_PAGE_VISITED_EVENT = 'Self-Paced Professional Learning Page Visited'.freeze,
     RP_LANDING_PAGE_VISITED_EVENT = 'Regional Partner Landing Page Visited'.freeze
   ].freeze
 end

--- a/pegasus/sites.v3/code.org/public/educate/professional-development-online.haml
+++ b/pegasus/sites.v3/code.org/public/educate/professional-development-online.haml
@@ -217,3 +217,5 @@ theme: responsive_full_width
         .content-footer
           %a.link-button{href: "/afe", aria:{label: hoc_s(:aria_label_call_to_action_afe)}}
             =hoc_s(:call_to_action_learn_more)
+
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::SELF_PACED_PL_PAGE_VISITED_EVENT


### PR DESCRIPTION
Adds a new Amplitude event for visiting a marketing page (the [self-paced PL marketing page](https://code.org/educate/professional-development-online) in this case). This event was added following the same format as [other marketing page visit events](https://github.com/code-dot-org/code-dot-org/pull/50582/files#diff-e695ec6220bc4d9f681e994dccd25c6dbaf43e09d6b2079e19784d277ba8f890R12-R13).

### Amplitude logging event (locally)
![SelfPacedAmplitude](https://github.com/code-dot-org/code-dot-org/assets/56283563/fa40e741-4097-4959-8553-704f21587e71)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-597&assignee=60d62161f65054006980bd71)
Associated Amplitude event: [here](https://data.amplitude.com/code-org/Code.org%20Tracking%20Plan/events/main/latest/Self-Paced%20Professional%20Learning%20Page%20Visited?view=All&tab=DETAILS&propertyValidityFilter=All%2520Properties)
Reference PR: [here](https://github.com/code-dot-org/code-dot-org/pull/50582)

## Testing story
Localhost testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
