### PR TITLE
[Google Blockly] sort blocks and skip childBlocks before comparing xml/json block arrays

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -130,19 +130,20 @@ function testJsonSerialization(workspace) {
   const experimentEnabled = experiments.isEnabled(experiments.BLOCKLY_JSON);
   const FIREHOSE_STUDY = 'blockly-json';
   const FIREHOSE_EVENT = 'block-differences';
+  const SORT_BY_POSITION = true;
   Blockly.Events.disable();
 
   // Create an array of blocks based on JSON serialization of the current workspace.
   const jsonSerialization = Blockly.serialization.workspaces.save(workspace);
   const tempJsonWorkspace = new Blockly.Workspace();
   Blockly.serialization.workspaces.load(jsonSerialization, tempJsonWorkspace);
-  const jsonBlocks = tempJsonWorkspace.getAllBlocks();
+  const jsonBlocks = tempJsonWorkspace.getAllBlocks(SORT_BY_POSITION);
 
   // Create an array of blocks based on the XML encoding of the current workspace.
   const xmlSerialization = Blockly.Xml.blockSpaceToDom(workspace);
   const tempXmlWorkspace = new Blockly.Workspace();
   Blockly.Xml.domToWorkspace(xmlSerialization, tempXmlWorkspace);
-  const xmlBlocks = tempXmlWorkspace.getAllBlocks();
+  const xmlBlocks = tempXmlWorkspace.getAllBlocks(SORT_BY_POSITION);
 
   // compareBlockArrays returns an array of differences found.
   const differences = compareBlockArrays(xmlBlocks, jsonBlocks);
@@ -186,6 +187,7 @@ export function compareBlockArrays(xmlBlocks, jsonBlocks) {
   const visited = new Set();
   // Some block properties are expected to hold different values, or refer to blocks already in the array.
   const keysToSkip = [
+    'childBlocks_', // a circular reference to an array of blocks that are also in the original array
     'parentBlock_', // a circular reference to another block in the array
     'sourceBlock_', // a circular reference to another block in the array
     'workspace', // a reference to the unique temporary workspaces used to create the two block arrays

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -175,6 +175,8 @@ function testJsonSerialization(workspace) {
       xmlSerialization: xmlSerialization,
     });
   }
+  tempJsonWorkspace.dispose();
+  tempXmlWorkspace.dispose();
   Blockly.Events.enable();
 }
 function sortBlocksById(blocks) {

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -150,9 +150,8 @@ function testJsonSerialization(workspace) {
   if (differences.length > 0 || experimentEnabled) {
     // Log a record to Firehose/Redshift.
     const recordData = {
-      projectUrl: dashboard.project.getShareUrl(),
-      blocklyVersion: Blockly.blockly_.VERSION,
       differences: differences,
+      blocklyVersion: Blockly.blockly_.VERSION,
     };
     firehoseClient.putRecord(
       {

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -138,12 +138,14 @@ function testJsonSerialization(workspace) {
   const tempJsonWorkspace = new Blockly.Workspace();
   Blockly.serialization.workspaces.load(jsonSerialization, tempJsonWorkspace);
   const jsonBlocks = tempJsonWorkspace.getAllBlocks(SORT_BY_POSITION);
+  sortBlocksById(jsonBlocks);
 
   // Create an array of blocks based on the XML encoding of the current workspace.
   const xmlSerialization = Blockly.Xml.blockSpaceToDom(workspace);
   const tempXmlWorkspace = new Blockly.Workspace();
   Blockly.Xml.domToWorkspace(xmlSerialization, tempXmlWorkspace);
   const xmlBlocks = tempXmlWorkspace.getAllBlocks(SORT_BY_POSITION);
+  sortBlocksById(xmlBlocks);
 
   // compareBlockArrays returns an array of differences found.
   const differences = compareBlockArrays(xmlBlocks, jsonBlocks);
@@ -174,6 +176,9 @@ function testJsonSerialization(workspace) {
     });
   }
   Blockly.Events.enable();
+}
+function sortBlocksById(blocks) {
+  blocks.sort((a, b) => (a.id > b.id ? 1 : -1));
 }
 
 // Used to find differences between blocks created from xml and json sources.


### PR DESCRIPTION
This updates the logging that was recently implemented for comparing blocks created from XML/JSON sources:
- https://github.com/code-dot-org/code-dot-org/pull/51739

While the experiment ran this morning, we did end up logging some differences. Many of these differences seem to be false signals due to the blocks being in a different order in each list used for the comparison. It turns out that the function we call to get the blocks (`getAllBlocks()`) has an optional parameter that sorts the list based on the blocks position on the workspace. (Documentation: https://developers.google.com/blockly/reference/js/blockly.workspace_class.getallblocks_1_method)

I confirmed with the Blockly team that without this argument, the blocks are returned in an undefined order. Based on some spot-checking of logged projects, it seems like this could be happening most often with blocks that are close together on the workspace, but this is merely anecdotal and hypothetical. For example, the `when hit an obstacle` and `when click` blocks were not in the same order in each list for this workspace:
<img width="330" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/54d0af87-58c9-45a3-9302-a658bb15960b">

Separate from this issue, I also found some logged records that showed we were occasionally hitting a longer recursive loop when checking big stacks of blocks. This is because blocks stacked together have a `childBlocks_` property that includes references to other blocks we'd already be checking. Adding this property to `keysToSkip` should make the test run more efficiently as we can skip comparing the same blocks multiple times.

With these changes, it's possible there could still be other differences logged the next time we run the experiment, but removing the common red herrings I saw today should help us narrow in on any actual issues that may exist.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
