### PR TITLE
Use String.prototype.charAt instead of .at

### DIFF
--- a/apps/src/templates/levelSummary/MultiResponses.jsx
+++ b/apps/src/templates/levelSummary/MultiResponses.jsx
@@ -18,7 +18,7 @@ const multiAnswerCounts = (responses, answerCount) => ({
     // Each response can be an index or a comma-separated list of indices.
     const indices = curr.text.split(',');
     indices.forEach(index => {
-      const letter = LETTERS.at(index);
+      const letter = LETTERS.charAt(index);
       acc[letter] = acc[letter] ? acc[letter] + 1 : 1;
     });
     return acc;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Use the older `String.prototype.charAt` in place of the newer `String.prototype.at`, to try to allow the build to pass.

## Links

Slack: https://codedotorg.slack.com/archives/C0T0PNTM3/p1684359034466229

## Testing story

Ran the MultiResponses unit tests locally, but that won't prove this passes in the real build. Neither will running them in drone, since that passed with the `.at` method originally.
