### PR TITLE
Revert "Update `selenium-webdriver` gem to 4.2.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,10 +106,10 @@ group :development, :test do
   gem 'net-http-persistent'
   gem 'rinku'
   gem 'rspec'
-  gem 'selenium-webdriver', '~> 4.2.0' # 4.x is required for Ruby 3 support; <4.3 required for Http:Persistent to not be deprecated yet
+  gem 'selenium-webdriver', '3.141.0'
   gem 'spring', '~> 3.1.1'
   gem 'spring-commands-testunit'
-  gem 'webdrivers', '~> 4.7' # 4.7 required for selenium 4.x
+  gem 'webdrivers', '~> 3.0'
 
   # For pegasus PDF generation / merging testing.
   gem 'parallel_tests'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,8 @@ GEM
     case_transform (0.2)
       activesupport
     cgi (0.3.6)
-    childprocess (4.1.0)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
     chunky_png (1.3.6)
     cld (0.11.0)
@@ -578,6 +579,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     net-ssh (5.2.0)
+    net_http_ssl_fix (0.0.10)
     netrc (0.11.0)
     newrelic_rpm (6.14.0)
     nio4r (2.5.8)
@@ -713,7 +715,7 @@ GEM
       thor (~> 1.0)
     rainbow (3.0.0)
     raindrops (0.20.0)
-    rake (12.3.3)
+    rake (13.0.6)
     rambling-trie (2.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -784,7 +786,7 @@ GEM
     ruby2_keywords (0.0.5)
     ruby_parser (3.18.1)
       sexp_processor (~> 4.16)
-    rubyzip (2.3.2)
+    rubyzip (1.2.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -805,11 +807,9 @@ GEM
       scenic (>= 1.4.0)
     scss_lint (0.60.0)
       sass (~> 3.5, >= 3.5.5)
-    selenium-webdriver (4.2.1)
-      childprocess (>= 0.5, < 5.0)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
-      websocket (~> 1.0)
+    selenium-webdriver (3.141.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2, >= 1.2.2)
     sequel (5.67.0)
     sexp_processor (4.16.0)
     shotgun (0.9.1)
@@ -888,10 +888,11 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (4.7.0)
+    webdrivers (3.7.2)
+      net_http_ssl_fix
       nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (> 3.141, < 5.0)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webfinger (1.0.2)
       activesupport
       httpclient (>= 2.4)
@@ -901,7 +902,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -1060,7 +1060,7 @@ DEPENDENCIES
   scenic
   scenic-mysql_adapter
   scss_lint
-  selenium-webdriver (~> 4.2.0)
+  selenium-webdriver (= 3.141.0)
   sequel (~> 5.29)
   shotgun
   sinatra (= 2.2.3)
@@ -1082,7 +1082,7 @@ DEPENDENCIES
   validates_email_format_of
   vcr
   web-console (~> 4.2.0)
-  webdrivers (~> 4.7)
+  webdrivers (~> 3.0)
   webmock (~> 3.8)
   xxhash
   youtube-dl.rb

--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -4,47 +4,43 @@
   {
     "name": "Chrome",
     "browserName": "chrome",
-    "browserVersion": "105",
-    "platformName": "Windows 10",
-    "sauce:options": {
-      "screenResolution": "1280x1024",
-      "extendedDebugging": true
-    }
+    "version": "105",
+    "platform": "Windows 10",
+    "screenResolution": "1280x1024",
+    "extendedDebugging": true
   },
   {
     "name": "Safari",
     "browserName": "Safari",
-    "browserVersion": "14",
-    "platformName": "macOS 11.00"
+    "platform": "macOS 11.00",
+    "version": "14",
+    "w3c": true
   },
   {
     "name": "Firefox",
     "browserName": "firefox",
-    "browserVersion": "112",
-    "platformName": "Windows 10"
+    "browserVersion": "79.0",
+    "platform": "Windows 10",
+    "w3c": true
   },
   {
     "name": "iPhone",
     "platformName": "iOS",
     "platformVersion": "15.4",
     "browserName": "safari",
-    "appium:deviceName": "iPhone Simulator",
+    "deviceName": "iPhone Simulator",
     "mobile": true,
-    "rotatable": true,
-    "sauce:options": {
-      "deviceOrientation": "LANDSCAPE"
-    }
+    "deviceOrientation": "landscape",
+    "rotatable": true
   },
   {
     "name": "iPad",
     "platformName": "iOS",
     "platformVersion": "14.5",
     "browserName": "safari",
-    "appium:deviceName": "iPad Simulator",
+    "deviceName": "iPad Simulator",
     "mobile": true,
-    "rotatable": true,
-    "sauce:options": {
-      "deviceOrientation": "LANDSCAPE"
-    }
+    "deviceOrientation": "landscape",
+    "rotatable": true
   }
 ]

--- a/dashboard/test/ui/features/step_definitions/dropdown.rb
+++ b/dashboard/test/ui/features/step_definitions/dropdown.rb
@@ -5,7 +5,7 @@ end
 And /^I press dropdown number (\d+)$/ do |n|
   dropdown_class = google_blockly? ? 'blocklyDropdownText' : 'blocklyText'
   text = @browser.find_elements(:class, dropdown_class)[n.to_i]
-  if @browser.browser == :safari
+  if @browser.browser == :Safari
     # Safari has an issue detecting SVG elements as interactive.
     # Click mouse in element location using Actions API as a workaround.
     @browser.action.move_to(text).click.perform

--- a/dashboard/test/ui/features/step_definitions/minecraft.rb
+++ b/dashboard/test/ui/features/step_definitions/minecraft.rb
@@ -3,7 +3,7 @@ Then /^I load the last Minecraft HoC level$/ do
     {
       on: [
         RSpec::Expectations::ExpectationNotMetError,
-        Selenium::WebDriver::Error::TimeoutError
+        Selenium::WebDriver::Error::TimeOutError
       ],
       sleep: 10,
       tries: 3

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -299,13 +299,15 @@ When /^I wait for (\d+(?:\.\d*)?) seconds?$/ do |seconds|
   sleep seconds.to_f
 end
 
-When /^I rotate to (landscape|portrait)$/ do |orientation|
+When /^I rotate to landscape$/ do
   if ENV['BS_ROTATABLE'] == "true"
-    $http_client.call(
-      :post,
-      "/wd/hub/session/#{@browser.session_id}/orientation",
-      {orientation: orientation.upcase}
-    )
+    @browser.rotate(:landscape)
+  end
+end
+
+When /^I rotate to portrait$/ do
+  if ENV['BS_ROTATABLE'] == "true"
+    @browser.rotate(:portrait)
   end
 end
 
@@ -501,7 +503,7 @@ When /^I click selector "([^"]*)" if I see it$/ do |selector|
     @browser.execute_script("return $(\"#{selector}:visible\").length != 0;")
   end
   @browser.execute_script("$(\"#{selector}:visible\")[0].click();")
-rescue Selenium::WebDriver::Error::TimeoutError
+rescue Selenium::WebDriver::Error::TimeOutError
   # Element never appeared, ignore it
 end
 
@@ -552,7 +554,7 @@ When /^I type "([^"]*)" into "([^"]*)" if I see it$/ do |input_text, selector|
     @browser.execute_script("return $(\"#{selector}:visible\").length != 0;")
   end
   type_into_selector("\"#{input_text}\"", selector)
-rescue Selenium::WebDriver::Error::TimeoutError
+rescue Selenium::WebDriver::Error::TimeOutError
   # Element never appeared, ignore it
 end
 
@@ -928,7 +930,7 @@ end
 def wait_for_jquery
   wait_until do
     @browser.execute_script("return (typeof jQuery !== 'undefined');")
-  rescue Selenium::WebDriver::Error::ScriptTimeoutError
+  rescue Selenium::WebDriver::Error::ScriptTimeOutError
     puts "execute_script timed out after 30 seconds, likely because this is \
 Safari and the browser was still on about:blank when wait_for_jquery \
 was called. Ignoring this error and continuing to wait..."

--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -22,19 +22,35 @@ def saucelabs_browser(test_run_name)
   is_tunnel = ENV['CIRCLE_BUILD_NUM']
   url = "http://#{CDO.saucelabs_username}:#{CDO.saucelabs_authkey}@#{is_tunnel ? 'localhost:4445' : 'ondemand.saucelabs.com:80'}/wd/hub"
 
-  capabilities = Selenium::WebDriver::Remote::Capabilities.new($browser_config.except('name'))
+  capabilities = Selenium::WebDriver::Remote::Capabilities.new($browser_config)
+  capabilities[:javascript_enabled] = 'true'
 
-  sauce_options = {
+  if ENV['BROWSER_CONFIG'] == 'Firefox'
+    # Firefox >= 66 has an issue with its content blocker causing page loads to block indefinitely.
+    # Set content blocking to 'strict' as a workaround.
+    profile = Selenium::WebDriver::Firefox::Profile.new
+    profile['browser.contentblocking.category'] = 'strict'
+    capabilities[:firefox_profile] = profile
+  end
+
+  sauce_capabilities = {
     name: test_run_name,
     tags: [ENV['GIT_BRANCH']],
     build: CDO.circle_run_identifier || ENV['BUILD'],
-    idleTimeout: 60,
-    seleniumVersion: Selenium::WebDriver::VERSION
+    idleTimeout: 60
   }
-  sauce_options[:tunnelIdentifier] = CDO.circle_run_identifier if CDO.circle_run_identifier
-  sauce_options[:priority] = ENV['PRIORITY'].to_i if ENV['PRIORITY']
-  capabilities["sauce:options"] ||= {}
-  capabilities["sauce:options"].merge!(sauce_options)
+  sauce_capabilities[:tunnelIdentifier] = CDO.circle_run_identifier if CDO.circle_run_identifier
+  sauce_capabilities[:priority] = ENV['PRIORITY'].to_i if ENV['PRIORITY']
+
+  # Use w3c-spec sauce:options capabilities format for compatible browsers.
+  # Ref: https://wiki.saucelabs.com/display/DOCS/Selenium+W3C+Capabilities+Support+-+Beta
+  if $browser_config['w3c']
+    sauce_capabilities['seleniumVersion'] = Selenium::WebDriver::VERSION
+    capabilities['sauce:options'] = sauce_capabilities
+    capabilities['platformName'] = capabilities['platform']
+  else
+    capabilities.merge!(sauce_capabilities)
+  end
 
   very_verbose "DEBUG: Capabilities: #{CGI.escapeHTML capabilities.inspect}"
 
@@ -42,7 +58,7 @@ def saucelabs_browser(test_run_name)
   with_read_timeout(5.minutes) do
     Selenium::WebDriver.for(:remote,
       url: url,
-      capabilities: capabilities,
+      desired_capabilities: capabilities,
       http_client: $http_client
     )
   end

--- a/dashboard/test/ui/features/support/hooks.rb
+++ b/dashboard/test/ui/features/support/hooks.rb
@@ -26,7 +26,7 @@ end
 
 Around do |_, block|
   block.call
-rescue Selenium::WebDriver::Error::TimeoutError => exception
+rescue Selenium::WebDriver::Error::TimeOutError => exception
   check_window_for_js_errors('after timeout')
   raise exception
 end

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -41,7 +41,7 @@ module SeleniumBrowser
       if (msg = exception.message.match(/unexpected response, code=(?<code>\d+).*\n(?<error>.*)/))
         error = msg[:error]
         error = JSON.parse(error)['value']['error'] rescue error
-        raise exception, "Error #{msg[:code]}: #{error}", exception.backtrace
+        exception.message.replace("Error #{msg[:code]}: #{error}")
       end
       raise
     end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#51635; there are indeed a few legitimate test failures that result from this change which were obscured by Drone.

Specifically, the `star_labs_` and `sprite_labs_dropdown` tests [consistently fail on both iPhone and iPad](https://codedotorg.slack.com/archives/C03CM903Y/p1684364912921629) with `Error 404: stale element reference (Selenium::WebDriver::Error::WebDriverError)`: 

- https://cucumber-logs.s3.amazonaws.com/test/test/iPad_star_labs_dropdown_output.html?versionId=dnqidl3JlZTOf.48I29mfWrMRhTbKMjI
- https://cucumber-logs.s3.amazonaws.com/test/test/iPad_star_labs_spritelab_spritelab_output.html?versionId=GMvpVWfmqIFXQVYHOffWe9U0Ubeh49CF
- https://cucumber-logs.s3.amazonaws.com/test/test/iPhone_star_labs_dropdown_output.html?versionId=itsIXOfSMw6Jep6yoDk8K2wsDyl_wEab
- https://cucumber-logs.s3.amazonaws.com/test/test/iPhone_star_labs_spritelab_spritelab_output.html?versionId=4T.cjn08tFLcZljWrZsV2cCVrnXv7_4a