### PR TITLE
Remove whitespace from level names to fix seeding

### DIFF
--- a/dashboard/config/scripts/virtual_pl_csd_summer_day2_async11.external
+++ b/dashboard/config/scripts/virtual_pl_csd_summer_day2_async11.external
@@ -1,4 +1,4 @@
-name ' virtual-pl-csd-summer-day2-async11'
+name 'virtual-pl-csd-summer-day2-async11'
 title 'title'
 description 'description here'
 

--- a/dashboard/config/scripts/virtual_pl_csd_summer_day2_async12.external
+++ b/dashboard/config/scripts/virtual_pl_csd_summer_day2_async12.external
@@ -1,4 +1,4 @@
-name ' virtual-pl-csd-summer-day2-async12'
+name 'virtual-pl-csd-summer-day2-async12'
 title 'title'
 description 'description here'
 

--- a/dashboard/config/scripts/virtual_pl_csd_summer_day2_async13.external
+++ b/dashboard/config/scripts/virtual_pl_csd_summer_day2_async13.external
@@ -1,4 +1,4 @@
-name ' virtual-pl-csd-summer-day2-async13'
+name 'virtual-pl-csd-summer-day2-async13'
 title 'title'
 description 'description here'
 

--- a/dashboard/config/scripts/virtual_pl_csd_summer_day2_async7.external
+++ b/dashboard/config/scripts/virtual_pl_csd_summer_day2_async7.external
@@ -1,4 +1,4 @@
-name ' virtual-pl-csd-summer-day2-async7'
+name 'virtual-pl-csd-summer-day2-async7'
 title 'title'
 description 'description here'
 

--- a/dashboard/config/scripts/virtual_pl_csd_summer_day2_async8.bubble_choice
+++ b/dashboard/config/scripts/virtual_pl_csd_summer_day2_async8.bubble_choice
@@ -1,4 +1,4 @@
-name ' virtual-pl-csd-summer-day2-async8'
+name 'virtual-pl-csd-summer-day2-async8'
 display_name 'Explore Resources in Web Lab and Game Lab'
 description '## Click on one of the options below to explore resources in Web Lab and Game Lab. 
 #### When you are finished you will return to this screen and have the option to either explore a new level or click finish to continue on to the next activity in this professional learning course.'

--- a/dashboard/config/scripts/virtual_pl_csd_summer_day2_async9.external
+++ b/dashboard/config/scripts/virtual_pl_csd_summer_day2_async9.external
@@ -1,4 +1,4 @@
-name ' virtual-pl-csd-summer-day2-async9'
+name 'virtual-pl-csd-summer-day2-async9'
 title 'title'
 description 'description here'
 


### PR DESCRIPTION
Seeding was failing on multiple environments with an error like:
```
Error parsing config/scripts/virtual_pl_csd_summer_day2_async11.external
rake aborted!
ActiveRecord::RecordInvalid: Validation failed: Name has already been taken
```

Strangely, locally, seeding was successful once then failed consistently (with that error) after that. The back trace pointed to [this line](https://github.com/code-dot-org/code-dot-org/blob/5e2b5ae6ecffb80a91925566ec83940c326e3fe5/dashboard/app/models/levels/dsl_defined.rb#L95), ie `level.update!(name: data[:name], game_id: Game.find_by(name: to_s).id, properties: data[:properties], md5: md5)`. What was happening was that we [strip whitespace from level names before validation](https://github.com/code-dot-org/code-dot-org/blob/5e2b5ae6ecffb80a91925566ec83940c326e3fe5/dashboard/app/models/levels/level.rb#L42) (and, therefore, before save). However, a couple of lines before the failing line we do `level = find_or_create_by({name: data[:name]})` _without stripping whitespace_. This means that it was trying to create a new level with whitespace in the name then, when it went to save that, had a conflict on the name field, with itself.

There's a longer term fix here that I can likely get out today but this should unblock the builds now.