### PR TITLE
Strip level name before looking for a level in DslDefined.setup

### DIFF
--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -89,7 +89,7 @@ class DSLDefined < Level
   end
 
   def self.setup(data, md5=nil)
-    level = find_or_create_by({name: data[:name]})
+    level = find_or_create_by({name: data[:name].strip})
     level.send(:write_attribute, 'properties', {})
 
     level.update!(name: data[:name], game_id: Game.find_by(name: to_s).id, properties: data[:properties], md5: md5)


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/51968. As whitespace is trimmed from the name when a level is saved, also trim that whitespace when looking for a level by name. I tested this with the issues that happened this morning and this would've prevented them. See the description of #51968 for more details.

There's likely to be other places we could fix but I didn't think it was worth the time to look for them. 