### PR TITLE
Fix link to activity sections in Lesson Agenda

### DIFF
--- a/apps/src/templates/lessonOverview/LessonAgenda.jsx
+++ b/apps/src/templates/lessonOverview/LessonAgenda.jsx
@@ -37,12 +37,12 @@ export default class LessonAgenda extends Component {
               <li style={{marginLeft: 15}} key={section.key}>
                 {section.duration > 0 && (
                   <a
-                    href={`#section-${section.key}`}
+                    href={`#activity-section-${section.key}`}
                   >{`${section.displayName}`}</a>
                 )}
                 {section.duration === 0 && (
                   <a
-                    href={`#section-${section.key}`}
+                    href={`#activity-section-${section.key}`}
                   >{`${section.displayName}`}</a>
                 )}
               </li>


### PR DESCRIPTION
Small fix to the lesson plan agenda. Activity sections use an id in the form of `activity-section-<key>` (code [here](https://github.com/code-dot-org/code-dot-org/blob/784471881167c187901910bdeefcbb87908aa62f/apps/src/templates/lessonOverview/activities/ActivitySection.jsx#L19)) and this was assuming the format was `section-<key>`. This was causing the links to not go anywhere.

I could write a test to check that the links use `activity-section` but as this is more of a disconnect between two components, rather than a logic issue, I opted not to. Happy to write that though if people think it would be useful.

For reference, the Lesson Agenda is the agenda section of the lesson plan here:
![Screenshot 2023-05-18 at 11 15 51 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/2cd0e67b-2044-41a4-9acb-3a6a9584cabe)
