### PR TITLE
Pin Version of `google-chrome-stable` Package

### DIFF
--- a/cookbooks/cdo-apps/recipes/google_chrome.rb
+++ b/cookbooks/cdo-apps/recipes/google_chrome.rb
@@ -11,4 +11,9 @@ apt_repository 'google-chrome' do
   retries 3
 end
 
-apt_package 'google-chrome-stable'
+apt_package 'google-chrome-stable' do
+  # Pin to a specific version so that all our servers work the same. In
+  # particular, staging and test having different versions here can result in
+  # unexpected differences building the apps package.
+  version '113.0.5672.126-1'
+end

--- a/cookbooks/cdo-apps/recipes/google_chrome.rb
+++ b/cookbooks/cdo-apps/recipes/google_chrome.rb
@@ -15,5 +15,8 @@ apt_package 'google-chrome-stable' do
   # Pin to a specific version so that all our servers work the same. In
   # particular, staging and test having different versions here can result in
   # unexpected differences building the apps package.
-  version '113.0.5672.126-1'
+  #
+  # This should be at least close to the version we target in browsers.json:
+  # https://github.com/code-dot-org/code-dot-org/blob/7c2530fc6f2f8115c5c0cfdbbda2538211493d6f/dashboard/test/ui/browsers.json#L7
+  version '103.0.5060.53-1'
 end


### PR DESCRIPTION
Right now, we have a couple different versions of this package installed across our servers. Checking with `apt-cache policy google-chrome-stable` reveals:

```
staging:
google-chrome-stable:
  Installed: 103.0.5060.53-1
  Candidate: 113.0.5672.126-1
  Version table:
     113.0.5672.126-1 500
        500 http://dl.google.com/linux/chrome/deb stable/main amd64 Packages
 *** 103.0.5060.53-1 100
        100 /var/lib/dpkg/status

test:
google-chrome-stable:
  Installed: 77.0.3865.90-1
  Candidate: 103.0.5060.53-1
  Version table:
     103.0.5060.53-1 500
        500 http://dl.google.com/linux/chrome/deb stable/main amd64 Packages
 *** 77.0.3865.90-1 100
        100 /var/lib/dpkg/status
```

The discrepancy between staging and test specifically is causing some problems; some apps code using newer browser features fails to build on test but passes on staging, which can lead to confusingly delayed DTT failures when staging builds the apps package at first and test only attempts to build some time after the offending PR has been merged.

To resolve, we explicitly specify which version we should target. I've chosen to target the version currently installed on staging because it's closest to the version we target for our UI tests, but we could alternatively choose to update to version 113.

## Links

See threads at https://codedotorg.slack.com/archives/C0T0PNR0D/p1683573120446859 and https://codedotorg.slack.com/archives/C0T0PNTM3/p1684359034466229and for more context.

## Testing story

Verified on an adhoc that we correctly install the targeted version.