### PR TITLE
SL-588: Surface PII error for share filtering failure case

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1272,7 +1272,7 @@
   "libraryCodeError": "We can't publish your library because there is an error in the code. Go look for the square red error indicator and fix the errors.",
   "libraryCodeProfanity": "It appears that your project contains inappropriate language. Please update your project to remove the {profanityCount, plural, one {word} other {words}} \"{profaneWords}\".",
   "libraryCreatorError": "There was an error creating your library. Contact support@code.org to resolve the issue.",
-  "libraryDetailsPII": "It appears your library name or description contains personally identifiable information. Please update your name or description to remove the {pIICount, plural, one {word} other {words}} \"{pIIWords}\".",
+  "libraryDetailsPII": "It appears your library name or description contains personally identifiable information. Please update your name or description to remove the word \"{pIIWord}\".",
   "libraryDetailsProfanity": "It appears your library name or description contains inappropriate language. Please update your name or description to remove the {profanityCount, plural, one {word} other {words}} \"{profaneWords}\".",
   "libraryDescriptionPlaceholder": "Write a description of your library",
   "libraryExportDuplicationFunctionError": "This function cannot be exported because there are multiple functions with this name.",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1272,6 +1272,7 @@
   "libraryCodeError": "We can't publish your library because there is an error in the code. Go look for the square red error indicator and fix the errors.",
   "libraryCodeProfanity": "It appears that your project contains inappropriate language. Please update your project to remove the {profanityCount, plural, one {word} other {words}} \"{profaneWords}\".",
   "libraryCreatorError": "There was an error creating your library. Contact support@code.org to resolve the issue.",
+  "libraryDetailsPII": "It appears your library name or description contains personally identifiable information. Please update your name or description to remove the {pIICount, plural, one {word} other {words}} \"{pIIWords}\".",
   "libraryDetailsProfanity": "It appears your library name or description contains inappropriate language. Please update your name or description to remove the {profanityCount, plural, one {word} other {words}} \"{profaneWords}\".",
   "libraryDescriptionPlaceholder": "Write a description of your library",
   "libraryExportDuplicationFunctionError": "This function cannot be exported because there are multiple functions with this name.",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1272,7 +1272,7 @@
   "libraryCodeError": "We can't publish your library because there is an error in the code. Go look for the square red error indicator and fix the errors.",
   "libraryCodeProfanity": "It appears that your project contains inappropriate language. Please update your project to remove the {profanityCount, plural, one {word} other {words}} \"{profaneWords}\".",
   "libraryCreatorError": "There was an error creating your library. Contact support@code.org to resolve the issue.",
-  "libraryDetailsPII": "It appears your library name or description contains personally identifiable information. Please update your name or description to remove the {pIICount, plural, one {word} other {words}} \"{pIIWords}\".",
+  "libraryDetailsPII": "It appears your library contains personally identifiable information. Please remove the {pIICount, plural, one {word} other {words}} \"{pIIWords}\".",
   "libraryDetailsProfanity": "It appears your library name or description contains inappropriate language. Please update your name or description to remove the {profanityCount, plural, one {word} other {words}} \"{profaneWords}\".",
   "libraryDescriptionPlaceholder": "Write a description of your library",
   "libraryExportDuplicationFunctionError": "This function cannot be exported because there are multiple functions with this name.",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1272,7 +1272,7 @@
   "libraryCodeError": "We can't publish your library because there is an error in the code. Go look for the square red error indicator and fix the errors.",
   "libraryCodeProfanity": "It appears that your project contains inappropriate language. Please update your project to remove the {profanityCount, plural, one {word} other {words}} \"{profaneWords}\".",
   "libraryCreatorError": "There was an error creating your library. Contact support@code.org to resolve the issue.",
-  "libraryDetailsPII": "It appears your library name or description contains personally identifiable information. Please update your name or description to remove the word \"{pIIWord}\".",
+  "libraryDetailsPII": "It appears your library name or description contains personally identifiable information. Please update your name or description to remove the {pIICount, plural, one {word} other {words}} \"{pIIWords}\".",
   "libraryDetailsProfanity": "It appears your library name or description contains inappropriate language. Please update your name or description to remove the {profanityCount, plural, one {word} other {words}} \"{profaneWords}\".",
   "libraryDescriptionPlaceholder": "Write a description of your library",
   "libraryExportDuplicationFunctionError": "This function cannot be exported because there are multiple functions with this name.",

--- a/apps/src/code-studio/components/libraries/LibraryClientApi.js
+++ b/apps/src/code-studio/components/libraries/LibraryClientApi.js
@@ -22,7 +22,8 @@ export default class LibraryClientApi {
           this.cacheBustSuffix = new Date().getTime();
           onSuccess(data);
         }
-      }
+      },
+      {includeResponseText: true}
     );
   }
 

--- a/apps/src/code-studio/components/libraries/LibraryClientApi.js
+++ b/apps/src/code-studio/components/libraries/LibraryClientApi.js
@@ -23,7 +23,7 @@ export default class LibraryClientApi {
           onSuccess(data);
         }
       },
-      {includeResponseText: true}
+      {includeDetails: true}
     );
   }
 

--- a/apps/src/code-studio/components/libraries/LibraryClientApi.js
+++ b/apps/src/code-studio/components/libraries/LibraryClientApi.js
@@ -22,8 +22,7 @@ export default class LibraryClientApi {
           this.cacheBustSuffix = new Date().getTime();
           onSuccess(data);
         }
-      },
-      {includeDetails: true}
+      }
     );
   }
 

--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -275,7 +275,7 @@ export default class LibraryPublisher extends React.Component {
     let errorMessage;
     switch (publishState) {
       case PublishState.INVALID_INPUT:
-        errorMessage = i18n.libraryDetailsInvalid();
+        errorMessage = i18n.libraryPublishInvalid();
         break;
       case PublishState.PII_INPUT:
         errorMessage = i18n.libraryDetailsPII({

--- a/apps/src/code-studio/initApp/clientApi.js
+++ b/apps/src/code-studio/initApp/clientApi.js
@@ -189,8 +189,9 @@ var base = {
    * @param {String} filename - The name of the file to create or update.
    * @param {NodeStyleCallback} callback - Expected result is the new collection
    *        object.
+   * @param {Object} opts - Options object.
    */
-  put: function (id, value, filename, callback) {
+  put: function (id, value, filename, callback, opts) {
     $.ajax({
       url: this.api_base_url + '/' + id + '/' + filename,
       type: 'put',
@@ -201,6 +202,9 @@ var base = {
         callback(null, data);
       })
       .fail(function (request, status, error) {
+        if (opts.includeResponseText) {
+          error += ' ' + request.responseText;
+        }
         var err = errorString(request, status, error);
         callback(err, false);
       });

--- a/apps/src/code-studio/initApp/clientApi.js
+++ b/apps/src/code-studio/initApp/clientApi.js
@@ -191,7 +191,7 @@ var base = {
    *        object.
    * @param {Object} opts - Options object.
    */
-  put: function (id, value, filename, callback, opts) {
+  put: function (id, value, filename, callback, opts = {}) {
     $.ajax({
       url: this.api_base_url + '/' + id + '/' + filename,
       type: 'put',

--- a/apps/src/code-studio/initApp/clientApi.js
+++ b/apps/src/code-studio/initApp/clientApi.js
@@ -202,10 +202,11 @@ var base = {
         callback(null, data);
       })
       .fail(function (request, status, error) {
-        if (opts.includeResponseText) {
-          error += ' ' + request.responseText;
+        const args = [request, status, error];
+        if (opts.includeDetails && request.responseJSON?.details) {
+          args.push(request.responseJSON?.details);
         }
-        var err = errorString(request, status, error);
+        var err = errorString(...args);
         callback(err, false);
       });
   },
@@ -235,10 +236,12 @@ var base = {
   },
 };
 
-function errorString(request, status, error) {
-  return new Error(
-    `httpStatusCode: ${request.status}; status: ${status}; error: ${error}`
-  );
+function errorString(request, status, error, details = '') {
+  let str = `httpStatusCode: ${request.status}; status: ${status}; error: ${error}`;
+  if (details.length) {
+    str += `; details: ${details}`;
+  }
+  return new Error(str);
 }
 
 module.exports = {

--- a/apps/src/code-studio/initApp/clientApi.js
+++ b/apps/src/code-studio/initApp/clientApi.js
@@ -189,7 +189,6 @@ var base = {
    * @param {String} filename - The name of the file to create or update.
    * @param {NodeStyleCallback} callback - Expected result is the new collection
    *        object.
-   * @param {Object} opts - Options object.
    */
   put: function (id, value, filename, callback) {
     $.ajax({

--- a/apps/src/code-studio/initApp/clientApi.js
+++ b/apps/src/code-studio/initApp/clientApi.js
@@ -191,7 +191,7 @@ var base = {
    *        object.
    * @param {Object} opts - Options object.
    */
-  put: function (id, value, filename, callback, opts = {}) {
+  put: function (id, value, filename, callback) {
     $.ajax({
       url: this.api_base_url + '/' + id + '/' + filename,
       type: 'put',
@@ -202,11 +202,9 @@ var base = {
         callback(null, data);
       })
       .fail(function (request, status, error) {
-        const args = [request, status, error];
-        if (opts.includeDetails && request.responseJSON?.details) {
-          args.push(request.responseJSON?.details);
-        }
-        var err = errorString(...args);
+        // json_bad_request helper adds details to the responseJSON
+        const details = request.responseJSON?.details || null;
+        const err = errorString(request, status, error, details);
         callback(err, false);
       });
   },
@@ -236,12 +234,11 @@ var base = {
   },
 };
 
-function errorString(request, status, error, details = '') {
-  let str = `httpStatusCode: ${request.status}; status: ${status}; error: ${error}`;
-  if (details.length) {
-    str += `; details: ${details}`;
-  }
-  return new Error(str);
+function errorString(request, status, error, details = null) {
+  return new Error(
+    `httpStatusCode: ${request.status}; status: ${status}; error: ${error}`,
+    {cause: details}
+  );
 }
 
 module.exports = {

--- a/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
@@ -293,6 +293,25 @@ describe('LibraryPublisher', () => {
         console.warn.restore();
       });
 
+      it('sets error state if library contains PII', async () => {
+        publishSpy.callsArgWith(1, {
+          message: 'httpStatusCode: 400; status: error; error: Bad request',
+          cause: {pIIWords: ['123-456-7890']},
+        });
+        sinon.stub(console, 'warn');
+        wrapper.setState({
+          libraryDescription: description,
+          selectedFunctions: selectedFunctions,
+        });
+
+        await wrapper.instance().validateAndPublish();
+
+        expect(wrapper.state().publishState).to.equal(PublishState.PII_INPUT);
+        expect(wrapper.state().pIIWords).to.equal(['123-456-7890']);
+
+        console.warn.restore();
+      });
+
       it('calls onPublishSuccess when it succeeds', async () => {
         publishSpy.callsArg(2);
         wrapper.setState({

--- a/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
@@ -307,7 +307,7 @@ describe('LibraryPublisher', () => {
         await wrapper.instance().validateAndPublish();
 
         expect(wrapper.state().publishState).to.equal(PublishState.PII_INPUT);
-        expect(wrapper.state().pIIWords).to.equal(['123-456-7890']);
+        expect(wrapper.state().pIIWords).to.deep.equal(['123-456-7890']);
 
         console.warn.restore();
       });

--- a/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
@@ -296,7 +296,7 @@ describe('LibraryPublisher', () => {
       it('sets error state if library contains PII', async () => {
         publishSpy.callsArgWith(1, {
           message: 'httpStatusCode: 400; status: error; error: Bad request',
-          cause: {profaneWords: ['123-456-7890']},
+          cause: {pIIWords: ['123-456-7890']},
         });
         sinon.stub(console, 'warn');
         wrapper.setState({

--- a/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
@@ -296,7 +296,7 @@ describe('LibraryPublisher', () => {
       it('sets error state if library contains PII', async () => {
         publishSpy.callsArgWith(1, {
           message: 'httpStatusCode: 400; status: error; error: Bad request',
-          cause: {pIIWords: ['123-456-7890']},
+          cause: {profaneWords: ['123-456-7890']},
         });
         sinon.stub(console, 'warn');
         wrapper.setState({
@@ -308,6 +308,46 @@ describe('LibraryPublisher', () => {
 
         expect(wrapper.state().publishState).to.equal(PublishState.PII_INPUT);
         expect(wrapper.state().pIIWords).to.equal(['123-456-7890']);
+
+        console.warn.restore();
+      });
+
+      it('sets generic error state if error has null cause', async () => {
+        publishSpy.callsArgWith(1, {
+          message: 'httpStatusCode: 400; status: error; error: Bad request',
+          cause: null,
+        });
+        sinon.stub(console, 'warn');
+        wrapper.setState({
+          libraryDescription: description,
+          selectedFunctions: selectedFunctions,
+        });
+
+        await wrapper.instance().validateAndPublish();
+
+        expect(wrapper.state().publishState).to.equal(
+          PublishState.ERROR_PUBLISH
+        );
+
+        console.warn.restore();
+      });
+
+      it('sets generic error state if error has another cause', async () => {
+        publishSpy.callsArgWith(1, {
+          message: 'httpStatusCode: 400; status: error; error: Bad request',
+          cause: {profaneWords: ['fart']},
+        });
+        sinon.stub(console, 'warn');
+        wrapper.setState({
+          libraryDescription: description,
+          selectedFunctions: selectedFunctions,
+        });
+
+        await wrapper.instance().validateAndPublish();
+
+        expect(wrapper.state().publishState).to.equal(
+          PublishState.ERROR_PUBLISH
+        );
 
         console.warn.restore();
       });

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -424,7 +424,7 @@ class FilesApi < Sinatra::Base
       # Once we have a better geocoding solution in H1, we should start filtering for addresses again.
       # Additional context: https://codedotorg.atlassian.net/browse/STAR-1361
       if share_failure && share_failure[:type] != "address"
-        halt 400, "Share failure: #{share_failure.inspect}"
+        return json_bad_request("ShareFailure: content=#{share_failure.content}")
       end
     end
 

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -423,7 +423,9 @@ class FilesApi < Sinatra::Base
       # TODO(JillianK): we are temporarily ignoring address share failures because our address detection is very broken.
       # Once we have a better geocoding solution in H1, we should start filtering for addresses again.
       # Additional context: https://codedotorg.atlassian.net/browse/STAR-1361
-      return bad_request if share_failure && share_failure[:type] != "address"
+      if share_failure && share_failure[:type] != "address"
+        halt 400, "Share failure: #{share_failure.inspect}"
+      end
     end
 
     # Don't allow project to be saved if it contains non-UTF-8 characters (causing error / project to not load when opened).

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -1,7 +1,6 @@
 require 'active_support/core_ext/numeric/time'
 require 'cdo/aws/s3'
 require 'cdo/rack/request'
-require 'sinatra/base'
 require 'cdo/sinatra'
 require 'cdo/image_moderation'
 require 'nokogiri'
@@ -424,7 +423,9 @@ class FilesApi < Sinatra::Base
       # Once we have a better geocoding solution in H1, we should start filtering for addresses again.
       # Additional context: https://codedotorg.atlassian.net/browse/STAR-1361
       if share_failure && share_failure[:type] != "address"
-        return json_bad_request("ShareFailure: content=#{share_failure.content}")
+        details_key = share_failure.type == ShareFiltering::FailureType::PROFANITY ? "profaneWords" : "pIIWords"
+        details = {details_key => [share_failure.content]}
+        return json_bad_request(details)
       end
     end
 

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext/numeric/time'
 require 'cdo/aws/s3'
 require 'cdo/rack/request'
+require 'sinatra/base'
 require 'cdo/sinatra'
 require 'cdo/image_moderation'
 require 'nokogiri'


### PR DESCRIPTION
Currently, if you try to save a library that contains PII (such as email or phone number), we return [“bad request”](https://github.com/code-dot-org/code-dot-org/blob/1e9554aabf2d7178b17cc4bfda21c4bacedfea20/dashboard/legacy/middleware/files_api.rb#L424). On the frontend, if we receive a bad request, we show the error message “There was an error publishing your library. Please check your internet connection and try again."

This PR modifies the error message: `It appears your library contains personally identifiable information. Please remove the {pIICount, plural, one {word} other {words}} \"{pIIWords}\".`

I added a `details` field to the bad request error, which contains a key -- either `pIIWords` or `profaneWords` -- depending on the share failure type (email, phone, address, or profanity). The  `errorString` function in the `clientApi` will include these details as the `cause` argument [in the Error constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause). The LibraryPublisher can then interpret the type of error by checking the `error.cause` for `pIIWords`.

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/SL-588

## Testing story

Tested locally with new error messages.

<img width="751" alt="Screenshot 2023-06-26 at 10 30 00 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/51939cd3-d1a4-46b2-aa58-2ced8952b033">

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
