### PR TITLE
Bump ml-playground version to fix dataset descriptions

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -63,7 +63,7 @@
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "2.16.0",
     "@code-dot-org/ml-activities": "0.0.26",
-    "@code-dot-org/ml-playground": "0.0.45",
+    "@code-dot-org/ml-playground": "0.0.47",
     "@code-dot-org/p5.play": "1.3.21-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.9",
     "@code-dot-org/redactable-markdown": "0.4.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1425,10 +1425,10 @@
     messageformat "^1.1.0"
     react-typist "^2.0.5"
 
-"@code-dot-org/ml-playground@0.0.45":
-  version "0.0.45"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-playground/-/ml-playground-0.0.45.tgz#02368c0cd1fd9bdcaece3b87c042b359ec7215d8"
-  integrity sha512-uI/aTbNmuJ1W8RKaUx5jIBMBivbCg9FSH8ch6QxlS1VTIWKOyz7AWfSC+kekNa7Q41Tcb+m1X2j6/Jj8ukqZVQ==
+"@code-dot-org/ml-playground@0.0.47":
+  version "0.0.47"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-playground/-/ml-playground-0.0.47.tgz#9d9cf99a95c216de1b68153866f8d963659199f5"
+  integrity sha512-V+S2u0smYnn1raobIYnHsbmgqY2EwHV4FUIIV9IjG1XstaCvpEqmMozQl6JJGKwZtDr0GLocarEztr6alyu5sw==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"


### PR DESCRIPTION
Get updated ml-playground version to fix missing descriptions in some levels. Description text (potential uses, potential misuses) was missing prior to this change. After, this change, descriptions appear (see screenshot below):

![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/6bad6d1e-d648-42c2-aaf8-27a6e0dbdb2b)

Bug fix in ml-playground repo:

https://github.com/code-dot-org/ml-playground/pull/301

Worth noting that this fix wasn't visible on the code-dot-org side until I manually ran `yarn build` -- `yarn start` does not seem to copy these static asset files. I wasn't able to easily determine why this was the case.

## Links

- bug discussion thread: [link](https://codedotorg.slack.com/archives/C03DBDN67B7/p1681910571638339)

## Testing story

Confirmed that the level reported as broken now shows dataset descriptions. Also confirmed a level with visible descriptions (`/s/csd7-2022/lessons/6/levels/4`) continued to have visible descriptions.