### PR TITLE
Replace 'subtype' with 'standalone_app' in Poetry.rb

### DIFF
--- a/dashboard/app/models/levels/poetry.rb
+++ b/dashboard/app/models/levels/poetry.rb
@@ -32,19 +32,20 @@ class Poetry < GamelabJr
     standalone_app_name
     available_poems
   )
+  # Note that standalone_app_name refers to the Poetry subtype.
 
-  # Set the default poem to nil if the subtype, i.e., standalone_app, does not have poems, or if the default poem is
-  # not in the list of poems for the subtype.
+  # Set the default poem to nil if the standalone_app does not have poems, or if the default poem is
+  # not in the list of poems for the standalone_app.
   def sanitize_default_poem
-    self.default_poem = nil if Poetry.subtypes_with_poems.exclude?(standalone_app_name) ||
+    self.default_poem = nil if Poetry.standalone_app_with_poems.exclude?(standalone_app_name) ||
       Poetry.poem_keys_for_standalone_app(standalone_app_name).exclude?(default_poem)
   end
 
-  # Set the available poems to nil if the subtype does not have poems.
-  # Also remove any available poems that are not in the list of poems for the subtype.
+  # Set the available poems to nil if the standalone_app does not have poems.
+  # Also remove any available poems that are not in the list of poems for the standalone_app.
   def sanitize_available_poems
-    self.available_poems = nil unless Poetry.subtypes_with_poems.include?(standalone_app_name)
-    return if Poetry.subtypes_with_poems.exclude?(standalone_app_name) || (available_poems && available_poems.empty?)
+    self.available_poems = nil unless Poetry.standalone_apps_with_poems.include?(standalone_app_name)
+    return if Poetry.standalone_apps_with_poems.exclude?(standalone_app_name) || (available_poems && available_poems.empty?)
     # filter out any invalid poems from available_poems
     self.available_poems = available_poems & Poetry.poem_keys_for_standalone_app(standalone_app_name)
   end
@@ -54,7 +55,7 @@ class Poetry < GamelabJr
     sanitize_available_poems
     # If there is a default poem and dropdown poem(s), check that the default poem is
     # in the dropdown poem list.
-    if default_poem.present? && Poetry.subtypes_with_poems.include?(standalone_app_name) &&
+    if default_poem.present? && Poetry.standalone_apps_with_poems.include?(standalone_app_name) &&
       available_poems && !available_poems.empty? && available_poems.exclude?(default_poem)
       errors.add(:default_poem, "selected default poem is not in dropdown poem list")
     end
@@ -73,7 +74,7 @@ class Poetry < GamelabJr
     [['Poetry', 'poetry'], ['Poetry HOC', 'poetry_hoc'],  ['Time Capsule', 'time_capsule']]
   end
 
-  def self.subtypes_with_poems
+  def self.standalone_apps_with_poems
     %w(poetry_hoc time_capsule)
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This small PR is a follow-up to [this PR](https://github.com/code-dot-org/code-dot-org/pull/51956). 
Poetry has 3 project types: 'poetry', 'poetry_hoc', and 'time_capsule'. After examining `poetry.rb`, I saw that now there are mixed references to the Poetry project type -  `standalone_app` and `subtype`. 

`standalone_app`  is used in other places in our codebase so I updated this file to be consistent. 

# Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
There is discussion about replacing `standalone_app` with `project_type` which was introduced by [this PR](https://github.com/code-dot-org/code-dot-org/pull/51634) because now there are two terms referring to the `Game.app`. This PR removes `subtype` since two is better than three!
[Slack discussion about which term to use](https://codedotorg.slack.com/archives/C03DBDN67B7/p1684425809820069)


<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
