### PR TITLE
Music: Fix level_data loading when using Next button

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -343,7 +343,6 @@ class UnconnectedMusicView extends React.Component {
   // When the user initiates going to the next panel in the app.
   onNextPanel = () => {
     this.progressManager?.next();
-    this.handlePanelChange();
 
     // Tell the external system (if there is one) about the new level.
     if (this.hasLevels() && this.props.navigateToLevelId) {


### PR DESCRIPTION
This fixes an issue in which pressing the "Next" button inside Music Lab was loading both the current level and the next level's "level_data" more or less simultaneously, and sometimes the new level would show the previous level's instructions.

@molly-moen did an excellent [analysis](https://codedotorg.slack.com/archives/C04TH8400AU/p1684446460936979?thread_ts=1684442468.772069&cid=C04TH8400AU) which is reproduced here with slight tweaks:

> When you click "Next" in a script-level, the following things happen:
> 1. `onNextPanel` calls `ProgressManager`’s `next`, which increments the step in the `ProgressManager` and then calls back to `MusicView`’s `onProgressChange`.
> 2. `onProgressChange` sets the current progress state in `musicRedux`, which is different from setting the current level in `progressRedux`.
> 3. `onNextPanel` then calls `handlePanelChange`, which fires off an async method to load the next level. It calls the update with `currentLevelIndex`, which has not been changed yet.
> 4. Back in `onNextPanel`, if we are a script-level, then we dispatch a `navigateToLevelId` in `progressRedux`. When we are a script-level, this will result in the new level index arriving in the `currentLevelIndex` prop.
> 5. In `componentDidUpdate`, we see that `currentLevelIndex` has changed, so we call `handlePanelChange` again with the correct new level index, which fires off a second async method to load the new level.
> 6. In some repro situations (sometimes on the first load for a given user on the progression), the first request finishes after the second request, so we see the old level data.
>
> Really, we are prematurely calling `handlePanelChange` in `onNextPanel`.

Given this analysis, the fix indeed seems to be to simply remove the unnecessary call to `handlePanelChange` in `onNextPanel`.
