### PR TITLE
Music: fix video close icon

### DIFF
--- a/apps/src/music/views/video.module.scss
+++ b/apps/src/music/views/video.module.scss
@@ -51,6 +51,6 @@
 .closeIcon {
   position: absolute;
   font-size: 35px;
-  left: 6px;
-  top: 1px;
+  left: 7px;
+  top: 2px;
 }


### PR DESCRIPTION
This makes a small fix to the video close icon's alignment, since we recently changed icon library version.

### before

<img width="129" alt="Screenshot 2023-05-19 at 11 31 11 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/ec83046a-a66d-4852-8d54-ad61692cc9b5">

### after

<img width="129" alt="Screenshot 2023-05-19 at 11 33 55 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/c13a3cc8-322e-4f55-896c-8e2d8829ac60">

