### PR TITLE
Update CdoFieldDropdown validation of initial values

### DIFF
--- a/apps/src/blockly/addons/cdoFieldDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldDropdown.js
@@ -7,14 +7,42 @@ import {
 
 export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
   /**
-   * Add special case for '???'.
-   * @override
+   * Ensure that the input value is a valid language-neutral option.
+   * @param newValue The input value.
+   * @returns A valid language-neutral option, or null if invalid.
+   * @override Add special case for '???' and accommodate valid initial values that are not surrounded
+   * by quotes in xml.
    */
   doClassValidation_(newValue) {
     if (newValue === EMPTY_OPTION) {
       return newValue;
     } else {
-      return super.doClassValidation_(newValue);
+      const options = this.getOptions(true);
+      let isValueValid = false;
+      options.forEach(option => {
+        if (option[1] === newValue) {
+          isValueValid = true;
+        } else if (option[1] === `"${newValue}"`) {
+          newValue = `"${newValue}"`;
+          isValueValid = true;
+        }
+      });
+
+      if (!isValueValid) {
+        if (this.sourceBlock_) {
+          console.warn(
+            "Cannot set the dropdown's value to an unavailable option." +
+              ' Block type: ' +
+              this.sourceBlock_.type +
+              ', Field name: ' +
+              this.name +
+              ', Value: ' +
+              newValue
+          );
+        }
+        return null;
+      }
+      return newValue;
     }
   }
 

--- a/apps/src/blockly/addons/cdoFieldDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldDropdown.js
@@ -17,32 +17,26 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     if (newValue === EMPTY_OPTION) {
       return newValue;
     } else {
-      const options = this.getOptions(true);
-      let isValueValid = false;
-      options.forEach(option => {
+      for (const option of this.getOptions(true)) {
         if (option[1] === newValue) {
-          isValueValid = true;
+          return newValue;
         } else if (option[1] === `"${newValue}"`) {
-          newValue = `"${newValue}"`;
-          isValueValid = true;
+          return `"${newValue}"`;
         }
-      });
-
-      if (!isValueValid) {
-        if (this.sourceBlock_) {
-          console.warn(
-            "Cannot set the dropdown's value to an unavailable option." +
-              ' Block type: ' +
-              this.sourceBlock_.type +
-              ', Field name: ' +
-              this.name +
-              ', Value: ' +
-              newValue
-          );
-        }
-        return null;
       }
-      return newValue;
+
+      if (this.sourceBlock_) {
+        console.warn(
+          "Cannot set the dropdown's value to an unavailable option." +
+            ' Block type: ' +
+            this.sourceBlock_.type +
+            ', Field name: ' +
+            this.name +
+            ', Value: ' +
+            newValue
+        );
+      }
+      return null;
     }
   }
 

--- a/apps/src/blockly/addons/cdoFieldDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldDropdown.js
@@ -17,14 +17,32 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     if (newValue === EMPTY_OPTION) {
       return newValue;
     } else {
-      if (
-        newValue.length > 0 &&
-        newValue.charAt(0) !== '"' &&
-        newValue.charAt(newValue.length - 1) !== '"'
-      ) {
-        newValue = `"${newValue}"`;
+      const options = this.getOptions(true);
+      let isValueValid = false;
+      options.forEach(option => {
+        if (option[1] === newValue) {
+          isValueValid = true;
+        } else if (option[1] === `"${newValue}"`) {
+          newValue = `"${newValue}"`;
+          isValueValid = true;
+        }
+      });
+
+      if (!isValueValid) {
+        if (this.sourceBlock_) {
+          console.warn(
+            "Cannot set the dropdown's value to an unavailable option." +
+              ' Block type: ' +
+              this.sourceBlock_.type +
+              ', Field name: ' +
+              this.name +
+              ', Value: ' +
+              newValue
+          );
+        }
+        return null;
       }
-      return super.doClassValidation_(newValue);
+      return newValue;
     }
   }
 

--- a/apps/src/blockly/addons/cdoFieldDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldDropdown.js
@@ -17,32 +17,14 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     if (newValue === EMPTY_OPTION) {
       return newValue;
     } else {
-      const options = this.getOptions(true);
-      let isValueValid = false;
-      options.forEach(option => {
-        if (option[1] === newValue) {
-          isValueValid = true;
-        } else if (option[1] === `"${newValue}"`) {
-          newValue = `"${newValue}"`;
-          isValueValid = true;
-        }
-      });
-
-      if (!isValueValid) {
-        if (this.sourceBlock_) {
-          console.warn(
-            "Cannot set the dropdown's value to an unavailable option." +
-              ' Block type: ' +
-              this.sourceBlock_.type +
-              ', Field name: ' +
-              this.name +
-              ', Value: ' +
-              newValue
-          );
-        }
-        return null;
+      if (
+        newValue.length > 0 &&
+        newValue.charAt(0) !== '"' &&
+        newValue.charAt(newValue.length - 1) !== '"'
+      ) {
+        newValue = `"${newValue}"`;
       }
-      return newValue;
+      return super.doClassValidation_(newValue);
     }
   }
 


### PR DESCRIPTION
This PR updates the overridden`doClassValidation_` to handle valid initial values from xml, whether or not the initial values have surrounding quotes.

Currently, if a block field has an initial value set without quotes, for example, 'spinning right' below:

```
  <block type="Poetry_startBehavior">
    <title name="ANIMATION_NAME">"twinkling_star"</title>
    <title name="BEHAVIOR">spinning_right</title>
  </block>
```
then there is a warning in the dev console:

![Screen Shot 2023-05-19 at 10 36 57 AM](https://github.com/code-dot-org/code-dot-org/assets/107423305/4c2116bb-2c9a-43c4-b78f-92eb0e3410f1)


Instead of 'spinning right', 'fluttering' is selected since it's the first option in the list of options:

<img width="331" alt="Screen Shot 2023-05-19 at 10 31 33 AM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/0c9c6bba-3441-430a-885e-0fc283d018c8">

The reason is that in the block config, the initial value, in this case, 'spinning right', is compared with the list of options which contain a second pair of quotes so that the initial value must be the string '"spinning right"', not 'spinning right' in order to be read correctly:

<img width="489" alt="Screen Shot 2023-05-19 at 10 39 17 AM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/1ccfd1ad-616d-483c-b5b2-7961a29578b8">


In [this commit](https://github.com/code-dot-org/code-dot-org/pull/51992/commits/f2e996a8baafab842d63f686b90718312125a404), if the initial value didn't have surrounding quotes, I added them, and then called on `super.doClassValidation_`. However, this caused a warning for the 'Poetry_whenLineShows' block for the 'N' field. 
```
  <block type="Poetry_whenLineShows">
    <title name="N">0</title>
  </block>
```
Since the block config lists options without an extra pair of quotes:

<img width="503" alt="Screen Shot 2023-05-19 at 10 25 25 AM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/dcceb49a-f757-404c-9521-d9e420ed3531">

Because the xml block configuration is not consistent for dropdown selections, I chose an implementation that first checks if the `newValue` is the same as an option and if not, check if adding quotes to it will get a match. If so, then reassign `newValue` with the additional quotes and mark it as a valid option.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested update locally on [this poetry levels](http://localhost-studio.code.org:3000/s/poetry-2021/lessons/1/levels/6).

Before:

![Screen Shot 2023-05-19 at 10 51 20 AM](https://github.com/code-dot-org/code-dot-org/assets/107423305/a0e6b47d-c6e7-4f44-89eb-7ea3bb8e7022)

After: There were no warnings in dev console referring to the dropdown's value.

![Screen Shot 2023-05-19 at 10 50 01 AM](https://github.com/code-dot-org/code-dot-org/assets/107423305/210277cc-0a70-4289-99d1-f22f8b501513)


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
