### PR TITLE
[Google Blockly] Skip logging if workspace is readonly

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -113,6 +113,7 @@ export function getUserTheme(themeOption) {
 }
 
 export function getCode(workspace) {
+  const shouldSave = workspace.options && !workspace.options.readOnly;
   const dcdoFlagSet = DCDO.get('blockly-json-experiment', false);
   const dcdoSampleRate = DCDO.get('blockly-json-sample-rate', 0);
   const experimentEnabled = experiments.isEnabled(experiments.BLOCKLY_JSON);
@@ -120,7 +121,11 @@ export function getCode(workspace) {
   // This feature can be turned off with DCDO.set('blockly-json-experiment', false).
   // Additionally rate must be specified, e.g. DCDO.set('blockly-json-sample-rate', 0.05).
   // The rate is ignored if the user has added ?enableExperiments=blocklyJson to the URL.
-  if (dcdoFlagSet && (experimentEnabled || dcdoSampleRate >= Math.random())) {
+  if (
+    shouldSave &&
+    dcdoFlagSet &&
+    (experimentEnabled || dcdoSampleRate >= Math.random())
+  ) {
     // Begin collecting data about our ability to correctly serialize a workspace in JSON format.
     setTimeout(() => {
       // Execute the Json serialization test asynchronously so we don't block saving.
@@ -222,8 +227,8 @@ export function compareBlockArrays(xmlBlocks, jsonBlocks) {
         differences.push({
           result: 'different number of keys',
           path: path,
-          keys1: keys1.toString(),
-          keys2: keys2.toString(),
+          arg1: arg1.toString(),
+          arg2: arg2.toString(),
         });
         return differences; // Don't try comparing properties if we have the wrong amount.
       }


### PR DESCRIPTION
This updates the logging that was recently implemented for comparing blocks created from XML/JSON sources:
- https://github.com/code-dot-org/code-dot-org/pull/51739


During the second round of the experiment this morning, we logged difference records for two types of cases:
1. We had some noisy logging to checking readOnly workspaces. We don't need to save for readOnly workspaces, so we can skip the test in those cases.
2. We had a few legitimate differences reported related to a specialized block field in Dance Party. However, I've been unable to reproduce the failure with those projects. In these cases, an array of `generatedOptions_` was found to have increased in length by one when serializing with JSON. To allow us to see the specific values that are changing, we can stringify the actual object arguments being compared.

For item 2, this would be expected to improve the clarity of certain records. Here's a hypothetical comparison for a difference found in the number of dropdown options in a block:
**Before** 
```
{
  "result": "different number of keys",
  "path": ".0.inputList.0.fieldRow.0.generatedOptions_",
  "keys1": "0,1,2",
  "keys2": "0,1,2,3"
}
```
**After:**
```
{
  "result": "different number of keys",
  "path": ".0.inputList.0.fieldRow.0.generatedOptions_",
  "keys1": "myDancer,]Tm$k.6A?M.aLF!]$ir:,Rename all myDancer,RENAME_ALL_ID,Rename this variable,RENAME_THIS_ID",
  "keys2": "myDancer,]Tm$k.6A?M.aLF!]$ir:,Rename all myDancer,RENAME_ALL_ID,Rename this variable,RENAME_THIS_ID,some new option label,some new value"
}
```
(Scroll to the right to see full strings. Note that the last option above is for illustrative purposes only. I haven't been able to repro the problem!)

Additional context on Slack: https://codedotorg.slack.com/archives/C03DBDN67B7/p1684504970060669
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
