### PR TITLE
Add Url Param Filtering for Curriculum Catalog

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {curriculumDataShape} from './curriculumCatalogShapes';
 import i18n from '@cdo/locale';
 import style from '../../../style/code-studio/curriculum_catalog_container.module.scss';
+import {queryParams} from '../../code-studio/utils';
 import HeaderBanner from '../HeaderBanner';
 import CourseCatalogBannerBackground from '../../../static/curriculum_catalog/course-catalog-banner-illustration-01.png';
 import CourseCatalogIllustration01 from '../../../static/curriculum_catalog/course-catalog-illustration-01.png';
@@ -54,19 +55,11 @@ const getEmptyFilters = () => {
 
 // Filters out invalid values for the given filter key.
 const getValidParamValues = (filterKey, paramValues) => {
-  return paramValues.filter(value => {
-    switch (filterKey) {
-      case 'grade':
-        return Object.keys(gradeLevelsMap).includes(value);
-      case 'duration':
-        return Object.keys(translatedCourseOfferingDurations).includes(value);
-      case 'topic':
-        return Object.keys(translatedCourseOfferingCsTopics).includes(value);
-      case 'device':
-        return Object.keys(translatedCourseOfferingDeviceTypes).includes(value);
-      default:
-        return false;
-    }
+  if (!Array.isArray(paramValues)) {
+    paramValues = [paramValues];
+  }
+  return paramValues.filter(paramValue => {
+    return Object.keys(filterTypes[filterKey].options).includes(paramValue);
   });
 };
 
@@ -75,19 +68,12 @@ const getValidParamValues = (filterKey, paramValues) => {
 // "filter_name:checked_value_1,checked_value_2,etc."
 const getInitialFilterStates = () => {
   const filterTypeKeys = Object.keys(filterTypes);
-  const urlParams = location.search?.substring(1).split('&');
+  const urlParams = queryParams();
 
   let filters = getEmptyFilters();
-  urlParams.forEach(keyValue => {
-    const [paramKey, paramCSV] = keyValue.split('=');
+  Object.keys(urlParams).forEach(paramKey => {
     if (filterTypeKeys.includes(paramKey)) {
-      const validParamValues = getValidParamValues(
-        paramKey,
-        paramCSV.split(',')
-      );
-      validParamValues.forEach(validValue =>
-        filters[paramKey].push(validValue)
-      );
+      filters[paramKey] = getValidParamValues(paramKey, urlParams[paramKey]);
     }
   });
   return filters;

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -52,6 +52,47 @@ const getEmptyFilters = () => {
   return filters;
 };
 
+// Filters out invalid values for the given filter key.
+const getValidParamValues = (filterKey, paramValues) => {
+  return paramValues.filter(value => {
+    switch (filterKey) {
+      case 'grade':
+        return Object.keys(gradeLevelsMap).includes(value);
+      case 'duration':
+        return Object.keys(translatedCourseOfferingDurations).includes(value);
+      case 'topic':
+        return Object.keys(translatedCourseOfferingCsTopics).includes(value);
+      case 'device':
+        return Object.keys(translatedCourseOfferingDeviceTypes).includes(value);
+      default:
+        return false;
+    }
+  });
+};
+
+// Returns initial filter states based on URL parameters (returns empty filters if
+// no relevant parameters in the URL). The filter params are of the form:
+// "filter_name:checked_value_1,checked_value_2,etc."
+const getInitialFilterStates = () => {
+  const filterTypeKeys = Object.keys(filterTypes);
+  const urlParams = location.search?.substring(1).split('&');
+
+  let filters = getEmptyFilters();
+  urlParams.forEach(keyValue => {
+    const [paramKey, paramCSV] = keyValue.split('=');
+    if (filterTypeKeys.includes(paramKey)) {
+      const validParamValues = getValidParamValues(
+        paramKey,
+        paramCSV.split(',')
+      );
+      validParamValues.forEach(validValue =>
+        filters[paramKey].push(validValue)
+      );
+    }
+  });
+  return filters;
+};
+
 // Returns whether the given curriculum matches the checked grade level filters.
 const filterByGradeLevel = (curriculum, gradeFilters) => {
   if (gradeFilters.length > 0) {
@@ -122,7 +163,9 @@ const filterByDevice = (curriculum, deviceFilters) => {
 
 const CurriculumCatalog = ({curriculaData, isEnglish}) => {
   const [filteredCurricula, setFilteredCurricula] = useState(curriculaData);
-  const [appliedFilters, setAppliedFilters] = useState(getEmptyFilters());
+  const [appliedFilters, setAppliedFilters] = useState(
+    getInitialFilterStates()
+  );
 
   // Filters out any Curriculum Catalog Cards of courses that do not match the filter criteria.
   useEffect(() => {

--- a/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
@@ -3,6 +3,7 @@ import {render, screen, fireEvent} from '@testing-library/react';
 import {Provider} from 'react-redux';
 import {configureStore} from '@reduxjs/toolkit';
 import {assert, expect} from '../../../util/reconfiguredChai';
+import {setWindowLocation} from '../../../../src/code-studio/utils';
 import responsive, {
   setResponsiveSize,
   ResponsiveSize,
@@ -222,7 +223,7 @@ describe('CurriculumCatalog', () => {
     // Filters for all courses that support:
     // - Grades 2 or 3
     // - Physical Computing or Interdisciplinary topics
-    // - Chromebooks or tablets
+    // - Tablets or No Device
     expect(
       screen.getAllByText('Learn more', {
         exact: false,
@@ -252,6 +253,120 @@ describe('CurriculumCatalog', () => {
       }).length
     ).to.equal(allFiltersAppliedShownCurricula.length);
     allFiltersAppliedShownCurricula.forEach(curriculum => {
+      expect(screen.getAllByText(curriculum.display_name).length).to.equal(1);
+    });
+  });
+});
+
+describe('CurriculumCatalog with url params', () => {
+  const defaultProps = {curriculaData: allCurricula, isEnglish: false};
+  let store;
+
+  beforeEach(() => {
+    store = configureStore({reducer: {responsive}});
+    store.dispatch(setResponsiveSize(ResponsiveSize.lg));
+  });
+
+  function renderWithUrlParams(urlParams) {
+    setWindowLocation({search: urlParams});
+    render(
+      <Provider store={store}>
+        <CurriculumCatalog {...defaultProps} />
+      </Provider>
+    );
+  }
+
+  it('no url params applies no filters on load', () => {
+    renderWithUrlParams('');
+
+    expect(
+      screen.getAllByText('Learn more', {
+        exact: false,
+      }).length
+    ).to.equal(allShownCurricula.length);
+    allShownCurricula.forEach(curriculum => {
+      expect(screen.getAllByText(curriculum.display_name).length).to.equal(1);
+    });
+  });
+
+  it('param with invalid filter key does not filter anything on load', () => {
+    renderWithUrlParams('?fakeKey=fakeValue');
+
+    expect(
+      screen.getAllByText('Learn more', {
+        exact: false,
+      }).length
+    ).to.equal(allShownCurricula.length);
+    allShownCurricula.forEach(curriculum => {
+      expect(screen.getAllByText(curriculum.display_name).length).to.equal(1);
+    });
+  });
+
+  it('param with valid filter key but no value does not filter anything on load', () => {
+    renderWithUrlParams('?duration=');
+
+    expect(
+      screen.getAllByText('Learn more', {
+        exact: false,
+      }).length
+    ).to.equal(allShownCurricula.length);
+    allShownCurricula.forEach(curriculum => {
+      expect(screen.getAllByText(curriculum.display_name).length).to.equal(1);
+    });
+  });
+
+  it('param with valid filter key but invalid value does not filter anything on load', () => {
+    renderWithUrlParams('?duration=fakeValue');
+
+    expect(
+      screen.getAllByText('Learn more', {
+        exact: false,
+      }).length
+    ).to.equal(allShownCurricula.length);
+    allShownCurricula.forEach(curriculum => {
+      expect(screen.getAllByText(curriculum.display_name).length).to.equal(1);
+    });
+  });
+
+  it('params with valid filter key and value applies filters on load', () => {
+    renderWithUrlParams('?duration=week');
+
+    expect(
+      screen.getAllByText('Learn more', {
+        exact: false,
+      }).length
+    ).to.equal(weeklongShownCurricula.length);
+    weeklongShownCurricula.forEach(curriculum => {
+      expect(screen.getAllByText(curriculum.display_name).length).to.equal(1);
+    });
+  });
+
+  it('params with some valid filter keys and some valid values applies valid filters on load', () => {
+    renderWithUrlParams(
+      '?grade=kindergarten&fakeKey=grade_4&grade=fakeValue&grade=grade_2'
+    );
+
+    expect(
+      screen.getAllByText('Learn more', {
+        exact: false,
+      }).length
+    ).to.equal(gradesKAnd2ShownCurricula.length);
+    gradesKAnd2ShownCurricula.forEach(curriculum => {
+      expect(screen.getAllByText(curriculum.display_name).length).to.equal(1);
+    });
+  });
+
+  it('params with different valid filter keys and different valid values are all applied on load', () => {
+    renderWithUrlParams(
+      '?grade=grade_2&grade=grade_3&topic=interdisciplinary&topic=physical_computing&device=tablet&device=no_device'
+    );
+
+    expect(
+      screen.getAllByText('Learn more', {
+        exact: false,
+      }).length
+    ).to.equal(multipleFiltersAppliedShownCurricula.length);
+    multipleFiltersAppliedShownCurricula.forEach(curriculum => {
       expect(screen.getAllByText(curriculum.display_name).length).to.equal(1);
     });
   });

--- a/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
@@ -3,7 +3,10 @@ import {render, screen, fireEvent} from '@testing-library/react';
 import {Provider} from 'react-redux';
 import {configureStore} from '@reduxjs/toolkit';
 import {assert, expect} from '../../../util/reconfiguredChai';
-import {setWindowLocation} from '../../../../src/code-studio/utils';
+import {
+  setWindowLocation,
+  resetWindowLocation,
+} from '../../../../src/code-studio/utils';
 import responsive, {
   setResponsiveSize,
   ResponsiveSize,
@@ -266,6 +269,7 @@ describe('CurriculumCatalog with url params', () => {
     store = configureStore({reducer: {responsive}});
     store.dispatch(setResponsiveSize(ResponsiveSize.lg));
   });
+  afterEach(resetWindowLocation);
 
   function renderWithUrlParams(urlParams) {
     setWindowLocation({search: urlParams});


### PR DESCRIPTION
Adds Url parameter filtering so that other parts of the site can send users to this page pre-filtered. It reads the url params and applies any with valid filter keys and valid filter values.

### No params applies no filters
![no_filters](https://github.com/code-dot-org/code-dot-org/assets/56283563/d73dde7d-7a7a-4de9-92c4-13e1d82751a8)

### Invalid params applies no filters
![fake_param](https://github.com/code-dot-org/code-dot-org/assets/56283563/ee34fb71-1a32-4870-87a7-42ed4841389d)

### Valid param is applied
![validParam](https://github.com/code-dot-org/code-dot-org/assets/56283563/f334bfba-1c1e-4f90-9e2a-388475d0f356)

### Multiple parameters are applied together
https://github.com/code-dot-org/code-dot-org/assets/56283563/ac9945ce-0fc4-4d42-8faa-f95a65dd19c3

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-555&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and adding unit tests.

## Follow-up work
Have the url params update when users change their selections so that their choices persist as they navigate to/from the catalog page.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
