### PR TITLE
Music: handle level change during load

### DIFF
--- a/apps/src/code-studio/components/progress/LessonProgress.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.jsx
@@ -27,7 +27,6 @@ class LessonProgress extends Component {
     setDesiredWidth: PropTypes.func,
     currentPageNumber: PropTypes.number,
     currentLevelId: PropTypes.string,
-    isLabLoading: PropTypes.bool,
     navigateToLevelId: PropTypes.func,
   };
 
@@ -70,10 +69,6 @@ class LessonProgress extends Component {
       if (currentLevelChanged || statusChanged || badgeChanged) {
         return true;
       }
-    }
-
-    if (this.props.isLabLoading !== nextProps.isLabLoading) {
-      return true;
     }
 
     return this.props.width !== nextProps.width;
@@ -182,18 +177,6 @@ class LessonProgress extends Component {
                 ? () => navigateToLevelId(level.id)
                 : undefined;
 
-              // If we have a clickable bubble, which means we could switch to that level
-              // without a page reload, then there are two cases in which we will disable it:
-              // Firstly, if it's for the current level.  This means it's already the big
-              // bubble, and clicking it will have no effect.  (Unlike in a normal level
-              // which doesn't support in-page reloads, in which case clicking this bubble
-              // would reload the page.)
-              // Secondly, if the active lab is currently loading.  To keep things simple
-              // for the lab, we don't allow switching to another level while one is loading.
-              const bubbleDisabled =
-                !!onBubbleClick &&
-                (level.isCurrentLevel || this.props.isLabLoading);
-
               return (
                 <div
                   key={index}
@@ -205,7 +188,7 @@ class LessonProgress extends Component {
                 >
                   <ProgressBubble
                     level={level}
-                    disabled={bubbleDisabled}
+                    disabled={false}
                     smallBubble={!isCurrent}
                     lessonName={lessonName}
                     onClick={onBubbleClick}
@@ -300,7 +283,6 @@ export default connect(
     isLessonExtras: state.progress.isLessonExtras,
     currentPageNumber: state.progress.currentPageNumber,
     currentLevelId: state.progress.currentLevelId,
-    isLabLoading: state.lab?.isLoading,
   }),
   dispatch => ({
     navigateToLevelId(levelId) {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -88,6 +88,7 @@ class UnconnectedMusicView extends React.Component {
     currentLevelId: PropTypes.string,
     levelCount: PropTypes.number,
     levelDataPath: PropTypes.string,
+    isLabLoading: PropTypes.bool,
     userId: PropTypes.number,
     userType: PropTypes.string,
     signInState: PropTypes.oneOf(Object.values(SignInState)),
@@ -149,6 +150,8 @@ class UnconnectedMusicView extends React.Component {
   }
 
   componentDidMount() {
+    const initialLevelIndex = this.props.currentLevelIndex;
+
     this.props.setIsLoading(true);
 
     this.analyticsReporter.startSession().then(() => {
@@ -246,7 +249,14 @@ class UnconnectedMusicView extends React.Component {
           );
           this.player.initialize(this.library);
           setInterval(this.updateTimer, 1000 / 30);
-          this.props.setIsLoading(false);
+
+          // If the level changed while we were loading, then hand off
+          // to handlePanelChange to load that new level.
+          if (this.props.currentLevelIndex !== initialLevelIndex) {
+            this.handlePanelChange();
+          } else {
+            this.props.setIsLoading(false);
+          }
         });
     });
   }
@@ -266,7 +276,7 @@ class UnconnectedMusicView extends React.Component {
     }
 
     if (prevProps.currentLevelIndex !== this.props.currentLevelIndex) {
-      this.goToPanel(this.props.currentLevelIndex);
+      this.goToPanel();
     }
 
     if (
@@ -358,29 +368,40 @@ class UnconnectedMusicView extends React.Component {
   };
 
   // When the external system lets us know that the user changed level.
-  goToPanel = specificStep => {
-    this.progressManager?.goToStep(specificStep);
-    this.handlePanelChange();
+  goToPanel = () => {
+    this.progressManager?.goToStep(this.props.currentLevelIndex);
+
+    // If we are already loading, then the existing execution of handlePanelChange
+    // will detect the change in active level and start loading again.
+    if (!this.props.isLabLoading) {
+      this.handlePanelChange();
+    }
   };
 
-  // Handle a change in panel.
+  // Handle a change in panel, including loading necessary data.
+  // Also handles a change in the active level index during this load.
   handlePanelChange = async () => {
+    let currentLevelIndexLoading;
+
     this.stopSong();
     this.props.setIsLoading(true);
 
-    await this.loadProgressionStep();
+    do {
+      currentLevelIndexLoading = this.props.currentLevelIndex;
 
-    this.setToolboxForProgress();
-    this.setAllowedSoundsForProgress();
+      await this.loadProgressionStep();
 
-    if (this.props.currentLevelId) {
-      // Change levels for the projects system. Only do this is we have a level.
-      await this.musicBlocklyWorkspace.changeLevels(
-        this.props.currentLevelId,
-        this.props.currentScriptId
-      );
-    }
+      this.setToolboxForProgress();
+      this.setAllowedSoundsForProgress();
 
+      if (this.props.currentLevelId) {
+        // Change levels for the projects system. Only do this if we have a level.
+        await this.musicBlocklyWorkspace.changeLevels(
+          this.props.currentLevelId,
+          this.props.currentScriptId
+        );
+      }
+    } while (currentLevelIndexLoading !== this.props.currentLevelIndex);
     this.props.setIsLoading(false);
   };
 
@@ -740,6 +761,8 @@ const MusicView = connect(
 
     // The URL path for retrieving level_data from the server.
     levelDataPath: getLevelDataPath(state),
+
+    isLabLoading: state.lab?.isLoading,
 
     userId: state.currentUser.userId,
     userType: state.currentUser.userType,


### PR DESCRIPTION
This code applies to a lab that is able to change levels without doing a page reload, which currently means Music Lab.

This is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/51858 (**Header: disable level switching if lab loading**), and in fact reverts that PR.  I realized that it was still possible to interrupt a lab load by using the browser navigation buttons, and so disabling the progress bubbles was not enough to prevent a level switch while a level was loading.

In this new approach, if the lab is in the midst of a load, that load will complete, but the code will then check whether the level changed during the load, and if so, it will load that new level instead.  This cycle can repeat, and the loading screen will continue showing, until the level that's loaded is the one we want to see.  Only one level load will be in-flight at a time.

This works whether it's the initial level being loaded or a subsequent one.