### PR TITLE
[Google Blockly] ignore extra generated options when comparing block arrays

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -224,6 +224,10 @@ export function compareBlockArrays(xmlBlocks, jsonBlocks) {
       const keys2 = Object.keys(arg2).sort();
 
       if (keys1.length !== keys2.length) {
+        if (path.endsWith('generatedOptions_') && keys2.length > keys1.length) {
+          // Blockly doesn't serialize all recent variable options to XML.
+          return differences;
+        }
         differences.push({
           result: 'different number of keys',
           path: path,


### PR DESCRIPTION
This updates the logging that was recently implemented for comparing blocks created from XML/JSON sources:

- https://github.com/code-dot-org/code-dot-org/pull/51739

An array of `generatedOptions_` has been found to have increased in length when serializing with JSON. To allow us to see the specific values that are changing, we began to stringify the actual object arguments being compared (https://github.com/code-dot-org/code-dot-org/pull/51996).

During the third round of the experiment, which I ran on Saturday morning, we were still logging differences for this case, but the expanded output enabled me to see exactly what was going on. Here is an example recent record that shows the difference in question:
```
[
    {
        "result": "different number of keys",
        "path": ".2.inputList.1.fieldRow.1.generatedOptions_",
        "arg1": "my_moose_dancer,4Z~$GDHs)D|A$Nsg|tX*,Rename all my_moose_dancer,RENAME_ALL_ID,Rename this variable,RENAME_THIS_ID",
        "arg2": "my_moose_dancer,4Z~$GDHs)D|A$Nsg|tX*,new_dancer,[lEA+7l2Wrvs2L2km2_|,Rename all my_moose_dancer,RENAME_ALL_ID,Rename this variable,RENAME_THIS_ID"
    }
]
```

The difference object above shows that arg2 (the JSON version) contains an additional `new_dancer,[lEA+7l2Wrvs2L2km2_|` (student friendly label, value/ var id) option for the dropdown field. 

_Why would the JSON serialization be adding more data to a block that wasn't normally there in the XML serialization?_ 

As it turns out, there actually may be a bug in how Blockly serializes blocks like this to XML.
If a user renames a single instance of a variable (as opposed to renaming all instances of the same variable), the dropdown will list options for both the old and new labels. However, after saving (with XML) and reloading the page, the old option is gone:

https://github.com/code-dot-org/code-dot-org/assets/43474485/825461db-1ca2-41ba-8fe3-65462d2b690f

|Original code|After renaming "this variable"|After saving and reloading|
|-|-|-|
|<img width="340" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/9e0bf322-0767-4cf6-a83d-622bdeb8ed40">|<img width="374" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/6dcace0b-cbb7-422d-85be-9c502fd6a60e">|<img width="368" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/2b541c5d-c60a-46d4-827f-8ba6683a0582">|

 Given that both options are present on the workspace after renaming, it seems like we should be saving it as well. 
Conveniently, when we use the JSON serializer, we actually do save both values!

Note that the bottom two dropdown options are code.org customizations to the variable field, so it's not really possible to reproduce this somewhere off of our platform like the [Blockly Playground](https://blockly-demo.appspot.com/static/tests/playground.html).
<img width="337" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/5eadf48d-d29b-40ed-969d-1fb44c5d5055">


Also note that this block's input type, `spritePicker` has not been used in any curriculum since 2019, but is still supported in both Dance and Sprite Lab projects.

## Proposal

**While comparing block arrays, if we come across `generatedOptions_` of different lengths, assume it's okay as long as there are more options in the JSON version.**

As an alternative, we could also only assume it's okay after performing a deep equality check on each option item. This felt needlessly complicated. 

I also considered deprecating this entire test at this point rather than patching. We have checked thousands of projects and found no differences, so we should be confident at this point that the JSON serialization works adequately. I decided to keep this utility around however as there is a chance we will want it later. For example, we might wish to re-visit this experiment when we begin converting XML to JSON on project load, or when we start saving JSON directly.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

1. Merge this patch so that we can run the experiment again if desired, hopefully finding no more differences.
2. Disconnect the experiment entirely, but keep the comparison utility around if desired.
3. Begin converting XML sources to JSON on page load.
4. Begin saving workspaces to JSON directly.

Steps 2-4 are all pretty interchangeable.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
