### PR TITLE
Re-enable and increase contained_levels limit in rollup script

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -147,8 +147,7 @@ def main
   CDO.log.info "contained_levels: #{contained_levels.size}"
   CDO.log.info "contained_level_answers: #{contained_level_answers.size}"
   CDO.log.info "level_sources: #{level_sources_multi_types.size}"
-  # TODO: Adjust and re-enable limits below as appropriate once we get the log info from above.
-  #raise "contained_levels too big: #{contained_levels.size} rows exceeds limit of 10000" if contained_levels.size > 10_000
+  raise "contained_levels too big: #{contained_levels.size} rows exceeds limit of 100000" if contained_levels.size > 100_000
   raise "contained_level_answers too big: #{contained_level_answers.size} rows exceeds limit of 100000" if contained_level_answers.size > 100_000
   raise "level_sources too big: #{level_sources_multi_types.size} rows exceeds limit of 100000" if level_sources_multi_types.size > 100_000
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Followup to #51896 and the original rejected #51849.

Re-enable the commented-out exception when `contained_levels` size is too large, and increase that limit from 10k to 100k. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- jira ticket: [TEACH-518](https://codedotorg.atlassian.net/browse/TEACH-518)
- slack thread: https://codedotorg.slack.com/archives/C03CK49G9/p1684528012347539
