### PR TITLE
Fix for TypeScript issues with yarn start

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -322,12 +322,6 @@ describe('entry tests', () => {
     },
   };
 
-  config.ts = {
-    default: {
-      tsconfig: './tsconfig.json',
-    },
-  };
-
   config.sass = {
     all: {
       options: {
@@ -1260,7 +1254,6 @@ describe('entry tests', () => {
     watch: {
       tasks: [
         'watch',
-        'ts',
         envConstants.HOT ? 'webpack-dev-server:watch' : 'webpack:watch',
       ],
       options: {

--- a/apps/src/music/views/SaveStatus.tsx
+++ b/apps/src/music/views/SaveStatus.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
 import {useSelector} from 'react-redux';
+import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
+import {projectUpdatedStatuses} from '@cdo/apps/code-studio/projectRedux';
 
 const commonI18n = require('@cdo/locale');
-const Spinner = require('@cdo/apps/code-studio/pd/components/spinner');
 const moduleStyles = require('./save-status.module.scss').default;
-const projectUpdatedStatuses =
-  require('@cdo/apps/code-studio/projectRedux').projectUpdatedStatuses;
 
 /**
  * Displays the project save status: a "Saving..." message with a spinner if saving,

--- a/apps/tsconfig.json
+++ b/apps/tsconfig.json
@@ -11,7 +11,9 @@
     "./src/javalab/**/*.js",
     "./src/lib/util/**/*.js",
     "./src/util/**/*.js*",
-    "./src/templates/**/*.js*"
+    "./src/templates/**/*.js*",
+    "./src/code-studio/pd/components/*.js*",
+    "./src/code-studio/*.js"
   ],
   "compilerOptions": {
     "jsx": "react",


### PR DESCRIPTION
This is a tentative fix for some intermittent issues we've been seeing with TypeScript and running `yarn start`. Specifically, we've noticed that occasionally TypeScript will fail to recognize the `@cdo/apps` path defined in tsconfig.json, saying the file does not exist, but only when running `yarn start`. When this occurs, we've noticed that `yarn build` succeeds.

The fix here is to remove the `ts` task from the list of watch tasks run during `yarn start`. I believe this was causing some issues where TypeScript was getting built too early/out of sync, and the `webpack:watch` step should take care of compiling TypeScript anyway.

I've also included some small test changes which updates JS import paths in a .tsx file from `require` to `import`. These changes were initially failing to build for me, but after updating the Gruntfile, they build successfully.

## Links

https://codedotorg.atlassian.net/browse/SL-861

## Testing story

Tested locally by first running `yarn clean` and manually deleting the .tscache folder. Then separately ran both yarn build and yarn start and confirmed that there were no build issues, and new changes were building.