### PR TITLE
Allow importing SCSS modules in TypeScript files

### DIFF
--- a/apps/src/Globals.d.ts
+++ b/apps/src/Globals.d.ts
@@ -1,0 +1,7 @@
+// Global TypeScript definitions
+
+// Type definition for SCSS modules imported in TypeScript files
+declare module '*.module.scss' {
+  const classes: {[key: string]: string};
+  export default classes;
+}

--- a/apps/src/music/views/ChordPanel.tsx
+++ b/apps/src/music/views/ChordPanel.tsx
@@ -6,8 +6,7 @@ import {ChordEventValue, PlayStyle} from '../player/interfaces/ChordEvent';
 import {generateGraphDataFromChord, ChordGraphNote} from '../utils/Chords';
 import PreviewControls from './PreviewControls';
 import musicI18n from '../locale';
-
-const moduleStyles = require('./chordPanel.module.scss').default;
+import moduleStyles from './chordPanel.module.scss';
 
 const NUM_OCTAVES = 3;
 const START_OCTAVE = 4;


### PR DESCRIPTION
This change enables `import`ing SCSS modules in TypeScript files (as opposed to using `require()`). We just need to add global type definitions for SCSS modules (defined in apps/src/Globals.d.ts), and TypeScript will treat the imported modules as the specified type (an object with string keys and string values). Definition structure has been copied from [here](https://www.npmjs.com/package/typescript-plugin-css-modules#custom-definitions).

<img width="491" alt="Screenshot 2023-05-23 at 10 05 56 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/e5aa59a7-a64d-452f-a9fd-7d1e2b330569">
<img width="584" alt="Screenshot 2023-05-23 at 9 59 11 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/5f466cc6-dba3-47b6-abbb-86c9800882b4">
<img width="392" alt="Screenshot 2023-05-23 at 9 59 36 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/87bbbe43-6282-42b4-bbd9-0b1b5b8a1dbd">


Ideally, we'd want to use something like https://www.npmjs.com/package/typescript-plugin-css-modules which provides full IntelliSense support for the actual class names inside the module file. Unfortunately, this doesn't work automatically because it just turns off if it encounters any error parsing files, and one common error it detects is that it can't resolve `@import 'color.scss';`, as there is no `color.scss` in apps (it's copied from shared/css during build time I believe). We'd have to come up with a workaround in order to use this plugin so I've made a separate JIRA for that: https://codedotorg.atlassian.net/browse/SL-873

## Testing story

Tested locally by converting one `require` statement to `import` in a TSX file. Confirmed that files build successfully, and new changes are built.