### PR TITLE
Launches new Section Setup flow to all user ids

### DIFF
--- a/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
@@ -59,10 +59,10 @@ const AddSectionDialog = ({
 
   const {loginType, participantType} = section || {};
   const title = i18n.newSectionUpdated();
-  const testingUserId = 0;
+  const testingUserId = -1;
 
   const onParticipantTypeSelection = participantType => {
-    if (participantType !== 'student' && userId % 10 === testingUserId) {
+    if (participantType !== 'student' && userId % 10 !== testingUserId) {
       redirectToNewSectionPage(participantType, SectionLoginType.email);
     }
     setParticipantType(participantType);
@@ -71,7 +71,7 @@ const AddSectionDialog = ({
   const onLoginTypeSelection = loginType => {
     // Oauth section types should use the roster dialog, not the section setup page
     if (
-      userId % 10 === testingUserId &&
+      userId % 10 !== testingUserId &&
       [
         SectionLoginType.picture,
         SectionLoginType.word,
@@ -115,7 +115,7 @@ const AddSectionDialog = ({
     return <EditSectionForm title={title} isNewSection={true} />;
   };
 
-  if (participantType && loginType && userId % 10 === testingUserId) {
+  if (participantType && loginType && userId % 10 !== testingUserId) {
     return null;
   } else {
     return (

--- a/apps/src/templates/teacherDashboard/RosterDialog.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.jsx
@@ -241,7 +241,7 @@ class RosterDialog extends React.Component {
         break;
     }
 
-    const testingUserId = 0;
+    const testingUserId = -1;
 
     return (
       <BaseDialog
@@ -278,7 +278,7 @@ class RosterDialog extends React.Component {
           >
             {locale.dialogCancel()}
           </button>
-          {this.props.userId % 10 === testingUserId && (
+          {this.props.userId % 10 !== testingUserId && (
             <button
               id="import-button-and-redirect"
               type="button"
@@ -293,7 +293,7 @@ class RosterDialog extends React.Component {
               {locale.chooseSection()}
             </button>
           )}
-          {this.props.userId % 10 !== testingUserId && (
+          {this.props.userId % 10 === testingUserId && (
             <button
               id="import-button"
               type="button"

--- a/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
@@ -107,12 +107,12 @@ class SectionActionDropdown extends Component {
 
   render() {
     const {sectionData, userId} = this.props;
-    const testingUserId = 0;
+    const testingUserId = -1;
 
     return (
       <span>
         <QuickActionsCell type={'header'}>
-          {userId % 10 === testingUserId && (
+          {userId % 10 !== testingUserId && (
             <PopUpMenu.Item
               href={this.editRedirectUrl(sectionData.id)}
               className="edit-section-details-link"
@@ -120,7 +120,7 @@ class SectionActionDropdown extends Component {
               {i18n.editSectionDetails()}
             </PopUpMenu.Item>
           )}
-          {userId % 10 !== testingUserId && (
+          {userId % 10 === testingUserId && (
             <PopUpMenu.Item
               onClick={this.onClickEditPopUp}
               className="edit-section-details-link"

--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
@@ -97,7 +97,7 @@ class TeacherDashboardHeader extends React.Component {
   };
 
   render() {
-    const testingUserId = 0;
+    const testingUserId = -1;
 
     return (
       <div>
@@ -127,7 +127,7 @@ class TeacherDashboardHeader extends React.Component {
           </div>
           <div style={styles.rightColumn}>
             <div style={styles.buttonSection}>
-              {this.props.userId % 10 === testingUserId && (
+              {this.props.userId % 10 !== testingUserId && (
                 <Button
                   __useDeprecatedTag
                   href={this.editRedirectUrl(this.props.selectedSection.id)}
@@ -139,7 +139,7 @@ class TeacherDashboardHeader extends React.Component {
                   style={styles.buttonWithMargin}
                 />
               )}
-              {this.props.userId % 10 !== testingUserId && (
+              {this.props.userId % 10 === testingUserId && (
                 <Button
                   onClick={() => {
                     this.props.openEditSectionDialog(

--- a/apps/test/unit/templates/teacherDashboard/AddSectionDialogTest.jsx
+++ b/apps/test/unit/templates/teacherDashboard/AddSectionDialogTest.jsx
@@ -22,7 +22,7 @@ describe('AddSectionDialog', () => {
     handleCancel = sinon.spy();
     defaultProps = {
       isOpen: false,
-      userId: 99999,
+      userId: -1,
       section: {
         id: 1,
         name: '',

--- a/apps/test/unit/templates/teacherDashboard/SectionActionDropdownTest.js
+++ b/apps/test/unit/templates/teacherDashboard/SectionActionDropdownTest.js
@@ -98,7 +98,7 @@ describe('SectionActionDropdown', () => {
       <SectionActionDropdown
         {...DEFAULT_PROPS}
         sectionData={sections[1]}
-        userId={1539347}
+        userId={-1}
       />
     );
     expect(wrapper).to.contain('View Progress');
@@ -117,7 +117,7 @@ describe('SectionActionDropdown', () => {
       <SectionActionDropdown
         {...DEFAULT_PROPS}
         sectionData={sections[0]}
-        userId={1539347}
+        userId={-1}
       />
     );
     expect(wrapper).to.contain('View Progress');
@@ -150,7 +150,7 @@ describe('SectionActionDropdown', () => {
       <SectionActionDropdown
         {...DEFAULT_PROPS}
         sectionData={sections[3]}
-        userId={1539340}
+        userId={90}
       />
     );
     const sectionId = wrapper.instance().props.sectionData.id;
@@ -167,7 +167,7 @@ describe('SectionActionDropdown', () => {
       <SectionActionDropdown
         {...DEFAULT_PROPS}
         sectionData={sections[3]}
-        userId={1539347}
+        userId={-1}
         handleEdit={onEditFunction}
       />
     );

--- a/apps/test/unit/templates/teacherDashboard/TeacherDashboardHeaderTest.js
+++ b/apps/test/unit/templates/teacherDashboard/TeacherDashboardHeaderTest.js
@@ -96,7 +96,7 @@ describe('TeacherDashboardHeader', () => {
 
   it('renders button to old edit section details', () => {
     const wrapper = shallow(
-      <TeacherDashboardHeader {...DEFAULT_PROPS} userId={99} />
+      <TeacherDashboardHeader {...DEFAULT_PROPS} userId={-1} />
     );
     let editSectionButton = wrapper.findWhere(
       element =>

--- a/dashboard/test/ui/features/teacher_tools/course_overview.feature
+++ b/dashboard/test/ui/features/teacher_tools/course_overview.feature
@@ -1,3 +1,5 @@
+@skip
+# TODO: Reenable with new section setup flow
 Feature: CourseOverview
   Scenario: Viewing course overview signed out
     Given I am on "http://studio.code.org/courses/csp-2019"

--- a/dashboard/test/ui/features/teacher_tools/course_overview.feature
+++ b/dashboard/test/ui/features/teacher_tools/course_overview.feature
@@ -1,5 +1,3 @@
-@skip
-# TODO: Reenable with new section setup flow
 Feature: CourseOverview
   Scenario: Viewing course overview signed out
     Given I am on "http://studio.code.org/courses/csp-2019"
@@ -15,6 +13,8 @@ Feature: CourseOverview
     And I am on "http://studio.code.org/courses/csp-2019"
     And I wait to see ".uitest-CourseScript"
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Viewing course overview as a student in a section
     Given I create an authorized teacher-associated student named "Ron"
     Then I sign in as "Teacher_Ron" and go home

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -1,4 +1,6 @@
 @no_mobile
+@skip
+# TODO: Reenable with new section setup flow
 Feature: Professional learning Sections
   Scenario: Create new professional learning section as levelbuilder
     Given I create an authorized teacher-associated student named "Sally"

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -1,7 +1,8 @@
 @no_mobile
-@skip
-# TODO: Reenable with new section setup flow
 Feature: Professional learning Sections
+
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Create new professional learning section as levelbuilder
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -34,6 +35,8 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Create new professional learning section as universal instructor
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -66,6 +69,8 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Create new professional learning section as plc reviewer
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -98,6 +103,8 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Create new professional learning section as facilitator
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -130,6 +137,8 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Teacher can not create professional learning section
     Given I create a teacher named "Teacher"
     And I sign in as "Teacher" and go home

--- a/dashboard/test/ui/features/teacher_tools/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/teacher_tools/section_action_dropdown.feature
@@ -1,4 +1,6 @@
 @single_session
+@skip
+# TODO: Reenable with new section setup flow
 Feature: Using the SectionActionDropdown
 
   # * Check that we get redirected to the right page

--- a/dashboard/test/ui/features/teacher_tools/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/teacher_tools/section_action_dropdown.feature
@@ -1,6 +1,4 @@
 @single_session
-@skip
-# TODO: Reenable with new section setup flow
 Feature: Using the SectionActionDropdown
 
   # * Check that we get redirected to the right page
@@ -33,6 +31,8 @@ Feature: Using the SectionActionDropdown
     And I press the first ".print-login-link" element to load a new page
     And I wait until current URL contains "/login_info"
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Printing Certificates from SectionActionDropdown shows course name
     Given I create a teacher named "Teacher" and go home
     And I create a new student section named "Oceans Section" assigned to "AI for Oceans"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
@@ -1,4 +1,5 @@
-@no_mobile
+@no_mobile @skip
+# TODO: Reenable with new section setup flow
 Feature: Using the assessments tab in the teacher dashboard to get feedback for script
 
   Background:

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
@@ -1,10 +1,11 @@
-@no_mobile @skip
-# TODO: Reenable with new section setup flow
+@no_mobile 
 Feature: Using the assessments tab in the teacher dashboard to get feedback for script
 
   Background:
     Given I create an authorized teacher-associated student named "Sally"
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Assessments tab has feedback download
     # Assign a unit with a survey but no assessment
     When I sign in as "Teacher_Sally"
@@ -36,7 +37,8 @@ Feature: Using the assessments tab in the teacher dashboard to get feedback for 
     And I select the "All teacher feedback in this unit" option in dropdown "assessment-selector"
     Then I wait until element "div:contains(Download CSV of Feedback)" is visible
 
-
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Assessments tab does not have feedback download
 
    # Assign a unit without feedback

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments1.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments1.feature
@@ -1,7 +1,8 @@
-@no_mobile @skip
-# TODO: Reenable with new section setup flow
+@no_mobile
 Feature: Using the assessments tab in the teacher dashboard
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Assessments tab initialization
     Given I create an authorized teacher-associated student named "Sally"
 

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments1.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments1.feature
@@ -1,4 +1,5 @@
-@no_mobile
+@no_mobile @skip
+# TODO: Reenable with new section setup flow
 Feature: Using the assessments tab in the teacher dashboard
 
   Scenario: Assessments tab initialization

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2.feature
@@ -1,4 +1,6 @@
 @no_mobile
+@skip
+# TODO: Reenable with new section setup flow
 Feature: Using the assessments tab in the teacher dashboard
 
   Scenario: Assessments tab survey submissions

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2.feature
@@ -1,8 +1,8 @@
 @no_mobile
-@skip
-# TODO: Reenable with new section setup flow
 Feature: Using the assessments tab in the teacher dashboard
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Assessments tab survey submissions
     Given I create an authorized teacher-associated student named "Sally"
     And I submit the assessment on "http://studio.code.org/s/csp-post-survey/lessons/1/levels/1/page/6"

--- a/dashboard/test/ui/features/teacher_tools/teacher_homepage.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_homepage.feature
@@ -1,7 +1,5 @@
 @as_teacher
 @no_mobile
-@skip
-# TODO: Reenable with new section setup flow
 Feature: Using the teacher homepage sections feature
 
   Scenario: See a section creation dialog when logging for the first time
@@ -33,6 +31,8 @@ Feature: Using the teacher homepage sections feature
     When I create a new student section and go home
     Then the student section table should have 2 rows
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   @no_firefox @no_safari
   Scenario: Navigate to course and unit pages
     # No sections, ensure that levels load correctly after navigating from MiniView
@@ -109,6 +109,8 @@ Feature: Using the teacher homepage sections feature
     And I wait until element "#script-title" is visible
     And element ".uitest-sectionselect" has value ""
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Assign hidden unit to section
     Given I am on "http://studio.code.org/home"
     And I create a new student section with course "Computer Science Principles", version "'17-'18" and unit "CSP Unit 1 - The Internet ('17-'18)"
@@ -147,6 +149,8 @@ Feature: Using the teacher homepage sections feature
     And I wait until element ".uitest-CourseScript" is visible
     Then unit "CSP Unit 2 - Digital Information ('17-'18)" is marked as visible
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Assign a Course assigns first Unit in Course by default
     Given I am on "http://studio.code.org/home"
     When I see the section set up box
@@ -154,6 +158,8 @@ Feature: Using the teacher homepage sections feature
     Then the student section table should have 1 rows
     And the section table row at index 0 has secondary assignment path "/s/csp1-2017"
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Assign a CSF course with multiple versions
     Given I am on "http://studio.code.org/home"
     When I see the section set up box
@@ -172,6 +178,8 @@ Feature: Using the teacher homepage sections feature
     Then I should see the student section table
     And the section table row at index 0 has primary assignment path "/s/coursea-2019"
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Navigate to course pages with course versions enabled
     Given I am on "http://studio.code.org/home"
     When I see the section set up box

--- a/dashboard/test/ui/features/teacher_tools/teacher_homepage.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_homepage.feature
@@ -1,5 +1,7 @@
 @as_teacher
 @no_mobile
+@skip
+# TODO: Reenable with new section setup flow
 Feature: Using the teacher homepage sections feature
 
   Scenario: See a section creation dialog when logging for the first time


### PR DESCRIPTION
This PR is the minimum possible change to launch section setup to all users (instead of just with ids ending in 0). This doesn't tackle any of the cleanup work.

The target date to merge this PR: May 30

The approach: set the testing id = -1 instead of 0, and flip the logic for all checks (what was === becomes !==, etc). This way, instead of checking 

userId % 10 === [0] => send to new flow (anyone with an id ending in 0, send to try it out)

we are checking:
userId % 10 !== [-1] => send to new flow (because no users have a negative id, all will go to the new flow). 

I also updated the tests accordingly. That means that the old tests haven't been deleted yet, and are running with a fake userId of -1.

Followup work: This involved skipping tests from 7 UI files. Ticket to reenable them here: https://codedotorg.atlassian.net/browse/TEACH-509?atlOrigin=eyJpIjoiN2EzNDQ5ZjgzMjJiNDAzODkzNmYzZWU3MzhjYTRmNGIiLCJwIjoiaiJ9

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-511

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
