### PR TITLE
Revert "Update `puma` Gem to 5.6.5"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,8 +126,8 @@ gem 'open_uri_redirections', require: false
 gem 'gctools', github: 'wjordan/gctools', ref: 'ruby-2.5'
 # Optimizes copy-on-write memory usage with GC before web-application fork.
 gem 'nakayoshi_fork'
-
-gem 'puma', '~> 5.0'
+# Ref: https://github.com/puma/puma/pull/1646
+gem 'puma', github: 'wjordan/puma', branch: 'debugging'
 gem 'puma_worker_killer'
 gem 'raindrops'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,13 @@ GIT
       omniauth-oauth2 (~> 1.4)
 
 GIT
+  remote: https://github.com/wjordan/puma.git
+  revision: 29a576120b30c34db7706c062ddf9a046723789f
+  branch: debugging
+  specs:
+    puma (3.12.0)
+
+GIT
   remote: https://github.com/wjordan/sprockets.git
   revision: 35caa45a78b739362b7db087b141f89e27d107c7
   ref: concurrent_asset_bundle_3.x
@@ -644,11 +651,9 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.0.1)
-    puma (5.6.5)
-      nio4r (~> 2.0)
-    puma_worker_killer (0.3.1)
+    puma_worker_killer (0.1.0)
       get_process_mem (~> 0.2)
-      puma (>= 2.7)
+      puma (>= 2.7, < 4)
     pusher (1.3.1)
       httpclient (~> 2.7)
       multi_json (~> 1.0)
@@ -669,6 +674,8 @@ GEM
     rack-openid (1.3.1)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
+    rack-parser (0.7.0)
+      rack
     rack-protection (2.2.3)
       rack
     rack-ssl-enforcer (0.2.9)
@@ -1019,7 +1026,7 @@ DEPENDENCIES
   pg
   phantomjs (~> 1.9.7.1)
   pry (~> 0.14.0)
-  puma (~> 5.0)
+  puma!
   puma_worker_killer
   pusher (~> 1.3.1)
   rack-cache

--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -39,3 +39,9 @@ unless DCDO.get('oobgc_middleware_disabled', false)
   require 'gctools/oobgc'
   out_of_band {GC::OOB.run}
 end
+
+# Log thread backtraces and GC stats from all worker processes every second when enabled.
+plugin :log_stats
+LogStats.threshold = -> {DCDO.get('logStatsDashboard', nil)}
+filter_gems = %w(puma sinatra actionview activesupport honeybadger newrelic rack)
+LogStats.backtrace_filter = ->(bt) {CDO.filter_backtrace(bt, filter_gems: filter_gems)}

--- a/pegasus/config/puma.rb
+++ b/pegasus/config/puma.rb
@@ -38,3 +38,9 @@ unless DCDO.get('oobgc_middleware_disabled', false)
   require 'gctools/oobgc'
   out_of_band {GC::OOB.run}
 end
+
+# Log thread backtraces and GC stats from all worker processes every second when enabled.
+plugin :log_stats
+LogStats.threshold = -> {DCDO.get('logStatsPegasus', nil)}
+filter_gems = %w(puma sinatra actionview activesupport honeybadger newrelic rack)
+LogStats.backtrace_filter = ->(bt) {CDO.filter_backtrace(bt, filter_gems: filter_gems)}


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#51929; got an error when attempting to upgrade the dashboard service on the test server:

```
bundler: failed to load command: puma (/usr/lib/ruby/gems/2.7.0/bin/puma)
Traceback (most recent call last):
        19: from /usr/local/bin/bundle:25:in `<main>'
        18: from /usr/local/bin/bundle:25:in `load'
        17: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/exe/bundle:36:in `<top (required)>'
        16: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
        15: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/exe/bundle:48:in `block in <top (required)>'
        14: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/cli.rb:25:in `start'
        13: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
        12: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/cli.rb:31:in `dispatch'
        11: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        10: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
         9: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
         8: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/cli.rb:486:in `exec'
         7: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/cli/exec.rb:23:in `run'
         6: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/cli/exec.rb:58:in `kernel_load'
         5: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/cli/exec.rb:58:in `load'
         4: from /usr/lib/ruby/gems/2.7.0/bin/puma:25:in `<top (required)>'
         3: from /usr/lib/ruby/gems/2.7.0/bin/puma:25:in `load'
         2: from /usr/lib/ruby/gems/2.7.0/gems/puma-5.6.5/bin/puma:8:in `<top (required)>'
         1: from /usr/lib/ruby/gems/2.7.0/gems/puma-5.6.5/bin/puma:8:in `new'
/usr/lib/ruby/gems/2.7.0/gems/puma-5.6.5/lib/puma/cli.rb:51:in `initialize': invalid option: d (OptionParser::InvalidOption)
        19: from /usr/local/bin/bundle:25:in `<main>'
        18: from /usr/local/bin/bundle:25:in `load'
        17: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/exe/bundle:36:in `<top (required)>'
        16: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
        15: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/exe/bundle:48:in `block in <top (required)>'
        14: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/cli.rb:25:in `start'
        13: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
        12: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/cli.rb:31:in `dispatch'
        11: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        10: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
         9: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
         8: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/cli.rb:486:in `exec'
         7: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/cli/exec.rb:23:in `run'
         6: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/cli/exec.rb:58:in `kernel_load'
         5: from /usr/lib/ruby/gems/2.7.0/gems/bundler-2.3.22/lib/bundler/cli/exec.rb:58:in `load'
         4: from /usr/lib/ruby/gems/2.7.0/bin/puma:25:in `<top (required)>'
         3: from /usr/lib/ruby/gems/2.7.0/bin/puma:25:in `load'
         2: from /usr/lib/ruby/gems/2.7.0/gems/puma-5.6.5/bin/puma:8:in `<top (required)>'
         1: from /usr/lib/ruby/gems/2.7.0/gems/puma-5.6.5/bin/puma:8:in `new'
/usr/lib/ruby/gems/2.7.0/gems/puma-5.6.5/lib/puma/cli.rb:51:in `initialize': ambiguous option: -d (OptionParser::AmbiguousOption)
```

Still not sure why we didn't get this error on my test adhocs, so reverting while we investigate.