### PR TITLE
Add lti_user_identites migration

### DIFF
--- a/dashboard/db/migrate/20230522232402_create_lti_user_identities.rb
+++ b/dashboard/db/migrate/20230522232402_create_lti_user_identities.rb
@@ -1,0 +1,12 @@
+class CreateLtiUserIdentities < ActiveRecord::Migration[6.1]
+  def change
+    create_table :lti_user_identities do |t|
+      t.string :subject, null: false
+      t.references :lti_integration, null: false, foreign_key: true, type: :bigint
+      t.references :user, null: false, foreign_key: true, type: :integer
+
+      t.timestamps
+    end
+    add_index :lti_user_identities, :subject
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_18_155319) do
+ActiveRecord::Schema.define(version: 2023_05_22_232402) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -761,6 +761,17 @@ ActiveRecord::Schema.define(version: 2023_05_18_155319) do
     t.index ["client_id"], name: "index_lti_integrations_on_client_id"
     t.index ["issuer"], name: "index_lti_integrations_on_issuer"
     t.index ["platform_id"], name: "index_lti_integrations_on_platform_id"
+  end
+
+  create_table "lti_user_identities", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+    t.string "subject", null: false
+    t.bigint "lti_integration_id", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["lti_integration_id"], name: "index_lti_user_identities_on_lti_integration_id"
+    t.index ["subject"], name: "index_lti_user_identities_on_subject"
+    t.index ["user_id"], name: "index_lti_user_identities_on_user_id"
   end
 
   create_table "metrics", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
@@ -2178,6 +2189,8 @@ ActiveRecord::Schema.define(version: 2023_05_18_155319) do
   add_foreign_key "circuit_playground_discount_applications", "schools"
   add_foreign_key "hint_view_requests", "users"
   add_foreign_key "level_concept_difficulties", "levels"
+  add_foreign_key "lti_user_identities", "lti_integrations"
+  add_foreign_key "lti_user_identities", "users"
   add_foreign_key "parental_permission_requests", "users"
   add_foreign_key "pd_application_emails", "pd_applications"
   add_foreign_key "pd_application_tags_applications", "pd_application_tags"


### PR DESCRIPTION
This PR is the first of two that adds a new LTI User Identity model. It contains only:

* schema.rb changes
* the migration file

This model creates two associations:

* `belongs_to :lti_integrations`
* `belongs_to :users`

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: [LTI Tech Spec](https://docs.google.com/document/d/1tTwAF40cnn2oUvK2CmRO-a5qYXkCR5rR5gBJS2-zV_U/edit?pli=1#)
- jira ticket: [P20-152](https://codedotorg.atlassian.net/browse/P20-152)
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
