### PR TITLE
Revert "Pin Version of `google-chrome-stable` Package"

### DIFF
--- a/cookbooks/cdo-apps/recipes/google_chrome.rb
+++ b/cookbooks/cdo-apps/recipes/google_chrome.rb
@@ -11,12 +11,4 @@ apt_repository 'google-chrome' do
   retries 3
 end
 
-apt_package 'google-chrome-stable' do
-  # Pin to a specific version so that all our servers work the same. In
-  # particular, staging and test having different versions here can result in
-  # unexpected differences building the apps package.
-  #
-  # This should be at least close to the version we target in browsers.json:
-  # https://github.com/code-dot-org/code-dot-org/blob/7c2530fc6f2f8115c5c0cfdbbda2538211493d6f/dashboard/test/ui/browsers.json#L7
-  version '103.0.5060.53-1'
-end
+apt_package 'google-chrome-stable'


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#51975; it turns out, Google regularly removes old versions of this package from the apt repository, so although v103 *was* available, I'm now seeing that only v113 is currently available:

```
$ apt-cache policy google-chrome-stable
google-chrome-stable:
  Installed: 113.0.5672.126-1
  Candidate: 113.0.5672.126-1
  Version table:
 *** 113.0.5672.126-1 500
        500 https://dl.google.com/linux/chrome/deb stable/main amd64 Packages
        100 /var/lib/dpkg/status
```

Because of that policy of theirs, our approach of installing a specific version will stop working very quickly, and testing on an adhoc indicates that this specific version we're installing has already stopped working. Going to revert this approach and instead look into one that will attempt to automatically keep the package up to date.

## Links

- https://superuser.com/a/1381368
- https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable