### PR TITLE
When clicking Learn More add ?viewAs=Instructor to URL

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -56,7 +56,7 @@ const CurriculumCatalogCard = ({
     isTranslated={isTranslated}
     translationIconTitle={i18n.courseInYourLanguage()}
     isEnglish={isEnglish}
-    pathToCourse={pathToCourse}
+    pathToCourse={pathToCourse + '?viewAs=Instructor'}
   />
 );
 


### PR DESCRIPTION
Adds `?viewAs=Instructor` to URL when clicking the 'Learn More' button on a Curriculum Catalog Card. This way, even if a user is signed out and views a curriculum they can still see the teacher resources.

### Original behavior when signed out (sends to student view)
https://github.com/code-dot-org/code-dot-org/assets/56283563/a8a9def2-1663-4c0a-9df5-bbe87c91dca6

### New behavior when signed out (sends to teacher view)
https://github.com/code-dot-org/code-dot-org/assets/56283563/91a048ab-3c71-4909-8674-3858d8f9baa7

### Behavior when signed in as teacher remains the same (sends to teacher view)
https://github.com/code-dot-org/code-dot-org/assets/56283563/f4694232-e4a7-485d-bbcd-7746eacd7345

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-604&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and drone build.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
