### PR TITLE
Fix Curriculum Catalog index error on levelbuilder

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -94,6 +94,7 @@ class CourseOffering < ApplicationRecord
   end
 
   def path_to_latest_published_version
+    return nil unless latest_published_version
     latest_published_version.content_root.link
   end
 


### PR DESCRIPTION
When navigating to [levelbuilder-studio.code.org/catalog](https://levelbuilder-studio.code.org/catalog), the page throws an error regarding a `nil` `latest_published_version`:
![levelbuilder_error](https://github.com/code-dot-org/code-dot-org/assets/56283563/dcd4c160-5db1-40ba-9549-c8b46450f766)

This PR ensures a valid `latest_published_version` before retrieving the `content_root`.

I don't think I can view the page locally the same way I can on levelbuilder (i.e. to repro the error), but I was able to view the page successfully with levelbuilder permissions and with `levelbuilder_mode: true` in my `locals.yml`. Even though I don't think I can fully test it locally, I feel confident in this change since I tried having that method return `nil` for all curricula and the page rendered fine (just without the curriculum catalog cards since the `path_to_latest_published_version`'s were all `nil`).

Plus, this page hasn't launched yet, and it is the levelbuilder version at that so worst case scenario the page loads but none of the curriculum catalog cards show up (in the case that all cards are running into this) on the levelbuilder version only (the non-levelbuilder versions run normally still) and we can fix from there.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-609&assignee=60d62161f65054006980bd71)

## Testing story
Local testing.

## Follow-up work
Monitoring staging and levelbuilder once this is merged and deployed in the case a revert or a fix-forward is needed.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
