### PR TITLE
Create specific channel for /projectbeats

### DIFF
--- a/dashboard/app/controllers/musiclab_controller.rb
+++ b/dashboard/app/controllers/musiclab_controller.rb
@@ -1,12 +1,38 @@
 class MusiclabController < ApplicationController
   ANALYTICS_KEY = CDO.amplitude_api_key
+  PROJECT_BEATS_LEVEL_NAME = 'projectbeats'
 
   def index
     view_options(no_footer: true, full_width: true)
     @body_classes = "music-black"
 
     projects = Projects.new(get_storage_id)
-    @channel_id = projects.most_recent_project_type('music') || ChannelToken.create_channel(request.ip, projects, type: 'music')
+
+    # Find the project ID (channel ID) for the /projectbeats Music Lab project. If there already
+    # is a channel ID with the 'projectbeats' level name, then use that. If not, find the most
+    # recent Music Lab project. If this project is standalone, it should be the existing
+    # /projectbeats project. Create a new project with the 'projectbeats' level name, and copy
+    # source code from the existing project so that users don't lose their code.
+    project_beats_id = projects.most_recent(PROJECT_BEATS_LEVEL_NAME, include_hidden: true)
+    if project_beats_id
+      @channel_id = project_beats_id
+    else
+      last_music_project_id = projects.most_recent_project_type('music')
+
+      new_project_data = {
+        name: 'New Project Beats Project',
+        level: polymorphic_url([PROJECT_BEATS_LEVEL_NAME.to_sym]),
+        hidden: true
+      }
+      new_project_beats_id =
+        ChannelToken.create_channel(request.ip, projects, data: new_project_data, type: 'music', standalone: false)
+
+      if last_music_project_id && Project.find_by_channel_id(last_music_project_id).standalone
+        SourceBucket.new.remix_source(last_music_project_id, new_project_beats_id, animation_list: [])
+      end
+
+      @channel_id = new_project_beats_id
+    end
   end
 
   def menu

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -317,10 +317,10 @@ class Projects
   end
 
   # Find the encrypted channel token for most recent project of the given level type.
-  def most_recent(key)
+  def most_recent(key, include_hidden = false)
     row = @table.where(storage_id: @storage_id).exclude(state: 'deleted').order(Sequel.desc(:updated_at)).find do |i|
       parsed = JSON.parse(i[:value])
-      !parsed['hidden'] && !parsed['frozen'] && parsed['level'].split('/').last == key
+      (include_hidden || !parsed['hidden']) && !parsed['frozen'] && parsed['level'].split('/').last == key
     rescue
       # Malformed channel, or missing level.
     end

--- a/dashboard/legacy/test/middleware/test_channels.rb
+++ b/dashboard/legacy/test/middleware/test_channels.rb
@@ -403,12 +403,19 @@ class ChannelsTest < Minitest::Test
 
     # These hidden and frozen projects should be skipped when considering most_recent
     post '/v3/channels', {hidden: true, level: 'projects/abc'}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+    hidden_channel_id = last_response.location.split('/').last
+
+    Timecop.travel 1
+
     post '/v3/channels', {frozen: true, level: 'projects/xyz'}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
 
     user_storage_id = storage_decrypt_id CGI.unescape @session.cookie_jar[storage_id_cookie_name]
 
     assert_equal abc_channel_id, Projects.new(user_storage_id).most_recent('abc')
     assert_equal xyz_channel_id, Projects.new(user_storage_id).most_recent('xyz')
+
+    # Includes hidden projects if include_hidden is true
+    assert_equal hidden_channel_id, Projects.new(user_storage_id).most_recent('abc', include_hidden: true)
   ensure
     Timecop.return
   end


### PR DESCRIPTION
Creates a separate, specific channel ID for projects created at /projectbeats. If there was an existing standalone music project, we'll copy sources to the new project so that users' code is preserved.

Note: there is still the outstanding issue that existing /projectbeats projects will show up in the user's gallery with an empty project type, but these new projects should all be hidden from the gallery, and we can take care of removing the old projects from the gallery as a follow-up.

## Links

https://codedotorg.atlassian.net/browse/SL-851

## Testing story

Tested locally by first creating a /projectbeats project without this change. Then applied this change and verified that code was preserved, but the new project doesn't appear in the gallery. Also verified that saving on allthethings doesn't affect the code on /projectbeats.