### PR TITLE
Quick string fix for Curriculum Catalog

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1523,7 +1523,7 @@
   "noAssessments": "It looks like there are no multi-question assessments or surveys in this course. Instead, you can measure the students’ progress using the 'Progress' tab. If you are interested in giving your students additional assessments, you can find recommended questions and areas in the lesson plans.",
   "noClassroomsFound": "No classrooms found.",
   "noColumnsInTable": "We couldn't find any columns in \"{table}\". Make sure this table is imported in your project.",
-  "noCurriculumSearchResultsBody": "None of our curricula match your exact criteria, but many of our offerings are flexible! Try broadening your search or consider building a custom curriculum from our more modular options (i.e. teaching two quarter-long curricula for a semester).",
+  "noCurriculumSearchResultsBody": "None of our curricula match your exact criteria, but many of our offerings are flexible! Try broadening your search or consider building a custom curriculum from our more modular options (e.g. teaching two quarter-long curricula for a semester).",
   "noCurriculumSearchResultsHeader": "No matching curricula",
   "noIconsFound": "No icons found",
   "noLevelPreviewAvailable": "No preview is available for this level. To view this level click \"{buttonText}\".",


### PR DESCRIPTION
Changes "i.e." to "e.g." in string shown to users when there's no filter results on the Curriculum Catalog page. @megcrenshaw spotted this issue in [this PR](https://github.com/code-dot-org/code-dot-org/pull/52042#discussion_r1204745961).
![fix_string](https://github.com/code-dot-org/code-dot-org/assets/56283563/43dc6746-ba09-49af-a398-86eec0a96b6a)

## Follow-up work
Let Jorge know there's a quick string change for this.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
