### PR TITLE
Project Beats: load samples from restricted folder if specified

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -77,6 +77,7 @@ export interface SoundData {
   length: number;
   type: SoundType;
   note?: number;
+  restricted?: boolean;
 }
 
 export interface SoundFolder {

--- a/apps/src/music/player/SamplePlayer.ts
+++ b/apps/src/music/player/SamplePlayer.ts
@@ -42,7 +42,10 @@ export default class SamplePlayer {
       .map(group => {
         return group.folders.map(folder => {
           return folder.sounds.map(sound => {
-            return group.path + '/' + folder.path + '/' + sound.src;
+            return {
+              path: group.path + '/' + folder.path + '/' + sound.src,
+              restricted: sound.restricted,
+            };
           });
         });
       })

--- a/apps/src/music/player/sound.js
+++ b/apps/src/music/player/sound.js
@@ -4,7 +4,7 @@ import WebAudio from './soundSub';
 var soundList = [];
 
 var baseSoundUrl;
-var restrictedSoundUrl;
+var restrictedSoundUrlPath;
 
 var audioSoundBuffers = [];
 var tagGroups = {};
@@ -16,7 +16,7 @@ var audioSystem = null;
 export function InitSound(desiredSounds) {
   // regular web version.
   baseSoundUrl = 'https://curriculum.code.org/media/musiclab/';
-  restrictedSoundUrl = '/restricted/musiclab/';
+  restrictedSoundUrlPath = '/restricted/musiclab/';
   audioSystem = new WebAudio();
 
   LoadSounds(desiredSounds);
@@ -53,14 +53,14 @@ async function LoadSounds(desiredSounds) {
 
   for (let i = 0; i < soundList.length; i++) {
     const sound = soundList[i];
-    const url = sound.restricted ? restrictedSoundUrl : baseSoundUrl;
+    const basePath = sound.restricted ? restrictedSoundUrlPath : baseSoundUrl;
     if (sound.restricted && !canLoadRestrictedContent) {
       // Skip loading restricted songs if we can't load restricted content.
       continue;
     }
 
     audioSystem.LoadSound(
-      url + sound.path + '.mp3',
+      basePath + sound.path + '.mp3',
       function (id, buffer) {
         audioSoundBuffers[id] = buffer;
       }.bind(this, i)

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -950,3 +950,12 @@ export function isTestEnvironment() {
 export function isProductionEnvironment() {
   return getEnvironment() === Environments.production;
 }
+
+/**
+ * Fetch cookies signed by cloudfront which grant access to restricted content.
+ * @returns {Promise<Response>}
+ * TODO: Reuse this in Dance Party (Dance.js and songs.js)
+ */
+export function fetchSignedCookies() {
+  return fetch('/dashboardapi/sign_cookies', {credentials: 'same-origin'});
+}


### PR DESCRIPTION
Load music lab samples from the [restricted](https://s3.console.aws.amazon.com/s3/buckets/cdo-restricted?region=us-east-1&prefix=restricted/&showversions=false) bucket, if specified in the manifest. This will be used for hosting licensed samples, in the same bucket we host licensed Dance Party music.

In the manifest, if we see `"restricted": true` in the song metadata, we'll try to load from the restricted bucket. We'll use the group name and folder name to compute the path, as we do with all other samples. For example:
```
{
  ...
  "id": "all-with-artists",
  "folders": [
    ...
    {
      "name": "Artist 1 Sample Pack",
      "path": "artist-1-sample-pack",
      "sounds": [
        {
          "name": "Artist 1 Sample A",
          "src": "artist-1-sample-a",
          "length": 2,
          "type": "beat",
      >>> "restricted": true
        }
      ]
    }
  ]
}
```

Given this, we'll load the sound at `/restricted/musiclab/all-with-artists/artist-1-sample-pack/artist-1-sample-a.mp3`



## Links

https://codedotorg.atlassian.net/browse/SL-875

## Testing story

Tested locally. Able to fetch restricted files from the restricted bucket, if specified.