### PR TITLE
Music: initial levelbuilder support

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -292,7 +292,14 @@ class LevelsController < ApplicationController
       return
     end
 
-    @level.assign_attributes(level_params)
+    update_level_params = level_params.to_h
+
+    # Parse the incoming level_data JSON so that it's stored in the database as a
+    # first-order member of the properties JSON, rather than simply as a string of
+    # JSON belonging to a single property.
+    update_level_params[:level_data] = JSON.parse(level_params[:level_data]) if level_params[:level_data]
+
+    @level.assign_attributes(update_level_params)
     @level.log_changes(current_user)
 
     if @level.save

--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -42,6 +42,7 @@
     = render partial: 'levels/editors/ailab', locals: {f: f} if @level.is_a? Ailab
     = render partial: 'levels/editors/javalab', locals: {f: f} if @level.is_a? Javalab
     = render partial: 'levels/editors/poetry', locals: {f: f} if @level.is_a? Poetry
+    = render partial: 'levels/editors/music', locals: {f: f} if @level.is_a? Music
     -# Widgets
     = render partial: 'levels/editors/frequency_analysis', locals: {f: f} if @level.is_a? FrequencyAnalysis
     = render partial: 'levels/editors/netsim', locals: {f: f} if @level.is_a? NetSim

--- a/dashboard/app/views/levels/editors/_music.html.haml
+++ b/dashboard/app/views/levels/editors/_music.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'levels/editors/fields/music_level_data', locals: {f: f}
+
+= render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_music_level_data.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_music_level_data.html.haml
@@ -3,4 +3,4 @@
 
 #level_data.in.collapse
   = f.label :music_level_data, 'Level data JSON'
-  = f.text_area :level_data, placeholder: 'Insert JSON Data', rows: 10, style: 'width: 90%', value: @level.level_data
+  = f.text_area :level_data, placeholder: 'Insert JSON Data', rows: 10, style: 'width: 90%', value: @level.level_data.to_json

--- a/dashboard/app/views/levels/editors/fields/_music_level_data.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_music_level_data.html.haml
@@ -1,0 +1,6 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#level_data"}}
+  Level Data
+
+#level_data.in.collapse
+  = f.label :music_level_data, 'Level data JSON'
+  = f.text_area :level_data, placeholder: 'Insert JSON Data', rows: 10, style: 'width: 90%', value: @level.level_data

--- a/dashboard/app/views/levels/new.html.haml
+++ b/dashboard/app/views/levels/new.html.haml
@@ -59,6 +59,7 @@
   %li= link_to 'Build a Free Response Level (use this for open-ended responses instead of Text Match)', new_level_path(type: 'FreeResponse')
   %li= link_to 'Build an External Link Level', new_level_path(type: 'ExternalLink')
   %li= link_to 'Build a Java Lab level', new_level_path(type: 'Javalab')
+  %li= link_to 'Build a Music Lab level', new_level_path(type: 'Music')
 
 %h2 Algebra
 %ul


### PR DESCRIPTION
This introduces initial, rudimentary levelbuilder support for Music Lab levels.

The editor simply allows freeform editing of the `level_data` JSON for a level.

<img width="1512" alt="Screenshot 2023-05-25 at 10 56 04 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/3a7b0f23-9400-449c-9a09-1da48df0fda8">
