### PR TITLE
Self-host google blockly assets

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -174,6 +174,12 @@ describe('entry tests', () => {
         },
         {
           expand: true,
+          cwd: 'node_modules/blockly/media',
+          src: ['**'],
+          dest: 'build/package/media/google_blockly',
+        },
+        {
+          expand: true,
           cwd: 'node_modules/@code-dot-org/craft/dist/assets',
           src: ['**'],
           dest: 'build/package/media/skins/craft',

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -577,6 +577,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
       },
       renderer: opt_options.renderer || Renderers.DEFAULT,
       comments: false,
+      media: '/blockly/media/google_blockly',
     };
     // CDO Blockly takes assetUrl as an inject option, and it's used throughout
     // apps, so we should also set it here.


### PR DESCRIPTION
Self-host google blockly assets (eg, the "click" sound you hear when you drag a block and connect it to another one), rather than loading them from `blockly-demo.appspot.com`, the default provided by Google.

The folder where these are placed is a little confusing -- similar assets for CDO Blockly are stored directly in the `blockly/media` folder (rather than in a subfolder). I add a `google_blockly` subfolder to distinguish from CDO Blockly assets.

## Links

- jira ticket: [SL-648](https://codedotorg.atlassian.net/browse/SL-648)

## Testing story

Tested manually on a Dance level that, with this change, I heard click sounds when dragging a block into the workspace and connecting it to another one. I confirmed the click audio file (along with other media files) being loaded from `/blockly/media/google_blockly` via dev tools.