### PR TITLE
Remove Property Lookup / Method Chaining for AWS Secrets that have JSON values

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -132,9 +132,6 @@ jotform_forms:
     post201:     90065524560150
     facilitator: 91405279991164
 
-# Learning Tools Interoperability (LTI)
-lti_credentials: !Secret
-
 # PagerDuty
 pagerduty_token: !Secret
 

--- a/config/levelbuilder.yml.erb
+++ b/config/levelbuilder.yml.erb
@@ -3,7 +3,6 @@ firebase_name: cdo-v3-lb
 use_acapela:                true
 use_pusher:                 true
 jotform_api_key:
-lti_credentials:
 devinternal_db_writer:
 db_admin:
 dashboard_microsoft_key:

--- a/lib/cdo/google/sheet.rb
+++ b/lib/cdo/google/sheet.rb
@@ -34,7 +34,7 @@ module Google
         Any edits you make to them (besides formatting) may be lost.
 
         Last updated: #{last_updated.strftime '%Y-%m-%d %l:%M%P GMT%:::z'}
-        Written by: #{CDO.gdrive_export_secret.client_email}
+        Written by: #{CDO.gdrive_export_secret['client_email']}
         Rows: #{rows.length - 1}
 
         Parts of this Google Sheet are auto-populated from our live application by an automated process.
@@ -72,7 +72,7 @@ module Google
         email = entry.email_address
         next if email.blank? ||
           email.end_with?('@code.org') ||
-          email == CDO.gdrive_export_secret.client_email
+          email == CDO.gdrive_export_secret['client_email']
         emails << email
       end
       emails

--- a/lib/cdo/secrets.rb
+++ b/lib/cdo/secrets.rb
@@ -150,9 +150,7 @@ module Cdo
     # @return [Array, Hash, String]
     private def parse_json(value)
       parsed = JSON.parse(value)
-      return parsed if parsed.is_a?(Array)
-      # Return with keys that are symbols to match the Object that was serialized to JSON and PUT into the Secret.
-      return parsed.deep_symbolize_keys if value.is_a?(Hash)
+      return parsed if parsed.is_a?(Array) || parsed.is_a?(Hash)
       return parsed.to_s
     rescue JSON::ParserError, TypeError
       value

--- a/lib/cdo/secrets.rb
+++ b/lib/cdo/secrets.rb
@@ -141,23 +141,17 @@ module Cdo
       exception.set_backtrace []
       raise
     end
-
-    # If +value+ is JSON, parse it.
-    #
-    # If +value+ is a JSON array, return it.
-    #
-    # If +value+ is a JSON object, wrap in ActiveSupport::OrderedOptions so
-    # property-method lookup chains are possible (e.g., secrets.secret.key).
-    #
+    
+    # If +value+ is a JSON array, return an Array.
+    # If +value+ is JSON return its string representation.
     # Otherwise, cast the value to a string.
     #
     # @param value[String]
-    # @return [Array, ActiveSupport::OrderedOptions, String]
+    # @return [Array, String]
     private def parse_json(value)
       parsed = JSON.parse(value)
       return parsed if parsed.is_a?(Array)
-      return ActiveSupport::OrderedOptions[parsed.symbolize_keys] if parsed.is_a?(Hash)
-      return parsed.to_s
+      return value
     rescue JSON::ParserError, TypeError
       value
     end

--- a/lib/cdo/secrets.rb
+++ b/lib/cdo/secrets.rb
@@ -143,14 +143,17 @@ module Cdo
     end
 
     # If +value+ is a JSON array, return an Array.
-    # If +value+ is JSON return, return a Hash.
-    # Otherwise, cast the value to a string.
+    # If +value+ is a JSON object, return a Hash.
+    # Otherwise, return +value+ cast to String.
     #
     # @param value[String]
     # @return [Array, Hash, String]
     private def parse_json(value)
-      # If the Secret value is parseable, its parsed type will be either Array or Hash.
-      return JSON.parse(value)
+      parsed = JSON.parse(value)
+      return parsed if parsed.is_a?(Array)
+      # Return with keys that are symbols to match the Object that was serialized to JSON and PUT into the Secret.
+      return parsed.deep_symbolize_keys if value.is_a?(Hash)
+      return parsed.to_s
     rescue JSON::ParserError, TypeError
       value
     end

--- a/lib/cdo/secrets.rb
+++ b/lib/cdo/secrets.rb
@@ -141,17 +141,16 @@ module Cdo
       exception.set_backtrace []
       raise
     end
-    
+
     # If +value+ is a JSON array, return an Array.
-    # If +value+ is JSON return its string representation.
+    # If +value+ is JSON return, return a Hash.
     # Otherwise, cast the value to a string.
     #
     # @param value[String]
-    # @return [Array, String]
+    # @return [Array, Hash, String]
     private def parse_json(value)
-      parsed = JSON.parse(value)
-      return parsed if parsed.is_a?(Array)
-      return value
+      # If the Secret value is parseable, its parsed type will be either Array or Hash.
+      return JSON.parse(value)
     rescue JSON::ParserError, TypeError
       value
     end

--- a/lib/test/cdo/test_secrets.rb
+++ b/lib/test/cdo/test_secrets.rb
@@ -1,6 +1,5 @@
 require_relative '../test_helper'
 require 'cdo/secrets'
-require 'json'
 
 class SecretsTest < Minitest::Test
   def setup
@@ -51,7 +50,7 @@ class SecretsTest < Minitest::Test
     assert_equal 2, api_requests
 
     # Secret value that is JSON must be parsed by the consumer of the Secret to access its properties.
-    assert_equal 'my_value', JSON.parse(@secrets.json)['my_key']
+    assert_equal 'my_value', @secrets.json['my_key']
   end
 
   def test_required

--- a/lib/test/cdo/test_secrets.rb
+++ b/lib/test/cdo/test_secrets.rb
@@ -49,8 +49,8 @@ class SecretsTest < Minitest::Test
     # Ensure API calls to GetSecretValue are cached.
     assert_equal 2, api_requests
 
-    # Secret value that is JSON must be parsed by the consumer of the Secret to access its properties.
-    assert_equal 'my_value', @secrets.json['my_key']
+    # Secret value that is JSON is returned as a Hash.
+    assert_equal 'my_value', @secrets.json[:my_key]
   end
 
   def test_required

--- a/lib/test/cdo/test_secrets.rb
+++ b/lib/test/cdo/test_secrets.rb
@@ -50,7 +50,7 @@ class SecretsTest < Minitest::Test
     assert_equal 2, api_requests
 
     # Secret value that is JSON is returned as a Hash.
-    assert_equal 'my_value', @secrets.json[:my_key]
+    assert_equal 'my_value', @secrets.json['my_key']
   end
 
   def test_required

--- a/lib/test/cdo/test_secrets.rb
+++ b/lib/test/cdo/test_secrets.rb
@@ -1,5 +1,6 @@
 require_relative '../test_helper'
 require 'cdo/secrets'
+require 'json'
 
 class SecretsTest < Minitest::Test
   def setup
@@ -49,8 +50,8 @@ class SecretsTest < Minitest::Test
     # Ensure API calls to GetSecretValue are cached.
     assert_equal 2, api_requests
 
-    # Property-method lookup chain on JSON secret value.
-    assert_equal 'my_value', @secrets.json.my_key
+    # Secret value that is JSON must be parsed by the consumer of the Secret to access its properties.
+    assert_equal 'my_value', JSON.parse(@secrets.json)['my_key']
   end
 
   def test_required

--- a/lib/test/cdo/test_secrets_config.rb
+++ b/lib/test/cdo/test_secrets_config.rb
@@ -79,6 +79,6 @@ class SecretsConfigTest < Minitest::Test
       foo: !Secret
     YAML
     assert_equal({bar: 'baz'}, config.foo)
-    assert_equal 'baz', config.foo.bar
+    assert_equal 'baz', config.foo['bar']
   end
 end

--- a/lib/test/cdo/test_secrets_config.rb
+++ b/lib/test/cdo/test_secrets_config.rb
@@ -78,7 +78,7 @@ class SecretsConfigTest < Minitest::Test
     load_configuration <<~YAML
       foo: !Secret
     YAML
-    assert_equal({bar: 'baz'}, config.foo)
-    assert_equal 'baz', config.foo[:bar]
+    assert_equal({'bar' => 'baz'}, config.foo)
+    assert_equal 'baz', config.foo['bar']
   end
 end

--- a/lib/test/cdo/test_secrets_config.rb
+++ b/lib/test/cdo/test_secrets_config.rb
@@ -79,6 +79,6 @@ class SecretsConfigTest < Minitest::Test
       foo: !Secret
     YAML
     assert_equal({bar: 'baz'}, config.foo)
-    assert_equal 'baz', config.foo['bar']
+    assert_equal 'baz', config.foo[:bar]
   end
 end


### PR DESCRIPTION
To remove an obstacle for implementation of RDS Proxy and Stack-Specific Secrets, stop supporting the ability to access the properties within the JSON value using method chaining (`CDO.config_setting.property_name`). RDS Proxy and Stack Secrets are implement in #48809 and a series of dependent changes referenced in that Pull Request.

The reason we are dropping support for property lookup via method chaining is that this functionality is only supported for `CDO.` configuration settings populated from a Secret (whose string value is a JSON object). If that configuration setting is sometimes set by a literal value in a config.yml.erb file (or globals.yml or locals.yml or Environment variable), we don't have existing logic that makes that JSON value navigable with method chaining. The specific issue is that on Development environments we want to set a hard coded database credentials:

in `config/development.yml.erb`:
``` yaml
db_credential_admin: {username: 'root', password: ''}
```
which is loaded from the rendered YAML file as a Hash and only allows accessing the properties via Hash key reference

```
[development] dashboard > CDO.db_credential_admin.class
=> Hash
[development] dashboard > CDO.db_credential_admin.username
Traceback (most recent call last):
        1: from (irb):3
NoMethodError (undefined method `username' for {"username"=>"root", "password"=>""}:Hash)
[development] dashboard > CDO.db_credential_admin['username']
=> "root"
```

In managed environments (provisioned via our CloudFormation template), the username and password are created and published as a JSON object to an AWS Secret.

This change ensures that any Ruby logic in our application that accesses the database username and password can do so with a consistent Hash key reference, regardless of whether the credential was configured via a literal JSON object in a YAML configuration file, or generated by a CloudFormation template.

The reason username & password must be stored together in a single AWS Secret is to comply with RDS Proxy's requirement for [configuration of username/password SQL authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-setup.html#rds-proxy-secrets-arns).

There are 3 existing `CDO.` configuration settings that are populated from an AWS Secret whose string value is a JSON object. We can find these by executing the following Ruby logic in the dashboard console of every managed environment (`staging`, `test`, etc.) including at least one `adhoc` environment.

``` ruby
CDO.to_h.each.select {|key, value| value.is_a?(Hash) || value.is_a?(Array)}.each {|key, value| puts "Name: #{key} / Type: #{value.class}"}
```

This identified the following `CDO.` configuration settings are populated from Secrets that are JSON objects:

- lti_credentials - No longer used. Removing its declaration in our configuration setting system in this Pull Request.
- ga_account - Currently is only used by converting the `ActiveSupport::OrderedOptions` to JSON. I've verified manually that the Hash that's now returned with this change converts to identical JSON.
- gdrive_export_secret - This Pull Request includes a change to access its property using Hash key reference syntax instead of property lookup method chaining.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
