### PR TITLE
Don't Stitch Flaky Eyes Test

### DIFF
--- a/dashboard/test/ui/features/star_labs/mobile_portait.feature
+++ b/dashboard/test/ui/features/star_labs/mobile_portait.feature
@@ -10,7 +10,11 @@ Feature: Look at mobile portait view
     Then I open my eyes to test "<test_name>"
     And I rotate to portrait
     And I wait for the page to fully load
-    And I see no difference for "initial load"
+    # Stitching whether with scroll or css behaves extremely erratically on
+    # mobile with the orientation warning, but fortunately this feature also
+    # doesn't allow the user to scroll the page so it's not necessary to even
+    # attempt. Disable stitching to prevent test flakiness.
+    And I see no difference for "initial load" using stitch mode "none"
     And I close my eyes
     Examples:
       | url                                                                      | test_name     |


### PR DESCRIPTION
Our eyes test for the mobile portrait "please rotate your device to landscape" warning has been extremely flaky lately, and even before being flaky it was extremely strange. The screenshot in Applitools ended up as a stitched-together amalgamation of various ways of scrolling the warning off the screen:

![image](https://github.com/code-dot-org/code-dot-org/assets/244100/4a2ddd2c-6369-41e4-8296-d15bbd5ee3b0)

As far as I can tell, this is not representative of the actual user experience and is an unexpected side effect of the CSS transforms that Applitools uses to emulate scrolling for [the default screenshot stitching functionality](https://github.com/code-dot-org/code-dot-org/blob/e7a7d84256629e459ebe8d05f12702aa41105e10/dashboard/test/ui/features/step_definitions/eyes_steps.rb#L58). The test is more accurate and more reliable when it doesn't attempt to stitch together a full-page screenshot:
![image](https://github.com/code-dot-org/code-dot-org/assets/244100/8475ff91-2493-4303-90f5-34b623cdd16d)

## Links

- test runs in [applitools](https://eyes.applitools.com/app/test-results/00000251717245100449/?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110) and [saucelabs](https://app.saucelabs.com/tests/f1aa8783ad804a249c1bdf208ef68c89)

## Testing story

Tested locally with `bundle exec ./runner.rb --html --eyes -c iPhone -f features/star_labs/mobile_portait.feature`

## Deployment strategy

We should make sure to inform the Dev of the Day of the expected eyes changes before merging