### PR TITLE
[Button] Add support of button types, added textOnly rebranded color

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -306,7 +306,6 @@ class ShareAllowedDialog extends React.Component {
                   </div>
                   <div>
                     <Button
-                      type="primary"
                       color={Button.ButtonColor.brandSecondaryDefault}
                       id="sharing-dialog-copy-button"
                       icon="clipboard"

--- a/apps/src/componentLibrary/StylizedBaseDialog.jsx
+++ b/apps/src/componentLibrary/StylizedBaseDialog.jsx
@@ -22,13 +22,8 @@ const FooterButtonColor = {
 const DialogStyle = makeEnum('default', 'simple');
 
 export function FooterButton(props) {
-  function color() {
-    if (props.color) {
-      return props.color;
-    }
-
-    return FooterButtonColor[props.type];
-  }
+  const {type, color, ...buttonProps} = props;
+  const buttonColor = color | FooterButtonColor[type] || undefined;
 
   // TODO: We shouldn't need to override <Button/> styles -- they should likely be default.
   // Tracked by https://codedotorg.atlassian.net/browse/STAR-1616.
@@ -37,7 +32,7 @@ export function FooterButton(props) {
     ...(styles.buttons[props.type] || {}),
   };
 
-  return <Button style={style} color={color()} {...props} />;
+  return <Button style={style} color={buttonColor} {...buttonProps} />;
 }
 
 // This component renders a <Button/>, so it will also accept/require any propTypes

--- a/apps/src/componentLibrary/StylizedBaseDialog.jsx
+++ b/apps/src/componentLibrary/StylizedBaseDialog.jsx
@@ -23,7 +23,7 @@ const DialogStyle = makeEnum('default', 'simple');
 
 export function FooterButton(props) {
   const {type, color, ...buttonProps} = props;
-  const buttonColor = color | FooterButtonColor[type] || undefined;
+  const buttonColor = color || FooterButtonColor[type] || undefined;
 
   // TODO: We shouldn't need to override <Button/> styles -- they should likely be default.
   // Tracked by https://codedotorg.atlassian.net/browse/STAR-1616.

--- a/apps/src/templates/Button.jsx
+++ b/apps/src/templates/Button.jsx
@@ -158,7 +158,7 @@ class Button extends React.Component {
         moduleStyles.textButton,
         'button-active-no-border',
         color === ButtonColor.brandSecondaryDefault &&
-          moduleStyles.rebrendedTextButton
+          moduleStyles.rebrandedTextButton
       );
     } else {
       className = classNames(

--- a/apps/src/templates/Button.jsx
+++ b/apps/src/templates/Button.jsx
@@ -44,6 +44,7 @@ const ButtonHeight = {
 
 class Button extends React.Component {
   static propTypes = {
+    type: PropTypes.oneOf(['button', 'submit', 'reset']),
     className: PropTypes.string,
     href: PropTypes.string,
     text: PropTypes.string,
@@ -84,6 +85,7 @@ class Button extends React.Component {
 
   render() {
     const {
+      type,
       color = ButtonColor.orange,
       size = ButtonSize.default,
       href,
@@ -154,7 +156,9 @@ class Button extends React.Component {
         this.props.className,
         moduleStyles.main,
         moduleStyles.textButton,
-        'button-active-no-border'
+        'button-active-no-border',
+        color === ButtonColor.brandSecondaryDefault &&
+          moduleStyles.rebrendedTextButton
       );
     } else {
       className = classNames(
@@ -165,8 +169,11 @@ class Button extends React.Component {
       );
     }
 
+    const buttonProps = Tag === 'button' ? {type} : {};
+
     return (
       <Tag
+        {...buttonProps}
         className={className}
         style={{...buttonStyle}}
         href={disabled ? '#' : href}

--- a/apps/src/templates/button.module.scss
+++ b/apps/src/templates/button.module.scss
@@ -321,7 +321,7 @@ a:visited,
     }
   }
 
-  &.rebrendedTextButton {
+  &.rebrandedTextButton {
     color: $brand_secondary_default;
     font-size: 16px;
     padding: 12px 16px;

--- a/apps/src/templates/button.module.scss
+++ b/apps/src/templates/button.module.scss
@@ -320,4 +320,19 @@ a:visited,
       background-color: unset;
     }
   }
+
+  &.rebrendedTextButton {
+    color: $brand_secondary_default;
+    font-size: 16px;
+    padding: 12px 16px;
+
+    &:hover {
+      color: $brand_secondary_dark;
+    }
+
+    &:focus {
+      @include focus-outline;
+      outline-offset: unset;
+    }
+  }
 }


### PR DESCRIPTION
* add support of button types to Button.jsx
* add support of rebranded textButton
* needed for https://github.com/code-dot-org/code-dot-org/pull/52038 and future work


Visuals:
<img width="908" alt="Знімок екрана 2023-05-26 о 18 22 01" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/57bd744f-f255-4b4e-8ffc-e54960fa81aa">

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
