### PR TITLE
Generic TypeScript HTTP Client

### DIFF
--- a/apps/src/lib/metrics/DashboardMetricsApi.ts
+++ b/apps/src/lib/metrics/DashboardMetricsApi.ts
@@ -1,4 +1,4 @@
-import {post} from '@cdo/apps/util/HttpClient';
+import HttpClient from '@cdo/apps/util/HttpClient';
 import {MetricsApi} from './MetricsApi';
 
 const BASE_URL = '/browser_events/';
@@ -8,6 +8,6 @@ const BASE_URL = '/browser_events/';
  */
 export default class DashboardMetricsApi implements MetricsApi {
   async sendLogs(logs: object[]): Promise<Response> {
-    return post(BASE_URL + 'put_logs', JSON.stringify({logs}), true);
+    return HttpClient.post(BASE_URL + 'put_logs', JSON.stringify({logs}), true);
   }
 }

--- a/apps/src/lib/metrics/DashboardMetricsApi.ts
+++ b/apps/src/lib/metrics/DashboardMetricsApi.ts
@@ -1,7 +1,4 @@
-import {
-  getAuthenticityToken,
-  AUTHENTICITY_TOKEN_HEADER,
-} from '../../util/AuthenticityTokenStore';
+import {post} from '@cdo/apps/util/HttpClient';
 import {MetricsApi} from './MetricsApi';
 
 const BASE_URL = '/browser_events/';
@@ -11,19 +8,6 @@ const BASE_URL = '/browser_events/';
  */
 export default class DashboardMetricsApi implements MetricsApi {
   async sendLogs(logs: object[]): Promise<Response> {
-    let token;
-    try {
-      token = await getAuthenticityToken();
-    } catch (error) {
-      return Response.error();
-    }
-
-    return fetch(BASE_URL + 'put_logs', {
-      method: 'POST',
-      body: JSON.stringify({logs}),
-      headers: {
-        [AUTHENTICITY_TOKEN_HEADER]: token,
-      },
-    });
+    return post(BASE_URL + 'put_logs', JSON.stringify({logs}), true);
   }
 }

--- a/apps/src/lib/metrics/MetricsReporter.ts
+++ b/apps/src/lib/metrics/MetricsReporter.ts
@@ -1,8 +1,6 @@
+import {isDevelopmentEnvironment} from '@cdo/apps/utils';
 import DashboardMetricsApi from './DashboardMetricsApi';
 import {MetricsApi} from './MetricsApi';
-
-const isDevelopmentEnvironment =
-  require('../../utils').isDevelopmentEnvironment;
 
 /**
  * If we receive an unauthorized response from the server, this may
@@ -57,7 +55,7 @@ class MetricsReporter {
     }
   }
 
-  private log(level: LogLevel, message: string | object) {
+  private async log(level: LogLevel, message: string | object) {
     const payload = {
       level,
       message,
@@ -69,7 +67,8 @@ class MetricsReporter {
       return;
     }
 
-    this.metricsApi.sendLogs([payload]).then(response => {
+    try {
+      const response = await this.metricsApi.sendLogs([payload]);
       if (!response.ok) {
         this.fallbackLog(payload);
       }
@@ -79,7 +78,9 @@ class MetricsReporter {
         // We will check again after a time period of CHECK_CAN_REPORT_INTERVAL
         this.setReportingDisabled();
       }
-    });
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   private getDeviceInfo(): object {

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -1,12 +1,10 @@
+import {ResponseValidator} from '@cdo/apps/util/HttpClient';
+
 export default class MusicLibrary {
   groups: FolderGroup[];
   private allowedSounds: Sounds | null;
 
-  constructor(libraryJson: {groups?: FolderGroup[]}) {
-    if (!libraryJson.groups || libraryJson.groups.length === 0) {
-      throw new Error(`Invalid library JSON: ${libraryJson}`);
-    }
-
+  constructor(libraryJson: LibraryJson) {
     this.groups = libraryJson.groups;
     this.allowedSounds = null;
   }
@@ -68,6 +66,18 @@ export default class MusicLibrary {
     return foldersCopy;
   }
 }
+
+export type LibraryJson = {
+  groups: FolderGroup[];
+};
+
+export const LibraryValidator: ResponseValidator<LibraryJson> = response => {
+  const libraryJson = response as LibraryJson;
+  if (!libraryJson.groups || libraryJson.groups.length === 0) {
+    throw new Error(`Invalid library JSON: ${response}`);
+  }
+  return libraryJson;
+};
 
 export type SoundType = 'beat' | 'bass' | 'lead' | 'fx';
 

--- a/apps/src/music/progress/ProgressManager.ts
+++ b/apps/src/music/progress/ProgressManager.ts
@@ -10,6 +10,11 @@ export abstract class Validator {
   abstract clear(): void;
 }
 
+export interface Progression {
+  path: string;
+  steps: ProgressionStep[];
+}
+
 // A validation inside the progression step.
 interface Validation {
   conditions: string[];
@@ -18,7 +23,7 @@ interface Validation {
 }
 
 // The definition of a progression step.
-interface ProgressionStep {
+export interface ProgressionStep {
   text: string;
   toolbox: {
     [key: string]: string;

--- a/apps/src/music/utils/Loader.ts
+++ b/apps/src/music/utils/Loader.ts
@@ -1,5 +1,9 @@
 // Utilities for retrieving various types of data for Music Lab.
 
+import {getJson} from '@cdo/apps/util/HttpClient';
+import MusicLibrary, {LibraryJson} from '../player/MusicLibrary';
+import {Progression, ProgressionStep} from '../progress/ProgressManager';
+
 const AppConfig = require('../appConfig').default;
 
 export const baseUrl = 'https://curriculum.code.org/media/musiclab/';
@@ -18,69 +22,67 @@ export const LevelSources = {
 };
 
 // Loads a sound library JSON file.
-export const loadLibrary = async () => {
+export const loadLibrary = async (): Promise<MusicLibrary> => {
   if (AppConfig.getValue('local-library') === 'true') {
     const localLibraryFilename = 'music-library';
     const localLibrary = require(`@cdo/static/music/${localLibraryFilename}.json`);
-    return localLibrary;
+    return new MusicLibrary(localLibrary as LibraryJson);
   } else {
     const libraryParameter = AppConfig.getValue('library');
     const libraryFilename = libraryParameter
       ? `music-library-${libraryParameter}.json`
       : 'music-library.json';
-    const response = await fetch(baseUrl + libraryFilename);
-    const library = await response.json();
-    return library;
+
+    const libraryJsonResponse = await getJson<LibraryJson>(
+      baseUrl + libraryFilename
+    );
+    return new MusicLibrary(libraryJsonResponse.value);
   }
 };
 
 // Loads a progression file.  This file can be used for prototyping a progression
 // before it's split into proper levels.
-const loadProgressionFile = async () => {
+const loadProgressionFile = async (): Promise<Progression> => {
   if (AppConfig.getValue('local-progression') === 'true') {
     const defaultProgressionFilename = 'music-progression';
     const progression = require(`@cdo/static/music/${defaultProgressionFilename}.json`);
-    return progression;
+    return progression as Progression;
   } else {
     const progressionParameter = AppConfig.getValue('progression');
     const progressionFilename = progressionParameter
       ? `music-progression-${progressionParameter}.json`
       : 'music-progression.json';
-    const response = await fetch(baseUrl + progressionFilename);
-    const progression = await response.json();
-    return progression;
+
+    return (await getJson<Progression>(baseUrl + progressionFilename)).value;
   }
 };
 
-// Loads level data from the dashboard, for a script level or a level.
-const loadLevelData = async (levelDataPath: string) => {
-  const response = await fetch(levelDataPath);
+interface LevelDataResponse {
+  level_data: ProgressionStep;
+}
 
-  if (!response.ok) {
-    throw new Error('Response not ok');
-  }
-
-  const levelData = await response.json();
-  return levelData;
-};
+interface ProgressionStepData {
+  progressionStep: ProgressionStep | undefined;
+  levelCount: number | undefined;
+}
 
 // Loads a progression step.
 export const loadProgressionStepFromSource = async (
   levelSource: LevelSource,
   levelDataPath: string,
   currentLevelIndex: number
-) => {
+): Promise<ProgressionStepData> => {
   let progressionStep = undefined;
   let levelCount = undefined;
 
   if (levelSource === LevelSource.LEVELS) {
     // Since we have levels, we'll asynchronously retrieve the current level data.
-    const response = await loadLevelData(levelDataPath);
-    progressionStep = response.level_data;
+    const response = await getJson<LevelDataResponse>(levelDataPath);
+    progressionStep = response.value.level_data;
   } else if (levelSource === LevelSource.LEVEL) {
     // Since we have a level, we'll asynchronously retrieve the current level data.
-    const response = await loadLevelData(levelDataPath);
-    progressionStep = response.level_data;
+    const response = await getJson<LevelDataResponse>(levelDataPath);
+    progressionStep = response.value.level_data;
     levelCount = 1;
   } else if (levelSource === LevelSource.FILE) {
     // Let's load from the progression file.  We'll grab the entire progression

--- a/apps/src/music/utils/Loader.ts
+++ b/apps/src/music/utils/Loader.ts
@@ -1,6 +1,6 @@
 // Utilities for retrieving various types of data for Music Lab.
 
-import {getJson, ResponseValidator} from '@cdo/apps/util/HttpClient';
+import HttpClient, {ResponseValidator} from '@cdo/apps/util/HttpClient';
 import MusicLibrary, {
   LibraryJson,
   LibraryValidator,
@@ -15,6 +15,15 @@ enum LevelSource {
   LEVELS = 'LEVELS',
   LEVEL = 'LEVEL',
   FILE = 'FILE',
+}
+
+type LevelDataResponse = {
+  level_data: ProgressionStep;
+};
+
+interface ProgressionStepData {
+  progressionStep: ProgressionStep | undefined;
+  levelCount: number | undefined;
 }
 
 // Exporting enum as object for use in JS files
@@ -36,7 +45,7 @@ export const loadLibrary = async (): Promise<MusicLibrary> => {
       ? `music-library-${libraryParameter}.json`
       : 'music-library.json';
 
-    const libraryJsonResponse = await getJson<LibraryJson>(
+    const libraryJsonResponse = await HttpClient.fetchJson<LibraryJson>(
       baseUrl + libraryFilename,
       {},
       LibraryValidator
@@ -57,19 +66,12 @@ const loadProgressionFile = async (): Promise<Progression> => {
     const progressionFilename = progressionParameter
       ? `music-progression-${progressionParameter}.json`
       : 'music-progression.json';
-
-    return (await getJson<Progression>(baseUrl + progressionFilename)).value;
+    const progressionResponse = await HttpClient.fetchJson<Progression>(
+      baseUrl + progressionFilename
+    );
+    return progressionResponse.value;
   }
 };
-
-type LevelDataResponse = {
-  level_data: ProgressionStep;
-};
-
-interface ProgressionStepData {
-  progressionStep: ProgressionStep | undefined;
-  levelCount: number | undefined;
-}
 
 const LevelDataValidator: ResponseValidator<LevelDataResponse> = response => {
   const levelDataResponse = response as LevelDataResponse;
@@ -91,7 +93,7 @@ export const loadProgressionStepFromSource = async (
 
   if (levelSource === LevelSource.LEVELS) {
     // Since we have levels, we'll asynchronously retrieve the current level data.
-    const response = await getJson<LevelDataResponse>(
+    const response = await HttpClient.fetchJson<LevelDataResponse>(
       levelDataPath,
       {},
       LevelDataValidator
@@ -99,7 +101,7 @@ export const loadProgressionStepFromSource = async (
     progressionStep = response.value.level_data;
   } else if (levelSource === LevelSource.LEVEL) {
     // Since we have a level, we'll asynchronously retrieve the current level data.
-    const response = await getJson<LevelDataResponse>(
+    const response = await HttpClient.fetchJson<LevelDataResponse>(
       levelDataPath,
       {},
       LevelDataValidator

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -27,7 +27,6 @@ import {
 import ProgressManager from '../progress/ProgressManager';
 import MusicValidator from '../progress/MusicValidator';
 import Video from './Video';
-import MusicLibrary from '../player/MusicLibrary';
 import {
   setIsPlaying,
   setCurrentPlayheadPosition,
@@ -198,69 +197,72 @@ class UnconnectedMusicView extends React.Component {
       promises.push(this.loadProgressionStep());
     }
 
-    Promise.all(promises).then(values => {
-      const libraryJson = values[0];
-      this.library = new MusicLibrary(libraryJson);
+    Promise.all(promises)
+      .then(values => {
+        this.library = values[0];
 
-      if (getBlockMode() === BlockMode.SIMPLE2) {
-        this.sequencer = new Simple2Sequencer(this.library);
-      } else {
-        this.sequencer = new MusicPlayerStubSequencer();
-      }
+        if (getBlockMode() === BlockMode.SIMPLE2) {
+          this.sequencer = new Simple2Sequencer(this.library);
+        } else {
+          this.sequencer = new MusicPlayerStubSequencer();
+        }
 
-      Globals.setLibrary(this.library);
-      Globals.setPlayer(this.player);
+        Globals.setLibrary(this.library);
+        Globals.setPlayer(this.player);
 
-      this.setAllowedSoundsForProgress();
+        this.setAllowedSoundsForProgress();
 
-      this.musicBlocklyWorkspace
-        .init(
-          document.getElementById('blockly-div'),
-          this.onBlockSpaceChange,
-          this.player,
-          this.getStartSources(),
-          this.progressManager?.getCurrentStepDetails().toolbox,
-          this.props.currentLevelId,
-          this.props.currentScriptId,
-          this.props.channelId
-        )
-        .then(() => {
-          this.musicBlocklyWorkspace.addSaveEventListener(
-            ProjectManagerEvent.SaveStart,
-            () => {
-              this.props.setProjectUpdatedSaving();
+        this.musicBlocklyWorkspace
+          .init(
+            document.getElementById('blockly-div'),
+            this.onBlockSpaceChange,
+            this.player,
+            this.getStartSources(),
+            this.progressManager?.getCurrentStepDetails().toolbox,
+            this.props.currentLevelId,
+            this.props.currentScriptId,
+            this.props.channelId
+          )
+          .then(() => {
+            this.musicBlocklyWorkspace.addSaveEventListener(
+              ProjectManagerEvent.SaveStart,
+              () => {
+                this.props.setProjectUpdatedSaving();
+              }
+            );
+            this.musicBlocklyWorkspace.addSaveEventListener(
+              ProjectManagerEvent.SaveSuccess,
+              status => {
+                this.props.setProjectUpdatedAt(status.updatedAt);
+              }
+            );
+            this.musicBlocklyWorkspace.addSaveEventListener(
+              ProjectManagerEvent.SaveNoop,
+              status => {
+                this.props.setProjectUpdatedAt(status.updatedAt);
+              }
+            );
+            this.musicBlocklyWorkspace.addSaveEventListener(
+              ProjectManagerEvent.SaveFail,
+              () => {
+                this.props.setProjectUpdatedError();
+              }
+            );
+            this.player.initialize(this.library);
+            setInterval(this.updateTimer, 1000 / 30);
+
+            // If the level changed while we were loading, then hand off
+            // to handlePanelChange to load that new level.
+            if (this.props.currentLevelIndex !== initialLevelIndex) {
+              this.handlePanelChange();
+            } else {
+              this.props.setIsLoading(false);
             }
-          );
-          this.musicBlocklyWorkspace.addSaveEventListener(
-            ProjectManagerEvent.SaveSuccess,
-            status => {
-              this.props.setProjectUpdatedAt(status.updatedAt);
-            }
-          );
-          this.musicBlocklyWorkspace.addSaveEventListener(
-            ProjectManagerEvent.SaveNoop,
-            status => {
-              this.props.setProjectUpdatedAt(status.updatedAt);
-            }
-          );
-          this.musicBlocklyWorkspace.addSaveEventListener(
-            ProjectManagerEvent.SaveFail,
-            () => {
-              this.props.setProjectUpdatedError();
-            }
-          );
-          this.player.initialize(this.library);
-          setInterval(this.updateTimer, 1000 / 30);
-
-          // If the level changed while we were loading, then hand off
-          // to handlePanelChange to load that new level.
-          if (this.props.currentLevelIndex !== initialLevelIndex) {
-            this.handlePanelChange();
-          } else {
-            this.props.setIsLoading(false);
-          }
-        });
-    });
+          });
+      })
+      .catch(error => {
+        this.onError(error);
+      });
   }
 
   componentDidUpdate(prevProps) {
@@ -317,6 +319,11 @@ class UnconnectedMusicView extends React.Component {
     if (this.hasLevels() && currentState.satisfied) {
       this.props.sendSuccessReport('music');
     }
+  };
+
+  onError = error => {
+    this.props.setIsPageError(true);
+    logError(error);
   };
 
   // Returns whether we just have a standalone level.
@@ -456,8 +463,7 @@ class UnconnectedMusicView extends React.Component {
         progressionStep = result.progressionStep;
         levelCount = result.levelCount;
       } catch (e) {
-        this.props.setIsPageError(true);
-        logError(e);
+        this.onError(e);
       }
 
       if (this.hasLevels()) {

--- a/apps/src/util/HttpClient.ts
+++ b/apps/src/util/HttpClient.ts
@@ -1,0 +1,63 @@
+import {
+  AUTHENTICITY_TOKEN_HEADER,
+  getAuthenticityToken,
+} from './AuthenticityTokenStore';
+
+/**
+ * Get a JSON response from the given endpoint and
+ * return it as the specified type. Can also perform
+ * response validation if provided a validator function.
+ */
+export async function getJson<ResponseType>(
+  endpoint: string,
+  init?: RequestInit,
+  validator?: ResponseValidator<ResponseType>
+): Promise<GetResponse<ResponseType>> {
+  const response = await fetch(endpoint, init);
+  if (!response.ok) {
+    throw new Error(response.status + ' ' + response.statusText);
+  }
+
+  const json = await response.json();
+  let value = json;
+
+  if (validator) {
+    value = validator(json);
+  }
+
+  return {
+    value,
+    response,
+  };
+}
+
+/**
+ * POST to the given endpoint. Adds the Rails authenticity
+ * token if useAuthenticityToken is true.
+ */
+export async function post(
+  endpoint: string,
+  body: string,
+  useAuthenticityToken = false,
+  headers: Record<string, string> = {}
+): Promise<Response> {
+  if (useAuthenticityToken) {
+    const token = await getAuthenticityToken();
+    headers[AUTHENTICITY_TOKEN_HEADER] = token;
+  }
+
+  return fetch(endpoint, {
+    method: 'POST',
+    body,
+    headers,
+  });
+}
+
+export type ResponseValidator<ResponseType> = (
+  bodyJson: Record<string, unknown>
+) => ResponseType;
+
+export type GetResponse<ResponseType> = {
+  value: ResponseType;
+  response: Response;
+};


### PR DESCRIPTION
Creates a generic, reusable Typescript HTTP client. In this PR, I've used it in various places within Music Lab where we were calling `fetch` directly, as well as in metrics reporting code.

The actual client isn't huge, but provides a few convenience features, especially relevant in TypeScript.
- `fetchJson()` fetches data from an endpoint, converts to JSON, and returns the value as the specified type, so clients don't need to manually call `await response.json()` and cast to the correct type.
- I also opted to pass the original response back, as some callers still need access to the response data such as headers (not directly used in this PR, but will be for lab lab code)
- Callers can also optionally provide a `validator` function to validate the response JSON and return a validated value. Currently, callers have to manually write validators for whatever types they want to validate; I did start going down a rabbit hole of generic type validations, using tools like [json-schema](https://json-schema.org/), even sharing common types between client and server, etc but figured this would be a good simple first step in creating better client side type validation.
- the `post()` function automatically retrieves the Rails authenticity token if specified.

For consistency, the client with `throw` on a network error as well as a not `ok` response. This does mean that callers need to wrap these calls in a `try/catch` if wanting to catch errors; however, this means that we don't need to separately check `response.ok` and wrap in a try/catch - just try/catch is sufficient. The Error message will contain the status code and status text.

Regarding error handling in music lab, my approach was to let errors bubble up to a common component (in this case MusicView), so they can be caught and logged consistently. For this, we just needed to add a `.catch()` to the initial load promise, as we were already `catch`ing the other network request (loading level data).


## Testing story

Tested locally with Music Lab and MetricsReporter

## Follow-up work

The next steps here are:
1) Use this client in ProjectManager/lab lab code, and add error handling where needed.
2) Wrap LabContainer in a [React error boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary), so that uncaught errors are still handled somewhere and we show a fallback UI instead of just dismounting the entire page.