### PR TITLE
10th Anniversary - fix homepage blurb string

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -304,7 +304,7 @@
   self_paced_pl_resources_desc_03: "Code.org has partnered with Amazon Future Engineer to offer teachers at underserved schools a growing number of resources and benefits at no cost! Find out if your school is eligible."
 
   tenth_anniversary_homepage_blurb: "Code.org is 10 years old!"
-  tenth_anniversary_homepage_link: "Check out the impact we've had"
+  tenth_anniversary_homepage_link: "Check out the impact we've had."
 
   hoc_live: 'Hour of Code Live'
   hoc_live_sign_up_title: 'Sign up for Hour of Code Live'

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -303,8 +303,8 @@
   self_paced_pl_resources_title_03: "Amazon Future Engineer"
   self_paced_pl_resources_desc_03: "Code.org has partnered with Amazon Future Engineer to offer teachers at underserved schools a growing number of resources and benefits at no cost! Find out if your school is eligible."
 
-  10th_anniversary_homepage_blurb: "Code.org is 10 years old!"
-  10th_anniversary_homepage_link: "Check out the impact we've had"
+  tenth_anniversary_homepage_blurb: "Code.org is 10 years old!"
+  tenth_anniversary_homepage_link: "Check out the impact we've had"
 
   hoc_live: 'Hour of Code Live'
   hoc_live_sign_up_title: 'Sign up for Hour of Code Live'


### PR DESCRIPTION
Fix strings for the 10th anniversary blurb on the homepage — needs to start with a letter and not a number.

**Original PR:** 
- https://github.com/code-dot-org/code-dot-org/pull/51943

**Jira ticket:** [ACQ-600](https://codedotorg.atlassian.net/browse/ACQ-600)