### PR TITLE
Define TextTooLong error class and update code paths to handle it

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -1,6 +1,7 @@
 require 'cdo/activity_constants'
 require 'cdo/share_filtering'
 require 'cdo/firehose'
+require 'cdo/web_purify'
 
 class ActivitiesController < ApplicationController
   include LevelsHelper
@@ -54,7 +55,7 @@ class ActivitiesController < ApplicationController
       if @level.game.sharing_filtered?
         begin
           share_failure = ShareFiltering.find_share_failure(params[:program], locale)
-        rescue OpenURI::HTTPError, IO::EAGAINWaitReadable => exception
+        rescue WebPurify::TextTooLongError, OpenURI::HTTPError, IO::EAGAINWaitReadable => exception
           # If WebPurify or Geocoder fail, the program will be allowed, and we
           # retain the share_filtering_error to log it alongside the level_source
           # ID below.

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/numeric/time'
 require 'cdo/aws/s3'
+require 'cdo/web_purify'
 require 'cdo/rack/request'
 require 'sinatra/base'
 require 'cdo/sinatra'
@@ -416,7 +417,7 @@ class FilesApi < Sinatra::Base
       begin
         share_failure = ShareFiltering.find_failure(body, request.locale)
       rescue StandardError => exception
-        return file_too_large(endpoint) if exception.message == "Profanity check failed: text is too long"
+        return file_too_large(endpoint) if exception.class == WebPurify::TextTooLongError
         details = exception.message.empty? ? nil : exception.message
         return json_bad_request(details)
       end

--- a/dashboard/legacy/middleware/helpers/profanity_privacy_helper.rb
+++ b/dashboard/legacy/middleware/helpers/profanity_privacy_helper.rb
@@ -91,7 +91,7 @@ def share_failure_from_body(body, locale)
 
   begin
     ShareFiltering.find_share_failure(blockly_source, locale)
-  rescue OpenURI::HTTPError, IO::EAGAINWaitReadable
+  rescue WebPurify::TextTooLongError, OpenURI::HTTPError, IO::EAGAINWaitReadable
     # If WebPurify or Geocoder are unavailable, default to viewable
     return false
   end

--- a/lib/cdo/web_purify.rb
+++ b/lib/cdo/web_purify.rb
@@ -19,6 +19,15 @@ module WebPurify
     'ja' => 'jp'
   }.freeze
 
+  class TextTooLongError < StandardError
+    attr_reader :text_length
+
+    def initialize(text_length)
+      @text_length = text_length
+      super
+    end
+  end
+
   # Note: If text has a string of text without whitespace longer than CHARACTER_LIMIT,
   # the entire substring will count as one long chunk and be given its own request to WebPurify.
   def self.split_text(text, max_chunk_length = CHARACTER_LIMIT)
@@ -52,7 +61,7 @@ module WebPurify
     # The request limit here happens to be the same as the simultaneous request limit for our WebPurify plan
     # The choice is arbitrary because requests are not currently parallelized, though they could be in the future
     if text.length > CHARACTER_LIMIT * REQUEST_LIMIT
-      raise StandardError.new("Profanity check failed: text is too long")
+      raise TextTooLongError.new(text.length)
     end
 
     # Convert language codes to a list of two character codes, comma separated.

--- a/lib/test/cdo/test_web_purify.rb
+++ b/lib/test/cdo/test_web_purify.rb
@@ -71,10 +71,10 @@ class WebPurifyTest < Minitest::Test
   end
 
   def test_find_potential_profanities_with_text_exceeding_maximum_length
-    err = assert_raises StandardError do
+    err = assert_raises WebPurify::TextTooLongError do
       WebPurify.find_potential_profanities(("a " * 60_000) + "a")
     end
-    assert_match "Profanity check failed: text is too long", err.message
+    assert_equal 120001, err.text_length
   end
 
   # Recording for this test was captured with an invalid API key


### PR DESCRIPTION
See: https://codedotorg.atlassian.net/browse/SL-879?search_id=d07cc22c-b968-4473-afc9-3261db472ab5

A [previous WebPurify refactor](https://github.com/code-dot-org/code-dot-org/pull/50766) removed the OpenURI:HTTPError that was being thrown when the profanity-checking payload exceeded the length limit of a URL-encoded string. However, to avoid profanity-checking arbitrarily large payloads, I [added a StandardError](https://github.com/code-dot-org/code-dot-org/pull/50766/files#diff-7f7b9ffe903479398ea459bc7a01594b25b89baaa2c8fdda6aeb85deb7f9aacbL418) that would throw if the payload is larger than 120k characters. 

I thought that I was handling [this error appropriately everywhere](https://github.com/code-dot-org/code-dot-org/pull/50766/files#diff-7f7b9ffe903479398ea459bc7a01594b25b89baaa2c8fdda6aeb85deb7f9aacbR418), but I missed where this is used in the `activities_controller` `milestone` code, and we started to see StandardErrors in production: [https://app.honeybadger.io/projects/3240/faults?sort=last_seen_desc&q=-is%3Aresolved -is%3Aignored message%3A"StandardError%3A+Profanity+check+failed%3A+text+is+too+long"](https://app.honeybadger.io/projects/3240/faults?sort=last_seen_desc&q=-is%3Aresolved%E2%80%81-is%3Aignored%E2%80%81message%3A%22StandardError%3A+Profanity+check+failed%3A+text+is+too+long%22). 

This PR defines a new `WebPurify::TextTooLongError` and handles it in both places. 

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/SL-879?search_id=d07cc22c-b968-4473-afc9-3261db472ab5

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
