### PR TITLE
Fix test by forcing rollover to next month

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -524,7 +524,8 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
 
   test 'setting virtual field as virtual when creating CSP/CSA summer workshop before a month of starting as a non-ws-admin does not raise error' do
     sign_in @organizer
-    session_start = (tomorrow_at 9) + 1.month
+    # Adding days forces the month to rollover if we're at the end of the month
+    session_start = (tomorrow_at 9) + 1.month + 3.days
     session_end = session_start + 8.hours
 
     post :create, params: {pd_workshop: workshop_params.merge(course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP, funding_type: nil, virtual: true, sessions_attributes: [{start: session_start, end: session_end}])}
@@ -796,7 +797,8 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   test 'updating virtual field in CSP/CSA summer workshop before a month of starting as a non-ws-admin does not raise error' do
     sign_in @organizer
     workshop = create :csp_summer_workshop, organizer: @organizer
-    session_start = (tomorrow_at 9) + 1.month
+    # Adding days forces the month to rollover if we're at the end of the month
+    session_start = (tomorrow_at 9) + 1.month + 3.days
     session_end = session_start + 8.hours
 
     put :update, params: {id: workshop.id, pd_workshop: workshop_params.merge(course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP, funding_type: nil, virtual: true, sessions_attributes: [{start: session_start, end: session_end}])}


### PR DESCRIPTION
Fixes the test failing here https://codedotorg.slack.com/archives/C03CM903Y/p1685450383887159.

This code illustrates the source of the problem:
```
[development] dashboard > last_day_of_month = _
=> 2023-05-31 09:00:00 -0500
[development] dashboard > last_day_of_month + 1.month
=> 2023-06-30 09:00:00 -0500
```

"When the same day does not exist for the corresponding month, the last day of the month is used instead" –– https://ruby-doc.org/stdlib-2.5.1/libdoc/date/rdoc/Date.html

[This article ](https://www.honeybadger.io/blog/activesupport-duration-helpers/) suggests that you add some extra days to "force" a rollover –– since we don't need such granularity in the functionality, adding days seems reasonable.

I tested this manually on the test machine via `RAILS_ENV=test RACK_ENV=test TZ=UTC bundle exec ruby -Itest ./test/controllers/api/v1/pd/workshops_controller_test.rb`, and the previously-failing tests are now passing. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
