### PR TITLE
Revert "Revert "Translating some of the last LP stories""

### DIFF
--- a/apps/.storybook/decorators.js
+++ b/apps/.storybook/decorators.js
@@ -1,7 +1,12 @@
-import {createStore, combineReducers} from 'redux';
+import {createStore, combineReducers, applyMiddleware} from 'redux';
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import responsive from '@cdo/apps/code-studio/responsiveRedux';
+import reduxThunk from 'redux-thunk';
 
 export const reduxStore = (reducers = {}, state = {}) => {
-  return createStore(combineReducers({isRtl, responsive, ...reducers}), state);
+  return createStore(
+    combineReducers({isRtl, responsive, ...reducers}),
+    state,
+    applyMiddleware(reduxThunk)
+  );
 };

--- a/apps/src/templates/UnassignSectionButton.story.jsx
+++ b/apps/src/templates/UnassignSectionButton.story.jsx
@@ -4,16 +4,15 @@ import {UnconnectedUnassignSectionButton as UnassignSectionButton} from './Unass
 import {fakeTeacherSectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/sectionAssignmentTestHelper';
 
 const assignedSection = fakeTeacherSectionsForDropdown[1];
-export default storybook => {
-  storybook.storiesOf('Buttons/UnassignSectionButton', module).addStoryTable([
-    {
-      name: 'UnassignSectionButton',
-      story: () => (
-        <UnassignSectionButton
-          sectionId={assignedSection.id}
-          unassignSection={action('unassignSection')}
-        />
-      ),
-    },
-  ]);
+
+export default {
+  name: 'UnassignSectionButton',
+  component: UnassignSectionButton,
 };
+
+export const Default = () => (
+  <UnassignSectionButton
+    sectionId={assignedSection.id}
+    unassignSection={action('unassignSection')}
+  />
+);

--- a/apps/src/templates/sectionProgress/standards/LessonStatusList.story.jsx
+++ b/apps/src/templates/sectionProgress/standards/LessonStatusList.story.jsx
@@ -1,45 +1,46 @@
 import React from 'react';
-import LessonStatusList from './LessonStatusList';
+import {UnconnectedLessonStatusList as LessonStatusList} from './LessonStatusList';
 import {unpluggedLessonList} from './standardsTestHelpers';
 import {action} from '@storybook/addon-actions';
-import {createStore, combineReducers} from 'redux';
-import {Provider} from 'react-redux';
 import sectionStandardsProgress from './sectionStandardsProgressRedux';
 import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import currentUser from '@cdo/apps/templates/currentUserRedux';
+import {reduxStore} from '@cdo/storybook/decorators';
+import {Provider} from 'react-redux';
 
-export default storybook => {
-  const store = createStore(
-    combineReducers({
-      sectionProgress,
-      sectionStandardsProgress,
-      unitSelection,
-      teacherSections,
-      currentUser,
-    }),
-    {
-      teacherSections: {
-        selectedSectionId: 11,
-      },
-      unitSelection: {
-        scriptId: 1,
-      },
-    }
-  );
-
-  return storybook
-    .storiesOf('Standards/LessonStatusList', module)
-    .add('overview', () => {
-      return (
-        <Provider store={store}>
-          <LessonStatusList
-            unpluggedLessonList={unpluggedLessonList}
-            selectedLessons={[]}
-            setSelectedLessons={action('set selected lessons')}
-          />
-        </Provider>
-      );
-    });
+const initialState = {
+  teacherSections: {
+    selectedSectionId: 11,
+  },
+  unitSelection: {
+    scriptId: 1,
+  },
 };
+
+const store = reduxStore(
+  {
+    sectionProgress,
+    sectionStandardsProgress,
+    unitSelection,
+    teacherSections,
+    currentUser,
+  },
+  initialState
+);
+
+export default {
+  title: 'LessonStatusList',
+  component: LessonStatusList,
+};
+
+export const Template = () => (
+  <Provider store={store}>
+    <LessonStatusList
+      unpluggedLessonList={unpluggedLessonList}
+      selectedLessons={[]}
+      setSelectedLessons={action('set selected lessons')}
+    />
+  </Provider>
+);

--- a/apps/src/templates/studioHomepages/TeacherHomepage.story.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.story.jsx
@@ -18,6 +18,7 @@ import {
 } from '../../../test/unit/templates/studioHomepages/homepagesTestData';
 
 const serverSections = taughtSections.map(serverSectionFromSection);
+const joinedServerSections = joinedSections.map(serverSectionFromSection);
 
 const serverCourses = [
   {
@@ -77,30 +78,16 @@ CoursesNoSections.args = {
 
 export const NoCoursesSections = Template.bind({});
 NoCoursesSections.args = {
-  fakeServerArgs: {sections: serverSections},
+  fakeServerArgs: {sections: joinedServerSections},
   props: {
     courses: [],
-    joinedStudentSections: [],
+    joinedStudentSections: joinedSections,
     joinedPlSections: [],
   },
 };
 
 export const CoursesSections = Template.bind({});
 CoursesSections.args = {
-  fakeServerArgs: {
-    courses: serverCourses,
-    sections: serverSections,
-  },
-  props: {
-    courses: courses,
-    topCourse: topCourse,
-    joinedStudentSections: [],
-    joinedPlSections: [],
-  },
-};
-
-export const CoursesSectionsStudentSections = Template.bind({});
-CoursesSectionsStudentSections.args = {
   fakeServerArgs: {
     courses: serverCourses,
     sections: serverSections,
@@ -117,7 +104,7 @@ export const StudentAndPLCoursesSectionsStudentSections = Template.bind({});
 StudentAndPLCoursesSectionsStudentSections.args = {
   fakeServerArgs: {
     courses: serverCourses,
-    sections: serverSections,
+    sections: joinedServerSections,
   },
   props: {
     courses: courses,
@@ -133,14 +120,14 @@ export const CoursesSectionsAndJoinedPLSections = Template.bind({});
 CoursesSectionsAndJoinedPLSections.args = {
   fakeServerArgs: {
     courses: serverCourses,
-    sections: serverSections,
+    sections: [].concat(serverSections, joinedServerSections),
   },
   props: {
     courses: courses,
     topCourse: topCourse,
     plCourses: plCourses,
     topPlCourse: topPlCourse,
-    joinedStudentSections: [],
+    joinedStudentSections: joinedSections,
     joinedPlSections: joinedPlSections,
   },
 };
@@ -167,6 +154,6 @@ function withFakeServer({courses = [], sections = []} = {}) {
   server.respondWith(
     'GET',
     '/dashboardapi/sections/available_participant_types',
-    successResponse([{availableParticipantTypes: ['student', 'teacher']}])
+    successResponse({availableParticipantTypes: ['student', 'teacher']})
   );
 }

--- a/apps/src/templates/studioHomepages/TeacherHomepage.story.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.story.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 import sinon from 'sinon';
-import {createStoreWithReducers, registerReducers} from '@cdo/apps/redux';
 import teacherSections, {
   serverSectionFromSection,
 } from '../teacherDashboard/teacherSectionsRedux';
@@ -34,175 +34,115 @@ const serverCourses = [
   },
 ];
 
-export default storybook => {
-  return storybook
-    .storiesOf('Homepages/Teachers/TeacherHomepage', module)
-    .addStoryTable([
-      {
-        name: 'Teacher Homepage - no courses, no sections',
-        description:
-          'Teacher Homepage - teacher does not have course progress, nor do they have sections',
-        story: () => {
-          withFakeServer();
-          registerReducers({teacherSections});
-          const store = createStoreWithReducers();
-          return (
-            <Provider store={store}>
-              <TeacherHomepage
-                announcements={[announcement]}
-                courses={[]}
-                plCourses={[]}
-                joinedStudentSections={[]}
-                joinedPlSections={[]}
-                isEnglish={true}
-                showCensusBanner={false}
-              />
-            </Provider>
-          );
-        },
-      },
-      {
-        name: 'Teacher Homepage - courses, no sections',
-        description:
-          'Teacher Homepage - teacher has course progress, but does not have sections',
-        story: () => {
-          withFakeServer({courses: serverCourses});
-          registerReducers({teacherSections});
-          const store = createStoreWithReducers();
-          return (
-            <Provider store={store}>
-              <TeacherHomepage
-                announcements={[announcement]}
-                topCourse={topCourse}
-                courses={courses}
-                joinedStudentSections={[]}
-                joinedPlSections={[]}
-                isEnglish={true}
-                showCensusBanner={false}
-              />
-            </Provider>
-          );
-        },
-      },
-      {
-        name: 'Teacher Homepage - no courses, sections',
-        description:
-          'Teacher Homepage - teacher does not have course progress, but does have sections',
-        story: () => {
-          withFakeServer({sections: serverSections});
-          registerReducers({teacherSections});
-          const store = createStoreWithReducers();
-          return (
-            <Provider store={store}>
-              <TeacherHomepage
-                announcements={[announcement]}
-                courses={[]}
-                joinedStudentSections={[]}
-                joinedPlSections={[]}
-                isEnglish={true}
-                showCensusBanner={false}
-              />
-            </Provider>
-          );
-        },
-      },
-      {
-        name: 'Teacher Homepage - courses and sections',
-        description:
-          'Teacher Homepage - teacher does have course progress, and does have sections',
-        story: () => {
-          withFakeServer({courses: serverCourses, sections: serverSections});
-          registerReducers({teacherSections});
-          const store = createStoreWithReducers();
-          return (
-            <Provider store={store}>
-              <TeacherHomepage
-                announcements={[announcement]}
-                courses={courses}
-                topCourse={topCourse}
-                joinedStudentSections={[]}
-                joinedPlSections={[]}
-                isEnglish={true}
-                showCensusBanner={false}
-              />
-            </Provider>
-          );
-        },
-      },
-      {
-        name: 'Teacher Homepage - courses, sections and joinedStudentSections',
-        description:
-          'Teacher Homepage - teacher does have course progress, and does have sections they own and sections in which they are a student',
-        story: () => {
-          withFakeServer({courses: serverCourses, sections: serverSections});
-          registerReducers({teacherSections});
-          const store = createStoreWithReducers();
-          return (
-            <Provider store={store}>
-              <TeacherHomepage
-                announcements={[announcement]}
-                courses={courses}
-                topCourse={topCourse}
-                joinedStudentSections={joinedSections}
-                joinedPlSections={[]}
-                isEnglish={true}
-                showCensusBanner={false}
-              />
-            </Provider>
-          );
-        },
-      },
-      {
-        name: 'Teacher Homepage - student and pl courses, sections, joinedStudentSections',
-        description:
-          'Teacher Homepage - teacher does have course progress in both student and pl courses, and does have sections they own and sections in which they are a student',
-        story: () => {
-          withFakeServer({courses: serverCourses, sections: serverSections});
-          registerReducers({teacherSections});
-          const store = createStoreWithReducers();
-          return (
-            <Provider store={store}>
-              <TeacherHomepage
-                announcements={[announcement]}
-                courses={courses}
-                topCourse={topCourse}
-                plCourses={plCourses}
-                topPlCourse={topPlCourse}
-                joinedStudentSections={joinedSections}
-                joinedPlSections={[]}
-                isEnglish={true}
-                showCensusBanner={false}
-              />
-            </Provider>
-          );
-        },
-      },
-      {
-        name: 'Teacher Homepage - courses, sections and joinedPlSections',
-        description:
-          'Teacher Homepage - teacher does have course progress in both student and pl courses, and does have sections they own and sections in which they are a student',
-        story: () => {
-          withFakeServer({courses: serverCourses, sections: serverSections});
-          registerReducers({teacherSections});
-          const store = createStoreWithReducers();
-          return (
-            <Provider store={store}>
-              <TeacherHomepage
-                announcements={[announcement]}
-                courses={courses}
-                topCourse={topCourse}
-                plCourses={plCourses}
-                topPlCourse={topPlCourse}
-                joinedStudentSections={[]}
-                joinedPlSections={joinedPlSections}
-                isEnglish={true}
-                showCensusBanner={false}
-              />
-            </Provider>
-          );
-        },
-      },
-    ]);
+export default {
+  title: 'TeacherHomepage',
+  component: TeacherHomepage,
+};
+
+const Template = args => {
+  withFakeServer(args.fakeServerArgs);
+  return (
+    <Provider store={reduxStore({teacherSections})}>
+      <TeacherHomepage
+        announcements={[announcement]}
+        isEnglish={true}
+        showCensusBanner={false}
+        {...args.props}
+      />
+    </Provider>
+  );
+};
+
+export const NoCoursesNoSections = Template.bind({});
+NoCoursesNoSections.args = {
+  fakeServerArgs: {},
+  props: {
+    courses: [],
+    plCourses: [],
+    joinedStudentSections: [],
+    joinedPlSections: [],
+  },
+};
+
+export const CoursesNoSections = Template.bind({});
+CoursesNoSections.args = {
+  fakeServerArgs: {courses: serverCourses},
+  props: {
+    topCourse: topCourse,
+    courses: courses,
+    joinedStudentSections: [],
+    joinedPlSections: [],
+  },
+};
+
+export const NoCoursesSections = Template.bind({});
+NoCoursesSections.args = {
+  fakeServerArgs: {sections: serverSections},
+  props: {
+    courses: [],
+    joinedStudentSections: [],
+    joinedPlSections: [],
+  },
+};
+
+export const CoursesSections = Template.bind({});
+CoursesSections.args = {
+  fakeServerArgs: {
+    courses: serverCourses,
+    sections: serverSections,
+  },
+  props: {
+    courses: courses,
+    topCourse: topCourse,
+    joinedStudentSections: [],
+    joinedPlSections: [],
+  },
+};
+
+export const CoursesSectionsStudentSections = Template.bind({});
+CoursesSectionsStudentSections.args = {
+  fakeServerArgs: {
+    courses: serverCourses,
+    sections: serverSections,
+  },
+  props: {
+    courses: courses,
+    topCourse: topCourse,
+    joinedStudentSections: joinedSections,
+    joinedPlSections: [],
+  },
+};
+
+export const StudentAndPLCoursesSectionsStudentSections = Template.bind({});
+StudentAndPLCoursesSectionsStudentSections.args = {
+  fakeServerArgs: {
+    courses: serverCourses,
+    sections: serverSections,
+  },
+  props: {
+    courses: courses,
+    topCourse: topCourse,
+    plCourses: plCourses,
+    topPlCourse: topPlCourse,
+    joinedStudentSections: joinedSections,
+    joinedPlSections: [],
+  },
+};
+
+export const CoursesSectionsAndJoinedPLSections = Template.bind({});
+CoursesSectionsAndJoinedPLSections.args = {
+  fakeServerArgs: {
+    courses: serverCourses,
+    sections: serverSections,
+  },
+  props: {
+    courses: courses,
+    topCourse: topCourse,
+    plCourses: plCourses,
+    topPlCourse: topPlCourse,
+    joinedStudentSections: [],
+    joinedPlSections: joinedPlSections,
+  },
 };
 
 function withFakeServer({courses = [], sections = []} = {}) {
@@ -223,5 +163,10 @@ function withFakeServer({courses = [], sections = []} = {}) {
     'GET',
     '/dashboardapi/sections/valid_course_offerings',
     successResponse([])
+  );
+  server.respondWith(
+    'GET',
+    '/dashboardapi/sections/available_participant_types',
+    successResponse([{availableParticipantTypes: ['student', 'teacher']}])
   );
 }

--- a/apps/test/unit/templates/studioHomepages/homepagesTestData.js
+++ b/apps/test/unit/templates/studioHomepages/homepagesTestData.js
@@ -88,6 +88,7 @@ export const taughtSections = [
     grade: 'K',
     providerManaged: false,
     hidden: false,
+    participantType: 'student',
   },
   {
     id: 15,
@@ -104,6 +105,7 @@ export const taughtSections = [
     grade: '7',
     providerManaged: false,
     hidden: false,
+    participantType: 'student',
   },
 ];
 
@@ -118,6 +120,7 @@ export const joinedSections = [
     numberOfStudents: 1,
     linkToStudents: manageStudentsUrl,
     code: 'ClassOneCode',
+    participantType: 'student',
   },
   {
     id: 12,
@@ -131,6 +134,7 @@ export const joinedSections = [
     numberOfStudents: 2,
     linkToStudents: manageStudentsUrl,
     code: 'ClassTwoCode',
+    participantType: 'student',
   },
   {
     id: 13,
@@ -143,6 +147,7 @@ export const joinedSections = [
     linkToStudents: manageStudentsUrl,
     login_type: 'google_classroom',
     code: 'DoNotShowThis',
+    participantType: 'student',
   },
   {
     id: 14,
@@ -155,6 +160,7 @@ export const joinedSections = [
     linkToStudents: manageStudentsUrl,
     login_type: 'clever',
     code: 'OrThisEither',
+    participantType: 'student',
   },
 ];
 
@@ -169,6 +175,7 @@ export const joinedPlSections = [
     numberOfStudents: 1,
     linkToStudents: manageStudentsUrl,
     code: 'ClassOneCode',
+    participantType: 'teacher',
   },
   {
     id: 12,
@@ -182,6 +189,7 @@ export const joinedPlSections = [
     numberOfStudents: 2,
     linkToStudents: manageStudentsUrl,
     code: 'ClassTwoCode',
+    participantType: 'teacher',
   },
   {
     id: 13,
@@ -194,6 +202,7 @@ export const joinedPlSections = [
     linkToStudents: manageStudentsUrl,
     login_type: 'google_classroom',
     code: 'DoNotShowThis',
+    participantType: 'teacher',
   },
   {
     id: 14,
@@ -206,6 +215,7 @@ export const joinedPlSections = [
     linkToStudents: manageStudentsUrl,
     login_type: 'clever',
     code: 'OrThisEither',
+    participantType: 'teacher',
   },
 ];
 


### PR DESCRIPTION
Take Two of updating these stories.

The original PR: https://github.com/code-dot-org/code-dot-org/pull/52090

I believe it was failing because the API call for availableParticipantTypes was not working properly. See slack thread [here](https://codedotorg.slack.com/archives/C03CK8E51/p1685474853261039). This PR also adds participant type to the helper sections because the student section tables were registering them as PL sections.

I am not entirely clear on why the last PR passed drone but failed Test. This PR also has a passing build, so I'm not sure how else to verify without merging and seeing if drone fails again. I did check for the error message from the slack thread, and don't see it showing up in drone.