### PR TITLE
Exit gracefully when there are no levelbuilder changes to commit

### DIFF
--- a/bin/content-push
+++ b/bin/content-push
@@ -83,11 +83,11 @@ def check_changes
 end
 
 def commit_changes(name)
+  ignore_levelbuilder_omissions
   exit 0 unless has_changes?
 
   branchname = GitUtils.current_branch
   exit 1 unless system("git add -A #{CONTENT_PATHS}")
-  ignore_levelbuilder_omissions
   exit 1 unless system("git commit -m '#{branchname} content changes (-#{name})'")
   exit 1 unless system("git pull")
   exit 1 unless system("git push")


### PR DESCRIPTION
Every holiday, the levelbuilder scoop throws an error because there are no changes to commit. My theory is that there are `schema.rb` and `schema_cache.rb` changes staged on levelbuilder. This means that `has_changes?` was true but, after those changes were reverted in `ignore_levelbuilder_omissions`, there were no changes to commit, throwing an error. Moving `ignore_levelbuilder_omissions` to be the first step ensures that `has_changes?` is only looking at changes that will actually be committed.

I tested this locally by making a minor change to `schema.rb` and no other changes. I got an exit code of 1 without my change and an exit code of 0 with my change.