### PR TITLE
[Google Blockly] Fix toolbox with categories when editing

### DIFF
--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -107,9 +107,9 @@ export default function initializeBlocklyXml(blocklyWrapper) {
 
       if (isNaN(block.y)) {
         block.y = cursor.y + frameSvgTop;
-        cursor.y +=
-          heightWidth.height + verticalSpaceBetweenBlocks + frameSvgSize;
       }
+      cursor.y +=
+        heightWidth.height + verticalSpaceBetweenBlocks + frameSvgSize;
 
       block.blockly_block.moveTo(
         new Blockly.utils.Coordinate(block.x, block.y)

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -107,9 +107,9 @@ export default function initializeBlocklyXml(blocklyWrapper) {
 
       if (isNaN(block.y)) {
         block.y = cursor.y + frameSvgTop;
+        cursor.y +=
+          heightWidth.height + verticalSpaceBetweenBlocks + frameSvgSize;
       }
-      cursor.y +=
-        heightWidth.height + verticalSpaceBetweenBlocks + frameSvgSize;
 
       block.blockly_block.moveTo(
         new Blockly.utils.Coordinate(block.x, block.y)

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -209,6 +209,8 @@ class Blockly < Level
         xml.child << category_node
         block.remove
       else
+        block.remove_attribute('x')
+        block.remove_attribute('y')
         block.remove
         category_node << block
       end

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -189,7 +189,7 @@ class Blockly < Level
     end
     xml = Nokogiri::XML(xml_string, &:noblanks)
     tag = Blockly.field_or_title(xml)
-    return xml_string if xml.nil? || xml.xpath('/xml/block[@type="category"]').empty?
+    return xml_string if xml.nil? || (xml.xpath('/xml/block[@type="category"]').empty? && xml.xpath('xml/block[@type="custom_category"]').empty?)
     default_category = category_node = Nokogiri::XML("<category name='Default'>").child
     xml.child << default_category
     xml.xpath('/xml/block').each do |block|

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -183,7 +183,7 @@ class Blockly < Level
   def self.convert_toolbox_to_category(xml_string)
     is_google_blockly = false
     google_blockly_namespace = "<xml xmlns=\"https://developers.google.com/blockly/xml\">"
-    if xml_string.include? google_namespace
+    if xml_string.include? google_blockly_namespace
       is_google_blockly = true
       xml_string[google_blockly_namespace] = "<xml>"
     end

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -180,12 +180,13 @@ class Blockly < Level
     PROCEDURE: 'Functions',
     VARIABLE: 'Variables',
   }
+
+  GOOGLE_BLOCKLY_NAMESPACE_XML = "<xml xmlns=\"https://developers.google.com/blockly/xml\">"
   def self.convert_toolbox_to_category(xml_string)
     is_google_blockly = false
-    google_blockly_namespace = "<xml xmlns=\"https://developers.google.com/blockly/xml\">"
-    if xml_string.include? google_blockly_namespace
+    if xml_string.include? GOOGLE_BLOCKLY_NAMESPACE_XML
       is_google_blockly = true
-      xml_string[google_blockly_namespace] = "<xml>"
+      xml_string[GOOGLE_BLOCKLY_NAMESPACE_XML] = "<xml>"
     end
     xml = Nokogiri::XML(xml_string, &:noblanks)
     tag = Blockly.field_or_title(xml)
@@ -218,15 +219,14 @@ class Blockly < Level
     default_category.remove if default_category.element_children.empty?
     xml_string = xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
     if is_google_blockly
-      xml_string["<xml>"] = google_blockly_namespace
+      xml_string["<xml>"] = GOOGLE_BLOCKLY_NAMESPACE_XML
     end
     return xml_string
   end
 
   def self.convert_category_to_toolbox(xml_string)
-    google_blockly_namespace = "<xml xmlns=\"https://developers.google.com/blockly/xml\">"
-    if xml_string.include? google_blockly_namespace
-      xml_string[google_blockly_namespace] = "<xml>"
+    if xml_string.include? GOOGLE_BLOCKLY_NAMESPACE_XML
+      xml_string[GOOGLE_BLOCKLY_NAMESPACE_XML] = "<xml>"
     end
     xml = Nokogiri::XML(xml_string, &:noblanks).child
     tag = Blockly.field_or_title(xml)

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -182,8 +182,13 @@ class Blockly < Level
   }
 
   GOOGLE_BLOCKLY_NAMESPACE_XML = "<xml xmlns=\"https://developers.google.com/blockly/xml\">"
+
+  # This function converts category blocks used by levelbuilders to edit the toolbox to category tags
+  # and places the appropriate blocks within each category
   def self.convert_toolbox_to_category(xml_string)
+    is_google_blockly = false
     if xml_string.include? GOOGLE_BLOCKLY_NAMESPACE_XML
+      is_google_blockly = true
       xml_string[GOOGLE_BLOCKLY_NAMESPACE_XML] = "<xml>"
     end
     xml = Nokogiri::XML(xml_string, &:noblanks)
@@ -215,9 +220,15 @@ class Blockly < Level
       end
     end
     default_category.remove if default_category.element_children.empty?
-    xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
+    xml_string = xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
+    if is_google_blockly
+      xml_string["<xml>"] = GOOGLE_BLOCKLY_NAMESPACE_XML
+    end
+    return xml_string
   end
 
+  # This function converts category tags to blocks so that levelbuilders can more easily edit
+  # a toolbox that contains categories.
   def self.convert_category_to_toolbox(xml_string)
     if xml_string.include? GOOGLE_BLOCKLY_NAMESPACE_XML
       xml_string[GOOGLE_BLOCKLY_NAMESPACE_XML] = "<xml>"

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -183,9 +183,7 @@ class Blockly < Level
 
   GOOGLE_BLOCKLY_NAMESPACE_XML = "<xml xmlns=\"https://developers.google.com/blockly/xml\">"
   def self.convert_toolbox_to_category(xml_string)
-    is_google_blockly = false
     if xml_string.include? GOOGLE_BLOCKLY_NAMESPACE_XML
-      is_google_blockly = true
       xml_string[GOOGLE_BLOCKLY_NAMESPACE_XML] = "<xml>"
     end
     xml = Nokogiri::XML(xml_string, &:noblanks)
@@ -217,11 +215,7 @@ class Blockly < Level
       end
     end
     default_category.remove if default_category.element_children.empty?
-    xml_string = xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
-    if is_google_blockly
-      xml_string["<xml>"] = GOOGLE_BLOCKLY_NAMESPACE_XML
-    end
-    return xml_string
+    xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
   end
 
   def self.convert_category_to_toolbox(xml_string)
@@ -253,8 +247,7 @@ class Blockly < Level
       xml << category.children
       #block.xpath('statement')[0] << wrap_blocks(category.xpath('block').to_a) unless category.xpath('block').empty?
     end
-    xml_string = xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
-    return xml_string
+    xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
   end
 
   # "counter" mutations should not be stored because it results in the language being

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -252,7 +252,6 @@ class Blockly < Level
       #block.xpath('statement')[0] << wrap_blocks(category.xpath('block').to_a) unless category.xpath('block').empty?
     end
     xml_string = xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
-    p xml_string
     return xml_string
   end
 

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -181,6 +181,12 @@ class Blockly < Level
     VARIABLE: 'Variables',
   }
   def self.convert_toolbox_to_category(xml_string)
+    is_google_blockly = false
+    google_blockly_namespace = "<xml xmlns=\"https://developers.google.com/blockly/xml\">"
+    if xml_string.include? google_namespace
+      is_google_blockly = true
+      xml_string[google_blockly_namespace] = "<xml>"
+    end
     xml = Nokogiri::XML(xml_string, &:noblanks)
     tag = Blockly.field_or_title(xml)
     return xml_string if xml.nil? || xml.xpath('/xml/block[@type="category"]').empty?
@@ -208,10 +214,18 @@ class Blockly < Level
       end
     end
     default_category.remove if default_category.element_children.empty?
-    xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
+    xml_string = xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
+    if is_google_blockly
+      xml_string["<xml>"] = google_blockly_namespace
+    end
+    return xml_string
   end
 
   def self.convert_category_to_toolbox(xml_string)
+    google_blockly_namespace = "<xml xmlns=\"https://developers.google.com/blockly/xml\">"
+    if xml_string.include? google_blockly_namespace
+      xml_string[google_blockly_namespace] = "<xml>"
+    end
     xml = Nokogiri::XML(xml_string, &:noblanks).child
     tag = Blockly.field_or_title(xml)
     return xml_string if xml.nil?
@@ -237,7 +251,9 @@ class Blockly < Level
       xml << category.children
       #block.xpath('statement')[0] << wrap_blocks(category.xpath('block').to_a) unless category.xpath('block').empty?
     end
-    xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
+    xml_string = xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
+    p xml_string
+    return xml_string
   end
 
   # "counter" mutations should not be stored because it results in the language being

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -252,6 +252,7 @@ class Blockly < Level
       #block.xpath('statement')[0] << wrap_blocks(category.xpath('block').to_a) unless category.xpath('block').empty?
     end
     xml_string = xml.serialize(save_with: XML_OPTIONS).delete("\n").strip
+    p xml_string
     return xml_string
   end
 

--- a/dashboard/config/scripts/levels/courseC_collector_prog22022.level
+++ b/dashboard/config/scripts/levels/courseC_collector_prog22022.level
@@ -1,7 +1,7 @@
 <Karel>
   <config><![CDATA[{
   "game_id": 25,
-  "created_at": "2023-03-21T08:34:16.000Z",
+  "created_at": "2022-01-06T19:46:18.000Z",
   "level_num": "custom",
   "user_id": 285,
   "properties": {
@@ -27,8 +27,8 @@
     "flower_type": "redWithNectar",
     "fast_get_nectar_animation": "false",
     "short_instructions": "Move Laurel to the treasure, then use `collect` to pick it up.",
-    "long_instructions": "Move Laurel to the treasure, then use the <xml><block type=\"collector_collect\" block-text=\"collect\"/></xml> \r\n block to pick it up.",
-    "authored_hints": "[{\"hint_class\":\"content\",\"hint_markdown\":\"You can use four <xml><block type=\\\"maze_move\\\"><title name=\\\"DIR\\\">moveForward</title></block></xml> blocks or use the <xml><block type=\\\"controls_repeat_dropdown\\\"><title name=\\\"TIMES\\\" config=\\\"3-10\\\">???</title></block></xml> block to make your program shorter.\",\"hint_id\":\"courseC_collector_prog2_a\",\"hint_type\":\"general\",\"hint_path\":\"\",\"hint_video\":\"\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/35f1470dc2ad2afc815155e695ef6e9b/courseC_collector_prog22022.mp3\"},{\"hint_class\":\"pointer\",\"hint_markdown\":\"Don't be afraid to make a mistake! Try adding blocks and running the code to see what will happen, even if you don't think you've solved the puzzle yet.\",\"hint_id\":\"courseC_collector_prog2_b\",\"hint_type\":\"general\",\"hint_path\":\"\",\"hint_video\":\"\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/249f9a599d949ae950f131138cdd91b7/courseC_collector_prog22022.mp3\"}]",
+    "long_instructions": "Move Laurel to the treasure, then use the <xml><block type=\"collector_collect\" block-text=\"collect\"/></xml> block to pick it up.",
+    "authored_hints": "[{\"hint_class\":\"content\",\"hint_markdown\":\"You can use four <xml><block type=\\\"maze_move\\\"><title name=\\\"DIR\\\">moveForward</title></block></xml> blocks or use the <xml><block type=\\\"controls_repeat_dropdown\\\"><title name=\\\"TIMES\\\" config=\\\"3-10\\\">???</title></block></xml> block to make your program shorter.\",\"hint_id\":\"courseC_collector_prog2_a\",\"hint_type\":\"general\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/35f1470dc2ad2afc815155e695ef6e9b/courseC_collector_prog2.mp3\"},{\"hint_class\":\"pointer\",\"hint_markdown\":\"Don't be afraid to make a mistake! Try adding blocks and running the code to see what will happen, even if you don't think you've solved the puzzle yet.\",\"hint_id\":\"courseC_collector_prog2_b\",\"hint_type\":\"general\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/249f9a599d949ae950f131138cdd91b7/courseC_collector_prog2.mp3\"}]",
     "instructions_important": "false",
     "min_collected": "1",
     "hide_share_and_remix": "false",
@@ -42,12 +42,12 @@
     "mini_rubric": "false",
     "top_level_procedure_autopopulate": "false",
     "show_type_hints": "false",
-    "hint_prompt_attempts_threshold": "1",
-    "preload_asset_list": null
+    "preload_asset_list": null,
+    "contained_level_names": null
   },
   "published": true,
   "notes": "Not enough blocks in workspace puzzle",
-  "audit_log": "[{\"changed_at\":\"2022-01-06T19:46:18.705+00:00\",\"changed\":[\"cloned from \\\"courseC_collector_prog2_2021\\\"\"],\"cloned_from\":\"courseC_collector_prog2_2021\"},{\"changed_at\":\"2023-05-23 12:44:21 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-23 18:54:53 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"long_instructions\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-23 18:57:13 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"long_instructions\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-23 19:08:08 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"long_instructions\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-26 11:45:17 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 17:09:59 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:23:38 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:25:12 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:34:06 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:34:55 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"}]",
+  "audit_log": "[{\"changed_at\":\"2022-01-06T19:46:18.705+00:00\",\"changed\":[\"cloned from \\\"courseC_collector_prog2_2021\\\"\"],\"cloned_from\":\"courseC_collector_prog2_2021\"}]",
   "level_concept_difficulty": {
     "sequencing": 3,
     "repeat_loops": 1
@@ -61,20 +61,19 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <category name="K1 blocks">
-          <block type="controls_repeat_simplified">
-            <field name="TIMES">5</field>
-          </block>
-          <block type="maze_moveNorth"/>
-        </category>
-        <category name="Actions">
-          <block type="maze_move">
-            <field name="DIR">moveForward</field>
-          </block>
-          <block type="maze_turn">
-            <field name="DIR">turnLeft</field>
-          </block>
-        </category>
+        <block type="maze_move">
+          <title name="DIR">moveForward</title>
+        </block>
+        <block type="maze_turn">
+          <title name="DIR">turnRight</title>
+        </block>
+        <block type="maze_turn">
+          <title name="DIR">turnLeft</title>
+        </block>
+        <block type="controls_repeat_dropdown">
+          <title name="TIMES" config="3-10">???</title>
+        </block>
+        <block type="collector_collect"/>
       </xml>
     </toolbox_blocks>
     <solution_blocks>

--- a/dashboard/config/scripts/levels/courseC_collector_prog22022.level
+++ b/dashboard/config/scripts/levels/courseC_collector_prog22022.level
@@ -1,7 +1,7 @@
 <Karel>
   <config><![CDATA[{
   "game_id": 25,
-  "created_at": "2022-01-06T19:46:18.000Z",
+  "created_at": "2023-03-21T08:34:16.000Z",
   "level_num": "custom",
   "user_id": 285,
   "properties": {
@@ -27,8 +27,8 @@
     "flower_type": "redWithNectar",
     "fast_get_nectar_animation": "false",
     "short_instructions": "Move Laurel to the treasure, then use `collect` to pick it up.",
-    "long_instructions": "Move Laurel to the treasure, then use the <xml><block type=\"collector_collect\" block-text=\"collect\"/></xml> block to pick it up.",
-    "authored_hints": "[{\"hint_class\":\"content\",\"hint_markdown\":\"You can use four <xml><block type=\\\"maze_move\\\"><title name=\\\"DIR\\\">moveForward</title></block></xml> blocks or use the <xml><block type=\\\"controls_repeat_dropdown\\\"><title name=\\\"TIMES\\\" config=\\\"3-10\\\">???</title></block></xml> block to make your program shorter.\",\"hint_id\":\"courseC_collector_prog2_a\",\"hint_type\":\"general\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/35f1470dc2ad2afc815155e695ef6e9b/courseC_collector_prog2.mp3\"},{\"hint_class\":\"pointer\",\"hint_markdown\":\"Don't be afraid to make a mistake! Try adding blocks and running the code to see what will happen, even if you don't think you've solved the puzzle yet.\",\"hint_id\":\"courseC_collector_prog2_b\",\"hint_type\":\"general\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/249f9a599d949ae950f131138cdd91b7/courseC_collector_prog2.mp3\"}]",
+    "long_instructions": "Move Laurel to the treasure, then use the <xml><block type=\"collector_collect\" block-text=\"collect\"/></xml> \r\n block to pick it up.",
+    "authored_hints": "[{\"hint_class\":\"content\",\"hint_markdown\":\"You can use four <xml><block type=\\\"maze_move\\\"><title name=\\\"DIR\\\">moveForward</title></block></xml> blocks or use the <xml><block type=\\\"controls_repeat_dropdown\\\"><title name=\\\"TIMES\\\" config=\\\"3-10\\\">???</title></block></xml> block to make your program shorter.\",\"hint_id\":\"courseC_collector_prog2_a\",\"hint_type\":\"general\",\"hint_path\":\"\",\"hint_video\":\"\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/35f1470dc2ad2afc815155e695ef6e9b/courseC_collector_prog22022.mp3\"},{\"hint_class\":\"pointer\",\"hint_markdown\":\"Don't be afraid to make a mistake! Try adding blocks and running the code to see what will happen, even if you don't think you've solved the puzzle yet.\",\"hint_id\":\"courseC_collector_prog2_b\",\"hint_type\":\"general\",\"hint_path\":\"\",\"hint_video\":\"\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/249f9a599d949ae950f131138cdd91b7/courseC_collector_prog22022.mp3\"}]",
     "instructions_important": "false",
     "min_collected": "1",
     "hide_share_and_remix": "false",
@@ -42,12 +42,12 @@
     "mini_rubric": "false",
     "top_level_procedure_autopopulate": "false",
     "show_type_hints": "false",
-    "preload_asset_list": null,
-    "contained_level_names": null
+    "hint_prompt_attempts_threshold": "1",
+    "preload_asset_list": null
   },
   "published": true,
   "notes": "Not enough blocks in workspace puzzle",
-  "audit_log": "[{\"changed_at\":\"2022-01-06T19:46:18.705+00:00\",\"changed\":[\"cloned from \\\"courseC_collector_prog2_2021\\\"\"],\"cloned_from\":\"courseC_collector_prog2_2021\"}]",
+  "audit_log": "[{\"changed_at\":\"2022-01-06T19:46:18.705+00:00\",\"changed\":[\"cloned from \\\"courseC_collector_prog2_2021\\\"\"],\"cloned_from\":\"courseC_collector_prog2_2021\"},{\"changed_at\":\"2023-05-23 12:44:21 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-23 18:54:53 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"long_instructions\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-23 18:57:13 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"long_instructions\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-23 19:08:08 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"long_instructions\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-26 11:45:17 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 17:09:59 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:23:38 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:25:12 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:34:06 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:34:55 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"}]",
   "level_concept_difficulty": {
     "sequencing": 3,
     "repeat_loops": 1
@@ -61,19 +61,20 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="maze_move">
-          <title name="DIR">moveForward</title>
-        </block>
-        <block type="maze_turn">
-          <title name="DIR">turnRight</title>
-        </block>
-        <block type="maze_turn">
-          <title name="DIR">turnLeft</title>
-        </block>
-        <block type="controls_repeat_dropdown">
-          <title name="TIMES" config="3-10">???</title>
-        </block>
-        <block type="collector_collect"/>
+        <category name="K1 blocks">
+          <block type="controls_repeat_simplified">
+            <field name="TIMES">5</field>
+          </block>
+          <block type="maze_moveNorth"/>
+        </category>
+        <category name="Actions">
+          <block type="maze_move">
+            <field name="DIR">moveForward</field>
+          </block>
+          <block type="maze_turn">
+            <field name="DIR">turnLeft</field>
+          </block>
+        </category>
       </xml>
     </toolbox_blocks>
     <solution_blocks>

--- a/dashboard/config/scripts/levels/poetry_module_conditionals_practice_2023.level
+++ b/dashboard/config/scripts/levels/poetry_module_conditionals_practice_2023.level
@@ -1,9 +1,5 @@
 <Poetry>
   <config><![CDATA[{
-  "game_id": 69,
-  "created_at": "2023-03-21T08:34:16.000Z",
-  "level_num": "custom",
-  "user_id": 13468,
   "properties": {
     "encrypted": "false",
     "skin": "gamelab",
@@ -21,7 +17,7 @@
     "embed": "false",
     "callout_json": "[]",
     "instructions_important": "false",
-    "long_instructions": "*You can use different effects or sprites based on the words the user chooses.*\r\n\r\n* Add an `if` block under one of the events in your code.\r\n* Select a variable that will already have a value, and word that the user might pick.\r\n* Inside the `if` block, add more code that will happen if the right word is selected. \r\n\r\n<xml><block type=\"gamelab_ifVarEquals\">\r\n      <title name=\"NUM\">animal</title>\r\n      <value name=\"VAL\">\r\n        <block type=\"Poetry_stringValue\">\r\n          <title name=\"TEXT\">Octopus</title>\r\n        </block>\r\n      </value>\r\n    </block></xml>",
+    "long_instructions": "*You can use different effects or sprites based on the words the user chooses.*\r\n\r\n* Add an `if` block under one of the events in your code.\r\n* Select a variable that will already have a value, and word that the user might pick.\r\n* Inside the `if` block, add more code that will happen if the right word is selected.\r\n\r\n<xml><block type=\"gamelab_ifVarEquals\">\r\n      <title name=\"NUM\">animal</title>\r\n      <value name=\"VAL\">\r\n        <block type=\"Poetry_stringValue\">\r\n          <title name=\"TEXT\">Octopus</title>\r\n        </block>\r\n      </value>\r\n    </block></xml>",
     "submittable": "false",
     "hide_share_and_remix": "true",
     "never_autoplay_video": "false",
@@ -46,8 +42,12 @@
     "name_suffix": "_2023",
     "preload_asset_list": null
   },
+  "game_id": 69,
   "published": true,
-  "audit_log": "[{\"changed_at\":\"2023-03-09T15:17:20.991+00:00\",\"changed\":[\"cloned from \\\"poetry_module_conditionals_practice\\\"\"],\"cloned_from\":\"poetry_module_conditionals_practice\"},{\"changed_at\":\"2023-03-14 21:23:41 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"project_template_level_name\",\"encrypted_examples\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1196,\"changed_by_email\":\"amy.woodman@code.org\"},{\"changed_at\":\"2023-05-26 10:42:07 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-26 11:02:07 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"long_instructions\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-26 11:45:21 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 14:24:49 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 14:26:42 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 14:27:31 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 14:36:02 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:12:24 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:13:18 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:39:35 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:41:24 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:41:52 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:43:26 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:44:35 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:47:29 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:51:08 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 18:47:14 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 18:48:12 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 18:48:45 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 18:49:22 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:04:44 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:05:16 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:17:21 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:29:43 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:31:41 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:36:24 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:42:44 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:48:50 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:51:11 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:52:57 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:05:55 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:08:17 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:09:35 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:16:48 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:17:09 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:18:51 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:19:45 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:00:31 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:00:46 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:23:23 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:30:45 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:31:28 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:32:33 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:33:23 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:36:59 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:37:14 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:37:31 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:37:58 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:38:23 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:38:42 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:39:41 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:40:08 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:41:37 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:42:04 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:42:38 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:42:55 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:43:15 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:44:46 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:45:44 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:47:43 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:48:40 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"}]",
+  "created_at": "2023-03-09T15:17:20.000Z",
+  "level_num": "custom",
+  "user_id": 13468,
+  "audit_log": "[{\"changed_at\":\"2023-03-09T15:17:20.991+00:00\",\"changed\":[\"cloned from \\\"poetry_module_conditionals_practice\\\"\"],\"cloned_from\":\"poetry_module_conditionals_practice\"},{\"changed_at\":\"2023-03-14 21:23:41 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"project_template_level_name\",\"encrypted_examples\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1196,\"changed_by_email\":\"amy.woodman@code.org\"}]",
   "level_concept_difficulty": {
   }
 }]]></config>
@@ -59,14 +59,185 @@
       </xml>
     </start_blocks>
     <toolbox_blocks>
-      <xml xmlns="https://developers.google.com/blockly/xml">
-        <category name="Default">
-          <block type="gamelab_checkTouching" id="Jw-TImW`f8Tc)N9,LrU|" x="147" y="55">
-            <field name="CONDITION">"when"</field>
+      <xml>
+        <category name="Events">
+          <block type="Poetry_whenLineShows">
+            <title name="N">0</title>
           </block>
-          <block type="gamelab_addBehaviorSimple" id="@`D-9i4UF7,qkzn__a~c" x="31" y="84"/>
+          <block type="gamelab_whenAllPromptsAnswered"/>
         </category>
-        <category name="Functions" custom="PROCEDURE"/>
+        <category name="Text">
+          <block type="Poetry_setTitle">
+            <value name="TITLE">
+              <shadow type="text">
+                <title name="TEXT"/>
+              </shadow>
+              <block type="gamelab_textJoin">
+                <title name="TEXT1"/>
+              </block>
+            </value>
+          </block>
+          <block type="Poetry_setAuthor">
+            <value name="AUTHOR">
+              <shadow type="text">
+                <title name="TEXT"/>
+              </shadow>
+              <block type="gamelab_textJoin">
+                <title name="TEXT1"/>
+              </block>
+            </value>
+          </block>
+          <block type="Poetry_addLine">
+            <value name="LINE">
+              <shadow type="text">
+                <title name="TEXT"/>
+              </shadow>
+              <block type="gamelab_textJoin">
+                <title name="TEXT1"/>
+              </block>
+            </value>
+          </block>
+          <block type="Poetry_animateText"/>
+          <block type="gamelab_textJoin">
+            <title name="TEXT1"/>
+          </block>
+        </category>
+        <category name="Variables">
+          <block type="gamelab_setPrompt">
+            <value name="QUESTION">
+              <shadow type="text" can_disconnect_from_parent="false">
+                <title name="TEXT"/>
+              </shadow>
+            </value>
+            <value name="VAR">
+              <block type="variables_get" movable="false">
+                <title name="VAR">???</title>
+              </block>
+            </value>
+          </block>
+          <block type="gamelab_setPromptWithChoices">
+            <value name="QUESTION">
+              <shadow type="text" can_disconnect_from_parent="false">
+                <title name="TEXT"/>
+              </shadow>
+            </value>
+            <value name="VAR">
+              <block type="variables_get" movable="false">
+                <title name="VAR">???</title>
+              </block>
+            </value>
+            <value name="A">
+              <shadow type="Poetry_stringValue" can_disconnect_from_parent="false">
+                <title name="TEXT"/>
+              </shadow>
+            </value>
+            <value name="B">
+              <shadow type="Poetry_stringValue" can_disconnect_from_parent="false">
+                <title name="TEXT"/>
+              </shadow>
+            </value>
+            <value name="C">
+              <shadow type="Poetry_stringValue" can_disconnect_from_parent="false">
+                <title name="TEXT"/>
+              </shadow>
+            </value>
+          </block>
+          <block type="gamelab_textVariableJoin">
+            <title name="VAR">???</title>
+          </block>
+        </category>
+        <category name="Effects">
+          <block type="Poetry_setFont">
+            <title name="FONT">"Courier"</title>
+          </block>
+          <block type="Poetry_setFontColor">
+            <value name="FILL">
+              <shadow type="colour_picker">
+                <title name="COLOUR">#99ff99</title>
+              </shadow>
+            </value>
+          </block>
+          <block type="Poetry_setTextEffect">
+            <title name="EFFECT">"fade"</title>
+          </block>
+          <block type="Poetry_addTextHighlight">
+            <value name="COLOR">
+              <shadow type="colour_picker" can_disconnect_from_parent="false">
+                <title name="COLOUR">#99ff99</title>
+              </shadow>
+            </value>
+          </block>
+          <block type="Poetry_playSound">
+            <title name="SOUND">"sound://category_loops/vibrant_game_welcome_to_heaven_loop_1.mp3"</title>
+          </block>
+          <block type="Poetry_playMusic">
+            <title name="SOUND">"placeholder"</title>
+          </block>
+          <block type="Poetry_setForegroundEffect">
+            <title name="EFFECT">"rain"</title>
+          </block>
+          <block type="Poetry_addFrame">
+            <title name="BRUSH">"rainbow"</title>
+          </block>
+          <block type="Poetry_setBackground">
+            <value name="COLOR">
+              <shadow type="colour_picker">
+                <title name="COLOUR">#cc0000</title>
+              </shadow>
+            </value>
+          </block>
+          <block type="Poetry_setBackgroundImageAs">
+            <title name="IMG">"cave"</title>
+          </block>
+          <block type="Poetry_setBackgroundEffect">
+            <title name="EFFECT">"colors"</title>
+            <title name="PALETTE">"grayscale"</title>
+          </block>
+        </category>
+        <category name="Sprites">
+          <block type="Poetry_makeNewSpriteAnon">
+            <title name="ANIMATION_NAME">"bear"</title>
+            <title name="LOCATION">{"x":75,"y":200}</title>
+          </block>
+          <block type="Poetry_setSize">
+            <title name="SPRITE">"bear"</title>
+            <title name="VAL">50</title>
+          </block>
+          <block type="Poetry_startBehavior">
+            <title name="ANIMATION_NAME">"bear"</title>
+            <title name="BEHAVIOR">fluttering</title>
+          </block>
+          <block type="Poetry_stopBehavior">
+            <title name="ANIMATION_NAME">"bear"</title>
+            <title name="BEHAVIOR">fluttering</title>
+          </block>
+          <block type="Poetry_destroy">
+            <title name="ANIMATION_NAME">"bear"</title>
+          </block>
+          <block type="Poetry_makeBurst">
+            <title name="EFFECT">"burst"</title>
+            <title name="NUM">10</title>
+            <title name="ANIMATION_NAME">"bear"</title>
+          </block>
+          <block type="Poetry_makeNumSprites">
+            <title name="NUM">3</title>
+            <title name="ANIMATION_NAME">"bear"</title>
+          </block>
+          <block type="Poetry_glideTo" id="26">
+            <title name="SPRITE">"night_cloud"</title>
+            <title name="LOCATION">{"x": 200, "y": 200}</title>
+          </block>
+        </category>
+        <category name="Logic">
+          <block type="gamelab_ifVarEquals">
+            <title name="NUM">???</title>
+            <value name="VAL">
+              <shadow type="Poetry_stringValue">
+                <title name="TEXT"/>
+              </shadow>
+            </value>
+          </block>
+        </category>
       </xml>
     </toolbox_blocks>
   </blocks>

--- a/dashboard/config/scripts/levels/poetry_module_conditionals_practice_2023.level
+++ b/dashboard/config/scripts/levels/poetry_module_conditionals_practice_2023.level
@@ -1,5 +1,9 @@
 <Poetry>
   <config><![CDATA[{
+  "game_id": 69,
+  "created_at": "2023-03-21T08:34:16.000Z",
+  "level_num": "custom",
+  "user_id": 13468,
   "properties": {
     "encrypted": "false",
     "skin": "gamelab",
@@ -17,7 +21,7 @@
     "embed": "false",
     "callout_json": "[]",
     "instructions_important": "false",
-    "long_instructions": "*You can use different effects or sprites based on the words the user chooses.*\r\n\r\n* Add an `if` block under one of the events in your code.\r\n* Select a variable that will already have a value, and word that the user might pick.\r\n* Inside the `if` block, add more code that will happen if the right word is selected.\r\n\r\n<xml><block type=\"gamelab_ifVarEquals\">\r\n      <title name=\"NUM\">animal</title>\r\n      <value name=\"VAL\">\r\n        <block type=\"Poetry_stringValue\">\r\n          <title name=\"TEXT\">Octopus</title>\r\n        </block>\r\n      </value>\r\n    </block></xml>",
+    "long_instructions": "*You can use different effects or sprites based on the words the user chooses.*\r\n\r\n* Add an `if` block under one of the events in your code.\r\n* Select a variable that will already have a value, and word that the user might pick.\r\n* Inside the `if` block, add more code that will happen if the right word is selected. \r\n\r\n<xml><block type=\"gamelab_ifVarEquals\">\r\n      <title name=\"NUM\">animal</title>\r\n      <value name=\"VAL\">\r\n        <block type=\"Poetry_stringValue\">\r\n          <title name=\"TEXT\">Octopus</title>\r\n        </block>\r\n      </value>\r\n    </block></xml>",
     "submittable": "false",
     "hide_share_and_remix": "true",
     "never_autoplay_video": "false",
@@ -42,12 +46,8 @@
     "name_suffix": "_2023",
     "preload_asset_list": null
   },
-  "game_id": 69,
   "published": true,
-  "created_at": "2023-03-09T15:17:20.000Z",
-  "level_num": "custom",
-  "user_id": 13468,
-  "audit_log": "[{\"changed_at\":\"2023-03-09T15:17:20.991+00:00\",\"changed\":[\"cloned from \\\"poetry_module_conditionals_practice\\\"\"],\"cloned_from\":\"poetry_module_conditionals_practice\"},{\"changed_at\":\"2023-03-14 21:23:41 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"project_template_level_name\",\"encrypted_examples\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1196,\"changed_by_email\":\"amy.woodman@code.org\"}]",
+  "audit_log": "[{\"changed_at\":\"2023-03-09T15:17:20.991+00:00\",\"changed\":[\"cloned from \\\"poetry_module_conditionals_practice\\\"\"],\"cloned_from\":\"poetry_module_conditionals_practice\"},{\"changed_at\":\"2023-03-14 21:23:41 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"project_template_level_name\",\"encrypted_examples\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1196,\"changed_by_email\":\"amy.woodman@code.org\"},{\"changed_at\":\"2023-05-26 10:42:07 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-26 11:02:07 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"long_instructions\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-26 11:45:21 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 14:24:49 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 14:26:42 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 14:27:31 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 14:36:02 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:12:24 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:13:18 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:39:35 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:41:24 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:41:52 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:43:26 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:44:35 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:47:29 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 16:51:08 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 18:47:14 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 18:48:12 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 18:48:45 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 18:49:22 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:04:44 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:05:16 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:17:21 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:29:43 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:31:41 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:36:24 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:42:44 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:48:50 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:51:11 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 19:52:57 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:05:55 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:08:17 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"encrypted_examples\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:09:35 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:16:48 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:17:09 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:18:51 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-30 20:19:45 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:00:31 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:00:46 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:23:23 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:30:45 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:31:28 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:32:33 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:33:23 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:36:59 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:37:14 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:37:31 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:37:58 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:38:23 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:38:42 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:39:41 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:40:08 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:41:37 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:42:04 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:42:38 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:42:55 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:43:15 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:44:46 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:45:44 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:47:43 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-05-31 09:48:40 -0500\",\"changed\":[\"toolbox_blocks\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"}]",
   "level_concept_difficulty": {
   }
 }]]></config>
@@ -59,185 +59,14 @@
       </xml>
     </start_blocks>
     <toolbox_blocks>
-      <xml>
-        <category name="Events">
-          <block type="Poetry_whenLineShows">
-            <title name="N">0</title>
+      <xml xmlns="https://developers.google.com/blockly/xml">
+        <category name="Default">
+          <block type="gamelab_checkTouching" id="Jw-TImW`f8Tc)N9,LrU|" x="147" y="55">
+            <field name="CONDITION">"when"</field>
           </block>
-          <block type="gamelab_whenAllPromptsAnswered"/>
+          <block type="gamelab_addBehaviorSimple" id="@`D-9i4UF7,qkzn__a~c" x="31" y="84"/>
         </category>
-        <category name="Text">
-          <block type="Poetry_setTitle">
-            <value name="TITLE">
-              <shadow type="text">
-                <title name="TEXT"/>
-              </shadow>
-              <block type="gamelab_textJoin">
-                <title name="TEXT1"/>
-              </block>
-            </value>
-          </block>
-          <block type="Poetry_setAuthor">
-            <value name="AUTHOR">
-              <shadow type="text">
-                <title name="TEXT"/>
-              </shadow>
-              <block type="gamelab_textJoin">
-                <title name="TEXT1"/>
-              </block>
-            </value>
-          </block>
-          <block type="Poetry_addLine">
-            <value name="LINE">
-              <shadow type="text">
-                <title name="TEXT"/>
-              </shadow>
-              <block type="gamelab_textJoin">
-                <title name="TEXT1"/>
-              </block>
-            </value>
-          </block>
-          <block type="Poetry_animateText"/>
-          <block type="gamelab_textJoin">
-            <title name="TEXT1"/>
-          </block>
-        </category>
-        <category name="Variables">
-          <block type="gamelab_setPrompt">
-            <value name="QUESTION">
-              <shadow type="text" can_disconnect_from_parent="false">
-                <title name="TEXT"/>
-              </shadow>
-            </value>
-            <value name="VAR">
-              <block type="variables_get" movable="false">
-                <title name="VAR">???</title>
-              </block>
-            </value>
-          </block>
-          <block type="gamelab_setPromptWithChoices">
-            <value name="QUESTION">
-              <shadow type="text" can_disconnect_from_parent="false">
-                <title name="TEXT"/>
-              </shadow>
-            </value>
-            <value name="VAR">
-              <block type="variables_get" movable="false">
-                <title name="VAR">???</title>
-              </block>
-            </value>
-            <value name="A">
-              <shadow type="Poetry_stringValue" can_disconnect_from_parent="false">
-                <title name="TEXT"/>
-              </shadow>
-            </value>
-            <value name="B">
-              <shadow type="Poetry_stringValue" can_disconnect_from_parent="false">
-                <title name="TEXT"/>
-              </shadow>
-            </value>
-            <value name="C">
-              <shadow type="Poetry_stringValue" can_disconnect_from_parent="false">
-                <title name="TEXT"/>
-              </shadow>
-            </value>
-          </block>
-          <block type="gamelab_textVariableJoin">
-            <title name="VAR">???</title>
-          </block>
-        </category>
-        <category name="Effects">
-          <block type="Poetry_setFont">
-            <title name="FONT">"Courier"</title>
-          </block>
-          <block type="Poetry_setFontColor">
-            <value name="FILL">
-              <shadow type="colour_picker">
-                <title name="COLOUR">#99ff99</title>
-              </shadow>
-            </value>
-          </block>
-          <block type="Poetry_setTextEffect">
-            <title name="EFFECT">"fade"</title>
-          </block>
-          <block type="Poetry_addTextHighlight">
-            <value name="COLOR">
-              <shadow type="colour_picker" can_disconnect_from_parent="false">
-                <title name="COLOUR">#99ff99</title>
-              </shadow>
-            </value>
-          </block>
-          <block type="Poetry_playSound">
-            <title name="SOUND">"sound://category_loops/vibrant_game_welcome_to_heaven_loop_1.mp3"</title>
-          </block>
-          <block type="Poetry_playMusic">
-            <title name="SOUND">"placeholder"</title>
-          </block>
-          <block type="Poetry_setForegroundEffect">
-            <title name="EFFECT">"rain"</title>
-          </block>
-          <block type="Poetry_addFrame">
-            <title name="BRUSH">"rainbow"</title>
-          </block>
-          <block type="Poetry_setBackground">
-            <value name="COLOR">
-              <shadow type="colour_picker">
-                <title name="COLOUR">#cc0000</title>
-              </shadow>
-            </value>
-          </block>
-          <block type="Poetry_setBackgroundImageAs">
-            <title name="IMG">"cave"</title>
-          </block>
-          <block type="Poetry_setBackgroundEffect">
-            <title name="EFFECT">"colors"</title>
-            <title name="PALETTE">"grayscale"</title>
-          </block>
-        </category>
-        <category name="Sprites">
-          <block type="Poetry_makeNewSpriteAnon">
-            <title name="ANIMATION_NAME">"bear"</title>
-            <title name="LOCATION">{"x":75,"y":200}</title>
-          </block>
-          <block type="Poetry_setSize">
-            <title name="SPRITE">"bear"</title>
-            <title name="VAL">50</title>
-          </block>
-          <block type="Poetry_startBehavior">
-            <title name="ANIMATION_NAME">"bear"</title>
-            <title name="BEHAVIOR">fluttering</title>
-          </block>
-          <block type="Poetry_stopBehavior">
-            <title name="ANIMATION_NAME">"bear"</title>
-            <title name="BEHAVIOR">fluttering</title>
-          </block>
-          <block type="Poetry_destroy">
-            <title name="ANIMATION_NAME">"bear"</title>
-          </block>
-          <block type="Poetry_makeBurst">
-            <title name="EFFECT">"burst"</title>
-            <title name="NUM">10</title>
-            <title name="ANIMATION_NAME">"bear"</title>
-          </block>
-          <block type="Poetry_makeNumSprites">
-            <title name="NUM">3</title>
-            <title name="ANIMATION_NAME">"bear"</title>
-          </block>
-          <block type="Poetry_glideTo" id="26">
-            <title name="SPRITE">"night_cloud"</title>
-            <title name="LOCATION">{"x": 200, "y": 200}</title>
-          </block>
-        </category>
-        <category name="Logic">
-          <block type="gamelab_ifVarEquals">
-            <title name="NUM">???</title>
-            <value name="VAL">
-              <shadow type="Poetry_stringValue">
-                <title name="TEXT"/>
-              </shadow>
-            </value>
-          </block>
-        </category>
+        <category name="Functions" custom="PROCEDURE"/>
       </xml>
     </toolbox_blocks>
   </blocks>


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
## Summary
This PR fixes a current bug in Google Blockly labs - when a toolbox contains categories and it is edited via the levelbuilder GUI using the Blockly interface, the categories are converted to blocks. However, the category blocks are not being converted back into the toolbox categories.

BEFORE UPDATE:
![image](https://github.com/code-dot-org/code-dot-org/assets/107423305/cd4d571e-139c-451c-bf94-93455a1b53bb)


Levelbuilder allows levelbuilders (i.e., curriculum writers) to use the Blockly interface to define a set of toolbox blocks. To create a categorized toolbox, there are special pink category blocks `<block type=”category”>` that are created (see image below) so that levelbuilders can manipulate which blocks should be contained within a given category. 


<img width="630" alt="Screen Shot 2023-05-31 at 2 43 03 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/fa34258b-7264-44af-bfa4-8313bb102777">


Once the toolbox is saved, the temporary category blocks should be serialized as `<category>` elements containing `<block>` elements. 

<img width="521" alt="Screen Shot 2023-05-31 at 2 39 27 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/d85d8913-3454-4732-8576-91e74456f9e8">

There were a couple additional issues which were resolved that are described in detail below.

## Implementation Details
I updated two functions in `levels/blockly.rb`:
- `convert_toolbox_to_category` - converts category blocks to category tags (when toolbox is saved)
- `convert_category_to_toolbox` - converts category tags to category blocks (in toolbox edit mode)

`Nokogiri::XML` is used to parse the stringified xml that stores the toolbox blocks and categories. When `xml.xpath` is used to traverse the blocks in the xml tree, `xml.xpath(/xml/block)` is used to access all blocks in xml and `xml.xpath(/xml/category)` is used to access all category tags. However, Google Blockly labs use the namespace `xmlns="https://developers.google.com/blockly/xml"` within the xml tag in order to disambiguate different types of xml tags. The addition of this namespace in Google Blockly labs means that `xml.xpath` is not accessing the blocks and categories while it is in CDO Blockly labs. To resolve this, I decided to temporarily remove the namespace from `xml_string`, and then add it back at the end after the conversion process.

Note that in mainline Blockly, this is done in a similar fashion in multiple places. Here is [an example](https://github.com/google/blockly/blob/6bae8a4b928741aeeaab516f0491da5613f0ebab/core/field.ts#L472) in `field.ts`. 

There were two additional issues that arose after the toolbox conversion was fixed.

1. Category blocks were placed on top of other blocks in the toolbox editor. The reason category blocks were not being placed correctly is that category blocks do not include x and y coordinates while other blocks do. 

<img width="438" alt="Screen Shot 2023-05-31 at 3 25 32 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/4c0d56fa-12a2-4ec4-9d32-14fb9db51710">

Thus, I remove the x and y coordinates of blocks before the toolbox is saved [here](https://github.com/code-dot-org/code-dot-org/blob/406d3b2795ef31b48dc215123ed2dc1b012d07fc/dashboard/app/models/levels/blockly.rb#L216-L217), so that the logic in [`cdoXml.js`](https://github.com/code-dot-org/code-dot-org/blob/5b7a9e0b4bde11eb60cd7d1042b8dbe0cdf4ec17/apps/src/blockly/addons/cdoXml.js#L87) places all the toolbox edit mode blocks in a sequence without overlap or gaps with the help of the `cursor`.


2. When a toolbox contains only custom categories ('Auto-populated Category') , the categories are not being converted into the toolbox categories and the blocks included in each custom category are not being displayed. (See image below). 

BEFORE UPDATE:
<img width="618" alt="Screen Shot 2023-05-31 at 2 57 46 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/02522583-b96b-4d7a-aca3-c0e262f4eb23">

This issue was resolved by adding another condition before the early `return` in `convert_toolbox_to_category` [here](https://github.com/code-dot-org/code-dot-org/blob/406d3b2795ef31b48dc215123ed2dc1b012d07fc/dashboard/app/models/levels/blockly.rb#L196).
If there are either 'category' blocks or 'custom_category' blocks, then we want to convert these blocks to category tags.

AFTER UPDATE video:


https://github.com/code-dot-org/code-dot-org/assets/107423305/1c40ad1e-e96c-472d-b50b-4703c58696a8


## Links
[jira ticket](https://codedotorg.atlassian.net/browse/SL-877)

## Testing story
I tested locally in both Google Blockly and CDO Blockly levelbuilder toolbox editors.


## Deployment strategy



## Follow-up work

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
