### PR TITLE
automatic recreation of expired certs

### DIFF
--- a/aws/cloudformation/update_certs
+++ b/aws/cloudformation/update_certs
@@ -27,12 +27,32 @@ end
 
 common_name = ARGV[0]
 required_certs = ARGV.dup
+
+def get_certificate_expiration(common_name)
+  # Run the Acmesmith command using Ruby's system-level command execution and capture its output
+  certificate_info = `acmesmith show-certificate #{common_name}`
+  not_after_line = certificate_info.split("\n").find { |line| line =~ /Not After/ }
+  not_after = Date.parse(not_after_line.split(': ').last)
+  return not_after;
+end
+
 begin
-  Acmesmith::Command.start ['current', common_name]
-rescue
-  CDO.log.info "Authorizing SSL certificates for #{common_name}"
-  required_certs.each do |auth|
-    Acmesmith::Command.start ['authorize', auth]
+  CDO.log.info "Checking for existing certificate for #{common_name}..."
+  Acmesmith::Command.start ['current', common_name] rescue raise 'cert not found'
+
+  CDO.log.info "Existing certificate found, checking expiration..."
+  expiration_date = get_certificate_expiration(common_name)
+  raise 'cert expired' if expiration_date < Date.today
+  CDO.log.info "Existing certificate for #{common_name} is valid until #{expiration_date}."
+rescue => e
+  case e.message
+  when 'cert not found'
+    CDO.log.info "No existing certificate found for #{common_name}. Authorizing a new one."
+  when 'cert expired'
+    CDO.log.info "Existing certificate for #{common_name} is expired. Requesting a new one."
+  else
+    raise e
   end
-  Acmesmith::Command.start ['request'].concat(required_certs)
+
+  Acmesmith::Command.start ['order'].concat(required_certs)
 end

--- a/aws/cloudformation/update_certs
+++ b/aws/cloudformation/update_certs
@@ -31,12 +31,15 @@ required_certs = ARGV.dup
 def get_certificate_expiration(common_name)
   # Run the Acmesmith command using Ruby's system-level command execution and capture its output
   certificate_info = `acmesmith show-certificate #{common_name}`
-  not_after_line = certificate_info.split("\n").find { |line| line =~ /Not After/ }
+  not_after_line = certificate_info.split("\n").find {|line| line.include?('Not After')}
   not_after = Date.parse(not_after_line.split(': ').last)
-  return not_after;
+  return not_after
 end
 
 begin
+  # Uncomment to force regeneration of a new certificate
+  # raise 'new cert'
+
   CDO.log.info "Checking for existing certificate for #{common_name}..."
   Acmesmith::Command.start ['current', common_name] rescue raise 'cert not found'
 
@@ -44,15 +47,18 @@ begin
   expiration_date = get_certificate_expiration(common_name)
   raise 'cert expired' if expiration_date < Date.today
   CDO.log.info "Existing certificate for #{common_name} is valid until #{expiration_date}."
-rescue => e
-  case e.message
+rescue => exception
+  case exception.message
   when 'cert not found'
-    CDO.log.info "No existing certificate found for #{common_name}. Authorizing a new one."
+    CDO.log.info "No existing certificate found for #{common_name}."
   when 'cert expired'
-    CDO.log.info "Existing certificate for #{common_name} is expired. Requesting a new one."
+    CDO.log.info "Existing certificate for #{common_name} is expired."
+  when 'new cert'
+    CDO.log.info "'new cert' error manually raised."
   else
-    raise e
+    raise exception
   end
 
+  CDO.log.info "Requesting new certificate for #{required_certs}"
   Acmesmith::Command.start ['order'].concat(required_certs)
 end


### PR DESCRIPTION
Our internal doc "How to update adhoc certificates" instructs the user to modify the script to raise an exception on a certain line. This modification allows the script to automatically discover expired certs and request a new one.

* detect expired certs
* switch to Acmesmith `order` instead of the deprecated `authorize` + `request` flow

## Links

- [Acmesmith docs](https://github.com/sorah/acmesmith)
- Jira [INF-898](https://codedotorg.atlassian.net/browse/INF-898)

## Testing story

Running the code with line 57 commented returns the following output:

```
> bundle exec ./update_certs adhoc-bugcrowd.cdn-code.org

Checking for existing certificate for adhoc-bugcrowd.cdn-code.org...
20230531-172230_4e6753fc8d9f5a7eab0d78f22a59c20afad
Existing certificate found, checking expiration...
Existing certificate for adhoc-bugcrowd.cdn-code.org is valid until 2023-08-29.
```

## Deployment strategy

This script is manually executed. It should be merged into `bugcrowd` as part of #52159 

## Follow-up work

#52159 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
