### PR TITLE
Add tooltip on Curriculum Catalog Card Labels

### DIFF
--- a/apps/src/templates/curriculumCatalog/CardLabels.jsx
+++ b/apps/src/templates/curriculumCatalog/CardLabels.jsx
@@ -33,7 +33,9 @@ const CardLabels = ({subjectsAndTopics}) => (
           </LabelTooltip>
         )}
       >
-        <div tabIndex="0">{subjectsAndTopics[0]}</div>
+        <div tabIndex="0" role="note">
+          {subjectsAndTopics[0]}
+        </div>
       </LabelOverlayTrigger>
     )}
     {subjectsAndTopics.length > 1 && (
@@ -50,7 +52,11 @@ const CardLabels = ({subjectsAndTopics}) => (
           </LabelTooltip>
         )}
       >
-        <div tabIndex="0">{`+${subjectsAndTopics.length - 1}`}</div>
+        <div
+          tabIndex="0"
+          role="note"
+          aria-label={subjectsAndTopics.slice(1).join(', ')}
+        >{`+${subjectsAndTopics.length - 1}`}</div>
       </LabelOverlayTrigger>
     )}
   </>

--- a/apps/src/templates/curriculumCatalog/CardLabels.jsx
+++ b/apps/src/templates/curriculumCatalog/CardLabels.jsx
@@ -1,0 +1,63 @@
+import {OverlayTrigger, Tooltip} from 'react-bootstrap-2';
+import React from 'react';
+import style from '@cdo/apps/templates/curriculumCatalog/curriculum_catalog_card.module.scss';
+import PropTypes from 'prop-types';
+
+// The arrowProps passed down in ReactBootstrap use styles that
+// conflict with the custom styles that we want, so they
+// are extracted out here.
+const LabelTooltip = React.forwardRef(
+  (
+    {arrowProps, ...props}, // eslint-disable-line react/prop-types
+    ref
+  ) => <Tooltip ref={ref} {...props} />
+);
+
+// Allow the tooltips to display on focus so that the information
+// can be shown via keyboard
+const LabelOverlayTrigger = props => (
+  <OverlayTrigger placement="top" trigger={['hover', 'focus']} {...props} />
+);
+
+const CardLabels = ({subjectsAndTopics}) => (
+  <>
+    {subjectsAndTopics.length > 0 && (
+      <LabelOverlayTrigger
+        overlay={props => (
+          <LabelTooltip
+            id="first-label-tooltip"
+            className={style.labelTooltip}
+            {...props}
+          >
+            {subjectsAndTopics[0]}
+          </LabelTooltip>
+        )}
+      >
+        <div tabIndex="0">{subjectsAndTopics[0]}</div>
+      </LabelOverlayTrigger>
+    )}
+    {subjectsAndTopics.length > 1 && (
+      <LabelOverlayTrigger
+        overlay={props => (
+          <LabelTooltip
+            id="remaining-labels-tooltip"
+            className={style.labelTooltip}
+            {...props}
+          >
+            {subjectsAndTopics.slice(1).map(label => (
+              <p key={label}>{label}</p>
+            ))}
+          </LabelTooltip>
+        )}
+      >
+        <div tabIndex="0">{`+${subjectsAndTopics.length - 1}`}</div>
+      </LabelOverlayTrigger>
+    )}
+  </>
+);
+
+CardLabels.propTypes = {
+  subjectsAndTopics: PropTypes.arrayOf(PropTypes.string),
+};
+
+export default CardLabels;

--- a/apps/src/templates/curriculumCatalog/CardLabels.jsx
+++ b/apps/src/templates/curriculumCatalog/CardLabels.jsx
@@ -33,7 +33,7 @@ const CardLabels = ({subjectsAndTopics}) => (
           </LabelTooltip>
         )}
       >
-        <div tabIndex="0" role="note">
+        <div tabIndex="0" role="tooltip">
           {subjectsAndTopics[0]}
         </div>
       </LabelOverlayTrigger>
@@ -54,7 +54,7 @@ const CardLabels = ({subjectsAndTopics}) => (
       >
         <div
           tabIndex="0"
-          role="note"
+          role="tooltip"
           aria-label={subjectsAndTopics.slice(1).join(', ')}
         >{`+${subjectsAndTopics.length - 1}`}</div>
       </LabelOverlayTrigger>

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -10,6 +10,7 @@ import {
   translatedCourseOfferingSchoolSubjects,
   translatedCourseOfferingDurations,
   subjectsAndTopicsOrder,
+  translatedLabels,
 } from '@cdo/apps/templates/teacherDashboard/CourseOfferingHelpers';
 import style from './curriculum_catalog_card.module.scss';
 import CardLabels from '@cdo/apps/templates/curriculumCatalog/CardLabels';
@@ -44,11 +45,7 @@ const CurriculumCatalogCard = ({
     subjectsAndTopics={intersection(
       subjectsAndTopicsOrder,
       concat(subjects, topics)
-    )?.map(
-      subject_or_topic_key =>
-        translatedCourseOfferingSchoolSubjects[subject_or_topic_key] ||
-        translatedCourseOfferingCsTopics[subject_or_topic_key]
-    )}
+    )?.map(subject_or_topic_key => translatedLabels[subject_or_topic_key])}
     quickViewButtonDescription={i18n.quickViewDescription({
       course_name: courseDisplayName,
     })}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import {Tooltip, OverlayTrigger} from 'react-bootstrap-2';
+import {concat, intersection} from 'lodash';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import Button from '@cdo/apps/templates/Button';
 import i18n from '@cdo/locale';
@@ -10,7 +12,6 @@ import {
   translatedCourseOfferingDurations,
   subjectsAndTopicsOrder,
 } from '@cdo/apps/templates/teacherDashboard/CourseOfferingHelpers';
-import {concat, intersection} from 'lodash';
 import style from './curriculum_catalog_card.module.scss';
 
 const CurriculumCatalogCard = ({
@@ -93,70 +94,110 @@ const CustomizableCurriculumCatalogCard = ({
   quickViewButtonText,
   isEnglish,
   pathToCourse,
-}) => (
-  <div
-    className={classNames(
-      style.curriculumCatalogCardContainer,
-      isEnglish
-        ? style.curriculumCatalogCardContainer_english
-        : style.curriculumCatalogCardContainer_notEnglish
-    )}
-  >
-    <img src={imageSrc} alt={imageAltText} />
-    <div className={style.curriculumInfoContainer}>
-      <div className={style.labelsAndTranslatabilityContainer}>
-        <div className={style.labelsContainer}>
-          {subjectsAndTopics.length > 0 && <div>{subjectsAndTopics[0]}</div>}
-          {subjectsAndTopics.length > 1 && (
-            <div>{`+${subjectsAndTopics.length - 1}`}</div>
+}) => {
+  const firstLabelText = subjectsAndTopics[0];
+  const renderFirstLabelTooltip = ({arrowProps, ...props}) => (
+    <Tooltip id="first-label-tooltip" className={style.labelTooltip} {...props}>
+      {firstLabelText}
+    </Tooltip>
+  );
+
+  const remainingLabelsNode = (
+    <>
+      {subjectsAndTopics.slice(1).map(label => (
+        <p key={label}>{label}</p>
+      ))}
+    </>
+  );
+  const renderRemainingLabelsTooltip = ({arrowProps, ...props}) => (
+    <Tooltip
+      id="remaining-labels-tooltip"
+      className={style.labelTooltip}
+      {...props}
+    >
+      {remainingLabelsNode}
+    </Tooltip>
+  );
+
+  return (
+    <div
+      className={classNames(
+        style.curriculumCatalogCardContainer,
+        isEnglish
+          ? style.curriculumCatalogCardContainer_english
+          : style.curriculumCatalogCardContainer_notEnglish
+      )}
+    >
+      <img src={imageSrc} alt={imageAltText} />
+      <div className={style.curriculumInfoContainer}>
+        <div className={style.labelsAndTranslatabilityContainer}>
+          <div className={style.labelsContainer}>
+            {subjectsAndTopics.length > 0 && (
+              <OverlayTrigger
+                placement="top"
+                trigger={['hover', 'focus']}
+                overlay={renderFirstLabelTooltip}
+              >
+                <div tabIndex="0">{subjectsAndTopics[0]}</div>
+              </OverlayTrigger>
+            )}
+            {subjectsAndTopics.length > 1 && (
+              <OverlayTrigger
+                placement="top"
+                trigger={['hover', 'focus']}
+                overlay={renderRemainingLabelsTooltip}
+              >
+                <div tabIndex="0">{`+${subjectsAndTopics.length - 1}`}</div>
+              </OverlayTrigger>
+            )}
+          </div>
+          {/*TODO [MEG]: Ensure this icon matches spec when we update FontAwesome */}
+          {isTranslated && (
+            <FontAwesome
+              icon="language"
+              className="fa-solid"
+              title={translationIconTitle}
+            />
           )}
         </div>
-        {/*TODO [MEG]: Ensure this icon matches spec when we update FontAwesome */}
-        {isTranslated && (
-          <FontAwesome
-            icon="language"
-            className="fa-solid"
-            title={translationIconTitle}
+        <h4>{courseDisplayName}</h4>
+        <div className={style.iconWithDescription}>
+          <FontAwesome icon="user" className="fa-solid" />
+          <p>{gradeRange}</p>
+        </div>
+        <div className={style.iconWithDescription}>
+          {/*TODO [MEG]: Update this to be clock fa-solid when we update FontAwesome */}
+          <FontAwesome icon="clock-o" />
+          <p>{duration}</p>
+        </div>
+        <div
+          className={classNames(
+            style.buttonsContainer,
+            isEnglish
+              ? style.buttonsContainer_english
+              : style.buttonsContainer_notEnglish
+          )}
+        >
+          <Button
+            __useDeprecatedTag
+            color={Button.ButtonColor.neutralDark}
+            type="button"
+            href={pathToCourse}
+            aria-label={quickViewButtonDescription}
+            text={quickViewButtonText}
           />
-        )}
-      </div>
-      <h4>{courseDisplayName}</h4>
-      <div className={style.iconWithDescription}>
-        <FontAwesome icon="user" className="fa-solid" />
-        <p>{gradeRange}</p>
-      </div>
-      <div className={style.iconWithDescription}>
-        {/*TODO [MEG]: Update this to be clock fa-solid when we update FontAwesome */}
-        <FontAwesome icon="clock-o" />
-        <p>{duration}</p>
-      </div>
-      <div
-        className={classNames(
-          style.buttonsContainer,
-          isEnglish
-            ? style.buttonsContainer_english
-            : style.buttonsContainer_notEnglish
-        )}
-      >
-        <Button
-          __useDeprecatedTag
-          color={Button.ButtonColor.neutralDark}
-          type="button"
-          href={pathToCourse}
-          aria-label={quickViewButtonDescription}
-          text={quickViewButtonText}
-        />
-        <Button
-          color={Button.ButtonColor.brandSecondaryDefault}
-          type="button"
-          onClick={() => {}}
-          aria-label={assignButtonDescription}
-          text={assignButtonText}
-        />
+          <Button
+            color={Button.ButtonColor.brandSecondaryDefault}
+            type="button"
+            onClick={() => {}}
+            aria-label={assignButtonDescription}
+            text={assignButtonText}
+          />
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 CustomizableCurriculumCatalogCard.propTypes = {
   courseDisplayName: PropTypes.string.isRequired,

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import {OverlayTrigger} from 'react-bootstrap-2';
 import {concat, intersection} from 'lodash';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import Button from '@cdo/apps/templates/Button';
@@ -13,7 +12,7 @@ import {
   subjectsAndTopicsOrder,
 } from '@cdo/apps/templates/teacherDashboard/CourseOfferingHelpers';
 import style from './curriculum_catalog_card.module.scss';
-import LabelTooltip from '@cdo/apps/templates/curriculumCatalog/LabelTooltip';
+import CardLabels from '@cdo/apps/templates/curriculumCatalog/CardLabels';
 
 const CurriculumCatalogCard = ({
   courseDisplayName,
@@ -108,42 +107,7 @@ const CustomizableCurriculumCatalogCard = ({
     <div className={style.curriculumInfoContainer}>
       <div className={style.labelsAndTranslatabilityContainer}>
         <div className={style.labelsContainer}>
-          {subjectsAndTopics.length > 0 && (
-            <OverlayTrigger
-              placement="top"
-              trigger={['hover', 'focus']}
-              overlay={props => (
-                <LabelTooltip
-                  id="first-label-tooltip"
-                  className={style.labelTooltip}
-                  {...props}
-                >
-                  {subjectsAndTopics[0]}
-                </LabelTooltip>
-              )}
-            >
-              <div tabIndex="0">{subjectsAndTopics[0]}</div>
-            </OverlayTrigger>
-          )}
-          {subjectsAndTopics.length > 1 && (
-            <OverlayTrigger
-              placement="top"
-              trigger={['hover', 'focus']}
-              overlay={props => (
-                <LabelTooltip
-                  id="remaining-labels-tooltip"
-                  className={style.labelTooltip}
-                  {...props}
-                >
-                  {subjectsAndTopics.slice(1).map(label => (
-                    <p key={label}>{label}</p>
-                  ))}
-                </LabelTooltip>
-              )}
-            >
-              <div tabIndex="0">{`+${subjectsAndTopics.length - 1}`}</div>
-            </OverlayTrigger>
-          )}
+          <CardLabels subjectsAndTopics={subjectsAndTopics} />
         </div>
         {/*TODO [MEG]: Ensure this icon matches spec when we update FontAwesome */}
         {isTranslated && (

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import {Tooltip, OverlayTrigger} from 'react-bootstrap-2';
+import {OverlayTrigger} from 'react-bootstrap-2';
 import {concat, intersection} from 'lodash';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import Button from '@cdo/apps/templates/Button';
@@ -13,6 +13,7 @@ import {
   subjectsAndTopicsOrder,
 } from '@cdo/apps/templates/teacherDashboard/CourseOfferingHelpers';
 import style from './curriculum_catalog_card.module.scss';
+import LabelTooltip from '@cdo/apps/templates/curriculumCatalog/LabelTooltip';
 
 const CurriculumCatalogCard = ({
   courseDisplayName,
@@ -95,28 +96,25 @@ const CustomizableCurriculumCatalogCard = ({
   isEnglish,
   pathToCourse,
 }) => {
-  const firstLabelText = subjectsAndTopics[0];
-  const renderFirstLabelTooltip = ({arrowProps, ...props}) => (
-    <Tooltip id="first-label-tooltip" className={style.labelTooltip} {...props}>
-      {firstLabelText}
-    </Tooltip>
+  const renderFirstLabelTooltip = props => (
+    <LabelTooltip
+      id="first-label-tooltip"
+      className={style.labelTooltip}
+      {...props}
+    >
+      {subjectsAndTopics[0]}
+    </LabelTooltip>
   );
-
-  const remainingLabelsNode = (
-    <>
-      {subjectsAndTopics.slice(1).map(label => (
-        <p key={label}>{label}</p>
-      ))}
-    </>
-  );
-  const renderRemainingLabelsTooltip = ({arrowProps, ...props}) => (
-    <Tooltip
+  const renderRemainingLabelsTooltip = props => (
+    <LabelTooltip
       id="remaining-labels-tooltip"
       className={style.labelTooltip}
       {...props}
     >
-      {remainingLabelsNode}
-    </Tooltip>
+      {subjectsAndTopics.slice(1).map(label => (
+        <p key={label}>{label}</p>
+      ))}
+    </LabelTooltip>
   );
 
   return (

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -95,107 +95,102 @@ const CustomizableCurriculumCatalogCard = ({
   quickViewButtonText,
   isEnglish,
   pathToCourse,
-}) => {
-  const renderFirstLabelTooltip = props => (
-    <LabelTooltip
-      id="first-label-tooltip"
-      className={style.labelTooltip}
-      {...props}
-    >
-      {subjectsAndTopics[0]}
-    </LabelTooltip>
-  );
-  const renderRemainingLabelsTooltip = props => (
-    <LabelTooltip
-      id="remaining-labels-tooltip"
-      className={style.labelTooltip}
-      {...props}
-    >
-      {subjectsAndTopics.slice(1).map(label => (
-        <p key={label}>{label}</p>
-      ))}
-    </LabelTooltip>
-  );
-
-  return (
-    <div
-      className={classNames(
-        style.curriculumCatalogCardContainer,
-        isEnglish
-          ? style.curriculumCatalogCardContainer_english
-          : style.curriculumCatalogCardContainer_notEnglish
-      )}
-    >
-      <img src={imageSrc} alt={imageAltText} />
-      <div className={style.curriculumInfoContainer}>
-        <div className={style.labelsAndTranslatabilityContainer}>
-          <div className={style.labelsContainer}>
-            {subjectsAndTopics.length > 0 && (
-              <OverlayTrigger
-                placement="top"
-                trigger={['hover', 'focus']}
-                overlay={renderFirstLabelTooltip}
-              >
-                <div tabIndex="0">{subjectsAndTopics[0]}</div>
-              </OverlayTrigger>
-            )}
-            {subjectsAndTopics.length > 1 && (
-              <OverlayTrigger
-                placement="top"
-                trigger={['hover', 'focus']}
-                overlay={renderRemainingLabelsTooltip}
-              >
-                <div tabIndex="0">{`+${subjectsAndTopics.length - 1}`}</div>
-              </OverlayTrigger>
-            )}
-          </div>
-          {/*TODO [MEG]: Ensure this icon matches spec when we update FontAwesome */}
-          {isTranslated && (
-            <FontAwesome
-              icon="language"
-              className="fa-solid"
-              title={translationIconTitle}
-            />
+}) => (
+  <div
+    className={classNames(
+      style.curriculumCatalogCardContainer,
+      isEnglish
+        ? style.curriculumCatalogCardContainer_english
+        : style.curriculumCatalogCardContainer_notEnglish
+    )}
+  >
+    <img src={imageSrc} alt={imageAltText} />
+    <div className={style.curriculumInfoContainer}>
+      <div className={style.labelsAndTranslatabilityContainer}>
+        <div className={style.labelsContainer}>
+          {subjectsAndTopics.length > 0 && (
+            <OverlayTrigger
+              placement="top"
+              trigger={['hover', 'focus']}
+              overlay={props => (
+                <LabelTooltip
+                  id="first-label-tooltip"
+                  className={style.labelTooltip}
+                  {...props}
+                >
+                  {subjectsAndTopics[0]}
+                </LabelTooltip>
+              )}
+            >
+              <div tabIndex="0">{subjectsAndTopics[0]}</div>
+            </OverlayTrigger>
+          )}
+          {subjectsAndTopics.length > 1 && (
+            <OverlayTrigger
+              placement="top"
+              trigger={['hover', 'focus']}
+              overlay={props => (
+                <LabelTooltip
+                  id="remaining-labels-tooltip"
+                  className={style.labelTooltip}
+                  {...props}
+                >
+                  {subjectsAndTopics.slice(1).map(label => (
+                    <p key={label}>{label}</p>
+                  ))}
+                </LabelTooltip>
+              )}
+            >
+              <div tabIndex="0">{`+${subjectsAndTopics.length - 1}`}</div>
+            </OverlayTrigger>
           )}
         </div>
-        <h4>{courseDisplayName}</h4>
-        <div className={style.iconWithDescription}>
-          <FontAwesome icon="user" className="fa-solid" />
-          <p>{gradeRange}</p>
-        </div>
-        <div className={style.iconWithDescription}>
-          {/*TODO [MEG]: Update this to be clock fa-solid when we update FontAwesome */}
-          <FontAwesome icon="clock-o" />
-          <p>{duration}</p>
-        </div>
-        <div
-          className={classNames(
-            style.buttonsContainer,
-            isEnglish
-              ? style.buttonsContainer_english
-              : style.buttonsContainer_notEnglish
-          )}
-        >
-          <Button
-            __useDeprecatedTag
-            color={Button.ButtonColor.neutralDark}
-            type="button"
-            href={pathToCourse}
-            aria-label={quickViewButtonDescription}
-            text={quickViewButtonText}
+        {/*TODO [MEG]: Ensure this icon matches spec when we update FontAwesome */}
+        {isTranslated && (
+          <FontAwesome
+            icon="language"
+            className="fa-solid"
+            title={translationIconTitle}
           />
-          <Button
-            color={Button.ButtonColor.brandSecondaryDefault}
-            type="button"
-            onClick={() => {}}
-            aria-label={assignButtonDescription}
-            text={assignButtonText}
-          />
-        </div>
+        )}
+      </div>
+      <h4>{courseDisplayName}</h4>
+      <div className={style.iconWithDescription}>
+        <FontAwesome icon="user" className="fa-solid" />
+        <p>{gradeRange}</p>
+      </div>
+      <div className={style.iconWithDescription}>
+        {/*TODO [MEG]: Update this to be clock fa-solid when we update FontAwesome */}
+        <FontAwesome icon="clock-o" />
+        <p>{duration}</p>
+      </div>
+      <div
+        className={classNames(
+          style.buttonsContainer,
+          isEnglish
+            ? style.buttonsContainer_english
+            : style.buttonsContainer_notEnglish
+        )}
+      >
+        <Button
+          __useDeprecatedTag
+          color={Button.ButtonColor.neutralDark}
+          type="button"
+          href={pathToCourse}
+          aria-label={quickViewButtonDescription}
+          text={quickViewButtonText}
+        />
+        <Button
+          color={Button.ButtonColor.brandSecondaryDefault}
+          type="button"
+          onClick={() => {}}
+          aria-label={assignButtonDescription}
+          text={assignButtonText}
+        />
       </div>
     </div>
-  );
-};
+  </div>
+);
 
 CustomizableCurriculumCatalogCard.propTypes = {
   courseDisplayName: PropTypes.string.isRequired,

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -95,6 +95,30 @@ $container-width: 309px;
   }
 }
 
+.labelTooltip {
+  opacity: 1;
+  margin-bottom: 0.75em;
+
+  :global(.tooltip-inner) { /* stylelint-disable-line selector-pseudo-class-no-unknown */
+    border-radius: 5px;
+    color: #fff;
+    background-color: #222;
+
+    p {
+      color: #fff;
+      margin: 0;
+    }
+  }
+
+  :global(.tooltip-arrow) { /* stylelint-disable-line selector-pseudo-class-no-unknown */
+    left: 50%;
+    bottom: 0;
+    border: 15px solid transparent;
+    border-top: 15px solid #222;
+    transform: translate(-50%, calc(100% - 8px));
+  }
+}
+
 .iconWithDescription {
   display: flex;
   align-items: center;

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -87,11 +87,6 @@ $container-width: 309px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-
-    &:hover {
-      max-width: inherit;
-      overflow: inherit;
-    }
   }
 }
 
@@ -158,6 +153,8 @@ $container-width: 309px;
   a:link,
   a:visited {
     width: 100%;
+    display: flex;
+    justify-content: center;
   }
 }
 

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -98,6 +98,7 @@ $container-width: 309px;
 .labelTooltip {
   opacity: 1;
   margin-bottom: 0.75em;
+  pointer-events: none;
 
   :global(.tooltip-inner) { /* stylelint-disable-line selector-pseudo-class-no-unknown */
     border-radius: 5px;

--- a/apps/src/templates/teacherDashboard/CourseOfferingHelpers.jsx
+++ b/apps/src/templates/teacherDashboard/CourseOfferingHelpers.jsx
@@ -15,16 +15,21 @@ export const translatedCourseOfferingCsTopics = {
   programming: i18n.courseOfferingCsTopicProgramming(),
 };
 
-export const translatedInterdisciplinary = {
-  interdisciplinary: i18n.courseOfferingInterdisciplinary(),
-};
-
 // Same list as CourseOfferingSchoolSubjects in sharedCourseConstants but with translated strings
 export const translatedCourseOfferingSchoolSubjects = {
   math: i18n.courseOfferingSchoolSubjectMath(),
   science: i18n.courseOfferingSchoolSubjectScience(),
   english_language_arts: i18n.courseOfferingSchoolSubjectEnglishLanguageArts(),
   history: i18n.courseOfferingSchoolSubjectHistory(),
+};
+
+export const translatedLabels = {
+  ...translatedCourseOfferingCsTopics,
+  ...translatedCourseOfferingSchoolSubjects,
+};
+
+export const translatedInterdisciplinary = {
+  interdisciplinary: i18n.courseOfferingInterdisciplinary(),
 };
 
 // Same list as DeviceTypes in sharedCourseConstants but with translated strings

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {pull} from 'lodash';
 import {expect} from '../../../util/reconfiguredChai';
 import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
 import {
   subjectsAndTopicsOrder,
   translatedCourseOfferingCsTopics,
+  translatedLabels,
 } from '@cdo/apps/templates/teacherDashboard/CourseOfferingHelpers';
 
 describe('CurriculumCatalogCard', () => {
@@ -83,6 +85,50 @@ describe('CurriculumCatalogCard', () => {
     );
 
     screen.getByText(`+${subjects.length + topics.length - 1}`);
+  });
+
+  it('renders tooltip showing remaining labels when hovering on plus sign', () => {
+    render(
+      <CurriculumCatalogCard
+        {...defaultProps}
+        subjects={subjects}
+        topics={topics}
+      />
+    );
+    const remainingLabels = pull(
+      [...subjects, ...topics],
+      subjectsAndTopicsOrder[firstSubjectIndexUsed]
+    );
+    const plusSignText = screen.getByText(
+      `+${subjects.length + topics.length - 1}`
+    );
+
+    // does not show when not hovered
+    remainingLabels.forEach(
+      label => expect(screen.queryByText(translatedLabels[label])).to.be.null
+    );
+
+    fireEvent.mouseOver(plusSignText);
+    remainingLabels.forEach(label => screen.getByText(translatedLabels[label]));
+  });
+
+  it('renders tooltip showing remaining labels when plus sign is focused', () => {
+    render(
+      <CurriculumCatalogCard
+        {...defaultProps}
+        subjects={subjects}
+        topics={topics}
+      />
+    );
+    const remainingLabels = pull(
+      [...subjects, ...topics],
+      subjectsAndTopicsOrder[firstSubjectIndexUsed]
+    );
+    const plusSignText = screen.getByText(
+      `+${subjects.length + topics.length - 1}`
+    );
+    plusSignText.focus();
+    remainingLabels.forEach(label => screen.getByText(translatedLabels[label]));
   });
 
   it('renders one topic, the first available from ordered list, if no subject present', () => {

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -87,6 +87,37 @@ describe('CurriculumCatalogCard', () => {
     screen.getByText(`+${subjects.length + topics.length - 1}`);
   });
 
+  it('renders tooltip showing full text of first label when hovering over it', () => {
+    render(
+      <CurriculumCatalogCard
+        {...defaultProps}
+        subjects={subjects}
+        topics={topics}
+      />
+    );
+    const firstLabelText =
+      translatedLabels[subjectsAndTopicsOrder[firstSubjectIndexUsed]];
+    const firstLabelNode = screen.getByText(firstLabelText);
+
+    fireEvent.mouseOver(firstLabelNode);
+    expect(screen.getAllByText(firstLabelText)).to.have.lengthOf(2);
+  });
+
+  it('renders tooltip showing full text of first label when focused on it', () => {
+    render(
+      <CurriculumCatalogCard
+        {...defaultProps}
+        subjects={subjects}
+        topics={topics}
+      />
+    );
+    const firstLabelText =
+      translatedLabels[subjectsAndTopicsOrder[firstSubjectIndexUsed]];
+    const firstLabelNode = screen.getByText(firstLabelText);
+    firstLabelNode.focus();
+    expect(screen.getAllByText(firstLabelText)).to.have.lengthOf(2);
+  });
+
   it('renders tooltip showing remaining labels when hovering on plus sign', () => {
     render(
       <CurriculumCatalogCard


### PR DESCRIPTION
Adds tooltip on hover of labels in the curriculum catalog cards.

Two callouts:
1) The full text on the first label in English is always shown, but in some languages (e.g. Italian), it gets cut off:
<img width="253" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/0526d1a0-4e17-4e19-85c6-de684d7a66ab">

Since we don't know when the full text is shown or not, we decided to show the tooltip on the first label as well.

2) To make the tooltips keyboard friendly, the labels are tab-navigable, and the tooltips show when the label is focused:
<img width="275" alt="Screenshot 2023-05-31 at 5 55 06 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/f5fbab40-42a5-4d18-bbd7-73cfafe06c0f"> 
<img width="254" alt="Screenshot 2023-05-31 at 5 55 14 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/db12b507-9f18-4fe7-b61e-9a3164dce5ba">

For the second label only (the +# label), the screenreader reads:
<img width="520" alt="Screenshot 2023-05-31 at 6 29 07 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/f8bb5a23-928f-4080-94e1-232618fe45c0">

And without keyboard, the tooltips appear on hover:
<img width="261" alt="Screenshot 2023-05-31 at 5 49 32 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/b413b165-8782-40f2-8e45-82913792dbf8">
<img width="278" alt="Screenshot 2023-05-31 at 5 49 26 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/2ee8b9c3-2d34-4d44-b290-5fafe5bb5542">

Finally, while modifying the original implementation of the labels which expands to show the full text (https://github.com/code-dot-org/code-dot-org/pull/51304), I also fixed a bug in which the text in other languages was not centered:
<img width="261" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/4fa94bcd-9bcb-43d2-80ee-035c9990f221">
It now looks like:
<img width="248" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/61b07bcc-bcf3-4168-8f46-17d7931556e3">


## Links

Looked here for data about aria-label overriding text: https://www.davidmacd.com/blog/does-aria-label-override-static-text.html. If you actually play the screenreader text, it reads the "+3" text which is not ideal, but the fix for that would mean either (a) having the label text be a header, or (b) adding a role to the text that's not accurate. I decided to keep the semantics better.

Notes about using `aria-label` on divs: https://www.w3.org/TR/using-aria/#label-support

Role definitions for use with `aria-label`: https://www.w3.org/TR/wai-aria-1.1/#role_definitions

Using tab index: https://bitsofco.de/how-and-when-to-use-the-tabindex-attribute/ 

Tooltip guides: 
- https://www.accessibility-developer-guide.com/examples/widgets/tooltips/ 
- https://sarahmhigley.com/writing/tooltips-in-wcag-21/ 
- https://github.com/w3c/aria/issues/979 
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role 
- https://www.w3.org/TR/wai-aria-1.1/#tooltip 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
