### PR TITLE
Update callout section text link color for better accessibility

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -22,8 +22,15 @@ body {
 // Use these classes to change a section's background color
 section.bg-neutral-light { background-color: $neutral_light; }
 section.bg-neutral-dark { background-color: $neutral_dark; }
-section.bg-primary-light { background-color: rgba($brand_primary_light, .5); }
 section.bg-secondary { background-color: $brand_secondary_light; }
+section.bg-primary-light {
+  background-color: rgba($brand_primary_light, .5);
+
+  a { color: $neutral_dark !important;
+    &:hover { color: $brand_secondary_dark !important; }
+    &.link-button { color: $neutral_white !important; }
+  }
+}
 
 // Centers a block-level element
 .centered { text-align: center !important; }


### PR DESCRIPTION
The purple brand color used on text links is not accessible against the light blue background in the callout sections used in the rebrand pages. Updating this to a charcoal link to pass AA and AAA WCAG contrast standards.

- The dark purple brand color on hover passes accessibility standards, so I kept that as-is.

https://github.com/code-dot-org/code-dot-org/assets/9256643/c16a6f49-37c6-45c8-9867-eef50208801b

**Jira ticket:** [ACQ-634](https://codedotorg.atlassian.net/browse/ACQ-634)

----

### Before
<img width="1061" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/6478772c-5f3f-4e1f-93ff-99f8865920a6">

### After
<img width="1050" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/e7b65478-3c2b-482a-bc7c-04005858be80">

