### PR TITLE
Create ErrorBoundary and use with LabContainer and MusicView

### DIFF
--- a/apps/src/code-studio/components/ErrorBoundary.tsx
+++ b/apps/src/code-studio/components/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import React, {ErrorInfo} from 'react';
+
+interface ErrorBoundaryProps {
+  fallback: React.ReactNode;
+  children: React.ReactNode;
+  onError: (error: Error, componentStack: string) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * A generic React Error Boundary component that can be used to catch
+ * errors thrown anywhere with its child components. Renders the provided
+ * fallback view if an error occurs, and calls the onError() callback.
+ *
+ * Note that this will not catch errors thrown inside async functions/Promises
+ */
+export default class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  static getDerivedStateFromError() {
+    return {hasError: true};
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError(error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/src/code-studio/components/LabContainer.jsx
+++ b/apps/src/code-studio/components/LabContainer.jsx
@@ -59,7 +59,7 @@ LabContainer.propTypes = {
   onError: PropTypes.func.isRequired,
 };
 
-const ErrorUI = () => (
+export const ErrorUI = () => (
   <div id="page-error-container" className={moduleStyles.pageErrorContainer}>
     <div id="page-error" className={moduleStyles.pageError}>
       <img
@@ -71,7 +71,7 @@ const ErrorUI = () => (
   </div>
 );
 
-const ErrorFallbackPage = () => (
+export const ErrorFallbackPage = () => (
   <div id="lab-container" className={moduleStyles.labContainer}>
     <ErrorUI />
   </div>

--- a/apps/src/code-studio/components/LabContainer.jsx
+++ b/apps/src/code-studio/components/LabContainer.jsx
@@ -15,8 +15,9 @@ import classNames from 'classnames';
 import moduleStyles from './LabContainer.module.scss';
 import i18n from '@cdo/locale';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import ErrorBoundary from './ErrorBoundary';
 
-const LabContainer = ({children}) => {
+const LabContainer = ({children, onError}) => {
   const isLabLoading = useSelector(state => state.lab.isLoading);
   const isPageError = useSelector(state => state.lab.isPageError);
 
@@ -25,45 +26,55 @@ const LabContainer = ({children}) => {
     : moduleStyles.fadeInBlock;
 
   return (
-    <div id="lab-container" className={moduleStyles.labContainer}>
-      {children}
-      <div
-        id="fade-overlay"
-        className={classNames(moduleStyles.solidBlock, overlayStyle)}
-      >
-        {isLabLoading && (
-          <div className={moduleStyles.slowLoadContainer}>
-            <div className={moduleStyles.spinnerContainer}>
-              <FontAwesome
-                icon="spinner"
-                className={classNames('fa-pulse', 'fa-3x')}
-              />
-            </div>
-            <div className={moduleStyles.spinnerText}>{i18n.slowLoading()}</div>
-          </div>
-        )}
-      </div>
-
-      {isPageError && (
+    <ErrorBoundary fallback={<ErrorFallbackPage />} onError={onError}>
+      <div id="lab-container" className={moduleStyles.labContainer}>
+        {children}
         <div
-          id="page-error-container"
-          className={moduleStyles.pageErrorContainer}
+          id="fade-overlay"
+          className={classNames(moduleStyles.solidBlock, overlayStyle)}
         >
-          <div id="page-error" className={moduleStyles.pageError}>
-            <img
-              className={moduleStyles.pageErrorImage}
-              src="/shared/images/sad-bee-avatar.png"
-            />
-            {i18n.loadingError()}
-          </div>
+          {isLabLoading && (
+            <div className={moduleStyles.slowLoadContainer}>
+              <div className={moduleStyles.spinnerContainer}>
+                <FontAwesome
+                  icon="spinner"
+                  className={classNames('fa-pulse', 'fa-3x')}
+                />
+              </div>
+              <div className={moduleStyles.spinnerText}>
+                {i18n.slowLoading()}
+              </div>
+            </div>
+          )}
         </div>
-      )}
-    </div>
+
+        {isPageError && <ErrorUI />}
+      </div>
+    </ErrorBoundary>
   );
 };
 
 LabContainer.propTypes = {
   children: PropTypes.node.isRequired,
+  onError: PropTypes.func.isRequired,
 };
+
+const ErrorUI = () => (
+  <div id="page-error-container" className={moduleStyles.pageErrorContainer}>
+    <div id="page-error" className={moduleStyles.pageError}>
+      <img
+        className={moduleStyles.pageErrorImage}
+        src="/shared/images/sad-bee-avatar.png"
+      />
+      {i18n.loadingError()}
+    </div>
+  </div>
+);
+
+const ErrorFallbackPage = () => (
+  <div id="lab-container" className={moduleStyles.labContainer}>
+    <ErrorUI />
+  </div>
+);
 
 export default LabContainer;

--- a/apps/src/sites/studio/pages/levels-music-main.js
+++ b/apps/src/sites/studio/pages/levels-music-main.js
@@ -5,11 +5,16 @@ import {Provider} from 'react-redux';
 import {getStore} from '@cdo/apps/redux';
 import LabContainer from '@cdo/apps/code-studio/components/LabContainer';
 import MusicLabView from '@cdo/apps/music/views/MusicView';
+import {logError} from '@cdo/apps/music/utils/MusicMetrics';
 
 $(document).ready(function () {
   ReactDOM.render(
     <Provider store={getStore()}>
-      <LabContainer>
+      <LabContainer
+        onError={(error, componentStack) =>
+          logError({error: error.toString(), componentStack})
+        }
+      >
         <MusicLabView />
       </LabContainer>
     </Provider>,

--- a/apps/src/sites/studio/pages/musiclab/index.js
+++ b/apps/src/sites/studio/pages/musiclab/index.js
@@ -4,15 +4,25 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import {getStore} from '@cdo/apps/redux';
 import MusicLabView from '@cdo/apps/music/views/MusicView';
+import ErrorBoundary from '@cdo/apps/code-studio/components/ErrorBoundary';
+import {logError} from '@cdo/apps/music/utils/MusicMetrics';
+import {ErrorFallbackPage} from '@cdo/apps/code-studio/components/LabContainer';
 
 $(document).ready(function () {
   const channelId = document.querySelector('script[data-channelid]').dataset
     .channelid;
 
   ReactDOM.render(
-    <Provider store={getStore()}>
-      <MusicLabView channelId={channelId} inIncubator={true} />
-    </Provider>,
+    <ErrorBoundary
+      fallback={<ErrorFallbackPage />}
+      onError={(error, componentStack) =>
+        logError({error: error.toString(), componentStack})
+      }
+    >
+      <Provider store={getStore()}>
+        <MusicLabView channelId={channelId} inIncubator={true} />
+      </Provider>
+    </ErrorBoundary>,
     document.getElementById('musiclab-container')
   );
 });


### PR DESCRIPTION
This creates a reusable [React Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) component and uses it with LabContainer, as well as on the incubator music lab page. This ensures that any uncaught exceptions will get handled and we'll show a fallback error UI instead of just dismounting the entire page. Also since this is part of LabContainer, in the future other labs should be able to leverage this just by providing an onError callback (likely just for logging). The presentation of the error page is at least for now the same as the lab error page.

Note: unfortunately this can't be a functional component since there is no hooks support for `componentDidCatch` (see [docs](https://react.dev/reference/react/Component#componentdidcatch-caveats)). Also worth noting that by design, this won't catch errors thrown inside async function or promises, so we'll need to still be diligent about wrapping those in try/catch blocks or adding .catch clauses.

Ex. when an uncaught error like this occurs:
<img width="1512" alt="Screenshot 2023-06-01 at 9 54 16 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/2d04b968-07ea-4ef0-82e8-ac3530d5911c">

Users will see:
<img width="1512" alt="Screenshot 2023-06-01 at 9 53 59 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/319841c2-c11d-4baa-b68d-d92a765fe91c">

And we'll log the error and component stack:
<img width="1184" alt="Screenshot 2023-06-01 at 9 55 57 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/a729b210-28cd-482c-908a-ea40d543ef0b">

## Links

https://codedotorg.atlassian.net/browse/SL-889

## Testing story

Tested locally by manually creating uncaught exceptions.