### PR TITLE
Add CPA emails

### DIFF
--- a/dashboard/app/mailers/parent_mailer.rb
+++ b/dashboard/app/mailers/parent_mailer.rb
@@ -14,4 +14,22 @@ class ParentMailer < ActionMailer::Base
 
     mail to: parent_email, subject: I18n.t('parent_mailer.parent_email_added_subject')
   end
+
+  # Email for parents of students under 13 to grant permission for their child to have a Code.org account.
+  # The email contains a link that grants permission when clicked.
+  def parent_permission_request(parent_email, permission_url)
+    @permission_url = permission_url
+    mail from: 'Code.org <noreply@code.org>', to: parent_email, subject: I18n.t('parent_mailer.parent_permission_request_subject')
+  end
+
+  # Reminder for parents who haven't granted permission for their child's account.
+  def parent_permission_reminder(parent_email, permission_url)
+    @permission_url = permission_url
+    mail from: 'Code.org <noreply@code.org>', to: parent_email, subject: I18n.t('parent_mailer.parent_permission_reminder_subject')
+  end
+
+  # Confirmation sent after a parent has granted permission for their child's code.org account.
+  def parent_permission_confirmation(parent_email)
+    mail from: 'Code.org <noreply@code.org>', to: parent_email, subject: I18n.t('parent_mailer.parent_permission_confirmation_subject')
+  end
 end

--- a/dashboard/app/views/parent_mailer/parent_permission_confirmation.html.haml
+++ b/dashboard/app/views/parent_mailer/parent_permission_confirmation.html.haml
@@ -1,0 +1,26 @@
+%p
+  Dear Parent/Guardian,
+
+%p
+  Thank you for approving your child's use of a Code.org® account (or adding a personal login to an existing Code.org account used in school).  By approving your child's account, you agree to the Code.org
+  %a{href:"https://code.org/tos"}Terms of Service
+  and
+  %a{href:"https://code.org/privacy"}Privacy Policy.
+
+%p
+  You can revoke your consent at any time by emailing us at
+  %a{href:"mailto:support@code.org"}support@code.org
+  from this email address.  You can also self-delete your child's account by signing in and clicking the user name in the top right corner of the screen, and then selecting "account settings." Simply scroll down to the bottom of that page and follow the instructions there to delete the  account. If you don't see the option for deletion, your child is still enrolled in one or more teachers' sections, and you'll need to ask the teachers to remove them first from that section before you can delete the account.
+
+%p
+  Code.org is a US-based nonprofit that provides free computer science courses and activities.  We collect limited personal data solely for the purpose of providing the services, including:  Display Name (we recommend using only first name - used to provide welcome); Username (not actual name); Passwords; Hashed Email Address (not stored in retrievable format - can't be used to contact student); Age (not birthday); and Gender (optional) (used for aggregate measurements).
+
+%p
+  We do not sell data or exploit it for financial gain. We do not sell ads.  We do not store student email addresses in a retrievable format.  For more information on Code.org accounts for children under 13 years old, please see our <u>Children's Privacy Notice</u>, which is part of our full
+  %a{href:"https://code.org/privacy"}Privacy Policy.
+
+%p
+  Thank you for allowing your child to learn with us.
+
+%p
+  The Code.org Team

--- a/dashboard/app/views/parent_mailer/parent_permission_reminder.html.haml
+++ b/dashboard/app/views/parent_mailer/parent_permission_reminder.html.haml
@@ -1,0 +1,33 @@
+%p
+  Dear Parent/Guardian,
+
+%p
+  You or your child under the age of 13 has attempted to create a  Code.org® account (or add a personal login to an existing Code.org account used in school). We previously sent an email asking you to approve your child's use of Code.org.
+
+%p
+  <u><em>Please click the button below to grant approval.</em></u>  If you do not grant approval, your child's account will not be activated and all account information (along with your email address) will be deleted after approximately 7-10 days.
+
+%a{href: @permission_url, style: 'width: 300px; height: 36px; border: 0; color: white; background-color: #4287f5; font: bolder 18px Arial; display: block; text-align: center; line-height: 36px; text-decoration: none; border-radius: 5px;'}
+  Allow my child to use Code.org
+
+%p
+  Code.org is a US-based nonprofit that provides free computer science courses and activities.  We collect limited personal data solely for the purpose of providing the services, including:  Display Name (we recommend using only first name - used to provide welcome); Username (not actual name); Passwords; Hashed Email Address (not stored in retrievable format - can't be used to contact student); Age (not birthday); and Gender (optional) (used for aggregate measurements).
+
+%p
+  We do not sell data or exploit it for financial gain. We do not sell ads.  We do not store student email addresses in a retrievable format.  For more information on Code.org accounts for children under 13 years old, please see our <u>Children's Privacy Notice</u>, which is part of our full
+  %a{href:"https://code.org/privacy"}Privacy Policy.
+
+%p
+  By approving your child's account, you agree to the Code.org
+  %a{href:"https://code.org/tos"}Terms of Service
+  and
+  %a{href:"https://code.org/privacy"}Privacy Policy.
+  You may withdraw your consent and delete the child's account at any time by contacting us at
+  %a{href:"mailto:support@code.org"}support@code.org
+  from your email address receiving this notice.  Your email address will not be used or disclosed by Code.org for any other purpose unless you provide a separate consent.
+
+%p
+  Thank you for allowing your child to learn with us.
+
+%p
+  The Code.org Team

--- a/dashboard/app/views/parent_mailer/parent_permission_request.html.haml
+++ b/dashboard/app/views/parent_mailer/parent_permission_request.html.haml
@@ -1,0 +1,30 @@
+%p
+  Dear Parent/Guardian,
+
+%p
+  You or your child under the age of 13 has attempted to create  a Code.org® account (or add a personal login to an existing Code.org account used in school).  Your email was provided as the parent/guardian for obtaining consent. <u><em>Please click the button below to grant approval.</em></u>  If you do not grant approval, your child's account will not be activated and all account information (along with your email address) will be deleted after approximately 7-10 days.
+
+%a{href: @permission_url, style: 'width: 300px; height: 36px; border: 0; color: white; background-color: #4287f5; font: bolder 18px Arial; display: block; text-align: center; line-height: 36px; text-decoration: none; border-radius: 5px;'}
+  Allow my child to use Code.org
+
+%p
+  Code.org is a US-based nonprofit that provides free computer science courses and activities.  We collect limited personal data solely for the purpose of providing the services, including:  Display Name (we recommend using only first name - used to provide welcome); Username (not actual name); Passwords; Hashed Email Address (not stored in retrievable format - can't be used to contact student); Age (not birthday); and Gender (optional) (used for aggregate measurements).
+
+%p
+  We do not sell data or exploit it for financial gain. We do not sell ads.  We do not store student email addresses in a retrievable format.  For more information on Code.org accounts for children under 13 years old, please see our <u>Children's Privacy Notice</u>, which is part of our full
+  %a{href:"https://code.org/privacy"}Privacy Policy.
+
+%p
+  By approving your child's account, you agree to the Code.org
+  %a{href:"https://code.org/tos"}Terms of Service
+  and
+  %a{href:"https://code.org/privacy"}Privacy Policy.
+  You may withdraw your consent and delete the child's account at any time by contacting us at
+  %a{href:"mailto:support@code.org"}support@code.org
+  from your email address receiving this notice.  Your email address will not be used or disclosed by Code.org for any other purpose unless you provide a separate consent.
+
+%p
+  Thank you for allowing your child to learn with us.
+
+%p
+  The Code.org Team

--- a/dashboard/test/mailers/parent_mailer_test.rb
+++ b/dashboard/test/mailers/parent_mailer_test.rb
@@ -24,4 +24,39 @@ class ParentMailerTest < ActionMailer::TestCase
     assert_equal ['support@code.org'], mail.reply_to
     assert links_are_complete_urls?(mail)
   end
+
+  test 'parent permission request' do
+    parent_email = 'parent@test.com'
+    permission_url = 'https://api.code.org/permission/foo'
+    mail = ParentMailer.parent_permission_request(parent_email, permission_url)
+
+    assert_equal I18n.t('parent_mailer.parent_permission_request_subject'), mail.subject
+    assert_equal [parent_email], mail.to
+    assert_equal ['noreply@code.org'], mail.from
+    assert_equal ['support@code.org'], mail.reply_to
+    assert links_are_complete_urls?(mail)
+  end
+
+  test 'parent permission reminder' do
+    parent_email = 'parent@test.com'
+    permission_url = 'https://api.code.org/permission/foo'
+    mail = ParentMailer.parent_permission_reminder(parent_email, permission_url)
+
+    assert_equal I18n.t('parent_mailer.parent_permission_reminder_subject'), mail.subject
+    assert_equal [parent_email], mail.to
+    assert_equal ['noreply@code.org'], mail.from
+    assert_equal ['support@code.org'], mail.reply_to
+    assert links_are_complete_urls?(mail)
+  end
+
+  test 'parent permission confirmation' do
+    parent_email = 'parent@test.com'
+    mail = ParentMailer.parent_permission_confirmation(parent_email)
+
+    assert_equal I18n.t('parent_mailer.parent_permission_confirmation_subject'), mail.subject
+    assert_equal [parent_email], mail.to
+    assert_equal ['noreply@code.org'], mail.from
+    assert_equal ['support@code.org'], mail.reply_to
+    assert links_are_complete_urls?(mail)
+  end
 end

--- a/dashboard/test/mailers/previews/parent_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/parent_mailer_preview.rb
@@ -6,4 +6,16 @@ class ParentMailerPreview < ActionMailer::Preview
     student = build :student
     ParentMailer.parent_email_added_to_student_account('fake_email@fake.com', student)
   end
+
+  def parent_permission_request_preview
+    ParentMailer.parent_permission_request('parent@test.com', 'https://code.org/permission')
+  end
+
+  def parent_permission_reminder_preview
+    ParentMailer.parent_permission_reminder('parent@test.com', 'https://code.org/permission')
+  end
+
+  def parent_permission_confirmation_preview
+    ParentMailer.parent_permission_confirmation('parent@test.com')
+  end
 end


### PR DESCRIPTION
Adds the three email templates for CPA along with the ParentMailer methods that will be used to send the emails, once other CPA work is done.

## Links

[Parent Letter Spec](https://docs.google.com/document/d/1Ml15JK6mcZBHgiBRc-Cpj11yZ53Gu8gD2tnNLVwfzGM/edit)
[JIRA Ticket](https://codedotorg.atlassian.net/browse/P20-134)

## Testing story

In addition to the unit tests, previews of the emails can be viewed locally at http://localhost-studio.code.org:3000/rails/mailers under `Parent Mailer`.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

This adds the emails themselves, but later on we will obviously need to actually call the functions to send the emails. This will require the work to generate parental consent links to be finished first.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
