### PR TITLE
Add controller action for posting browser metric events

### DIFF
--- a/dashboard/app/controllers/browser_events_controller.rb
+++ b/dashboard/app/controllers/browser_events_controller.rb
@@ -70,6 +70,7 @@ class BrowserEventsController < ApplicationController
     return nil unless metric_datum["name"]
 
     # Replace the 'name' key with 'metric_name'
+    # (AWS Ruby SDK requires a 'metric_name' parameter)
     metric_datum["metric_name"] = metric_datum["name"]
     metric_datum.delete("name")
     # put_metric_data requires ISO timestamp

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1050,6 +1050,7 @@ Dashboard::Application.routes.draw do
     get '/offline-files.json', action: :offline_files, controller: :offline
 
     post '/browser_events/put_logs', to: 'browser_events#put_logs'
+    post '/browser_events/put_metric_data', to: 'browser_events#put_metric_data'
 
     get '/get_token', to: 'authenticity_token#get_token'
   end


### PR DESCRIPTION
Extends the existing browser events controller to add functionality to post metrics (to the [PutMetricData](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html) Cloudwatch endpoint).

Example metrics in Cloudwatch:

<img width="1072" alt="Screenshot 2023-06-01 at 3 59 06 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/65d98638-e87c-487c-94ff-4faeed03e07c">

## Links

https://codedotorg.atlassian.net/browse/SL-800

## Testing story

Tested locally with front end changes (future PR). Verified metrics appear correctly.

## Deployment strategy

## Follow-up work

Front end implementation: https://codedotorg.atlassian.net/browse/SL-801