### PR TITLE
Instrument `import_pegasus_data`

### DIFF
--- a/cookbooks/cdo-apps/templates/default/newrelic.yml.erb
+++ b/cookbooks/cdo-apps/templates/default/newrelic.yml.erb
@@ -209,6 +209,10 @@ test:
   # It almost never makes sense to turn on the agent when running
   # unit, functional or integration tests or the like.
   monitor_mode: false
+  # Temporarily enable instrumentation for one specific Rake task which has
+  # been mysteriously executing outside the context of a build
+  rake:
+    tasks: ["seed:import_pegasus_data"]
 
 # Turn on the agent in production for 24x7 monitoring. NewRelic
 # testing shows an average performance impact of < 5 ms per


### PR DESCRIPTION
Enable NewRelic Rake task instrumentation on test for import_pegasus_data, in the hopes of being able to better identify precisely from which other task it is being invoked when that invocation happens outside the context of a regular build.

## Links

- [NewRelic Documentation](https://docs.newrelic.com/docs/apm/agents/ruby-agent/background-jobs/rake-instrumentation/#enabling-rake-support)
- [relevant slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1685662344686269?thread_ts=1685490581.253859&cid=C0T0PNTM3)
- Follow-up to https://github.com/code-dot-org/code-dot-org/pull/52181

## Testing story

I'm not at all sure how to test this and at this point have done zero testing. Open to suggestions!