### PR TITLE
Return error when section fails to save

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -67,7 +67,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
         restrict_section: params[:restrict_section].nil? ? false : params[:restrict_section]
       }
     )
-    render head :bad_request unless section
+    return head :bad_request unless section.persisted?
 
     # TODO: Move to an after_create step on Section model when old API is fully deprecated
     current_user.assign_script @unit if @unit

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -281,6 +281,21 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
       returned_json.with_indifferent_access
   end
 
+  test 'invalid params does not create section and returns an error' do
+    sign_in @facilitator
+    
+    assert_does_not_create(Section) do
+      # As is, this will fail because the grade "PL" is not provided but
+      # this test is meant to ensure a non-200 is returned when creating a section fails
+      post :create, params: {
+        login_type: Section::LOGIN_TYPE_EMAIL,
+        participant_type: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher,
+      }
+ 
+      assert_response :bad_request
+    end
+  end
+
   test 'current user owns the created section' do
     sign_in @teacher
     post :create, params: {


### PR DESCRIPTION
Turns out `create` has some unexpected -- at least to me -- behavior, in particular "The resulting object is returned whether the object was saved successfully to the database or not." ([source](https://apidock.com/rails/v5.2.3/ActiveRecord/Persistence/ClassMethods/create)) This means that we have been silently failing on section create for years -- though I don't think it actually happens very often -- because `section` is never nil.

My solution here is to check if it's persisted but another option is to use `create!`, which throws an error if the object can't be saved. Open to discussion on which direction to go!