### PR TITLE
[Google Blockly] Add unit tests for CdoFieldDropdown function that handles config

### DIFF
--- a/apps/src/blockly/addons/cdoFieldDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldDropdown.js
@@ -90,7 +90,10 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     // See CDO implementation at https://github.com/code-dot-org/blockly/blob/main/core/ui/fields/field_dropdown.js#L305
     this.config = element.getAttribute('config');
     if (this.config) {
-      this.menuGenerator_ = this.getUpdatedOptionsFromConfig(this.config);
+      this.menuGenerator_ = getUpdatedOptionsFromConfig(
+        this.config,
+        this.menuGenerator_
+      );
     }
     // Call super so value is set.
     super.fromXml(element);
@@ -109,54 +112,56 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     super.toXml(element);
     return element;
   }
-
-  /**
-   * Converts language-neutral string to humnan-readable string.
-   */
-  toHumanReadableString(text) {
-    return text.replace(/['"]+/g, '').toLowerCase();
-  }
-
-  /**
-   * Updates field options based on `config` attribute of field
-   * @param config attribute of field
-   * @return Array of option arrays
-   */
-  getUpdatedOptionsFromConfig(config) {
-    // If `menuGenerator_` is an array, it is an array of options with
-    // each option represented by an array containing 2 elements -
-    // a human-readable string and a language-neutral string. For example,
-    // [['first item', 'ITEM1'], ['second item', 'ITEM2'], ['third item', 'ITEM3']].
-    // Options are included in the block definition.
-    const originalOptionsMap = Array.isArray(this.menuGenerator_)
-      ? this.menuGenerator_.reduce((optionsMap, curr) => {
-          optionsMap[curr[1]] = curr[0];
-          return optionsMap;
-        }, {})
-      : {};
-
-    const numberList = printerStyleNumberRangeToList(config);
-    // If numberList is assigned a non-empty array, it contains a list of numbers.
-    // Convert this list to a string of dropdown options separated by commas and assign to options.
-    // Otherwise, assign options to config string.
-    // Note that `config` is either a printer-style number range or a string of options separated
-    // by commas, but not both. For example, a `config` like "1,6-9, &quot;SLOTH&quot;"
-    // would NOT be supported.
-    let options =
-      numberList.length > 0 ? numberListToString(numberList) : config;
-    options = options.split(',').map(val => {
-      val = val.trim();
-      // If val is one of the options in this.menuGenerator_,
-      // human-readable string is displayed.
-      if (originalOptionsMap[val]) {
-        return [originalOptionsMap[val], val];
-      } else {
-        // Remove quotes and display option with lowercase characters.
-        // For example, "GIRAFFE" would be transformed to giraffe.
-        const humanReadableVal = this.toHumanReadableString(val);
-        return [humanReadableVal, val];
-      }
-    });
-    return options;
-  }
 }
+
+/**
+ * Converts language-neutral string to humnan-readable string.
+ */
+function toHumanReadableString(text) {
+  return text.replace(/['"]+/g, '').toLowerCase();
+}
+
+/**
+ * Updates field options based on `config` attribute of field
+ * @param config attribute of field
+ * @return Array of option arrays
+ */
+function getUpdatedOptionsFromConfig(config, menuGenerator) {
+  // If `menuGenerator_` is an array, it is an array of options with
+  // each option represented by an array containing 2 elements -
+  // a human-readable string and a language-neutral string. For example,
+  // [['first item', 'ITEM1'], ['second item', 'ITEM2'], ['third item', 'ITEM3']].
+  // Options are included in the block definition.
+  const originalOptionsMap = Array.isArray(menuGenerator)
+    ? menuGenerator.reduce((optionsMap, curr) => {
+        optionsMap[curr[1]] = curr[0];
+        return optionsMap;
+      }, {})
+    : {};
+  const numberList = printerStyleNumberRangeToList(config);
+  // If numberList is assigned a non-empty array, it contains a list of numbers.
+  // Convert this list to a string of dropdown options separated by commas and assign to options.
+  // Otherwise, assign options to config string.
+  // Note that `config` is either a printer-style number range or a string of options separated
+  // by commas, but not both. For example, a `config` like "1,6-9, &quot;SLOTH&quot;"
+  // would NOT be supported.
+  let options = numberList.length > 0 ? numberListToString(numberList) : config;
+  options = options.split(',').map(val => {
+    val = val.trim();
+    // If val is one of the options in this.menuGenerator_,
+    // human-readable string is displayed.
+    if (originalOptionsMap[val]) {
+      return [originalOptionsMap[val], val];
+    } else {
+      // Remove quotes and display option with lowercase characters.
+      // For example, "GIRAFFE" would be transformed to giraffe.
+      const humanReadableVal = toHumanReadableString(val);
+      return [humanReadableVal, val];
+    }
+  });
+  return options;
+}
+
+export var __TestInterface = {
+  getUpdatedOptionsFromConfig: getUpdatedOptionsFromConfig,
+};

--- a/apps/src/blockly/addons/cdoFieldDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldDropdown.js
@@ -90,9 +90,15 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     // See CDO implementation at https://github.com/code-dot-org/blockly/blob/main/core/ui/fields/field_dropdown.js#L305
     this.config = element.getAttribute('config');
     if (this.config) {
+      // If `menuGenerator_` is an array, it is an array of options with
+      // each option represented by an array containing 2 elements -
+      // a human-readable string and a language-neutral string. For example,
+      // [['first item', 'ITEM1'], ['second item', 'ITEM2'], ['third item', 'ITEM3']].
+      // Options are included in the block definition.
+      const existingOptionsMap = arrayToMap(this.menuGenerator_);
       this.menuGenerator_ = getUpdatedOptionsFromConfig(
         this.config,
-        this.menuGenerator_
+        existingOptionsMap
       );
     }
     // Call super so value is set.
@@ -122,22 +128,27 @@ function toHumanReadableString(text) {
 }
 
 /**
- * Updates field options based on `config` attribute of field
- * @param config attribute of field
- * @return Array of option arrays
+ * Converts an array of option arrays to a map of options
+ * For example the array [['first item', 'ITEM1'], ['second item', 'ITEM2']]
+ * would be converted to {'first item': 'ITEM1', 'second item': 'ITEM2'}
+ * @param optionsArray  field
+ * @return map of options
  */
-function getUpdatedOptionsFromConfig(config, menuGenerator) {
-  // If `menuGenerator_` is an array, it is an array of options with
-  // each option represented by an array containing 2 elements -
-  // a human-readable string and a language-neutral string. For example,
-  // [['first item', 'ITEM1'], ['second item', 'ITEM2'], ['third item', 'ITEM3']].
-  // Options are included in the block definition.
-  const originalOptionsMap = Array.isArray(menuGenerator)
-    ? menuGenerator.reduce((optionsMap, curr) => {
+export function arrayToMap(optionsArray) {
+  return Array.isArray(optionsArray)
+    ? optionsArray.reduce((optionsMap, curr) => {
         optionsMap[curr[1]] = curr[0];
         return optionsMap;
       }, {})
     : {};
+}
+
+/**
+ * Updates field options based on `config` attribute of field
+ * @param config attribute of field
+ * @return Array of option arrays
+ */
+export function getUpdatedOptionsFromConfig(config, existingOptionsMap) {
   const numberList = printerStyleNumberRangeToList(config);
   // If numberList is assigned a non-empty array, it contains a list of numbers.
   // Convert this list to a string of dropdown options separated by commas and assign to options.
@@ -150,8 +161,8 @@ function getUpdatedOptionsFromConfig(config, menuGenerator) {
     val = val.trim();
     // If val is one of the options in this.menuGenerator_,
     // human-readable string is displayed.
-    if (originalOptionsMap[val]) {
-      return [originalOptionsMap[val], val];
+    if (existingOptionsMap[val]) {
+      return [existingOptionsMap[val], val];
     } else {
       // Remove quotes and display option with lowercase characters.
       // For example, "GIRAFFE" would be transformed to giraffe.
@@ -161,7 +172,3 @@ function getUpdatedOptionsFromConfig(config, menuGenerator) {
   });
   return options;
 }
-
-export var __TestInterface = {
-  getUpdatedOptionsFromConfig: getUpdatedOptionsFromConfig,
-};

--- a/apps/src/blockly/addons/cdoFieldImageDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldImageDropdown.js
@@ -111,7 +111,7 @@ export class CdoFieldImageDropdown extends FieldGridDropdown {
   }
 }
 
-function fixMenuGenerator(menuGenerator, width, height) {
+export function fixMenuGenerator(menuGenerator, width, height) {
   // Google Blockly supports images in dropdowns but has a different format,
   // so we just need to restructure our menu items before passing through to
   // the FieldDropdown constructor.

--- a/apps/src/blockly/addons/cdoFieldImageDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldImageDropdown.js
@@ -132,7 +132,3 @@ export function fixMenuGenerator(menuGenerator, width, height) {
     return [{src: url, width: width, height: height, alt: code_id}, code_id];
   });
 }
-
-export var __TestInterface = {
-  fixMenuGenerator: fixMenuGenerator,
-};

--- a/apps/test/unit/blockly/addons/cdoFieldDropdownTest.js
+++ b/apps/test/unit/blockly/addons/cdoFieldDropdownTest.js
@@ -1,0 +1,59 @@
+import {__TestInterface} from '@cdo/apps/blockly/addons/cdoFieldDropdown';
+import {expect} from '../../../util/reconfiguredChai';
+
+describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () => {
+  const getUpdatedOptionsFromConfig =
+    __TestInterface.getUpdatedOptionsFromConfig;
+
+  it('test config string with printer-style number range', () => {
+    const config = '2, 6-8';
+    const options = getUpdatedOptionsFromConfig(config);
+    expect(options).to.deep.equal([
+      ['2', '2'],
+      ['6', '6'],
+      ['7', '7'],
+      ['8', '8'],
+    ]);
+  });
+
+  it('test config string with printer-style number range', () => {
+    const config = '2, 5, 9';
+    const options = getUpdatedOptionsFromConfig(config);
+    expect(options).to.deep.equal([
+      ['2', '2'],
+      ['5', '5'],
+      ['9', '9'],
+    ]);
+  });
+
+  it('test config string with fewer options than menuGenerator', () => {
+    const config = "'CAT', 'SLOTH'";
+    const menuGenerator = [
+      ['cat', "'CAT'"],
+      ['sloth', "'SLOTH'"],
+      ['alien', "'ALIEN'"],
+      ['bear', "'BEAR'"],
+    ];
+    const options = getUpdatedOptionsFromConfig(config, menuGenerator);
+    expect(options).to.deep.equal([
+      ['cat', "'CAT'"],
+      ['sloth', "'SLOTH'"],
+    ]);
+  });
+
+  it('test config string with option not included in menuGenerator', () => {
+    const config = "'CAT', 'SLOTH', 'GIRAFFE'";
+    const menuGenerator = [
+      ['cat', "'CAT'"],
+      ['sloth', "'SLOTH'"],
+      ['alien', "'ALIEN'"],
+      ['bear', "'BEAR'"],
+    ];
+    const options = getUpdatedOptionsFromConfig(config, menuGenerator);
+    expect(options).to.deep.equal([
+      ['cat', "'CAT'"],
+      ['sloth', "'SLOTH'"],
+      ['giraffe', "'GIRAFFE'"],
+    ]);
+  });
+});

--- a/apps/test/unit/blockly/addons/cdoFieldDropdownTest.js
+++ b/apps/test/unit/blockly/addons/cdoFieldDropdownTest.js
@@ -4,28 +4,34 @@ import {expect} from '../../../util/reconfiguredChai';
 describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () => {
   const getUpdatedOptionsFromConfig =
     __TestInterface.getUpdatedOptionsFromConfig;
+
   describe('Test config string with printer-style number range', () => {
     it('Config only has a number range', () => {
       const config = '6-8';
       const options = getUpdatedOptionsFromConfig(config);
+
       expect(options).to.deep.equal([
         ['6', '6'],
         ['7', '7'],
         ['8', '8'],
       ]);
     });
+
     it('Config has only numbers separated by commas', () => {
       const config = '2, 5, 11';
       const options = getUpdatedOptionsFromConfig(config);
+
       expect(options).to.deep.equal([
         ['2', '2'],
         ['5', '5'],
         ['11', '11'],
       ]);
     });
+
     it('Config has number range and numbers separated by commas', () => {
       const config = '2, 4, 16-18';
       const options = getUpdatedOptionsFromConfig(config);
+
       expect(options).to.deep.equal([
         ['2', '2'],
         ['4', '4'],
@@ -35,6 +41,7 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
       ]);
     });
   });
+
   describe('Test config string that does not contain numbers', () => {
     it('Config has with fewer options than menuGenerator', () => {
       const config = "'CAT', 'SLOTH'";
@@ -45,11 +52,13 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
         ['bear', "'BEAR'"],
       ];
       const options = getUpdatedOptionsFromConfig(config, menuGenerator);
+
       expect(options).to.deep.equal([
         ['cat', "'CAT'"],
         ['sloth', "'SLOTH'"],
       ]);
     });
+
     it('Config has an option not included in menuGenerator', () => {
       const config = "'CAT', 'SLOTH', 'GIRAFFE'";
       const menuGenerator = [
@@ -59,6 +68,7 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
         ['bear', "'BEAR'"],
       ];
       const options = getUpdatedOptionsFromConfig(config, menuGenerator);
+
       expect(options).to.deep.equal([
         ['cat', "'CAT'"],
         ['sloth', "'SLOTH'"],

--- a/apps/test/unit/blockly/addons/cdoFieldDropdownTest.js
+++ b/apps/test/unit/blockly/addons/cdoFieldDropdownTest.js
@@ -1,14 +1,14 @@
-import {__TestInterface} from '@cdo/apps/blockly/addons/cdoFieldDropdown';
+import {
+  getUpdatedOptionsFromConfig,
+  arrayToMap,
+} from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import {expect} from '../../../util/reconfiguredChai';
 
-describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () => {
-  const getUpdatedOptionsFromConfig =
-    __TestInterface.getUpdatedOptionsFromConfig;
-
+describe('Testing function getUpdateOptionsFromConfig', () => {
   describe('Test config string with printer-style number range', () => {
     it('Config only has a number range', () => {
       const config = '6-8';
-      const options = getUpdatedOptionsFromConfig(config);
+      const options = getUpdatedOptionsFromConfig(config, {});
 
       expect(options).to.deep.equal([
         ['6', '6'],
@@ -19,7 +19,7 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
 
     it('Config has only numbers separated by commas', () => {
       const config = '2, 5, 11';
-      const options = getUpdatedOptionsFromConfig(config);
+      const options = getUpdatedOptionsFromConfig(config, {});
 
       expect(options).to.deep.equal([
         ['2', '2'],
@@ -30,7 +30,7 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
 
     it('Config has number range and numbers separated by commas', () => {
       const config = '2, 4, 16-18';
-      const options = getUpdatedOptionsFromConfig(config);
+      const options = getUpdatedOptionsFromConfig(config, {});
 
       expect(options).to.deep.equal([
         ['2', '2'],
@@ -51,7 +51,8 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
         ['alien', "'ALIEN'"],
         ['bear', "'BEAR'"],
       ];
-      const options = getUpdatedOptionsFromConfig(config, menuGenerator);
+      const existingOptionsMap = arrayToMap(menuGenerator);
+      const options = getUpdatedOptionsFromConfig(config, existingOptionsMap);
 
       expect(options).to.deep.equal([
         ['cat', "'CAT'"],
@@ -67,7 +68,8 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
         ['alien', "'ALIEN'"],
         ['bear', "'BEAR'"],
       ];
-      const options = getUpdatedOptionsFromConfig(config, menuGenerator);
+      const existingOptionsMap = arrayToMap(menuGenerator);
+      const options = getUpdatedOptionsFromConfig(config, existingOptionsMap);
 
       expect(options).to.deep.equal([
         ['cat', "'CAT'"],
@@ -83,8 +85,8 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
         ['rotation', "'rotation'"],
         ['direction', "'direction'"],
       ];
-      const options = getUpdatedOptionsFromConfig(config, menuGenerator);
-
+      const existingOptionsMap = arrayToMap(menuGenerator);
+      const options = getUpdatedOptionsFromConfig(config, existingOptionsMap);
       expect(options).to.deep.equal([
         ['size', "'scale'"],
         ['rotation', "'rotation'"],

--- a/apps/test/unit/blockly/addons/cdoFieldDropdownTest.js
+++ b/apps/test/unit/blockly/addons/cdoFieldDropdownTest.js
@@ -4,56 +4,66 @@ import {expect} from '../../../util/reconfiguredChai';
 describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () => {
   const getUpdatedOptionsFromConfig =
     __TestInterface.getUpdatedOptionsFromConfig;
-
-  it('test config string with printer-style number range', () => {
-    const config = '2, 6-8';
-    const options = getUpdatedOptionsFromConfig(config);
-    expect(options).to.deep.equal([
-      ['2', '2'],
-      ['6', '6'],
-      ['7', '7'],
-      ['8', '8'],
-    ]);
+  describe('test config string with printer-style number range', () => {
+    it('only a number range', () => {
+      const config = '6-8';
+      const options = getUpdatedOptionsFromConfig(config);
+      expect(options).to.deep.equal([
+        ['6', '6'],
+        ['7', '7'],
+        ['8', '8'],
+      ]);
+    });
+    it('only numbers separated by commas', () => {
+      const config = '2, 5, 11';
+      const options = getUpdatedOptionsFromConfig(config);
+      expect(options).to.deep.equal([
+        ['2', '2'],
+        ['5', '5'],
+        ['11', '11'],
+      ]);
+    });
+    it('number range and numbers separated by commas', () => {
+      const config = '2, 4, 16-18';
+      const options = getUpdatedOptionsFromConfig(config);
+      expect(options).to.deep.equal([
+        ['2', '2'],
+        ['4', '4'],
+        ['16', '16'],
+        ['17', '17'],
+        ['18', '18'],
+      ]);
+    });
   });
-
-  it('test config string with printer-style number range', () => {
-    const config = '2, 5, 9';
-    const options = getUpdatedOptionsFromConfig(config);
-    expect(options).to.deep.equal([
-      ['2', '2'],
-      ['5', '5'],
-      ['9', '9'],
-    ]);
-  });
-
-  it('test config string with fewer options than menuGenerator', () => {
-    const config = "'CAT', 'SLOTH'";
-    const menuGenerator = [
-      ['cat', "'CAT'"],
-      ['sloth', "'SLOTH'"],
-      ['alien', "'ALIEN'"],
-      ['bear', "'BEAR'"],
-    ];
-    const options = getUpdatedOptionsFromConfig(config, menuGenerator);
-    expect(options).to.deep.equal([
-      ['cat', "'CAT'"],
-      ['sloth', "'SLOTH'"],
-    ]);
-  });
-
-  it('test config string with option not included in menuGenerator', () => {
-    const config = "'CAT', 'SLOTH', 'GIRAFFE'";
-    const menuGenerator = [
-      ['cat', "'CAT'"],
-      ['sloth', "'SLOTH'"],
-      ['alien', "'ALIEN'"],
-      ['bear', "'BEAR'"],
-    ];
-    const options = getUpdatedOptionsFromConfig(config, menuGenerator);
-    expect(options).to.deep.equal([
-      ['cat', "'CAT'"],
-      ['sloth', "'SLOTH'"],
-      ['giraffe', "'GIRAFFE'"],
-    ]);
+  describe('test config string', () => {
+    it('test config string with fewer options than menuGenerator', () => {
+      const config = "'CAT', 'SLOTH'";
+      const menuGenerator = [
+        ['cat', "'CAT'"],
+        ['sloth', "'SLOTH'"],
+        ['alien', "'ALIEN'"],
+        ['bear', "'BEAR'"],
+      ];
+      const options = getUpdatedOptionsFromConfig(config, menuGenerator);
+      expect(options).to.deep.equal([
+        ['cat', "'CAT'"],
+        ['sloth', "'SLOTH'"],
+      ]);
+    });
+    it('test config string with option not included in menuGenerator', () => {
+      const config = "'CAT', 'SLOTH', 'GIRAFFE'";
+      const menuGenerator = [
+        ['cat', "'CAT'"],
+        ['sloth', "'SLOTH'"],
+        ['alien', "'ALIEN'"],
+        ['bear', "'BEAR'"],
+      ];
+      const options = getUpdatedOptionsFromConfig(config, menuGenerator);
+      expect(options).to.deep.equal([
+        ['cat', "'CAT'"],
+        ['sloth', "'SLOTH'"],
+        ['giraffe', "'GIRAFFE'"],
+      ]);
+    });
   });
 });

--- a/apps/test/unit/blockly/addons/cdoFieldDropdownTest.js
+++ b/apps/test/unit/blockly/addons/cdoFieldDropdownTest.js
@@ -4,8 +4,8 @@ import {expect} from '../../../util/reconfiguredChai';
 describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () => {
   const getUpdatedOptionsFromConfig =
     __TestInterface.getUpdatedOptionsFromConfig;
-  describe('test config string with printer-style number range', () => {
-    it('only a number range', () => {
+  describe('Test config string with printer-style number range', () => {
+    it('Config only has a number range', () => {
       const config = '6-8';
       const options = getUpdatedOptionsFromConfig(config);
       expect(options).to.deep.equal([
@@ -14,7 +14,7 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
         ['8', '8'],
       ]);
     });
-    it('only numbers separated by commas', () => {
+    it('Config has only numbers separated by commas', () => {
       const config = '2, 5, 11';
       const options = getUpdatedOptionsFromConfig(config);
       expect(options).to.deep.equal([
@@ -23,7 +23,7 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
         ['11', '11'],
       ]);
     });
-    it('number range and numbers separated by commas', () => {
+    it('Config has number range and numbers separated by commas', () => {
       const config = '2, 4, 16-18';
       const options = getUpdatedOptionsFromConfig(config);
       expect(options).to.deep.equal([
@@ -35,8 +35,8 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
       ]);
     });
   });
-  describe('test config string', () => {
-    it('test config string with fewer options than menuGenerator', () => {
+  describe('Test config string that does not contain numbers', () => {
+    it('Config has with fewer options than menuGenerator', () => {
       const config = "'CAT', 'SLOTH'";
       const menuGenerator = [
         ['cat', "'CAT'"],
@@ -50,7 +50,7 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
         ['sloth', "'SLOTH'"],
       ]);
     });
-    it('test config string with option not included in menuGenerator', () => {
+    it('Config has an option not included in menuGenerator', () => {
       const config = "'CAT', 'SLOTH', 'GIRAFFE'";
       const menuGenerator = [
         ['cat', "'CAT'"],

--- a/apps/test/unit/blockly/addons/cdoFieldDropdownTest.js
+++ b/apps/test/unit/blockly/addons/cdoFieldDropdownTest.js
@@ -75,5 +75,20 @@ describe('Testing CdoFieldDropdown function - getUpdateOptionsFromConfig', () =>
         ['giraffe', "'GIRAFFE'"],
       ]);
     });
+
+    it('Config has an option for which human-readable string is different from language-neutral string', () => {
+      const config = "'scale', 'rotation'";
+      const menuGenerator = [
+        ['size', "'scale'"],
+        ['rotation', "'rotation'"],
+        ['direction', "'direction'"],
+      ];
+      const options = getUpdatedOptionsFromConfig(config, menuGenerator);
+
+      expect(options).to.deep.equal([
+        ['size', "'scale'"],
+        ['rotation', "'rotation'"],
+      ]);
+    });
   });
 });

--- a/apps/test/unit/blockly/addons/cdoFieldImageDropdownTest.js
+++ b/apps/test/unit/blockly/addons/cdoFieldImageDropdownTest.js
@@ -1,4 +1,4 @@
-import {__TestInterface} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
+import {fixMenuGenerator} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
 import {expect} from '../../../util/reconfiguredChai';
 
 describe('CdoFieldImageDropdown', () => {
@@ -11,11 +11,7 @@ describe('CdoFieldImageDropdown', () => {
     const width = 25;
     const height = 50;
 
-    const fixedOptions = __TestInterface.fixMenuGenerator(
-      options,
-      width,
-      height
-    );
+    const fixedOptions = fixMenuGenerator(options, width, height);
     expect(fixedOptions).to.deep.equal([
       [
         {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds unit tests for the `CdoFieldDropdown` function `getUpdateOptionsFromConfig` that handles XML config for this field. It is a follow-up to [this PR](https://github.com/code-dot-org/code-dot-org/pull/51750) which added the handling.

I updated `CdoFieldDropdown.js` so that the function is exported, similar to how `fixMenuGenerator` [is exported](https://github.com/code-dot-org/code-dot-org/blob/00eaea1f87e713ffd51e95f1d0c8e51e3506f441/apps/src/blockly/addons/cdoFieldImageDropdown.js#L136) in `CdoFieldImageDropdown.js`. 

## Links
[jira ticket](https://codedotorg.atlassian.net/browse/SL-880)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
