### PR TITLE
Add extra assert to possibly debug flaky test

### DIFF
--- a/dashboard/test/controllers/api_controller_queries_test.rb
+++ b/dashboard/test/controllers/api_controller_queries_test.rb
@@ -20,6 +20,9 @@ class ApiControllerQueriesTest < ActionDispatch::IntegrationTest
       end
       create :teacher_feedback, student: students.first, teacher: section.teacher, level: script_level.level, script: script
     end
+    # This test has been flaky due to one fewer query on the teacher_feedbacks table.
+    # Without a better theory for why, assert that there are teacher_feedback entries.
+    refute_empty section.teacher.teacher_feedbacks
 
     sign_in_as section.teacher
 


### PR DESCRIPTION
`ApiControllerQueriesTest` has been flaky lately in the DTT. Looking at the logs, one fewer query is being made in those failures. The query that is skipped looks like: `TeacherFeedback Load (0.0ms)  SELECT `teacher_feedbacks`.* FROM `teacher_feedbacks` WHERE `teacher_feedbacks`.`deleted_at` IS NULL AND `teacher_feedbacks`.`student_id` IN (163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 155, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 156, 183, 184, 185) AND `teacher_feedbacks`.`script_id` = 430 AND `teacher_feedbacks`.`id` = 4 ORDER BY `teacher_feedbacks`.`created_at` DESC` and the stack trace traces this to [this line](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/helpers/users_helper.rb#L214). I cannot figure out why there is sometimes one fewer query. One unlikely theory, which I'm testing for here, is that the teacher feedback object isn't created for some reason.