### PR TITLE
Remove trailing whitespace

### DIFF
--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -283,7 +283,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
 
   test 'invalid params does not create section and returns an error' do
     sign_in @facilitator
-    
+
     assert_does_not_create(Section) do
       # As is, this will fail because the grade "PL" is not provided but
       # this test is meant to ensure a non-200 is returned when creating a section fails
@@ -291,7 +291,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
         login_type: Section::LOGIN_TYPE_EMAIL,
         participant_type: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher,
       }
- 
+
       assert_response :bad_request
     end
   end


### PR DESCRIPTION
I'm not sure why the commit hook didn't catch this but it was caught in the staging build.

Error:
```
Offenses:

dashboard/test/controllers/api/v1/sections_controller_test.rb:286:1: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
dashboard/test/controllers/api/v1/sections_controller_test.rb:294:1: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
```