### PR TITLE
Fix flaky workshop controller test

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -177,7 +177,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
 
     new_workshop_params = workshop_params(can_update_regional_partner)
 
-    workshop_start_date = Date.parse(new_workshop_params[:sessions_attributes].select {|s| s.key?(:start)}.min_by {|s| Date.parse(s[:start])}[:start])
+    workshop_start_date = new_workshop_params[:sessions] ? Date.parse(new_workshop_params[:sessions].select {|s| s[:start]}.min_by {|s| Date.parse(s[:start])}[:start]) : @workshop.workshop_starting_date
 
     if @workshop.virtual != new_workshop_params[:virtual] && user_cannot_freely_edit_virtual(new_workshop_params[:course], new_workshop_params[:subject], workshop_start_date)
       render json: {error: "non-workshop-admin cannot change CSP/CSA Summer Workshop virtual field within a month of it starting."}, status: :bad_request

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -800,16 +800,8 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     # Using '32.days' instead of '1.month' due to the inconsistency of the length of 'month' and it guarantees at least 1 month has passed.
     session_start = (tomorrow_at 9) + 32.days
     session_end = session_start + 8.hours
-    session = create(:pd_session, start: session_start, end: session_end)
-
-    workshop_month_away_params = workshop_params.merge(
-      course: Pd::Workshop::COURSE_CSP,
-      subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP,
-      organizer: @organizer,
-      funding_type: nil,
-      sessions: [session]
-    )
-    workshop = create :workshop, workshop_month_away_params
+    session = create :pd_session, start: session_start, end: session_end
+    workshop = create :workshop, workshop_params.merge(course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP, organizer: @organizer, funding_type: nil, sessions: [session])
 
     put :update, params: {id: workshop.id, pd_workshop: {virtual: true}}
 

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -795,14 +795,24 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   end
 
   test 'updating virtual field in CSP/CSA summer workshop before a month of starting as a non-ws-admin does not raise error' do
-    skip 'flaky test'
     sign_in @organizer
-    workshop = create :csp_summer_workshop, organizer: @organizer
+
     # Using '32.days' instead of '1.month' due to the inconsistency of the length of 'month' and it guarantees at least 1 month has passed.
     session_start = (tomorrow_at 9) + 32.days
     session_end = session_start + 8.hours
+    session = create(:pd_session, start: session_start, end: session_end)
 
-    put :update, params: {id: workshop.id, pd_workshop: workshop_params.merge(course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP, funding_type: nil, virtual: true, sessions_attributes: [{start: session_start, end: session_end}])}
+    workshop_month_away_params = workshop_params.merge(
+      course: Pd::Workshop::COURSE_CSP,
+      subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP,
+      organizer: @organizer,
+      funding_type: nil,
+      sessions: [session]
+    )
+    workshop = create :workshop, workshop_month_away_params
+
+    put :update, params: {id: workshop.id, pd_workshop: {virtual: true}}
+
     assert_response :success
   end
 


### PR DESCRIPTION
This PR actually completes the work attempted in [this PR](https://github.com/code-dot-org/code-dot-org/pull/52158). We weren't sure on the issue and simplified the test in hopes of resolving the flakiness but it didn't work. Since then, I investigated further and found where the flakiness was coming from:
1. The test was previously updating both the `start` time of the workshop session and the `virtual` status of it at the same time. Since the `virtual` field's ability to be changed relies on the `start` time, if they were updated in different orders there would be different outcomes.
2. The `virtual` field's ability to be updated depended on both the `sessions` field of the workshop and the `sessions_attributes` field of the new workshop params. There are ties between `sessions` and `sessions_attributes` but they are not one and the same, so this PR simplifies the logic to only use `sessions` so that updating them doesn't involve changin both fields.

With this simplification and the updated test, we should see it be less flaky and understand better why it failed if it does so.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-635&assignee=60d62161f65054006980bd71)
Slack thread discussion: [here](https://codedotorg.slack.com/archives/C03CM903Y/p1685450383887159)
Previous PR: [here](https://github.com/code-dot-org/code-dot-org/pull/52158)

## Testing story
Local testing to ensure the same behavior as before as well as updating the tests.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
