### PR TITLE
Assign course to section(s) from curriculum catalog

### DIFF
--- a/apps/src/sites/studio/pages/curriculum_catalog/index.js
+++ b/apps/src/sites/studio/pages/curriculum_catalog/index.js
@@ -12,7 +12,7 @@ $(document).ready(function () {
   const {curriculaData, isEnglish, sections} = catalogData;
 
   const store = getStore();
-  store.dispatch(setSections(sections));
+  sections && store.dispatch(setSections(sections));
 
   ReactDOM.render(
     <Provider store={store}>

--- a/apps/src/sites/studio/pages/curriculum_catalog/index.js
+++ b/apps/src/sites/studio/pages/curriculum_catalog/index.js
@@ -5,13 +5,17 @@ import {Provider} from 'react-redux';
 import {getStore} from '@cdo/apps/redux';
 import CurriculumCatalog from '../../../../templates/curriculumCatalog/CurriculumCatalog';
 import getScriptData from '@cdo/apps/util/getScriptData';
+import {setSections} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 $(document).ready(function () {
   const catalogData = getScriptData('catalog');
-  const {curriculaData, isEnglish} = catalogData;
+  const {curriculaData, isEnglish, sections} = catalogData;
+
+  const store = getStore();
+  store.dispatch(setSections(sections));
 
   ReactDOM.render(
-    <Provider store={getStore()}>
+    <Provider store={store}>
       <CurriculumCatalog curriculaData={curriculaData} isEnglish={isEnglish} />
     </Provider>,
     document.getElementById('curriculum-catalog-container')

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -255,6 +255,7 @@ const styles = {
   grid: {
     display: 'grid',
     gridTemplateColumns: '33% 33% 34%',
+    marginBottom: 10,
   },
   functionSelector: {
     display: 'flex',

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -193,7 +193,7 @@ const MultipleSectionsAssigner = ({
       >
         Select All
       </a>
-      <div style={{textAlign: 'right'}}>
+      <div style={styles.buttonContainer}>
         <Button
           text={i18n.dialogCancel()}
           onClick={onClose}
@@ -202,7 +202,6 @@ const MultipleSectionsAssigner = ({
         <Button
           id="confirm-assign"
           text={i18n.confirmAssignment()}
-          style={{marginLeft: 5}}
           onClick={reassignSections}
           color={Button.ButtonColor.orange}
         />
@@ -234,6 +233,11 @@ const styles = {
     fontSize: 16,
     marginBottom: 5,
     fontWeight: 'bold',
+  },
+  buttonContainer: {
+    display: 'flex',
+    gap: 5,
+    justifyContent: 'flex-end',
   },
   content: {
     fontSize: 14,
@@ -271,9 +275,6 @@ const styles = {
     fontSize: 16,
     cursor: 'pointer',
     color: color.link_color,
-    ':hover': {
-      color: color.link_color,
-    },
   },
 };
 

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -20,7 +20,7 @@ const MultipleSectionsAssigner = ({
   courseOfferingId,
   courseVersionId,
   scriptId,
-  reassignConfirm,
+  reassignConfirm = () => {},
   isOnCoursePage,
   isStandAloneUnit,
   participantAudience,

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -167,7 +167,6 @@ const MultipleSectionsAssigner = ({
       <div style={styles.header} className="uitest-confirm-assignment-dialog">
         {i18n.yourSectionsList()}
       </div>
-      <hr />
       <div style={styles.grid}>
         {sections &&
           sections.map(
@@ -186,6 +185,7 @@ const MultipleSectionsAssigner = ({
               )
           )}
       </div>
+      <hr />
       <a
         style={styles.selectAllSectionsLabel}
         onClick={selectAllHandler}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -17,7 +17,6 @@ import {
   BodyOneText,
 } from '@cdo/apps/componentLibrary/typography';
 import CheckboxDropdown from '../CheckboxDropdown';
-import {sectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
 import {
   translatedCourseOfferingCsTopics,
@@ -257,7 +256,6 @@ const CurriculumCatalog = ({curriculaData, isEnglish}) => {
                   isTranslated={false} // TODO [MEG]: actually pass in this data
                   isEnglish={isEnglish}
                   pathToCourse={course_version_path}
-                  sectionsForAssign={sectionsForDropdown}
                   courseVersionId={course_version_id}
                   courseId={course_id}
                   courseOfferingId={course_offering_id}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -17,6 +17,7 @@ import {
   BodyOneText,
 } from '@cdo/apps/componentLibrary/typography';
 import CheckboxDropdown from '../CheckboxDropdown';
+import {sectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
 import {
   translatedCourseOfferingCsTopics,
@@ -239,6 +240,11 @@ const CurriculumCatalog = ({curriculaData, isEnglish}) => {
                 school_subject,
                 cs_topic,
                 course_version_path,
+                course_version_id,
+                course_id,
+                course_offering_id,
+                script_id,
+                is_standalone_unit,
               }) => (
                 <CurriculumCatalogCard
                   key={key}
@@ -251,6 +257,12 @@ const CurriculumCatalog = ({curriculaData, isEnglish}) => {
                   isTranslated={false} // TODO [MEG]: actually pass in this data
                   isEnglish={isEnglish}
                   pathToCourse={course_version_path}
+                  sectionsForAssign={sectionsForDropdown}
+                  courseVersionId={course_version_id}
+                  courseId={course_id}
+                  courseOfferingId={course_offering_id}
+                  scriptId={script_id}
+                  isStandAloneUnit={is_standalone_unit}
                 />
               )
             )}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -31,8 +31,6 @@ const CurriculumCatalogCard = ({
   imageSrc = 'https://images.code.org/0a24eb3b51bd86e054362f0760c6e64e-image-1681413990565.png',
   subjects = [],
   topics = [],
-  isTranslated = false,
-  isEnglish,
   pathToCourse,
   ...props
 }) => (
@@ -60,9 +58,7 @@ const CurriculumCatalogCard = ({
     })}
     quickViewButtonText={i18n.learnMore()}
     imageAltText={imageAltText}
-    isTranslated={isTranslated}
     translationIconTitle={i18n.courseInYourLanguage()}
-    isEnglish={isEnglish}
     pathToCourse={pathToCourse + '?viewAs=Instructor'}
     {...props}
   />

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -108,74 +108,76 @@ const CustomizableCurriculumCatalogCard = ({
   const [isAssignDialogOpen, setIsAssignDialogOpen] = useState(false);
 
   return (
-    <div
-      className={classNames(
-        style.curriculumCatalogCardContainer,
-        isEnglish
-          ? style.curriculumCatalogCardContainer_english
-          : style.curriculumCatalogCardContainer_notEnglish
-      )}
-    >
-      <img src={imageSrc} alt={imageAltText} />
-      <div className={style.curriculumInfoContainer}>
-        <div className={style.labelsAndTranslatabilityContainer}>
-          <div className={style.labelsContainer}>
-            <CardLabels subjectsAndTopics={subjectsAndTopics} />
-          </div>
-        </div>
-        {isTranslated && (
-          <FontAwesome
-            icon="language"
-            className="fa-solid"
-            title={translationIconTitle}
-          />
+    <>
+      <div
+        className={classNames(
+          style.curriculumCatalogCardContainer,
+          isEnglish
+            ? style.curriculumCatalogCardContainer_english
+            : style.curriculumCatalogCardContainer_notEnglish
         )}
-        <h4>{courseDisplayName}</h4>
-        <div className={style.iconWithDescription}>
-          <FontAwesome icon="user" className="fa-solid" />
-          <p>{gradeRange}</p>
-        </div>
-        <div className={style.iconWithDescription}>
-          <FontAwesome icon="clock" className="fa-solid" />
-          <p>{duration}</p>
-        </div>
-        <div
-          className={classNames(
-            style.buttonsContainer,
-            isEnglish
-              ? style.buttonsContainer_english
-              : style.buttonsContainer_notEnglish
-          )}
-        >
-          <Button
-            __useDeprecatedTag
-            color={Button.ButtonColor.neutralDark}
-            type="button"
-            href={pathToCourse}
-            aria-label={quickViewButtonDescription}
-            text={quickViewButtonText}
-          />
-          <Button
-            color={Button.ButtonColor.brandSecondaryDefault}
-            type="button"
-            onClick={() => {
-              setIsAssignDialogOpen(true);
-            }}
-            aria-label={assignButtonDescription}
-            text={assignButtonText}
-          />
-          {isAssignDialogOpen && (
-            <MultipleSectionsAssigner
-              assignmentName={courseDisplayName}
-              onClose={() => setIsAssignDialogOpen(false)}
-              sections={sectionsForDropdown}
-              participantAudience={'student'}
-              {...props}
+      >
+        <img src={imageSrc} alt={imageAltText} />
+        <div className={style.curriculumInfoContainer}>
+          <div className={style.labelsAndTranslatabilityContainer}>
+            <div className={style.labelsContainer}>
+              <CardLabels subjectsAndTopics={subjectsAndTopics} />
+            </div>
+          </div>
+          {isTranslated && (
+            <FontAwesome
+              icon="language"
+              className="fa-solid"
+              title={translationIconTitle}
             />
           )}
+          <h4>{courseDisplayName}</h4>
+          <div className={style.iconWithDescription}>
+            <FontAwesome icon="user" className="fa-solid" />
+            <p>{gradeRange}</p>
+          </div>
+          <div className={style.iconWithDescription}>
+            <FontAwesome icon="clock" className="fa-solid" />
+            <p>{duration}</p>
+          </div>
+          <div
+            className={classNames(
+              style.buttonsContainer,
+              isEnglish
+                ? style.buttonsContainer_english
+                : style.buttonsContainer_notEnglish
+            )}
+          >
+            <Button
+              __useDeprecatedTag
+              color={Button.ButtonColor.neutralDark}
+              type="button"
+              href={pathToCourse}
+              aria-label={quickViewButtonDescription}
+              text={quickViewButtonText}
+            />
+            <Button
+              color={Button.ButtonColor.brandSecondaryDefault}
+              type="button"
+              onClick={() => {
+                setIsAssignDialogOpen(true);
+              }}
+              aria-label={assignButtonDescription}
+              text={assignButtonText}
+            />
+          </div>
         </div>
       </div>
-    </div>
+      {isAssignDialogOpen && (
+        <MultipleSectionsAssigner
+          assignmentName={courseDisplayName}
+          onClose={() => setIsAssignDialogOpen(false)}
+          sections={sectionsForDropdown}
+          participantAudience={'student'}
+          {...props}
+        />
+      )}
+    </>
   );
 };
 

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {concat, intersection} from 'lodash';
@@ -14,6 +14,14 @@ import {
 } from '@cdo/apps/templates/teacherDashboard/CourseOfferingHelpers';
 import style from './curriculum_catalog_card.module.scss';
 import CardLabels from '@cdo/apps/templates/curriculumCatalog/CardLabels';
+import MultipleSectionsAssigner from '@cdo/apps/templates/MultipleSectionsAssigner';
+import {connect} from 'react-redux';
+import {
+  assignToSection,
+  sectionsForDropdown,
+  unassignSection,
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 
 const CurriculumCatalogCard = ({
   courseDisplayName,
@@ -26,8 +34,9 @@ const CurriculumCatalogCard = ({
   isTranslated = false,
   isEnglish,
   pathToCourse,
+  ...props
 }) => (
-  <CustomizableCurriculumCatalogCard
+  <ConnectedCustomizableCurriculumCatalogCard
     assignButtonText={i18n.assign()}
     assignButtonDescription={i18n.assignDescription({
       course_name: courseDisplayName,
@@ -55,6 +64,7 @@ const CurriculumCatalogCard = ({
     translationIconTitle={i18n.courseInYourLanguage()}
     isEnglish={isEnglish}
     pathToCourse={pathToCourse + '?viewAs=Instructor'}
+    {...props}
   />
 );
 
@@ -74,6 +84,11 @@ CurriculumCatalogCard.propTypes = {
   ),
   isEnglish: PropTypes.bool.isRequired,
   pathToCourse: PropTypes.string.isRequired,
+  courseVersionId: PropTypes.number,
+  courseId: PropTypes.number,
+  courseOfferingId: PropTypes.number,
+  scriptId: PropTypes.number,
+  isStandAloneUnit: PropTypes.bool,
 };
 
 const CustomizableCurriculumCatalogCard = ({
@@ -91,65 +106,75 @@ const CustomizableCurriculumCatalogCard = ({
   quickViewButtonText,
   isEnglish,
   pathToCourse,
-}) => (
-  <div
-    className={classNames(
-      style.curriculumCatalogCardContainer,
-      isEnglish
-        ? style.curriculumCatalogCardContainer_english
-        : style.curriculumCatalogCardContainer_notEnglish
-    )}
-  >
-    <img src={imageSrc} alt={imageAltText} />
-    <div className={style.curriculumInfoContainer}>
-      <div className={style.labelsAndTranslatabilityContainer}>
-        <div className={style.labelsContainer}>
-          <CardLabels subjectsAndTopics={subjectsAndTopics} />
+  sectionsForDropdown,
+  ...props
+}) => {
+  const [isAssignDialogOpen, setIsAssignDialogOpen] = useState(false);
+
+  return (
+    <div
+      className={classNames(
+        style.curriculumCatalogCardContainer,
+        isEnglish
+          ? style.curriculumCatalogCardContainer_english
+          : style.curriculumCatalogCardContainer_notEnglish
+      )}
+    >
+      <img src={imageSrc} alt={imageAltText} />
+      <div className={style.curriculumInfoContainer}>
+        <div className={style.labelsAndTranslatabilityContainer}>
+          <div className={style.labelsContainer}>
+            <CardLabels subjectsAndTopics={subjectsAndTopics} />
+          </div>
         </div>
-        {isTranslated && (
-          <FontAwesome
-            icon="language"
-            className="fa-solid"
-            title={translationIconTitle}
+        <h4>{courseDisplayName}</h4>
+        <div className={style.iconWithDescription}>
+          <FontAwesome icon="user" className="fa-solid" />
+          <p>{gradeRange}</p>
+        </div>
+        <div className={style.iconWithDescription}>
+          <FontAwesome icon="clock" className="fa-solid" />
+          <p>{duration}</p>
+        </div>
+        <div
+          className={classNames(
+            style.buttonsContainer,
+            isEnglish
+              ? style.buttonsContainer_english
+              : style.buttonsContainer_notEnglish
+          )}
+        >
+          <Button
+            __useDeprecatedTag
+            color={Button.ButtonColor.neutralDark}
+            type="button"
+            href={pathToCourse}
+            aria-label={quickViewButtonDescription}
+            text={quickViewButtonText}
           />
-        )}
-      </div>
-      <h4>{courseDisplayName}</h4>
-      <div className={style.iconWithDescription}>
-        <FontAwesome icon="user" className="fa-solid" />
-        <p>{gradeRange}</p>
-      </div>
-      <div className={style.iconWithDescription}>
-        <FontAwesome icon="clock" className="fa-solid" />
-        <p>{duration}</p>
-      </div>
-      <div
-        className={classNames(
-          style.buttonsContainer,
-          isEnglish
-            ? style.buttonsContainer_english
-            : style.buttonsContainer_notEnglish
-        )}
-      >
-        <Button
-          __useDeprecatedTag
-          color={Button.ButtonColor.neutralDark}
-          type="button"
-          href={pathToCourse}
-          aria-label={quickViewButtonDescription}
-          text={quickViewButtonText}
-        />
-        <Button
-          color={Button.ButtonColor.brandSecondaryDefault}
-          type="button"
-          onClick={() => {}}
-          aria-label={assignButtonDescription}
-          text={assignButtonText}
-        />
+          <Button
+            color={Button.ButtonColor.brandSecondaryDefault}
+            type="button"
+            onClick={() => {
+              setIsAssignDialogOpen(true);
+            }}
+            aria-label={assignButtonDescription}
+            text={assignButtonText}
+          />
+          {isAssignDialogOpen && (
+            <MultipleSectionsAssigner
+              assignmentName={courseDisplayName}
+              onClose={() => setIsAssignDialogOpen(false)}
+              sections={sectionsForDropdown}
+              participantAudience={'student'}
+              {...props}
+            />
+          )}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 CustomizableCurriculumCatalogCard.propTypes = {
   courseDisplayName: PropTypes.string.isRequired,
@@ -163,11 +188,31 @@ CustomizableCurriculumCatalogCard.propTypes = {
   quickViewButtonText: PropTypes.string.isRequired,
   assignButtonText: PropTypes.string.isRequired,
   pathToCourse: PropTypes.string.isRequired,
-
+  courseVersionId: PropTypes.number,
+  courseId: PropTypes.number,
+  courseOfferingId: PropTypes.number,
+  scriptId: PropTypes.number,
+  isStandAloneUnit: PropTypes.bool,
+  sectionsForDropdown: PropTypes.arrayOf(sectionForDropdownShape).isRequired,
   // for screenreaders
   imageAltText: PropTypes.string,
   quickViewButtonDescription: PropTypes.string.isRequired,
   assignButtonDescription: PropTypes.string.isRequired,
 };
+
+const ConnectedCustomizableCurriculumCatalogCard = connect(
+  (state, ownProps) => ({
+    sectionsForDropdown: sectionsForDropdown(
+      state.teacherSections,
+      ownProps.courseOfferingId,
+      ownProps.courseVersionId,
+      state.progress.scriptId
+    ),
+  }),
+  {
+    assignToSection,
+    unassignSection,
+  }
+)(CustomizableCurriculumCatalogCard);
 
 export default CurriculumCatalogCard;

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -23,7 +23,7 @@ import {
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 
-const CurriculumCatalogCard = ({
+export const UnconnectedCurriculumCatalogCard = ({
   courseDisplayName,
   duration,
   gradesArray,
@@ -34,7 +34,7 @@ const CurriculumCatalogCard = ({
   pathToCourse,
   ...props
 }) => (
-  <ConnectedCustomizableCurriculumCatalogCard
+  <CustomizableCurriculumCatalogCard
     assignButtonText={i18n.assign()}
     assignButtonDescription={i18n.assignDescription({
       course_name: courseDisplayName,
@@ -64,7 +64,7 @@ const CurriculumCatalogCard = ({
   />
 );
 
-CurriculumCatalogCard.propTypes = {
+UnconnectedCurriculumCatalogCard.propTypes = {
   courseDisplayName: PropTypes.string.isRequired,
   duration: PropTypes.oneOf(Object.keys(translatedCourseOfferingDurations))
     .isRequired,
@@ -123,6 +123,13 @@ const CustomizableCurriculumCatalogCard = ({
             <CardLabels subjectsAndTopics={subjectsAndTopics} />
           </div>
         </div>
+        {isTranslated && (
+          <FontAwesome
+            icon="language"
+            className="fa-solid"
+            title={translationIconTitle}
+          />
+        )}
         <h4>{courseDisplayName}</h4>
         <div className={style.iconWithDescription}>
           <FontAwesome icon="user" className="fa-solid" />
@@ -196,7 +203,7 @@ CustomizableCurriculumCatalogCard.propTypes = {
   assignButtonDescription: PropTypes.string.isRequired,
 };
 
-const ConnectedCustomizableCurriculumCatalogCard = connect(
+const CurriculumCatalogCard = connect(
   (state, ownProps) => ({
     sectionsForDropdown: sectionsForDropdown(
       state.teacherSections,
@@ -209,6 +216,6 @@ const ConnectedCustomizableCurriculumCatalogCard = connect(
     assignToSection,
     unassignSection,
   }
-)(CustomizableCurriculumCatalogCard);
+)(UnconnectedCurriculumCatalogCard);
 
 export default CurriculumCatalogCard;

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -23,7 +23,7 @@ import {
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 
-export const UnconnectedCurriculumCatalogCard = ({
+const CurriculumCatalogCard = ({
   courseDisplayName,
   duration,
   gradesArray,
@@ -64,7 +64,7 @@ export const UnconnectedCurriculumCatalogCard = ({
   />
 );
 
-UnconnectedCurriculumCatalogCard.propTypes = {
+CurriculumCatalogCard.propTypes = {
   courseDisplayName: PropTypes.string.isRequired,
   duration: PropTypes.oneOf(Object.keys(translatedCourseOfferingDurations))
     .isRequired,
@@ -203,19 +203,17 @@ CustomizableCurriculumCatalogCard.propTypes = {
   assignButtonDescription: PropTypes.string.isRequired,
 };
 
-const CurriculumCatalogCard = connect(
+export default connect(
   (state, ownProps) => ({
     sectionsForDropdown: sectionsForDropdown(
       state.teacherSections,
       ownProps.courseOfferingId,
       ownProps.courseVersionId,
-      state.progress.scriptId
+      state.progress?.scriptId
     ),
   }),
   {
     assignToSection,
     unassignSection,
   }
-)(UnconnectedCurriculumCatalogCard);
-
-export default CurriculumCatalogCard;
+)(CurriculumCatalogCard);

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -173,7 +173,7 @@ const CustomizableCurriculumCatalogCard = ({
           assignmentName={courseDisplayName}
           onClose={() => setIsAssignDialogOpen(false)}
           sections={sectionsForDropdown}
-          participantAudience={'student'}
+          participantAudience="student"
           {...props}
         />
       )}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
@@ -1,12 +1,19 @@
 import React from 'react';
+import {Provider} from 'react-redux';
 import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
+import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {configureStore} from '@reduxjs/toolkit';
 
 export default {
   title: 'CurriculumCatalogCard',
   component: CurriculumCatalogCard,
 };
 
-const Template = args => <CurriculumCatalogCard {...args} />;
+const Template = args => (
+  <Provider store={configureStore({reducer: {teacherSections}})}>
+    <CurriculumCatalogCard {...args} />
+  </Provider>
+);
 
 const defaultArgs = {
   courseDisplayName: 'Computer Science Principles',

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -18,7 +18,6 @@ const USER_EDITABLE_SECTION_PROPS = [
   'loginType',
   'lessonExtras',
   'pairingAllowed',
-  'participantType',
   'ttsAutoplayEnabled',
   'participantType',
   'courseId',

--- a/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
@@ -11,6 +11,7 @@ import responsive, {
   setResponsiveSize,
   ResponsiveSize,
 } from '@cdo/apps/code-studio/responsiveRedux';
+import {restoreRedux} from '@cdo/apps/redux';
 import CurriculumCatalog from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalog';
 import {
   allCurricula,
@@ -25,6 +26,10 @@ import {
   noGradesCurriculum,
   noPathCurriculum,
 } from './CurriculumCatalogTestHelper';
+import teacherSections, {
+  setSections,
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {sections} from '../studioHomepages/fakeSectionUtils';
 
 describe('CurriculumCatalog', () => {
   const defaultProps = {curriculaData: allCurricula, isEnglish: false};
@@ -34,8 +39,9 @@ describe('CurriculumCatalog', () => {
   let replaceStateOrig = window.history.replaceState;
 
   beforeEach(() => {
-    store = configureStore({reducer: {responsive}});
+    store = configureStore({reducer: {responsive, teacherSections}});
     store.dispatch(setResponsiveSize(ResponsiveSize.lg));
+    store.dispatch(setSections(sections));
 
     replacedLocation = undefined;
     window.history.replaceState = (_, __, newLocation) => {
@@ -44,6 +50,7 @@ describe('CurriculumCatalog', () => {
   });
 
   afterEach(() => {
+    restoreRedux();
     resetWindowLocation();
     window.history.replaceState = replaceStateOrig;
   });

--- a/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {Provider} from 'react-redux';
-import {configureStore} from '@reduxjs/toolkit';
 import {assert, expect} from '../../../util/reconfiguredChai';
 import {
   setWindowLocation,
@@ -11,7 +10,12 @@ import responsive, {
   setResponsiveSize,
   ResponsiveSize,
 } from '@cdo/apps/code-studio/responsiveRedux';
-import {restoreRedux, stubRedux} from '@cdo/apps/redux';
+import {
+  getStore,
+  registerReducers,
+  restoreRedux,
+  stubRedux,
+} from '@cdo/apps/redux';
 import CurriculumCatalog from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalog';
 import {
   allCurricula,
@@ -40,7 +44,8 @@ describe('CurriculumCatalog', () => {
 
   beforeEach(() => {
     stubRedux();
-    store = configureStore({reducer: {responsive, teacherSections}});
+    registerReducers({responsive, teacherSections});
+    store = getStore();
     store.dispatch(setResponsiveSize(ResponsiveSize.lg));
     store.dispatch(setSections(sections));
 

--- a/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
@@ -11,7 +11,7 @@ import responsive, {
   setResponsiveSize,
   ResponsiveSize,
 } from '@cdo/apps/code-studio/responsiveRedux';
-import {restoreRedux} from '@cdo/apps/redux';
+import {restoreRedux, stubRedux} from '@cdo/apps/redux';
 import CurriculumCatalog from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalog';
 import {
   allCurricula,
@@ -39,6 +39,7 @@ describe('CurriculumCatalog', () => {
   let replaceStateOrig = window.history.replaceState;
 
   beforeEach(() => {
+    stubRedux();
     store = configureStore({reducer: {responsive, teacherSections}});
     store.dispatch(setResponsiveSize(ResponsiveSize.lg));
     store.dispatch(setSections(sections));

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -244,4 +244,20 @@ describe('CurriculumCatalogCard', () => {
       ),
     });
   });
+
+  it('clicking Assign button shows sections', () => {
+    renderCurriculumCard();
+
+    const assignButton = screen.getByRole('button', {
+      name: new RegExp(
+        `Assign ${defaultProps.courseDisplayName} to your classroom`
+      ),
+    });
+
+    sections.forEach(
+      section => expect(screen.queryByText(section.name)).to.be.null
+    );
+    fireEvent.click(assignButton);
+    sections.forEach(section => screen.getByText(section.name));
+  });
 });

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -10,8 +10,12 @@ import {
 } from '@cdo/apps/templates/teacherDashboard/CourseOfferingHelpers';
 import {sections} from '../studioHomepages/fakeSectionUtils';
 import {Provider} from 'react-redux';
-import {configureStore} from '@reduxjs/toolkit';
-import {restoreRedux, stubRedux} from '@cdo/apps/redux';
+import {
+  getStore,
+  registerReducers,
+  restoreRedux,
+  stubRedux,
+} from '@cdo/apps/redux';
 import teacherSections, {
   setSections,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
@@ -47,7 +51,8 @@ describe('CurriculumCatalogCard', () => {
 
   beforeEach(() => {
     stubRedux();
-    store = configureStore({reducer: {teacherSections}});
+    registerReducers({teacherSections});
+    store = getStore();
     store.dispatch(setSections(sections));
     defaultProps = {
       courseDisplayName: 'AI for Oceans',

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import {fireEvent, render, screen} from '@testing-library/react';
 import {pull} from 'lodash';
 import {expect} from '../../../util/reconfiguredChai';
-import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
+import {UnconnectedCurriculumCatalogCard as CurriculumCatalogCard} from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
 import {
   subjectsAndTopicsOrder,
   translatedCourseOfferingCsTopics,
   translatedLabels,
 } from '@cdo/apps/templates/teacherDashboard/CourseOfferingHelpers';
+import {sections} from '../studioHomepages/fakeSectionUtils';
 
 describe('CurriculumCatalogCard', () => {
   const translationIconTitle = 'Curriculum is available in your language';
@@ -37,6 +38,7 @@ describe('CurriculumCatalogCard', () => {
       gradesArray: ['4', '5', '6', '7', '8'],
       isEnglish: true,
       pathToCourse: '/s/course',
+      sectionsForDropdown: sections,
     };
   });
 

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -11,7 +11,7 @@ import {
 import {sections} from '../studioHomepages/fakeSectionUtils';
 import {Provider} from 'react-redux';
 import {configureStore} from '@reduxjs/toolkit';
-import {restoreRedux} from '@cdo/apps/redux';
+import {restoreRedux, stubRedux} from '@cdo/apps/redux';
 import teacherSections, {
   setSections,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
@@ -46,6 +46,7 @@ describe('CurriculumCatalogCard', () => {
     );
 
   beforeEach(() => {
+    stubRedux();
     store = configureStore({reducer: {teacherSections}});
     store.dispatch(setSections(sections));
     defaultProps = {

--- a/apps/test/unit/templates/studioHomepages/fakeSectionUtils.js
+++ b/apps/test/unit/templates/studioHomepages/fakeSectionUtils.js
@@ -24,6 +24,7 @@ export const sections = [
     courseOfferingId: null,
     courseVersionId: null,
     unitId: null,
+    isAssigned: true,
   },
   {
     id: 12,
@@ -42,6 +43,7 @@ export const sections = [
     courseOfferingId: null,
     courseVersionId: null,
     unitId: null,
+    isAssigned: true,
   },
 ];
 

--- a/apps/test/unit/templates/studioHomepages/fakeSectionUtils.js
+++ b/apps/test/unit/templates/studioHomepages/fakeSectionUtils.js
@@ -25,6 +25,7 @@ export const sections = [
     courseVersionId: null,
     unitId: null,
     isAssigned: true,
+    participant_type: 'student',
   },
   {
     id: 12,
@@ -43,7 +44,8 @@ export const sections = [
     courseOfferingId: null,
     courseVersionId: null,
     unitId: null,
-    isAssigned: true,
+    isAssigned: false,
+    participant_type: 'student',
   },
 ];
 

--- a/dashboard/app/controllers/curriculum_catalog_controller.rb
+++ b/dashboard/app/controllers/curriculum_catalog_controller.rb
@@ -3,9 +3,14 @@ class CurriculumCatalogController < ApplicationController
   def index
     view_options(full_width: true, responsive_content: true, no_padding_container: true)
 
+    unless current_user&.student?
+      @sections = current_user.try {|u| u.sections.all.reject(&:hidden).map(&:summarize)}
+    end
+
     @catalog_data = {
       curriculaData: CourseOffering.assignable_published_for_students_course_offerings.sort_by(&:display_name).map(&:summarize_for_catalog),
-      isEnglish: language == "en"
+      isEnglish: language == "en",
+      sections: @sections
     }
   end
 end

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -98,6 +98,20 @@ class CourseOffering < ApplicationRecord
     latest_published_version.content_root.link
   end
 
+  def course_id
+    return unless latest_published_version&.content_root_type == 'UnitGroup'
+    latest_published_version.content_root.id
+  end
+
+  def script_id
+    return unless latest_published_version&.content_root_type == 'Unit'
+    latest_published_version.content_root.id
+  end
+
+  def standalone_unit?
+    latest_published_version&.content_root_type == 'Unit'
+  end
+
   def self.should_cache?
     Unit.should_cache?
   end
@@ -248,7 +262,12 @@ class CourseOffering < ApplicationRecord
       cs_topic: cs_topic,
       school_subject: school_subject,
       device_compatibility: device_compatibility,
-      course_version_path: path_to_latest_published_version
+      course_version_path: path_to_latest_published_version,
+      course_version_id: latest_published_version&.id,
+      course_id: course_id,
+      course_offering_id: id,
+      script_id: script_id,
+      is_standalone_unit: standalone_unit?
     }
   end
 


### PR DESCRIPTION
When a signed-in teacher has sections, they can now assign courses and units from our catalog page!

This card is specifically for signed-in teachers with sections. See follow-up work for more.

I did need to apply some inline styles to the MultipleSectionsAssigner component to make the right/left styling compatible with RTL pages. No other changes were necessary!

What the component looks like from the unit overview page in production:
<img width="505" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/42243189-5833-4d3e-9c76-4c3a76337d61">

**See screenshot in comment at the bottom for the newest version of these –– placement of the horizontal line changed, as well as padding on the Select All**
What the component looks like from the unit overview page (should be unchanged from what's above):
<img width="479" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/7aa86602-f659-4991-bdcd-50b3fdbb71d5">

What the component looks like in RTL languages:
<img width="477" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/037a2159-3e5a-46b5-9e8d-c2f128e935d5">

From the catalog page, there is a pesky underline in the <a> tag –– I've created a follow-up ticket for this issue, as this tag should be a `button` for accessibility (it's not a link to a new page)
<img width="514" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/593a98d0-8a44-4eef-83ce-cd11e1af43d5">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I added a unit test for this, but I think the bulk of the test coverage will come from UI and/or eyes tests

### Manual testing:

**Screenshots are from before I disentangled the catalog styling from the dialog styling! See updated styling above**

My local teacher account started with the following sections assigned:
<img width="805" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/60add027-b1f4-421f-816b-1216b66b9772">

When I go to the curriculum catalog card and click on "Course 1", I see:
<img width="803" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/67f27c15-7ac9-4691-9b59-bce51411203b">

If I uncheck "test", the course is un-assigned:
<img width="803" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/35a6e44c-0ec7-45f1-a389-7be73dca3065">

When I go to the curriculum catalog card and click on "Course 2", I see:
<img width="801" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/71db0d9b-ba9b-44f9-9e33-8856b3f0c756">

If I check both sections, the course is assigned to both:
<img width="829" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/c47badba-63de-4adc-a598-81027410fab9">

And if I select a totally different course and assign it:
<img width="801" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/ab88878c-45d3-4f0f-8245-aa2ae3bb281c">

I see:
<img width="814" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/2c77efac-7c45-423a-9a13-222d0a691e77">


## Deployment strategy

## Follow-up work

- We're still getting the final spec for a confirmation message for when a course was successfully assigned –– will follow up with that in a separate PR. Ticket here https://codedotorg.atlassian.net/browse/ACQ-643
- Need to add keyboard accessibility to the dialog component (https://codedotorg.atlassian.net/browse/ACQ-553)
- Need to add functionality for signed-out users, and for signed-in teachers who do not have sections (https://codedotorg.atlassian.net/browse/ACQ-521 and https://codedotorg.atlassian.net/browse/ACQ-621)
- The "Select All" is currently an anchor tag, presumably for styling purposes. Unfortunately, that's not accessible, as the functionality is a button. Also unfortunately, with CSS-in-JS styles, you can't add styles specific to state (e.g. hover) :(. So it's not a quick fix. Ticket here: https://codedotorg.atlassian.net/browse/ACQ-642

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
