### PR TITLE
P20-216: Correct sync-all script algorithm

### DIFF
--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -40,7 +40,8 @@ class I18nSync
 
   def run
     if @options[:interactive]
-      return_to_staging_branch
+      # force switch to the staging branch before sync-in as it contains the most relevant English content
+      return_to_staging_branch(force: true)
       sync_in if should_i "sync in"
       sync_up if should_i "sync up"
       CreateI18nPullRequests.in_and_up if @options[:with_pull_request] && should_i("create the in & up PR")
@@ -138,15 +139,16 @@ class I18nSync
     end
   end
 
-  def return_to_staging_branch
+  def return_to_staging_branch(force: false)
     case GitUtils.current_branch
     when "staging"
       # If we're already on staging, we don't need to bother
       return
     when /^i18n-sync/
-      # If we're on an i18n sync branch, only return to staging if the branch
-      # has been merged.
-      return unless GitUtils.current_branch_merged_into? "origin/staging"
+      unless force
+        # If we're on an i18n sync branch, only return to staging if the branch has been merged.
+        return unless GitUtils.current_branch_merged_into?('origin/staging')
+      end
     else
       # If we're on some other branch, then we're in some kind of weird state,
       # so error out.

--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -40,15 +40,17 @@ class I18nSync
 
   def run
     if @options[:interactive]
-      # force switch to the staging branch before sync-in as it contains the most relevant English content
+      # download and distribute translations from the previous sync
+      return_to_staging_branch
+      sync_down if should_i "sync down"
+      sync_out(true) if should_i "sync out"
+      CreateI18nPullRequests.down_and_out if @options[:with_pull_request] && should_i("create the down & out PR")
+
+      # force switch to the staging branch to collect and upload the most relevant English content
       return_to_staging_branch(force: true)
       sync_in if should_i "sync in"
       sync_up if should_i "sync up"
       CreateI18nPullRequests.in_and_up if @options[:with_pull_request] && should_i("create the in & up PR")
-      sync_down if should_i "sync down"
-      sync_out(true) if should_i "sync out"
-      CreateI18nPullRequests.down_and_out if @options[:with_pull_request] && should_i("create the down & out PR")
-      return_to_staging_branch
     elsif @options[:command]
       case @options[:command]
       when 'in'


### PR DESCRIPTION
## Issue
Because we squash-merge the `i18n-sync-down-out-mm-dd-yyyy` PR, the following `i18n-sync-in-up-mm-dd-yyyy` PR includes all the commits and changes made during the previous `sync-down-out`.

## Soluction
It makes more sense first run `sync-down-out` on the previous `I18n-sync-in-up-*` or `staging` branch to download existing translations for the last `sync-in-up` and then run `sync-in-up` on the `staging` branch as it contains the most relevant English content.

## JIRA
[P20-216](https://codedotorg.atlassian.net/browse/P20-216)

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
