### PR TITLE
Block save of bad project thumbnail URLs

### DIFF
--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -470,16 +470,7 @@ class Projects
   # DCDO flag in place to choose when to enable/disable logging (off by default).
   def validate_thumbnail_url(channel_id, thumbnail_url)
     return true unless thumbnail_url
-
-    if !valid_thumbnail_url?(thumbnail_url) && DCDO.get('log_thumbnail_url_validation', false)
-      # raise ValidationError
-      Honeybadger.notify(
-        error_class: 'Project::ValidationError',
-        error_message: 'A project was saved with an unexpected thumbnail URL.',
-        context: {channel_id: channel_id, thumbnail_url: thumbnail_url}
-      )
-    end
-
+    raise ValidationError unless valid_thumbnail_url?(thumbnail_url)
     true
   end
 

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -465,9 +465,6 @@ class Projects
     'unknown'
   end
 
-  # Temporarily logging rather than erroring in order
-  # to confirm that only valid thumbnail URLs are present in existing projects.
-  # DCDO flag in place to choose when to enable/disable logging (off by default).
   def validate_thumbnail_url(channel_id, thumbnail_url)
     return true unless thumbnail_url
     raise ValidationError unless valid_thumbnail_url?(thumbnail_url)

--- a/dashboard/legacy/test/middleware/helpers/test_projects.rb
+++ b/dashboard/legacy/test/middleware/helpers/test_projects.rb
@@ -208,44 +208,42 @@ class ProjectsTest < Minitest::Test
     assert_nil project.get(channel_id)[:projectType]
   end
 
-  # Commenting out temporarily until we have confirmed that only valid thumbnail URLs
-  # are present in existing projects.
-  # def test_project_throws_on_update_with_invalid_thumbnail_url
-  #   signedin_storage_id = create_storage_id_for_user(20)
-  #   project = Projects.new(signedin_storage_id)
-  #   channel_id = project.create({}, ip: 123)
-  #
-  #   assert_raises Projects::ValidationError do
-  #     project.update(channel_id, {'thumbnailUrl' => 'bad.com'}, 123)
-  #   end
-  # end
-  #
-  # def test_project_update_succeeds_with_valid_thumbnail_url
-  #   signedin_storage_id = create_storage_id_for_user(20)
-  #   project = Projects.new(signedin_storage_id)
-  #   channel_id = project.create({}, ip: 123)
-  #
-  #   expected_thumbnail_url = "/v3/files/#{channel_id}/.metadata/thumbnail.png"
-  #   updated_value = project.update(channel_id, {'thumbnailUrl' => expected_thumbnail_url}, 123)
-  #   assert_equal expected_thumbnail_url, updated_value['thumbnailUrl']
-  # end
-  #
-  # def test_project_throws_on_create_with_invalid_thumbnail_url
-  #   signedin_storage_id = create_storage_id_for_user(20)
-  #   project = Projects.new(signedin_storage_id)
-  #
-  #   assert_raises Projects::ValidationError do
-  #     project.create({'thumbnailUrl' => 'bad.com'}, ip: 123)
-  #   end
-  # end
-  #
-  # def test_project_create_succeeds_with_valid_thumbnail_url
-  #   signedin_storage_id = create_storage_id_for_user(20)
-  #   project = Projects.new(signedin_storage_id)
-  #
-  #   expected_thumbnail_url = '/v3/files/parentChannelId123/.metadata/thumbnail.png'
-  #   channel_id = project.create({'thumbnailUrl' => expected_thumbnail_url}, ip: 123)
-  #
-  #   assert_equal expected_thumbnail_url, project.get(channel_id)['thumbnailUrl']
-  # end
+  def test_project_throws_on_update_with_invalid_thumbnail_url
+    signedin_storage_id = create_storage_id_for_user(20)
+    project = Projects.new(signedin_storage_id)
+    channel_id = project.create({}, ip: 123)
+
+    assert_raises Projects::ValidationError do
+      project.update(channel_id, {'thumbnailUrl' => 'bad.com'}, 123)
+    end
+  end
+
+  def test_project_update_succeeds_with_valid_thumbnail_url
+    signedin_storage_id = create_storage_id_for_user(20)
+    project = Projects.new(signedin_storage_id)
+    channel_id = project.create({}, ip: 123)
+
+    expected_thumbnail_url = "/v3/files/#{channel_id}/.metadata/thumbnail.png"
+    updated_value = project.update(channel_id, {'thumbnailUrl' => expected_thumbnail_url}, 123)
+    assert_equal expected_thumbnail_url, updated_value['thumbnailUrl']
+  end
+
+  def test_project_throws_on_create_with_invalid_thumbnail_url
+    signedin_storage_id = create_storage_id_for_user(20)
+    project = Projects.new(signedin_storage_id)
+
+    assert_raises Projects::ValidationError do
+      project.create({'thumbnailUrl' => 'bad.com'}, ip: 123)
+    end
+  end
+
+  def test_project_create_succeeds_with_valid_thumbnail_url
+    signedin_storage_id = create_storage_id_for_user(20)
+    project = Projects.new(signedin_storage_id)
+
+    expected_thumbnail_url = '/v3/files/parentChannelId123/.metadata/thumbnail.png'
+    channel_id = project.create({'thumbnailUrl' => expected_thumbnail_url}, ip: 123)
+
+    assert_equal expected_thumbnail_url, project.get(channel_id)['thumbnailUrl']
+  end
 end

--- a/dashboard/legacy/test/middleware/helpers/test_projects.rb
+++ b/dashboard/legacy/test/middleware/helpers/test_projects.rb
@@ -207,4 +207,45 @@ class ProjectsTest < Minitest::Test
     channel_id = project.create({}, ip: 123)
     assert_nil project.get(channel_id)[:projectType]
   end
+
+  # Commenting out temporarily until we have confirmed that only valid thumbnail URLs
+  # are present in existing projects.
+  # def test_project_throws_on_update_with_invalid_thumbnail_url
+  #   signedin_storage_id = create_storage_id_for_user(20)
+  #   project = Projects.new(signedin_storage_id)
+  #   channel_id = project.create({}, ip: 123)
+  #
+  #   assert_raises Projects::ValidationError do
+  #     project.update(channel_id, {'thumbnailUrl' => 'bad.com'}, 123)
+  #   end
+  # end
+  #
+  # def test_project_update_succeeds_with_valid_thumbnail_url
+  #   signedin_storage_id = create_storage_id_for_user(20)
+  #   project = Projects.new(signedin_storage_id)
+  #   channel_id = project.create({}, ip: 123)
+  #
+  #   expected_thumbnail_url = "/v3/files/#{channel_id}/.metadata/thumbnail.png"
+  #   updated_value = project.update(channel_id, {'thumbnailUrl' => expected_thumbnail_url}, 123)
+  #   assert_equal expected_thumbnail_url, updated_value['thumbnailUrl']
+  # end
+  #
+  # def test_project_throws_on_create_with_invalid_thumbnail_url
+  #   signedin_storage_id = create_storage_id_for_user(20)
+  #   project = Projects.new(signedin_storage_id)
+  #
+  #   assert_raises Projects::ValidationError do
+  #     project.create({'thumbnailUrl' => 'bad.com'}, ip: 123)
+  #   end
+  # end
+  #
+  # def test_project_create_succeeds_with_valid_thumbnail_url
+  #   signedin_storage_id = create_storage_id_for_user(20)
+  #   project = Projects.new(signedin_storage_id)
+  #
+  #   expected_thumbnail_url = '/v3/files/parentChannelId123/.metadata/thumbnail.png'
+  #   channel_id = project.create({'thumbnailUrl' => expected_thumbnail_url}, ip: 123)
+  #
+  #   assert_equal expected_thumbnail_url, project.get(channel_id)['thumbnailUrl']
+  # end
 end

--- a/dashboard/legacy/test/middleware/test_channels.rb
+++ b/dashboard/legacy/test/middleware/test_channels.rb
@@ -456,6 +456,34 @@ class ChannelsTest < Minitest::Test
     assert_equal 'gamelab', Projects.table.where(id: storage_app_id).first[:project_type]
   end
 
+  # Commenting out temporarily until we have confirmed that only valid thumbnail URLs
+  # are present in existing projects.
+  # def test_update_with_good_thumbnail_url_succeeds
+  #   post '/v3/channels', {abc: 123}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+  #   channel_id = last_response.location.split('/').last
+  #
+  #   post "/v3/channels/#{channel_id}", {thumbnailUrl: "/v3/files/#{channel_id}/.metadata/thumbnail.png"}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+  #   assert last_response.successful?
+  # end
+  #
+  # def test_update_with_bad_thumbnail_url_fails
+  #   post '/v3/channels', {abc: 123}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+  #   channel_id = last_response.location.split('/').last
+  #
+  #   post "/v3/channels/#{channel_id}", {thumbnailUrl: "bad.com"}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+  #   assert_equal 400, last_response.status
+  # end
+  #
+  # def test_create_with_good_thumbnail_url_succeeds
+  #   post '/v3/channels', {thumbnailUrl: '/v3/files/parentChannelId123/.metadata/thumbnail.png'}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+  #   assert last_response.redirection?
+  # end
+  #
+  # def test_create_with_bad_thumbnail_fails
+  #   post '/v3/channels', {thumbnailUrl: "bad.com"}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+  #   assert_equal 400, last_response.status
+  # end
+
   private
 
   def timestamp(time)

--- a/dashboard/legacy/test/middleware/test_channels.rb
+++ b/dashboard/legacy/test/middleware/test_channels.rb
@@ -456,33 +456,31 @@ class ChannelsTest < Minitest::Test
     assert_equal 'gamelab', Projects.table.where(id: storage_app_id).first[:project_type]
   end
 
-  # Commenting out temporarily until we have confirmed that only valid thumbnail URLs
-  # are present in existing projects.
-  # def test_update_with_good_thumbnail_url_succeeds
-  #   post '/v3/channels', {abc: 123}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
-  #   channel_id = last_response.location.split('/').last
-  #
-  #   post "/v3/channels/#{channel_id}", {thumbnailUrl: "/v3/files/#{channel_id}/.metadata/thumbnail.png"}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
-  #   assert last_response.successful?
-  # end
-  #
-  # def test_update_with_bad_thumbnail_url_fails
-  #   post '/v3/channels', {abc: 123}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
-  #   channel_id = last_response.location.split('/').last
-  #
-  #   post "/v3/channels/#{channel_id}", {thumbnailUrl: "bad.com"}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
-  #   assert_equal 400, last_response.status
-  # end
-  #
-  # def test_create_with_good_thumbnail_url_succeeds
-  #   post '/v3/channels', {thumbnailUrl: '/v3/files/parentChannelId123/.metadata/thumbnail.png'}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
-  #   assert last_response.redirection?
-  # end
-  #
-  # def test_create_with_bad_thumbnail_fails
-  #   post '/v3/channels', {thumbnailUrl: "bad.com"}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
-  #   assert_equal 400, last_response.status
-  # end
+  def test_update_with_good_thumbnail_url_succeeds
+    post '/v3/channels', {abc: 123}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+    channel_id = last_response.location.split('/').last
+
+    post "/v3/channels/#{channel_id}", {thumbnailUrl: "/v3/files/#{channel_id}/.metadata/thumbnail.png"}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+    assert last_response.successful?
+  end
+
+  def test_update_with_bad_thumbnail_url_fails
+    post '/v3/channels', {abc: 123}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+    channel_id = last_response.location.split('/').last
+
+    post "/v3/channels/#{channel_id}", {thumbnailUrl: "bad.com"}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+    assert_equal 400, last_response.status
+  end
+
+  def test_create_with_good_thumbnail_url_succeeds
+    post '/v3/channels', {thumbnailUrl: '/v3/files/parentChannelId123/.metadata/thumbnail.png'}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+    assert last_response.redirection?
+  end
+
+  def test_create_with_bad_thumbnail_fails
+    post '/v3/channels', {thumbnailUrl: "bad.com"}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+    assert_equal 400, last_response.status
+  end
 
   private
 


### PR DESCRIPTION
Blocks saving projects if they contain unexpected thumbnail URLs. This PR follows two other PRs where we logged (rather than blocked) when unexpected thumbnail URLs were observed in projects:

https://github.com/code-dot-org/code-dot-org/pull/51981
https://github.com/code-dot-org/code-dot-org/pull/52076

I've been logging for a day with the current logic, and have not observed any projects with unexpected URLs, so I think we're safe to actually prevent saving is we observe unexpected URLs.

## Links

- jira ticket: [SL-696](https://codedotorg.atlassian.net/browse/SL-696)

## Testing story

Added unit tests to cover this behavior -- I also manually tested saving a project locally with good and bad thumbnail URLs and got the expected result in each case.