### PR TITLE
Allow level data access on level ID pages to signed out users

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -7,8 +7,8 @@ EMPTY_XML = '<xml></xml>'.freeze
 class LevelsController < ApplicationController
   include LevelsHelper
   include ActiveSupport::Inflector
-  before_action :authenticate_user!, except: [:show, :embed_level, :get_rubric, :get_serialized_maze]
-  before_action :require_levelbuilder_mode_or_test_env, except: [:show, :embed_level, :get_rubric, :get_serialized_maze]
+  before_action :authenticate_user!, except: [:show, :level_data, :embed_level, :get_rubric, :get_serialized_maze]
+  before_action :require_levelbuilder_mode_or_test_env, except: [:show, :level_data, :embed_level, :get_rubric, :get_serialized_maze]
   load_and_authorize_resource except: [:create]
 
   before_action :set_level, only: [:show, :edit, :update, :destroy]

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -69,7 +69,7 @@ class Ability
     can [:show, :index], DataDoc
 
     # If you can see a level, you can also do these things:
-    can [:embed_level, :get_rubric, :get_serialized_maze], Level do |level|
+    can [:embed_level, :get_rubric, :get_serialized_maze, :level_data], Level do |level|
       can? :read, level
     end
 


### PR DESCRIPTION
Music lab levels were erroring on load of level pages like /levels/:id because we were redirecting users to sign in on requests to the `/levels/:id/level_data` route, which is used in music lab levels (and hopefully will be used more as lab lab progresses) to load level configuration. The change that introduced this route has more context and can be found here:

https://github.com/code-dot-org/code-dot-org/pull/51670

This change allows access to this route for signed out users, fixing the error observed on these pages. It seems appropriate to me to align access to this route with the rest of our `show` logic for levels (which is generally allowed for signed out users), but folks with more music lab / lab lab experience should check my understanding.

## Links

- jira ticket: [SL-897](https://codedotorg.atlassian.net/browse/SL-897)

## Testing story

Tested that the /levels/:id page corresponding with the music lab allthethings level (/s/allthethings/lessons/46/levels/1) errored without this change, and does not error with it when viewing as a signed out user.