### PR TITLE
Disable oauth account linking for U13

### DIFF
--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -37,6 +37,7 @@ class ManageLinkedAccounts extends React.Component {
     isGoogleClassroomStudent: PropTypes.bool.isRequired,
     isCleverStudent: PropTypes.bool.isRequired,
     userAge: PropTypes.number,
+    usIp: PropTypes.bool,
   };
 
   cannotDisconnectGoogle = authOption => {
@@ -162,6 +163,7 @@ class ManageLinkedAccounts extends React.Component {
                   }
                   error={option.error}
                   userAge={this.props.userAge}
+                  usIp={this.props.usIp}
                 />
               );
             })}
@@ -180,6 +182,7 @@ export default connect(state => ({
   isGoogleClassroomStudent: state.manageLinkedAccounts.isGoogleClassroomStudent,
   isCleverStudent: state.manageLinkedAccounts.isCleverStudent,
   userAge: getScriptData('edit').userAge,
+  usIp: getScriptData('edit').usIp,
 }))(ManageLinkedAccounts);
 
 class OauthConnection extends React.Component {
@@ -191,6 +194,7 @@ class OauthConnection extends React.Component {
     disconnectDisabledStatus: PropTypes.string,
     error: PropTypes.string,
     userAge: PropTypes.number,
+    usIp: PropTypes.bool,
   };
 
   getDisconnectDisabledTooltip = () => {
@@ -204,8 +208,8 @@ class OauthConnection extends React.Component {
     }
   };
 
-  shouldDisableConnectButton = userAge => {
-    return !!(window.CPA_EXPERIENCE && userAge < 13);
+  shouldDisableConnectButton = (userAge, usIp) => {
+    return !!(window.CPA_EXPERIENCE && usIp && userAge < 13);
   };
 
   render() {
@@ -217,6 +221,7 @@ class OauthConnection extends React.Component {
       email,
       error,
       userAge,
+      usIp,
     } = this.props;
     // if given an email, we are already connected to this provider and should
     // present the option to disconnect. Otherwise, we should present the
@@ -269,7 +274,8 @@ class OauthConnection extends React.Component {
                 text={buttonText}
                 disabled={
                   !!disconnectDisabledMessage ||
-                  (!isConnected && this.shouldDisableConnectButton(userAge))
+                  (!isConnected &&
+                    this.shouldDisableConnectButton(userAge, usIp))
                 }
               />
               <RailsAuthenticityToken />

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -209,7 +209,15 @@ class OauthConnection extends React.Component {
   };
 
   shouldDisableConnectButton = (userAge, usIp) => {
-    return !!(window.CPA_EXPERIENCE && usIp && userAge < 13);
+    // Clever is a special case where the school district owns/manages the data.
+    if (this.props.credentialType === OAuthProviders.clever) {
+      return false;
+    }
+    return !!(
+      window.CPA_EXPERIENCE &&
+      this.props.usIp &&
+      this.props.userAge < 13
+    );
   };
 
   render() {
@@ -220,8 +228,6 @@ class OauthConnection extends React.Component {
       id,
       email,
       error,
-      userAge,
-      usIp,
     } = this.props;
     // if given an email, we are already connected to this provider and should
     // present the option to disconnect. Otherwise, we should present the
@@ -274,8 +280,7 @@ class OauthConnection extends React.Component {
                 text={buttonText}
                 disabled={
                   !!disconnectDisabledMessage ||
-                  (!isConnected &&
-                    this.shouldDisableConnectButton(userAge, usIp))
+                  (!isConnected && this.shouldDisableConnectButton())
                 }
               />
               <RailsAuthenticityToken />

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -10,6 +10,7 @@ import {connect} from 'react-redux';
 import RailsAuthenticityToken from '../../util/RailsAuthenticityToken';
 import {OAuthProviders} from '@cdo/apps/lib/ui/accounts/constants';
 import {isCodeOrgBrowser} from '@cdo/apps/lib/kits/maker/util/browserChecks';
+import getScriptData from '@cdo/apps/util/getScriptData';
 
 export const ENCRYPTED = `*** ${i18n.encrypted()} ***`;
 const authOptionPropType = PropTypes.shape({
@@ -35,6 +36,7 @@ class ManageLinkedAccounts extends React.Component {
     userHasPassword: PropTypes.bool.isRequired,
     isGoogleClassroomStudent: PropTypes.bool.isRequired,
     isCleverStudent: PropTypes.bool.isRequired,
+    userAge: PropTypes.number,
   };
 
   cannotDisconnectGoogle = authOption => {
@@ -159,6 +161,7 @@ class ManageLinkedAccounts extends React.Component {
                     option.id ? this.disconnectDisabledStatus(option) : null
                   }
                   error={option.error}
+                  userAge={this.props.userAge}
                 />
               );
             })}
@@ -176,6 +179,7 @@ export default connect(state => ({
   userHasPassword: state.manageLinkedAccounts.userHasPassword,
   isGoogleClassroomStudent: state.manageLinkedAccounts.isGoogleClassroomStudent,
   isCleverStudent: state.manageLinkedAccounts.isCleverStudent,
+  userAge: getScriptData('edit').userAge,
 }))(ManageLinkedAccounts);
 
 class OauthConnection extends React.Component {
@@ -186,6 +190,7 @@ class OauthConnection extends React.Component {
     email: PropTypes.string,
     disconnectDisabledStatus: PropTypes.string,
     error: PropTypes.string,
+    userAge: PropTypes.number,
   };
 
   getDisconnectDisabledTooltip = () => {
@@ -199,6 +204,10 @@ class OauthConnection extends React.Component {
     }
   };
 
+  shouldDisableConnectButton = userAge => {
+    return !!(window.CPA_EXPERIENCE && userAge < 13);
+  };
+
   render() {
     const {
       credentialType,
@@ -207,6 +216,7 @@ class OauthConnection extends React.Component {
       id,
       email,
       error,
+      userAge,
     } = this.props;
     // if given an email, we are already connected to this provider and should
     // present the option to disconnect. Otherwise, we should present the
@@ -257,7 +267,10 @@ class OauthConnection extends React.Component {
                 type="submit"
                 style={styles.button}
                 text={buttonText}
-                disabled={!!disconnectDisabledMessage}
+                disabled={
+                  !!disconnectDisabledMessage ||
+                  (!isConnected && this.shouldDisableConnectButton(userAge))
+                }
               />
               <RailsAuthenticityToken />
             </form>

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -37,7 +37,7 @@ class ManageLinkedAccounts extends React.Component {
     isGoogleClassroomStudent: PropTypes.bool.isRequired,
     isCleverStudent: PropTypes.bool.isRequired,
     userAge: PropTypes.number,
-    usIp: PropTypes.bool,
+    userStateCode: PropTypes.string,
   };
 
   cannotDisconnectGoogle = authOption => {
@@ -163,7 +163,7 @@ class ManageLinkedAccounts extends React.Component {
                   }
                   error={option.error}
                   userAge={this.props.userAge}
-                  usIp={this.props.usIp}
+                  userStateCode={this.props.userStateCode}
                 />
               );
             })}
@@ -182,7 +182,7 @@ export default connect(state => ({
   isGoogleClassroomStudent: state.manageLinkedAccounts.isGoogleClassroomStudent,
   isCleverStudent: state.manageLinkedAccounts.isCleverStudent,
   userAge: getScriptData('edit').userAge,
-  usIp: getScriptData('edit').usIp,
+  userStateCode: getScriptData('edit').userStateCode,
 }))(ManageLinkedAccounts);
 
 class OauthConnection extends React.Component {
@@ -194,7 +194,7 @@ class OauthConnection extends React.Component {
     disconnectDisabledStatus: PropTypes.string,
     error: PropTypes.string,
     userAge: PropTypes.number,
-    usIp: PropTypes.bool,
+    userStateCode: PropTypes.string,
   };
 
   getDisconnectDisabledTooltip = () => {
@@ -208,14 +208,14 @@ class OauthConnection extends React.Component {
     }
   };
 
-  shouldDisableConnectButton = (userAge, usIp) => {
+  shouldDisableConnectButton = (userAge, userStateCode) => {
     // Clever is a special case where the school district owns/manages the data.
     if (this.props.credentialType === OAuthProviders.clever) {
       return false;
     }
     return !!(
       window.CPA_EXPERIENCE &&
-      this.props.usIp &&
+      this.props.userStateCode === 'CO' &&
       this.props.userAge < 13
     );
   };

--- a/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
+++ b/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
@@ -259,13 +259,22 @@ describe('ManageLinkedAccounts', () => {
       restoreOnWindow('CPA_EXPERIENCE', undefined);
     });
 
-    it('disables the connect button for users under 13 when CPA is enabled', () => {
+    it('disables the connect button for US-based users under 13 when CPA is enabled', () => {
       const wrapper = mount(
-        <ManageLinkedAccounts {...DEFAULT_PROPS} userAge={12} />
+        <ManageLinkedAccounts {...DEFAULT_PROPS} userAge={12} usIp={true} />
       );
       const googleConnectButton = wrapper.find('BootstrapButton').at(0);
       expect(googleConnectButton).to.have.attr('disabled');
       expect(googleConnectButton).to.be.disabled();
+    });
+
+    it('only disables the buttons when the user IP is in the US, even if they are under 13', () => {
+      const wrapper = mount(
+        <ManageLinkedAccounts {...DEFAULT_PROPS} userAge={12} usIp={false} />
+      );
+      const googleConnectButton = wrapper.find('BootstrapButton').at(0);
+      expect(googleConnectButton).to.not.have.attr('disabled');
+      expect(googleConnectButton).to.not.be.disabled();
     });
   });
 

--- a/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
+++ b/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
@@ -250,6 +250,25 @@ describe('ManageLinkedAccounts', () => {
     expect(googleConnectButton).to.have.attr('disabled');
   });
 
+  describe('CPA lockout to prevent students from connecting oauth accounts without parent permission', () => {
+    beforeEach(() => {
+      replaceOnWindow('CPA_EXPERIENCE', 'true');
+    });
+
+    afterEach(() => {
+      restoreOnWindow('CPA_EXPERIENCE', undefined);
+    });
+
+    it('disables the connect button for users under 13 when CPA is enabled', () => {
+      const wrapper = mount(
+        <ManageLinkedAccounts {...DEFAULT_PROPS} userAge={12} />
+      );
+      const googleConnectButton = wrapper.find('BootstrapButton').at(0);
+      expect(googleConnectButton).to.have.attr('disabled');
+      expect(googleConnectButton).to.be.disabled();
+    });
+  });
+
   describe('in the Maker App', () => {
     beforeEach(() => {
       replaceOnWindow('MakerBridge', true);

--- a/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
+++ b/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
@@ -259,18 +259,26 @@ describe('ManageLinkedAccounts', () => {
       restoreOnWindow('CPA_EXPERIENCE', undefined);
     });
 
-    it('disables the connect button for US-based users under 13 when CPA is enabled', () => {
+    it('disables the connect button for Colorado-based users under 13 when CPA is enabled', () => {
       const wrapper = mount(
-        <ManageLinkedAccounts {...DEFAULT_PROPS} userAge={12} usIp={true} />
+        <ManageLinkedAccounts
+          {...DEFAULT_PROPS}
+          userAge={12}
+          userStateCode={'CO'}
+        />
       );
       const googleConnectButton = wrapper.find('BootstrapButton').at(0);
       expect(googleConnectButton).to.have.attr('disabled');
       expect(googleConnectButton).to.be.disabled();
     });
 
-    it('only disables the buttons when the user IP is in the US, even if they are under 13', () => {
+    it('only disables the buttons when the user IP is in the CO, even if they are under 13', () => {
       const wrapper = mount(
-        <ManageLinkedAccounts {...DEFAULT_PROPS} userAge={12} usIp={false} />
+        <ManageLinkedAccounts
+          {...DEFAULT_PROPS}
+          userAge={12}
+          userStateCode={'WA'}
+        />
       );
       const googleConnectButton = wrapper.find('BootstrapButton').at(0);
       expect(googleConnectButton).to.not.have.attr('disabled');
@@ -279,7 +287,11 @@ describe('ManageLinkedAccounts', () => {
 
     it('Does not disable the Clever connect button', () => {
       const wrapper = mount(
-        <ManageLinkedAccounts {...DEFAULT_PROPS} userAge={12} usIp={true} />
+        <ManageLinkedAccounts
+          {...DEFAULT_PROPS}
+          userAge={12}
+          userStateCode={'CO'}
+        />
       );
       const cleverConnectButton = wrapper.find('BootstrapButton').at(2);
       expect(cleverConnectButton).to.not.have.attr('disabled');

--- a/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
+++ b/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
@@ -276,6 +276,15 @@ describe('ManageLinkedAccounts', () => {
       expect(googleConnectButton).to.not.have.attr('disabled');
       expect(googleConnectButton).to.not.be.disabled();
     });
+
+    it('Does not disable the Clever connect button', () => {
+      const wrapper = mount(
+        <ManageLinkedAccounts {...DEFAULT_PROPS} userAge={12} usIp={true} />
+      );
+      const cleverConnectButton = wrapper.find('BootstrapButton').at(2);
+      expect(cleverConnectButton).to.not.have.attr('disabled');
+      expect(cleverConnectButton).to.not.be.disabled();
+    });
   });
 
   describe('in the Maker App', () => {

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -1,4 +1,8 @@
 - require '../shared/middleware/helpers/experiments'
+- require 'geocoder'
+- location = Geocoder.search(request.ip).try(:first)
+- country_code = location&.country_code.to_s.upcase
+- us_ip = ['US', 'RD', nil].include?(country_code)
 - @page_title = t('activerecord.attributes.user.edit_header')
 - no_email = current_user.no_personal_email? || params[:noEmail] == 'true'
 
@@ -235,7 +239,8 @@
       isGoogleClassroomStudent: current_user.google_classroom_student?,
       isCleverStudent: current_user.clever_student?,
       dependentStudents: current_user.dependent_students,
-      studentCount: current_user.students.count
+      studentCount: current_user.students.count,
+      usIp: us_ip,
     }.to_json
   }
 %script{src: webpack_asset_path('js/devise/registrations/edit.js'), data: script_data}

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -1,8 +1,7 @@
 - require '../shared/middleware/helpers/experiments'
 - require 'geocoder'
 - location = Geocoder.search(request.ip).try(:first)
-- country_code = location&.country_code.to_s.upcase
-- us_ip = ['US', 'RD', nil].include?(country_code)
+- state_code = location&.state_code.to_s.upcase
 - @page_title = t('activerecord.attributes.user.edit_header')
 - no_email = current_user.no_personal_email? || params[:noEmail] == 'true'
 
@@ -240,7 +239,7 @@
       isCleverStudent: current_user.clever_student?,
       dependentStudents: current_user.dependent_students,
       studentCount: current_user.students.count,
-      usIp: us_ip,
+      userStateCode: state_code,
     }.to_json
   }
 %script{src: webpack_asset_path('js/devise/registrations/edit.js'), data: script_data}


### PR DESCRIPTION
Currently gated behind the CPA feature flag. Disables new oauth account connections for students under 13.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[JIRA ticket](https://codedotorg.atlassian.net/browse/P20-62)

## Testing story

To test locally, navigate to the account settings page and add the query param `?cpa_experience=true` to your URL. With the CPA experience feature flag enabled, the "connect" buttons for the various oauth providers will be disabled if the user's age is < 13.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

While this disables the "connect" button, it's possible that someone could inject a >13 age value into the react component to re-enable the button. This would require a decent amount of work, and it's probably unlikely that an <13 student would do it. If we're ok with a good-faith but not bulletproof solution, disabling the button like this should work.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
