### PR TITLE
Refactor browser-detector to expose browser name and version.

### DIFF
--- a/apps/src/util/browser-detector.js
+++ b/apps/src/util/browser-detector.js
@@ -1,58 +1,74 @@
 // We support IE 11+
+function isIE() {
+  return navigator.userAgent.indexOf('MSIE') !== -1 || isIE11();
+}
+
+function IEVersion() {
+  return isIE11()
+    ? '11'
+    : navigator.userAgent
+        .substring(navigator.userAgent.lastIndexOf('MSIE') + 5)
+        .split('.')[0];
+}
+
 function isUnsupportedIE() {
-  var isIE = navigator.userAgent.indexOf('MSIE') !== -1;
-  var IEVersion = navigator.appVersion.indexOf('Trident/');
-  var IEBelow8 = isIE && IEVersion < 8;
-
-  var IE7 = navigator.userAgent.match('MSIE 7.0;');
-  var IE8 = navigator.userAgent.match('MSIE 8.0;');
-  var IE9 = navigator.userAgent.match('MSIE 9.0;');
-  var IE10 = navigator.userAgent.match('MSIE 10.0;');
-
-  var unsupported = IEBelow8 || IE7 || IE8 || IE9 || IE10;
-  return unsupported;
+  return isIE() && IEVersion() < 11;
 }
 
 // We support Chrome 33.x +
-function isUnsupportedChrome() {
-  var isChrome = navigator.userAgent.lastIndexOf('Chrome/') !== -1;
-  var chromeVersion = navigator.userAgent
+function isChrome() {
+  return navigator.userAgent.lastIndexOf('Chrome/') !== -1;
+}
+
+function chromeVersion() {
+  return navigator.userAgent
     .substring(navigator.userAgent.lastIndexOf('Chrome/') + 7)
     .split('.')[0];
-  var unsupported = isChrome && chromeVersion < 33;
-  return unsupported;
+}
+
+function isUnsupportedChrome() {
+  return isChrome() && chromeVersion() < 33;
 }
 
 // We support Safari 7.0.x +
-function isUnsupportedSafari() {
-  var isSafari = navigator.userAgent.indexOf('Safari/') !== -1;
-  var safariVersion = navigator.userAgent
+function isSafari() {
+  return navigator.userAgent.indexOf('Safari/') !== -1;
+}
+
+function safariVersion() {
+  return navigator.userAgent
     .substring(navigator.userAgent.lastIndexOf('Version/') + 8)
     .split('.')[0];
-  var unsupported = isSafari && safariVersion < 7;
-  return unsupported;
+}
+
+function isUnsupportedSafari() {
+  return isSafari() && safariVersion() < 7;
 }
 
 // We support Firefox 25.x +
-function isUnsupportedFirefox() {
-  var isFirefox = navigator.userAgent.indexOf('Firefox') !== -1;
-  var firefoxVersion = navigator.userAgent
+function isFirefox() {
+  return navigator.userAgent.indexOf('Firefox') !== -1;
+}
+
+function firefoxVersion() {
+  return navigator.userAgent
     .substring(navigator.userAgent.lastIndexOf('Firefox/') + 8)
     .split('.')[0];
-  var unsupported = isFirefox && firefoxVersion < 25;
-  return unsupported;
+}
+
+function isUnsupportedFirefox() {
+  return isFirefox() && firefoxVersion() < 25;
 }
 
 // https://support.code.org/hc/en-us/articles/202591743
 // for the full list of supported browsers
 export function isUnsupportedBrowser() {
-  var isUnsupported = false;
-  isUnsupported =
+  return (
     isUnsupportedIE() ||
     isUnsupportedChrome() ||
     isUnsupportedSafari() ||
-    isUnsupportedFirefox();
-  return isUnsupported;
+    isUnsupportedFirefox()
+  );
 }
 
 // Detect a mobile device.
@@ -97,4 +113,24 @@ export function isStorageAvailable(type) {
   } catch (e) {
     return false;
   }
+}
+
+export function getBrowserName(includeVersion = false) {
+  if (isChrome()) {
+    return 'Chrome' + (includeVersion ? ` ${chromeVersion()}` : '');
+  }
+
+  if (isIE()) {
+    return 'Internet Explorer' + (includeVersion ? ` ${IEVersion()}` : '');
+  }
+
+  if (isFirefox()) {
+    return 'Firefox' + (includeVersion ? ` ${firefoxVersion()}` : '');
+  }
+
+  if (isSafari()) {
+    return 'Safari' + (includeVersion ? ` ${safariVersion()}` : '');
+  }
+
+  return 'Unknown';
 }

--- a/apps/src/util/browser-detector.js
+++ b/apps/src/util/browser-detector.js
@@ -115,6 +115,10 @@ export function isStorageAvailable(type) {
   }
 }
 
+/**
+ * Get the current browser and, if specified, the current browser version.
+ * Returns the user agent string if the browser is unknown.
+ */
 export function getBrowserName(includeVersion = false) {
   if (isChrome()) {
     return 'Chrome' + (includeVersion ? ` ${chromeVersion()}` : '');
@@ -132,5 +136,5 @@ export function getBrowserName(includeVersion = false) {
     return 'Safari' + (includeVersion ? ` ${safariVersion()}` : '');
   }
 
-  return 'Unknown';
+  return navigator.userAgent;
 }

--- a/apps/test/unit/util/browser-detector-test.js
+++ b/apps/test/unit/util/browser-detector-test.js
@@ -1,0 +1,128 @@
+import {isUnsupportedBrowser, isIE11} from '@cdo/apps/util/browser-detector';
+import sinon from 'sinon';
+import {expect} from '../../util/reconfiguredChai';
+
+describe('Browser Detector', () => {
+  let userAgentStub;
+  let appVersionStub;
+
+  beforeEach(() => {
+    userAgentStub = sinon.stub(navigator, 'userAgent');
+    appVersionStub = sinon.stub(navigator, 'appVersion');
+  });
+
+  afterEach(() => {
+    userAgentStub.restore();
+    appVersionStub.restore();
+  });
+
+  describe('IE', () => {
+    const IE7 = 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)';
+    const IE8 =
+      'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)';
+    const IE9 =
+      'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)';
+    const IE10 =
+      'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)';
+    const IE11 =
+      'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko';
+
+    let MSInputMethodContextOriginal;
+    let documentModeOriginal;
+
+    beforeEach(() => {
+      MSInputMethodContextOriginal = window.MSInputMethodContext;
+      documentModeOriginal = document.documentMode;
+    });
+
+    afterEach(() => {
+      window.MSInputMethodContext = MSInputMethodContextOriginal;
+      document.documentMode = documentModeOriginal;
+    });
+
+    function stubIE11() {
+      window.MSInputMethodContext = true;
+      document.documentMode = true;
+    }
+
+    it('Detects unsupported IE versions', () => {
+      // IE 7 (not supported)
+      userAgentStub.value(IE7);
+      expect(isUnsupportedBrowser()).to.be.true;
+
+      // IE 8 (not supported)
+      userAgentStub.value(IE8);
+      expect(isUnsupportedBrowser()).to.be.true;
+
+      // IE 9 (not supported)
+      userAgentStub.value(IE9);
+      expect(isUnsupportedBrowser()).to.be.true;
+
+      // IE 10 (not supported)
+      userAgentStub.value(IE10);
+      expect(isUnsupportedBrowser()).to.be.true;
+
+      // IE 11 (supported)
+      stubIE11();
+      userAgentStub.value(IE11);
+      expect(isUnsupportedBrowser()).to.be.false;
+    });
+
+    it('Detects if browser is IE11', () => {
+      userAgentStub.value(IE9);
+      expect(isIE11()).to.be.false;
+
+      stubIE11();
+      userAgentStub.value(IE11);
+      expect(isIE11()).to.be.true;
+    });
+  });
+
+  describe('Chrome', () => {
+    it('Detects unsupported Chrome versions', () => {
+      // Chrome < 33 (not supported)
+      userAgentStub.value(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.0.0 Safari/537.36'
+      );
+      expect(isUnsupportedBrowser()).to.be.true;
+
+      // Chrome > 33 (supported)
+      userAgentStub.value(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36'
+      );
+      expect(isUnsupportedBrowser()).to.be.false;
+    });
+  });
+
+  describe('Safari', () => {
+    it('Detects unsupported Safari versions', () => {
+      // Safari < 7 (not supported)
+      userAgentStub.value(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/6.0.3 Safari/605.1.15'
+      );
+      expect(isUnsupportedBrowser()).to.be.true;
+
+      // Safari > 7 (supported)
+      userAgentStub.value(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Safari/605.1.15'
+      );
+      expect(isUnsupportedBrowser()).to.be.false;
+    });
+  });
+
+  describe('Firefox', () => {
+    it('Detects unsupported Firefox versions', () => {
+      // Firefox < 25 (not supported)
+      userAgentStub.value(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:70.0) Gecko/20100101 Firefox/22.0'
+      );
+      expect(isUnsupportedBrowser()).to.be.true;
+    });
+
+    // Firefox > 25 (supported)
+    userAgentStub.value(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:70.0) Gecko/20100101 Firefox/70.0'
+    );
+    expect(isUnsupportedBrowser()).to.be.false;
+  });
+});

--- a/apps/test/unit/util/browser-detector-test.js
+++ b/apps/test/unit/util/browser-detector-test.js
@@ -1,4 +1,8 @@
-import {isUnsupportedBrowser, isIE11} from '@cdo/apps/util/browser-detector';
+import {
+  isUnsupportedBrowser,
+  isIE11,
+  getBrowserName,
+} from '@cdo/apps/util/browser-detector';
 import sinon from 'sinon';
 import {expect} from '../../util/reconfiguredChai';
 
@@ -76,53 +80,97 @@ describe('Browser Detector', () => {
       userAgentStub.value(IE11);
       expect(isIE11()).to.be.true;
     });
+
+    it('Detects IE browser and version', () => {
+      userAgentStub.value(IE9);
+      expect(getBrowserName(false)).to.equal('Internet Explorer');
+      expect(getBrowserName(true)).to.equal('Internet Explorer 9');
+
+      stubIE11();
+      userAgentStub.value(IE11);
+      expect(getBrowserName(false)).to.equal('Internet Explorer');
+      expect(getBrowserName(true)).to.equal('Internet Explorer 11');
+    });
   });
 
   describe('Chrome', () => {
+    const chrome30 =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.0.0 Safari/537.36';
+    const chrome114 =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36';
+
     it('Detects unsupported Chrome versions', () => {
       // Chrome < 33 (not supported)
-      userAgentStub.value(
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.0.0 Safari/537.36'
-      );
+      userAgentStub.value(chrome30);
       expect(isUnsupportedBrowser()).to.be.true;
 
       // Chrome > 33 (supported)
-      userAgentStub.value(
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36'
-      );
+      userAgentStub.value(chrome114);
       expect(isUnsupportedBrowser()).to.be.false;
+    });
+
+    it('Detects Chrome browser and version', () => {
+      userAgentStub.value(chrome30);
+      expect(getBrowserName(false)).to.equal('Chrome');
+      expect(getBrowserName(true)).to.equal('Chrome 30');
+
+      userAgentStub.value(chrome114);
+      expect(getBrowserName(false)).to.equal('Chrome');
+      expect(getBrowserName(true)).to.equal('Chrome 114');
     });
   });
 
   describe('Safari', () => {
+    const safari6 =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/6.0.3 Safari/605.1.15';
+    const safari13 =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Safari/605.1.15';
+
     it('Detects unsupported Safari versions', () => {
       // Safari < 7 (not supported)
-      userAgentStub.value(
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/6.0.3 Safari/605.1.15'
-      );
+      userAgentStub.value(safari6);
       expect(isUnsupportedBrowser()).to.be.true;
 
       // Safari > 7 (supported)
-      userAgentStub.value(
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Safari/605.1.15'
-      );
+      userAgentStub.value(safari13);
       expect(isUnsupportedBrowser()).to.be.false;
+    });
+
+    it('Detects Safari browser and version', () => {
+      userAgentStub.value(safari6);
+      expect(getBrowserName(false)).to.equal('Safari');
+      expect(getBrowserName(true)).to.equal('Safari 6');
+
+      userAgentStub.value(safari13);
+      expect(getBrowserName(false)).to.equal('Safari');
+      expect(getBrowserName(true)).to.equal('Safari 13');
     });
   });
 
   describe('Firefox', () => {
+    const firefox22 =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:70.0) Gecko/20100101 Firefox/22.0';
+    const firefox70 =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:70.0) Gecko/20100101 Firefox/70.0';
+
     it('Detects unsupported Firefox versions', () => {
       // Firefox < 25 (not supported)
-      userAgentStub.value(
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:70.0) Gecko/20100101 Firefox/22.0'
-      );
+      userAgentStub.value(firefox22);
       expect(isUnsupportedBrowser()).to.be.true;
 
       // Firefox > 25 (supported)
-      userAgentStub.value(
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:70.0) Gecko/20100101 Firefox/70.0'
-      );
+      userAgentStub.value(firefox70);
       expect(isUnsupportedBrowser()).to.be.false;
+    });
+
+    it('Detects Firefox browser and version', () => {
+      userAgentStub.value(firefox22);
+      expect(getBrowserName(false)).to.equal('Firefox');
+      expect(getBrowserName(true)).to.equal('Firefox 22');
+
+      userAgentStub.value(firefox70);
+      expect(getBrowserName(false)).to.equal('Firefox');
+      expect(getBrowserName(true)).to.equal('Firefox 70');
     });
   });
 });

--- a/apps/test/unit/util/browser-detector-test.js
+++ b/apps/test/unit/util/browser-detector-test.js
@@ -173,4 +173,12 @@ describe('Browser Detector', () => {
       expect(getBrowserName(true)).to.equal('Firefox 70');
     });
   });
+
+  describe('Unknown browser', () => {
+    it('Returns the user agent string if browser is unknown', () => {
+      const unknownBrowser = 'unknown browser';
+      userAgentStub.value(unknownBrowser);
+      expect(getBrowserName(false)).to.equal(unknownBrowser);
+    });
+  });
 });

--- a/apps/test/unit/util/browser-detector-test.js
+++ b/apps/test/unit/util/browser-detector-test.js
@@ -117,12 +117,12 @@ describe('Browser Detector', () => {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:70.0) Gecko/20100101 Firefox/22.0'
       );
       expect(isUnsupportedBrowser()).to.be.true;
-    });
 
-    // Firefox > 25 (supported)
-    userAgentStub.value(
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:70.0) Gecko/20100101 Firefox/70.0'
-    );
-    expect(isUnsupportedBrowser()).to.be.false;
+      // Firefox > 25 (supported)
+      userAgentStub.value(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:70.0) Gecko/20100101 Firefox/70.0'
+      );
+      expect(isUnsupportedBrowser()).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
This refactors some of `browser-detector` to expose the browser name and browser version. browser-detector already had logic to parse this information from the userAgent string; this just reorganizes the code a bit so we can expose that information outside of this file. I'm planning on using this in some reporting in order to aggregate by browser and browser version.

## Testing story

Tested locally and added a unit test that ran against the original code to make sure there were no breaking changes.