### PR TITLE
Upgrade @code-dot-org/piskel

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -65,7 +65,7 @@
     "@code-dot-org/ml-activities": "0.0.26",
     "@code-dot-org/ml-playground": "0.0.47",
     "@code-dot-org/p5.play": "1.3.21-cdo",
-    "@code-dot-org/piskel": "0.13.0-cdo.9",
+    "@code-dot-org/piskel": "0.13.0-cdo.11",
     "@code-dot-org/redactable-markdown": "0.4.0",
     "@react-bootstrap/pagination": "^1.0.0",
     "@storybook/addon-actions": "^6.5.10",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1458,10 +1458,10 @@
     opentype.js "^0.4.9"
     reqwest "^1.1.5"
 
-"@code-dot-org/piskel@0.13.0-cdo.9":
-  version "0.13.0-cdo.9"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/piskel/-/piskel-0.13.0-cdo.9.tgz#84b8ad23bd73e2821229061fa1bcb52e461236de"
-  integrity sha512-BhbuhlxFkXd3+OmnaK9DGIOY+v6qMLH3UJmkBBAF9SEh88mb+MMvT/vXT8Txv1b4/RrnXZJD1nEMUsya5gx3vQ==
+"@code-dot-org/piskel@0.13.0-cdo.11":
+  version "0.13.0-cdo.11"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/piskel/-/piskel-0.13.0-cdo.11.tgz#314037380b9b02dbdda461e575a0e93e53cd1539"
+  integrity sha512-S6L0Z0aIAtm1301tQga4PG7ogShiJLZNlhxIdsVGYQVITHu7YVi+MkMvSTqfE4l7uswY1J6oOOk7fXyqKLfXMQ==
   dependencies:
     messageformat "^2.3.0"
 


### PR DESCRIPTION
This upgrade contains a fix for the [blinking animations issue](https://codedotorg.atlassian.net/browse/SL-50). Previously we hid any blank frames, so an animation would "blink" and you wouldn't be able to see or edit the blank frame. 

## Links

- jira ticket: [SL-50](https://codedotorg.atlassian.net/browse/SL-50)
- [Piskel PR](https://github.com/code-dot-org/piskel/pull/54)

## Testing story
Tested locally--before the upgrade if you added a blank frame to an animation and navigated away, the gif would blink but the blank frame would disappear. Now the blank frame still shows up.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
