### PR TITLE
Add publish metric functionality to front end reporter

### DIFF
--- a/apps/src/lib/metrics/DashboardMetricsApi.ts
+++ b/apps/src/lib/metrics/DashboardMetricsApi.ts
@@ -1,5 +1,6 @@
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {MetricsApi} from './MetricsApi';
+import {MetricDatum} from './types';
 
 const BASE_URL = '/browser_events/';
 
@@ -9,5 +10,13 @@ const BASE_URL = '/browser_events/';
 export default class DashboardMetricsApi implements MetricsApi {
   async sendLogs(logs: object[]): Promise<Response> {
     return HttpClient.post(BASE_URL + 'put_logs', JSON.stringify({logs}), true);
+  }
+
+  async sendMetricData(metricData: MetricDatum[]) {
+    return HttpClient.post(
+      BASE_URL + 'put_metric_data',
+      JSON.stringify({metricData}),
+      true
+    );
   }
 }

--- a/apps/src/lib/metrics/MetricsApi.ts
+++ b/apps/src/lib/metrics/MetricsApi.ts
@@ -1,6 +1,15 @@
+import {MetricDatum} from './types';
+
 /**
  * Interface for interacting with a metrics service API.
  */
 export interface MetricsApi {
+  /**
+   * Send a list of log objects.
+   */
   sendLogs: (logs: object[]) => Promise<Response>;
+  /**
+   * Send a list of metric data.
+   */
+  sendMetricData: (metricData: MetricDatum[]) => Promise<Response>;
 }

--- a/apps/src/lib/metrics/MetricsReporter.ts
+++ b/apps/src/lib/metrics/MetricsReporter.ts
@@ -1,6 +1,8 @@
+import {getBrowserName} from '@cdo/apps/util/browser-detector';
 import {isDevelopmentEnvironment} from '@cdo/apps/utils';
 import DashboardMetricsApi from './DashboardMetricsApi';
 import {MetricsApi} from './MetricsApi';
+import {LogLevel, MetricDatum, MetricDimension, MetricUnit} from './types';
 
 /**
  * If we receive an unauthorized response from the server, this may
@@ -12,8 +14,6 @@ const CHECK_CAN_REPORT_INTERVAL_MINUTES = 30;
 const CHECK_CAN_REPORT_INTERVAL_MS =
   CHECK_CAN_REPORT_INTERVAL_MINUTES * 60 * 1000;
 const LOCAL_STORAGE_KEY_NAME = 'cdo-metrics-reporter-last-check-time';
-
-type LogLevel = 'INFO' | 'WARNING' | 'SEVERE';
 
 /**
  * Reports logs and metrics, intended primarily for developer-facing
@@ -34,6 +34,9 @@ class MetricsReporter {
       parseInt(localStorage.getItem(LOCAL_STORAGE_KEY_NAME) || '0') || 0;
   }
 
+  /**
+   * Publish an information log message. Can be a string or a structured object
+   */
   logInfo(message: string | object) {
     this.log('INFO', message);
     if (isDevelopmentEnvironment()) {
@@ -41,6 +44,9 @@ class MetricsReporter {
     }
   }
 
+  /**
+   * Publish a warning log message. Can be a string or a structured object
+   */
   logWarning(message: string | object) {
     this.log('WARNING', message);
     if (isDevelopmentEnvironment()) {
@@ -48,10 +54,41 @@ class MetricsReporter {
     }
   }
 
+  /**
+   * Publish an error log message. Can be a string or a structured object
+   */
   logError(message: string | object) {
     this.log('SEVERE', message);
     if (isDevelopmentEnvironment()) {
       console.error('[MetricsReporter] ' + JSON.stringify(message));
+    }
+  }
+
+  /**
+   * Increment a counter metric.
+   */
+  incrementCounter(name: string, dimensions: MetricDimension[] = []) {
+    this.publishMetric(name, 1, 'Count', dimensions);
+  }
+
+  /**
+   * Publish a metric.
+   */
+  publishMetric(
+    name: string,
+    value: number,
+    unit: MetricUnit,
+    dimensions: MetricDimension[] = []
+  ) {
+    const metric = {
+      name,
+      value,
+      unit,
+      dimensions: dimensions.concat(this.getDeviceDimensions()),
+    };
+    this.sendMetric(metric);
+    if (isDevelopmentEnvironment()) {
+      console.info('[MetricsReporter] ' + JSON.stringify(metric));
     }
   }
 
@@ -68,17 +105,33 @@ class MetricsReporter {
     }
 
     try {
-      const response = await this.metricsApi.sendLogs([payload]);
-      if (!response.ok) {
-        this.fallbackLog(payload);
-      }
-
-      if (response.status === 401) {
-        // Unauthorized response from server; client logging is likely disabled.
-        // We will check again after a time period of CHECK_CAN_REPORT_INTERVAL
-        this.setReportingDisabled();
-      }
+      await this.metricsApi.sendLogs([payload]);
     } catch (error) {
+      this.fallbackLog(payload);
+      this.handleError(error as Error);
+    }
+  }
+
+  private async sendMetric(metric: MetricDatum) {
+    if (!this.isReportingEnabled()) {
+      this.fallbackLog(metric);
+      return;
+    }
+
+    try {
+      await this.metricsApi.sendMetricData([metric]);
+    } catch (error) {
+      this.fallbackLog(metric);
+      this.handleError(error as Error);
+    }
+  }
+
+  private handleError(error: Error) {
+    if (error.message.includes('401')) {
+      // Unauthorized response from server; client logging is likely disabled.
+      // We will check again after a time period of CHECK_CAN_REPORT_INTERVAL
+      this.setReportingDisabled();
+    } else {
       console.error(error);
     }
   }
@@ -91,6 +144,23 @@ class MetricsReporter {
       hostname: window.location.hostname,
       full_path: window.location.href,
     };
+  }
+
+  private getDeviceDimensions(): MetricDimension[] {
+    return [
+      {
+        name: 'Hostname',
+        value: window.location.hostname,
+      },
+      {
+        name: 'Browser',
+        value: getBrowserName(),
+      },
+      {
+        name: 'BrowserVersion',
+        value: getBrowserName(true),
+      },
+    ];
   }
 
   private fallbackLog(payload: object) {

--- a/apps/src/lib/metrics/types.ts
+++ b/apps/src/lib/metrics/types.ts
@@ -1,0 +1,42 @@
+export type LogLevel = 'INFO' | 'WARNING' | 'SEVERE';
+
+export interface MetricDatum {
+  name: string;
+  dimensions: MetricDimension[];
+  value: number;
+  unit: MetricUnit;
+}
+
+export interface MetricDimension {
+  name: string;
+  value: string;
+}
+
+export type MetricUnit =
+  | 'Seconds'
+  | 'Microseconds'
+  | 'Milliseconds'
+  | 'Bytes'
+  | 'Kilobytes'
+  | 'Megabytes'
+  | 'Gigabytes'
+  | 'Terabytes'
+  | 'Bits'
+  | 'Kilobits'
+  | 'Megabits'
+  | 'Gigabits'
+  | 'Terabits'
+  | 'Percent'
+  | 'Count'
+  | 'Bytes/Second'
+  | 'Kilobytes/Second'
+  | 'Megabytes/Second'
+  | 'Gigabytes/Second'
+  | 'Terabytes/Second'
+  | 'Bits/Second'
+  | 'Kilobits/Second'
+  | 'Megabits/Second'
+  | 'Gigabits/Second'
+  | 'Terabits/Second'
+  | 'Count/Second'
+  | 'None';


### PR DESCRIPTION
Adds functionality to publish metrics, hooked up to the put_metrics route on dashboard which forwards metrics to Cloudwatch.

## Links

Backend implementation to handle and forward metrics to Cloudwatch: https://github.com/code-dot-org/code-dot-org/pull/52187
JIRA: https://codedotorg.atlassian.net/browse/SL-800

## Testing story

Tested locally with sample metrics (from music lab).