### PR TITLE
Fix duplication of blocks when toggling between long/short instructions

### DIFF
--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -115,7 +115,7 @@ function removeCommentNodes(root) {
  */
 export function convertXmlToBlockly(xmlContainer, isRtl) {
   // blockSpaceContainers are elements (div or span) that contain read-only block spaces
-  // We add the class name 'block-space-container' to these elements when they are created
+  // We add the class name 'readonly-block-space-container' to these elements when they are created
   // so that they can be easily removed  to prevent the duplication of blocks when toggling
   // between long/short instructions or when the blocks are rendered in the levelbuilder
   // edit mode.

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -115,7 +115,6 @@ function removeCommentNodes(root) {
  */
 export function convertXmlToBlockly(xmlContainer, isRtl) {
   const xmls = xmlContainer.getElementsByTagName('xml');
-  console.log('convertXmlToBlockly - xmlContainer', xmlContainer);
   // remove divs and spans with style.display = 'inline-block';
   const blockSpaceContainers = xmlContainer.getElementsByClassName(
     'block-space-container'

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -115,12 +115,9 @@ function removeCommentNodes(root) {
  */
 export function convertXmlToBlockly(xmlContainer, isRtl) {
   // Remove any divs and/or spans with class name 'block-space-container'.
-  const blockSpaceContainers = xmlContainer.getElementsByClassName(
-    'block-space-container'
-  );
-  for (let i = blockSpaceContainers.length - 1; i >= 0; i--) {
-    blockSpaceContainers[i].remove();
-  }
+  Array.from(
+    xmlContainer.getElementsByClassName('block-space-container')
+  ).forEach(container => container.remove());
 
   const xmls = xmlContainer.getElementsByTagName('xml');
   Array.prototype.forEach.call(xmls, function (xml) {

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -115,6 +115,14 @@ function removeCommentNodes(root) {
  */
 export function convertXmlToBlockly(xmlContainer, isRtl) {
   const xmls = xmlContainer.getElementsByTagName('xml');
+  console.log('convertXmlToBlockly - xmlContainer', xmlContainer);
+  // remove divs and spans with style.display = 'inline-block';
+  const blockSpaceContainers = xmlContainer.getElementsByClassName(
+    'block-space-container'
+  );
+  for (let i = blockSpaceContainers.length - 1; i >= 0; i--) {
+    blockSpaceContainers[i].remove();
+  }
 
   Array.prototype.forEach.call(xmls, function (xml) {
     // Skip conversion if XML already has a blockspace
@@ -135,6 +143,7 @@ export function convertXmlToBlockly(xmlContainer, isRtl) {
 
     // create a container and insert the blockspace into it
     const blockSpaceContainer = document.createElement(inline ? 'span' : 'div');
+    blockSpaceContainer.classList.add('block-space-container');
     if (inline) {
       // SVGs don't play nicely if they're rendered into purely inline elements,
       // so if our container is a span it should be inline-block

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -109,12 +109,16 @@ function removeCommentNodes(root) {
 
 /**
  * Converts any inline XML in the container element into embedded
- * readonly BlockSpaces
+ * read-only BlockSpaces in long instructions or authored hints in the Instructions panel.
  * @param {Element} xmlContainer The element in which to search for XML
  * @param {Boolean} isRtl True if we are displaying in RTL
  */
 export function convertXmlToBlockly(xmlContainer, isRtl) {
-  // Remove any divs and/or spans with class name 'block-space-container'.
+  // blockSpaceContainers are elements (div or span) that contain read-only block spaces
+  // We add the class name 'block-space-container' to these elements when they are created
+  // so that they can be easily removed  to prevent the duplication of blocks when toggling
+  // between long/short instructions or when the blocks are rendered in the levelbuilder
+  // edit mode.
   Array.from(
     xmlContainer.getElementsByClassName('block-space-container')
   ).forEach(container => container.remove());

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -120,7 +120,7 @@ export function convertXmlToBlockly(xmlContainer, isRtl) {
   // between long/short instructions or when the blocks are rendered in the levelbuilder
   // edit mode.
   Array.from(
-    xmlContainer.getElementsByClassName('block-space-container')
+    xmlContainer.getElementsByClassName('readonly-block-space-container')
   ).forEach(container => container.remove());
 
   const xmls = xmlContainer.getElementsByTagName('xml');
@@ -143,7 +143,7 @@ export function convertXmlToBlockly(xmlContainer, isRtl) {
 
     // create a container and insert the blockspace into it
     const blockSpaceContainer = document.createElement(inline ? 'span' : 'div');
-    blockSpaceContainer.classList.add('block-space-container');
+    blockSpaceContainer.classList.add('readonly-block-space-container');
     if (inline) {
       // SVGs don't play nicely if they're rendered into purely inline elements,
       // so if our container is a span it should be inline-block

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -115,7 +115,7 @@ function removeCommentNodes(root) {
  */
 export function convertXmlToBlockly(xmlContainer, isRtl) {
   const xmls = xmlContainer.getElementsByTagName('xml');
-  // remove divs and spans with style.display = 'inline-block';
+  // Remove any divs and/or spans with class name 'block-space-container'.
   const blockSpaceContainers = xmlContainer.getElementsByClassName(
     'block-space-container'
   );

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -114,7 +114,6 @@ function removeCommentNodes(root) {
  * @param {Boolean} isRtl True if we are displaying in RTL
  */
 export function convertXmlToBlockly(xmlContainer, isRtl) {
-  const xmls = xmlContainer.getElementsByTagName('xml');
   // Remove any divs and/or spans with class name 'block-space-container'.
   const blockSpaceContainers = xmlContainer.getElementsByClassName(
     'block-space-container'
@@ -123,6 +122,7 @@ export function convertXmlToBlockly(xmlContainer, isRtl) {
     blockSpaceContainers[i].remove();
   }
 
+  const xmls = xmlContainer.getElementsByTagName('xml');
   Array.prototype.forEach.call(xmls, function (xml) {
     // Skip conversion if XML already has a blockspace
     if (xml.getElementsByTagName('svg').length) {

--- a/dashboard/app/views/levels/editors/fields/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/fields/_authored_hints.haml
@@ -69,14 +69,6 @@
               callback: function(editor, change) {
                 const xmlContainer = space.find('.markdown_preview').get(0);
 
-                // Prevent rendering multiple copies of a block svg by removing
-                // all Blockly SVG containers before converting any XML into blocks.
-                const blocklySvgs = xmlContainer.querySelectorAll('svg[class*="readOnlyBlockSpace"]');
-                // Loop through each Blockly svg element and remove its parent element
-                blocklySvgs.forEach(svg => {
-                  svg.parentNode.remove();
-                });
-
                 convertXmlToBlockly(xmlContainer);
                 space.find('.hint_markdown').val(editor.getValue());
                 space.find('.hint_markdown').trigger('change');

--- a/dashboard/app/views/levels/editors/fields/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/fields/_authored_hints.haml
@@ -69,6 +69,14 @@
               callback: function(editor, change) {
                 const xmlContainer = space.find('.markdown_preview').get(0);
 
+                // Prevent rendering multiple copies of a block svg by removing
+                // all Blockly SVG containers before converting any XML into blocks.
+                const blocklySvgs = xmlContainer.querySelectorAll('svg[class*="readOnlyBlockSpace"]');
+                // Loop through each Blockly svg element and remove its parent element
+                blocklySvgs.forEach(svg => {
+                  svg.parentNode.remove();
+                });
+
                 convertXmlToBlockly(xmlContainer);
                 space.find('.hint_markdown').val(editor.getValue());
                 space.find('.hint_markdown').trigger('change');

--- a/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
@@ -21,13 +21,6 @@
     callback: function (editor, change) {
       const xmlContainer = document.getElementById('level_long_instructions_preview');
 
-      // Prevent rendering multiple copies of a block svg by removing
-      // all Blockly SVG containers before converting any XML into blocks.
-      const blocklySvgs = xmlContainer.querySelectorAll('svg[class*="readOnlyBlockSpace"]');
-      // Loop through each svg element and remove its parent element
-      blocklySvgs.forEach(svg => {
-        svg.parentNode.remove();
-      });
       convertXmlToBlockly(xmlContainer);
 
       localStorage.setItem('markdown_' + '#{@level.id || html_escape(params[:type])}', editor.getValue());

--- a/dashboard/config/scripts/levels/courseB_Scrat_ramp12022.level
+++ b/dashboard/config/scripts/levels/courseB_Scrat_ramp12022.level
@@ -1,14 +1,13 @@
 <Maze>
   <config><![CDATA[{
-  "published": true,
   "game_id": 25,
-  "created_at": "2023-03-21T10:34:16.000Z",
+  "created_at": "2022-01-07T18:56:34.000Z",
   "level_num": "custom",
   "user_id": 19,
   "properties": {
     "maze": "[[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,4,4,4,4,0,0],[0,0,4,4,4,4,0,0],[0,0,4,4,2,3,0,0],[0,0,4,4,4,4,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0]]",
     "skin": "scrat",
-    "short_instructions": "For this puzzle, snap the blocks together and press \"Run\"!",
+    "short_instructions": "For this puzzle, snap the blocks together and press \"▶ Run\"!",
     "start_direction": "1",
     "step_mode": "0",
     "is_k1": "true",
@@ -28,7 +27,8 @@
     "definition_highlight": "false",
     "definition_collapse": "false",
     "disable_examples": "false",
-    "authored_hints": "[{\"hint_class\":\"content\",\"hint_markdown\":\"If Scrat isn't doing what you want, make sure both of the blocks have been fully clicked together, then click \\\"Run\\\" again.\",\"hint_id\":\"1\",\"hint_type\":\"general\",\"hint_path\":\"\",\"hint_video\":\"\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/0d28057f01208bf0f34a20d831d4419b/courseB_Scrat_ramp12022.mp3\"},{\"hint_class\":\"pointer\",\"hint_markdown\":\"Don't be afraid to make a mistake! Try something, and if it doesn't work, try something else! <xml><block type=\\\"when_run\\\" block-text=\\\"when run\\\"/></xml> \",\"hint_id\":\"2\",\"hint_type\":\"general\",\"hint_path\":\"\",\"hint_video\":\"\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/bb851554b85b4eea8938708ed314e0fe/courseB_Scrat_ramp12022.mp3\"}]",
+    "authored_hints": "[{\"hint_class\":\"content\",\"hint_markdown\":\"If Scrat isn't doing what you want, make sure both of the blocks have been fully clicked together, then click \\\"Run\\\" again.\",\"hint_id\":\"1\",\"hint_type\":\"general\",\"hint_path\":\"\",\"hint_video\":\"\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/0d28057f01208bf0f34a20d831d4419b/courseB_Scrat_ramp1_2018.mp3\"},{\"hint_class\":\"pointer\",\"hint_markdown\":\"Don't be afraid to make a mistake! Try something, and if it doesn't work, try something else!\",\"hint_id\":\"2\",\"hint_type\":\"general\",\"hint_path\":\"\",\"hint_video\":\"\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/f9107970d452e3adacdbf74a4c1b9556/courseB_Scrat_ramp1_2018.mp3\"}]",
+    "long_instructions": "To get Scrat to the acorn, snap the <xml><block type=\"maze_moveEast\" block-text=\"move East\"/></xml> block to the bottom of the <xml><block type=\"when_run\" block-text=\"when run\"/></xml> block, then press \"▶ Run\"!",
     "callout_json": "[\r\n {\r\n  \"localization_key\": \"grade2_CaringForNewPet_0_1\",\r\n  \"callout_text\": \"After connecting all the blocks, press \\\"Run\\\" to start your program.\",\r\n  \"element_id\": \"#runButton\",\r\n  \"on\": \"\",\r\n  \"qtip_config\": {\r\n   \"codeStudio\": {\r\n    \"canReappear\": false,\r\n    \"dropletPaletteCategory\": \"\"\r\n   },\r\n   \"style\": {\r\n    \"classes\": \"\"\r\n   },\r\n   \"position\": {\r\n    \"my\": \"left top\",\r\n    \"at\": \"top center\",\r\n    \"adjust\": {\r\n     \"x\": 0,\r\n     \"y\": 0\r\n    }\r\n   }\r\n  }\r\n }\r\n]",
     "instructions_important": "true",
     "hide_share_and_remix": "false",
@@ -43,13 +43,12 @@
     "include_shared_functions": "false",
     "encrypted": "false",
     "mini_rubric": "false",
-    "hint_prompt_attempts_threshold": "1",
-    "maze_data": null,
-    "long_instructions": "Long: To get Scrat to the acorn, snap the <xml><block type=\"maze_moveEast\" block-text=\"move East\"/></xml> block to the bottom of the <xml><block type=\"when_run\" block-text=\"when run\"/></xml> block, then press \"Run\"!",
-    "preload_asset_list": null
+    "preload_asset_list": null,
+    "contained_level_names": null
   },
+  "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2022-01-07T18:56:34.718+00:00\",\"changed\":[\"cloned from \\\"courseB_Scrat_ramp1_2021\\\"\"],\"cloned_from\":\"courseB_Scrat_ramp1_2021\"},{\"changed_at\":\"2023-06-07 15:18:11 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-06-07 15:19:47 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"long_instructions\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-06-07 15:20:53 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"short_instructions\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-06-07 15:21:35 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-06-09 09:16:50 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-06-09 09:17:30 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-06-13 10:21:33 -0700\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"}]",
+  "audit_log": "[{\"changed_at\":\"2022-01-07T18:56:34.718+00:00\",\"changed\":[\"cloned from \\\"courseB_Scrat_ramp1_2021\\\"\"],\"cloned_from\":\"courseB_Scrat_ramp1_2021\"}]",
   "level_concept_difficulty": {
     "sequencing": 1,
     "debugging": 1

--- a/dashboard/config/scripts/levels/courseB_Scrat_ramp12022.level
+++ b/dashboard/config/scripts/levels/courseB_Scrat_ramp12022.level
@@ -1,13 +1,14 @@
 <Maze>
   <config><![CDATA[{
+  "published": true,
   "game_id": 25,
-  "created_at": "2022-01-07T18:56:34.000Z",
+  "created_at": "2023-03-21T10:34:16.000Z",
   "level_num": "custom",
   "user_id": 19,
   "properties": {
     "maze": "[[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,4,4,4,4,0,0],[0,0,4,4,4,4,0,0],[0,0,4,4,2,3,0,0],[0,0,4,4,4,4,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0]]",
     "skin": "scrat",
-    "short_instructions": "For this puzzle, snap the blocks together and press \"▶ Run\"!",
+    "short_instructions": "For this puzzle, snap the blocks together and press \"Run\"!",
     "start_direction": "1",
     "step_mode": "0",
     "is_k1": "true",
@@ -27,8 +28,7 @@
     "definition_highlight": "false",
     "definition_collapse": "false",
     "disable_examples": "false",
-    "authored_hints": "[{\"hint_class\":\"content\",\"hint_markdown\":\"If Scrat isn't doing what you want, make sure both of the blocks have been fully clicked together, then click \\\"Run\\\" again.\",\"hint_id\":\"1\",\"hint_type\":\"general\",\"hint_path\":\"\",\"hint_video\":\"\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/0d28057f01208bf0f34a20d831d4419b/courseB_Scrat_ramp1_2018.mp3\"},{\"hint_class\":\"pointer\",\"hint_markdown\":\"Don't be afraid to make a mistake! Try something, and if it doesn't work, try something else!\",\"hint_id\":\"2\",\"hint_type\":\"general\",\"hint_path\":\"\",\"hint_video\":\"\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/f9107970d452e3adacdbf74a4c1b9556/courseB_Scrat_ramp1_2018.mp3\"}]",
-    "long_instructions": "To get Scrat to the acorn, snap the <xml><block type=\"maze_moveEast\" block-text=\"move East\"/></xml> block to the bottom of the <xml><block type=\"when_run\" block-text=\"when run\"/></xml> block, then press \"▶ Run\"!",
+    "authored_hints": "[{\"hint_class\":\"content\",\"hint_markdown\":\"If Scrat isn't doing what you want, make sure both of the blocks have been fully clicked together, then click \\\"Run\\\" again.\",\"hint_id\":\"1\",\"hint_type\":\"general\",\"hint_path\":\"\",\"hint_video\":\"\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/0d28057f01208bf0f34a20d831d4419b/courseB_Scrat_ramp12022.mp3\"},{\"hint_class\":\"pointer\",\"hint_markdown\":\"Don't be afraid to make a mistake! Try something, and if it doesn't work, try something else! <xml><block type=\\\"when_run\\\" block-text=\\\"when run\\\"/></xml> \",\"hint_id\":\"2\",\"hint_type\":\"general\",\"hint_path\":\"\",\"hint_video\":\"\",\"tts_url\":\"https://tts.code.org/sharon22k/180/100/bb851554b85b4eea8938708ed314e0fe/courseB_Scrat_ramp12022.mp3\"}]",
     "callout_json": "[\r\n {\r\n  \"localization_key\": \"grade2_CaringForNewPet_0_1\",\r\n  \"callout_text\": \"After connecting all the blocks, press \\\"Run\\\" to start your program.\",\r\n  \"element_id\": \"#runButton\",\r\n  \"on\": \"\",\r\n  \"qtip_config\": {\r\n   \"codeStudio\": {\r\n    \"canReappear\": false,\r\n    \"dropletPaletteCategory\": \"\"\r\n   },\r\n   \"style\": {\r\n    \"classes\": \"\"\r\n   },\r\n   \"position\": {\r\n    \"my\": \"left top\",\r\n    \"at\": \"top center\",\r\n    \"adjust\": {\r\n     \"x\": 0,\r\n     \"y\": 0\r\n    }\r\n   }\r\n  }\r\n }\r\n]",
     "instructions_important": "true",
     "hide_share_and_remix": "false",
@@ -43,12 +43,13 @@
     "include_shared_functions": "false",
     "encrypted": "false",
     "mini_rubric": "false",
-    "preload_asset_list": null,
-    "contained_level_names": null
+    "hint_prompt_attempts_threshold": "1",
+    "maze_data": null,
+    "long_instructions": "Long: To get Scrat to the acorn, snap the <xml><block type=\"maze_moveEast\" block-text=\"move East\"/></xml> block to the bottom of the <xml><block type=\"when_run\" block-text=\"when run\"/></xml> block, then press \"Run\"!",
+    "preload_asset_list": null
   },
-  "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2022-01-07T18:56:34.718+00:00\",\"changed\":[\"cloned from \\\"courseB_Scrat_ramp1_2021\\\"\"],\"cloned_from\":\"courseB_Scrat_ramp1_2021\"}]",
+  "audit_log": "[{\"changed_at\":\"2022-01-07T18:56:34.718+00:00\",\"changed\":[\"cloned from \\\"courseB_Scrat_ramp1_2021\\\"\"],\"cloned_from\":\"courseB_Scrat_ramp1_2021\"},{\"changed_at\":\"2023-06-07 15:18:11 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-06-07 15:19:47 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"long_instructions\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-06-07 15:20:53 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"short_instructions\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-06-07 15:21:35 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-06-09 09:16:50 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-06-09 09:17:30 -0500\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"},{\"changed_at\":\"2023-06-13 10:21:33 -0700\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"alice.fisher+levelbuilder@code.org\"}]",
   "level_concept_difficulty": {
     "sequencing": 1,
     "debugging": 1


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior. 
-->
This PR fixes a bug in Blockly labs (both CDO and Google) in the top instructions panel - when the 'long' instructions include  blocks, these blocks duplicate when the user toggled between 'long' and 'short' instructions. 

BEFORE UPDATE:

<img width="1680" alt="image-20230317-181443" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/b52c9a0e-a4ed-4b72-89ec-ff550627a810">


In  `instructions/utils.js`, I updated the function `convertXmlToBlockly` that is called on in `MarkdownInstructions.jsx`. I added a class name to the `blockSpaceContainer` element so that any existing blockspace containers can be easily removed before they are created per XML element. 

The `convertXmlToBlockly` function is also called on in `_authored_hints.haml` and `_long_instructions` so that when levelbuilders are editing markdown in edit mode, they can view the rendered blocks. There were fixes for [long instructions](https://github.com/code-dot-org/code-dot-org/pull/52037) and [authored hints](https://github.com/code-dot-org/code-dot-org/pull/51638) to address the duplicate blocks bug which can now be removed because the update in this PR resolves this duplicate block issue more generally. 

AFTER UPDATE:


https://github.com/code-dot-org/code-dot-org/assets/107423305/3749790c-77f3-4804-82c0-0b0c38f60547


<details>

<summary>Background/Context (optional)</summary>

This bug was previously solved by [this PR](https://github.com/code-dot-org/code-dot-org/pull/28453). I think there was  a regression from [this more recent PR](https://github.com/code-dot-org/code-dot-org/pull/44270) which addressed issues in rendering instructions. In particular, [this line](https://github.com/code-dot-org/code-dot-org/blob/87eefe3c2d56d8dc19affee45e0b558c82713bd9/apps/src/templates/instructions/utils.js#L144).
[Slack discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1679075945283839)
</details>




## Links
[jira ticket](https://codedotorg.atlassian.net/browse/SL-693)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally in both Google and CDO Blockly labs that included long and short instructions. I also checked in both Google and CDO blockly levelbuilder edit mode that there were no duplicate blocks rendered in the long instructions or the authored hints markdown.

## Follow-up
I noticed that on this level, once the hints are opened, they do not close when the browser is refreshed after this update. They do disappear when the 'Less' button is clicked. This happens when on production. Unsure if this should be fixed. Will consult with curriculum.
[jira ticket](https://codedotorg.atlassian.net/browse/SL-901)
UPDATE: I checked with @mikeharv and he confirmed that this is expected behavior.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
