### PR TITLE
P20 cpa lockout glue

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1971,6 +1971,7 @@
   "sessionLockoutHeaderThanksDescription": "An image of a penguin happily dancing.",
   "sessionLockoutPendingPrompt": "We sent an email to {pendingEmail}. Didn't receive anything? Update your parent or guardian's email below or send another request.",
   "sessionLockoutNote": "Note: Your account will be deleted if we do not receive your parent or guardian's permission by {deleteDate}.",
+  "sessionLockoutLastEmailSent": "Last email sent:",
   "sessionLockoutParentEmailField": "Parent/Guardian Email:",
   "sessionLockoutParentStatusField": "Permission Request:",
   "sessionLockoutSubmit": "Send permission request",

--- a/apps/src/templates/sessions/LockoutPanel.jsx
+++ b/apps/src/templates/sessions/LockoutPanel.jsx
@@ -29,14 +29,15 @@ export default function LockoutPanel(props) {
   // This will set the email to the current pending email and fire off the
   // form as though they had typed in the same email again.
   const resendPermissionEmail = event => {
-    // Don't submit the form... we will do that ourselves.
-    event.preventDefault();
-
     const field = document.getElementById('parent-email');
     field.value = props.pendingEmail;
 
     const form = document.getElementById('lockout-panel-form');
     form.submit();
+  };
+
+  const signOut = event => {
+    window.location.href = 'users/sign_out';
   };
 
   // Get the current locale.
@@ -130,9 +131,11 @@ export default function LockoutPanel(props) {
           {/* This is a floating 'link' that resends the pending email. */}
           {props.pendingEmail && (
             <Button
+              id="lockout-resend"
               styleAsText={true}
               style={styles.resendLink}
               text={i18n.sessionLockoutResendEmail()}
+              type="button"
               onClick={resendPermissionEmail}
             />
           )}
@@ -164,7 +167,7 @@ export default function LockoutPanel(props) {
               {/* Show a 'Last email sent' prompt when available. */}
               {props.pendingEmail && (
                 <p style={styles.lastEmail}>
-                  <em>
+                  <em id="lockout-last-email-date">
                     Last email sent:{' '}
                     {props.requestDate.toLocaleDateString(locale, {
                       ...dateOptions,
@@ -181,15 +184,19 @@ export default function LockoutPanel(props) {
         <div style={styles.buttons}>
           {/* A sign-out button. */}
           <Button
+            id="lockout-signout"
+            type="button"
             style={styles.button}
             text={i18n.signOutButton()}
             color={Button.ButtonColor.gray}
-            href="/users/sign_out"
+            onClick={signOut}
           />
 
           {/* The submit button. */}
           {/* An empty onClick will still submit the form. */}
           <Button
+            id="lockout-submit"
+            type="submit"
             style={styles.button}
             text={
               props.pendingEmail

--- a/apps/src/templates/sessions/LockoutPanel.jsx
+++ b/apps/src/templates/sessions/LockoutPanel.jsx
@@ -61,8 +61,11 @@ export default function LockoutPanel(props) {
   });
   const pendingPromptParts = pendingPrompt.split('{pendingEmail}');
 
-  const csrfToken = document.querySelector('meta[name="csrf-token"]')
-    .attributes['content'].value;
+  const tokenElement = document.querySelector('meta[name="csrf-token"]');
+  let csrfToken = '';
+  if (tokenElement) {
+    csrfToken = tokenElement.attributes['content'].value;
+  }
 
   return (
     <div style={styles.container} className="lockout-panel">

--- a/apps/src/templates/sessions/LockoutPanel.jsx
+++ b/apps/src/templates/sessions/LockoutPanel.jsx
@@ -171,7 +171,7 @@ export default function LockoutPanel(props) {
               {props.pendingEmail && (
                 <p style={styles.lastEmail}>
                   <em id="lockout-last-email-date">
-                    Last email sent:{' '}
+                    {i18n.sessionLockoutLastEmailSent() + ' '}
                     {props.requestDate.toLocaleDateString(locale, {
                       ...dateOptions,
                       hour: 'numeric',

--- a/apps/src/templates/sessions/LockoutPanel.jsx
+++ b/apps/src/templates/sessions/LockoutPanel.jsx
@@ -34,7 +34,9 @@ export default function LockoutPanel(props) {
 
     const field = document.getElementById('parent-email');
     field.value = props.pendingEmail;
-    this.submit();
+
+    const form = document.getElementById('lockout-panel-form');
+    form.submit();
   };
 
   // Get the current locale.
@@ -58,6 +60,9 @@ export default function LockoutPanel(props) {
   });
   const pendingPromptParts = pendingPrompt.split('{pendingEmail}');
 
+  const csrfToken = document.querySelector('meta[name="csrf-token"]')
+    .attributes['content'].value;
+
   return (
     <div style={styles.container} className="lockout-panel">
       {/* Header image: Depends of if permission request is sent. */}
@@ -78,7 +83,8 @@ export default function LockoutPanel(props) {
       </h2>
 
       {/* This form will post a permission request for the student.*/}
-      <form action={props.apiURL} method="post">
+      <form id="lockout-panel-form" action={props.apiURL} method="post">
+        <input type="hidden" value={csrfToken} name="authenticity_token" />
         {/* The top prompt, which depends on whether or not a request is pending. */}
         {props.pendingEmail && (
           <p>
@@ -151,6 +157,7 @@ export default function LockoutPanel(props) {
                 onInput={onEmailUpdate}
                 onBlur={onEmailUpdate}
                 defaultValue={props.pendingEmail}
+                name="parent-email"
                 id="parent-email"
               />
 

--- a/dashboard/app/controllers/policy_compliance_controller.rb
+++ b/dashboard/app/controllers/policy_compliance_controller.rb
@@ -48,14 +48,14 @@ class PolicyComplianceController < ApplicationController
     # Create a ParentalPermissionRequest token for user and parent email
     # When the student 'updates' the parental email, we actually just create a
     # new request row.
-    permission_request = ParentalPermissionRequest.find_or_create_by(
+    permission_request = ParentalPermissionRequest.find_or_initialize_by(
       user: current_user,
       parent_email: params.require(:'parent-email')
     )
 
     # If we are making a new request but already sent too many today,
     # just bail and return whence we came
-    if !permission_request.persisted? && permission_requests >= 3
+    if permission_request.new_record? && permission_requests >= 3
       redirect_back fallback_location: lockout_path and return
     end
 

--- a/dashboard/app/controllers/policy_compliance_controller.rb
+++ b/dashboard/app/controllers/policy_compliance_controller.rb
@@ -82,7 +82,8 @@ class PolicyComplianceController < ApplicationController
       url_for(
         action: :child_account_consent,
         controller: :policy_compliance,
-        token: permission_request.uuid
+        token: permission_request.uuid,
+        only_path: false,
       )
     ).deliver_now
 

--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -64,7 +64,7 @@ class SessionsController < Devise::SessionsController
     @request_date = DateTime.now
 
     # Determine the deletion date as the creation time of the account + 7 days
-    @delete_date = current_user.created_at + (3600 * 24 * 7)
+    @delete_date = current_user.created_at.since(7.days)
 
     # Find any existing permission request for this user
     # Students might have issued a few requests. We render the latest one.

--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -59,8 +59,11 @@ class SessionsController < Devise::SessionsController
   # GET /lockout
   # This page is for accounts that are locked until parental permission compliance.
   def lockout
+    # If the student isn't signed in, go to the login page
+    return redirect_to new_user_session_path unless current_user
+
     # Basic defaults. If the @pending_email is empty, the request was never sent
-    @pending_email = ""
+    @pending_email = ''
     @request_date = DateTime.now
 
     # Determine the deletion date as the creation time of the account + 7 days

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2676,9 +2676,6 @@ class User < ApplicationRecord
 
   # Values for the `child_account_compliance_state` attribute
   module ChildAccountCompliance
-    # The student's account does not have compliance.
-    ACCOUNT_CREATED = 'c'.freeze
-
     # The student's account has been used to issue a request to a parent.
     REQUEST_SENT = 's'.freeze
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2337,6 +2337,13 @@ class User < ApplicationRecord
     return true
   end
 
+  # Updates the child_account_compliance_state attribute to the given state.
+  # @param {String} new_state - A constant from User::ChildAccountCompliance
+  def update_child_account_compliance(new_state)
+    self.child_account_compliance_state = new_state
+    self.child_account_compliance_state_last_updated = DateTime.now.new_offset(0)
+  end
+
   # When creating an account, we want to look for any channels that got created
   # for this user before they signed in, and if any of them are in our Applab HOC
   # course, we will create a UserScript entry so that they get a course card
@@ -2669,6 +2676,12 @@ class User < ApplicationRecord
 
   # Values for the `child_account_compliance_state` attribute
   module ChildAccountCompliance
+    # The student's account does not have compliance.
+    ACCOUNT_CREATED = 'c'.freeze
+
+    # The student's account has been used to issue a request to a parent.
+    REQUEST_SENT = 's'.freeze
+
     # The student's account has been approved by their parent.
     PERMISSION_GRANTED = 'g'.freeze
   end

--- a/dashboard/app/views/sessions/lockout.html.haml
+++ b/dashboard/app/views/sessions/lockout.html.haml
@@ -1,4 +1,14 @@
-#lockout-container{:data => {request_date: (DateTime.now - 6).iso8601, delete_date: (DateTime.now + 2).iso8601, pending_email: "", api_url: "/permissions"}}
+#lockout-container{
+  data: {
+    request_date: @request_date.iso8601,
+    delete_date: @delete_date.iso8601,
+    pending_email: @pending_email,
+    api_url: url_for(
+      action: :child_account_consent,
+      controller: :policy_compliance
+    ),
+  }
+}
 
 - content_for(:head) do
   %script{src: webpack_asset_path('js/sessions/lockout.js')}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1061,5 +1061,7 @@ Dashboard::Application.routes.draw do
     # Policy Compliance
     get '/policy_compliance/child_account_consent/', to:
       'policy_compliance#child_account_consent'
+    post '/policy_compliance/child_account_consent/', to:
+      'policy_compliance#child_account_consent_request'
   end
 end

--- a/dashboard/test/controllers/policy_compliance_controller_test.rb
+++ b/dashboard/test/controllers/policy_compliance_controller_test.rb
@@ -45,4 +45,153 @@ class PolicyComplianceControllerTest < ActionDispatch::IntegrationTest
       assert_response :ok
     end
   end
+
+  test "must authenticate user when submitting parental permission request" do
+    post '/policy_compliance/child_account_consent', params:
+      {
+        'parent-email': 'parent@example.com',
+      }
+    assert_redirected_to new_user_session_path
+  end
+
+  test "must provide a parent email to the request api" do
+    user = create(:young_student, :without_parental_permission)
+    sign_in user
+
+    post '/policy_compliance/child_account_consent', params:
+      {
+      }
+    assert_response :bad_request
+  end
+
+  test "given a user already has parental permission, should just redirect back" do
+    permission = create :parental_permission_request, :granted
+    user = permission.user
+    user.child_account_compliance_state = User::ChildAccountCompliance::PERMISSION_GRANTED
+
+    sign_in user
+
+    assert_emails 0 do
+      post '/policy_compliance/child_account_consent', params:
+        {
+          'parent-email': permission.parent_email,
+        }
+      assert_redirected_to lockout_path
+    end
+  end
+
+  test "should update user and send an email to the parent upon creating the request" do
+    user = create(:young_student, :without_parental_permission)
+    sign_in user
+
+    assert_emails 1 do
+      post '/policy_compliance/child_account_consent', params:
+        {
+          'parent-email': 'parent@example.com',
+        }
+      assert_redirected_to lockout_path
+      user.reload
+      assert_equal User::ChildAccountCompliance::REQUEST_SENT, user.child_account_compliance_state
+      assert_not_empty user.child_account_compliance_state_last_updated
+    end
+  end
+
+  test "given a user already has sent a parental permission, should resend if specifying the same email" do
+    permission = create :parental_permission_request
+    user = permission.user
+
+    sign_in user
+
+    assert_emails 1 do
+      post '/policy_compliance/child_account_consent', params:
+        {
+          'parent-email': permission.parent_email,
+        }
+      assert_redirected_to lockout_path
+    end
+  end
+
+  test "given a user already has sent a parental permission, should still send if child specifies a different one" do
+    permission = create :parental_permission_request
+    user = permission.user
+
+    sign_in user
+
+    assert_emails 1 do
+      post '/policy_compliance/child_account_consent', params:
+        {
+          'parent-email': 'parent@differentemail.com',
+        }
+      assert_redirected_to lockout_path
+    end
+  end
+
+  test "given a user already has sent a parental permission, should just redirect and not send email after the third time" do
+    user = create(:young_student, :without_parental_permission)
+    sign_in user
+
+    assert_emails 3 do
+      4.times do
+        post '/policy_compliance/child_account_consent', params:
+          {
+            'parent-email': 'parent@example.com',
+          }
+        assert_redirected_to lockout_path
+      end
+    end
+  end
+
+  test "a user should not be able to send more than 3 unique parental request emails per day" do
+    user = create(:young_student, :without_parental_permission)
+    sign_in user
+
+    assert_emails 3 do
+      4.times do |i|
+        post '/policy_compliance/child_account_consent', params:
+          {
+            'parent-email': "parent#{i}@example.com",
+          }
+        assert_redirected_to lockout_path
+      end
+    end
+  end
+
+  test "a user should be able to send a new request the following day" do
+    # Create existing permission requests
+    permission = create :parental_permission_request, :old
+    create :parental_permission_request, :old, parent_email: 'parent_second@example.com', user: permission.user
+    create :parental_permission_request, :old, parent_email: 'parent_third@example.com', user: permission.user
+
+    # Sign in
+    user = permission.user
+    sign_in user
+
+    # Do a new email
+    assert_emails 1 do
+      post '/policy_compliance/child_account_consent', params:
+        {
+          'parent-email': "parent_newest@example.com",
+        }
+      assert_redirected_to lockout_path
+    end
+  end
+
+  test "registration email should be given a fully qualified path to the token endpoint" do
+    user = create(:young_student, :without_parental_permission)
+    sign_in user
+
+    post '/policy_compliance/child_account_consent', params:
+      {
+        'parent-email': "parent@example.com",
+      }
+    assert_redirected_to lockout_path
+
+    mail = ActionMailer::Base.deliveries.first
+    token_endpoint_url = url_for(
+      action: :child_account_consent,
+      controller: :policy_compliance,
+      only_path: false,
+    )
+    assert mail.body.to_s.include?(token_endpoint_url)
+  end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -360,6 +360,14 @@ FactoryBot.define do
         email {''}
         hashed_email {nil}
       end
+
+      trait :without_parental_permission do
+        child_account_compliance_state {''}
+      end
+
+      trait :with_parental_permission do
+        child_account_compliance_state {User::ChildAccountCompliance::PERMISSION_GRANTED}
+      end
     end
 
     # We have some tests which want to create student accounts which don't have any authentication setup.
@@ -1708,7 +1716,19 @@ FactoryBot.define do
   end
 
   factory :parental_permission_request do
-    user {create :student}
+    user {create :young_student, :without_parental_permission}
     parent_email {"contact@example.domain"}
+    resends_sent {0}
+
+    trait :old do
+      after(:create) do |permission|
+        permission.created_at = permission.created_at - 2.days
+        permission.save
+      end
+    end
+
+    trait :granted do
+      user {create :young_student, :with_parental_permission}
+    end
   end
 end

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -1,0 +1,86 @@
+Feature: Policy Compliance and Parental Permission
+
+  Scenario: New under 13 account should be able to send a parental request.
+    Given I create a young student in Colorado who has never signed in named "Sally Student" and go home
+
+    # TODO: Can possibly get rid of this when the lockout is redirected on sign in
+    Given I am on "http://studio.code.org/lockout"
+
+    # It should not be a pending request
+    Then I wait to see "#lockout-panel-form"
+    And element "#permission-status" contains text "Not Submitted"
+
+    # Type in the email do re-enable the button
+    And I press keys "parent@example.com" for element "#parent-email"
+    Then element "#lockout-submit" is enabled
+
+    # Ensure that we are now "pending"
+    When I press "lockout-submit"
+    Then I wait to see "#lockout-panel-form"
+    And element "#permission-status" contains text "Pending"
+
+  Scenario: New under 13 account should be able to elect to sign out at the lockout.
+    Given I create a young student in Colorado who has never signed in named "Sally Student" and go home
+
+    # TODO: Can possibly get rid of this when the lockout is redirected on sign in
+    Given I am on "http://studio.code.org/lockout"
+
+    # It should not be a pending request
+    Then I wait to see "#lockout-panel-form"
+    And element "#permission-status" contains text "Not Submitted"
+
+    # The sign out button should navigate and show the sign in button
+    When I press "lockout-signout"
+    Then I wait to see "#header_user_signin"
+
+  Scenario: New under 13 account should be able to resend the email
+    Given I create a young student in Colorado who has never signed in named "Sally Student" and go home
+
+    # TODO: Can possibly get rid of this when the lockout is redirected on sign in
+    Given I am on "http://studio.code.org/lockout"
+
+    # It should not be a pending request
+    Then I wait to see "#lockout-panel-form"
+    And element "#permission-status" contains text "Not Submitted"
+
+    # Type in the email do re-enable the button
+    And I press keys "parent@example.com" for element "#parent-email"
+    Then element "#lockout-submit" is enabled
+
+    # Ensure that we are now "pending"
+    When I press "lockout-submit"
+    Then I wait to see "#lockout-panel-form"
+    And element "#permission-status" contains text "Pending"
+
+    # Perform a "resend"
+    When I press "lockout-resend"
+    Then I wait to see "#lockout-panel-form"
+
+  Scenario: New under 13 account should be able to send a different email
+    Given I create a young student in Colorado who has never signed in named "Sally Student" and go home
+
+    # TODO: Can possibly get rid of this when the lockout is redirected on sign in
+    Given I am on "http://studio.code.org/lockout"
+
+    # It should not be a pending request
+    Then I wait to see "#lockout-panel-form"
+    And element "#permission-status" contains text "Not Submitted"
+
+    # Type in the email do re-enable the button
+    And I press keys "parent@example.com" for element "#parent-email"
+    Then element "#lockout-submit" is enabled
+
+    # Ensure that we are now "pending"
+    When I press "lockout-submit"
+    Then I wait to see "#lockout-panel-form"
+    And element "#permission-status" contains text "Pending"
+
+    # Type in the email do re-enable the button
+    When I clear the text from element "#parent-email"
+    And I press keys "parent2@example.com" for element "#parent-email"
+    Then element "#lockout-submit" is enabled
+
+    # Ensure that the new email was used
+    When I press "lockout-submit"
+    Then I wait to see "#lockout-panel-form"
+    And element "#parent-email" has value "parent2@example.com"

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -107,11 +107,21 @@ def create_user(name, url: '/users.json', code: 201, **user_opts)
   end
 end
 
-And(/^I create a (young )?student( who has never signed in)? named "([^"]*)"( and go home)?$/) do |young, new_account, name, home|
+And(/^I create a (young )?student( in Colorado)?( who has never signed in)? named "([^"]*)"( and go home)?$/) do |young, locked, new_account, name, home|
   age = young ? '10' : '16'
   sign_in_count = new_account ? 0 : 2
 
-  create_user(name, age: age, sign_in_count: sign_in_count)
+  user_opts = {
+    age: age,
+    sign_in_count: sign_in_count
+  }
+
+  if locked
+    user_opts[:country_code] = "US"
+    user_opts[:us_state] = "CO"
+  end
+
+  create_user(name, **user_opts)
   navigate_to replace_hostname('http://studio.code.org') if home
 end
 


### PR DESCRIPTION
Adds the API endpoint for creating a permission request from the LockoutPanel UI presented to students locked out via the CPA mechanism imposed on new accounts.

There are multiple actions for students:

* Create a permission request when there has been none.
* Resend the "pending" permission request.
* Send a new permission request to another email.

There are several abuse concerns addressed in the implementation. These are discussed in "Security" below.

When creating a permission request, the user must be authenticated. There is no actual check that they are actually locked out, but it will not continue if the student has _received_ parental permission. So, once permission is granted, it remains granted.

When resending, there is a limit (see Security) but otherwise the process is actually the same. It sends the same email it would have sent the first time.

When sending a new email, the newest email takes precedence, but all prior permission requests will be honored. You can only send up to three (see Security).

On cases where no email is actually sent (limits reached / already granted permission), there is a redirect to the lockout panel, but no error messaging is shown. The user then assumes that the email or action happened. This only happens in seemingly malicious cases or rare cases.

## Links

- jira ticket: [P20-120](https://codedotorg.atlassian.net/browse/P20-120)

## Security

There are two abuse vectors apparent in the naive design that are now addressed.

1. Users could send permission requests to an unlimited number of unique email addresses.
2. Users could send an unlimited number of resent permission requests to one particular email address.

Both are avenues to pester or spam external email accounts and also to overwhelm our capability to send email.

They have been addressed in a somewhat simple fashion: a reference count. Only three emails of each type will be sent and then the application will silently not send the emails afterward. For permission requests, this is imposed per day.

To facilitate this, a prior PR added a `resends_sent` column to the `PermissionRequest` table. This keeps track, for one particular parental email address / user coupling, of the number of resends. When this reaches 3, the controller logic will bail back to the lockout page without committing a change.

Also, for the parental permission requests themselves, there is logic to ask the DB engine if there have been at least 3 such requests in the current calendar day. If so, it similarly bails to the lockout page.

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

There are new UI test factories for creating conforming students. So, the UI feature creates such a student in Colorado, which in the future (not right now) will have the lockdown enforced upon account creation.

Beyond manual testing, there are prior storybooks for the lockout panel that have been reviewed as changes to the panel were made.

There are a set of integration tests for the controller logic.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

Normally this is all behind the experiment flag, but this logic does not need to be. You can only interact with this API chain _if and only if_ you end up on the lockout page.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
