### PR TITLE
[Sprite Lab] Fix whenSpriteCreated bug

### DIFF
--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -549,21 +549,14 @@ export default class CoreLibrary {
   }
 
   runSpriteCreatedEvents(newSprite) {
-    const matchingInputEvents = this.inputEvents.filter(inputEvent => {
-      if (inputEvent.type === 'whenSpriteCreated') {
-        const inputEventName = inputEvent.args.name;
-        const inputEventCostume = inputEvent.args.costume;
-        if (inputEventName !== undefined && inputEventName === newSprite.name) {
-          return true;
-        } else if (
-          inputEventCostume === newSprite.getAnimationLabel() ||
-          inputEventCostume === 'all'
-        ) {
-          return true;
-        }
-      }
-      return false;
-    });
+    const matchingInputEvents = this.inputEvents.filter(
+      inputEvent =>
+        inputEvent.type === 'whenSpriteCreated' &&
+        ((inputEvent.args.name !== undefined &&
+          inputEvent.args.name === newSprite.name) ||
+          inputEvent.args.costume === newSprite.getAnimationLabel() ||
+          inputEvent.args.costume === 'all')
+    );
     matchingInputEvents.forEach(inputEvent => {
       this.eventLog.push(`spriteCreated: ${newSprite.id}`);
       inputEvent.callback({newSprite: newSprite.id});

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -400,6 +400,7 @@ export default class CoreLibrary {
    * @returns {Number} A unique id to reference the sprite.
    */
   addSprite(opts) {
+    console.log('addSprite');
     if (this.reachedSpriteMax()) {
       return;
     } else if (this.reachedSpriteWarningThreshold()) {
@@ -549,10 +550,14 @@ export default class CoreLibrary {
   }
 
   runSpriteCreatedEvents(newSprite) {
+    console.log('depend on inputEvent');
+    console.log('this.inputEvents', this.inputEvents);
     const matchingInputEvents = this.inputEvents.filter(inputEvent => {
       if (inputEvent.type === 'whenSpriteCreated') {
         const inputEventName = inputEvent.args.name;
         const inputEventCostume = inputEvent.args.costume;
+        console.log(inputEventName);
+        console.log(inputEventCostume);
         if (inputEventName !== undefined && inputEventName === newSprite.name) {
           return true;
         } else if (

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -549,13 +549,21 @@ export default class CoreLibrary {
   }
 
   runSpriteCreatedEvents(newSprite) {
-    const matchingInputEvents = this.inputEvents.filter(
-      inputEvent =>
-        inputEvent.type === 'whenSpriteCreated' &&
-        (inputEvent.args.name === newSprite.name ||
-          inputEvent.args.costume === newSprite.getAnimationLabel() ||
-          inputEvent.args.costume === 'all')
-    );
+    const matchingInputEvents = this.inputEvents.filter(inputEvent => {
+      if (inputEvent.type === 'whenSpriteCreated') {
+        const inputEventName = inputEvent.args.name;
+        const inputEventCostume = inputEvent.args.costume;
+        if (inputEventName !== undefined && inputEventName === newSprite.name) {
+          return true;
+        } else if (
+          inputEventCostume === newSprite.getAnimationLabel() ||
+          inputEventCostume === 'all'
+        ) {
+          return true;
+        }
+      }
+      return false;
+    });
     matchingInputEvents.forEach(inputEvent => {
       this.eventLog.push(`spriteCreated: ${newSprite.id}`);
       inputEvent.callback({newSprite: newSprite.id});

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -400,7 +400,6 @@ export default class CoreLibrary {
    * @returns {Number} A unique id to reference the sprite.
    */
   addSprite(opts) {
-    console.log('addSprite');
     if (this.reachedSpriteMax()) {
       return;
     } else if (this.reachedSpriteWarningThreshold()) {
@@ -550,14 +549,10 @@ export default class CoreLibrary {
   }
 
   runSpriteCreatedEvents(newSprite) {
-    console.log('depend on inputEvent');
-    console.log('this.inputEvents', this.inputEvents);
     const matchingInputEvents = this.inputEvents.filter(inputEvent => {
       if (inputEvent.type === 'whenSpriteCreated') {
         const inputEventName = inputEvent.args.name;
         const inputEventCostume = inputEvent.args.costume;
-        console.log(inputEventName);
-        console.log(inputEventCostume);
         if (inputEventName !== undefined && inputEventName === newSprite.name) {
           return true;
         } else if (

--- a/apps/src/p5lab/spritelab/commands/eventCommands.js
+++ b/apps/src/p5lab/spritelab/commands/eventCommands.js
@@ -23,6 +23,7 @@ export const commands = {
   },
 
   keyPressed(condition, key, callback) {
+    console.log('keyPressed', key);
     if (condition === 'when' || condition === 'while') {
       this.addEvent(condition + 'press', {key: key}, callback);
     }
@@ -37,6 +38,7 @@ export const commands = {
   },
 
   spriteClicked(condition, spriteArg, callback) {
+    console.log('spriteclicked');
     if (condition === 'when' || condition === 'while') {
       this.addEvent(condition + 'click', {sprite: spriteArg}, callback);
     }
@@ -48,6 +50,7 @@ export const commands = {
 
   whenSpriteCreated(spriteArg, callback) {
     if (spriteArg) {
+      console.log('whenSpriteCreated');
       this.addEvent('whenSpriteCreated', spriteArg, callback);
     }
   },

--- a/apps/src/p5lab/spritelab/commands/eventCommands.js
+++ b/apps/src/p5lab/spritelab/commands/eventCommands.js
@@ -23,7 +23,6 @@ export const commands = {
   },
 
   keyPressed(condition, key, callback) {
-    console.log('keyPressed', key);
     if (condition === 'when' || condition === 'while') {
       this.addEvent(condition + 'press', {key: key}, callback);
     }
@@ -38,7 +37,6 @@ export const commands = {
   },
 
   spriteClicked(condition, spriteArg, callback) {
-    console.log('spriteclicked');
     if (condition === 'when' || condition === 'while') {
       this.addEvent(condition + 'click', {sprite: spriteArg}, callback);
     }
@@ -50,7 +48,6 @@ export const commands = {
 
   whenSpriteCreated(spriteArg, callback) {
     if (spriteArg) {
-      console.log('whenSpriteCreated');
       this.addEvent('whenSpriteCreated', spriteArg, callback);
     }
   },


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR fixes a bug in Sprite Lab (CDO version) - the blocks in the `whenSpriteCreated` event fire regardless of the type of sprite costume they’re bound to. (Example: 'purple bunny' below.)

<img width="290" alt="Screen Shot 2023-06-11 at 10 34 40 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/3d3d884b-d670-48c6-9219-af716ca06c6c">


Refer to the screencast video below of [this project](https://studio.code.org/projects/spritelab/dIZnEgo_G1kTiQZ1zah9tf2Tl-QXJecgbDCmJ5v68ns).

BEFORE UPDATE:

https://github.com/code-dot-org/code-dot-org/assets/107423305/98867dff-f266-4eb2-9b56-0f8378d12039

The reason for this bug is that in `runSpriteCreatedEvents` in `spritelab/CoreLibrary.js`, when both `inputEvent.args.name` and `newSprite.name` are `undefined` the condition for filtering the `inputEvents` for the `whenSpriteCreated` evaluates to `true` and the `whenSpriteCreated` event is incorrectly made. So I added a check to make sure the event name is not `undefined`. I also refactored the filtering of the input events for easier readability.

AFTER UPDATE:

https://github.com/code-dot-org/code-dot-org/assets/107423305/b3c4d2a4-03e0-4505-8386-a10fed41d90a



## Links
[jira ticket](https://codedotorg.atlassian.net/browse/SL-903)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
