### PR TITLE
Rubocop Target Ruby 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
     - 'dashboard/db/schema.rb'
     - 'pegasus/test/test_string.rb' # Parser does not support non-utf8 escape sequences
   DisplayCopNames: true
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Rails:
   Enabled: true

--- a/bin/cron/zendesk_slack_report
+++ b/bin/cron/zendesk_slack_report
@@ -195,14 +195,14 @@ def get_tickets_by_group
 
   # Report out for each Slack room
   MONITORING_GROUPS.each do |slack_room, groups|
-    group_messages = groups.map do |group_name|
+    group_messages = groups.filter_map do |group_name|
       count = group_counts[group_name] || 0
       next nil if count == 0
 
       url = Zendesk.group_url(group: group_name, statuses: STATUSES_TO_REPORT)
       statuses = STATUSES_TO_REPORT.join('/')
       "<#{url}|#{group_name} has #{count} #{statuses} Zendesk tickets.>"
-    end.compact
+    end
 
     # Don't post if there's nothing to report
     next if group_messages.empty?
@@ -232,7 +232,7 @@ def get_tickets_by_user
 
   # Report out for each Slack room
   MONITORING_USERS.each do |slack_room, users|
-    user_messages = users.map do |user|
+    user_messages = users.filter_map do |user|
       user_email = "#{user}@code.org"
       count = user_counts[user_email] || 0
       next nil if count == 0
@@ -240,7 +240,7 @@ def get_tickets_by_user
       url = Zendesk.user_url(user: user_email, statuses: STATUSES_TO_REPORT)
       statuses = STATUSES_TO_REPORT.join('/')
       "<#{url}|#{user_email} has #{count} #{statuses} Zendesk tickets.>"
-    end.compact
+    end
 
     # Don't post if there's nothing to report
     next if user_messages.empty?

--- a/bin/oneoff/backfill_data/backfill_script_level_ids_teacher_feedbacks_3.rb
+++ b/bin/oneoff/backfill_data/backfill_script_level_ids_teacher_feedbacks_3.rb
@@ -27,7 +27,7 @@ def update_script_level_ids_based_on_assignment
 
         # All scripts assigned by the teacher that gave the feedback
         scripts_assigned_by_feedback_giver =
-          student_sections_taught_by_feedback_giver.map(&:script).compact
+          student_sections_taught_by_feedback_giver.filter_map(&:script)
 
         # The associated script levels in any of the scripts assigned by the feedback giver
         candidate_script_levels = associated_script_levels.where(

--- a/bin/oneoff/backfill_data/backfill_section_start.rb
+++ b/bin/oneoff/backfill_data/backfill_section_start.rb
@@ -11,11 +11,11 @@ ActiveRecord::Base.record_timestamps = false
 Section.find_in_batches(start: min_id) do |group|
   puts "Processing sections #{group.first.id} - #{group.last.id}"
   group.each do |section|
-    first_activity_at = section.students.map do |student|
+    first_activity_at = section.students.filter_map do |student|
       user_scripts = student.user_scripts
       user_scripts = user_scripts.where(script_id: section.script_id) if section.script_id
       user_scripts.where('started_at > ?', section.created_at).minimum(:started_at)
-    end.compact.min
+    end.min
     begin
       section.update!(first_activity_at: first_activity_at) if first_activity_at
     rescue

--- a/bin/remove_script_remnants
+++ b/bin/remove_script_remnants
@@ -31,9 +31,9 @@ def get_all_progress(script_id)
   data[:user_levels] = UserLevel.
     where(script_id: script_id).
     where(user_id:
-      data[:user_scripts].map do |user_script|
+      data[:user_scripts].filter_map do |user_script|
         user_script['user_id']
-      end.compact
+      end
     ).
     to_a.
     map(&:serializable_hash)

--- a/dashboard/app/controllers/api/v1/pd/teacher_attendance_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/teacher_attendance_report_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::Pd::TeacherAttendanceReportController < Api::V1::Pd::ReportContro
   def index
     @workshops = load_filtered_ended_workshops
 
-    report = @workshops.map do |workshop|
+    report = @workshops.filter_map do |workshop|
       ::Pd::Payment::PaymentFactory.get_payment(workshop).try do |workshop_summary|
         workshop_summary.teacher_summaries.map do |teacher_summary|
           teacher_summary.generate_teacher_progress_report_line_item(
@@ -16,7 +16,7 @@ class Api::V1::Pd::TeacherAttendanceReportController < Api::V1::Pd::ReportContro
           )
         end
       end
-    end.compact.flatten
+    end.flatten
 
     respond_to do |format|
       format.json do

--- a/dashboard/app/controllers/api/v1/pd/workshop_summary_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_summary_report_controller.rb
@@ -7,11 +7,11 @@ class Api::V1::Pd::WorkshopSummaryReportController < Api::V1::Pd::ReportControll
   def index
     @workshops = load_filtered_ended_workshops
 
-    report = @workshops.map do |workshop|
+    report = @workshops.filter_map do |workshop|
       ::Pd::Payment::PaymentFactory.get_payment(workshop).try do |workshop_summary|
         workshop_summary.generate_organizer_report_line_item(current_user.permission?(UserPermission::WORKSHOP_ADMIN))
       end
-    end.compact
+    end
 
     respond_to do |format|
       format.json do

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -90,8 +90,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
       # teachercon
       cities = current_user.
         regional_partners.
-        map {|partner| get_matching_teachercon(partner)}.
-        compact.
+        filter_map {|partner| get_matching_teachercon(partner)}.
         to_set.
         pluck(:city).
         map {|city| "%#{city}%"}

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -269,14 +269,14 @@ class ApiController < ApplicationController
       level_map = student.user_levels_by_level(script)
       paired_user_level_ids = PairedUserLevel.pairs(level_map.values.map(&:id))
       student_levels = script_levels.map do |script_level|
-        user_levels = script_level.level_ids.map do |id|
+        user_levels = script_level.level_ids.filter_map do |id|
           contained_levels = Unit.cache_find_level(id).contained_levels
           if contained_levels.any?
             level_map[contained_levels.first.id]
           else
             level_map[id]
           end
-        end.compact
+        end
         user_levels_ids = user_levels.map(&:id)
         level_class = (best_activity_css_class user_levels).dup
         paired = (paired_user_level_ids & user_levels_ids).any?
@@ -567,7 +567,7 @@ class ApiController < ApplicationController
     data = section.students.map do |student|
       student_hash = {id: student.id, name: student.name}
 
-      text_response_levels.map do |level_hash|
+      text_response_levels.filter_map do |level_hash|
         last_attempt = student.last_attempt_for_any(level_hash[:levels])
         response = last_attempt.try(:level_source).try(:data)
         next unless response
@@ -579,7 +579,7 @@ class ApiController < ApplicationController
           response: response,
           url: build_script_level_url(level_hash[:script_level], section_id: section.id, user_id: student.id)
         }
-      end.compact
+      end
     end.flatten
 
     render json: data

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -281,7 +281,7 @@ class ApplicationController < ActionController::Base
     end
 
     # replace pairings
-    session[:pairings] = pairings_from_params[:pairings].map do |pairing_param|
+    session[:pairings] = pairings_from_params[:pairings].filter_map do |pairing_param|
       other_user = User.find(pairing_param[:id])
       if current_user.can_pair_with? other_user
         other_user.id
@@ -289,7 +289,7 @@ class ApplicationController < ActionController::Base
         # TODO: should this cause an error to be returned to the user?
         nil
       end
-    end.compact
+    end
 
     session[:pairing_section_id] = pairings_from_params[:section_id].to_i
   end

--- a/dashboard/app/controllers/code_reviews_controller.rb
+++ b/dashboard/app/controllers/code_reviews_controller.rb
@@ -96,8 +96,7 @@ class CodeReviewsController < ApplicationController
     # For each Follower object, get the user_ids of the other members in the
     # code review group; combine the results and return as a single array.
     followeds.
-      map {|followed| followed.code_review_group&.followers&.pluck(:student_user_id)}.
-      compact.
+      filter_map {|followed| followed.code_review_group&.followers&.pluck(:student_user_id)}.
       flatten.
       select {|user_id| user_id != student.id}
   end

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -10,10 +10,10 @@ class LevelStarterAssetsController < ApplicationController
 
   # GET /level_starter_assets/:level_name
   def show
-    starter_assets = (@level&.project_template_level&.starter_assets || @level.starter_assets || []).map do |friendly_name, uuid_name|
+    starter_assets = (@level&.project_template_level&.starter_assets || @level.starter_assets || []).filter_map do |friendly_name, uuid_name|
       file_obj = get_object(uuid_name)
       summarize(file_obj, friendly_name, uuid_name)
-    end.compact
+    end
 
     render json: {starter_assets: starter_assets}
   end

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -184,7 +184,7 @@ module UsersHelper
       progress
     end
     timestamp_by_user = progress_by_user.transform_values do |user|
-      user.values.map {|level| level[:last_progress_at]}.compact.max
+      user.values.filter_map {|level| level[:last_progress_at]}.max
     end
 
     [progress_by_user, timestamp_by_user]

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -140,7 +140,7 @@ class CourseVersion < ApplicationRecord
 
   def self.course_offering_keys(content_root_type)
     Rails.cache.fetch("course_version/course_offering_keys/#{content_root_type}", force: !should_cache?) do
-      CourseVersion.includes(:course_offering).where(content_root_type: content_root_type).map {|cv| cv.course_offering&.key}.compact.uniq.sort
+      CourseVersion.includes(:course_offering).where(content_root_type: content_root_type).filter_map {|cv| cv.course_offering&.key}.uniq.sort
     end
   end
 

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -82,7 +82,7 @@ class Foorm::Submission < ApplicationRecord
       return {question_name => choices[answer]}
     when ANSWER_MULTI_SELECT
       choices = question_details[:choices]
-      return {question_name => answer.map {|selected| choices[selected]}.compact.sort.join(', ')}
+      return {question_name => answer.filter_map {|selected| choices[selected]}.sort.join(', ')}
     end
 
     # Return blank hash if question_type not found

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -631,13 +631,13 @@ class Lesson < ApplicationRecord
   def update_objectives(objectives)
     return unless objectives
 
-    self.objectives = objectives.map do |objective|
+    self.objectives = objectives.filter_map do |objective|
       next nil if objective['description'].blank?
       persisted_objective = objective['id'].blank? ? Objective.new(key: SecureRandom.uuid) : Objective.find(objective['id'])
       persisted_objective.description = objective['description']
       persisted_objective.save!
       persisted_objective
-    end.compact
+    end
   end
 
   # Used for seeding from JSON. Returns the full set of information needed to

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -570,9 +570,9 @@ class Blockly < Level
         return loc_val
       end
     else
-      val = [game.app, game.name].map do |name|
+      val = [game.app, game.name].filter_map do |name|
         I18n.t("data.level.instructions.#{name}_#{level_num}", default: nil)
-      end.compact.first
+      end.first
       return val unless val.nil?
     end
   end

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -229,7 +229,7 @@ class LevelGroup < DSLDefined
 
       # Go through each student, and make sure to shuffle their results for additional
       # anonymity.
-      results = section.students.map do |student|
+      results = section.students.filter_map do |student|
         # Skip student if they haven't submitted for this LevelGroup.
         user_level = UserLevel.find_by(
           user: student,
@@ -239,7 +239,7 @@ class LevelGroup < DSLDefined
         next unless user_level.try(:submitted)
 
         get_sublevel_result(sublevel, student.last_attempt(sublevel).try(:level_source).try(:data))
-      end.compact.shuffle
+      end.shuffle
 
       answers = sublevel.properties.try(:[], "answers")
       answer_texts = answers.map {|answer| answer["text"]} if answers

--- a/dashboard/app/models/pd/workshop_daily_survey.rb
+++ b/dashboard/app/models/pd/workshop_daily_survey.rb
@@ -66,11 +66,11 @@ module Pd
     end
 
     def self.get_form_id_for_subjects_and_day(subjects, day)
-      subjects.map do |subject|
+      subjects.filter_map do |subject|
         get_form_id_for_subject_and_day subject, day
       rescue
         nil
-      end.compact
+      end
     end
 
     def self.get_form_id_for_subject_and_day(subject, day)

--- a/dashboard/app/models/plc/enrollment_unit_assignment.rb
+++ b/dashboard/app/models/plc/enrollment_unit_assignment.rb
@@ -69,7 +69,7 @@ class Plc::EnrollmentUnitAssignment < ApplicationRecord
   end
 
   def focus_area_lesson_ids
-    plc_module_assignments.map {|a| a.plc_learning_module.lesson.id unless a.plc_learning_module.required?}.compact
+    plc_module_assignments.filter_map {|a| a.plc_learning_module.lesson.id unless a.plc_learning_module.required?}
   end
 
   def summarize_progress

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -46,9 +46,9 @@ class School < ApplicationRecord
   # Gets the full address of the school.
   # @return [String] The full address.
   def full_address
-    %w(address_line1 address_line2 address_line3 city state zip).map do |col|
+    %w(address_line1 address_line2 address_line3 city state zip).filter_map do |col|
       attributes[col].presence
-    end.compact.join(' ')
+    end.join(' ')
   end
 
   def most_recent_school_stats

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1662,7 +1662,7 @@ class User < ApplicationRecord
 
   # Returns the set of courses the user has been assigned to or has progress in.
   def courses_as_participant
-    visible_scripts.map(&:unit_group).compact.concat(section_courses).uniq
+    visible_scripts.filter_map(&:unit_group).concat(section_courses).uniq
   end
 
   # Checks if there are any launched scripts assigned to the user.
@@ -1758,7 +1758,7 @@ class User < ApplicationRecord
 
     pl_user_scripts = user_scripts.select {|us| us.script.pl_course?}
 
-    user_script_data = pl_user_scripts.map do |user_script|
+    user_script_data = pl_user_scripts.filter_map do |user_script|
       # Skip this script if we are excluding the primary script and this is the
       # primary script.
       if exclude_primary_script && user_script[:script_id] == primary_script_id
@@ -1773,7 +1773,7 @@ class User < ApplicationRecord
           link: script_path(script),
         }
       end
-    end.compact
+    end
 
     user_course_data = courses_as_participant.select(&:pl_course?).map(&:summarize_short)
 
@@ -1798,7 +1798,7 @@ class User < ApplicationRecord
 
     user_student_scripts = user_scripts.select {|us| !us.script.pl_course?}
 
-    user_script_data = user_student_scripts.map do |user_script|
+    user_script_data = user_student_scripts.filter_map do |user_script|
       # Skip this script if we are excluding the primary script and this is the
       # primary script.
       if exclude_primary_script && user_script[:script_id] == primary_script_id
@@ -1813,7 +1813,7 @@ class User < ApplicationRecord
           link: script_path(script),
         }
       end
-    end.compact
+    end
 
     user_course_data = courses_as_participant.select {|c| !c.pl_course?}.map(&:summarize_short)
 
@@ -1839,7 +1839,7 @@ class User < ApplicationRecord
   def section_courses
     # In the future we may want to make it so that if assigned a script, but that
     # script has a default course, it shows up as a course here
-    all_sections.map(&:unit_group).compact.uniq
+    all_sections.filter_map(&:unit_group).uniq
   end
 
   def visible_scripts
@@ -2529,7 +2529,7 @@ class User < ApplicationRecord
   end
 
   def code_review_groups
-    followeds.map(&:code_review_group).compact
+    followeds.filter_map(&:code_review_group)
   end
 
   private def account_age_in_years
@@ -2544,7 +2544,7 @@ class User < ApplicationRecord
   # Returns a list of all curriculums that the teacher currently has sections for
   # ex: ["csf", "csd"]
   private def curriculums_being_taught
-    @curriculums_being_taught ||= sections.map {|section| section.script&.curriculum_umbrella}.compact.uniq
+    @curriculums_being_taught ||= sections.filter_map {|section| section.script&.curriculum_umbrella}.uniq
   end
 
   private def has_attended_pd?

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -302,7 +302,7 @@ class Projects
   end
 
   def to_a
-    @table.where(storage_id: @storage_id).exclude(state: 'deleted').map do |row|
+    @table.where(storage_id: @storage_id).exclude(state: 'deleted').filter_map do |row|
       channel_id = storage_encrypt_channel_id(row[:storage_id], row[:id])
       begin
         Projects.merged_row_value(
@@ -313,7 +313,7 @@ class Projects
       rescue JSON::ParserError
         nil
       end
-    end.compact
+    end
   end
 
   # Find the encrypted channel token for most recent project of the given level type.

--- a/dashboard/lib/autocomplete_helper.rb
+++ b/dashboard/lib/autocomplete_helper.rb
@@ -16,9 +16,9 @@ class AutocompleteHelper
   end
 
   def self.get_query_terms(query)
-    query.strip.split(/\s+|\W+/).map do |w|
+    query.strip.split(/\s+|\W+/).filter_map do |w|
       w.upcase.presence
-    end.compact
+    end
   end
 
   # Formats the query string for boolean full-text search.

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -51,8 +51,7 @@ class LevelLoader
       # Load level properties from disk and build a collection of levels that
       # have changed.
       changed_levels = level_file_paths.
-          map {|path| load_custom_level path, level_md5s_by_name}.
-          compact.
+          filter_map {|path| load_custom_level path, level_md5s_by_name}.
           select(&:changed?)
 
       if [:development, :adhoc].include?(rack_env) && !CDO.properties_encryption_key
@@ -67,7 +66,7 @@ class LevelLoader
 
       # activerecord-import (with MySQL, anyway) doesn't save associated
       # models, so we've got to do this manually.
-      changed_lcds = changed_levels.map(&:level_concept_difficulty).compact
+      changed_lcds = changed_levels.filter_map(&:level_concept_difficulty)
       lcd_update_columns = LevelConceptDifficulty.columns.map(&:name).map(&:to_sym).
           reject {|column| %i{id level_id created_at}.include? column}
       LevelConceptDifficulty.import! changed_lcds, on_duplicate_key_update: lcd_update_columns

--- a/dashboard/lib/mega_section.rb
+++ b/dashboard/lib/mega_section.rb
@@ -203,8 +203,7 @@ class MegaSection
     " non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.".
       split(/[.,]/).
       sample(rng.rand(3..6)).
-      map(&:strip).
-      compact.
+      filter_map(&:strip).
       map(&:capitalize).
       join('. ') + '.'
   end

--- a/dashboard/lib/pd/foorm/submission_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/submission_analytics_parser.rb
@@ -110,7 +110,7 @@ module Pd::Foorm
           choices = question_details[:choices]
           additional_attributes = {
             response_value: answer,
-            response_text: answer.map {|selected| choices[selected]}.compact.sort.join(', ')
+            response_text: answer.filter_map {|selected| choices[selected]}.sort.join(', ')
           }
 
           reshaped_submission_answer.merge! additional_attributes

--- a/dashboard/lib/pd/jot_form/form_questions.rb
+++ b/dashboard/lib/pd/jot_form/form_questions.rb
@@ -88,7 +88,7 @@ module Pd
       # @return [Hash] {question_name => answer_data}, sorted by appearance order in the form
       # @see Question#process_answers
       def process_answers(answers_data, show_hidden_questions: false)
-        questions_with_form_data = answers_data.map do |question_id, answer_data|
+        questions_with_form_data = answers_data.filter_map do |question_id, answer_data|
           question = get_question_by_id_or_name(question_id)
           raise "Unrecognized question id #{question_id}" unless question
 
@@ -104,7 +104,7 @@ module Pd
             question: question,
             form_data: form_data
           }
-        end.compact
+        end
 
         questions_with_form_data.
           sort_by {|d| d[:question].order}.

--- a/dashboard/lib/pd/payment/payment_calculator_base.rb
+++ b/dashboard/lib/pd/payment/payment_calculator_base.rb
@@ -101,7 +101,7 @@ module Pd::Payment
     def get_session_attendance_summaries(workshop)
       workshop.sessions.map do |session|
         session_attendances = Pd::Attendance.where(pd_session_id: session.id.to_s)
-        enrollment_ids = session_attendances.all.map(&:resolve_enrollment).compact.map(&:id).uniq
+        enrollment_ids = session_attendances.all.filter_map(&:resolve_enrollment).map(&:id).uniq
         SessionAttendanceSummary.new session.hours, enrollment_ids
       end
     end

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -172,13 +172,13 @@ module ProjectsList
     #   where `version` corresponds to an S3 version of the library.
     # @return [Array<String>] The channel_ids of libraries that have been updated since the given version.
     def fetch_updated_library_channels(libraries)
-      project_ids = libraries.map do |library|
+      project_ids = libraries.filter_map do |library|
         _, id = storage_decrypt_channel_id(library['channel_id'])
         library['project_id'] = id
         id
       rescue
         nil
-      end.compact.uniq
+      end.uniq
 
       return [] if project_ids.nil_or_empty?
 
@@ -333,7 +333,7 @@ module ProjectsList
             exclude(published_at: nil).
             order(Sequel.desc(:published_at)).
             limit(limit).
-            map {|project_and_user| get_published_project_and_user_data project_and_user}.compact
+            filter_map {|project_and_user| get_published_project_and_user_data project_and_user}
         end
       end
     end

--- a/dashboard/lib/sample_data.rb
+++ b/dashboard/lib/sample_data.rb
@@ -246,8 +246,7 @@ class SampleData
     " non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.".
       split(/[.,]/).
       sample(rng.rand(3..6)).
-      map(&:strip).
-      compact.
+      filter_map(&:strip).
       map(&:capitalize).
       join('. ') + '.'
   end

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -48,9 +48,9 @@ module Services
           # lesson with a title page.
           script.lessons.each do |lesson|
             ChatClient.log("Gathering resources for #{lesson.key.inspect}") if DEBUG
-            lesson_pdfs = lesson.resources.map do |resource|
+            lesson_pdfs = lesson.resources.filter_map do |resource|
               fetch_resource_pdf(resource, pdfs_dir) if resource.should_include_in_pdf?
-            end.compact
+            end
 
             next if lesson_pdfs.empty?
 

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -20,8 +20,8 @@ module CustomRake
 end
 
 module TimedTask
-  def timed_task(*args, &block)
-    CustomRake::TimedTask.define_task(*args, &block)
+  def timed_task(...)
+    CustomRake::TimedTask.define_task(...)
   end
 end
 

--- a/dashboard/test/models/pd/payment_term_test.rb
+++ b/dashboard/test/models/pd/payment_term_test.rb
@@ -90,7 +90,7 @@ class Pd::PaymentTermTest < ActiveSupport::TestCase
     create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Date.today + 2.months, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1)
 
     [term_1, term_2].map(&:reload)
-    assert_empty [term_1, term_2].map(&:end_date).compact
+    assert_empty [term_1, term_2].filter_map(&:end_date)
 
     # this should truncate term 2
     create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: 3.months.from_now.to_date, course: Pd::Workshop::COURSE_CSF)

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -368,12 +368,12 @@ end
 # ]
 #
 def browser_features
-  ($browsers.product features_to_run).map do |browser, feature|
+  ($browsers.product features_to_run).filter_map do |browser, feature|
     arguments = cucumber_arguments_for_browser(browser, $options)
     scenario_count = ParallelTests::Cucumber::Scenarios.all([feature], test_options: arguments).length
     next if scenario_count.zero?
     [browser, feature]
-  end.compact
+  end
 end
 
 def test_type

--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -179,7 +179,7 @@ module AWS
       params = YAML.load(template)['Parameters']
       # rubocop:enable Security/YAMLLoad
       return [] unless params
-      params.map do |key, properties|
+      params.filter_map do |key, properties|
         value = CDO[key.underscore] || ENV[key.underscore.upcase]
         param = {parameter_key: key}
         if value
@@ -196,7 +196,7 @@ module AWS
             HighLine.new.ask("Enter value for Parameter #{key}:", String)
         end
         param
-      end.compact
+      end
     end
 
     private def base_options

--- a/lib/cdo/aws/s3_packaging.rb
+++ b/lib/cdo/aws/s3_packaging.rb
@@ -111,14 +111,14 @@ class S3Packaging
   def log_bundle_size
     stats = JSON.parse(File.read(@source_location + '/build/package/js/stats.json'))
     Metrics.write_batch_metric(
-      stats['assets'].map do |asset|
+      stats['assets'].filter_map do |asset|
         next nil unless asset['name'].end_with? '.js'
         {
           name: 'bundle_size',
           metadata: asset['name'],
           value: asset['size'],
         }
-      end.compact
+      end
     )
   rescue => exception
     # Just log and continue

--- a/lib/cdo/data/logging/timed_task_with_logging.rb
+++ b/lib/cdo/data/logging/timed_task_with_logging.rb
@@ -22,7 +22,7 @@ module CustomRake
 end
 
 module TimedTaskWithLogging
-  def timed_task_with_logging(*args, &block)
-    CustomRake::TimedTaskWithLogging.define_task(*args, &block)
+  def timed_task_with_logging(...)
+    CustomRake::TimedTaskWithLogging.define_task(...)
   end
 end

--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -247,7 +247,7 @@ module LessonImportHelper
 
   def self.create_lesson_activities(activities_data, levels, lesson)
     position = 1
-    activities = activities_data.map do |a|
+    activities = activities_data.filter_map do |a|
       if a['name'] == 'Lesson Modifications' && convert_virtual_lesson_modification_activity_to_announcement(a, lesson)
         nil
       else
@@ -263,7 +263,7 @@ module LessonImportHelper
         lesson_activity.activity_sections = create_activity_sections(a['content'].strip_utf8mb4, lesson_activity.id, levels)
         lesson_activity
       end
-    end.compact
+    end
 
     # Create a lesson with all the levels in them
     # TODO use the [code-studio] syntax from CB instead

--- a/lib/cdo/test_flakiness.rb
+++ b/lib/cdo/test_flakiness.rb
@@ -53,7 +53,7 @@ class TestFlakiness
       break if new_jobs.empty?
       jobs += new_jobs
     end
-    jobs.group_by {|job| job['name']}.map do |name, samples|
+    jobs.group_by {|job| job['name']}.filter_map do |name, samples|
       passed = samples.select {|job| job['passed']}
       next if passed.empty?
       summary = {
@@ -64,7 +64,7 @@ class TestFlakiness
         'duration' => 1.0 * passed.sum {|job| job['end_time'].to_f - job['start_time'].to_f} / passed.count
       }
       [name, summary]
-    end.compact.to_h
+    end.to_h
   end
 
   # Recommends a number of re-runs based on the flakiness score.

--- a/pegasus/helper_modules/hoc_event_review.rb
+++ b/pegasus/helper_modules/hoc_event_review.rb
@@ -43,13 +43,12 @@ module HocEventReview
     events_query(**rest).
       select(:data, :secret, :processed_data).
       limit(100).
-      map do |form|
+      filter_map do |form|
         next unless form[:processed_data]
         JSON.parse(form[:data]).
           merge(secret: form[:secret]).
           merge(JSON.parse(form[:processed_data]))
-      end.
-      compact
+      end
   end
 
   private_class_method def self.events_query(

--- a/pegasus/helpers/hourofcode_survey_helpers.rb
+++ b/pegasus/helpers/hourofcode_survey_helpers.rb
@@ -1,5 +1,5 @@
 def generate_hoc_survey_report
-  PEGASUS_DB[:forms].where(kind: 'HocSurvey2014').map do |row|
+  PEGASUS_DB[:forms].where(kind: 'HocSurvey2014').filter_map do |row|
     data = JSON.parse(row[:data]) rescue {}
 
     {
@@ -23,5 +23,5 @@ def generate_hoc_survey_report
       district: data['teacher_district_s'],
       prize_choice: data['prize_choice_s']
     }
-  end.compact
+  end
 end


### PR DESCRIPTION
Update rubocop configuration to target our actual current version of ruby, and automatically fix resulting failures with `bundle exec rubocop --auto-correct-all`

The vast majority of the changes just involve using [the new `Enumerable#filter_map` method](https://ruby-doc.org/core-2.7.0/Enumerable.html#method-i-filter_map) rather than `map` with `compact`, but there are also a couple fixes with the new argument forwarding shorthand syntax. Both kinds of fixes are straightforward.

## Links

- https://blog.saeloun.com/2019/12/04/ruby-2-7-adds-new-operator-for-arguments-forwarding/
- https://blog.saeloun.com/2019/05/25/ruby-2-7-enumerable-filter-map/

## Testing story

Relying on existing tests to verify that this does not result in any change to functionality.