### PR TITLE
Revert "Edit and new section tests"

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/teacher_tools/section_action_dropdown.feature
@@ -31,6 +31,8 @@ Feature: Using the SectionActionDropdown
     And I press the first ".print-login-link" element to load a new page
     And I wait until current URL contains "/login_info"
 
+  @skip
+  # TODO TEACH-509
   Scenario: Printing Certificates from SectionActionDropdown shows course name
     Given I create a teacher named "Teacher" and go home
     And I create a new "Hour of Code" student section named "Oceans Section" assigned to "AI for Oceans"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
@@ -4,6 +4,8 @@ Feature: Using the assessments tab in the teacher dashboard to get feedback for 
   Background:
     Given I create an authorized teacher-associated student named "Sally"
 
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Assessments tab has feedback download
     # Assign a unit with a survey but no assessment
     When I sign in as "Teacher_Sally"
@@ -37,6 +39,9 @@ Feature: Using the assessments tab in the teacher dashboard to get feedback for 
     And I select the "All teacher feedback in this unit" option in dropdown "assessment-selector"
     Then I wait until element "div:contains(Download CSV of Feedback)" is visible
 
+
+  @skip
+  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Assessments tab does not have feedback download
    # Assign a unit without feedback
     When I sign in as "Teacher_Sally" and go home


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#52292; the "Assessments tab has feedback download" Scenario enabled by that PR is failing consistently on Firefox. See thread at https://codedotorg.slack.com/archives/C045UAX4WKH/p1686611628069129 for more context