### PR TITLE
deduplicate and sort facilitator dropdown in workshop dashboard

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/course_facilitators_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/course_facilitators_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::Pd::CourseFacilitatorsController < ApplicationController
         Pd::CourseFacilitator.facilitators_for_course(params.require(:course))
       else
         Pd::CourseFacilitator.all.map(&:facilitator)
-      end
+      end.uniq.sort_by(&:name)
 
     render json: facilitators, each_serializer: Api::V1::Pd::CourseFacilitatorSerializer
   end

--- a/dashboard/test/controllers/api/v1/pd/course_facilitators_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/course_facilitators_controller_test.rb
@@ -15,4 +15,19 @@ class Api::V1::Pd::CourseFacilitatorsControllerTest < ::ActionController::TestCa
       params: {course: Pd::Workshop::COURSES.first}
     )
   end
+
+  test 'index returns unique and sorted list of facilitators' do
+    facilitator1 = create :facilitator, name: 'B'
+    facilitator2 = create :facilitator, name: 'A'
+
+    create :pd_course_facilitator, facilitator: facilitator1, course: Pd::Workshop::COURSE_CSF
+    create :pd_course_facilitator, facilitator: facilitator2, course: Pd::Workshop::COURSE_CSF
+    create :pd_course_facilitator, facilitator: facilitator2, course: Pd::Workshop::COURSE_CSD
+
+    sign_in create(:workshop_organizer)
+    get :index
+    assert_response :success
+    response_body = JSON.parse(response.body)
+    assert_equal [facilitator2, facilitator1].map(&:email), response_body.map {|f| f['email']}
+  end
 end


### PR DESCRIPTION
quick fix for a quirk in the workshop dashboard which came up in meetings week and is a request from Andrea. The facilitator dropdown has lots of duplicates and is sorted by user id (see https://studio.code.org/pd/workshop_dashboard/workshops/filter). This PR removes the duplicates and sorts by name. Sorting by name is the convention on this existing codepath: https://github.com/code-dot-org/code-dot-org/blob/14946602a32f3d4712b461cab3e5f1b2b47cc046/dashboard/app/models/pd/course_facilitator.rb#L21

### before
note the names are a little weird because I have many facilitators with the same name but different emails. so, you have to look at the name and the email to see the dupes:
<img width="947" alt="Screenshot 2023-06-13 at 5 59 18 AM" src="https://github.com/code-dot-org/code-dot-org/assets/8001765/cc9197ec-46c9-4c47-ab43-fcf03d2212ce">

### after
<img width="956" alt="Screenshot 2023-06-13 at 5 59 53 AM" src="https://github.com/code-dot-org/code-dot-org/assets/8001765/a8cec52e-a7cf-4179-9b4d-36933e5114b1">




## Testing story

- new unit test
- manually verified http://localhost-studio.code.org/pd/workshop_dashboard/workshops/filter
- manually verified the "edit workshop form" still shows the right list of facilitators locally