### PR TITLE
Conditionally add family name to user summarize method

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2048,6 +2048,7 @@ class User < ApplicationRecord
       id: id,
       name: name,
       username: username,
+      family_name: DCDO.get('family-name-features', false) ? properties&.dig('family_name') : nil,
       email: email,
       hashed_email: hashed_email,
       user_type: user_type,

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4776,28 +4776,9 @@ class UserTest < ActiveSupport::TestCase
 
     DCDO.stubs(:get).with('family-name-features', false).returns(true)
 
-    assert_equal(
-      {
-        id: user.id,
-        name: user.name,
-        username: user.username,
-        family_name: family_name,
-        email: user.email,
-        hashed_email: user.hashed_email,
-        user_type: user.user_type,
-        gender: user.gender,
-        gender_teacher_input: nil,
-        birthday: user.birthday,
-        secret_words: user.secret_words,
-        secret_picture_name: user.secret_picture.name,
-        secret_picture_path: user.secret_picture.path,
-        location: "/v2/users/#{user.id}",
-        age: user.age,
-        sharing_disabled: false,
-        has_ever_signed_in: user.has_ever_signed_in?
-      },
-      user.summarize
-    )
+    assert(user.summarize.key?(:family_name))
+    assert_equal(family_name, user.summarize[:family_name])
+
     DCDO.unstub(:get)
   end
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4774,6 +4774,8 @@ class UserTest < ActiveSupport::TestCase
     family_name = 'TestFamilyName'
     user.properties = {family_name: family_name}
 
+    assert_nil(user.summarize[:family_name])
+
     DCDO.stubs(:get).with('family-name-features', false).returns(true)
 
     assert(user.summarize.key?(:family_name))

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3690,6 +3690,7 @@ class UserTest < ActiveSupport::TestCase
         id: @student.id,
         name: @student.name,
         username: @student.username,
+        family_name: nil,
         email: @student.email,
         hashed_email: @student.hashed_email,
         user_type: @student.user_type,

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4769,6 +4769,38 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 1, user.properties['section_attempts']
   end
 
+  test 'family name is added to summarize' do
+    user = create :user
+    family_name = 'TestFamilyName'
+    user.properties = {family_name: family_name}
+
+    DCDO.stubs(:get).with('family-name-features', false).returns(true)
+
+    assert_equal(
+      {
+        id: user.id,
+        name: user.name,
+        username: user.username,
+        family_name: family_name,
+        email: user.email,
+        hashed_email: user.hashed_email,
+        user_type: user.user_type,
+        gender: user.gender,
+        gender_teacher_input: nil,
+        birthday: user.birthday,
+        secret_words: user.secret_words,
+        secret_picture_name: user.secret_picture.name,
+        secret_picture_path: user.secret_picture.path,
+        location: "/v2/users/#{user.id}",
+        age: user.age,
+        sharing_disabled: false,
+        has_ever_signed_in: user.has_ever_signed_in?
+      },
+      user.summarize
+    )
+    DCDO.unstub(:get)
+  end
+
   test 'school_info_school returns the school associated with the user' do
     school = create :school
     school_info = create :school_info, school: school


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

If the DCDO flag is set to `true`, expose a new `family_name` key in the user object returned from `User.summarize`. This change also exposes the new key in the user API.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- spec: [Tech Spec: Sort by Family Name](https://docs.google.com/document/d/1uoQ64oZ2etQoXovkIJq-UH79UkSWQLf_EtuC9fCnWWQ/edit)
- jira tickets: 
  - [TEACH-552](https://codedotorg.atlassian.net/browse/TEACH-552)
  - [TEACH-547](https://codedotorg.atlassian.net/browse/TEACH-547)
  - [TEACH-549](https://codedotorg.atlassian.net/browse/TEACH-549)


