### PR TITLE
Remove maker skinny banner from code.org/educate/applab

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/applab.haml
+++ b/pegasus/sites.v3/code.org/public/educate/applab.haml
@@ -26,9 +26,6 @@ video_player: true
 
 .clear
 
-%div{style: "margin-top: 3em;"}
-  = view :maker_skinny_banner
-
 #resources.tile-container-responsive
   = view :top_hoc_tutorial_applab, image_match_youtube_height: true
 


### PR DESCRIPTION
Removed the Maker skinny banner partial from https://code.org/educate/applab to prevent rebrand styles from overriding legacy styles. 

### Failed eyes test:
![image](https://github.com/code-dot-org/code-dot-org/assets/9256643/883a3fc7-8a60-4a1b-9337-43916ce511e1)
