### PR TITLE
Update Puma to 5.6.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,10 +125,10 @@ gem 'open_uri_redirections', require: false
 # Optimizes copy-on-write memory usage with GC before web-application fork.
 gem 'nakayoshi_fork'
 
-# Ref: https://github.com/puma/puma/pull/1646
-gem 'puma', github: 'wjordan/puma', branch: 'debugging'
+gem 'puma', '~> 5.0'
 gem 'puma_worker_killer'
 gem 'raindrops'
+gem 'sd_notify' # required for Puma to support systemd's Type=notify
 
 gem 'chronic', '~> 0.10.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,13 +99,6 @@ GIT
       omniauth-oauth2 (~> 1.4)
 
 GIT
-  remote: https://github.com/wjordan/puma.git
-  revision: 29a576120b30c34db7706c062ddf9a046723789f
-  branch: debugging
-  specs:
-    puma (3.12.0)
-
-GIT
   remote: https://github.com/wjordan/sprockets.git
   revision: 35caa45a78b739362b7db087b141f89e27d107c7
   ref: concurrent_asset_bundle_3.x
@@ -641,6 +634,8 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.0.1)
+    puma (5.6.5)
+      nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)
       puma (>= 2.7)
@@ -795,6 +790,7 @@ GEM
       scenic (>= 1.4.0)
     scss_lint (0.60.0)
       sass (~> 3.5, >= 3.5.5)
+    sd_notify (0.1.1)
     selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -1014,7 +1010,7 @@ DEPENDENCIES
   pg
   phantomjs (~> 1.9.7.1)
   pry (~> 0.14.0)
-  puma!
+  puma (~> 5.0)
   puma_worker_killer
   pusher (~> 1.3.1)
   rack-cache
@@ -1048,6 +1044,7 @@ DEPENDENCIES
   scenic
   scenic-mysql_adapter
   scss_lint
+  sd_notify
   selenium-webdriver (~> 4.0)
   sequel (~> 5.29)
   shotgun

--- a/cookbooks/cdo-apps/templates/default/puma.service.erb
+++ b/cookbooks/cdo-apps/templates/default/puma.service.erb
@@ -7,7 +7,8 @@ After=network.target
 # and our own existing configuration at
 # https://github.com/code-dot-org/code-dot-org/blob/e38737f7befb317871dbf18f46c8f65b3dc282ab/cookbooks/cdo-apps/templates/default/puma.sh.erb
 [Service]
-Type=simple
+Type=notify
+WatchdogSec=10
 
 User=<%= @user %>
 WorkingDirectory=<%= @app_root %>


### PR DESCRIPTION
The latest 5.x version, specifically. Follow-up to https://github.com/code-dot-org/code-dot-org/pull/52313 now that we no longer rely on the daemonization functionality which was removed in this version.

Also update our SystemD service to take advantage of the new `sd_notify` support.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Testing story

Testing on adhocs both that [this update works on its own](http://adhoc-puma-5-6-5-studio.cdn-code.org/courses) and that [it can be applied cleanly to existing servers](http://adhoc-puma-5-6-5-testing-studio.cdn-code.org/courses).