### PR TITLE
Remove family name on follower destroy

### DIFF
--- a/dashboard/app/models/follower.rb
+++ b/dashboard/app/models/follower.rb
@@ -53,4 +53,15 @@ class Follower < ApplicationRecord
   def assign_script
     student_user.assign_script(section.script) if section.script
   end
+
+  after_destroy :remove_family_name, if: proc {DCDO.get('family-name-features', false)}
+  def remove_family_name
+    # If the student is in zero sections, and has a family name set,
+    # remove the family name.
+    if student_user.properties['family_name'] && student_user.sections_as_student.empty?
+      # can't remove keys from properties directly, so just set it to nil.
+      student_user.properties['family_name'] = nil
+      student_user.save!
+    end
+  end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

When a Follower is destroyed (i.e. a user is removed from a section), if the user is in zero other sections, and the DCDO flag is set, remove any `family_name` from the user account.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [Tech Spec: Sort by Family Name](https://docs.google.com/document/d/1uoQ64oZ2etQoXovkIJq-UH79UkSWQLf_EtuC9fCnWWQ/edit)
- jira tickets: 
  - [TEACH-548](https://codedotorg.atlassian.net/browse/TEACH-548)
  - [TEACH-549](https://codedotorg.atlassian.net/browse/TEACH-549)
- [slack discussion](https://codedotorg.slack.com/archives/CFTFD6BPV/p1685556451932679?thread_ts=1684951512.186579&cid=CFTFD6BPV)

