### PR TITLE
Fix Violations of and Reenable `Style/QuotedSymbols`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -435,13 +435,6 @@ Style/OpenStructUse:
 Style/OptionalBooleanParameter:
   Enabled: false
 
-# Offense count: 94
-# This cop supports safe auto-correction (--auto-correct).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: same_as_string_literals, single_quotes, double_quotes
-Style/QuotedSymbols:
-  Enabled: false
-
 # Offense count: 14
 # This cop supports safe auto-correction (--auto-correct).
 Style/RedundantAssignment:

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -15,19 +15,19 @@ CROWDIN_PROJECTS = {
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg_files_to_sync_out.json")
   },
-  "codeorg-markdown": {
+  'codeorg-markdown': {
     config_file: File.join(File.dirname(__FILE__), "codeorg_markdown_crowdin.yml"),
     identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-markdown_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-markdown_files_to_sync_out.json")
   },
-  "hour-of-code": {
+  'hour-of-code': {
     config_file: File.join(File.dirname(__FILE__), "hourofcode_crowdin.yml"),
     identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "hour-of-code_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "hour-of-code_files_to_sync_out.json")
   },
-  "codeorg-restricted": {
+  'codeorg-restricted': {
     config_file: File.join(File.dirname(__FILE__), "codeorg_restricted_crowdin.yml"),
     identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-restricted_etags.json"),
@@ -36,13 +36,13 @@ CROWDIN_PROJECTS = {
 }
 
 CROWDIN_TEST_PROJECTS = {
-  "codeorg-testing": {
+  'codeorg-testing': {
     config_file: File.join(File.dirname(__FILE__), "codeorg-testing_crowdin.yml"),
     identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_files_to_sync_out.json")
   },
-  "codeorg-markdown-testing": {
+  'codeorg-markdown-testing': {
     config_file: File.join(File.dirname(__FILE__), "codeorg-testing_markdown_crowdin.yml"),
     identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_markdown_etags.json"),

--- a/dashboard/lib/services/globally_unique_identifiers.rb
+++ b/dashboard/lib/services/globally_unique_identifiers.rb
@@ -44,7 +44,7 @@ module Services
 
       keys = result.named_captures
       course_version = CourseVersion.joins(:course_offering).
-        find_by(key: keys["CourseVersion"], "course_offerings.key": keys["CourseOffering"])
+        find_by(key: keys["CourseVersion"], 'course_offerings.key': keys["CourseOffering"])
       return Vocabulary.find_by(key: keys["Vocabulary"], course_version: course_version)
     end
 
@@ -76,7 +76,7 @@ module Services
 
       keys = result.named_captures
       course_version = CourseVersion.joins(:course_offering).
-        find_by(key: keys["CourseVersion"], "course_offerings.key": keys["CourseOffering"])
+        find_by(key: keys["CourseVersion"], 'course_offerings.key': keys["CourseOffering"])
       return Resource.find_by(key: keys["Resource"], course_version: course_version)
     end
 

--- a/dashboard/lib/services/i18n/curriculum_sync_utils/sync_out.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/sync_out.rb
@@ -62,7 +62,7 @@ module Services
               # Only these lessons guarantee that their relative position is unique.
               lessons = Lesson.joins(:script).
                 where(
-                  "scripts.name": route_params[:script_id],
+                  'scripts.name': route_params[:script_id],
                   relative_position: route_params[:position].to_i,
                 ).select(&:numbered_lesson?)
               if lessons.count == 0

--- a/dashboard/test/config/application_test.rb
+++ b/dashboard/test/config/application_test.rb
@@ -15,7 +15,7 @@ class ApplicationTest < ActiveSupport::TestCase
 
     # Second, verify that we get the English string back even from another
     # locale
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     assert_equal I18n.t("data.test.example"), "english"
 

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -270,7 +270,7 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ::ActionController::TestC
       role: "Counselor",
       grades_teaching: ["Kindergarten", "Grade 1", "Grade 2"],
       attended_csf_intro_workshop: "No",
-      csf_course_experience: {"Course A": "none", "Course B": "a few lessons", "Course E": "most lessons"},
+      csf_course_experience: {'Course A': "none", 'Course B': "a few lessons", 'Course E': "most lessons"},
       csf_courses_planned: ["Course E", "Course F"],
       csf_intro_intent: "No",
       years_teaching: "30",

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
@@ -33,7 +33,7 @@ module Api::V1::Pd
       assert_equal 'CS Discoveries', response[:course_name]
       assert_not_empty response[:questions]
       assert_not_empty response[:this_workshop]
-      assert_equal 4, response[:this_workshop][:"Day 5"][:general][:response_count]
+      assert_equal 4, response[:this_workshop][:'Day 5'][:general][:response_count]
 
       assert_not_empty response[:workshop_rollups]
       general_rollup = response[:workshop_rollups][:general]
@@ -236,7 +236,7 @@ module Api::V1::Pd
 
       assert_equal 7, response[:this_workshop]['Post Workshop'][:facilitator][:response_count][facilitator_1_id]
 
-      overall_facilitator = response[:this_workshop]['Post Workshop'][:facilitator][:"surveys/pd/workshop_csf_intro_post_test.0"]
+      overall_facilitator = response[:this_workshop]['Post Workshop'][:facilitator][:'surveys/pd/workshop_csf_intro_post_test.0']
       facilitator_effectiveness = overall_facilitator[:facilitator_effectiveness]
       # Verify see results for facilitator 1
       assert_not_nil facilitator_effectiveness[facilitator_1_id][:on_track]

--- a/dashboard/test/lib/announcements_test.rb
+++ b/dashboard/test/lib/announcements_test.rb
@@ -45,7 +45,7 @@ class AnnouncementsTest < ActiveSupport::TestCase
   test 'quietly reject invalid data' do
     incomplete_banner_data = {
       pages: {
-        "/courses": "test"
+        '/courses': "test"
       },
       banners: {
         test: {

--- a/dashboard/test/lib/pd/foorm/rollup_creator_test.rb
+++ b/dashboard/test/lib/pd/foorm/rollup_creator_test.rb
@@ -122,7 +122,7 @@ module Pd::Foorm
 
     def setup_csd_workshop
       rollup_configuration = JSON.parse(File.read('test/fixtures/rollup_config.json'), symbolize_names: true)
-      questions_to_summarize = rollup_configuration[:"CS Discoveries"]
+      questions_to_summarize = rollup_configuration[:'CS Discoveries']
       workshop = create :csd_summer_workshop
       create :day_5_workshop_foorm_submission, :answers_low, pd_workshop_id: workshop.id
       create :day_5_workshop_foorm_submission, :answers_high, pd_workshop_id: workshop.id
@@ -134,7 +134,7 @@ module Pd::Foorm
 
     def setup_csf_workshop
       rollup_configuration = JSON.parse(File.read('test/fixtures/rollup_config.json'), symbolize_names: true)
-      questions_to_summarize = rollup_configuration[:"CS Fundamentals"]
+      questions_to_summarize = rollup_configuration[:'CS Fundamentals']
       workshop = create :csf_workshop
       @facilitator_id = workshop.facilitators.pluck(:id).first
       @facilitators = {@facilitator_id => "name"}

--- a/dashboard/test/lib/pd/foorm/rollup_helper_test.rb
+++ b/dashboard/test/lib/pd/foorm/rollup_helper_test.rb
@@ -17,7 +17,7 @@ module Pd::Foorm
     end
 
     test 'creates question details for CSD rollup' do
-      questions_to_summarize = @rollup_configuration[:"CS Discoveries"]
+      questions_to_summarize = @rollup_configuration[:'CS Discoveries']
       question_details = RollupHelper.get_question_details_for_rollup(@parsed_forms_csd, questions_to_summarize)
 
       expected_question_details = {
@@ -63,7 +63,7 @@ module Pd::Foorm
     end
 
     test 'creates question details for both general and facilitator questions' do
-      questions_to_summarize = @rollup_configuration[:"CS Fundamentals"]
+      questions_to_summarize = @rollup_configuration[:'CS Fundamentals']
       csf_forms = FoormParser.parse_forms([@csf_intro_post])
       question_details = RollupHelper.get_question_details_for_rollup(csf_forms, questions_to_summarize)
       expected_facilitator_question = {
@@ -95,7 +95,7 @@ module Pd::Foorm
       @parsed_forms = FoormParser.parse_forms([@daily_survey_day_0, @daily_survey_day_5, inconsistent_form])
       question_details = RollupHelper.get_question_details_for_rollup(
         @parsed_forms,
-        @rollup_configuration[:"CS Discoveries"]
+        @rollup_configuration[:'CS Discoveries']
       )
 
       assert_nil question_details[:expertise_rating]

--- a/dashboard/test/lib/pd/foorm/workshop_summarizer_test.rb
+++ b/dashboard/test/lib/pd/foorm/workshop_summarizer_test.rb
@@ -100,12 +100,12 @@ module Pd::Foorm
       facilitator_answers = summarized_answers['Post Workshop'.to_s][:facilitator]['surveys/pd/workshop_csf_intro_post_test.0']
       assert_not_empty facilitator_answers
       expected_matrix_data = {
-        demonstrated_knowledge: {"7": 1, "1": 1},
-        built_equitable: {"7": 1, "1": 1},
-        on_track: {"7": 1, "1": 1},
-        productive_discussions: {"7": 1, "1": 1},
-        ways_equitable: {"7": 1, "1": 1},
-        healthy_relationship: {"7": 1, "1": 1}
+        demonstrated_knowledge: {'7': 1, '1': 1},
+        built_equitable: {'7': 1, '1': 1},
+        on_track: {'7': 1, '1': 1},
+        productive_discussions: {'7': 1, '1': 1},
+        ways_equitable: {'7': 1, '1': 1},
+        healthy_relationship: {'7': 1, '1': 1}
       }.with_indifferent_access
 
       assert_equal expected_matrix_data, facilitator_answers[:facilitator_effectiveness][facilitator.id]
@@ -136,21 +136,21 @@ module Pd::Foorm
       ).with_indifferent_access
 
       expected_matrix_data_high = {
-        demonstrated_knowledge: {"7": 1},
-        built_equitable: {"7": 1},
-        on_track: {"7": 1},
-        productive_discussions: {"7": 1},
-        ways_equitable: {"7": 1},
-        healthy_relationship: {"7": 1}
+        demonstrated_knowledge: {'7': 1},
+        built_equitable: {'7': 1},
+        on_track: {'7': 1},
+        productive_discussions: {'7': 1},
+        ways_equitable: {'7': 1},
+        healthy_relationship: {'7': 1}
       }.with_indifferent_access
 
       expected_matrix_data_low = {
-        demonstrated_knowledge: {"1": 3},
-        built_equitable: {"1": 3},
-        on_track: {"1": 3},
-        productive_discussions: {"1": 3},
-        ways_equitable: {"1": 3},
-        healthy_relationship: {"1": 3}
+        demonstrated_knowledge: {'1': 3},
+        built_equitable: {'1': 3},
+        on_track: {'1': 3},
+        productive_discussions: {'1': 3},
+        ways_equitable: {'1': 3},
+        healthy_relationship: {'1': 3}
       }.with_indifferent_access
 
       facilitator_answers = summarized_answers['Post Workshop'.to_s][:facilitator]['surveys/pd/workshop_csf_intro_post_test.0']

--- a/dashboard/test/lib/services/i18n/curriculum_sync_utils/render_translations_test.rb
+++ b/dashboard/test/lib/services/i18n/curriculum_sync_utils/render_translations_test.rb
@@ -4,7 +4,7 @@ class Services::I18n::CurriculumSyncUtils::RenderTranslationsTest < ActiveSuppor
   setup_all do
     @lesson = create(:lesson, overview: "This is the english overview")
     @activity_section = create(:activity_section, name: "English name", description: "English description")
-    @test_locale = :"te-ST"
+    @test_locale = :'te-ST'
     custom_i18n = {
       "data" => {
         "lessons" => {

--- a/dashboard/test/models/activity_section_test.rb
+++ b/dashboard/test/models/activity_section_test.rb
@@ -83,7 +83,7 @@ class ActivitySectionTest < ActiveSupport::TestCase
       description: "English description",
       tips: [{"type" => "typeTip", "markdown" => "English tip"}]
     )
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     custom_i18n = {
       "data" => {
         "activity_sections" => {

--- a/dashboard/test/models/concerns/text_to_speech_test.rb
+++ b/dashboard/test/models/concerns/text_to_speech_test.rb
@@ -107,7 +107,7 @@ class TextToSpeechTest < ActiveSupport::TestCase
     translatable_level = create :level, name: 'TTS test Short Instructions',
       type: 'Blockly', short_instructions: "regular instructions in English"
 
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {
@@ -125,7 +125,7 @@ class TextToSpeechTest < ActiveSupport::TestCase
     translatable_level = create :level, name: 'TTS test Long Instructions',
       type: 'Blockly', long_instructions: "long instructions in English"
 
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {
@@ -152,7 +152,7 @@ class TextToSpeechTest < ActiveSupport::TestCase
     outer_level = create :level, name: 'level 4', type: 'Blockly'
     outer_level.update(contained_level_names: [contained_level.name])
 
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {
@@ -178,7 +178,7 @@ class TextToSpeechTest < ActiveSupport::TestCase
       type: 'Blockly', short_instructions: "regular instructions in English",
       tts_short_instructions_override: "instructions override"
 
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {

--- a/dashboard/test/models/dsl_defined_test.rb
+++ b/dashboard/test/models/dsl_defined_test.rb
@@ -15,7 +15,7 @@ class DSLDefinedLevelTest < ActiveSupport::TestCase
   end
 
   test 'localized_property can return localized data' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {
@@ -38,7 +38,7 @@ class DSLDefinedLevelTest < ActiveSupport::TestCase
   end
 
   test 'localized_property can return partially-localized data' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -1298,7 +1298,7 @@ class LessonTest < ActiveSupport::TestCase
 
     test "get_localized_property can retrieve translations" do
       lesson = create(:lesson, overview: "This is the english overview")
-      test_locale = :"te-ST"
+      test_locale = :'te-ST'
       custom_i18n = {
         "data" => {
           "lessons" => {

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -625,7 +625,7 @@ class LevelTest < ActiveSupport::TestCase
   end
 
   test 'localizes callouts' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     level_name = 'test_localize_callouts'
 
     I18n.locale = test_locale
@@ -660,7 +660,7 @@ class LevelTest < ActiveSupport::TestCase
   end
 
   test 'handles bad callout localization data' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     level_name = 'test_localize_callouts'
     I18n.locale = test_locale
 
@@ -709,7 +709,7 @@ class LevelTest < ActiveSupport::TestCase
   end
 
   test 'localizes rubric properties' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     level_name = 'test_localize_callouts'
 
     I18n.locale = test_locale
@@ -748,7 +748,7 @@ class LevelTest < ActiveSupport::TestCase
   end
 
   test 'handles rubric properties localization with non-existent translations' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     level_name = 'test_localize_callouts'
 
     I18n.locale = test_locale
@@ -1353,7 +1353,7 @@ class LevelTest < ActiveSupport::TestCase
   end
 
   test 'localized_teacher_markdown reads from top-level locale' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     level_name = 'test_localize_teacher_markdown'
 
     custom_i18n = {
@@ -1383,7 +1383,7 @@ class LevelTest < ActiveSupport::TestCase
   end
 
   test 'localized_teacher_markdown reads from dsl locale for DSL-based levels' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     level_name = 'test_dsl_localize_teacher_markdown'
 
     custom_i18n = {

--- a/dashboard/test/models/levels/ailab_test.rb
+++ b/dashboard/test/models/levels/ailab_test.rb
@@ -25,7 +25,7 @@ class AilabTest < ActiveSupport::TestCase
       translated_dynamic_instructions[k] = v.sub 'Original', 'Translated'
     end
 
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {

--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -222,7 +222,7 @@ class BlocklyTest < ActiveSupport::TestCase
   end
 
   test 'localized shared_blocks' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {
@@ -288,7 +288,7 @@ class BlocklyTest < ActiveSupport::TestCase
   end
 
   test 'original object is not mutated' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {
@@ -334,7 +334,7 @@ class BlocklyTest < ActiveSupport::TestCase
   end
 
   test 'nil is returned if level_objects is blank' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {
@@ -364,7 +364,7 @@ class BlocklyTest < ActiveSupport::TestCase
   end
 
   test 'does not return a translated string if block text does not exist' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {
@@ -425,7 +425,7 @@ class BlocklyTest < ActiveSupport::TestCase
   end
 
   test 'does not return translated strings when I18n translation does not exist' do
-    test_locale = :"es-ST"
+    test_locale = :'es-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {
@@ -491,7 +491,7 @@ class BlocklyTest < ActiveSupport::TestCase
   end
 
   test 'option that contains a period in the key is translated' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       "data" => {
@@ -500,8 +500,8 @@ class BlocklyTest < ActiveSupport::TestCase
             "text" => "vérifier la {LEVEL}",
             "options" => {
               "LEVEL" => {
-                "LEVELS.Whole": "Entier",
-                "LEVELS.Half": "Moitié",
+                'LEVELS.Whole': "Entier",
+                'LEVELS.Half': "Moitié",
               }
             }
           }
@@ -535,7 +535,7 @@ class BlocklyTest < ActiveSupport::TestCase
   end
 
   test 'localizes authored hints' do
-    test_locale = :"es-MX"
+    test_locale = :'es-MX'
     level_name = 'test_localize_authored_hints'
 
     I18n.locale = test_locale
@@ -576,7 +576,7 @@ class BlocklyTest < ActiveSupport::TestCase
   test 'localizes authored hints with embedded behavior block' do
     DCDO.stubs(:get).with(Blockly::BLOCKLY_I18N_IN_TEXT_DCDO_KEY, false).returns(true)
     DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
-    test_locale = :"es-MX"
+    test_locale = :'es-MX'
     level_name = 'test_localize_authored_hints_with_embedded_behavior_block'
     hint = <<~HINT
       oración de muestra: <xml><block type=\"gamelab_addBehaviorSimple\" uservisible=\"false\"><value name=\"SPRITE\"><block type=\"gamelab_getAllSprites\"></block></value><value name=\"BEHAVIOR\"><block type=\"gamelab_behavior_get\"><mutation></mutation><title name=\"VAR\">wandering</title></block></value></block></xml>.
@@ -800,7 +800,7 @@ class BlocklyTest < ActiveSupport::TestCase
   end
 
   test 'handles bad authored hint localization data' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     level_name = 'test_localize_authored_hints'
     I18n.locale = test_locale
 
@@ -923,7 +923,7 @@ class BlocklyTest < ActiveSupport::TestCase
         }
       }
     }
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     level = create(
       :level,

--- a/dashboard/test/models/objective_test.rb
+++ b/dashboard/test/models/objective_test.rb
@@ -24,7 +24,7 @@ class ObjectiveTest < ActiveSupport::TestCase
 
   test "summarize retrives translations" do
     objective = create(:objective, description: "English description")
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     custom_i18n = {
       "data" => {
         "objectives" => {

--- a/dashboard/test/models/resource_test.rb
+++ b/dashboard/test/models/resource_test.rb
@@ -152,7 +152,7 @@ class ResourceTest < ActiveSupport::TestCase
 
   test "summarize retrives translations" do
     resource = create(:resource, name: "English name")
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     custom_i18n = {
       "data" => {
         "resources" => {

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -580,7 +580,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     unit_group = create :unit_group, name: 'my-unit-group', family_name: 'my-family', version_year: '1999', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
     CourseOffering.add_course_offering(unit_group)
 
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       'data' => {
@@ -646,7 +646,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     unit1.reload
     unit2.reload
 
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     I18n.locale = test_locale
     custom_i18n = {
       'data' => {

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1519,7 +1519,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'send localized password reset email for student' do
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     translated_subject = 'subject in te-ST'
     translated_hello = 'hello in te-ST'
     custom_i18n = {
@@ -3365,7 +3365,7 @@ class UserTest < ActiveSupport::TestCase
 
   class RecentCoursesAndScripts < ActiveSupport::TestCase
     setup do
-      test_locale = :"te-ST"
+      test_locale = :'te-ST'
       I18n.locale = test_locale
       custom_i18n = {
         'data' => {

--- a/dashboard/test/models/vocabulary_test.rb
+++ b/dashboard/test/models/vocabulary_test.rb
@@ -110,7 +110,7 @@ class VocabularyTest < ActiveSupport::TestCase
       "#{vocabulary.key}/#{course_offering.key}/#{course_version.key}",
       Services::GloballyUniqueIdentifiers.build_vocab_key(vocabulary)
     )
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     custom_i18n = {
       "data" => {
         "vocabularies" => {

--- a/lib/test/cdo/test_i18n_backend.rb
+++ b/lib/test/cdo/test_i18n_backend.rb
@@ -81,7 +81,7 @@ class I18nSmartTranslateTest < Minitest::Test
       "data" => {
         "some.keys" => {
           "with|a,variety" => {
-            "of-separators": "translation"
+            'of-separators': "translation"
           }
         }
       }
@@ -98,7 +98,7 @@ class I18nSmartTranslateTest < Minitest::Test
       "data" => {
         "some.keys" => {
           "with|all,of-the" => {
-            "separators_that we/support": "translation"
+            'separators_that we/support': "translation"
           }
         }
       }

--- a/lib/test/dynamic_config/test_gatekeeper.rb
+++ b/lib/test/dynamic_config/test_gatekeeper.rb
@@ -4,11 +4,11 @@ require 'dynamic_config/gatekeeper'
 
 class DynamicConfigGatekeeperTest < Minitest::Test
   MOCK_DATA = {
-    "basic feature": {
+    'basic feature': {
       "[]" => true
     },
-    "empty feature": {},
-    "complex feature": {
+    'empty feature': {},
+    'complex feature': {
       "[]" => true,
       "[[\"type\",\"query\"]]" => false
     }
@@ -83,9 +83,9 @@ class DynamicConfigGatekeeperTest < Minitest::Test
   def test_to_hash
     @mock_datastore.expect(:all, MOCK_DATA)
     expected = {
-      "basic feature": [{"rule" => nil, "value" => true}],
-      "empty feature": [],
-      "complex feature": [
+      'basic feature': [{"rule" => nil, "value" => true}],
+      'empty feature': [],
+      'complex feature': [
         {"rule" => nil, "value" => true},
         {"rule" => nil, "where" => {"type" => "query"}, "value" => false}
       ]
@@ -96,7 +96,7 @@ class DynamicConfigGatekeeperTest < Minitest::Test
 
   def test_feature_names
     @mock_datastore.expect(:all, MOCK_DATA)
-    assert_equal(Set[:"basic feature", :"complex feature"], @gatekeeper.feature_names)
+    assert_equal(Set[:'basic feature', :'complex feature'], @gatekeeper.feature_names)
     @mock_datastore.verify
   end
 

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -217,7 +217,7 @@ class Homepage
   def self.get_actions(request)
     # Show a Latin American specific video to users browsing in Spanish or
     # Portuguese to promote LATAM HOC.
-    latam_language_codes = [:"es-MX", :"es-ES", :"pt-BR", :"pt-PT"]
+    latam_language_codes = [:'es-MX', :'es-ES', :'pt-BR', :'pt-PT']
 
     if latam_language_codes.include?(I18n.locale)
       youtube_id = "EGgdCryC8Uo"

--- a/pegasus/test/test_hourofcode_helpers.rb
+++ b/pegasus/test/test_hourofcode_helpers.rb
@@ -91,7 +91,7 @@ class HourOfCodeHelpersTest < Minitest::Test
         en: 'English'
       },
       locale_code: {
-        "es-es": "Spanish (Spain)"
+        'es-es': "Spanish (Spain)"
       }
     }
     I18n.backend.store_translations I18n.default_locale, sources
@@ -111,13 +111,13 @@ class HourOfCodeHelpersTest < Minitest::Test
   end
 
   def test_get_translated_language_names
-    test_locale = :"te-ST"
+    test_locale = :'te-ST'
     translations = {
       language_code: {
         en: 'Inglesa'
       },
       locale_code: {
-        "es-es": "Español (España)"
+        'es-es': "Español (España)"
       }
     }
     I18n.enforce_available_locales = false

--- a/shared/test/test_aws_s3_integration.rb
+++ b/shared/test/test_aws_s3_integration.rb
@@ -76,7 +76,7 @@ class AwsS3IntegrationTest < Minitest::Test
     parsed_url = URI.parse(presigned_url)
     body = 'Testing S3 presigned upload'
     Net::HTTP.start(parsed_url.host) do |http|
-      http.send_request("PUT", parsed_url.request_uri, body, {"content-type": ""})
+      http.send_request("PUT", parsed_url.request_uri, body, {'content-type': ""})
     end
 
     downloaded = AWS::S3.download_from_bucket(TEST_BUCKET, key)


### PR DESCRIPTION
> Checks if the quotes used for quoted symbols match the configured defaults. By default uses the same configuration as `Style/StringLiterals`; if that cop is not enabled, the default `EnforcedStyle` is `single_quotes`.
>
> String interpolation is always kept in double quotes.

Fix applied automatically with `bundle exec rubocop --auto-correct --only Style/QuotedSymbols`

As usual with these `Style` cops, I'm of two minds about this one. Consistency is good, but I'm wary of anything that makes it easier to mistake Symbols for Strings.

## Links

- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/QuotedSymbols
- https://docs.rubocop.org/rubocop/cops_style.html#stylequotedsymbols