### PR TITLE
Support font awesome pro in storybook

### DIFF
--- a/apps/.storybook/preview-head.html
+++ b/apps/.storybook/preview-head.html
@@ -1,4 +1,5 @@
 <link rel="stylesheet" media="all" href="css/application.css" />
+<link rel="stylesheet" media="all" href="css/font-awesome.css" />
 <link rel="stylesheet" media="all" href="css/levelbuilder.css" />
 <link rel="stylesheet" media="all" href="css/pd.css" />
 <link rel="stylesheet" media="all" href="css/droplet/droplet.min.css" />

--- a/apps/package.json
+++ b/apps/package.json
@@ -30,7 +30,7 @@
     "start:gamelab": "DEV=1 grunt dev --app=gamelab;",
     "start:craft": "DEV=1 grunt dev --app=craft --watch-notify;",
     "test-audio": "echo \"Open your browser to http://127.0.0.1:8080/test/audio/audio_test.html\" && http-server .",
-    "prestorybook": "curl -o build/package/css/application.css http://localhost-studio.code.org:3000/assets/application.css || curl -o build/package/css/application.css https://code-dot-org.github.io/cdo-styleguide/css/application.css",
+    "prestorybook": "curl -o build/package/css/application.css http://localhost-studio.code.org:3000/assets/application.css || curl -o build/package/css/application.css https://code-dot-org.github.io/cdo-styleguide/css/application.css; curl -o build/package/css/font-awesome.css http://localhost-studio.code.org:3000/assets/font-awesome.css",
     "storybook": "start-storybook -p 9001",
     "storybook:deploy": "./script/deploy-storybook.sh",
     "storybook:test": "grunt storybookTest"


### PR DESCRIPTION
Load new Font Awesome Pro (v6) files in Storybook when developing locally. This isn't causing major issues yet (since we don't use V6 icons very much), but will be needed as we continue to add them.

## Testing story

I haven't 100% tested this change, as I'm hitting CORS errors trying to request the files. I am at least seeing font-awesome.css appear in the apps build directory, and seeing us try to load it (hence, CORS errors), so I'm optimistic it will work once we figure out the CORS issue.

Note that this fix requires `dashboard-server` to be running before starting storybook locally, which is already a requirement in order to load `application.css`.