### PR TITLE
Increase Health Check Timeout to 5 Minutes

### DIFF
--- a/aws/cloudformation/bootstrap_frontend.sh.erb
+++ b/aws/cloudformation/bootstrap_frontend.sh.erb
@@ -22,5 +22,5 @@ export AWS_METADATA_SERVICE_NUM_ATTEMPTS=30
 
 # Make sure server passes health check.
 # The status code determines success/failure of the instance launch.
-curl --silent --show-error --fail --retry 10 --retry-connrefused --retry-max-time 60 \
+curl --silent --show-error --fail --retry 10 --retry-connrefused --retry-max-time 300 \
   localhost:80/health_check > /dev/null


### PR DESCRIPTION
We currently wait for a maximum of 60 seconds for frontend servers to come online, but recent changes in
https://github.com/code-dot-org/code-dot-org/pull/52313 mean that we now get to this point in the build process while the web servers are still restarting (rather than blocking earlier in the build process until we detect that they're up and running).

Both because of that and because curl's exponentional backoff logic mean that we only actually get in 5 or 6 retries in 60 seconds rather than the full 10 we have configured, increase timeout to give the web servers a better chance of being fully started up.