### PR TITLE
Define a Chef Resource for Reloading SystemD

### DIFF
--- a/cookbooks/cdo-apps/libraries/cdo_apps.rb
+++ b/cookbooks/cdo-apps/libraries/cdo_apps.rb
@@ -45,6 +45,18 @@ module CdoApps
 
       variables app_name: app_name
       source "#{app_server}.service.erb"
+      notifies :run, "execute[restart #{app_name} service]", :immediately
+    end
+
+    # Define an execute resource for restarting (or starting) the entire
+    # SystemD service, which can be invoked by other Chef resources
+    execute "restart #{app_name} service" do
+      command "systemctl daemon-reload && systemctl restart #{app_name}"
+
+      # Don't run by default; rely on notifications.
+      action :nothing
+
+      only_if {File.exist? unit_file}
     end
 
     template init_script do


### PR DESCRIPTION
And invoke it after making changes to SystemD configuration, so we don't need to do so manually.

Extracted from https://github.com/code-dot-org/code-dot-org/pull/52313, so we can still gain the benefits of this fix even though the major changes in that PR were reverted.