### PR TITLE
Remove family name on account upgrade

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1040,6 +1040,14 @@ class User < ApplicationRecord
         new_attributes[:email] = email
       end
       update!(new_attributes)
+
+      # Remove family name, in case it was set on the student account.
+      if DCDO.get('family-name-features', false)
+        properties['family_name'] = nil
+        save!
+      end
+
+      self
     end
   rescue
     false # Relevant errors are set on the user model, so we rescue and return false here.

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -2359,6 +2359,24 @@ class UserTest < ActiveSupport::TestCase
     assert_nil user.parent_email
   end
 
+  test 'upgrade_to_teacher given valid params should delete family_name property' do
+    DCDO.stubs(:get).with('family-name-features', false).returns(true)
+
+    family_name = 'TestFamName'
+    user = User.create(@good_data)
+    user.properties = {family_name: family_name}
+    user.save!
+
+    assert_equal family_name, user.properties['family_name']
+
+    assert user.upgrade_to_teacher('example@email.com', email_preference_params)
+
+    user.reload
+    assert_nil user.properties['family_name']
+
+    DCDO.unstub(:get)
+  end
+
   def assert_parent_email_params_equals_email_preference(parent_email_params, email_preference)
     assert_equal parent_email_params[:parent_email_preference_email], email_preference.email
     assert_equal parent_email_params[:parent_email_preference_opt_in].casecmp?('yes'), email_preference.opt_in

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -2363,9 +2363,7 @@ class UserTest < ActiveSupport::TestCase
     DCDO.stubs(:get).with('family-name-features', false).returns(true)
 
     family_name = 'TestFamName'
-    user = User.create(@good_data)
-    user.properties = {family_name: family_name}
-    user.save!
+    user = User.create(@good_data.merge({properties: {family_name: family_name}}))
 
     assert_equal family_name, user.properties['family_name']
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

When a student account is upgraded to a teacher account, if the DCDO flag is set, remove any `family_name` from the account. We never want family names attached to a teacher account, since we have no use for them and there's no way for a user to edit their own `family_name`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [Tech Spec: Sort by Family Name](https://docs.google.com/document/d/1uoQ64oZ2etQoXovkIJq-UH79UkSWQLf_EtuC9fCnWWQ/edit)
- jira tickets: 
  - [TEACH-551](https://codedotorg.atlassian.net/browse/TEACH-551)
  - [TEACH-549](https://codedotorg.atlassian.net/browse/TEACH-549)

