### PR TITLE
Remove non-existent s3 bucket from template

### DIFF
--- a/aws/cloudformation/s3_buckets.yml
+++ b/aws/cloudformation/s3_buckets.yml
@@ -101,24 +101,6 @@ Resources:
               {
                 AWS: [!Sub "arn:aws:iam::${DeveloperAccount}:role/DroneWorker"],
               }
-  SpritelabAnimationBucket:
-    Type: "AWS::S3::Bucket"
-    Properties:
-      BucketName: "cdo-spritelab-animation-library"
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: "aws:kms"
-      VersioningConfiguration:
-        Status: "Enabled"
-      LoggingConfiguration:
-        DestinationBucketName: "cdo-logs"
-        LogFilePrefix: "s3/cdo-spritelab-animation-library"
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
   # for curriculumbuilder
   CurriculumBucket:
     Type: "AWS::S3::Bucket"


### PR DESCRIPTION
This bucket does not exist ([link](https://s3.console.aws.amazon.com/s3/buckets?region=us-east-1))

* no references to this bucket in code or docs
* no cloudfront distributions route to this bucket
* no Route53 records point to this bucket

Resolves [XTEAM-339](https://codedotorg.atlassian.net/browse/XTEAM-339)

## Deployment strategy

s3_buckets.yml is deployed manually to the "s3-buckets" stack. While there is significant drift in this stack, this is the only change to the template, and therefore the only action would be the (attempted) deletion of this bucket. The update may fail, as the bucket is already gone, but that can be resolved manually when the stack is updated. 

## Follow-up work

Resolve drift in INF-958
- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated **(no references to bucket in code or docs)**
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
