### PR TITLE
Fix crontab to use login shell to pickup PATH

### DIFF
--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -23,13 +23,13 @@ HOME=/home/ubuntu
 # Note that the CI_ONLY_BUILD environment variable is necessary; the server is
 # not set up to actually serve a version of the website, and it will fail to
 # build correctly if not thus restricted.
-0 */4 * * * bash -lc cd /home/ubuntu/code-dot-org && CI_ONLY_BUILD=true bundle exec ./bin/cronjob ./aws/ci_build >>/tmp/cronlog 2>&1
+0 */4 * * * bash -lc "cd /home/ubuntu/code-dot-org && CI_ONLY_BUILD=true bundle exec ./bin/cronjob ./aws/ci_build >>/tmp/cronlog 2>&1"
 
 # Run the I18n Sync!
 # Sync is scheduled for 12:30 AM PST every Monday; run around midnight so the
 # sync is hopefully finished by start of day on Monday, offset by 30 minutes so
 # we don't conflict with the ci_build which runs on the hour.
-30 8 * * MON (bash -lc cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1
+30 8 * * MON bash -lc "(cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1"
 
 # Run the sync down periodically throughout the week. Specifically:
 # - Run it every 4 hours. This is a somewhat arbitrarily-chosen frequency
@@ -39,14 +39,14 @@ HOME=/home/ubuntu
 # - Run it every day except Monday. This is done so we don't conflict with the
 #   full sync, and also because we expect to spend Monday verifiying the
 #   results of the full sync.
-# 30 */4 * * SUN,TUE-SAT bash -lc cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
+# 30 */4 * * SUN,TUE-SAT bash -lc "cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
 
 # Periodically check to see if the I18n Sync PRs have been merged and attempt
 # to return to staging.
-0 */1 * * * bash -lc cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
+0 */1 * * * bash -lc "cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
 
 # Update string translation status to Redshift
-0 0 * * * bash -lc cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
+0 0 * * * bash -lc "cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
 
 # Run the Crowdin translation validator tool
-# 30 0 * * * bash -lc cd /home/ubuntu/code-dot-org && (bundle exec bin/i18n/translation_monitor/run_crowdin_validator.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
+# 30 0 * * * bash -lc "cd /home/ubuntu/code-dot-org && (bundle exec bin/i18n/translation_monitor/run_crowdin_validator.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"

--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -16,7 +16,6 @@
 # Where can I ask a question about this config?
 # Reach out to the #i18n slack channel.
 
-PATH=/home/ubuntu/.rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 HOME=/home/ubuntu
 
 # Run a CI Build to update the server from staging. We do this primarily to
@@ -24,13 +23,13 @@ HOME=/home/ubuntu
 # Note that the CI_ONLY_BUILD environment variable is necessary; the server is
 # not set up to actually serve a version of the website, and it will fail to
 # build correctly if not thus restricted.
-0 */4 * * * cd /home/ubuntu/code-dot-org && CI_ONLY_BUILD=true bundle exec ./bin/cronjob ./aws/ci_build >>/tmp/cronlog 2>&1
+0 */4 * * * bash -lc cd /home/ubuntu/code-dot-org && CI_ONLY_BUILD=true bundle exec ./bin/cronjob ./aws/ci_build >>/tmp/cronlog 2>&1
 
 # Run the I18n Sync!
 # Sync is scheduled for 12:30 AM PST every Monday; run around midnight so the
 # sync is hopefully finished by start of day on Monday, offset by 30 minutes so
 # we don't conflict with the ci_build which runs on the hour.
-30 8 * * MON (cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1
+30 8 * * MON (bash -lc cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1
 
 # Run the sync down periodically throughout the week. Specifically:
 # - Run it every 4 hours. This is a somewhat arbitrarily-chosen frequency
@@ -40,14 +39,14 @@ HOME=/home/ubuntu
 # - Run it every day except Monday. This is done so we don't conflict with the
 #   full sync, and also because we expect to spend Monday verifiying the
 #   results of the full sync.
-# 30 */4 * * SUN,TUE-SAT cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
+# 30 */4 * * SUN,TUE-SAT bash -lc cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
 
 # Periodically check to see if the I18n Sync PRs have been merged and attempt
 # to return to staging.
-0 */1 * * * cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
+0 */1 * * * bash -lc cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
 
 # Update string translation status to Redshift
-0 0 * * * cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
+0 0 * * * bash -lc cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
 
 # Run the Crowdin translation validator tool
-# 30 0 * * * cd /home/ubuntu/code-dot-org && (bundle exec bin/i18n/translation_monitor/run_crowdin_validator.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
+# 30 0 * * * bash -lc cd /home/ubuntu/code-dot-org && (bundle exec bin/i18n/translation_monitor/run_crowdin_validator.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error

--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -23,13 +23,13 @@ HOME=/home/ubuntu
 # Note that the CI_ONLY_BUILD environment variable is necessary; the server is
 # not set up to actually serve a version of the website, and it will fail to
 # build correctly if not thus restricted.
-0 */4 * * * bash -lc "cd /home/ubuntu/code-dot-org && CI_ONLY_BUILD=true bundle exec ./bin/cronjob ./aws/ci_build >>/tmp/cronlog 2>&1"
+0 */4 * * * BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && CI_ONLY_BUILD=true bundle exec ./bin/cronjob ./aws/ci_build >>/tmp/cronlog 2>&1"
 
 # Run the I18n Sync!
 # Sync is scheduled for 12:30 AM PST every Monday; run around midnight so the
 # sync is hopefully finished by start of day on Monday, offset by 30 minutes so
 # we don't conflict with the ci_build which runs on the hour.
-30 8 * * MON bash -lc "(cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1"
+30 8 * * MON BASH_ENV=~/.bashrc bash -lc "(cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1"
 
 # Run the sync down periodically throughout the week. Specifically:
 # - Run it every 4 hours. This is a somewhat arbitrarily-chosen frequency
@@ -39,14 +39,14 @@ HOME=/home/ubuntu
 # - Run it every day except Monday. This is done so we don't conflict with the
 #   full sync, and also because we expect to spend Monday verifiying the
 #   results of the full sync.
-# 30 */4 * * SUN,TUE-SAT bash -lc "cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
+# 30 */4 * * SUN,TUE-SAT BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
 
 # Periodically check to see if the I18n Sync PRs have been merged and attempt
 # to return to staging.
-0 */1 * * * bash -lc "cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
+0 */1 * * * BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
 
 # Update string translation status to Redshift
-0 0 * * * bash -lc "cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
+0 0 * * * BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
 
 # Run the Crowdin translation validator tool
-# 30 0 * * * bash -lc "cd /home/ubuntu/code-dot-org && (bundle exec bin/i18n/translation_monitor/run_crowdin_validator.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
+# 30 0 * * * BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && (bundle exec bin/i18n/translation_monitor/run_crowdin_validator.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"


### PR DESCRIPTION
We have an error in the automated i18n sync that isn't picking up the correct version of Node. This is due to crontab using the hardcoded PATH in the crontab definition rather than the PATH as set in the login shell. The correct PATH in the login shell contains the path to Node via nvm.

This PR adds the prefix `bash -lc` before the cron commands which will force crontab to use the login shell. This PR also removes the hardcoded PATH variable definition.

See [running-the-job-with-a-login-shell](https://www.baeldung.com/linux/load-env-variables-in-cron-job#running-the-job-with-a-login-shell) for using `bash -lc`.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
