### PR TITLE
Music: remove progression file support

### DIFF
--- a/apps/src/music/progress/ProgressManager.ts
+++ b/apps/src/music/progress/ProgressManager.ts
@@ -10,11 +10,6 @@ export abstract class Validator {
   abstract clear(): void;
 }
 
-export interface Progression {
-  path: string;
-  steps: ProgressionStep[];
-}
-
 // A validation inside the progression step.
 interface Validation {
   conditions: string[];

--- a/apps/src/music/utils/Loader.ts
+++ b/apps/src/music/utils/Loader.ts
@@ -11,24 +11,8 @@ const AppConfig = require('../appConfig').default;
 
 export const baseUrl = 'https://curriculum.code.org/media/musiclab/';
 
-enum LevelSource {
-  LEVELS = 'LEVELS',
-  LEVEL = 'LEVEL',
-}
-
 type LevelDataResponse = {
   level_data: ProgressionStep;
-};
-
-interface ProgressionStepData {
-  progressionStep: ProgressionStep | undefined;
-  levelCount: number | undefined;
-}
-
-// Exporting enum as object for use in JS files
-export const LevelSources = {
-  LEVELS: LevelSource.LEVELS,
-  LEVEL: LevelSource.LEVEL,
 };
 
 // Loads a sound library JSON file.
@@ -63,30 +47,14 @@ const LevelDataValidator: ResponseValidator<LevelDataResponse> = response => {
 
 // Loads a progression step.
 export const loadProgressionStepFromSource = async (
-  levelSource: LevelSource,
   levelDataPath: string
-): Promise<ProgressionStepData> => {
-  let progressionStep = undefined;
-  let levelCount = undefined;
+): Promise<ProgressionStep> => {
+  // Asynchronously retrieve the current level data.
+  const response = await HttpClient.fetchJson<LevelDataResponse>(
+    levelDataPath,
+    {},
+    LevelDataValidator
+  );
 
-  if (levelSource === LevelSource.LEVELS) {
-    // Since we have levels, we'll asynchronously retrieve the current level data.
-    const response = await HttpClient.fetchJson<LevelDataResponse>(
-      levelDataPath,
-      {},
-      LevelDataValidator
-    );
-    progressionStep = response.value.level_data;
-  } else if (levelSource === LevelSource.LEVEL) {
-    // Since we have a level, we'll asynchronously retrieve the current level data.
-    const response = await HttpClient.fetchJson<LevelDataResponse>(
-      levelDataPath,
-      {},
-      LevelDataValidator
-    );
-    progressionStep = response.value.level_data;
-    levelCount = 1;
-  }
-
-  return {progressionStep, levelCount};
+  return response.value.level_data;
 };

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -306,19 +306,12 @@ class UnconnectedMusicView extends React.Component {
     return this.props.progressLevelType === ProgressLevelType.SCRIPT_LEVEL;
   };
 
-  // Returns whether we have a progression file.
-  hasProgressionFile = () => {
-    return AppConfig.getValue('load-progression') === 'true';
-  };
-
   // Returns whether we have a progression.
   // Note that even a standalone level has a progression in the sense that we
   // will show instructions and feedback, but we'll only show them for that
   // standalone level.
   hasProgression = () => {
-    return (
-      this.isStandaloneLevel() || this.hasLevels() || this.hasProgressionFile()
-    );
+    return this.isStandaloneLevel() || this.hasLevels();
   };
 
   hasNoProgressHeader = () => {
@@ -410,8 +403,6 @@ class UnconnectedMusicView extends React.Component {
       ? LevelSources.LEVELS
       : this.isStandaloneLevel()
       ? LevelSources.LEVEL
-      : this.hasProgressionFile()
-      ? LevelSources.FILE
       : undefined;
 
     if (progressionSource) {
@@ -420,9 +411,7 @@ class UnconnectedMusicView extends React.Component {
       try {
         const result = await loadProgressionStepFromSource(
           progressionSource,
-          this.props.levelDataPath,
-          // Special case: used for progression file:
-          this.props.currentLevelIndex
+          this.props.levelDataPath
         );
         progressionStep = result.progressionStep;
         levelCount = result.levelCount;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -19,7 +19,6 @@ import AppConfig, {getBlockMode, setAppConfig} from '../appConfig';
 import SoundUploader from '../utils/SoundUploader';
 import {
   baseUrl,
-  LevelSources,
   loadLibrary,
   loadProgressionStepFromSource,
 } from '../utils/Loader';
@@ -395,35 +394,26 @@ class UnconnectedMusicView extends React.Component {
   };
 
   loadProgressionStep = async () => {
-    const progressionSource = this.isScriptLevel()
-      ? LevelSources.LEVELS
-      : this.isSingleLevel()
-      ? LevelSources.LEVEL
-      : undefined;
+    let progressionStep;
 
-    if (progressionSource) {
-      let progressionStep;
-
-      try {
-        const result = await loadProgressionStepFromSource(
-          progressionSource,
-          this.props.levelDataPath
-        );
-        progressionStep = result.progressionStep;
-      } catch (e) {
-        this.onError(e);
-      }
-
-      if (this.isScriptLevel()) {
-        // Get the level count from the external array of levels.
-        this.props.setLevelCount(this.props.levels.length);
-      } else {
-        this.props.setLevelCount(1);
-      }
-
-      this.progressManager.setProgressionStep(progressionStep);
-      this.props.setShowInstructions(!!progressionStep);
+    try {
+      progressionStep = await loadProgressionStepFromSource(
+        this.props.levelDataPath
+      );
+    } catch (e) {
+      this.onError(e);
     }
+
+    if (this.isScriptLevel()) {
+      // Determine the level count from the external array of levels.
+      this.props.setLevelCount(this.props.levels.length);
+    } else {
+      // This must be a single level.
+      this.props.setLevelCount(1);
+    }
+
+    this.progressManager.setProgressionStep(progressionStep);
+    this.props.setShowInstructions(!!progressionStep);
   };
 
   clearCode = () => {

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -65,27 +65,6 @@ const optionsList = [
     ],
   },
   {
-    name: 'load-progression',
-    type: 'radio',
-    values: [
-      {value: 'false', description: "Don't load a progression."},
-      {value: 'true', description: 'Load a progression'},
-    ],
-  },
-  {
-    name: 'local-progression',
-    type: 'radio',
-    values: [
-      {value: 'false', description: 'Use online progression file.'},
-      {value: 'true', description: 'Use local progression file.'},
-    ],
-  },
-  {
-    name: 'progression',
-    type: 'string',
-    description: 'Use a specific progression file.',
-  },
-  {
     name: 'storage-type',
     type: 'radio',
     values: [


### PR DESCRIPTION
Before Music Lab was integrated into our level system, it was possible to move through a progression provided by a JSON file.  Now that we are using our level system, this support has been removed.  

I've left our default progression file intact [here](https://github.com/code-dot-org/code-dot-org/blob/f5836a6cf533f0f1542ba46eccac07e244247538/apps/static/music/music-progression.json), since it serves as a nice reference of what can go into level definitions.