### PR TITLE
Music: fix fade boundary

### DIFF
--- a/apps/src/code-studio/components/LabContainer.module.scss
+++ b/apps/src/code-studio/components/LabContainer.module.scss
@@ -53,7 +53,7 @@
     width: 100%;
     height: 100%;
     position: fixed;
-    top: 55px;
+    top: 52px;
     left: 0;
     right: 0;
     bottom: 0;


### PR DESCRIPTION
A tiny fix so that the fade provided by `LabContainer` fully covers the Music Lab UI.