### PR TITLE
Upgrade piskel and fix blinking animation issue

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -65,7 +65,7 @@
     "@code-dot-org/ml-activities": "0.0.26",
     "@code-dot-org/ml-playground": "0.0.47",
     "@code-dot-org/p5.play": "1.3.21-cdo",
-    "@code-dot-org/piskel": "0.13.0-cdo.9",
+    "@code-dot-org/piskel": "0.13.0-cdo.12",
     "@code-dot-org/redactable-markdown": "0.4.0",
     "@react-bootstrap/pagination": "^1.0.0",
     "@storybook/addon-actions": "^6.5.10",

--- a/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
+++ b/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
@@ -175,7 +175,8 @@ class PiskelEditor extends React.Component {
           if (this.props.currentAnimation !== key) {
             this.loadSelectedAnimation_(this.props);
           }
-        }
+        },
+        animationProps.frameCount
       );
     }
   }

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1356,7 +1356,8 @@
   integrity sha512-v6tl9bSsbCjYJNR3hgvIvCGo/hLjk+ow2QdNE8ly2UTz8dBZ+MYYKZ3sFng1qDVy+WM8IbR45gPOx4RD+UjSXw==
 
 "@cdo/interpreted@link:../dashboard/config/libraries":
-  version "0.1.0"
+  version "0.0.0"
+  uid ""
 
 "@code-dot-org/artist@0.2.1":
   version "0.2.1"
@@ -1458,10 +1459,10 @@
     opentype.js "^0.4.9"
     reqwest "^1.1.5"
 
-"@code-dot-org/piskel@0.13.0-cdo.9":
-  version "0.13.0-cdo.9"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/piskel/-/piskel-0.13.0-cdo.9.tgz#84b8ad23bd73e2821229061fa1bcb52e461236de"
-  integrity sha512-BhbuhlxFkXd3+OmnaK9DGIOY+v6qMLH3UJmkBBAF9SEh88mb+MMvT/vXT8Txv1b4/RrnXZJD1nEMUsya5gx3vQ==
+"@code-dot-org/piskel@0.13.0-cdo.12":
+  version "0.13.0-cdo.12"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/piskel/-/piskel-0.13.0-cdo.12.tgz#e9c87f3b8f605b1d10b8e98af033d6407e01f52f"
+  integrity sha512-Ut877HHRa+xkzfVSEo4o1IkMDoZr9yVdWP+DH6avhRgtp8gmvH9RQm45EBEG68leaQ24aAx+yiHuOPieC49/wQ==
   dependencies:
     messageformat "^2.3.0"
 


### PR DESCRIPTION
See [this Piskel PR](https://github.com/code-dot-org/piskel/pull/58) for details on how the piskel upgrade fixes the blinking animation issue.

This PR upgrades piskel to pick up the above changes. It also passes the new `frameCount` parameter to `loadSpritesheet` so we can avoid an extra blank frame for an uneven spritesheet (see PR linked above for details).
 
## Links

- jira ticket: [SL-50](https://codedotorg.atlassian.net/browse/SL-50)

## Testing story
Tested locally on Chrome and Firefox that we can see blank frames, but extra blank frames never get added.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
