### PR TITLE
Use dcdo for javabuilder-demo urls

### DIFF
--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -175,11 +175,12 @@ module Cdo
     end
 
     def javabuilder_demo_url(path = '', scheme = '')
-      'wss://javabuilder-demo.code.org'
+      DCDO.get("javabuilder_demo_websocket_url", 'wss://javabuilder-demo.code.org')
     end
 
     def javabuilder_demo_upload_url(path = '', scheme = '')
-      'https://javabuilder-demo-http.code.org/seedsources/sources.json'
+      http_url = DCDO.get("javabuilder_demo_http_url", 'https://javabuilder-demo-http.code.org')
+      http_url + "/seedsources/sources.json"
     end
 
     # Get a list of all languages for which we want to link to a localized


### PR DESCRIPTION
Small update to enable dcdo flags for javabuilder-demo urls. This will enable us to change urls without a deploy. They fall back to the existing urls, so we won't need to set the flags until we change the urls.

## Links

- jira ticket: [SL-909](https://codedotorg.atlassian.net/browse/SL-909)

## Testing story
Tested locally that the demo urls still return the expected urls.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
