### PR TITLE
Revert "do not require teacher application on AYW workshops"

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -131,7 +131,7 @@ class Pd::Workshop < ApplicationRecord
   # Whether enrollment in this workshop requires an application
   def require_application?
     courses = [COURSE_CSP, COURSE_CSD, COURSE_CSA]
-    subjects = [SUBJECT_SUMMER_WORKSHOP]
+    subjects = ACADEMIC_YEAR_SUBJECTS.concat([SUBJECT_SUMMER_WORKSHOP])
     courses.include?(course) && subjects.include?(subject) &&
       regional_partner && regional_partner.link_to_partner_application.blank?
   end

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1520,9 +1520,9 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert workshop.require_application?
   end
 
-  test 'CSD academic year workshop must not require teacher application' do
+  test 'CSD academic year workshop must require teacher application' do
     workshop = create :csd_academic_year_workshop, regional_partner: @regional_partner
-    refute workshop.require_application?
+    assert workshop.require_application?
   end
 
   test 'CSA summer workshop must require teacher application' do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#50988 in order to re-enable ayw restrictions that require a teacher application.

Jira task: https://codedotorg.atlassian.net/browse/ACQ-502