### PR TITLE
Music: show pretty JSON in levelbuilder

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_music_level_data.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_music_level_data.html.haml
@@ -3,4 +3,4 @@
 
 #level_data.in.collapse
   = f.label :music_level_data, 'Level data JSON'
-  = f.text_area :level_data, placeholder: 'Insert JSON Data', rows: 10, style: 'width: 90%', value: @level.level_data.to_json
+  = f.text_area :level_data, placeholder: 'Insert JSON Data', rows: 10, style: 'width: 90%', value: JSON.pretty_generate(@level.level_data)


### PR DESCRIPTION
A small improvement to the Music Lab levelbuilder experience, in which the JSON is now shown in a prettier form in the text editor.

### before

<img width="1512" alt="Screenshot 2023-06-21 at 7 18 34 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/5578416e-16f8-4a14-b630-b2d068297cf0">

### after

<img width="1512" alt="Screenshot 2023-06-21 at 7 18 08 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/eb7dc218-e45e-44b1-8ae8-9b4cc52f994c">

