### PR TITLE
Tutorial explorer: modal capture for VoiceOver

### DIFF
--- a/apps/src/tutorialExplorer/tutorialDetail.jsx
+++ b/apps/src/tutorialExplorer/tutorialDetail.jsx
@@ -126,7 +126,7 @@ export default class TutorialDetail extends React.Component {
               className="modal-dialog modal-lg"
               onClick={e => e.stopPropagation()}
             >
-              <div className="modal-content">
+              <div className="modal-content" aria-modal="true" role="dialog">
                 <div
                   className="modal-header"
                   style={styles.tutorialDetailModalHeader}


### PR DESCRIPTION
Thanks to @megcrenshaw and the thread started at https://github.com/code-dot-org/code-dot-org/pull/51326#issuecomment-1584926421, the modal dialog at https://code.org/learn now "captures" macOS VoiceOver, meaning that pressing `ctrl-option-[left arrow]` can no longer take VoiceOver focus out of the modal while it's showing.

We had to add both `aria-modal="true"` and `role="dialog"` to a parent `div` of the modal for this to work.
