### PR TITLE
Add rename functionality to ProjectManager

### DIFF
--- a/apps/src/labs/projects/ProjectManager.ts
+++ b/apps/src/labs/projects/ProjectManager.ts
@@ -231,8 +231,10 @@ export default class ProjectManager {
     return true;
   }
 
-  // Check if we can save immediately. If we can, initiate a save.
-  // If we cannot, enqueue a save if one has not already been enqueued and
+  // Check if we can save immediately. If a save is in progress, we must wait. Otherwise,
+  // if forceSave is true or it has been at least 30 seconds since our last save,
+  // initiate a save.
+  // If we cannot save now, enqueue a save if one has not already been enqueued and
   // return a noop response.
   private enqueueSaveOrSave(forceSave: boolean) {
     if (!this.canSave(forceSave)) {

--- a/apps/src/labs/projects/ProjectManager.ts
+++ b/apps/src/labs/projects/ProjectManager.ts
@@ -13,9 +13,9 @@
 import {SourcesStore} from './SourcesStore';
 import {ChannelsStore} from './ChannelsStore';
 import {Channel, Source} from '../types';
+import _ from 'lodash';
 
 export default class ProjectManager {
-  private sourceToSave: Source | undefined;
   private readonly channelId: string;
   private readonly sourcesStore: SourcesStore;
   private readonly channelsStore: ChannelsStore;
@@ -29,7 +29,9 @@ export default class ProjectManager {
   private saveFailListeners: ((response: Response) => void)[] = [];
   private saveStartListeners: (() => void)[] = [];
   private lastSource: string | undefined;
-  private channel: Channel | undefined;
+  private sourceToSave: Source | undefined;
+  private lastChannel: Channel | undefined;
+  private channelToSave: Channel | undefined;
   // Id of the last timeout we set on a save, or undefined if there is no current timeout.
   // When we enqueue a save, we set a timeout to execute the save after the save interval.
   // If we force a save or destroy the ProjectManager, we clear the remaining timeout,
@@ -66,8 +68,8 @@ export default class ProjectManager {
       return channelResponse;
     }
 
-    this.channel = await channelResponse.json();
-    const channelString = JSON.stringify(this.channel);
+    this.lastChannel = await channelResponse.json();
+    const channelString = JSON.stringify(this.lastChannel);
     const project = {source, channel: channelString};
     const blob = new Blob([JSON.stringify(project)], {
       type: 'application/json',
@@ -111,14 +113,20 @@ export default class ProjectManager {
       return this.getNoopResponseAndSendSaveNoopEvent();
     }
     this.sourceToSave = source;
-    if (!this.canSave(forceSave)) {
-      if (!this.saveQueued) {
-        this.enqueueSave();
-      }
+    this.enqueueSaveOrSave(forceSave);
+  }
+
+  async rename(name: string, forceSave = false) {
+    if (this.destroyed || !this.lastChannel) {
+      // If we have already been destroyed or the channel does not exist,
+      // don't attempt to rename.
       return this.getNoopResponseAndSendSaveNoopEvent();
-    } else {
-      this.saveHelper();
     }
+    if (!this.channelToSave) {
+      this.channelToSave = _.cloneDeep(this.lastChannel);
+    }
+    this.channelToSave.name = name;
+    this.enqueueSaveOrSave(forceSave);
   }
 
   addSaveSuccessListener(listener: (channel: Channel, source: Source) => void) {
@@ -142,7 +150,9 @@ export default class ProjectManager {
 
   /**
    * Helper function to save a project, called either after a timeout or directly by save().
-   * On a save, we check if there are unsaved changes. If there are none, we can skip the save.
+   * On a save, we check if there are unsaved changes to the source or channel.
+   * If there are none, we can skip the save. If only the channel changed, we can
+   * skip saving the source.
    * Only if the source save succeeds do we update the channel, as the
    * channel is metadata about the project and we don't want to save it unless the source
    * save succeeded.
@@ -150,34 +160,42 @@ export default class ProjectManager {
    * otherwise it will contain failure or no-op information.
    */
   private async saveHelper(): Promise<Response> {
-    if (!this.sourceToSave || !this.channel) {
+    if (!this.sourceToSave || !this.lastChannel) {
       return this.getNoopResponseAndSendSaveNoopEvent();
     }
     this.resetSaveState();
     this.saveInProgress = true;
     this.nextSaveTime = Date.now() + this.saveInterval;
     this.executeSaveStartListeners();
-    // If the source has not actually changed, no need to save again.
-    if (!this.sourceChanged()) {
+    const sourceChanged = this.sourceChanged();
+    const channelChanged = this.channelChanged();
+    // If neither source nor channel has actually changed, no need to save again.
+    if (!sourceChanged && !channelChanged) {
       this.saveInProgress = false;
       return this.getNoopResponseAndSendSaveNoopEvent();
     }
+    // Only save the source if it has changed.
+    if (sourceChanged) {
+      const sourceResponse = await this.sourcesStore.save(
+        this.channelId,
+        this.sourceToSave
+      );
+      if (!sourceResponse.ok) {
+        this.saveInProgress = false;
+        this.executeSaveFailListeners(sourceResponse);
 
-    const sourceResponse = await this.sourcesStore.save(
-      this.channelId,
-      this.sourceToSave
-    );
-    if (!sourceResponse.ok) {
-      this.saveInProgress = false;
-      this.executeSaveFailListeners(sourceResponse);
-
-      // TODO: Should we wrap this response in some way?
-      // Maybe add a more specific statusText to the response?
-      return sourceResponse;
+        // TODO: Should we wrap this response in some way?
+        // Maybe add a more specific statusText to the response?
+        return sourceResponse;
+      }
+      this.lastSource = JSON.stringify(this.sourceToSave);
     }
-    this.lastSource = JSON.stringify(this.sourceToSave);
 
-    const channelResponse = await this.channelsStore.save(this.channel);
+    // Always save the channel--either the channel has changed and/or the source changed.
+    // Even if only the source changed, we still update the channel to modify the last
+    // updated time.
+    this.channelToSave ||= this.lastChannel;
+    const channelResponse = await this.channelsStore.save(this.channelToSave);
     if (!channelResponse.ok) {
       this.saveInProgress = false;
       this.executeSaveFailListeners(channelResponse);
@@ -190,8 +208,9 @@ export default class ProjectManager {
     const channelSaveResponse = await channelResponse.json();
 
     this.saveInProgress = false;
-    this.channel = channelSaveResponse as Channel;
-    this.executeSaveSuccessListeners(this.channel, this.sourceToSave);
+    this.lastChannel = channelSaveResponse as Channel;
+    this.channelToSave = undefined;
+    this.executeSaveSuccessListeners(this.lastChannel, this.sourceToSave);
     return new Response();
   }
 
@@ -208,15 +227,23 @@ export default class ProjectManager {
     return true;
   }
 
-  private enqueueSave() {
-    this.saveQueued = true;
-
-    this.currentTimeoutId = window.setTimeout(
-      () => {
-        this.saveHelper();
-      },
-      this.nextSaveTime ? this.nextSaveTime - Date.now() : this.saveInterval
-    );
+  private enqueueSaveOrSave(forceSave: boolean) {
+    if (!this.canSave(forceSave)) {
+      if (!this.saveQueued) {
+        // enqueue a save
+        this.saveQueued = true;
+        this.currentTimeoutId = window.setTimeout(
+          () => {
+            this.saveHelper();
+          },
+          this.nextSaveTime ? this.nextSaveTime - Date.now() : this.saveInterval
+        );
+      }
+      return this.getNoopResponseAndSendSaveNoopEvent();
+    } else {
+      // if we can save immediately, save now.
+      this.saveHelper();
+    }
   }
 
   private getNoopResponse() {
@@ -225,7 +252,7 @@ export default class ProjectManager {
 
   private getNoopResponseAndSendSaveNoopEvent() {
     const noopResponse = this.getNoopResponse();
-    this.executeSaveNoopListeners(this.channel);
+    this.executeSaveNoopListeners(this.lastChannel);
     return noopResponse;
   }
 
@@ -234,6 +261,18 @@ export default class ProjectManager {
       return false;
     }
     return this.lastSource !== JSON.stringify(this.sourceToSave);
+  }
+
+  private channelChanged(): boolean {
+    // If we don't have a channel to save or a last channel, we can't compare.
+    // It isn't possible to have a channelToSave without a lastChannel,
+    // as we create channelToSave from lastChannel.
+    if (!this.channelToSave || !this.lastChannel) {
+      return false;
+    }
+    return (
+      JSON.stringify(this.lastChannel) !== JSON.stringify(this.channelToSave)
+    );
   }
 
   private resetSaveState(): void {

--- a/apps/src/labs/projects/ProjectManager.ts
+++ b/apps/src/labs/projects/ProjectManager.ts
@@ -13,7 +13,6 @@
 import {SourcesStore} from './SourcesStore';
 import {ChannelsStore} from './ChannelsStore';
 import {Channel, Source} from '../types';
-import _ from 'lodash';
 
 export default class ProjectManager {
   private readonly channelId: string;
@@ -127,7 +126,9 @@ export default class ProjectManager {
       return this.getNoopResponseAndSendSaveNoopEvent();
     }
     if (!this.channelToSave) {
-      this.channelToSave = _.cloneDeep(this.lastChannel);
+      this.channelToSave = JSON.parse(
+        JSON.stringify(this.lastChannel)
+      ) as Channel;
     }
     this.channelToSave.name = name;
     return this.enqueueSaveOrSave(forceSave);


### PR DESCRIPTION
Add a rename function to the project manager. This isn't currently used anywhere, but will be incorporated into standalone projects in Music Lab. As part of this I added back some logic I removed in a [previous refactor PR](https://github.com/code-dot-org/code-dot-org/pull/52200/files#diff-2749c1e244f87a7016a81200c914cc0d882770dac9d1a12e62fc48036a0a1a7bL142), which checks both the source and channel for changes and only saves if one of them has changed. I added that back in because for rename we will create or update a `channelToSave` field, then enqueue a save as normal. This is because we don't want competing channel saves going on between source and channel updates. We can also reuse this pattern if we have any other channel fields that we want to modify during lab execution.

## Links

- jira ticket: [SL-891](https://codedotorg.atlassian.net/browse/SL-891)


## Testing story
Tested locally that project saving still works, and if I manually add a rename call, that will rename the project.


## Follow-up work
As we implement Music Lab as a standalone project, we will want to incorporate renaming. [Task is here](https://codedotorg.atlassian.net/browse/SL-914).


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
