### PR TITLE
Restoring PL section setup ui tests

### DIFF
--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -171,7 +171,7 @@ export default function SectionsSetUpContainer({
       : null;
 
     const computedGrades =
-      participantType === 'teacher' ? ['pl'] : section.grade;
+      participantType === 'student' ? section.grade : ['pl'];
 
     const section_data = {
       login_type: loginType,

--- a/dashboard/test/ui/config/course_offerings/ui-test-teacher-pl-course.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-teacher-pl-course.json
@@ -3,5 +3,9 @@
   "display_name": "Teacher PL Course",
   "category": "pl_other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": "Professional Learning",
+  "marketing_initiative": "PL",
+  "grade_levels": "pl",
+  "header": "Self-Paced"
 }

--- a/dashboard/test/ui/config/course_offerings/ui-test-teacher-pl-course.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-teacher-pl-course.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": "Professional Learning",
-  "marketing_initiative": "PL",
-  "grade_levels": "pl",
-  "header": "Self-Paced"
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": "summer_workshops_612"
 }

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -1,8 +1,6 @@
 @no_mobile
 Feature: Professional learning Sections
 
-  @skip
-  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Create new professional learning section as levelbuilder
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -22,12 +20,13 @@ Feature: Professional learning Sections
     When I select facilitator participant type
 
     # Edit Section Form
-    Then I wait to see "#uitest-section-name"
-    And I press keys "My Section of Teachers" for element "#uitest-section-name"
-    Then I wait to see "#uitest-assignment-family"
-    When I select the "ui-test-teacher-pl-course" option in dropdown "uitest-assignment-family"
-    And I press the save button to create a new section
-    And I wait for the dialog to close using jQuery
+    Then I wait to see "#sections-set-up-container"
+    And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
+    And I wait until element "button:contains("Professional Learning")" is visible
+    And I click selector "button:contains("Professional Learning")"
+    And I press the first "input[name="6-12 Summer Workshops"]" element
+    And I press the first "#uitest-save-section-changes" element
+    And I wait until element "#classroom-sections" is visible
 
     # Professional Learning Sections Table
     Then I should see the professional learning section table
@@ -35,8 +34,6 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
-  @skip
-  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Create new professional learning section as universal instructor
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -56,12 +53,13 @@ Feature: Professional learning Sections
     When I select facilitator participant type
 
     # Edit Section Form
-    Then I wait to see "#uitest-section-name"
-    And I press keys "My Section of Teachers" for element "#uitest-section-name"
-    Then I wait to see "#uitest-assignment-family"
-    When I select the "ui-test-teacher-pl-course" option in dropdown "uitest-assignment-family"
-    And I press the save button to create a new section
-    And I wait for the dialog to close using jQuery
+    Then I wait to see "#sections-set-up-container"
+    And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
+    And I wait until element "button:contains("Professional Learning")" is visible
+    And I click selector "button:contains("Professional Learning")"
+    And I press the first "input[name="6-12 Summer Workshops"]" element
+    And I press the first "#uitest-save-section-changes" element
+    And I wait until element "#classroom-sections" is visible
 
     # Professional Learning Sections Table
     Then I should see the professional learning section table
@@ -69,8 +67,6 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
-  @skip
-  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Create new professional learning section as plc reviewer
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -90,12 +86,13 @@ Feature: Professional learning Sections
     When I select facilitator participant type
 
     # Edit Section Form
-    Then I wait to see "#uitest-section-name"
-    And I press keys "My Section of Teachers" for element "#uitest-section-name"
-    Then I wait to see "#uitest-assignment-family"
-    When I select the "ui-test-facilitator-pl-course" option in dropdown "uitest-assignment-family"
-    And I press the save button to create a new section
-    And I wait for the dialog to close using jQuery
+    Then I wait to see "#sections-set-up-container"
+    And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
+    And I wait until element "button:contains("Professional Learning")" is visible
+    And I click selector "button:contains("Professional Learning")"
+    And I press the first "input[name="6-12 Summer Workshops"]" element
+    And I press the first "#uitest-save-section-changes" element
+    And I wait until element "#classroom-sections" is visible
 
     # Professional Learning Sections Table
     Then I should see the professional learning section table
@@ -103,8 +100,6 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
-  @skip
-  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Create new professional learning section as facilitator
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -124,12 +119,13 @@ Feature: Professional learning Sections
     When I select teacher participant type
 
     # Edit Section Form
-    Then I wait to see "#uitest-section-name"
-    And I press keys "My Section of Teachers" for element "#uitest-section-name"
-    Then I wait to see "#uitest-assignment-family"
-    When I select the "ui-test-teacher-pl-course" option in dropdown "uitest-assignment-family"
-    And I press the save button to create a new section
-    And I wait for the dialog to close using jQuery
+    Then I wait to see "#sections-set-up-container"
+    And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
+    And I wait until element "button:contains("Professional Learning")" is visible
+    And I click selector "button:contains("Professional Learning")"
+    And I press the first "input[name="6-12 Summer Workshops"]" element
+    And I press the first "#uitest-save-section-changes" element
+    And I wait until element "#classroom-sections" is visible
 
     # Professional Learning Sections Table
     Then I should see the professional learning section table
@@ -137,8 +133,6 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
-  @skip
-  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Teacher can not create professional learning section
     Given I create a teacher named "Teacher"
     And I sign in as "Teacher" and go home
@@ -149,8 +143,7 @@ Feature: Professional learning Sections
 
     # Participant Type Picker Does Not Show
     Then I should see the new section dialog
-    Then I select email login
-    Then I wait to see "#uitest-section-name"
+    And element ".uitest-teacher-type" is not visible
 
   Scenario: Teacher tries to join professional learning section for teachers
     Given I create an authorized teacher-associated student named "Sally"

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -22,8 +22,8 @@ Feature: Professional learning Sections
     # Edit Section Form
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
-    And I wait until element "button:contains("Professional Learning")" is visible
-    And I click selector "button:contains("Professional Learning")"
+    And I wait until element "button:contains(Professional Learning)" is visible
+    And I click selector "button:contains(Professional Learning)"
     And I press the first "input[name="6-12 Summer Workshops"]" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
@@ -55,8 +55,8 @@ Feature: Professional learning Sections
     # Edit Section Form
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
-    And I wait until element "button:contains("Professional Learning")" is visible
-    And I click selector "button:contains("Professional Learning")"
+    And I wait until element "button:contains(Professional Learning)" is visible
+    And I click selector "button:contains(Professional Learning)"
     And I press the first "input[name="6-12 Summer Workshops"]" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
@@ -88,8 +88,8 @@ Feature: Professional learning Sections
     # Edit Section Form
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
-    And I wait until element "button:contains("Professional Learning")" is visible
-    And I click selector "button:contains("Professional Learning")"
+    And I wait until element "button:contains(Professional Learning)" is visible
+    And I click selector "button:contains(Professional Learning)"
     And I press the first "input[name="6-12 Summer Workshops"]" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
@@ -121,8 +121,8 @@ Feature: Professional learning Sections
     # Edit Section Form
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
-    And I wait until element "button:contains("Professional Learning")" is visible
-    And I click selector "button:contains("Professional Learning")"
+    And I wait until element "button:contains(Professional Learning)" is visible
+    And I click selector "button:contains(Professional Learning)"
     And I press the first "input[name="6-12 Summer Workshops"]" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -19,12 +19,12 @@ Feature: Professional learning Sections
     And element ".uitest-facilitator-type" is visible
     When I select facilitator participant type
 
-    # Edit Section Form
+    # New Section details
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
     And I click selector "button:contains(Professional Learning)"
-    And I press the first "input[name="6-12 Summer Workshops"]" element
+    And I press the first "input[name='6-12 Summer Workshops']" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
 
@@ -52,12 +52,12 @@ Feature: Professional learning Sections
     And element ".uitest-facilitator-type" is visible
     When I select facilitator participant type
 
-    # Edit Section Form
+    # New Section details
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
     And I click selector "button:contains(Professional Learning)"
-    And I press the first "input[name="6-12 Summer Workshops"]" element
+    And I press the first "input[name='6-12 Summer Workshops']" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
 
@@ -85,12 +85,12 @@ Feature: Professional learning Sections
     And element ".uitest-facilitator-type" is visible
     When I select facilitator participant type
 
-    # Edit Section Form
+    # New Section details
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
     And I click selector "button:contains(Professional Learning)"
-    And I press the first "input[name="6-12 Summer Workshops"]" element
+    And I press the first "input[name='6-12 Summer Workshops']" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
 
@@ -118,12 +118,12 @@ Feature: Professional learning Sections
     And element ".uitest-facilitator-type" is not visible
     When I select teacher participant type
 
-    # Edit Section Form
+    # New Section details
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
     And I click selector "button:contains(Professional Learning)"
-    And I press the first "input[name="6-12 Summer Workshops"]" element
+    And I press the first "input[name='6-12 Summer Workshops']" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
 

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -24,7 +24,7 @@ Feature: Professional learning Sections
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
     And I click selector "button:contains(Professional Learning)"
-    And I press the first "input[name='6-12 Summer Workshops']" element
+    And I press the first "input[name='Teacher PL Course']" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
 
@@ -57,7 +57,7 @@ Feature: Professional learning Sections
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
     And I click selector "button:contains(Professional Learning)"
-    And I press the first "input[name='6-12 Summer Workshops']" element
+    And I press the first "input[name='Teacher PL Course']" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
 
@@ -90,7 +90,7 @@ Feature: Professional learning Sections
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
     And I click selector "button:contains(Professional Learning)"
-    And I press the first "input[name='6-12 Summer Workshops']" element
+    And I press the first "input[name='Teacher PL Course']" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
 
@@ -123,7 +123,7 @@ Feature: Professional learning Sections
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
     And I click selector "button:contains(Professional Learning)"
-    And I press the first "input[name='6-12 Summer Workshops']" element
+    And I press the first "input[name='Teacher PL Course']" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
 

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -23,8 +23,9 @@ Feature: Professional learning Sections
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
-    And I click selector "button:contains(Professional Learning)"
-    And I press the first "input[name='Teacher PL Course']" element
+    # TODO TEACH-592: Seed PL courses so we can test course assignment
+    # And I click selector "button:contains(Professional Learning)"
+    # And I press the first "input[name='Teacher PL Course']" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
 
@@ -56,8 +57,6 @@ Feature: Professional learning Sections
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
-    And I click selector "button:contains(Professional Learning)"
-    And I press the first "input[name='Teacher PL Course']" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
 
@@ -89,8 +88,6 @@ Feature: Professional learning Sections
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
-    And I click selector "button:contains(Professional Learning)"
-    And I press the first "input[name='Teacher PL Course']" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
 
@@ -122,8 +119,6 @@ Feature: Professional learning Sections
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
-    And I click selector "button:contains(Professional Learning)"
-    And I press the first "input[name='Teacher PL Course']" element
     And I press the first "#uitest-save-section-changes" element
     And I wait until element "#classroom-sections" is visible
 


### PR DESCRIPTION
Working to get the 5 skipped scenarios passing again for professional learning sections in the new section flow. I altered these to match the new section creation flow steps that [Kaitie implemented in this pr](https://github.com/code-dot-org/code-dot-org/pull/52144). The edits should match across the scenarios.

I added a todo followup [item/ticket to seed PL courses](https://codedotorg.atlassian.net/browse/TEACH-592) and get course assignment testing working. For now, these scenarios are meant to verify that users with different roles can be added to the PL sections, so will merge as-is. 

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-555

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
