### PR TITLE
Move level data loading to lab redux

### DIFF
--- a/apps/src/code-studio/components/LabContainer.jsx
+++ b/apps/src/code-studio/components/LabContainer.jsx
@@ -27,7 +27,13 @@ const LabContainer = ({children, onError}) => {
 
   return (
     <ErrorBoundary fallback={<ErrorFallbackPage />} onError={onError}>
-      <div id="lab-container" className={moduleStyles.labContainer}>
+      <div
+        id="lab-container"
+        className={classNames(
+          moduleStyles.labContainer,
+          isLabLoading && moduleStyles.labContainerLoading
+        )}
+      >
         {children}
         <div
           id="fade-overlay"

--- a/apps/src/code-studio/components/LabContainer.module.scss
+++ b/apps/src/code-studio/components/LabContainer.module.scss
@@ -45,6 +45,10 @@
   right: 0;
   font-size: 13px;
 
+  &Loading {
+    pointer-events: none;
+  }
+
   .solidBlock {
     display: flex;
     align-items: center;

--- a/apps/src/code-studio/progressReduxSelectors.js
+++ b/apps/src/code-studio/progressReduxSelectors.js
@@ -90,10 +90,10 @@ export const getProgressLevelType = state => {
 };
 
 /**
- * Returns the dashboard URL path to retrieve the level_data for a script
+ * Returns the dashboard URL path to retrieve the level properties for a script
  * level (if we have lessons) or a level (if we don't have lessons).
  */
-export const getLevelDataPath = state => {
+export const getLevelPropertiesPath = state => {
   if (state.progress.lessons) {
     const scriptName = state.progress.scriptName;
     const lessonPosition = state.progress.lessons?.find(
@@ -104,10 +104,10 @@ export const getLevelDataPath = state => {
         state.progress,
         state.progress.currentLessonId
       ).findIndex(level => level.isCurrentLevel) + 1;
-    return `/s/${scriptName}/lessons/${lessonPosition}/levels/${levelNumber}/level_data`;
+    return `/s/${scriptName}/lessons/${lessonPosition}/levels/${levelNumber}/level_properties`;
   } else {
     const levelId = state.progress.currentLevelId;
-    return `/levels/${levelId}/level_data`;
+    return `/levels/${levelId}/level_properties`;
   }
 };
 

--- a/apps/src/labs/projects/ProjectContainer.tsx
+++ b/apps/src/labs/projects/ProjectContainer.tsx
@@ -11,6 +11,7 @@ import {ProjectManagerStorageType} from '@cdo/apps/labs/types';
 import LabRegistry from '../LabRegistry';
 import {loadProject, setUpForLevel} from '../labRedux';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {getLevelPropertiesPath} from '@cdo/apps/code-studio/progressReduxSelectors';
 
 const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
   children,
@@ -25,6 +26,8 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
   const scriptId = useSelector(
     (state: {progress: {scriptId: number}}) => state.progress.scriptId
   );
+
+  const levelPropertiesPath = useSelector(getLevelPropertiesPath);
 
   const dispatch = useAppDispatch();
 
@@ -47,7 +50,11 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
       promise = dispatch(loadProject());
     } else {
       promise = dispatch(
-        setUpForLevel({levelId: parseInt(currentLevelId), scriptId})
+        setUpForLevel({
+          levelId: parseInt(currentLevelId),
+          scriptId,
+          levelPropertiesPath,
+        })
       );
     }
     return () => {
@@ -55,7 +62,7 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
       // An early return could happen if the level is changed mid-load.
       promise.abort();
     };
-  }, [channelId, currentLevelId, scriptId, dispatch]);
+  }, [channelId, currentLevelId, scriptId, levelPropertiesPath, dispatch]);
 
   useEffect(() => {
     window.addEventListener('beforeunload', event => {

--- a/apps/src/labs/types.ts
+++ b/apps/src/labs/types.ts
@@ -70,6 +70,28 @@ export interface Level {
   isAquaticLevel: boolean;
 }
 
+export interface LevelProperties {
+  // Not a complete list; add properties as needed.
+  isProjectLevel: boolean;
+  hideAndShareRemix: boolean;
+  levelData: LevelData;
+}
+
+// Generic level configuration data used by labs that don't require
+// reloads between levels. Labs may define more specific fields.
+export interface LevelData {
+  text: string;
+  validations: Validation[];
+  startSources: Source;
+}
+
+// Validation in the level.
+export interface Validation {
+  conditions: string[];
+  message: string;
+  next: boolean;
+}
+
 // TODO: these are not all the properties of app options.
 // Fill this in as we need them.
 export interface AppOptions {

--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -13,7 +13,7 @@ import musicI18n from '../locale';
 
 const baseCategoryCssConfig = {
   container: moduleStyles.toolboxCategoryContainer,
-  row: moduleStyles.toolboxRow,
+  row: `${moduleStyles.toolboxRow} blocklyTreeRow`, // Used to look up category labels in UI tests
   label: moduleStyles.toolboxLabel,
 };
 

--- a/apps/src/music/progress/ProgressManager.ts
+++ b/apps/src/music/progress/ProgressManager.ts
@@ -1,6 +1,8 @@
 // This file contains a generic ProgressManager which any lab can include,
 // if it wants to make progress without reloading the page.
 
+import {LevelData} from '@cdo/apps/labs/types';
+
 // Abstract class that validates a set of conditions. How
 // the validation works is up to the implementor.
 export abstract class Validator {
@@ -8,25 +10,6 @@ export abstract class Validator {
   abstract checkConditions(): void;
   abstract conditionsMet(conditions: string[]): boolean;
   abstract clear(): void;
-}
-
-// A validation inside the progression step.
-interface Validation {
-  conditions: string[];
-  message: string;
-  next: boolean;
-}
-
-// The definition of a progression step.
-export interface ProgressionStep {
-  text: string;
-  toolbox: {
-    [key: string]: string;
-  };
-  sounds: {
-    [key: string]: string;
-  };
-  validations: Validation[];
 }
 
 // The current progress state.
@@ -43,7 +26,7 @@ export const initialProgressState: ProgressState = {
 };
 
 export default class ProgressManager {
-  private progressionStep: ProgressionStep | undefined;
+  private levelData: LevelData | undefined;
   private validator: Validator;
   private onProgressChange: () => void;
   private currentProgressState: ProgressState;
@@ -53,7 +36,7 @@ export default class ProgressManager {
     validator: Validator,
     onProgressChange: () => void
   ) {
-    this.progressionStep = undefined;
+    this.levelData = undefined;
     this.validator = validator;
     this.onProgressChange = onProgressChange;
     this.currentProgressState = initialProgressState;
@@ -62,24 +45,16 @@ export default class ProgressManager {
     }
   }
 
-  setProgressionStep(progressionStep: ProgressionStep) {
-    this.progressionStep = progressionStep;
-  }
-
-  getProgressionStep(): ProgressionStep | undefined {
-    return this.progressionStep;
+  setLevelData(levelData: LevelData) {
+    this.levelData = levelData;
   }
 
   getCurrentState(): ProgressState {
     return this.currentProgressState;
   }
 
-  getCurrentStepDetails() {
-    return this.progressionStep;
-  }
-
   updateProgress(): void {
-    const validations = this.progressionStep?.validations;
+    const validations = this.levelData?.validations;
 
     if (!validations) {
       return;

--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -42,8 +42,6 @@ interface MusicState {
   playbackEvents: PlaybackEvent[];
   /** The current last measure of the song */
   lastMeasure: number;
-  /** The number of levels in the current progression */
-  levelCount: number | undefined;
   // TODO: Currently Music Lab is the only Lab that uses
   // this progress system, but in the future, we may want to
   // move this into a more generic, high-level, lab-agnostic
@@ -62,7 +60,6 @@ const initialState: MusicState = {
   isBeatPadShowing: true,
   playbackEvents: [],
   lastMeasure: 0,
-  levelCount: undefined,
   currentProgressState: {...initialProgressState},
 };
 
@@ -150,9 +147,6 @@ const musicSlice = createSlice({
       state.playbackEvents.push(...action.payload.events);
       state.lastMeasure = action.payload.lastMeasure;
     },
-    setLevelCount: (state, action: PayloadAction<number>) => {
-      state.levelCount = action.payload;
-    },
   },
 });
 
@@ -202,5 +196,4 @@ export const {
   setCurrentProgressState,
   clearPlaybackEvents,
   addPlaybackEvents,
-  setLevelCount,
 } = musicSlice.actions;

--- a/apps/src/music/types.ts
+++ b/apps/src/music/types.ts
@@ -3,7 +3,20 @@
 // However, this requires depending on files outside of apps/src,
 // so this approach is still being investigated. For now, this type
 // is an object whose keys are all functions which return strings,
+
+import {LevelData} from '../labs/types';
+
 // matching what we expect for a locale object.
 export type MusicLocale = {
   [key: string]: (replaceMap?: {[key: string]: string}) => string;
 };
+
+// TODO: Use this interface when converting MusicView to TypeScript
+export interface MusicLevelData extends LevelData {
+  toolbox: {
+    [key: string]: string;
+  };
+  sounds: {
+    [key: string]: string;
+  };
+}

--- a/apps/src/music/utils/Loader.ts
+++ b/apps/src/music/utils/Loader.ts
@@ -1,19 +1,14 @@
 // Utilities for retrieving various types of data for Music Lab.
 
-import HttpClient, {ResponseValidator} from '@cdo/apps/util/HttpClient';
+import HttpClient from '@cdo/apps/util/HttpClient';
 import MusicLibrary, {
   LibraryJson,
   LibraryValidator,
 } from '../player/MusicLibrary';
-import {ProgressionStep} from '../progress/ProgressManager';
 
 const AppConfig = require('../appConfig').default;
 
 export const baseUrl = 'https://curriculum.code.org/media/musiclab/';
-
-type LevelDataResponse = {
-  level_data: ProgressionStep;
-};
 
 // Loads a sound library JSON file.
 export const loadLibrary = async (): Promise<MusicLibrary> => {
@@ -34,27 +29,4 @@ export const loadLibrary = async (): Promise<MusicLibrary> => {
     );
     return new MusicLibrary(libraryJsonResponse.value);
   }
-};
-
-const LevelDataValidator: ResponseValidator<LevelDataResponse> = response => {
-  const levelDataResponse = response as LevelDataResponse;
-  if (response.level_data === undefined) {
-    throw new Error('Missing required parameter: level_data');
-  }
-
-  return levelDataResponse;
-};
-
-// Loads a progression step.
-export const loadProgressionStepFromSource = async (
-  levelDataPath: string
-): Promise<ProgressionStep> => {
-  // Asynchronously retrieve the current level data.
-  const response = await HttpClient.fetchJson<LevelDataResponse>(
-    levelDataPath,
-    {},
-    LevelDataValidator
-  );
-
-  return response.value.level_data;
 };

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -245,7 +245,7 @@ class UnconnectedMusicView extends React.Component {
     if (!prevProps.labReadyForReload && this.props.labReadyForReload) {
       if (this.getStartSources() || this.props.source) {
         let codeToLoad = this.getStartSources();
-        if (this.props.source && this.props.source.source) {
+        if (this.props.source?.source) {
           codeToLoad = JSON.parse(this.props.source.source);
         }
         this.musicBlocklyWorkspace.loadCode(codeToLoad);

--- a/apps/src/util/HttpClient.ts
+++ b/apps/src/util/HttpClient.ts
@@ -4,7 +4,7 @@ import {
 } from './AuthenticityTokenStore';
 
 export type ResponseValidator<ResponseType> = (
-  bodyJson: Record<string, unknown>
+  bodyJson: object
 ) => ResponseType;
 
 export type GetResponse<ResponseType> = {

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -7,8 +7,8 @@ EMPTY_XML = '<xml></xml>'.freeze
 class LevelsController < ApplicationController
   include LevelsHelper
   include ActiveSupport::Inflector
-  before_action :authenticate_user!, except: [:show, :level_data, :embed_level, :get_rubric, :get_serialized_maze]
-  before_action :require_levelbuilder_mode_or_test_env, except: [:show, :level_data, :embed_level, :get_rubric, :get_serialized_maze]
+  before_action :authenticate_user!, except: [:show, :level_properties, :embed_level, :get_rubric, :get_serialized_maze]
+  before_action :require_levelbuilder_mode_or_test_env, except: [:show, :level_properties, :embed_level, :get_rubric, :get_serialized_maze]
   load_and_authorize_resource except: [:create]
 
   before_action :set_level, only: [:show, :edit, :update, :destroy]
@@ -140,10 +140,10 @@ class LevelsController < ApplicationController
     )
   end
 
-  # Get a JSON summary of a level's information, used in modern labs that don't
+  # Get a JSON summary of a level's properties, used in modern labs that don't
   # reload the page between level views.
-  def level_data
-    render json: {level_data: @level.properties["level_data"]}
+  def level_properties
+    render json: @level.properties.camelize_keys
   end
 
   # GET /levels/1/edit

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -178,7 +178,7 @@ class ScriptLevelsController < ApplicationController
   # Get a JSON summary of a level's information, used in modern labs that don't
   # reload the page between level views.  Note that this can be cached for a relatively
   # long amount of time, including by the CDN, and does not vary per user.
-  def level_data
+  def level_properties
     authorize! :read, ScriptLevel
 
     @script = ScriptLevelsController.get_script(request)
@@ -187,7 +187,7 @@ class ScriptLevelsController < ApplicationController
 
     @level = @script_level.level
 
-    render json: {level_data: @level.properties["level_data"]}
+    render json: @level.properties.camelize_keys
   end
 
   # Get a list of hidden lessons for the current users section

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -320,7 +320,7 @@ Dashboard::Application.routes.draw do
         post 'clone'
         post 'update_start_code'
         post 'update_exemplar_code'
-        get 'level_data'
+        get 'level_properties'
       end
     end
 
@@ -472,9 +472,9 @@ Dashboard::Application.routes.draw do
             get 'page/:puzzle_page', to: 'script_levels#show', as: 'puzzle_page', format: false
             # /s/xxx/lessons/yyy/levels/zzz/sublevel/sss
             get 'sublevel/:sublevel_position', to: 'script_levels#show', as: 'sublevel', format: false
-            # Get the level data via JSON.
-            # /s/xxx/lessons/yyy/levels/zzz/level_data
-            get 'level_data', to: 'script_levels#level_data'
+            # Get the level's properties via JSON.
+            # /s/xxx/lessons/yyy/levels/zzz/level_properties
+            get 'level_properties', to: 'script_levels#level_properties'
           end
         end
         resources :script_levels, only: [:show], path: "/levels", format: false do

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -83,7 +83,7 @@ class LevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"level_data" => {"hello" => "there"}, "other" => "other"}, body)
+    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil}, body)
   end
 
   test "should get filtered levels with just page param" do

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -77,7 +77,7 @@ class LevelsControllerTest < ActionController::TestCase
   end
 
   test "should return level_properties " do
-    level = create :music, name: 'music 1', properties: {level_data: {hello: "there"}, other: "other"}
+    level = create :maze, name: 'music 1', properties: {level_data: {hello: "there"}, other: "other"}
 
     get :level_properties, params: {id: level}
     assert_response :success

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -76,14 +76,14 @@ class LevelsControllerTest < ActionController::TestCase
     )
   end
 
-  test "should return level_data " do
-    level = create :maze, name: 'music 1', properties: {level_data: {hello: "there"}, other: "other"}
+  test "should return level_properties " do
+    level = create :music, name: 'music 1', properties: {level_data: {hello: "there"}, other: "other"}
 
-    get :level_data, params: {id: level}
+    get :level_properties, params: {id: level}
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"level_data" => {"hello" => "there"}}, body)
+    assert_equal({"level_data" => {"hello" => "there"}, "other" => "other"}, body)
   end
 
   test "should get filtered levels with just page param" do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -92,7 +92,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     script = create(:script)
     lesson_group = create(:lesson_group, script: script)
     lesson = create(:lesson, script: script, lesson_group: lesson_group)
-    level = create :music, name: 'music 1', properties: {level_data: {hello: "there"}, other: "other"}
+    level = create :maze, name: 'music 1', properties: {level_data: {hello: "there"}, other: "other"}
     script_level = create(
       :script_level,
       lesson: lesson,

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -88,11 +88,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     AzureTextToSpeech.unstub(:get_voices)
   end
 
-  test "should return level_data " do
+  test "should return level_properties " do
     script = create(:script)
     lesson_group = create(:lesson_group, script: script)
     lesson = create(:lesson, script: script, lesson_group: lesson_group)
-    level = create :maze, name: 'music 1', properties: {level_data: {hello: "there"}, other: "other"}
+    level = create :music, name: 'music 1', properties: {level_data: {hello: "there"}, other: "other"}
     script_level = create(
       :script_level,
       lesson: lesson,
@@ -100,11 +100,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       levels: [level]
     )
 
-    get :level_data, params: script_level_params(script_level)
+    get :level_properties, params: script_level_params(script_level)
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"level_data" => {"hello" => "there"}}, body)
+    assert_equal({"level_data" => {"hello" => "there"}, "other" => "other"}, body)
   end
 
   test 'should show script level for csp1-2020 lockable lesson with lesson plan' do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -104,7 +104,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"level_data" => {"hello" => "there"}, "other" => "other"}, body)
+    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil}, body)
   end
 
   test 'should show script level for csp1-2020 lockable lesson with lesson plan' do

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
@@ -8,7 +8,7 @@ Scenario: Dragging play sound block
   And I rotate to landscape
 
   # Wait until we see the first category.
-  And I wait until element "#blockly-0" is visible
+  And I wait until element ".blocklyTreeRow" is visible
 
   # Also wait until we see the "when run" block.
   And I wait until element "[data-id='when-run-block']" is visible
@@ -17,7 +17,7 @@ Scenario: Dragging play sound block
   And element ".timeline-element" is not visible
 
   # Open the first category.
-  And I press "blockly-0"
+  And I press the first ".blocklyTreeRow" element
 
   # Drag the "play sound" block and attach it to the "when run" block.
   Then I drag block "play-sound-block" to block "when-run-block"


### PR DESCRIPTION
Move level data out of MusicView and into labRedux, so it's fetched alongside other project data. This helps simplify logic since all loading is happening in one place. We can hook into the same labReadyForReload and aborted promise mechanisms.

I also modified the `level_data` API to instead return the full level properties object (and renamed to `level_properties`). We'll need a few fields from the level properties object (ex. hideShareAndRemix, isProjectLevel) for later changes.

## Links

Related to: https://codedotorg.atlassian.net/browse/SL-892

## Testing story

Tested locally with script levels, single levels, standalone levels, and /projectbeats.