### PR TITLE
Remove all mentions of physical curriculum guide

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -248,10 +248,6 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
             this.props.workshopSubject === DEEP_DIVE && (
               <td>{enrollment.attended_csf_intro_workshop}</td>
             )}
-          {this.props.workshopCourse === CSF &&
-            this.props.workshopSubject === DEEP_DIVE && (
-              <td>{enrollment.csf_has_physical_curriculum_guide}</td>
-            )}
           {this.props.workshopCourse === CSP &&
             this.props.workshopSubject ===
               SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS && (

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -90,11 +90,6 @@ const ATTENDED_CSF_COURSES_OPTIONS = {
   'Nope, I have never attended a CS Fundamentals workshop.': 'No',
 };
 
-const CSF_HAS_CURIICULUM_COPY_OPTIONS = {
-  'Yes, and I will bring it to the workshop.': 'Yes',
-  'Nope. I will need a new copy provided. Thanks!': 'No',
-};
-
 const REPLACE_EXISTING_OPTIONS = [
   'Yes, this course will replace an existing computer science course',
   'No, this course will be added to the schedule in addition to an existing computer science course',
@@ -273,10 +268,6 @@ export default class EnrollForm extends React.Component {
       explain_csf_course_other: this.state.explain_csf_course_other,
       attended_csf_intro_workshop:
         ATTENDED_CSF_COURSES_OPTIONS[this.state.attended_csf_intro_workshop],
-      csf_has_physical_curriculum_guide:
-        CSF_HAS_CURIICULUM_COPY_OPTIONS[
-          this.state.csf_has_physical_curriculum_guide
-        ],
       previous_courses: this.state.previous_courses,
       replace_existing: this.state.replace_existing,
       csf_intro_intent: this.state.csf_intro_intent,
@@ -645,26 +636,6 @@ export default class EnrollForm extends React.Component {
                 type="radio"
                 required={true}
               />
-              <ButtonList
-                id="csf_has_physical_curriculum_guide"
-                key="csf_has_physical_curriculum_guide"
-                answers={Object.keys(CSF_HAS_CURIICULUM_COPY_OPTIONS)}
-                groupName="csf_has_physical_curriculum_guide"
-                label="Do you have a physical copy of the 2019-2020 CS Fundamentals Curriculum Guide that you can bring to the workshop?"
-                onChange={this.handleChange}
-                selectedItems={this.state.csf_has_physical_curriculum_guide}
-                validationState={
-                  Object.prototype.hasOwnProperty.call(
-                    this.state.errors,
-                    'csf_has_physical_curriculum_guide'
-                  )
-                    ? VALIDATION_STATE_ERROR
-                    : null
-                }
-                errorText={this.state.errors.csf_has_physical_curriculum_guide}
-                type="radio"
-                required={true}
-              />
             </FormGroup>
           )}
 
@@ -852,10 +823,7 @@ export default class EnrollForm extends React.Component {
       ) {
         requiredFields.push('csf_intro_intent');
       } else if (this.props.workshop_subject === DEEP_DIVE) {
-        requiredFields.push(
-          'attended_csf_intro_workshop',
-          'csf_has_physical_curriculum_guide'
-        );
+        requiredFields.push('attended_csf_intro_workshop');
       }
     }
 

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
@@ -51,7 +51,6 @@ describe('Enroll Form', () => {
     grades_teaching: ['Pre-K'],
     csf_intro_intent: 'Yes',
     attended_csf_intro_workshop: 'Yes',
-    csf_has_physical_curriculum_guide: 'Yes',
     years_teaching: '10',
     years_teaching_cs: '5',
     taught_ap_before: 'Yes',
@@ -212,7 +211,6 @@ describe('Enroll Form', () => {
       'role',
       'grades_teaching',
       'attended_csf_intro_workshop',
-      'csf_has_physical_curriculum_guide',
     ];
     const requiredParams = {
       ...baseParams,

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -128,7 +128,6 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
       attended_csf_intro_workshop: params[:attended_csf_intro_workshop],
       csf_course_experience: params[:csf_course_experience],
       csf_courses_planned: params[:csf_courses_planned],
-      csf_has_physical_curriculum_guide: params[:csf_has_physical_curriculum_guide],
       previous_courses: params[:previous_courses],
       replace_existing: params[:replace_existing],
       csf_intro_intent: params[:csf_intro_intent],

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -79,7 +79,6 @@ class Pd::Enrollment < ApplicationRecord
     attended_csf_intro_workshop
     csf_course_experience
     csf_courses_planned
-    csf_has_physical_curriculum_guide
     previous_courses
     replace_existing
     csf_intro_intent

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -1,7 +1,7 @@
 class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
   attributes :id, :first_name, :last_name, :email, :alternate_email, :application_id, :district_name, :school, :role,
     :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
-    :csf_courses_planned, :csf_has_physical_curriculum_guide, :user_id, :attended,
+    :csf_courses_planned, :user_id, :attended,
     :pre_workshop_survey, :previous_courses, :replace_existing, :attendances,
     :scholarship_status, :enrolled_date, :years_teaching, :years_teaching_cs, :taught_ap_before, :planning_to_teach_ap
 

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -275,7 +275,6 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ::ActionController::TestC
       csf_intro_intent: "No",
       years_teaching: "30",
       years_teaching_cs: "10",
-      csf_has_physical_curriculum_guide: "No",
       previous_courses: "I don’t have experience teaching any of these courses",
       replace_existing: "I don’t know",
       csf_intro_other_factors: "I want to learn computer science concepts.",

--- a/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
+++ b/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
@@ -9,7 +9,7 @@ class Api::V1::Pd::WorkshopEnrollmentSerializerTest < ::ActionController::TestCa
     expected_attributes = [
       :id, :first_name, :last_name, :email, :alternate_email, :application_id, :district_name, :school, :role,
       :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
-      :csf_courses_planned, :csf_has_physical_curriculum_guide, :user_id, :attended,
+      :csf_courses_planned, :user_id, :attended,
       :pre_workshop_survey, :previous_courses, :replace_existing, :attendances,
       :scholarship_status, :enrolled_date, :years_teaching, :years_teaching_cs,
       :taught_ap_before, :planning_to_teach_ap


### PR DESCRIPTION
Removes all mentions of a physical curriculum guide for CSF. I did a find for `csf_has_physical_curriculum_guide` and went from there.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
