### PR TITLE
Remove unneccessary steps, plus a speculative flakiness fix

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/multi.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multi.feature
@@ -44,13 +44,13 @@ Scenario: Rendering in another language
   Then element ".multi h1" has "es-MX" text from key "data.dsls.2-3 Algorithms Multi 1.title"
 
 Scenario: Does not scroll horizontally
-  Given I am on "http://studio.code.org/s/allthethings/lessons/9/levels/2/lang/en-US?noautoplay=true"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/9/levels/2?noautoplay=true"
   When I rotate to landscape
   And element ".submitButton" is visible
   Then there is no horizontal scrollbar
 
 Scenario: Can render without a question
-  Given I am on "http://studio.code.org/s/allthethings/lessons/9/levels/4/lang/en-US?noautoplay=true"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/9/levels/4?noautoplay=true"
   When I rotate to landscape
   And element ".submitButton" is visible
   Then element ".multi-question" is not visible

--- a/dashboard/test/ui/features/teacher_tools/level_types/multi.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multi.feature
@@ -1,14 +1,14 @@
 Feature: Playing multi levels
 
 Scenario: Loading the level
-  Given I am on "http://studio.code.org/s/course1/lessons/2/levels/2/lang/en-US?noautoplay=true"
+  Given I am on "http://studio.code.org/s/course1/lessons/2/levels/2?noautoplay=true"
   Then I rotate to landscape
   And I wait to see ".submitButton"
   And element ".submitButton" is visible
   And element ".multi-question" has text "Which algorithm gets the Flurb to the flowers?"
 
 Scenario: Clicking an option enables submit and submitting the correct answer wins
-  Given I am on "http://studio.code.org/s/course1/lessons/2/levels/2/lang/en-US?noautoplay=true"
+  Given I am on "http://studio.code.org/s/course1/lessons/2/levels/2?noautoplay=true"
   Then I rotate to landscape
   And I wait to see ".submitButton"
   And element ".submitButton" is visible

--- a/dashboard/test/ui/features/teacher_tools/level_types/multi.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multi.feature
@@ -1,15 +1,17 @@
 Feature: Playing multi levels
 
-Background:
-  Given I am on "http://studio.code.org/s/course1/lessons/2/levels/2?noautoplay=true"
+Scenario: Loading the level
+  Given I am on "http://studio.code.org/s/course1/lessons/2/levels/2/lang/en-US?noautoplay=true"
   Then I rotate to landscape
   And I wait to see ".submitButton"
   And element ".submitButton" is visible
-
-Scenario: Loading the level
   And element ".multi-question" has text "Which algorithm gets the Flurb to the flowers?"
 
 Scenario: Clicking an option enables submit and submitting the correct answer wins
+  Given I am on "http://studio.code.org/s/course1/lessons/2/levels/2/lang/en-US?noautoplay=true"
+  Then I rotate to landscape
+  And I wait to see ".submitButton"
+  And element ".submitButton" is visible
   And element ".submitButton:first" is disabled
   And element ".submitButton:last" is disabled
   And I press ".answerbutton[index=1]" using jQuery
@@ -19,6 +21,10 @@ Scenario: Clicking an option enables submit and submitting the correct answer wi
   And I wait to see ".modal"
 
 Scenario: Submitting an incorrect option
+  Given I am on "http://studio.code.org/s/course1/lessons/2/levels/2/lang/en-US?noautoplay=true"
+  Then I rotate to landscape
+  And I wait to see ".submitButton"
+  And element ".submitButton" is visible
   And element ".submitButton:first" is disabled
   And element ".submitButton:last" is disabled
   And I press ".answerbutton[index=0]" using jQuery
@@ -38,13 +44,13 @@ Scenario: Rendering in another language
   Then element ".multi h1" has "es-MX" text from key "data.dsls.2-3 Algorithms Multi 1.title"
 
 Scenario: Does not scroll horizontally
-  Given I am on "http://studio.code.org/s/allthethings/lessons/9/levels/2?noautoplay=true"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/9/levels/2/lang/en-US?noautoplay=true"
   When I rotate to landscape
   And element ".submitButton" is visible
   Then there is no horizontal scrollbar
 
 Scenario: Can render without a question
-  Given I am on "http://studio.code.org/s/allthethings/lessons/9/levels/4?noautoplay=true"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/9/levels/4/lang/en-US?noautoplay=true"
   When I rotate to landscape
   And element ".submitButton" is visible
   Then element ".multi-question" is not visible
@@ -52,7 +58,7 @@ Scenario: Can render without a question
 Scenario: Standalone level without retries locks after answer is submitted
   Given I create a student named "Sally Student"
   And I sign in as "Sally Student"
-  Given I am on "http://studio.code.org/s/allthethings/lessons/9/levels/5?noautoplay=true"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/9/levels/5/lang/en-US?noautoplay=true"
   When I rotate to landscape
   And element ".submitButton" is visible
   And element ".submitButton" is disabled


### PR DESCRIPTION
Part of https://codedotorg.atlassian.net/browse/TEACH-507, I did two things:
1. Removed the `Background` section of the multi test as only about half the tests actually used those steps. Nothing incredible, but it speeds up running this feature by a few seconds
2. A speculative flakiness fix. I noticed the error message `iPad_teacher_tools_level_types_multi first selenium error: expected "Respuesta incorrecta" to include "Incorrect answer" (RSpec::Expectations::ExpectationNotMetError)` appearing quite a bit and it looks like the last test `Standalone level without retries locks after answer is submitted` runs after `Rendering in another language` and the language is still set to Spanish.

I'd still like to get the tests that just test a header has loaded out of our UI test suite, or at least combined with other tests, but that will likely be my focus next sprint.