### PR TITLE
Revert "Fix Violations of and Reenable `Rails/Date`"

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -174,6 +174,12 @@ Rails/ApplicationMailer:
 Rails/AssertNot:
   Enabled: false
 
+# Offense count: 123
+# Configuration parameters: EnforcedStyle, AllowToTime.
+# SupportedStyles: strict, flexible
+Rails/Date:
+  Enabled: false
+
 # Offense count: 472
 # This cop supports unsafe auto-correction (--auto-correct-all).
 # Configuration parameters: Whitelist, AllowedMethods, AllowedReceivers.

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -76,7 +76,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
   # regional partners, and an empty set for everyone else.
   def upcoming_teachercons
     workshops = Pd::Workshop.
-      scheduled_start_on_or_after(Time.zone.today.beginning_of_day).
+      scheduled_start_on_or_after(Date.today.beginning_of_day).
       where(subject: Pd::Workshop::SUBJECT_TEACHER_CON)
 
     if params[:course]
@@ -150,7 +150,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
       conditions[:subject] = Pd::Workshop::SUBJECT_CSF_201
     end
 
-    @workshops = Pd::Workshop.scheduled_start_on_or_after(Time.zone.today.beginning_of_day).
+    @workshops = Pd::Workshop.scheduled_start_on_or_after(Date.today.beginning_of_day).
       where(conditions).where.not(processed_location: nil)
     if params['geojson']
       render json: to_geojson(@workshops)

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -157,7 +157,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
 
   # POST /api/v1/users/<user_id>/postpone_census_banner
   def postpone_census_banner
-    today = Time.zone.today
+    today = Date.today
     year = today.year
     # Find the next scheduled date that is at least 2 weeks away
     scheduled_display_dates = [
@@ -177,7 +177,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
 
   # POST /api/v1/users/<user_id>/dismiss_census_banner
   def dismiss_census_banner
-    today = Time.zone.today
+    today = Date.today
     year = today.year
 
     # if they dismiss Aug 1 or later then don't show until next November

--- a/dashboard/app/controllers/concerns/pd/workshop_filters.rb
+++ b/dashboard/app/controllers/concerns/pd/workshop_filters.rb
@@ -21,7 +21,7 @@ module Pd::WorkshopFilters
   #  - course: null (all), 'csf', or '-csf' (not CSF)
   def load_filtered_ended_workshops
     # Default to the last week, by schedule
-    end_date = params[:end] || Time.zone.today
+    end_date = params[:end] || Date.today
     start_date = params[:start] || (end_date - 1.week)
     query_by = params[:query_by] || QUERY_BY_SCHEDULE
     course = params[:course]

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -258,11 +258,11 @@ class Pd::Workshop < ApplicationRecord
   end
 
   def self.scheduled_start_in_days(days)
-    Pd::Workshop.joins(:sessions).group_by_id.having("(DATE(MIN(start)) = ?)", Time.zone.today + days.days)
+    Pd::Workshop.joins(:sessions).group_by_id.having("(DATE(MIN(start)) = ?)", Date.today + days.days)
   end
 
   def self.scheduled_end_in_days(days)
-    Pd::Workshop.joins(:sessions).group_by_id.having("(DATE(MAX(end)) = ?)", Time.zone.today + days.days)
+    Pd::Workshop.joins(:sessions).group_by_id.having("(DATE(MAX(end)) = ?)", Date.today + days.days)
   end
 
   # Filters by date the workshop actually ended, regardless of scheduled session times.
@@ -285,7 +285,7 @@ class Pd::Workshop < ApplicationRecord
   # @return [Pd::Workshop, nil]
   def self.nearest
     joins(:sessions).
-      select("pd_workshops.*, ABS(DATEDIFF(pd_sessions.start, '#{Time.zone.today}')) AS day_diff").
+      select("pd_workshops.*, ABS(DATEDIFF(pd_sessions.start, '#{Date.today}')) AS day_diff").
       order("day_diff ASC").
       first
   end
@@ -295,7 +295,7 @@ class Pd::Workshop < ApplicationRecord
   # @return [Pd::Workshop, nil]
   def self.with_nearest_attendance_by(teacher)
     joins(sessions: :attendances).where(pd_attendances: {teacher_id: teacher.id}).
-      select("pd_workshops.*, ABS(DATEDIFF(pd_sessions.start, '#{Time.zone.today}')) AS day_diff").
+      select("pd_workshops.*, ABS(DATEDIFF(pd_sessions.start, '#{Date.today}')) AS day_diff").
       order("day_diff").
       first
   end

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -79,7 +79,7 @@ class RegionalPartner < ApplicationRecord
     apps_close_str = apps_close_date_teacher
     if apps_close_str
       close_date = Date.parse(apps_close_str)
-      return close_date.before?(Time.zone.today)
+      return close_date.before?(Date.today)
     end
 
     false

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2255,7 +2255,7 @@ class User < ApplicationRecord
   def show_census_teacher_banner?
     # Must have an NCES school to show the banner
     users_school = try(:school_info).try(:school)
-    teacher? && users_school && (next_census_display.nil? || Time.zone.today >= next_census_display.to_date)
+    teacher? && users_school && (next_census_display.nil? || Date.today >= next_census_display.to_date)
   end
 
   # Returns the name of the donor for the donor teacher banner and donor footer, or nil if none.

--- a/dashboard/lib/services/complete_application_reminder.rb
+++ b/dashboard/lib/services/complete_application_reminder.rb
@@ -22,7 +22,7 @@ class Services::CompleteApplicationReminder
     def applications_needing_initial_reminder
       incomplete_applications_with_email.select do |app|
         most_recent_update = most_recently_updated(app)
-        most_recent_update.before?(Time.zone.today - 6.days) && most_recent_update.after?(Time.zone.today - 14.days) &&
+        most_recent_update.before?(Date.today - 6.days) && most_recent_update.after?(Date.today - 14.days) &&
           app.emails.where(email_type: 'complete_application_initial_reminder').count == 0
       end
     end
@@ -33,7 +33,7 @@ class Services::CompleteApplicationReminder
     # @return [Enumerable<Pd::Application::ApplicationBase>]
     def applications_needing_final_reminder
       incomplete_applications_with_email.select do |app|
-        most_recently_updated(app).before?(Time.zone.today - 13.days) &&
+        most_recently_updated(app).before?(Date.today - 13.days) &&
           app.emails.where(email_type: 'complete_application_final_reminder').count == 0
       end
     end

--- a/dashboard/scripts/update_under_13_students.rb
+++ b/dashboard/scripts/update_under_13_students.rb
@@ -7,7 +7,7 @@ puts "Starting to batch update all students under 13."
 num_students_updated = 0
 
 batch_size = 10000
-min_birthday = Time.zone.today - 13.years
+min_birthday = Date.today - 13.years
 User.where('birthday IS NULL OR birthday > ?', min_birthday).in_batches(of: batch_size) do |where|
   values = where.pluck(:id, :properties)
   values = values.map do |id, properties|

--- a/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
@@ -184,7 +184,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
 
   test 'filter by schedule' do
     skip 'test is flaky for 6 hours per day due to time zone differences'
-    start_date = Time.zone.today - 6.months
+    start_date = Date.today - 6.months
     end_date = start_date + 1.month
 
     workshop_in_range = create :workshop, :ended, sessions_from: start_date + 2.weeks
@@ -209,7 +209,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
 
   test 'filter by end date' do
     skip 'test is flaky for 6 hours per day due to time zone differences'
-    start_date = Time.zone.today - 6.months
+    start_date = Date.today - 6.months
     end_date = start_date + 1.month
 
     workshop_in_range = create :workshop, :ended, ended_at: start_date + 2.weeks

--- a/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
@@ -150,7 +150,7 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ::ActionController::Tes
   end
 
   test 'filter by schedule' do
-    start_date = Time.zone.today - 6.months
+    start_date = Date.today - 6.months
     end_date = start_date + 1.month
 
     workshop_in_range = create :workshop, :ended, sessions_from: start_date + 2.weeks
@@ -169,7 +169,7 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ::ActionController::Tes
   end
 
   test 'filter by end date' do
-    start_date = Time.zone.today - 6.months
+    start_date = Date.today - 6.months
     end_date = start_date + 1.month
 
     workshop_in_range = create :workshop, :ended, ended_at: start_date + 2.weeks

--- a/dashboard/test/controllers/concerns/pd/workshop_filters_test.rb
+++ b/dashboard/test/controllers/concerns/pd/workshop_filters_test.rb
@@ -80,8 +80,8 @@ class Pd::WorkshopFiltersTest < ActionController::TestCase
   end
 
   test 'filter_workshops with start and end' do
-    start_date = Time.zone.today.to_s
-    end_date = (Time.zone.today + 1.day).to_s
+    start_date = Date.today.to_s
+    end_date = (Date.today + 1.day).to_s
     expects(:scheduled_start_on_or_after).with(start_date)
     expects(:scheduled_start_on_or_before).with(end_date)
 
@@ -299,8 +299,8 @@ class Pd::WorkshopFiltersTest < ActionController::TestCase
 
   # Defaults to 1 week ending today by scheduled start date
   def set_default_date_expectations
-    expects(:scheduled_start_on_or_before).with(Time.zone.today)
-    expects(:scheduled_start_on_or_after).with(Time.zone.today - 1.week)
+    expects(:scheduled_start_on_or_before).with(Date.today)
+    expects(:scheduled_start_on_or_after).with(Date.today - 1.week)
   end
 
   def expects(method_name)

--- a/dashboard/test/controllers/followers_controller_test.rb
+++ b/dashboard/test/controllers/followers_controller_test.rb
@@ -225,7 +225,7 @@ class FollowersControllerTest < ActionController::TestCase
 
       assert_equal 'A name', assigns(:user).name
       assert_equal 'f', assigns(:user).gender
-      assert_equal Time.zone.today - 13.years, assigns(:user).birthday
+      assert_equal Date.today - 13.years, assigns(:user).birthday
       assert_equal AuthenticationOption::EMAIL, assigns(:user).primary_contact_info.credential_type
       assert_equal User::TYPE_STUDENT, assigns(:user).user_type
     end
@@ -250,7 +250,7 @@ class FollowersControllerTest < ActionController::TestCase
 
       assert_equal 'A name', assigns(:user).name
       assert_equal 'f', assigns(:user).gender
-      assert_equal Time.zone.today - 11.years, assigns(:user).birthday
+      assert_equal Date.today - 11.years, assigns(:user).birthday
       assert_equal AuthenticationOption::EMAIL, assigns(:user).primary_contact_info.credential_type
       assert_equal '', assigns(:user).email
       assert_equal User.hash_email('studentx@school.edu'), assigns(:user).hashed_email

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -191,7 +191,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         name: {'first' => 'Hat', 'last' => 'Cat'},
         email: 'hat.cat@example.com',
         user_type: 'student',
-        dob: Time.zone.today - 10.years,
+        dob: Date.today - 10.years,
         gender: 'f'
       },
     )
@@ -251,7 +251,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         name: {'first' => 'Hat', 'last' => 'Cat'},
         email: 'hat.cat@example.com',
         user_type: 'student',
-        dob: Time.zone.today - 10.years,
+        dob: Date.today - 10.years,
         gender: 'f'
       },
     )
@@ -301,7 +301,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         name: 'someone',
         email: 'test@email.com',
         user_type: User::TYPE_STUDENT,
-        dob: Time.zone.today - 20.years,
+        dob: Date.today - 20.years,
         gender: 'f'
       },
       credentials: {
@@ -1691,7 +1691,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         name: args[:name] || 'someone',
         email: args[:email] || 'new@example.com',
         user_type: args[:user_type] || 'teacher',
-        dob: args[:dob] || (Time.zone.today - 20.years),
+        dob: args[:dob] || (Date.today - 20.years),
         gender: args[:gender] || 'f'
       },
       credentials: {

--- a/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCase
   def prepare_scenario
-    @csf_workshop = create :workshop, :ended, num_sessions: 3, course: Pd::Workshop::COURSE_CSF, ended_at: Time.zone.today - 1.day
-    @csd_workshop = create :workshop, :ended, num_sessions: 3, course: Pd::Workshop::COURSE_CSD, ended_at: Time.zone.today - 2.days
+    @csf_workshop = create :workshop, :ended, num_sessions: 3, course: Pd::Workshop::COURSE_CSF, ended_at: Date.today - 1.day
+    @csd_workshop = create :workshop, :ended, num_sessions: 3, course: Pd::Workshop::COURSE_CSD, ended_at: Date.today - 2.days
     @csp_workshop = create :workshop, num_sessions: 3, course: Pd::Workshop::COURSE_CSP
 
     @teacher = create(:teacher, email: 'test_email@foo.com', user_type: 'teacher')
@@ -104,7 +104,7 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
   test 'FiT workshops do not interfere with other pending exit surveys' do
     # Fake CSF workshop (older than the FiT workshop) which should
     # produce a pending exit survey
-    csf_workshop = create :csf_workshop, :ended, ended_at: Time.zone.today - 1.day
+    csf_workshop = create :csf_workshop, :ended, ended_at: Date.today - 1.day
 
     # Fake FiT workshop, which should not produce an exit survey
     fit_workshop = create :fit_workshop, :ended
@@ -146,7 +146,7 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
   test 'Facilitator workshops do not interfere with other pending exit surveys' do
     # Fake CSF workshop (older than the Facilitator workshop) which should
     # produce a pending exit survey
-    csf_workshop = create :csf_workshop, :ended, ended_at: Time.zone.today - 1.day
+    csf_workshop = create :csf_workshop, :ended, ended_at: Date.today - 1.day
 
     # Fake Facilitator workshop, which should not produce an exit survey
     facilitator_workshop = create :facilitator_workshop, :ended

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -148,7 +148,7 @@ module Pd
     test 'enrollment code override is used when fetching the workshop for a user' do
       setup_summer_workshop
       other_summer_workshop = create :summer_workshop,
-        regional_partner: @regional_partner, facilitators: @facilitators, sessions_from: Time.zone.today + 1.month
+        regional_partner: @regional_partner, facilitators: @facilitators, sessions_from: Date.today + 1.month
       other_enrollment = create :pd_enrollment, :from_user, workshop: other_summer_workshop, user: @enrolled_summer_teacher
       create :pd_attendance, session: other_summer_workshop.sessions[0], teacher: @enrolled_summer_teacher, enrollment: other_enrollment
 

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -241,7 +241,7 @@ class RegistrationsControllerTest < ActionController::TestCase
 
       assert_equal 'A name', assigns(:user).name
       assert_equal 'f', assigns(:user).gender
-      assert_equal Time.zone.today - 13.years, assigns(:user).birthday
+      assert_equal Date.today - 13.years, assigns(:user).birthday
       assert_equal AuthenticationOption::EMAIL, assigns(:user).primary_contact_info.credential_type
       assert_equal User::TYPE_STUDENT, assigns(:user).user_type
       assert_equal '', assigns(:user).email
@@ -264,7 +264,7 @@ class RegistrationsControllerTest < ActionController::TestCase
 
       assert_equal 'A name', assigns(:user).name
       assert_equal 'f', assigns(:user).gender
-      assert_equal Time.zone.today - 13.years, assigns(:user).birthday
+      assert_equal Date.today - 13.years, assigns(:user).birthday
       assert_equal AuthenticationOption::EMAIL, assigns(:user).primary_contact_info.credential_type
       assert_equal User::TYPE_STUDENT, assigns(:user).user_type
       assert_equal '', assigns(:user).email

--- a/dashboard/test/integration/omniauth/utils.rb
+++ b/dashboard/test/integration/omniauth/utils.rb
@@ -22,7 +22,7 @@ module OmniauthCallbacksControllerTests
           name: args[:name] || 'someone',
           email: args[:email] || 'auth_test@code.org',
           user_type: args[:user_type].presence,
-          dob: args[:dob] || (Time.zone.today - 20.years),
+          dob: args[:dob] || (Date.today - 20.years),
           gender: args[:gender] || 'f'
         },
         credentials: {

--- a/dashboard/test/integration/registration/new_account_tracking_test.rb
+++ b/dashboard/test/integration/registration/new_account_tracking_test.rb
@@ -174,7 +174,7 @@ module RegistrationsControllerTests
           name: args[:name] || 'someone',
           email: args[:email] || EMAIL,
           user_type: args[:user_type] || 'teacher',
-          dob: args[:dob] || (Time.zone.today - 20.years),
+          dob: args[:dob] || (Date.today - 20.years),
           gender: args[:gender] || 'f'
         },
         credentials: {

--- a/dashboard/test/integration/registration/update_test.rb
+++ b/dashboard/test/integration/registration/update_test.rb
@@ -40,7 +40,7 @@ module RegistrationsControllerTests
         put '/users', params: {format: :js, user: {age: 9}}
         assert_response :no_content
 
-        assert_equal Time.zone.today - 9.years, assigns(:user).birthday
+        assert_equal Date.today - 9.years, assigns(:user).birthday
       end
     end
 

--- a/dashboard/test/models/concerns/pd/jot_form_backed_form_test.rb
+++ b/dashboard/test/models/concerns/pd/jot_form_backed_form_test.rb
@@ -321,7 +321,7 @@ module Pd
     test 'jotform sync gets questions syncs new answers for each form' do
       form_ids = Array.new(2) {get_form_id}
       last_submission_id = get_submission_id
-      min_date = Time.zone.today
+      min_date = Date.today
       form_ids.each do |form_id|
         DummyForm.expects(:get_min_date).with(form_id).returns(min_date)
         DummyForm.expects(:get_questions).with(form_id, force_sync: true).returns(

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -102,7 +102,7 @@ module Pd::Application
     end
 
     test 'accepted_at updates times' do
-      today = Time.zone.today.to_time
+      today = Date.today.to_time
       tomorrow = Date.tomorrow.to_time
       application = create :pd_teacher_application
       assert_nil application.accepted_at
@@ -205,18 +205,18 @@ module Pd::Application
     test 'get_first_selected_workshop single local workshop' do
       Pd::Workshop.any_instance.stubs(:process_location)
 
-      workshop = create :workshop, location_address: 'Address', sessions_from: Time.zone.today, num_sessions: 1
+      workshop = create :workshop, location_address: 'Address', sessions_from: Date.today, num_sessions: 1
       application = create :pd_teacher_application, form_data_hash: (
       build :pd_teacher_application_hash,
         regional_partner_workshop_ids: [workshop.id],
-        able_to_attend_multiple: ["#{Time.zone.today.strftime '%B %-d, %Y'} in Address"]
+        able_to_attend_multiple: ["#{Date.today.strftime '%B %-d, %Y'} in Address"]
       )
 
       assert_equal workshop, application.get_first_selected_workshop
     end
 
     test 'get_first_selected_workshop multiple local workshops' do
-      workshops = (1..3).map {|i| create :workshop, num_sessions: 2, sessions_from: Time.zone.today + i, location_address: %w(tba TBA tba)[i - 1]}
+      workshops = (1..3).map {|i| create :workshop, num_sessions: 2, sessions_from: Date.today + i, location_address: %w(tba TBA tba)[i - 1]}
 
       application = create :pd_teacher_application, form_data_hash: (
       build(:pd_teacher_application_hash, :with_multiple_workshops,
@@ -233,7 +233,7 @@ module Pd::Application
     end
 
     test 'get_first_selected_workshop multiple local workshops no selection returns first' do
-      workshops = (1..2).map {|i| create :workshop, num_sessions: 2, sessions_from: Time.zone.today + i}
+      workshops = (1..2).map {|i| create :workshop, num_sessions: 2, sessions_from: Date.today + i}
 
       application = create :pd_teacher_application, form_data_hash: (
       build(:pd_teacher_application_hash, :with_multiple_workshops,
@@ -269,7 +269,7 @@ module Pd::Application
     end
 
     test 'get_first_selected_workshop ignores deleted workshop from multiple list' do
-      workshops = (1..2).map {|i| create :workshop, num_sessions: 2, sessions_from: Time.zone.today + i}
+      workshops = (1..2).map {|i| create :workshop, num_sessions: 2, sessions_from: Date.today + i}
 
       application = create :pd_teacher_application, form_data_hash: (
       build(:pd_teacher_application_hash, :with_multiple_workshops,
@@ -286,8 +286,8 @@ module Pd::Application
     end
 
     test 'get_first_selected_workshop picks correct workshop even when multiple are on the same day' do
-      workshop_1 = create :workshop, num_sessions: 2, sessions_from: Time.zone.today + 2
-      workshop_2 = create :workshop, num_sessions: 2, sessions_from: Time.zone.today + 2
+      workshop_1 = create :workshop, num_sessions: 2, sessions_from: Date.today + 2
+      workshop_2 = create :workshop, num_sessions: 2, sessions_from: Date.today + 2
       workshop_1.update_column(:location_address, 'Location 1')
       workshop_2.update_column(:location_address, 'Location 2')
 

--- a/dashboard/test/models/pd/payment_term_test.rb
+++ b/dashboard/test/models/pd/payment_term_test.rb
@@ -10,7 +10,7 @@ class Pd::PaymentTermTest < ActiveSupport::TestCase
     @program_manager_1, @program_manager_2 = pms.map(&:program_manager)
     @regional_partner_1, @regional_partner_2 = pms.map(&:regional_partner)
 
-    @workshop_1 = create :workshop, num_sessions: 1, sessions_from: Time.zone.today, organizer: @program_manager_1
+    @workshop_1 = create :workshop, num_sessions: 1, sessions_from: Date.today, organizer: @program_manager_1
     @workshop_2 = create :workshop, num_sessions: 1, sessions_from: 3.months.from_now.to_date, organizer: @program_manager_1
     @workshop_3 = create :workshop, organizer: @program_manager_2
   end
@@ -42,7 +42,7 @@ class Pd::PaymentTermTest < ActiveSupport::TestCase
   end
 
   test 'handles date ranges correctly' do
-    term_1 = create :pd_payment_term, regional_partner: @regional_partner_1, start_date: Time.zone.today - 1.month, end_date: 1.month.from_now.to_date
+    term_1 = create :pd_payment_term, regional_partner: @regional_partner_1, start_date: Date.today - 1.month, end_date: 1.month.from_now.to_date
     term_2 = create :pd_payment_term, regional_partner: @regional_partner_1, start_date: 1.month.from_now.to_date
 
     assert_equal term_1, Pd::PaymentTerm.for_workshop(@workshop_1)
@@ -61,12 +61,12 @@ class Pd::PaymentTermTest < ActiveSupport::TestCase
   end
 
   test 'validations for payment terms' do
-    term_1 = build(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Time.zone.today, properties: {})
+    term_1 = build(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Date.today, properties: {})
     refute term_1.valid?
 
     assert_equal ['Must have either per attendee payment or fixed payment'], term_1.errors.full_messages
 
-    term_2 = build(:pd_payment_term, start_date: Time.zone.today)
+    term_2 = build(:pd_payment_term, start_date: Date.today)
     term_2.save
 
     assert_equal ['Regional partner must exist'], term_2.errors.full_messages
@@ -78,7 +78,7 @@ class Pd::PaymentTermTest < ActiveSupport::TestCase
   end
 
   test 'Old payment terms get truncated' do
-    term_1 = create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Time.zone.today)
+    term_1 = create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Date.today)
 
     # A term for a specific course should not truncate this
     term_2 = create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: 1.month.from_now.to_date, course: Pd::Workshop::COURSE_CSF)
@@ -87,7 +87,7 @@ class Pd::PaymentTermTest < ActiveSupport::TestCase
     assert_nil term_1.end_date
 
     # this should not truncate term 1 or 2
-    create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Time.zone.today + 2.months, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1)
+    create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Date.today + 2.months, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1)
 
     [term_1, term_2].map(&:reload)
     assert_empty [term_1, term_2].filter_map(&:end_date)
@@ -107,11 +107,11 @@ class Pd::PaymentTermTest < ActiveSupport::TestCase
     # Old ends new as detailed in payment_term.rb has been handled by the above test case
 
     # Old contains new
-    term_1 = create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Time.zone.today)
+    term_1 = create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Date.today)
     term_2 = create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: 1.month.from_now.to_date, end_date: 2.months.from_now.to_date)
 
     term_1.reload
-    assert_equal Time.zone.today..1.month.from_now.to_date, term_1.date_range
+    assert_equal Date.today..1.month.from_now.to_date, term_1.date_range
     new_terms = Pd::PaymentTerm.where(regional_partner: @regional_partner_1, start_date: 2.months.from_now.to_date)
     assert_equal 2.months.from_now.to_date..Date::Infinity.new, new_terms.first.date_range
     assert_equal 1, new_terms.size
@@ -120,7 +120,7 @@ class Pd::PaymentTermTest < ActiveSupport::TestCase
 
     # New ends during old
     term_1 = create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: 1.month.from_now.to_date)
-    term_2 = create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Time.zone.today, end_date: 2.months.from_now.to_date)
+    term_2 = create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Date.today, end_date: 2.months.from_now.to_date)
 
     term_1.reload
     assert_equal 2.months.from_now.to_date..Date::Infinity.new, term_1.date_range
@@ -129,16 +129,16 @@ class Pd::PaymentTermTest < ActiveSupport::TestCase
 
     # New contains old
     term_1 = create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: 1.month.from_now.to_date, end_date: 2.months.from_now.to_date)
-    create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Time.zone.today)
+    create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Date.today)
 
     refute Pd::PaymentTerm.exists?(term_1.id)
   end
 
   test 'No overlap means no changes' do
-    term_1 = create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Time.zone.today, end_date: 1.month.from_now)
+    term_1 = create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: Date.today, end_date: 1.month.from_now)
     create(:pd_payment_term, regional_partner: @regional_partner_1, start_date: 2.months.from_now)
 
     term_1.reload
-    assert_equal Time.zone.today..1.month.from_now.to_date, term_1.date_range
+    assert_equal Date.today..1.month.from_now.to_date, term_1.date_range
   end
 end

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -417,7 +417,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'send_follow_up only teachers attended workshop get follow up emails' do
-    workshop = create :csf_intro_workshop, :ended, sessions_from: Time.zone.today - 30.days
+    workshop = create :csf_intro_workshop, :ended, sessions_from: Date.today - 30.days
 
     teacher_attended = create(:pd_workshop_participant, workshop: workshop, enrolled: true, attended: true)
     create(:pd_workshop_participant, workshop: workshop, enrolled: true)
@@ -429,7 +429,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'send_follow_up all teachers attended workshop get follow up emails' do
-    workshop = create :csf_intro_workshop, :ended, sessions_from: Time.zone.today - 30.days
+    workshop = create :csf_intro_workshop, :ended, sessions_from: Date.today - 30.days
 
     teacher_count = 3
     create_list :pd_workshop_participant, teacher_count, workshop: workshop, enrolled: true, attended: true
@@ -440,7 +440,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'send_follow_up exception in email delivery raises honeybadger but does not stop batch' do
-    workshop = create :csf_intro_workshop, :ended, sessions_from: Time.zone.today - 30.days
+    workshop = create :csf_intro_workshop, :ended, sessions_from: Date.today - 30.days
 
     teacher_count = 3
     create_list :pd_workshop_participant, teacher_count, workshop: workshop, enrolled: true, attended: true
@@ -459,9 +459,9 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'send_follow_up only workshop ended exactly 30 days ago get follow up emails' do
-    workshop_31d = create :csf_intro_workshop, :ended, sessions_from: Time.zone.today - 31.days
-    workshop_30d = create :csf_intro_workshop, :ended, sessions_from: Time.zone.today - 30.days
-    workshop_29d = create :csf_intro_workshop, :ended, sessions_from: Time.zone.today - 29.days
+    workshop_31d = create :csf_intro_workshop, :ended, sessions_from: Date.today - 31.days
+    workshop_30d = create :csf_intro_workshop, :ended, sessions_from: Date.today - 30.days
+    workshop_29d = create :csf_intro_workshop, :ended, sessions_from: Date.today - 29.days
 
     create(:pd_workshop_participant, workshop: workshop_31d, enrolled: true, attended: true)
     teacher_30d = create(:pd_workshop_participant, workshop: workshop_30d, enrolled: true, attended: true)
@@ -514,7 +514,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'start date filters' do
-    pivot_date = Time.zone.today
+    pivot_date = Date.today
     workshop_before = create :workshop, sessions: [create(:pd_session, start: pivot_date - 1.week)]
     # Start in the middle of the day. Since the filter is by date, this should be included in all the queries.
     workshop_pivot = create :workshop, sessions: [create(:pd_session, start: pivot_date + 8.hours)]
@@ -557,26 +557,26 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   test 'future scope' do
     future_workshops = [
       # Today
-      a = create(:workshop, sessions_from: Time.zone.today),
+      a = create(:workshop, sessions_from: Date.today),
 
       # Next week
-      b = create(:workshop, sessions_from: Time.zone.today + 1.week)
+      b = create(:workshop, sessions_from: Date.today + 1.week)
     ]
 
     # Excluded (not future) workshops:
     # Last week
-    c = create :workshop, sessions_from: Time.zone.today - 1.week
+    c = create :workshop, sessions_from: Date.today - 1.week
     # Today, but ended
-    d = create :workshop, :ended, sessions_from: Time.zone.today
+    d = create :workshop, :ended, sessions_from: Date.today
     # Next week, but ended
-    e = create :workshop, :ended, sessions_from: Time.zone.today + 1.week
+    e = create :workshop, :ended, sessions_from: Date.today + 1.week
 
     workshop_ids = [a, b, c, d, e].map(&:id)
     assert_equal future_workshops, Pd::Workshop.where(id: workshop_ids).future
   end
 
   test 'end date filters' do
-    pivot_date = Time.zone.today
+    pivot_date = Date.today
     workshop_before = create :workshop, ended_at: pivot_date - 1.week
     # End in the middle of the day. Since the filter is by date, this should be included in all the queries.
     workshop_pivot = create :workshop, ended_at: pivot_date + 8.hours
@@ -598,7 +598,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   test 'order_by_start' do
     # 5 workshops in date order, each with 1-5 sessions (only the first matters)
     workshops = Array.new(5) do |i|
-      build :workshop, num_sessions: rand(1..5), sessions_from: Time.zone.today + i.days
+      build :workshop, num_sessions: rand(1..5), sessions_from: Date.today + i.days
     end
     # save out of order
     workshops.shuffle.each(&:save!)
@@ -876,8 +876,8 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'workshop starting date picks the day of the first session' do
     workshop = create :workshop, sessions: [
-      session1 = create(:pd_session, start: Time.zone.today + 15.days),
-      session2 = create(:pd_session, start: Time.zone.today + 20.days)
+      session1 = create(:pd_session, start: Date.today + 15.days),
+      session2 = create(:pd_session, start: Date.today + 20.days)
     ]
     assert_equal session1.start, workshop.workshop_starting_date
     assert_equal session2.start, workshop.workshop_ending_date
@@ -885,12 +885,12 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'workshop date range string for single session workshop' do
     workshop = create :workshop, num_sessions: 1
-    assert_equal Time.zone.today.strftime('%B %e, %Y'), workshop.workshop_date_range_string
+    assert_equal Date.today.strftime('%B %e, %Y'), workshop.workshop_date_range_string
   end
 
   test 'workshop date range string for multi session workshop' do
     workshop = create :workshop, num_sessions: 2
-    assert_equal "#{Time.zone.today.strftime('%B %e, %Y')} - #{Date.tomorrow.strftime('%B %e, %Y')}", workshop.workshop_date_range_string
+    assert_equal "#{Date.today.strftime('%B %e, %Y')} - #{Date.tomorrow.strftime('%B %e, %Y')}", workshop.workshop_date_range_string
   end
 
   test 'workshop_dashboard_url' do
@@ -1321,10 +1321,10 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'nearest' do
-    target = create :workshop, sessions_from: Time.zone.today + 1.week
+    target = create :workshop, sessions_from: Date.today + 1.week
 
-    x = create :workshop, sessions_from: Time.zone.today + 2.weeks
-    y = create :workshop, sessions_from: Time.zone.today - 2.weeks
+    x = create :workshop, sessions_from: Date.today + 2.weeks
+    y = create :workshop, sessions_from: Date.today - 2.weeks
 
     ids = [target, x, y].map(&:id)
 
@@ -1332,9 +1332,9 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'nearest is independent of creation order' do
-    x = create :workshop, sessions_from: Time.zone.today - 2.weeks
-    target = create :workshop, sessions_from: Time.zone.today + 1.week
-    y = create :workshop, sessions_from: Time.zone.today + 2.weeks
+    x = create :workshop, sessions_from: Date.today - 2.weeks
+    target = create :workshop, sessions_from: Date.today + 1.week
+    y = create :workshop, sessions_from: Date.today + 2.weeks
 
     ids = [x, target, y].map(&:id)
 
@@ -1352,18 +1352,18 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'nearest combined with subject and enrollment' do
     user = create :teacher
-    target = create :csp_summer_workshop, sessions_from: Time.zone.today + 1.day
+    target = create :csp_summer_workshop, sessions_from: Date.today + 1.day
     create :pd_enrollment, :from_user, user: user, workshop: target
 
-    same_subject_farther = create :csp_summer_workshop, sessions_from: Time.zone.today + 1.week
+    same_subject_farther = create :csp_summer_workshop, sessions_from: Date.today + 1.week
     create :pd_enrollment, :from_user, user: user, workshop: same_subject_farther
 
-    different_subject_closer = create :workshop, sessions_from: Time.zone.today,
+    different_subject_closer = create :workshop, sessions_from: Date.today,
       course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_TEACHER_CON
     create :pd_enrollment, :from_user, user: user, workshop: different_subject_closer
 
     # closer, not enrolled
-    create :csp_summer_workshop, sessions_from: Time.zone.today
+    create :csp_summer_workshop, sessions_from: Date.today
 
     found = Pd::Workshop.where(subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP).enrolled_in_by(user).nearest
     assert_equal target, found
@@ -1373,7 +1373,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     teacher = create :teacher
 
     # 2 workshops on the same day
-    workshops = create_list :workshop, 2, num_sessions: 2, sessions_from: Time.zone.today - 1.day
+    workshops = create_list :workshop, 2, num_sessions: 2, sessions_from: Date.today - 1.day
 
     # Attend first session from one
     create :pd_attendance, session: workshops[0].sessions[0], teacher: teacher
@@ -1394,8 +1394,8 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     other_teacher = create :teacher
 
     # 2 workshops on the same day for each course
-    csd_workshops = create_list :workshop, 2, num_sessions: 2, sessions_from: Time.zone.today - 1.day, course: COURSE_CSD
-    csp_workshops = create_list :workshop, 2, num_sessions: 2, sessions_from: Time.zone.today - 1.day, course: COURSE_CSP
+    csd_workshops = create_list :workshop, 2, num_sessions: 2, sessions_from: Date.today - 1.day, course: COURSE_CSD
+    csp_workshops = create_list :workshop, 2, num_sessions: 2, sessions_from: Date.today - 1.day, course: COURSE_CSP
 
     # Enroll in the first of each
     create :pd_enrollment, :from_user, user: teacher, workshop: csd_workshops[0]
@@ -1574,6 +1574,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   def today
-    Time.zone.today
+    Date.today.in_time_zone
   end
 end

--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -173,13 +173,13 @@ class RegionalPartnerTest < ActiveSupport::TestCase
     create :regional_partner_program_manager, regional_partner: regional_partner, program_manager: partner_organizer
 
     future_partner_workshops = [
-      create(:workshop, organizer: partner_organizer, sessions_from: Time.zone.today),
+      create(:workshop, organizer: partner_organizer, sessions_from: Date.today),
       create(:workshop, organizer: partner_organizer, sessions_from: Date.tomorrow)
     ]
 
     # excluded (past or ended) partner workshops
     create :workshop, organizer: partner_organizer, sessions_from: Date.yesterday
-    create :workshop, :ended, organizer: partner_organizer, sessions_from: Time.zone.today
+    create :workshop, :ended, organizer: partner_organizer, sessions_from: Date.today
 
     assert_equal future_partner_workshops, regional_partner.future_pd_workshops_organized
   end
@@ -190,13 +190,13 @@ class RegionalPartnerTest < ActiveSupport::TestCase
     create :regional_partner_program_manager, regional_partner: regional_partner, program_manager: partner_organizer
 
     future_partner_workshops = [
-      create(:workshop, organizer: partner_organizer, sessions_from: Time.zone.today),
+      create(:workshop, organizer: partner_organizer, sessions_from: Date.today),
       create(:workshop, organizer: partner_organizer, sessions_from: Date.tomorrow)
     ]
 
     # excluded (past or ended) partner workshops
     create :workshop, organizer: partner_organizer, sessions_from: Date.yesterday
-    create :workshop, :ended, organizer: partner_organizer, sessions_from: Time.zone.today
+    create :workshop, :ended, organizer: partner_organizer, sessions_from: Date.today
 
     assert_equal future_partner_workshops, regional_partner.future_pd_workshops_organized
   end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -577,7 +577,7 @@ class UserTest < ActiveSupport::TestCase
       assert_creates(User) do
         user = User.create(@good_data.merge({age: '7', email: 'new@email.com'}))
 
-        assert_equal Date.new(Time.zone.today.year - 7, Time.zone.today.month, Time.zone.today.day), user.birthday
+        assert_equal Date.new(Date.today.year - 7, Date.today.month, Date.today.day), user.birthday
         assert_equal 7, user.age
       end
     end
@@ -588,7 +588,7 @@ class UserTest < ActiveSupport::TestCase
       assert_creates(User) do
         user = User.create(@good_data.merge({age: '21+', email: 'new@email.com'}))
 
-        assert_equal Date.new(Time.zone.today.year - 21, Time.zone.today.month, Time.zone.today.day), user.birthday
+        assert_equal Date.new(Date.today.year - 21, Date.today.month, Date.today.day), user.birthday
         assert_equal "21+", user.age
       end
     end
@@ -630,7 +630,7 @@ class UserTest < ActiveSupport::TestCase
       assert_equal 7, user.age
 
       user.update(age: '9')
-      assert_equal Date.new(Time.zone.today.year - 9, Time.zone.today.month, Time.zone.today.day), user.birthday
+      assert_equal Date.new(Date.today.year - 9, Date.today.month, Date.today.day), user.birthday
       assert_equal 9, user.age
     end
   end
@@ -669,7 +669,7 @@ class UserTest < ActiveSupport::TestCase
     user = User.create(@good_data.merge({age: '7', email: 'new@email.com'}))
     assert_equal 7, user.age
 
-    Timecop.freeze(Time.zone.today + 40) do
+    Timecop.freeze(Date.today + 40) do
       assert_no_difference('user.reload.birthday') do
         user.update(age: '7')
       end
@@ -3051,20 +3051,20 @@ class UserTest < ActiveSupport::TestCase
 
   test "age is nil for Google OAuth users under age 4" do
     # Users created this way will be asked for their age when they first sign in.
-    three_year_old = create :user, birthday: (Time.zone.today - 3.years), provider: 'google_oauth2'
+    three_year_old = create :user, birthday: (Date.today - 3.years), provider: 'google_oauth2'
     assert_nil three_year_old.age
   end
 
   test "age is set exactly for Google OAuth users between ages 4 and 20" do
-    four_year_old = build :user, birthday: (Time.zone.today - 4.years), provider: 'google_oauth2'
+    four_year_old = build :user, birthday: (Date.today - 4.years), provider: 'google_oauth2'
     assert_equal 4, four_year_old.age
 
-    twenty_year_old = build :user, birthday: (Time.zone.today - 20.years), provider: 'google_oauth2'
+    twenty_year_old = build :user, birthday: (Date.today - 20.years), provider: 'google_oauth2'
     assert_equal 20, twenty_year_old.age
   end
 
   test "age is 21+ for Google OAuth users over the age of 20" do
-    twenty_something = create :user, birthday: (Time.zone.today - 22.years), provider: 'google_oauth2'
+    twenty_something = create :user, birthday: (Date.today - 22.years), provider: 'google_oauth2'
     assert_equal '21+', twenty_something.age
   end
 
@@ -3076,20 +3076,20 @@ class UserTest < ActiveSupport::TestCase
 
   test "age is nil for Clever users under age 4" do
     # Users created this way will be asked for their age when they first sign in.
-    three_year_old = create :user, birthday: (Time.zone.today - 3.years), provider: 'clever'
+    three_year_old = create :user, birthday: (Date.today - 3.years), provider: 'clever'
     assert_nil three_year_old.age
   end
 
   test "age is set exactly for Clever users between ages 4 and 20" do
-    four_year_old = build :user, birthday: (Time.zone.today - 4.years), provider: 'clever'
+    four_year_old = build :user, birthday: (Date.today - 4.years), provider: 'clever'
     assert_equal 4, four_year_old.age
 
-    twenty_year_old = build :user, birthday: (Time.zone.today - 20.years), provider: 'clever'
+    twenty_year_old = build :user, birthday: (Date.today - 20.years), provider: 'clever'
     assert_equal 20, twenty_year_old.age
   end
 
   test "age is 21+ for Clever users over the age of 20" do
-    twenty_something = create :user, birthday: (Time.zone.today - 22.years), provider: 'clever'
+    twenty_something = create :user, birthday: (Date.today - 22.years), provider: 'clever'
     assert_equal '21+', twenty_something.age
   end
 
@@ -3732,12 +3732,12 @@ class UserTest < ActiveSupport::TestCase
 
   test 'students share setting updates after turning 13 if they are in no sections' do
     # create a birthday 12 years ago
-    birthday = Time.zone.today - (12 * 365)
+    birthday = Date.today - (12 * 365)
     student = create :user, birthday: birthday
     assert student.reload.sharing_disabled
 
     # go forward in time to a day past the student's 13th birthday
-    Timecop.travel(Time.zone.today + 366) do
+    Timecop.travel(Date.today + 366) do
       # student signs in
       student.sign_in_count = 2
       student.save
@@ -3749,7 +3749,7 @@ class UserTest < ActiveSupport::TestCase
 
   test 'students share setting does not update after turning 13 if they are in sections' do
     # create a birthday 12 years ago
-    birthday = Time.zone.today - (12 * 365)
+    birthday = Date.today - (12 * 365)
     student = create :user, birthday: birthday
 
     teacher = create :teacher
@@ -3759,7 +3759,7 @@ class UserTest < ActiveSupport::TestCase
     assert student.reload.sharing_disabled
 
     # go forward in time to a day past the student's 13th birthday
-    Timecop.travel(Time.zone.today + 366) do
+    Timecop.travel(Date.today + 366) do
       # student signs in
       student.sign_in_count = 2
       student.save


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#50760; we have an unusual eyes test failure that we think might have been caused by this change, so speculatively reverting it to confirm. See thread at https://codedotorg.slack.com/archives/C04540KNGDQ/p1687529632830099?thread_ts=1687529632.830099&cid=C04540KNGDQ for more