### PR TITLE
Call `daemon-reload` Before `restart` in SystemD

### DIFF
--- a/lib/cdo/rake_utils.rb
+++ b/lib/cdo/rake_utils.rb
@@ -32,7 +32,9 @@ module RakeUtils
   end
 
   def self.restart_service(id)
-    sudo 'systemctl', 'restart', id.to_s if OS.linux? && CDO.chef_managed
+    return unless OS.linux? && CDO.chef_managed
+    sudo 'systemctl', 'daemon-reload'
+    sudo 'systemctl', 'restart', id.to_s
   end
 
   def self.system_(*args)


### PR DESCRIPTION
Otherwise, restarting can fail if the relevant configuration has been updated by another part of our build process.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/52351, which applied the same fix to our Chef-invoked restarts, but forgot to do so for our Ruby-invoked restarts.