### PR TITLE
Preserve `/run/unicorn` Directory

### DIFF
--- a/cookbooks/cdo-apps/templates/default/puma.service.erb
+++ b/cookbooks/cdo-apps/templates/default/puma.service.erb
@@ -17,6 +17,10 @@ WorkingDirectory=<%= @app_root %>
 # to get created at /run/unicorn from back when we used that
 RuntimeDirectory=unicorn
 
+# Because both dashboard and pegasus use the same runtime directory, we don't
+# want either to try to clean it up after themselves on restart
+RuntimeDirectoryPreserve=yes
+
 <%= @export_env ? @export_env.map{|k,v|"Environment=#{k}=#{v}"}.join("\n") : '' %>
 Environment=LANG=en_US.UTF-8
 


### PR DESCRIPTION
Because both the Dashboard and Pegasus web servers use the same `/run/` directory, we want to prevent either service from trying to clean the directory up after itself on restart.

Note that this is a strong signal that these services should in fact not be using the same `/run/` directory; we should probably do something like `/run/dashboard/web_server.sock` rather than `/run/unicorn/dashboard.sock`

## Links

https://www.freedesktop.org/software/systemd/man/systemd.exec.html#RuntimeDirectoryPreserve