### PR TITLE
Verify Successful Dashboard Service Start

### DIFF
--- a/aws/cloudformation/bootstrap_frontend.sh.erb
+++ b/aws/cloudformation/bootstrap_frontend.sh.erb
@@ -20,7 +20,10 @@ ps aux | grep "cluster worker" | grep dashboard | head -n 3 | tr --squeeze-repea
 export AWS_METADATA_SERVICE_TIMEOUT=30
 export AWS_METADATA_SERVICE_NUM_ATTEMPTS=30
 
-# Make sure server passes health check.
+# Ensure the instance launch has completed successfully by requesting the Health Check endpoint for Pegasus via nginx
+# (localhost:80/health_check) and also Dashboard directly via its Unix socket, bypassing nginx.
 # The status code determines success/failure of the instance launch.
 curl --silent --show-error --fail --retry 10 --retry-connrefused --retry-max-time 300 \
-  localhost:80/health_check > /dev/null
+  localhost:80/health_check > /dev/null \
+&& curl --silent --show-error --fail --retry 10 --retry-connrefused --retry-max-time 300 \
+  --unix-socket /run/unicorn/dashboard.sock localhost:80/health_check > /dev/null

--- a/aws/cloudformation/bootstrap_frontend.sh.erb
+++ b/aws/cloudformation/bootstrap_frontend.sh.erb
@@ -20,10 +20,10 @@ ps aux | grep "cluster worker" | grep dashboard | head -n 3 | tr --squeeze-repea
 export AWS_METADATA_SERVICE_TIMEOUT=30
 export AWS_METADATA_SERVICE_NUM_ATTEMPTS=30
 
-# Ensure the instance launch has completed successfully by requesting the Health Check endpoint for Pegasus via nginx
-# (localhost:80/health_check) and also Dashboard directly via its Unix socket, bypassing nginx.
+# Ensure the instance launch has completed successfully by requesting the Health Check endpoint for Pegasus
+# and  Dashboard via nginx (port 80), setting the Hostname to "studio" to ensure nginx routes the request to Dashboard.
 # The status code determines success/failure of the instance launch.
-curl --silent --show-error --fail --retry 10 --retry-connrefused --retry-max-time 300 \
-  localhost:80/health_check > /dev/null \
-&& curl --silent --show-error --fail --retry 10 --retry-connrefused --retry-max-time 300 \
-  --unix-socket /run/unicorn/dashboard.sock localhost:80/health_check > /dev/null
+curl --silent --show-error --fail --retry 10 --retry-connrefused --retry-max-time 300 --output /dev/null \
+  localhost:80/health_check \
+&& curl --silent --show-error --fail --retry 10 --retry-connrefused --retry-max-time 300 --output /dev/null \
+  -H "Host: studio" localhost:80/health_check


### PR DESCRIPTION
When the Auto Scaling Group launches a web application server EC2 Instance, verify that Dashboard has completed started successfully by invoking its health check endpoint before signaling to CloudFormation that the resource has provisioned successfully. Previously we were only verifying that nginx and Pegasus had started successfully.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

We don't have a reliable way to provision an adhoc with Auto Scaling Group enabled.  The updated bash command works on a production web application server:

``` bash
ubuntu@ip-10-0-0-194:~$ curl --silent --show-error --fail --retry 10 --retry-connrefused --retry-max-time 300 --output /dev/null \
>   localhost:80/health_check \
> && curl --silent --show-error --fail --retry 10 --retry-connrefused --retry-max-time 300 --output /dev/null \
>   -H "Host: studio" localhost:80/health_check
ubuntu@ip-10-0-0-194:~$ echo $?
0
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
