### PR TITLE
Add emergency mode to new project manager

### DIFF
--- a/apps/src/labs/projects/ProjectManager.ts
+++ b/apps/src/labs/projects/ProjectManager.ts
@@ -205,7 +205,8 @@ export default class ProjectManager {
     // project's 'last saved' time shown in the UI may be inaccurate for
     // all projects that were saved while emergency mode was active.
     if (!this.reduceChannelUpdates || !this.initialSaveComplete) {
-      // Always save the channel--either the channel has changed and/or the source changed.
+      // As long as we are not in emergency mode, always save the channel,
+      // as either the channel has changed and/or the source changed.
       // Even if only the source changed, we still update the channel to modify the last
       // updated time.
       this.channelToSave ||= this.lastChannel;
@@ -220,8 +221,6 @@ export default class ProjectManager {
       }
       const channelSaveResponse = await channelResponse.json();
       this.lastChannel = channelSaveResponse as Channel;
-    } else {
-      console.log('Skipping channel metadata update');
     }
 
     this.saveInProgress = false;

--- a/apps/src/labs/projects/ProjectManager.ts
+++ b/apps/src/labs/projects/ProjectManager.ts
@@ -55,7 +55,6 @@ export default class ProjectManager {
     this.channelsStore = channelsStore;
     this.reduceChannelUpdates = reduceChannelUpdates;
     this.initialSaveComplete = false;
-    console.log(`reduceChannelUpdates: ${reduceChannelUpdates}`);
   }
 
   // Load the project from the sources and channels store.
@@ -204,6 +203,7 @@ export default class ProjectManager {
     // the database. The main user-visible effect of this is that the
     // project's 'last saved' time shown in the UI may be inaccurate for
     // all projects that were saved while emergency mode was active.
+
     if (!this.reduceChannelUpdates || !this.initialSaveComplete) {
       // As long as we are not in emergency mode, always save the channel,
       // as either the channel has changed and/or the source changed.

--- a/apps/src/labs/projects/ProjectManager.ts
+++ b/apps/src/labs/projects/ProjectManager.ts
@@ -105,8 +105,6 @@ export default class ProjectManager {
     this.destroy();
   }
 
-  // TODO: Add functionality to reduce channel updates during
-  // HoC "emergency mode" (see 1182-1187 in project.js).
   /**
    * Enqueue a save to happen in the next saveInterval, unless a force save is requested.
    * If a save is already enqueued, update this.sourceToSave with the given source.
@@ -155,9 +153,6 @@ export default class ProjectManager {
   addSaveStartListener(listener: () => void) {
     this.saveStartListeners.push(listener);
   }
-
-  // TODO: Add rename function. Rename sets the name on the channel.
-  // https://codedotorg.atlassian.net/browse/SL-891
 
   /**
    * Helper function to save a project, called either after a timeout or directly by save().

--- a/apps/src/labs/projects/ProjectManagerFactory.ts
+++ b/apps/src/labs/projects/ProjectManagerFactory.ts
@@ -23,7 +23,8 @@ export default class ProjectManagerFactory {
     return new ProjectManager(
       this.getSourcesStore(projectManagerStorageType),
       this.getChannelsStore(projectManagerStorageType),
-      projectId
+      projectId,
+      false // reduceChannelUpdates will only be true for a project in a script.
     );
   }
 
@@ -43,11 +44,13 @@ export default class ProjectManagerFactory {
   ): Promise<ProjectManager> {
     const channelsStore = this.getChannelsStore(projectManagerStorageType);
     let channelId: string | undefined = undefined;
+    let reduceChannelUpdates = false;
     const response = await channelsStore.loadForLevel(levelId, scriptId);
     if (response.ok) {
       const responseBody = await response.json();
       if (responseBody && responseBody.channel) {
         channelId = responseBody.channel;
+        reduceChannelUpdates = responseBody.reduceChannelUpdates;
       }
     }
     if (!channelId) {
@@ -56,7 +59,8 @@ export default class ProjectManagerFactory {
     return new ProjectManager(
       this.getSourcesStore(projectManagerStorageType),
       channelsStore,
-      channelId
+      channelId,
+      reduceChannelUpdates
     );
   }
 


### PR DESCRIPTION
We have the concept of "emergency mode" during hour of code, which allows us to reduce channel updates for a given script during periods of high usage. This PR updates the get project for level api to also query the gatekeeper setting `updateChannelOnSave`, and add the response to the object returned by the api. Previously we just returned `{channelId: <channelId>}`, now we return `{channelId: <channelId>, reduceChannelUpdates: <true/false>}`. We don't need to worry about emergency mode for projects that are not in the context of a script, because we only use emergency mode for projects inside a script (standalone projects are never in emergency mode).  We then use the `reduceChannelUpdates` value in the ProjectManager to decide if we should send channel updates after our first save.


## Links
- jira ticket: [SL-803](https://codedotorg.atlassian.net/browse/SL-803)


## Testing story
Tested locally by turning on emergency mode for `allthethings` and seeing that we were correctly reducing channel updates. If emergency mode was not on, we don't reduce channel updates.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
