### PR TITLE
disable flaky application dashboard tests

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application_dashboard.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application_dashboard.feature
@@ -14,7 +14,9 @@ Feature: Teacher Application Dashboard
     And I press the first ".Select-option" element
     Then I wait until element "span:contains('Withdrawn')" is visible
     And I wait until element "td:contains('Unreviewed')" is not visible
-    And I see no difference for "Admin Course View"
+    # Eyes snapshot temporarily disabled due to flakiness.
+    # Fix tracked here: https://codedotorg.atlassian.net/browse/ACQ-620
+    # And I see no difference for "Admin Course View"
 
     # Access the Detail View by navigating to the first row's "view application" button href
     # rather than clicking so it does not open in a new tab.
@@ -33,5 +35,7 @@ Feature: Teacher Application Dashboard
     Then I wait until element "table#summary-csp-teachers" is visible
     Then I click selector "table#summary-csp-teachers ~ .btn:contains(View accepted cohort)"
     Then I wait until element "table#cohort-view" is visible
-    And I see no difference for "Admin Cohort View"
+    # Eyes snapshot temporarily disabled due to flakiness.
+    # Fix tracked here: https://codedotorg.atlassian.net/browse/ACQ-620
+    # And I see no difference for "Admin Cohort View"
     And I close my eyes


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/ACQ-670 . I chose which eyes diffs to disable based on the diffs here: https://eyes.applitools.com/app/test-results/00000251714757694606/?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110

![Screenshot 2023-06-26 at 11 35 46 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/0e00e886-8dff-4904-a77f-498e0feed52d)
