### PR TITLE
Project Beats: remove step/level index from ProgressManager

### DIFF
--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -29,6 +29,7 @@ import {setVerified} from '@cdo/apps/code-studio/verifiedInstructorRedux';
 import {authorizeLockable} from './lessonLockRedux';
 import {updateBrowserForLevelNavigation} from './browserNavigation';
 import {TestResults} from '@cdo/apps/constants';
+import {nextLevelId} from './progressReduxSelectors';
 
 interface ProgressState {
   currentLevelId: string | null;
@@ -296,6 +297,17 @@ export function navigateToLevelId(levelId: string): ProgressThunkAction {
 
     updateBrowserForLevelNavigation(state, newLevel.url, levelId);
     dispatch(setCurrentLevelId(levelId));
+  };
+}
+
+// Navigate to the next level in the progression, if it exists.
+export function navigateToNextLevel(): ProgressThunkAction {
+  return (dispatch, getState) => {
+    const levelId = nextLevelId(getState());
+    if (levelId === undefined) {
+      return;
+    }
+    dispatch(navigateToLevelId(levelId));
   };
 }
 

--- a/apps/src/code-studio/progressReduxSelectors.js
+++ b/apps/src/code-studio/progressReduxSelectors.js
@@ -207,6 +207,47 @@ export const levelsForLessonId = (state, lessonId) => {
   );
 };
 
+/**
+ * Get the index of the current level. On script levels, check
+ * which level has isCurrentLevel set. For single levels, return 0.
+ * Otherwise, return undefined.
+ */
+export const currentLevelIndex = state => {
+  if (getProgressLevelType(state) === ProgressLevelType.LEVEL) {
+    return 0;
+  }
+  if (getProgressLevelType(state) === ProgressLevelType.SCRIPT_LEVEL) {
+    return levelsForLessonId(
+      state.progress,
+      state.progress.currentLessonId
+    ).findIndex(level => level.isCurrentLevel);
+  }
+  return undefined;
+};
+
+/**
+ * Get the next level ID in the progression if it exists.
+ * Returns undefined if not currently in a script level or
+ * currently on the last level.
+ */
+export const nextLevelId = state => {
+  if (getProgressLevelType(state) !== ProgressLevelType.SCRIPT_LEVEL) {
+    return undefined;
+  }
+
+  const levels = levelsForLessonId(
+    state.progress,
+    state.progress.currentLessonId
+  );
+  const currentLevelIndex = levels.findIndex(level => level.isCurrentLevel);
+  if (currentLevelIndex === levels.length - 1) {
+    return undefined;
+  }
+
+  const nextLevel = levels[currentLevelIndex + 1];
+  return nextLevel.id;
+};
+
 export const lessonExtrasUrl = (state, lessonId) =>
   state.lessonExtrasEnabled
     ? state.lessons.find(lesson => lesson.id === lessonId)

--- a/apps/src/music/progress/ProgressManager.ts
+++ b/apps/src/music/progress/ProgressManager.ts
@@ -14,13 +14,11 @@ export abstract class Validator {
 
 // The current progress state.
 export interface ProgressState {
-  step: number;
   satisfied: boolean;
   message: string | null;
 }
 
 export const initialProgressState: ProgressState = {
-  step: 0,
   satisfied: false,
   message: null,
 };
@@ -31,22 +29,20 @@ export default class ProgressManager {
   private onProgressChange: () => void;
   private currentProgressState: ProgressState;
 
-  constructor(
-    initialStep: number | undefined,
-    validator: Validator,
-    onProgressChange: () => void
-  ) {
+  constructor(validator: Validator, onProgressChange: () => void) {
     this.levelData = undefined;
     this.validator = validator;
     this.onProgressChange = onProgressChange;
     this.currentProgressState = initialProgressState;
-    if (initialStep !== undefined) {
-      this.currentProgressState.step = initialStep;
-    }
   }
 
-  setLevelData(levelData: LevelData) {
+  /**
+   * Update the ProgressManager with level data for a new level.
+   * Resets validation status internally.
+   */
+  onLevelChange(levelData: LevelData) {
     this.levelData = levelData;
+    this.resetValidation();
   }
 
   getCurrentState(): ProgressState {
@@ -93,19 +89,10 @@ export default class ProgressManager {
     this.onProgressChange();
   }
 
-  // Advance to the next step.  Advances the state internally and calls
-  // the change handler.
-  next(): void {
-    this.goToStep(this.currentProgressState.step + 1);
-  }
-
-  // Go to a specific step.  Adjusts the state internally and calls the
-  // change handler.
-  goToStep(specificStep: number): void {
+  private resetValidation() {
     // Give the lab the chance to clear accumulated satisfied conditions.
     this.validator.clear();
 
-    this.currentProgressState.step = specificStep;
     this.currentProgressState.satisfied = false;
     this.currentProgressState.message = null;
 


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/52417. This simplifies some logic around managing level index and current step inside the ProgressManager as it no longer needs to. Any time a new level is loaded, level data will be loaded by lab redux and we'll refresh the ProgressManager automatically. This also moves some of the level index calculation logic out of MusicView and into progressReduxSelectors.

## Links

https://codedotorg.atlassian.net/browse/SL-921

## Testing story

Tested locally.