### PR TITLE
Update code.org/ai blue callout banner

### DIFF
--- a/i18n/locales/source/hourofcode/en.yml
+++ b/i18n/locales/source/hourofcode/en.yml
@@ -222,10 +222,6 @@
   teachai_launch_blog_desc_01: "Education, nonprofit, and tech leaders come together to offer guidance on integrating AI safely into classrooms worldwide"
   teachai_launch_blog_desc_02: "TeachAI aims to integrate AI education into primary and secondary curricula around the world through new reports, policy recommendations, and public engagement opportunities."
 
-  ai_pl_callout_title: "Join us for AI EmpowerED!"
-  ai_pl_callout_desc_01: "Discover the transformative potential of artificial intelligence (AI) in education with our free online learning series for educators."
-  ai_pl_callout_desc_02: "Sign up for 'Fireside Chat with Sal Khan and Hadi Partovi' where the founders of Khan Academy and Code.org to discover how generative AI can become your most reliable teaching assistant."
-
   ai_hero_heading: "Artificial intelligence isn't magic… It's just code!"
   ai_hero_desc: "Demystify artificial intelligence (AI) by learning how it's changing the ways we live, work, and learn."
   ai_intro_heading: "Why learn about AI?"

--- a/i18n/locales/source/hourofcode/en.yml
+++ b/i18n/locales/source/hourofcode/en.yml
@@ -222,6 +222,10 @@
   teachai_launch_blog_desc_01: "Education, nonprofit, and tech leaders come together to offer guidance on integrating AI safely into classrooms worldwide"
   teachai_launch_blog_desc_02: "TeachAI aims to integrate AI education into primary and secondary curricula around the world through new reports, policy recommendations, and public engagement opportunities."
 
+  ai_pl_callout_title: "Join us for AI EmpowerED!"
+  ai_pl_callout_desc_01: "Discover the transformative potential of artificial intelligence (AI) in education with our free online learning series for educators."
+  ai_pl_callout_desc_02: "Sign up for 'Fireside Chat with Sal Khan and Hadi Partovi' where the founders of Khan Academy and Code.org to discover how generative AI can become your most reliable teaching assistant."
+
   ai_hero_heading: "Artificial intelligence isn't magic… It's just code!"
   ai_hero_desc: "Demystify artificial intelligence (AI) by learning how it's changing the ways we live, work, and learn."
   ai_intro_heading: "Why learn about AI?"

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -47,7 +47,6 @@ class DCDOBase < DynamicConfigBase
       'webserial-on-chromeos': DCDO.get('webserial-on-chromeos', true),
       'csta-form-extension': DCDO.get('csta-form-extension', false),
       'pl-launch-hero-banner': DCDO.get('pl-launch-hero-banner', false),
-      'teach-ai-launch-2023': DCDO.get('teach-ai-launch-2023', false)
     }
   end
 end

--- a/pegasus/sites.v3/code.org/public/ai.haml
+++ b/pegasus/sites.v3/code.org/public/ai.haml
@@ -20,11 +20,10 @@ theme: responsive_full_width
     .text-wrapper.col-60
       %h1{style: "color: white"}=hoc_s(:ai_hero_heading)
       %p{style: "color: white"}=hoc_s(:ai_hero_desc)
-      - if !!DCDO.get('teach-ai-launch-2023', false)
-        %a.link-button.has-icon{href: "#teach-ai-callout"}
-          %div.flex-wrapper
-            %i{class: "#{icon_megaphone}"}
-            =hoc_s(:call_to_action_special_announcement)
+      %a.link-button.has-icon{href: "#teach-ai-callout"}
+        %div.flex-wrapper
+          %i{class: "#{icon_megaphone}"}
+          =hoc_s(:call_to_action_special_announcement)
     %figure.col-33{style: "float: right"}
       %img.fade-in-out{src: "/images/banners/ai-bot-wizard.svg", alt: "", style: "z-index: 10"}
       %img{src: "/images/banners/ai-bot-default.svg", alt: "", style: "position: relative;"}
@@ -59,16 +58,16 @@ theme: responsive_full_width
             %p.no-margin-bottom=hoc_s(:ai_intro_list_desc_03)
     .clear
 
-- if !!DCDO.get('teach-ai-launch-2023', false)
-  %section.bg-primary-light.blog-post-callout{id: "teach-ai-callout"}
-    .wrapper
-      %i{class: "#{icon_megaphone}"}
-      .text-wrapper
-        %h2.heading-lg=hoc_s(:teachai_launch_blog_title)
-        %p
-          %strong=hoc_s(:teachai_launch_blog_desc_01)
-        %p.body-two=hoc_s(:teachai_launch_blog_desc_02)
-        %a.link-button{href: "https://teachai.org/launch", target: "_blank", rel: "noopener noreferrer"}=hoc_s(:call_to_action_read_more)
+
+%section.bg-primary-light.blog-post-callout{id: "teach-ai-callout"}
+  .wrapper
+    %i{class: "#{icon_megaphone}"}
+    .text-wrapper
+      %h2.heading-lg=hoc_s(:teachai_launch_blog_title)
+      %p
+        %strong=hoc_s(:teachai_launch_blog_desc_01)
+      %p.body-two=hoc_s(:teachai_launch_blog_desc_02)
+      %a.link-button{href: "https://teachai.org/launch", target: "_blank", rel: "noopener noreferrer"}=hoc_s(:call_to_action_read_more)
 
 %section.bg-neutral-light
   .wrapper

--- a/pegasus/sites.v3/code.org/public/ai.haml
+++ b/pegasus/sites.v3/code.org/public/ai.haml
@@ -20,7 +20,7 @@ theme: responsive_full_width
     .text-wrapper.col-60
       %h1{style: "color: white"}=hoc_s(:ai_hero_heading)
       %p{style: "color: white"}=hoc_s(:ai_hero_desc)
-      %a.link-button.has-icon{href: "#teach-ai-callout"}
+      %a.link-button.has-icon{href: "#ai-pl-callout"}
         %div.flex-wrapper
           %i{class: "#{icon_megaphone}"}
           =hoc_s(:call_to_action_special_announcement)
@@ -59,15 +59,15 @@ theme: responsive_full_width
     .clear
 
 
-%section.bg-primary-light.blog-post-callout{id: "teach-ai-callout"}
+%section.bg-primary-light.blog-post-callout{id: "ai-pl-callout"}
   .wrapper
     %i{class: "#{icon_megaphone}"}
     .text-wrapper
-      %h2.heading-lg=hoc_s(:teachai_launch_blog_title)
+      %h2.heading-lg=hoc_s(:ai_pl_callout_title)
       %p
-        %strong=hoc_s(:teachai_launch_blog_desc_01)
-      %p.body-two=hoc_s(:teachai_launch_blog_desc_02)
-      %a.link-button{href: "https://teachai.org/launch", target: "_blank", rel: "noopener noreferrer"}=hoc_s(:call_to_action_read_more)
+        %strong=hoc_s(:ai_pl_callout_desc_01)
+      %p.body-two=hoc_s(:ai_pl_callout_desc_02)
+      %a.link-button{href: "https://code.zoom.us/webinar/register/8616874889915/WN_TGKpfOD8Rw-z5Q-D3ZiuLQ", target: "_blank", rel: "noopener noreferrer"}=hoc_s(:signup_submit_label)
 
 %section.bg-neutral-light
   .wrapper

--- a/pegasus/sites.v3/code.org/views/ai_skinny_banner_2023.haml
+++ b/pegasus/sites.v3/code.org/views/ai_skinny_banner_2023.haml
@@ -1,13 +1,13 @@
-- if !!DCDO.get('teach-ai-launch-2023', false)
-  = inline_css '/generated/ai-skinny-banner-2023.css'
 
-  .ai-skinny-banner-2023-default
-    %a{href: "/ai"}
-      .wrapper
-        %img{src: "/images/banners/ai-bot-crop.svg", alt: ""}
-        .text-wrapper
-          %h1=hoc_s(:ai_2023_banner_title)
-          %p=hoc_s(:ai_2023_banner_skinny_desc)
-        .button-wrapper
-          %button=hoc_s(:call_to_action_learn_more)
-      .clear
+= inline_css '/generated/ai-skinny-banner-2023.css'
+
+.ai-skinny-banner-2023-default
+  %a{href: "/ai"}
+    .wrapper
+      %img{src: "/images/banners/ai-bot-crop.svg", alt: ""}
+      .text-wrapper
+        %h1=hoc_s(:ai_2023_banner_title)
+        %p=hoc_s(:ai_2023_banner_skinny_desc)
+      .button-wrapper
+        %button=hoc_s(:call_to_action_learn_more)
+    .clear

--- a/pegasus/sites.v3/code.org/views/homepage_teach_ai_banner.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_teach_ai_banner.haml
@@ -1,13 +1,12 @@
-- if !!DCDO.get('teach-ai-launch-2023', false)
-  = inline_css 'generated/homepage-teach-ai-banner.css'
+= inline_css 'generated/homepage-teach-ai-banner.css'
 
-  .homepage-teach-ai-banner
-    %a{href: "https://teachai.org/launch/", target: "_blank", rel: "noopener noreferrer"}
-      .wrapper
-        %img{src: "/images/banners/teach-ai-logo-cutout.svg", alt: ""}
-        .text-wrapper
-          %h1=hoc_s(:teach_ai_homepage_banner_title)
-          %p=hoc_s(:teach_ai_homepage_banner_desc)
-        .button-wrapper
-          %button=hoc_s(:call_to_action_learn_more)
-  .clear
+.homepage-teach-ai-banner
+  %a{href: "https://teachai.org/launch/", target: "_blank", rel: "noopener noreferrer"}
+    .wrapper
+      %img{src: "/images/banners/teach-ai-logo-cutout.svg", alt: ""}
+      .text-wrapper
+        %h1=hoc_s(:teach_ai_homepage_banner_title)
+        %p=hoc_s(:teach_ai_homepage_banner_desc)
+      .button-wrapper
+        %button=hoc_s(:call_to_action_learn_more)
+.clear

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -250,6 +250,10 @@
   teachai_launch_blog_desc_01: "Education, nonprofit, and tech leaders come together to offer guidance on integrating AI safely into classrooms worldwide"
   teachai_launch_blog_desc_02: "TeachAI aims to integrate AI education into primary and secondary curricula around the world through new reports, policy recommendations, and public engagement opportunities."
 
+  ai_pl_callout_title: "Join us for AI EmpowerED!"
+  ai_pl_callout_desc_01: "Discover the transformative potential of artificial intelligence (AI) in education with our free online learning series for educators."
+  ai_pl_callout_desc_02: 'Sign up for "Fireside Chat with Sal Khan and Hadi Partovi" where the founders of Khan Academy and Code.org discover how generative AI can become your most reliable teaching assistant.'
+
   ai_hero_heading: "Artificial intelligence isn't magic… It's just code!"
   ai_hero_desc: "Demystify artificial intelligence (AI) by learning how it's changing the ways we live, work, and learn."
   ai_intro_heading: "Why learn about AI?"


### PR DESCRIPTION
Updated the blue banner on code.org/ai to push to registration for the first webinar in the AI PL series so that our google ads will help with conversion before we have the landing page fully up. 

Put the translations in and not sure how to show the actual text but you can see it in the PR.

Also removed the teach AI DCDO

<img width="1034" alt="Screenshot 2023-06-27 at 7 12 55 AM" src="https://github.com/code-dot-org/code-dot-org/assets/208083/e8de120a-9d3a-4c82-b533-dca6f22400f1">
