### PR TITLE
Fix saving error on Music Lab single level pages

### DIFF
--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -31,7 +31,7 @@ import {updateBrowserForLevelNavigation} from './browserNavigation';
 import {TestResults} from '@cdo/apps/constants';
 import {nextLevelId} from './progressReduxSelectors';
 
-interface ProgressState {
+export interface ProgressState {
   currentLevelId: string | null;
   currentLessonId: number | undefined;
   deeperLearningCourse: boolean | null;

--- a/apps/src/labs/labRedux.ts
+++ b/apps/src/labs/labRedux.ts
@@ -60,7 +60,7 @@ const initialState: LabState = {
 export const setUpForLevel = createAsyncThunk(
   'lab/setUpForLevel',
   async (
-    payload: {levelId: number; scriptId: number; levelPropertiesPath: string},
+    payload: {levelId: number; scriptId?: number; levelPropertiesPath: string},
     thunkAPI
   ) => {
     // Check for an existing project manager and clean it up, if it exists.

--- a/apps/src/labs/projects/ProjectContainer.tsx
+++ b/apps/src/labs/projects/ProjectContainer.tsx
@@ -12,6 +12,7 @@ import LabRegistry from '../LabRegistry';
 import {loadProject, setUpForLevel} from '../labRedux';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {getLevelPropertiesPath} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {ProgressState} from '@cdo/apps/code-studio/progressRedux';
 
 const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
   children,
@@ -24,7 +25,7 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
   );
   // TODO: Convert progress redux to typescript so this can be typed better
   const scriptId = useSelector(
-    (state: {progress: {scriptId: number}}) => state.progress.scriptId
+    (state: {progress: ProgressState}) => state.progress.scriptId || undefined
   );
 
   const levelPropertiesPath = useSelector(getLevelPropertiesPath);

--- a/apps/src/labs/projects/ProjectContainer.tsx
+++ b/apps/src/labs/projects/ProjectContainer.tsx
@@ -46,7 +46,7 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
         )
       );
       promise = dispatch(loadProject());
-    } else {
+    } else if (currentLevelId !== null) {
       promise = dispatch(
         setUpForLevel({
           levelId: parseInt(currentLevelId),

--- a/apps/src/labs/projects/ProjectContainer.tsx
+++ b/apps/src/labs/projects/ProjectContainer.tsx
@@ -19,11 +19,8 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
   channelId,
 }) => {
   const currentLevelId = useSelector(
-    // TODO: Convert progress redux to typescript so this can be typed better
-    (state: {progress: {currentLevelId: string}}) =>
-      state.progress.currentLevelId
+    (state: {progress: ProgressState}) => state.progress.currentLevelId
   );
-  // TODO: Convert progress redux to typescript so this can be typed better
   const scriptId = useSelector(
     (state: {progress: ProgressState}) => state.progress.scriptId || undefined
   );


### PR DESCRIPTION
Quick fix for an issue @breville spotted. Occasionally on Music Lab single levels (levels/xxxxx pages), we'd see console errors on save. 

<img width="610" alt="Screenshot 2023-06-27 at 11 18 52 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/d6657c4e-bf8d-4e1f-a690-f2e1af57a49a">

One reason for this is that we were trying to hit the projects channels API (script/id/level/id) endpoint with a `null` script ID, (script/null/level/12345). 

<img width="559" alt="Screenshot 2023-06-27 at 11 20 07 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/9d526002-ac04-4311-97be-5ac05dad214b">

We have logic to not include the script ID if it's not present, but that was looking for `undefined` while the value being passed was `null`. The fix is just to pass an `undefined` value if script Id is not present - but we can also make use of the ProgressState type for better type inference now that the progress redux store is in TypeScript.