### PR TITLE
[LTI] Authenticate Controller v1

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -59,7 +59,6 @@ class LtiV1Controller < ApplicationController
 
     # verify the jwt via the integration's public keyset
     decoded_jwt = get_decoded_jwt(integration, id_token)
-    # decoded_jwt = decoded_jwt_no_auth
 
     jwt_verifier = JwtVerifier.new(decoded_jwt, integration)
 

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -42,10 +42,46 @@ class LtiV1Controller < ApplicationController
     redirect_to auth_redirect_url.to_s
   end
 
+  def authenticate
+    id_token = params[:id_token]
+    return unauthorized_status unless id_token
+    begin
+      decoded_jwt_no_auth = JSON::JWT.decode(id_token, :skip_verification)
+    rescue
+      return unauthorized_status
+    end
+    # client_id is the aud[ience] in the JWT
+    extracted_client_id = decoded_jwt_no_auth[:aud]
+    extracted_issuer_id = decoded_jwt_no_auth[:iss]
+
+    integration = LtiIntegration.find_by({client_id: extracted_client_id, issuer: extracted_issuer_id})
+    return unauthorized_status unless integration
+
+    # verify the jwt via the integration's public keyset
+    decoded_jwt = get_decoded_jwt(integration, id_token)
+    # decoded_jwt = decoded_jwt_no_auth
+
+    jwt_verifier = JwtVerifier.new(decoded_jwt, integration)
+
+    if jwt_verifier.verify_jwt
+      target_link_uri = decoded_jwt_no_auth[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri']
+      redirect_to target_link_uri
+    else
+      return unauthorized_status(*jwt_verifier.errors)
+    end
+  end
+
+  def get_decoded_jwt(integration, id_token)
+    public_jwk_url = integration.jwks_url
+    response = JSON.parse(HTTParty.get(public_jwk_url).body)
+    jwk_set = JSON::JWK::Set.new response
+    JSON::JWT.decode(id_token, jwk_set)
+  end
+
   private
 
-  def unauthorized_status
-    render(status: :unauthorized, json: {error: 'Unauthorized'})
+  def unauthorized_status(error = 'Unauthorized')
+    render(status: :unauthorized, json: {error: error})
   end
 
   def create_and_set_nonce

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -63,10 +63,10 @@ class LtiV1Controller < ApplicationController
     jwt_verifier = JwtVerifier.new(decoded_jwt, integration)
 
     if jwt_verifier.verify_jwt
-      target_link_uri = decoded_jwt_no_auth[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri']
+      target_link_uri = decoded_jwt[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri']
       redirect_to target_link_uri
     else
-      return unauthorized_status(*jwt_verifier.errors)
+      return unauthorized_status
     end
   end
 
@@ -79,8 +79,8 @@ class LtiV1Controller < ApplicationController
 
   private
 
-  def unauthorized_status(error = 'Unauthorized')
-    render(status: :unauthorized, json: {error: error})
+  def unauthorized_status
+    render(status: :unauthorized, json: {error: 'Unauthorized'})
   end
 
   def create_and_set_nonce

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -57,8 +57,12 @@ class LtiV1Controller < ApplicationController
     integration = LtiIntegration.find_by({client_id: extracted_client_id, issuer: extracted_issuer_id})
     return unauthorized_status unless integration
 
-    # verify the jwt via the integration's public keyset
-    decoded_jwt = get_decoded_jwt(integration, id_token)
+    begin
+      # verify the jwt via the integration's public keyset
+      decoded_jwt = get_decoded_jwt(integration, id_token)
+    rescue
+      return unauthorized_status
+    end
 
     jwt_verifier = JwtVerifier.new(decoded_jwt, integration)
 

--- a/dashboard/app/helpers/jwt_verifier.rb
+++ b/dashboard/app/helpers/jwt_verifier.rb
@@ -1,0 +1,58 @@
+class JwtVerifier
+  attr_reader :errors
+
+  def initialize(jwt, integration)
+    @jwt = jwt
+    @integration = integration
+    @errors = []
+  end
+
+  def verify_jwt
+    verify_audience(@jwt)
+    verify_expiration(@jwt)
+    errors.empty?
+  end
+
+  private
+
+  def verify_audience(jwt)
+    if jwt.key? :aud
+      aud = jwt[:aud]
+      aud_array = [*aud]
+      errors << 'Audience must be a string or Array of strings.' unless aud_array.all?(String)
+      if jwt.key? :azp
+        verify_azp(aud, jwt[:azp])
+      else
+        errors << 'Audience does not match client_id' unless public_key_matches_one_of_client_ids(aud)
+      end
+    else
+      errors << 'Audience does not exist'
+    end
+  end
+
+  def verify_azp(aud, azp)
+    errors << 'Audience does not contain/match Authorized Party' unless azp_in_aud(aud, azp)
+    errors << 'Audience does not match client_id' unless public_key_matches_one_of_client_ids(aud)
+  end
+
+  def verify_expiration(jwt)
+    now = Time.zone.now
+    if jwt.key? :exp
+      errors << "Expiration time of #{jwt[:exp]} before #{now.to_i}" unless Time.zone.at(jwt[:exp]) > Time.zone.now
+    else
+      errors << 'Expiration time does not exist'
+    end
+  end
+
+  def azp_in_aud(aud, azp)
+    if aud.is_a? Array
+      aud.include? azp
+    else
+      aud == azp
+    end
+  end
+
+  def public_key_matches_one_of_client_ids(aud)
+    LtiIntegration.exists?(client_id: aud)
+  end
+end

--- a/dashboard/app/helpers/jwt_verifier.rb
+++ b/dashboard/app/helpers/jwt_verifier.rb
@@ -22,8 +22,6 @@ class JwtVerifier
       errors << 'Audience must be a string or Array of strings.' unless aud_array.all?(String)
       if jwt.key? :azp
         verify_azp(aud, jwt[:azp])
-      else
-        errors << 'Audience does not match client_id' unless public_key_matches_one_of_client_ids(aud)
       end
     else
       errors << 'Audience does not exist'
@@ -32,7 +30,6 @@ class JwtVerifier
 
   def verify_azp(aud, azp)
     errors << 'Audience does not contain/match Authorized Party' unless azp_in_aud(aud, azp)
-    errors << 'Audience does not match client_id' unless public_key_matches_one_of_client_ids(aud)
   end
 
   def verify_expiration(jwt)
@@ -50,9 +47,5 @@ class JwtVerifier
     else
       aud == azp
     end
-  end
-
-  def public_key_matches_one_of_client_ids(aud)
-    LtiIntegration.exists?(client_id: aud)
   end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -595,6 +595,7 @@ Dashboard::Application.routes.draw do
 
     # LTI API endpoints
     match '/lti/v1/login(/:platform_id)', to: 'lti_v1#login', via: [:get, :post]
+    post '/lti/v1/authenticate', to: 'lti_v1#login'
 
     get '/notes/:key', to: 'notes#index'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -595,7 +595,7 @@ Dashboard::Application.routes.draw do
 
     # LTI API endpoints
     match '/lti/v1/login(/:platform_id)', to: 'lti_v1#login', via: [:get, :post]
-    post '/lti/v1/authenticate', to: 'lti_v1#login'
+    post '/lti/v1/authenticate', to: 'lti_v1#authenticate'
 
     get '/notes/:key', to: 'notes#index'
 

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -1,8 +1,34 @@
+require 'json'
+require 'jwt'
 require "test_helper"
 
 class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   setup_all do
     @integration = create :lti_integration
+    # create an arbitrary key for testing JWTs
+    @key = SecureRandom.alphanumeric 10
+  end
+
+  def create_jwt(payload)
+    JWT.encode(payload, @key)
+  end
+
+  def create_valid_jwt(aud_is_array)
+    target_link_uri = @integration.auth_redirect_url
+    aud = if aud_is_array
+            [@integration.client_id]
+          else
+            @integration.client_id
+          end
+    payload = {
+      aud: aud,
+      iss: @integration.issuer,
+      azp: @integration.client_id,
+      exp: 7.days.from_now.to_i,
+      'https://purl.imsglobal.org/spec/lti/claim/target_link_uri': target_link_uri
+    }
+    LtiV1Controller.any_instance.stubs(:get_decoded_jwt).returns payload
+    create_jwt(payload)
   end
 
   test 'given no params, return unauthorized' do
@@ -55,5 +81,59 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_equal parsed_url[:login_hint], login_hint
     assert_not_nil parsed_url[:state]
     assert_not_nil parsed_url[:nonce]
+  end
+
+  test 'auth - given no params, return unauthorized' do
+    post '/lti/v1/authenticate'
+    assert_response :unauthorized
+  end
+
+  test 'auth - given no client_id (aud) in jwt return unauthorized' do
+    payload = {data: 'test'}
+    jwt = create_jwt(payload)
+    post '/lti/v1/authenticate', params: {id_token: jwt}
+    assert_response :unauthorized
+  end
+
+  test 'auth - given no issuer id in jwt return unauthorized' do
+    jwt = create_jwt({aud: @integration.client_id})
+    post '/lti/v1/authenticate', params: {id_token: jwt}
+    assert_response :unauthorized
+  end
+
+  test 'auth - given wrong client id in jwt return unauthorized' do
+    jwt = create_jwt({aud: ''})
+    post '/lti/v1/authenticate', params: {id_token: jwt}
+    assert_response :unauthorized
+  end
+
+  test 'auth - given audience as non-String return unauthorized' do
+  end
+
+  test 'auth - audience does not contain azp return unauthorized' do
+  end
+
+  test 'auth - audience does not match client_id with azp present - unauthorized' do
+  end
+
+  test 'auth - expiration time past return unauthorized' do
+  end
+
+  test 'auth - given audience not a client id return unauthorized' do
+  end
+
+  test 'auth - given a valid jwt with the audience as an array, redirect to target_link_url' do
+    aud_is_array = true
+    jwt = create_valid_jwt(aud_is_array)
+    post '/lti/v1/authenticate', params: {id_token: jwt}
+    assert_response :redirect
+  end
+
+  test 'auth - given a valid jwt, redirect to target_link_url' do
+    aud_is_array = false
+    jwt = create_valid_jwt(aud_is_array)
+    post '/lti/v1/authenticate', params: {id_token: jwt}
+    assert_response :redirect
+    # could confirm more things here
   end
 end


### PR DESCRIPTION
Create a /lti/v1/authenticate route and preliminary JWT validation

Jira ticket - https://codedotorg.atlassian.net/browse/P20-105

Modeled off of this Rails example - https://github.com/instructure/mc-lti-1.3-test-tool/blob/main/app/controllers/launch_controller.rb
(e.g. the jwt_verifier is very similar)

Spec doc - https://docs.google.com/document/d/1tTwAF40cnn2oUvK2CmRO-a5qYXkCR5rR5gBJS2-zV_U/edit#heading=h.3h1vv0tqoh3q

## Testing story

Two-fold testing story - testing with a live LMS running and writing tests.

### Live LMS Testing
1. Set up a locally running version of Canvas - https://github.com/instructure/canvas-lms/wiki/Quick-Start
2. Enroll your developer keys in Canvas - http://canvas.docker/accounts/site_admin/developer_keys
  a. the JWK is not used, so feel free to put whatever you want there
  b. Target Link URI, Redirect URI, OpenID Connect URI are very important
![Screenshot 2023-06-27 at 1 38 04 PM](https://github.com/code-dot-org/code-dot-org/assets/131800576/33d5b202-cbfc-4e0c-bf69-4ae710c88de0)
3. Add a module to your canvas class linking to the external site

![Screenshot 2023-06-27 at 1 41 47 PM](https://github.com/code-dot-org/code-dot-org/assets/131800576/f66825f7-557d-4749-bf95-44d18c2a4f36)

3. Add a LTI Integration into your db via `./bin/dashboard-console` matching the client_id

```
=> #<LtiIntegration id: 2, name: nil, platform_id: "5181590d-f11f-439c-9761-0bfbff127b8f", issuer: "https://canvas.instructure.com", client_id: "10000000000003", platform_name: "\ncanvas", auth_redirect_url: "http://canvas.docker/api/lti/authorize_redirect", jwks_url: "http://canvas.docker/api/lti/security/jwks", access_token_url: "http://canvas.docker/api/lti/access_token", admin_email: nil, created_at: "2023-06-22 01:53:17.160408000 +0000", updated_at: "2023-06-22 23:49:38.307061000 +0000">
```

4. Click the module and launch code.org from there! The `/lti/v1/login` endpoint should be hit, then redirected back to Canvas, then back to `/lti/v1/authenticate` then to `target_link_uri` what you provided in the developer keys step - http://localhost-studio.code.org:3000/courses for me.

![Screenshot 2023-06-27 at 1 42 22 PM](https://github.com/code-dot-org/code-dot-org/assets/131800576/112b399b-c417-4c16-816d-1b80ea32f723)


Screen Recording cause I think it's really cool

https://github.com/code-dot-org/code-dot-org/assets/131800576/91f2e251-3dbb-4c04-acfe-cda487f31945



### New tests

```
➜  dashboard git:(elf-p20-105-lti-auth) ✗ bundle exec spring testunit ./test/controllers/lti_v1_controller_test.rb
Running via Spring preloader in process 66165
Started with run options --seed 22815

  19/19: [===================================================================================================================================================================] 100% Time: 00:00:10, Time: 00:00:10

Finished in 11.01109s
19 tests, 24 assertions, 0 failures, 0 errors, 0 skips
➜  dashboard git:(elf-p20-105-lti-auth) ✗ 
```

## Security

This PR does not address the state and nonce part of the jira ticket as we decided to come up with a different approach for saving those between requests.

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
