### PR TITLE
[Google analytics] - Reorder custom dimension initialization 4/n

### DIFF
--- a/apps/src/lib/util/GoogleAnalyticsReporter.js
+++ b/apps/src/lib/util/GoogleAnalyticsReporter.js
@@ -78,8 +78,17 @@ class GoogleAnalyticsReporter {
     if (this.isGoogleAnalytics4Enabled) {
       gtag('js', new Date());
       window.dataLayer = window.dataLayer || [];
-      gtag('config', this.googleAnalyticsGTag);
+      const {userAnalyticsDimensions = {}} = window;
+      this.initializeCustomDimensions(userAnalyticsDimensions);
+      gtag('config', this.googleAnalyticsGTag, userAnalyticsDimensions);
     }
+  }
+
+  initializeCustomDimensions(userAnalyticsDimensions) {
+    Object.entries(userAnalyticsDimensions).forEach(([dimension, value]) => {
+      this.setCustomDimension(dimension, value);
+    });
+    this.setCustomDimension('anonymizeIp', true);
   }
 
   addEventListener() {

--- a/apps/src/sites/code.org/pages/views/theme_google_analytics.js
+++ b/apps/src/sites/code.org/pages/views/theme_google_analytics.js
@@ -1,11 +1,3 @@
 import googleAnalyticsReporter from '@cdo/apps/lib/util/GoogleAnalyticsReporter';
 
-const {userAnalyticsDimensions = {}} = window;
-
-Object.entries(userAnalyticsDimensions).forEach(([dimension, value]) => {
-  googleAnalyticsReporter.setCustomDimension(dimension, value);
-});
-
-googleAnalyticsReporter.setCustomDimension('anonymizeIp', true);
-
 googleAnalyticsReporter.sendPageView();

--- a/apps/src/sites/hourofcode.com/pages/views/theme_google_analytics.js
+++ b/apps/src/sites/hourofcode.com/pages/views/theme_google_analytics.js
@@ -1,11 +1,3 @@
 import googleAnalyticsReporter from '@cdo/apps/lib/util/GoogleAnalyticsReporter';
 
-const {userAnalyticsDimensions = {}} = window;
-
-Object.entries(userAnalyticsDimensions).forEach(([dimension, value]) => {
-  googleAnalyticsReporter.setCustomDimension(dimension, value);
-});
-
-googleAnalyticsReporter.setCustomDimension('anonymizeIp', true);
-
 googleAnalyticsReporter.sendPageView();


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
I am reordering the moment when the customs dimensions are initialized since I am sending the event "page_view" on ga4, before the dimensions are set. 
This takes care of it. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

- opened studio.code.org, code.org, hour of code.

Also used tag assistant to verify the data is there now:

![image](https://github.com/code-dot-org/code-dot-org/assets/108825710/ce17340b-4bc7-4be6-bf0b-3a2afe313f03)


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
