### PR TITLE
Add family_name to serialized_attrs

### DIFF
--- a/dashboard/app/models/follower.rb
+++ b/dashboard/app/models/follower.rb
@@ -58,9 +58,9 @@ class Follower < ApplicationRecord
   def remove_family_name
     # If the student is in zero sections, and has a family name set,
     # remove the family name.
-    if student_user.properties['family_name'] && student_user.sections_as_student.empty?
+    if student_user.family_name && student_user.sections_as_student.empty?
       # can't remove keys from properties directly, so just set it to nil.
-      student_user.properties['family_name'] = nil
+      student_user.family_name = nil
       student_user.save!
     end
   end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -136,6 +136,7 @@ class User < ApplicationRecord
     child_account_compliance_state_last_updated
     us_state
     country_code
+    family_name
   )
 
   attr_accessor(
@@ -1043,7 +1044,7 @@ class User < ApplicationRecord
 
       # Remove family name, in case it was set on the student account.
       if DCDO.get('family-name-features', false)
-        properties['family_name'] = nil
+        self.family_name = nil
         save!
       end
 
@@ -2056,7 +2057,7 @@ class User < ApplicationRecord
       id: id,
       name: name,
       username: username,
-      family_name: DCDO.get('family-name-features', false) ? properties&.dig('family_name') : nil,
+      family_name: DCDO.get('family-name-features', false) ? family_name : nil,
       email: email,
       hashed_email: hashed_email,
       user_type: user_type,

--- a/dashboard/test/models/follower_test.rb
+++ b/dashboard/test/models/follower_test.rb
@@ -79,15 +79,16 @@ class FollowerTest < ActiveSupport::TestCase
     DCDO.stubs(:get).with('family-name-features', false).returns(true)
 
     student = @follower.student_user
-    student.properties = {family_name: 'test'}
+    student.family_name = 'test'
     student.save!
+    student.reload
 
-    assert_equal 'test', student.properties['family_name']
+    assert_equal 'test', student.family_name
 
     @follower.destroy
     student.reload
 
-    assert_nil student.properties['family_name']
+    assert_nil student.family_name
 
     DCDO.unstub(:get)
   end
@@ -96,15 +97,16 @@ class FollowerTest < ActiveSupport::TestCase
     DCDO.stubs(:get).with('family-name-features', false).returns(false)
 
     student = @follower.student_user
-    student.properties = {family_name: 'test'}
+    student.family_name = 'test'
     student.save!
+    student.reload
 
-    assert_equal 'test', student.properties['family_name']
+    assert_equal 'test', student.family_name
 
     @follower.destroy
     student.reload
 
-    assert_equal 'test', student.properties['family_name']
+    assert_equal 'test', student.family_name
 
     DCDO.unstub(:get)
   end
@@ -113,17 +115,18 @@ class FollowerTest < ActiveSupport::TestCase
     DCDO.stubs(:get).with('family-name-features', false).returns(true)
 
     student = @follower.student_user
-    student.properties = {family_name: 'test'}
+    student.family_name = 'test'
     student.save!
+    student.reload
 
     create(:follower, student_user: student)
 
-    assert_equal 'test', student.properties['family_name']
+    assert_equal 'test', student.family_name
 
     @follower.destroy
     student.reload
 
-    assert_equal 'test', student.properties['family_name']
+    assert_equal 'test', student.family_name
 
     DCDO.unstub(:get)
   end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -2363,14 +2363,15 @@ class UserTest < ActiveSupport::TestCase
     DCDO.stubs(:get).with('family-name-features', false).returns(true)
 
     family_name = 'TestFamName'
-    user = User.create(@good_data.merge({properties: {family_name: family_name}}))
+    user = User.create(@good_data.merge({family_name: family_name}))
+    user.reload
 
-    assert_equal family_name, user.properties['family_name']
+    assert_equal family_name, user.family_name
 
     assert user.upgrade_to_teacher('example@email.com', email_preference_params)
 
     user.reload
-    assert_nil user.properties['family_name']
+    assert_nil user.family_name
 
     DCDO.unstub(:get)
   end
@@ -4788,7 +4789,7 @@ class UserTest < ActiveSupport::TestCase
   test 'family name is added to summarize' do
     user = create :user
     family_name = 'TestFamilyName'
-    user.properties = {family_name: family_name}
+    user.family_name = family_name
 
     assert_nil(user.summarize[:family_name])
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Add `user.properties['family_name']` to the User model's `serialized_attrs` list, and refactor the code to use that.

Followup to https://github.com/code-dot-org/code-dot-org/pull/52358#discussion_r1235589851, refactoring code introduced in #52358, #52334, and #52358.

Adding platform and infra to the review request list mostly as an FYI, since this change was already discussed in previous PRs.

Screenshots of the data still flowing in as expected:

![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/f9971f60-0863-4af7-9a21-d8e85e25eb4d)
![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/718cca1f-2b86-4ada-8514-a66bf11be0ce)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [Tech Spec: Sort by Family Name](https://docs.google.com/document/d/1uoQ64oZ2etQoXovkIJq-UH79UkSWQLf_EtuC9fCnWWQ/edit)


