### PR TITLE
Remove the CSC tile from self paced PL until launch

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/professional-development-online.haml
+++ b/pegasus/sites.v3/code.org/public/educate/professional-development-online.haml
@@ -86,25 +86,6 @@ theme: responsive_full_width
             =hoc_s(:call_to_action_explore_curriculum)
       .action-block.action-block--one-col.flex-space-between
         .content-wrapper
-          %p.overline=hoc_s(:module_grade_k_5_teachers)
-          %h3=hoc_s(:module_label_teaching_csc)
-          %img{src: "/images/self-paced-pl-tile-csc.png", alt: "", style: "width: 100%"}
-          %p
-            %strong=hoc_s(:module_label_curriculum)
-            =hoc_s(:curriculum_name_csc_02)
-          %p
-            %strong=hoc_s(:module_label_duration)
-            =hoc_s(:module_duration_2_hrs)
-          %p
-            %strong=hoc_s(:module_label_prerequisites)
-            =hoc_s(:module_prerequisites_none)
-        .content-footer
-          %a.link-button{href: CDO.studio_url("/s/self-paced-pl-csc-2023"), aria:{label: hoc_s(:aria_label_call_to_action_teaching_csc)}}
-            =hoc_s(:call_to_action_start_pl)
-          %a.link-button.secondary{href: "/educate/csc", aria:{label: hoc_s(:aria_label_call_to_action_curriculum_csc)}}
-            =hoc_s(:call_to_action_explore_curriculum)
-      .action-block.action-block--one-col.flex-space-between
-        .content-wrapper
           %p.overline=hoc_s(:module_grade_6_10_teachers)
           %h3=hoc_s(:module_label_teaching_csd)
           %img{src: "/images/self-paced-pl-tile-csd.png", alt: "", style: "width: 100%"}


### PR DESCRIPTION
Remove the CSC tile from the self paced PL page until July 10th launch. We will revert this on July 5th.

![Screenshot 2023-06-28 at 11 49 49 AM](https://github.com/code-dot-org/code-dot-org/assets/208083/779ad89c-f611-42bd-9e2e-2e1499012059)

