### PR TITLE
Change DOTD script to use Slack display_name

### DIFF
--- a/bin/cron/update_dotd
+++ b/bin/cron/update_dotd
@@ -18,7 +18,7 @@ def main
 
   primary_dotd_user = nil
   if primary_dotd_email
-    primary_dotd_user = Slack.user_name(primary_dotd_email)
+    primary_dotd_user = Slack.display_name(primary_dotd_email)
   end
   primary_dotd_user ||= '(ERROR: check schedule)'
 

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -36,17 +36,19 @@ class Slack
   SLACK_TOKEN = CDO.methods.include?(:slack_token) ? CDO.slack_token.freeze : nil
   SLACK_BOT_TOKEN = CDO.methods.include?(:slack_bot_token) ? CDO.slack_bot_token.freeze : nil
 
-  # Returns the user (mention) name of the user.
+  # Returns the Slack display_name of the user.
+  # WARNING: Slack has deprecated the 'name' field in their users API. Use this method
+  # instead. Source: https://api.slack.com/types/user
   # WARNING: Does not include the mention character '@'.
   # @param email [String] The email of the Slack user.
   # @raise [ArgumentError] If the email does not correspond to a Slack user.
-  # @return [nil | String] The user (mention) name for the Slack user.
-  def self.user_name(email)
+  # @return [nil | String] The display name for the Slack user.
+  def self.display_name(email)
     members = post_to_slack("https://slack.com/api/users.list")['members']
     raise "Failed to query users.list" unless members
     user = members.find {|member| email == member['profile']['email']}
     raise "Slack email #{email} not found" unless user
-    user['name']
+    user['display_name']
   end
 
   def self.user_id(name)


### PR DESCRIPTION
- Adds a new method to the Slack lib to retrieve `display_name` instead of `name`, which is now deprecated.
- Removes the method that retrieves the deprecated name field.
- Switches the update_dotd script to use display_name instead.

This should fix the problem with Brian's name in the DOTD topic being `brian261`: https://codedotorg.slack.com/archives/C0T0PNTM3/p1687960847743839

Some examples of `name` vs. `display_name`:
```
{
    "name"=>"brian261", 
    "display_name"=>"Brian",
}

{
    "name"=>"carl.reiner",
    "display_name"=>"carl",
}

{
    "name"=>"erin.ferreirae",
    "display_name"=>"elf",
}
```

Note: I searched and didn't see any other references to the `Slack.user_name` function

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
