### PR TITLE
Disallow family name on teachers/PL participants

### DIFF
--- a/dashboard/app/models/follower.rb
+++ b/dashboard/app/models/follower.rb
@@ -52,7 +52,7 @@ class Follower < ApplicationRecord
   validate :cannot_follow_yourself, unless: -> {deleted?}
   validate :teacher_must_be_teacher, unless: -> {deleted?}
   validate :student_cannot_be_admin
-  validate :pl_participant_cannot_have_family_name, if: proc {DCDO.get('family-name-features', false)}
+  validate :pl_participant_cannot_have_family_name
 
   validates_presence_of :student_user, unless: -> {deleted?}
   validates_presence_of :section, unless: -> {deleted?}

--- a/dashboard/app/models/follower.rb
+++ b/dashboard/app/models/follower.rb
@@ -42,9 +42,17 @@ class Follower < ApplicationRecord
     errors.add(:student_user, 'cannot be admin') if student_user.admin?
   end
 
+  def pl_participant_cannot_have_family_name
+    return unless section && student_user
+    if section.pl_section? && student_user.family_name
+      errors.add(:student_user, 'cannot have family_name as a PL participant')
+    end
+  end
+
   validate :cannot_follow_yourself, unless: -> {deleted?}
   validate :teacher_must_be_teacher, unless: -> {deleted?}
   validate :student_cannot_be_admin
+  validate :pl_participant_cannot_have_family_name, if: proc {DCDO.get('family-name-features', false)}
 
   validates_presence_of :student_user, unless: -> {deleted?}
   validates_presence_of :section, unless: -> {deleted?}

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -555,7 +555,7 @@ class User < ApplicationRecord
 
   before_save :remove_cleartext_emails, if: -> {student? && migrated? && user_type_changed?}
 
-  validate :no_family_name_for_teachers, if: -> {DCDO.get('family-name-features', false)}
+  validate :no_family_name_for_teachers
   def no_family_name_for_teachers
     if family_name && (teacher? || sections_as_pl_participant.any?)
       errors.add(:family_name, "can't be set for teachers or PL participants")

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -555,6 +555,8 @@ class User < ApplicationRecord
 
   before_save :remove_cleartext_emails, if: -> {student? && migrated? && user_type_changed?}
 
+  before_save :remove_family_name, if: -> {DCDO.get('family-name-features', false) && sections_as_pl_participant.any?}
+
   before_validation :update_share_setting, unless: :under_13?
 
   def make_teachers_21
@@ -629,6 +631,12 @@ class User < ApplicationRecord
   # in migrated students' AuthenticationOptions.
   def remove_cleartext_emails
     authentication_options.with_deleted.update_all(email: '')
+  end
+
+  # Remove family name from properties.
+  # Record must be saved afterwards to persist to database.
+  def remove_family_name
+    self.family_name = nil
   end
 
   # Given a cleartext email finds the first user that has a matching email or hash.

--- a/dashboard/test/models/follower_test.rb
+++ b/dashboard/test/models/follower_test.rb
@@ -112,6 +112,9 @@ class FollowerTest < ActiveSupport::TestCase
   end
 
   test 'cannot create a follower for a PL section and a user with a family name' do
+    # Provide a default stub, so the CI doesn't get tripped up on random other
+    # DCDO calls when creating the follower.
+    DCDO.stubs(:get).returns(false)
     DCDO.stubs(:get).with('family-name-features', false).returns(true)
 
     teacher = create(:teacher)

--- a/dashboard/test/models/follower_test.rb
+++ b/dashboard/test/models/follower_test.rb
@@ -111,26 +111,6 @@ class FollowerTest < ActiveSupport::TestCase
     DCDO.unstub(:get)
   end
 
-  test 'cannot create a follower for a PL section and a user with a family name' do
-    # Provide a default stub, so the CI doesn't get tripped up on random other
-    # DCDO calls when creating the follower.
-    DCDO.stubs(:get).returns(false)
-    DCDO.stubs(:get).with('family-name-features', false).returns(true)
-
-    teacher = create(:teacher)
-    pl_section = create :section, :teacher_participants, user_id: teacher.id
-
-    pl_participant = create(:user)
-    pl_participant.family_name = 'TestFamName'
-    pl_participant.save!
-
-    assert_raises(ActiveRecord::RecordInvalid) do
-      create :follower, section: pl_section, student_user: pl_participant
-    end
-
-    DCDO.unstub(:get)
-  end
-
   test 'deleting one of many followers keeps the associated student family name' do
     DCDO.stubs(:get).with('family-name-features', false).returns(true)
 
@@ -149,5 +129,18 @@ class FollowerTest < ActiveSupport::TestCase
     assert_equal 'test', student.family_name
 
     DCDO.unstub(:get)
+  end
+
+  test 'cannot create a follower for a PL section and a user with a family name' do
+    teacher = create(:teacher)
+    pl_section = create :section, :teacher_participants, user_id: teacher.id
+
+    pl_participant = create(:user)
+    pl_participant.family_name = 'TestFamName'
+    pl_participant.save!
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      create :follower, section: pl_section, student_user: pl_participant
+    end
   end
 end

--- a/dashboard/test/models/follower_test.rb
+++ b/dashboard/test/models/follower_test.rb
@@ -122,8 +122,7 @@ class FollowerTest < ActiveSupport::TestCase
     pl_participant.save!
 
     assert_raises(ActiveRecord::RecordInvalid) do
-      #create :follower, student_user
-      Follower.create!(section_id: pl_section.id, student_user_id: pl_participant.id)
+      create :follower, section: pl_section, student_user: pl_participant
     end
 
     DCDO.unstub(:get)

--- a/dashboard/test/models/follower_test.rb
+++ b/dashboard/test/models/follower_test.rb
@@ -111,6 +111,24 @@ class FollowerTest < ActiveSupport::TestCase
     DCDO.unstub(:get)
   end
 
+  test 'cannot create a follower for a PL section and a user with a family name' do
+    DCDO.stubs(:get).with('family-name-features', false).returns(true)
+
+    teacher = create(:teacher)
+    pl_section = create :section, :teacher_participants, user_id: teacher.id
+
+    pl_participant = create(:user)
+    pl_participant.family_name = 'TestFamName'
+    pl_participant.save!
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      #create :follower, student_user
+      Follower.create!(section_id: pl_section.id, student_user_id: pl_participant.id)
+    end
+
+    DCDO.unstub(:get)
+  end
+
   test 'deleting one of many followers keeps the associated student family name' do
     DCDO.stubs(:get).with('family-name-features', false).returns(true)
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4801,6 +4801,52 @@ class UserTest < ActiveSupport::TestCase
     DCDO.unstub(:get)
   end
 
+  test 'family name is removed from pl participants' do
+    user = create :user
+    family_name = 'TestFamilyName'
+    user.family_name = family_name
+
+    user.save!
+    user.reload
+
+    assert_equal(family_name, user.family_name)
+
+    pl_section = create :section, :teacher_participants, user_id: @teacher.id
+    Follower.create!(section_id: pl_section.id, student_user_id: user.id)
+
+    DCDO.stubs(:get).with('family-name-features', false).returns(true)
+
+    user.save!
+    user.reload
+
+    assert_nil(user.family_name)
+
+    DCDO.unstub(:get)
+  end
+
+  test 'family name is not removed from students' do
+    user = create :user
+    family_name = 'TestFamilyName'
+    user.family_name = family_name
+
+    user.save!
+    user.reload
+
+    assert_equal(family_name, user.family_name)
+
+    section = create :section, user_id: @teacher.id
+    Follower.create!(section_id: section.id, student_user_id: user.id)
+
+    DCDO.stubs(:get).with('family-name-features', false).returns(true)
+
+    user.save!
+    user.reload
+
+    assert_equal(family_name, user.family_name)
+
+    DCDO.unstub(:get)
+  end
+
   test 'school_info_school returns the school associated with the user' do
     school = create :school
     school_info = create :school_info, school: school

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4801,48 +4801,32 @@ class UserTest < ActiveSupport::TestCase
     DCDO.unstub(:get)
   end
 
-  test 'family name is removed from pl participants' do
+  test 'family name is not allowed on pl participants' do
+    DCDO.stubs(:get).with('family-name-features', false).returns(true)
+
     user = create :user
     family_name = 'TestFamilyName'
-    user.family_name = family_name
-
-    user.save!
-    user.reload
-
-    assert_equal(family_name, user.family_name)
 
     pl_section = create :section, :teacher_participants, user_id: @teacher.id
     Follower.create!(section_id: pl_section.id, student_user_id: user.id)
 
-    DCDO.stubs(:get).with('family-name-features', false).returns(true)
+    assert(user.valid?)
 
-    user.save!
-    user.reload
+    user.family_name = family_name
 
-    assert_nil(user.family_name)
+    assert_not(user.valid?)
 
     DCDO.unstub(:get)
   end
 
-  test 'family name is not removed from students' do
-    user = create :user
+  test 'family name is not allowed on teachers' do
+    DCDO.stubs(:get).with('family-name-features', false).returns(true)
+
+    user = create :teacher
     family_name = 'TestFamilyName'
     user.family_name = family_name
 
-    user.save!
-    user.reload
-
-    assert_equal(family_name, user.family_name)
-
-    section = create :section, user_id: @teacher.id
-    Follower.create!(section_id: section.id, student_user_id: user.id)
-
-    DCDO.stubs(:get).with('family-name-features', false).returns(true)
-
-    user.save!
-    user.reload
-
-    assert_equal(family_name, user.family_name)
+    assert_not(user.valid?)
 
     DCDO.unstub(:get)
   end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4802,8 +4802,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'family name is not allowed on pl participants' do
-    DCDO.stubs(:get).with('family-name-features', false).returns(true)
-
     user = create :user
     family_name = 'TestFamilyName'
 
@@ -4815,20 +4813,14 @@ class UserTest < ActiveSupport::TestCase
     user.family_name = family_name
 
     assert_not(user.valid?)
-
-    DCDO.unstub(:get)
   end
 
   test 'family name is not allowed on teachers' do
-    DCDO.stubs(:get).with('family-name-features', false).returns(true)
-
     user = create :teacher
     family_name = 'TestFamilyName'
     user.family_name = family_name
 
     assert_not(user.valid?)
-
-    DCDO.unstub(:get)
   end
 
   test 'school_info_school returns the school associated with the user' do


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Add a `before_save` hook to users, that removes the family name (if set) from PL participants. 

Family names will be set from the "manage students" tab in section settings, which also exists for PL sections. We don't want teachers to ever have a family name set, so we will be hiding the UI elements in PL sections to prevent that from happening. This adds some extra backend protection, just in case.

Adding infra/platform to reviewers, to make sure this approach is OK.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [Tech Spec: Sort by Family Name](https://docs.google.com/document/d/1uoQ64oZ2etQoXovkIJq-UH79UkSWQLf_EtuC9fCnWWQ/edit)
- jira: [TEACH-577](https://codedotorg.atlassian.net/browse/TEACH-577)

