### PR TITLE
Pass full sources response to labs

### DIFF
--- a/apps/src/labs/labRedux.ts
+++ b/apps/src/labs/labRedux.ts
@@ -137,10 +137,10 @@ const labSlice = createSlice({
     setChannel(state, action: PayloadAction<Channel>) {
       state.channel = action.payload;
     },
-    setSources(state, action: PayloadAction<ProjectSources>) {
+    setSources(state, action: PayloadAction<ProjectSources | undefined>) {
       state.sources = action.payload;
     },
-    setLevelData(state, action: PayloadAction<LevelData>) {
+    setLevelData(state, action: PayloadAction<LevelData | undefined>) {
       state.levelData = action.payload;
     },
     setLabReadyForReload(state, action: PayloadAction<boolean>) {
@@ -227,14 +227,8 @@ function setProjectAndLevelData(
   }
   const {channel, sources, levelData} = data;
   dispatch(setChannel(channel));
-
-  if (sources) {
-    dispatch(setSources(sources));
-  }
-  if (levelData) {
-    dispatch(setLevelData(levelData));
-  }
-
+  dispatch(setSources(sources));
+  dispatch(setLevelData(levelData));
   dispatch(setLabReadyForReload(true));
 }
 

--- a/apps/src/labs/projects/ChannelsStore.ts
+++ b/apps/src/labs/projects/ChannelsStore.ts
@@ -8,7 +8,7 @@ import * as channelsApi from './channelsApi';
 import * as projectsApi from './projectsApi';
 
 export interface ChannelsStore {
-  load: (key: string) => Promise<Response>;
+  load: (key: string) => Promise<Channel>;
 
   loadForLevel: (levelId: number, scriptId?: number) => Promise<Response>;
 
@@ -23,7 +23,7 @@ export class LocalChannelsStore implements ChannelsStore {
 
   load(key: string) {
     this.localStorageKey = key;
-    return Promise.resolve(new Response('{}'));
+    return Promise.resolve({} as Channel);
   }
 
   // We don't support changing keys for local storage, so we just return the

--- a/apps/src/labs/projects/channelsApi.ts
+++ b/apps/src/labs/projects/channelsApi.ts
@@ -3,12 +3,16 @@
  * metadata about a project.
  */
 
+import HttpClient from '@cdo/apps/util/HttpClient';
 import {Channel} from '../types';
 
 const rootUrl = '/v3/channels';
 
-export async function get(channelId: string): Promise<Response> {
-  return fetch(`${rootUrl}/${channelId}`);
+export async function get(channelId: string): Promise<Channel> {
+  const {value} = await HttpClient.fetchJson<Channel>(
+    `${rootUrl}/${channelId}`
+  );
+  return value;
 }
 
 export async function update(channel: Channel): Promise<Response> {

--- a/apps/src/labs/projects/sourcesApi.ts
+++ b/apps/src/labs/projects/sourcesApi.ts
@@ -3,25 +3,33 @@
  * A source is the code of a project.
  */
 
-import {Source, SourceUpdateOptions} from '../types';
+import {ProjectSources, SourceUpdateOptions} from '../types';
 import {SOURCE_FILE} from '../constants';
+import HttpClient, {GetResponse} from '@cdo/apps/util/HttpClient';
+import {SourceResponseValidator} from '../responseValidators';
 const {stringifyQueryParams} = require('@cdo/apps/utils');
 
 const rootUrl = (channelId: string) =>
   `/v3/sources/${channelId}/${SOURCE_FILE}`;
 
-export async function get(channelId: string): Promise<Response> {
-  return fetch(rootUrl(channelId));
+export async function get(
+  channelId: string
+): Promise<GetResponse<ProjectSources>> {
+  return HttpClient.fetchJson<ProjectSources>(
+    rootUrl(channelId),
+    {},
+    SourceResponseValidator
+  );
 }
 
 export async function update(
   channelId: string,
-  source: Source,
+  sources: ProjectSources,
   options?: SourceUpdateOptions
 ): Promise<Response> {
   const url = rootUrl(channelId) + stringifyQueryParams(options);
   return fetch(url, {
     method: 'PUT',
-    body: JSON.stringify({source: JSON.stringify(source)}),
+    body: JSON.stringify(sources),
   });
 }

--- a/apps/src/labs/responseValidators.ts
+++ b/apps/src/labs/responseValidators.ts
@@ -1,0 +1,23 @@
+import {ResponseValidator} from '@cdo/apps/util/HttpClient';
+import {BlocklySource, ProjectSources} from './types';
+
+export const SourceResponseValidator: ResponseValidator<
+  ProjectSources
+> = response => {
+  const projectSources = response as ProjectSources;
+  if (!projectSources.source) {
+    throw new Error('Missing required field: source');
+  }
+
+  // Currently only Blockly JSON sources are supported.
+  const blocklySource = JSON.parse(projectSources.source) as BlocklySource;
+  if (blocklySource.blocks === undefined) {
+    throw new Error('Missing required field: blocks');
+  }
+
+  if (blocklySource.variables === undefined) {
+    throw new Error('Missing required field: variables');
+  }
+
+  return projectSources;
+};

--- a/apps/src/labs/types.ts
+++ b/apps/src/labs/types.ts
@@ -18,6 +18,14 @@ export interface Channel {
 
 export type DefaultChannel = Pick<Channel, 'name'>;
 
+// Represents the structure of the full project sources object (i.e. the main.json file)
+export interface ProjectSources {
+  // Stringified source code. Some labs (ex. Javalab) store multiple files
+  // as nested JSON which we'll need to support eventually.
+  source: string;
+  // Add other properties (animations, html, etc) as needed.
+}
+
 // We will eventually make this a union type to include other source types.
 export type Source = BlocklySource;
 
@@ -29,7 +37,8 @@ export interface SourceUpdateOptions {
 }
 
 export interface Project {
-  source: Source;
+  // When projects are loaded for the first time, sources may not be present
+  sources?: ProjectSources;
   channel: Channel;
 }
 

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -30,7 +30,6 @@ import FieldChord from './FieldChord';
 import {Renderers} from '@cdo/apps/blockly/constants';
 import musicI18n from '../locale';
 import {logError, logWarning} from '../utils/MusicMetrics';
-import LabRegistry from '@cdo/apps/labs/LabRegistry';
 
 /**
  * Wraps the Blockly workspace for Music Lab. Provides functions to setup the
@@ -385,16 +384,9 @@ export default class MusicBlocklyWorkspace {
     return 'musicLabSavedCode' + getBlockMode();
   }
 
-  // Load the workspace with the given code, and call save.
+  // Load the workspace with the given code.
   loadCode(code) {
     Blockly.serialization.workspaces.load(code, this.workspace);
-    this.saveCode();
-  }
-
-  saveCode(forceSave = false) {
-    LabRegistry.getInstance()
-      .getProjectManager()
-      .save(this.getCode(), forceSave);
   }
 
   callUserGeneratedCode(fn, args = []) {


### PR DESCRIPTION
Previously, we were passing the just the `source` portion of the main.json file to labs. However, in order to enable artist variants in music lab, we'll need the full contents of the response to access other properties. Additionally as we support other labs, we'll probably want access to other properties (like animations, html, etc). This modifies lab lab code to pass down the full object rather than just the source portion.

I also had a couple changes on another branch which felt relevant to pull in here - used HttpClient to preserve types when making API requests, and streamlining some of the loading logic a bit so that we pass back a `Project` type rather than a `Response`, just for better type safety. Also included some logging for load errors since I was reworking some of the loading logic.

## Testing story

Tested locally.