### PR TITLE
[LTI] Validate iat and refactor tests

### DIFF
--- a/dashboard/app/helpers/jwt_verifier.rb
+++ b/dashboard/app/helpers/jwt_verifier.rb
@@ -41,6 +41,15 @@ class JwtVerifier
     end
   end
 
+  def verify_issued_time(jwt)
+    now = Time.zone.now
+    if jwt.key? :iat
+      errors << "Issued at time of #{jwt[:iat]} after #{now.to_i}" unless Time.zone.at(jwt[:iat]) < now
+    else
+      errors << 'Issued at time does not exist'
+    end
+  end
+
   def azp_in_aud(aud, azp)
     if aud.is_a? Array
       aud.include? azp

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -147,7 +147,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
-  test 'auth - error raised for issued at time in past' do
+  test 'auth - error raised for issued at time in future' do
     payload = get_valid_payload
     payload[:iat] = 3.days.from_now.to_i
     jwt = create_jwt(payload)


### PR DESCRIPTION
Followup from https://github.com/code-dot-org/code-dot-org/pull/52476 tracked in https://codedotorg.atlassian.net/browse/P20-279

Validate that the issued at (iat) time is in the past.

## Testing story

* Added new tests to lti_v1_controller_tests
* Ran the cycle through Canvas


- [X] Tests provide adequate coverage
- [X] Privacy and Security impacts have been assessed
- [X] Code is well-commented
- [X] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Pull Request is labeled appropriately
- [X] Follow-up work items (including potential tech debt) are tracked and linked
