### PR TITLE
Cache state and nonce

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -106,10 +106,12 @@ class LtiV1Controller < ApplicationController
   end
 
   def write_cache(key, value)
+    # TODO: Add error handling
     CDO.shared_cache.write(key, value.to_json, expires_in: 1.minute)
   end
 
   def read_cache(key)
+    # TODO: Add error handling
     json_value = CDO.shared_cache.read(key)
     JSON.parse(json_value).symbolize_keys
   end

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -94,7 +94,7 @@ class LtiV1Controller < ApplicationController
 
   private
 
-  @namespace = "lti_v1_controller"
+  NAMESPACE = "lti_v1_controller".freeze
 
   def unauthorized_status
     render(status: :unauthorized, json: {error: 'Unauthorized'})
@@ -109,12 +109,12 @@ class LtiV1Controller < ApplicationController
 
   def write_cache(key, value)
     # TODO: Add error handling
-    CDO.shared_cache.write("#{@namespace}/#{key}", value.to_json, expires_in: 1.minute)
+    CDO.shared_cache.write("#{NAMESPACE}/#{key}", value.to_json, expires_in: 1.minute)
   end
 
   def read_cache(key)
     # TODO: Add error handling
-    json_value = CDO.shared_cache.read("#{@namespace}/#{key}")
+    json_value = CDO.shared_cache.read("#{NAMESPACE}/#{key}")
     JSON.parse(json_value).symbolize_keys
   end
 

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -25,6 +25,12 @@ class LtiV1Controller < ApplicationController
     lti_integration = LtiIntegration.find_by(query_params)
     return unauthorized_status unless lti_integration
 
+    state_and_nonce = create_state_and_nonce
+    # set cache key as state value, since we get this back in the final response
+    # from the LTI Platform, and can use it to query for these values in the
+    # authenticate controller action.
+    write_cache(state_and_nonce[:state], state_and_nonce)
+
     auth_redirect_url = URI(lti_integration[:auth_redirect_url])
     auth_redirect_url.query = {
       scope: 'openid',
@@ -33,9 +39,9 @@ class LtiV1Controller < ApplicationController
       redirect_uri: CDO.studio_url('/lti/v1/authenticate', CDO.default_scheme),
       login_hint:  params[:login_hint],
       lti_message_hint: params[:lti_message_hint].to_s, # Required by Canvas
-      state: create_and_set_state,
+      state: state_and_nonce[:state],
       response_mode: 'form_post',
-      nonce: create_and_set_nonce,
+      nonce: state_and_nonce[:nonce],
       prompt: 'none',
     }.to_query
 
@@ -56,6 +62,11 @@ class LtiV1Controller < ApplicationController
 
     integration = LtiIntegration.find_by({client_id: extracted_client_id, issuer: extracted_issuer_id})
     return unauthorized_status unless integration
+
+    # check state and nonce in response and id_token against cached values
+    cached_state_and_nonce = read_cache params[:state]
+    return unauthorized_status unless (params[:state] == cached_state_and_nonce[:state]) &&
+      (decoded_jwt_no_auth[:nonce] == cached_state_and_nonce[:nonce])
 
     begin
       # verify the jwt via the integration's public keyset
@@ -87,30 +98,20 @@ class LtiV1Controller < ApplicationController
     render(status: :unauthorized, json: {error: 'Unauthorized'})
   end
 
-  def create_and_set_nonce
-    # generate nonce, this will be set as a cookie.
-    nonce = generate_random_string 10
-    # generate hashed nonce, this will be returned to the LTI Platform in the
-    # request params https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes
-    hashed_nonce = Digest::SHA2.hexdigest nonce
-    set_cookie('nonce', nonce)
-
-    hashed_nonce
-  end
-
-  def create_and_set_state
+  def create_state_and_nonce
     state = generate_random_string 10
-    set_cookie('state', state)
+    nonce = Digest::SHA2.hexdigest(generate_random_string(10))
 
-    state
+    {state: state, nonce: nonce}
   end
 
-  def set_cookie(name, value)
-    cookies[:"#{name}"] = {
-      value: value,
-      httponly: true,
-      same_site: :strict,
-    }
+  def write_cache(key, value)
+    CDO.shared_cache.write(key, value.to_json, expires_in: 1.minute)
+  end
+
+  def read_cache(key)
+    json_value = CDO.shared_cache.read(key)
+    JSON.parse(json_value).symbolize_keys
   end
 
   def generate_random_string(length)

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -94,6 +94,8 @@ class LtiV1Controller < ApplicationController
 
   private
 
+  @namespace = "lti_v1_controller"
+
   def unauthorized_status
     render(status: :unauthorized, json: {error: 'Unauthorized'})
   end
@@ -107,12 +109,12 @@ class LtiV1Controller < ApplicationController
 
   def write_cache(key, value)
     # TODO: Add error handling
-    CDO.shared_cache.write(key, value.to_json, expires_in: 1.minute)
+    CDO.shared_cache.write("#{@namespace}/#{key}", value.to_json, expires_in: 1.minute)
   end
 
   def read_cache(key)
     # TODO: Add error handling
-    json_value = CDO.shared_cache.read(key)
+    json_value = CDO.shared_cache.read("#{@namespace}/#{key}")
     JSON.parse(json_value).symbolize_keys
   end
 

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -1,6 +1,6 @@
 require 'json'
 require 'jwt'
-require "test_helper"
+require 'test_helper'
 
 class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   setup_all do
@@ -87,6 +87,10 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   test 'login - given a valid platform_id, return redirect' do
     get "/lti/v1/login/#{@integration.platform_id}", params: {}
     assert_response :redirect
+  end
+
+  test 'login - given a valid client_id, write_cache should be called' do
+    # TODO: Figure out how to test write_method was called inside login controller action
   end
 
   test 'login - given valid parameters, redirect URL should have valid auth request params' do

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -90,7 +90,8 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'login - given a valid client_id, write_cache should be called' do
-    # TODO: Figure out how to test write_method was called inside login controller action
+    LtiV1Controller.any_instance.expects(:write_cache)
+    get '/lti/v1/login', params: {client_id: @integration.client_id, iss: @integration.issuer}
   end
 
   test 'login - given valid parameters, redirect URL should have valid auth request params' do

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -3,14 +3,17 @@ require 'jwt'
 require "test_helper"
 
 class LtiV1ControllerTest < ActionDispatch::IntegrationTest
-  setup do
+  setup_all do
     @integration = create :lti_integration
     # create an arbitrary key for testing JWTs
     @key = SecureRandom.alphanumeric 10
     # create arbitary state and nonce values
     @state = 'state'
     @nonce = 'nonce'
-    # stub cache reads
+  end
+
+  setup do
+    # stub cache reads for each test
     LtiV1Controller.any_instance.stubs(:read_cache).returns({state: @state, nonce: @nonce})
   end
 


### PR DESCRIPTION
This PR adds a change from using cookies to store the `state` and `nonce` values for the LTI auth handshake, in favor of memcache. The reason to move away from cookies was we can't access them in the authenticate controller, as it's a POST and the LTI Platform is not sending these.

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

```
bundle exec spring testunit ./test/controllers/lti_v1_controller_test.rb
Running via Spring preloader in process 14066
Started with run options --seed 33147

  17/17: [===================================================================] 100% Time: 00:00:17, Time: 00:00:17

Finished in 18.82259s
17 tests, 24 assertions, 0 failures, 0 errors, 0 skips
```

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
