### PR TITLE
Project Beats: load library based on level or sources

### DIFF
--- a/apps/src/code-studio/components/LabContainer.jsx
+++ b/apps/src/code-studio/components/LabContainer.jsx
@@ -16,12 +16,13 @@ import moduleStyles from './LabContainer.module.scss';
 import i18n from '@cdo/locale';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import ErrorBoundary from './ErrorBoundary';
+import {isLabLoading} from '@cdo/apps/labs/labRedux';
 
 const LabContainer = ({children, onError}) => {
-  const isLabLoading = useSelector(state => state.lab.isLoading);
+  const isLoading = useSelector(isLabLoading);
   const isPageError = useSelector(state => state.lab.isPageError);
 
-  const overlayStyle = isLabLoading
+  const overlayStyle = isLoading
     ? moduleStyles.showingBlock
     : moduleStyles.fadeInBlock;
 
@@ -31,7 +32,7 @@ const LabContainer = ({children, onError}) => {
         id="lab-container"
         className={classNames(
           moduleStyles.labContainer,
-          isLabLoading && moduleStyles.labContainerLoading
+          isLoading && moduleStyles.labContainerLoading
         )}
       >
         {children}
@@ -39,7 +40,7 @@ const LabContainer = ({children, onError}) => {
           id="fade-overlay"
           className={classNames(moduleStyles.solidBlock, overlayStyle)}
         >
-          {isLabLoading && (
+          {isLoading && (
             <div className={moduleStyles.slowLoadContainer}>
               <div className={moduleStyles.spinnerContainer}>
                 <FontAwesome

--- a/apps/src/labs/labRedux.ts
+++ b/apps/src/labs/labRedux.ts
@@ -33,7 +33,10 @@ import {
 } from './progress/ProgressManager';
 
 export interface LabState {
-  // If we are currently loading a lab.
+  // If we are currently loading common data for a project or level. Should only be used internally
+  // by this Redux file.
+  isLoadingProjectOrLevel: boolean;
+  // If the lab is loading. Can be updated by lab-specific components.
   isLoading: boolean;
   isPageError: boolean;
   // channel for the current project, or undefined if there is no current project.
@@ -51,6 +54,7 @@ export interface LabState {
 }
 
 const initialState: LabState = {
+  isLoadingProjectOrLevel: false,
   isLoading: false,
   isPageError: false,
   channel: undefined,
@@ -131,6 +135,12 @@ export const loadProject = createAsyncThunk(
   }
 );
 
+// Selectors
+
+// If any load is currently in progress.
+export const isLabLoading = (state: {lab: LabState}) =>
+  state.lab.isLoadingProjectOrLevel || state.lab.isLoading;
+
 const labSlice = createSlice({
   name: 'lab',
   initialState,
@@ -159,32 +169,32 @@ const labSlice = createSlice({
   },
   extraReducers: builder => {
     builder.addCase(setUpForLevel.fulfilled, state => {
-      state.isLoading = false;
+      state.isLoadingProjectOrLevel = false;
     });
     builder.addCase(setUpForLevel.rejected, (state, action) => {
       // If the set up was aborted, that means another load got started
       // before we finished. Therefore we only set loading to false if the
       // action was not aborted.
       if (!action.meta.aborted) {
-        state.isLoading = false;
+        state.isLoadingProjectOrLevel = false;
       }
     });
     builder.addCase(setUpForLevel.pending, state => {
-      state.isLoading = true;
+      state.isLoadingProjectOrLevel = true;
     });
     builder.addCase(loadProject.fulfilled, state => {
-      state.isLoading = false;
+      state.isLoadingProjectOrLevel = false;
     });
     builder.addCase(loadProject.rejected, (state, action) => {
       // If the set up was aborted, that means another load got started
       // before we finished. Therefore we only set loading to false if the
       // action was not aborted.
       if (!action.meta.aborted) {
-        state.isLoading = false;
+        state.isLoadingProjectOrLevel = false;
       }
     });
     builder.addCase(loadProject.pending, state => {
-      state.isLoading = true;
+      state.isLoadingProjectOrLevel = true;
     });
   },
 });

--- a/apps/src/labs/types.ts
+++ b/apps/src/labs/types.ts
@@ -23,6 +23,8 @@ export interface ProjectSources {
   // Stringified source code. Some labs (ex. Javalab) store multiple files
   // as nested JSON which we'll need to support eventually.
   source: string;
+  // Optional lab-specific configuration for this project
+  labConfig?: {[key: string]: object};
   // Add other properties (animations, html, etc) as needed.
 }
 

--- a/apps/src/music/utils/Loader.ts
+++ b/apps/src/music/utils/Loader.ts
@@ -10,14 +10,23 @@ const AppConfig = require('../appConfig').default;
 
 export const baseUrl = 'https://curriculum.code.org/media/musiclab/';
 
-// Loads a sound library JSON file.
-export const loadLibrary = async (): Promise<MusicLibrary> => {
+/**
+ * Loads a sound library JSON file.
+ *
+ * @param libraryName specific library to load (optional). If a library is specified by
+ * URL param, that will take precedence.
+ * @returns the Music Library
+ */
+export const loadLibrary = async (
+  libraryName?: string
+): Promise<MusicLibrary> => {
   if (AppConfig.getValue('local-library') === 'true') {
     const localLibraryFilename = 'music-library';
     const localLibrary = require(`@cdo/static/music/${localLibraryFilename}.json`);
     return new MusicLibrary(localLibrary as LibraryJson);
   } else {
-    const libraryParameter = AppConfig.getValue('library');
+    // URL param takes precendence over provided library name.
+    const libraryParameter = AppConfig.getValue('library') || libraryName;
     const libraryFilename = libraryParameter
       ? `music-library-${libraryParameter}.json`
       : 'music-library.json';

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -150,6 +150,8 @@ class UnconnectedMusicView extends React.Component {
 
     this.state = {
       showingVideo: true,
+      loadedLibrary: false,
+      currentLibraryName: null,
     };
 
     // Music Lab currently does not support share and remix
@@ -170,38 +172,9 @@ class UnconnectedMusicView extends React.Component {
     window.addEventListener('beforeunload', event => {
       this.analyticsReporter.endSession();
     });
-
-    const promises = [];
-
-    // Load library data.
-    promises.push(loadLibrary());
-
-    Promise.all(promises)
-      .then(values => {
-        this.library = values[0];
-
-        if (getBlockMode() === BlockMode.SIMPLE2) {
-          this.sequencer = new Simple2Sequencer(this.library);
-        } else {
-          this.sequencer = new MusicPlayerStubSequencer();
-        }
-
-        Globals.setLibrary(this.library);
-        Globals.setPlayer(this.player);
-
-        this.musicBlocklyWorkspace.init(
-          document.getElementById('blockly-div'),
-          this.onBlockSpaceChange,
-          this.player
-        );
-        this.player.initialize(this.library);
-      })
-      .catch(error => {
-        this.onError(error);
-      });
   }
 
-  componentDidUpdate(prevProps) {
+  async componentDidUpdate(prevProps) {
     this.musicBlocklyWorkspace.resizeBlockly();
     if (
       prevProps.userId !== this.props.userId ||
@@ -237,6 +210,17 @@ class UnconnectedMusicView extends React.Component {
     // If we just finished loading the lab, then we need to update the
     // sources and level data.
     if (!prevProps.labReadyForReload && this.props.labReadyForReload) {
+      // Load and initialize the library and player if not done already.
+      // Read the library name first from level data, or from the project
+      // sources if not present on the level. If there is no library name
+      // specified on the level or sources, we will fallback to loading the
+      // default library.
+      let libraryName = this.props.levelData?.library;
+      if (!libraryName && this.props.sources?.labConfig?.music) {
+        libraryName = this.props.sources.labConfig.music.library;
+      }
+      await this.loadAndInitializePlayer(libraryName);
+
       if (this.getStartSources() || this.props.sources) {
         let codeToLoad = this.getStartSources();
         if (this.props.sources?.source) {
@@ -255,6 +239,46 @@ class UnconnectedMusicView extends React.Component {
       this.props.setLabReadyForReload(false);
     }
   }
+
+  // Load the library and initialize the music player, if not already loaded.
+  // Currently, we only load one library per progression.
+  loadAndInitializePlayer = async libraryName => {
+    if (this.state.loadedLibrary) {
+      return;
+    }
+
+    this.props.setIsLoading(true);
+
+    try {
+      this.library = await loadLibrary(libraryName);
+    } catch (error) {
+      this.onError(error);
+      return;
+    }
+
+    if (getBlockMode() === BlockMode.SIMPLE2) {
+      this.sequencer = new Simple2Sequencer(this.library);
+    } else {
+      this.sequencer = new MusicPlayerStubSequencer();
+    }
+
+    Globals.setLibrary(this.library);
+    Globals.setPlayer(this.player);
+
+    this.musicBlocklyWorkspace.init(
+      document.getElementById('blockly-div'),
+      this.onBlockSpaceChange,
+      this.player
+    );
+    this.player.initialize(this.library);
+
+    this.setState({
+      loadedLibrary: true,
+      currentLibraryName: libraryName,
+    });
+
+    this.props.setIsLoading(false);
+  };
 
   onError = error => {
     this.props.setIsPageError(true);
@@ -441,8 +465,16 @@ class UnconnectedMusicView extends React.Component {
     const workspaceCode = this.musicBlocklyWorkspace.getCode();
     const sourcesToSave = {
       source: JSON.stringify(workspaceCode),
-      // TODO save library name to sources
     };
+
+    // Save the current library to sources as part of labConfig if present
+    if (this.state.currentLibraryName) {
+      sourcesToSave.labConfig = {
+        music: {
+          library: this.state.currentLibraryName,
+        },
+      };
+    }
 
     LabRegistry.getInstance()
       .getProjectManager()

--- a/apps/static/music/music-library.json
+++ b/apps/static/music/music-library.json
@@ -5,8 +5,6 @@
       "name": "All",
       "imageSrc": "all.png",
       "path": "all-by-type",
-      "bpm": 80,
-      "key": "c#",
       "folders": [
         {
           "name": "Piano",
@@ -1289,57 +1287,6 @@
               "src": "piano_chords",
               "length": 4,
               "type": "lead"
-            },
-            {
-              "name": "Piano Sequenced",
-              "src": "piano_sequenced",
-              "length": 2,
-              "type": "lead",
-              "sequence": {
-                "instrument": "piano",
-                "events": [
-                  {
-                    "position": 1,
-                    "noteOffset": 9,
-                    "length": 1
-                  },
-                  {
-                    "position": 5,
-                    "noteOffset": 4,
-                    "length": 1
-                  },
-                  {
-                    "position": 9,
-                    "noteOffset": 11,
-                    "length": 1
-                  },
-                  {
-                    "position": 13,
-                    "noteOffset": 7,
-                    "length": 1
-                  },
-                  {
-                    "position": 17,
-                    "noteOffset": 9,
-                    "length": 1
-                  },
-                  {
-                    "position": 21,
-                    "noteOffset": 4,
-                    "length": 1
-                  },
-                  {
-                    "position": 25,
-                    "noteOffset": 6,
-                    "length": 1
-                  },
-                  {
-                    "position": 29,
-                    "noteOffset": 7,
-                    "length": 1
-                  }
-                ]
-              }
             }
           ]
         },

--- a/apps/static/music/music-library.json
+++ b/apps/static/music/music-library.json
@@ -5,6 +5,8 @@
       "name": "All",
       "imageSrc": "all.png",
       "path": "all-by-type",
+      "bpm": 80,
+      "key": "c#",
       "folders": [
         {
           "name": "Piano",
@@ -1287,6 +1289,57 @@
               "src": "piano_chords",
               "length": 4,
               "type": "lead"
+            },
+            {
+              "name": "Piano Sequenced",
+              "src": "piano_sequenced",
+              "length": 2,
+              "type": "lead",
+              "sequence": {
+                "instrument": "piano",
+                "events": [
+                  {
+                    "position": 1,
+                    "noteOffset": 9,
+                    "length": 1
+                  },
+                  {
+                    "position": 5,
+                    "noteOffset": 4,
+                    "length": 1
+                  },
+                  {
+                    "position": 9,
+                    "noteOffset": 11,
+                    "length": 1
+                  },
+                  {
+                    "position": 13,
+                    "noteOffset": 7,
+                    "length": 1
+                  },
+                  {
+                    "position": 17,
+                    "noteOffset": 9,
+                    "length": 1
+                  },
+                  {
+                    "position": 21,
+                    "noteOffset": 4,
+                    "length": 1
+                  },
+                  {
+                    "position": 25,
+                    "noteOffset": 6,
+                    "length": 1
+                  },
+                  {
+                    "position": 29,
+                    "noteOffset": 7,
+                    "length": 1
+                  }
+                ]
+              }
             }
           ]
         },


### PR DESCRIPTION
Load the music library based on level data, or sources, if present. This allows us to 'lock' projects to a specific library if specified by the level or in the sources. Additionally, we save the loaded library name to the sources object, so that when the project is remixed or shared, standalone versions of the project are also 'locked' to the same library. This effectively enables artist-specific (technically library-specific) variants of music lab without needing distinct project subtypes.

Note that in this current implementation, we'll only load the first library we encounter when the page is loaded. This means we only support one library per progression. We could in theory reload the library on level change, but this would involve unloading samples from the audio system, so I felt it would be better to look into that as a separate task.

## Links

https://codedotorg.atlassian.net/browse/SL-923

## Testing story

Tested locally by manually setting a specific library on a level, then opening the standalone version of that project and confirming that the same library was loaded. Also manually remixed the project (navigating to /remix) and confirmed that the same library was loaded on the remixed project as well.