### PR TITLE
Fixing bug where locked out students could not request parent permission

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -343,6 +343,8 @@ class ApplicationController < ActionController::Base
       locale_path,
       # Avoid an infinite redirect loop to the lockout page
       lockout_path,
+      # The locked out student needs access to the policy consent API's
+      policy_compliance_child_account_consent_path,
     ].include?(request.path)
 
     redirect_to lockout_path unless current_user.child_account_policy_compliant?

--- a/dashboard/test/controllers/application_controller_test.rb
+++ b/dashboard/test/controllers/application_controller_test.rb
@@ -59,6 +59,15 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     refute_redirect_to '/lockout'
   end
 
+  test "locked out account can access the policy consent routes" do
+    user = create(:locked_out_student)
+    sign_in user
+    get '/policy_compliance/child_account_consent'
+    refute_redirect_to '/lockout'
+    post '/policy_compliance/child_account_consent'
+    refute_redirect_to '/lockout'
+  end
+
   test "an anonymous user should not be redirected to the lockout page." do
     get '/'
     refute_redirect_to '/lockout'


### PR DESCRIPTION
Bug - When a locked out student on the /lockout page clicked the button to send a parent permission request email, nothing happened.
Cause - If a user is locked out, there are a few URLs which won't result in them being redirect to the `/lockout` page. The [Policy Compliance routes](https://github.com/code-dot-org/code-dot-org/blob/ba2f866519396ee4b11eaf3fc7e80a1a625ceb80/dashboard/config/routes.rb#L1062C24-L1062C24) which send and support the parent permission request emails were being blocked.
Fix - Add the Policy Compliance routes to the lockout exclusion list.


## Testing story
* Unit tests
* Manually tested on localhost. I made sure to add the `cpa_experience=cpa_new_user_lockout` cookie to my browser session to make sure all HTTP requests to my localhost-studio.code.org instance had the lockout experience.
  1. Create locked out student
  1. Request Parent Permission
  1. Look at the server log for the parent permission email and open the consent URL in my browser
  1. Confirm the student can now navigate to pages other than /lockout.
