### PR TITLE
Fixing missing translation for unknown US state

### DIFF
--- a/dashboard/app/helpers/application_helper.rb
+++ b/dashboard/app/helpers/application_helper.rb
@@ -42,7 +42,7 @@ module ApplicationHelper
   end
 
   def us_state_options
-    User::US_STATE_DROPDOWN_OPTIONS.map do |code, name|
+    User.us_state_dropdown_options.map do |code, name|
       [name, code]
     end
   end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2638,7 +2638,6 @@ class User < ApplicationRecord
   end
 
   US_STATE_DROPDOWN_OPTIONS = {
-    '??' => I18n.t('signup_form.us_state_dropdown_options.other'),
     'AL' => 'Alabama', 'AK' => 'Alaska', 'AZ' => 'Arizona', 'AR' => 'Arkansas',
     'CA' => 'California', 'CO' => 'Colorado', 'CT' => 'Connecticut',
     'DE' => 'Delaware', 'FL' => 'Florida', 'GA' => 'Georgia', 'HI' => 'Hawaii',
@@ -2655,7 +2654,15 @@ class User < ApplicationRecord
     'UT' => 'Utah', 'VT' => 'Vermont', 'VA' => 'Virginia', 'WA' => 'Washington',
     'DC' => 'Washington D.C.', 'WV' => 'West Virginia', 'WI' => 'Wisconsin',
     'WY' => 'Wyoming'
-  }
+  }.freeze
+
+  # Returns a Hash of US state codes to state names meant for use in dropdown
+  # selection inputs for User accounts.
+  # Includes a '??' state code for a location not listed.
+  def self.us_state_dropdown_options
+    {'??' => I18n.t('signup_form.us_state_dropdown_options.other')}.
+      merge(US_STATE_DROPDOWN_OPTIONS)
+  end
 
   # Verifies that the serialized attribute "us_state" is a 2 character string
   # representing a US State or "??" which represents a "N/A" kind of response.
@@ -2670,7 +2677,7 @@ class User < ApplicationRecord
       return
     end
     # Report an error if an invalid value was submitted (probably tampering).
-    unless US_STATE_DROPDOWN_OPTIONS.include?(us_state)
+    unless User.us_state_dropdown_options.include?(us_state)
       errors.add(:us_state, :invalid)
     end
   end


### PR DESCRIPTION
![image showing a dropdown box with US state names and one of the options says "translation missing"](https://github.com/code-dot-org/code-dot-org/assets/1372238/7470e715-27b4-4cdb-bd5a-cf6c91741274)

Bug - When a student is creating a new account and goes to select which US state they live in, one of the options says `translation missing: en.signup_form.us_state_dropdown_options.other`.
Cause - The string for the `??` option is be set before the I18n library has loaded translations.
Fix - Prepend the `'??' => I18n.t('signup_form.us_state_dropdown_options.other')` pair before each request.

This also makes sure the correct language is used for the particular user. Before, it was being set to English only because it was loaded only once when the server started.

## Testing story
* Manually tested on localhost by creating a new user and having the query string option `?cpa_experience=true`
