### PR TITLE
Remove us state auto detection when creating an account

### DIFF
--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -4,7 +4,6 @@
 - require 'geocoder'
 - location = Geocoder.search(request.ip).try(:first)
 - country_code = location&.country_code.to_s.upcase
-- state_code = location&.state_code.to_s.upcase
 - us_ip = ['US', 'RD', nil].include?(country_code)
 - @page_title = t('activerecord.attributes.user.finish_sign_up_header')
 
@@ -107,8 +106,7 @@
           - if @user.errors[:us_state].present?
             %p.error= @user.errors[:us_state].join('\n')
         .span5
-          = f.select :us_state, us_state_options, selected: state_code,
-          include_blank: true
+          = f.select :us_state, us_state_options, include_blank: true
           = f.hidden_field :country_code, value: country_code
 
     - if experiment_value('gender', request)

--- a/dashboard/app/views/followers/student_user_new.html.haml
+++ b/dashboard/app/views/followers/student_user_new.html.haml
@@ -1,7 +1,6 @@
 - require 'cpa'
 - location = Geocoder.search(request.ip).try(:first)
 - country_code = location&.country_code.to_s.upcase
-- state_code = location&.state_code.to_s.upcase
 - require '../shared/middleware/helpers/experiments'
 - content_for(:head) do
   %meta{name: "robots", content: "noindex"}/
@@ -83,8 +82,7 @@
               - if Cpa.cpa_experience(request)
                 .itemblock
                   = f.label :us_state, t('signup_form.us_state')
-                  = f.select :us_state, us_state_options, selected: state_code,
-                  include_blank: true
+                  = f.select :us_state, us_state_options, include_blank: true
                   = f.hidden_field :country_code, value: country_code
                 %br/
               - if experiment_value('gender', request)


### PR DESCRIPTION
When a student is creating a new account and they live in the United State, we need to ask them what US state they live in. We use some geolocation to detect what state they are in and auto select the dropdown option. However, the state detection is not reliable from a legal standpoint, so we need to remove the auto selection.