### PR TITLE
Fix Violations of and Reenable `Style/CollectionCompact`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -259,11 +259,6 @@ Style/ClassEqualityComparison:
 Style/ClassVars:
   Enabled: false
 
-# Offense count: 6
-# This cop supports unsafe auto-correction (--auto-correct-all).
-Style/CollectionCompact:
-  Enabled: false
-
 # Offense count: 161
 # This cop supports unsafe auto-correction (--auto-correct-all).
 # Configuration parameters: PreferredMethods, MethodsAcceptingSymbol.

--- a/dashboard/app/models/levels/ailab.rb
+++ b/dashboard/app/models/levels/ailab.rb
@@ -93,7 +93,7 @@ class Ailab < Level
       level_prop['teacherMarkdown'] = nil
 
       # Don't set nil values
-      level_prop.reject! {|_, value| value.nil?}
+      level_prop.compact!
     end
     options.freeze
   end

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -446,7 +446,7 @@ class Blockly < Level
       level_prop['teacherMarkdown'] = nil
 
       # Set some values that Blockly expects on the root of its options string
-      level_prop.reject! {|_, value| value.nil?}
+      level_prop.compact!
     end
     options.freeze
   end

--- a/dashboard/app/models/levels/fish.rb
+++ b/dashboard/app/models/levels/fish.rb
@@ -65,7 +65,7 @@ class Fish < Level
       level_prop['teacherMarkdown'] = nil
 
       # Don't set nil values
-      level_prop.reject! {|_, value| value.nil?}
+      level_prop.compact!
     end
     options.freeze
   end

--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -141,7 +141,7 @@ class Javalab < Level
       end
 
       # Don't set nil values
-      level_prop.reject! {|_, value| value.nil?}
+      level_prop.compact!
     end
     options.freeze
   end

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -304,7 +304,7 @@ class Level < ApplicationRecord
 
   def filter_level_attributes(level_hash)
     %w(name id updated_at type solution_level_source_id ideal_level_source_id md5).each {|field| level_hash.delete field}
-    level_hash.reject! {|_, v| v.nil?}
+    level_hash.compact!
     level_hash
   end
 

--- a/dashboard/app/models/levels/weblab.rb
+++ b/dashboard/app/models/levels/weblab.rb
@@ -75,7 +75,7 @@ class Weblab < Level
       level_prop['teacherMarkdown'] = nil
 
       # Don't set nil values
-      level_prop.reject! {|_, value| value.nil?}
+      level_prop.compact!
     end
     options.freeze
   end


### PR DESCRIPTION
> Checks for places where custom logic on rejection nils from arrays and hashes can be replaced with `{Array,Hash}#{compact,compact!}`.

Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Style/CollectionCompact`



## Links

- https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/CollectionCompact
- https://docs.rubocop.org/rubocop/cops_style.html#stylecollectioncompact

## Testing story

Note that this automatic fixup is potentially unsafe; specifically, in the situation where the collection being acted upon is a Hash-like Array, `[[1, 2], [3, nil]].reject { |_, value| value.nil? }` and `[[1, 2], [3, nil]].compact` are not compatible. I manually inspected each of the violations, and I believe all instances of this pattern in our codebase are operating on actual Hashes, which should work just fine.

Also relying on existing tests to verify that this does not represent any change in functionality.