### PR TITLE
Reinstall Ruby when Target Install Directory Changes

### DIFF
--- a/cookbooks/cdo-ruby/recipes/ruby-build.rb
+++ b/cookbooks/cdo-ruby/recipes/ruby-build.rb
@@ -28,5 +28,8 @@ execute 'install ruby with ruby build' do
   # our old apt approach did, but the directory we target here is also the one
   # RubyGems will target, and local is more appropriate for that installation
   command "ruby-build #{node['cdo-ruby']['version']} /usr/local"
-  not_if "which ruby && ruby --version | grep --quiet '^ruby #{node['cdo-ruby']['version']}'"
+
+  # Only actually execute this if there's a change to either the install
+  # directory or the version of ruby that we're trying to install
+  not_if "(which ruby | grep --quiet --fixed-strings '/usr/local/bin/ruby') && (ruby --version | grep --quiet '^ruby #{node['cdo-ruby']['version']}')"
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/50661; our current logic will only try to embark on the time-consuming process of building and installing a new version of ruby when the version we're targeting changes. Unfortunately, that means we don't do anything when we try to change the location that ruby installs to unless we also change the version.

In order to support our ability to update the Ruby installation directory, update our gating logic to also examine that.

## Testing story

Tested on an adhoc.