### PR TITLE
Optionally disable projects if specified by level

### DIFF
--- a/apps/src/labs/LabRegistry.ts
+++ b/apps/src/labs/LabRegistry.ts
@@ -28,4 +28,8 @@ export default class LabRegistry {
   public getProjectManager() {
     return this.projectManager;
   }
+
+  public clearProjectManager() {
+    this.projectManager = null;
+  }
 }

--- a/apps/src/labs/labRedux.ts
+++ b/apps/src/labs/labRedux.ts
@@ -97,6 +97,20 @@ export const setUpWithLevel = createAsyncThunk(
       levelProperties.isProjectLevel,
       false
     );
+    const disableProjects = convertOptionalStringToBoolean(
+      levelProperties.disableProjects,
+      false
+    );
+
+    if (disableProjects) {
+      // If projects are disabled on this level, we can skip loading projects data.
+      setProjectAndLevelData(
+        {levelProperties},
+        thunkAPI.signal.aborted,
+        thunkAPI.dispatch
+      );
+      return;
+    }
 
     // Create a new project manager. If we have a channel id,
     // default to loading the project for that channel. Otherwise
@@ -178,7 +192,7 @@ const labSlice = createSlice({
     setIsPageError(state, action: PayloadAction<boolean>) {
       state.isPageError = action.payload;
     },
-    setChannel(state, action: PayloadAction<Channel>) {
+    setChannel(state, action: PayloadAction<Channel | undefined>) {
       state.channel = action.payload;
     },
     setSources(state, action: PayloadAction<ProjectSources | undefined>) {
@@ -267,7 +281,7 @@ async function setUpAndLoadProject(
 // thunk dispatch method.
 function setProjectAndLevelData(
   data: {
-    channel: Channel;
+    channel?: Channel;
     sources?: ProjectSources;
     levelProperties?: LevelProperties;
   },
@@ -317,6 +331,7 @@ async function cleanUpProjectManager() {
   // Save any unsaved code and clear out any remaining enqueued
   // saves from the existing project manager.
   await existingProjectManager?.cleanUp();
+  LabRegistry.getInstance().clearProjectManager();
 }
 
 export const {

--- a/apps/src/labs/types.ts
+++ b/apps/src/labs/types.ts
@@ -85,6 +85,7 @@ export interface LevelProperties {
   // Not a complete list; add properties as needed.
   isProjectLevel?: 'true' | 'false';
   hideShareAndRemix?: 'true' | 'false';
+  disableProjects?: 'true' | 'false';
   levelData: LevelData;
 }
 

--- a/apps/src/labs/types.ts
+++ b/apps/src/labs/types.ts
@@ -85,6 +85,10 @@ export interface LevelProperties {
   // Not a complete list; add properties as needed.
   isProjectLevel?: 'true' | 'false';
   hideShareAndRemix?: 'true' | 'false';
+  // TODO: Rework this field into an "enableProjects" or more complex list of
+  // "enabledFeatures" that is calculated on the back end. For now, since
+  // the only labs we support have projects enabled, it's easier to make this a
+  // disabled flag for specific exceptions.
   disableProjects?: 'true' | 'false';
   levelData: LevelData;
 }

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -478,7 +478,7 @@ class UnconnectedMusicView extends React.Component {
 
     LabRegistry.getInstance()
       .getProjectManager()
-      .save(sourcesToSave, forceSave);
+      ?.save(sourcesToSave, forceSave);
   };
 
   loadCode = code => {


### PR DESCRIPTION
Adds a mechanism to skip loading project data if the level doesn't use projects. This will be useful in adding an upcoming standalone video level to music lab progressions.

TODO: as per some offline discussion with @molly-moen and @breville, we'll probably want to turn this `disableProjects` flag into at least an `enableProjects` flag or a more complex list of `enabledFeatures` that's calculated on the back end. For now, most level types do use projects by default, so it's easier to default to always loading projects. However ideally, we could store a computation on the back-end that knows which level types have projects enabled by default and also handle one-off per-level exceptions.