### PR TITLE
Target `/usr/local` Rather than `/usr` for Bundle

### DIFF
--- a/cookbooks/cdo-apps/templates/default/puma.service.erb
+++ b/cookbooks/cdo-apps/templates/default/puma.service.erb
@@ -28,7 +28,7 @@ RuntimeDirectoryPreserve=yes
 <%= @export_env ? @export_env.map{|k,v|"Environment=#{k}=#{v}"}.join("\n") : '' %>
 Environment=LANG=en_US.UTF-8
 
-ExecStart=/usr/bin/bundle exec puma -C <%= @src_file %> -e <%= @env %>
+ExecStart=/usr/local/bin/bundle exec puma -C <%= @src_file %> -e <%= @env %>
 Restart=always
 
 [Install]


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/50661, which updated the location to which we install Ruby and the various Ruby executables.

Right now, this is working fine on our persistent managed servers because they still have the old Ruby executables on the filesystem, but will cause adhocs to break with `Failed to start dashboard service.`

## Testing story

Tested on an adhoc that manually updating `/lib/systemd/system/dashboard.service` to match this change is sufficient to get it working again.