### PR TITLE
Use `/usr/bin/env ruby` Rather than `/usr/bin/ruby`

### DIFF
--- a/aws/emr/cdo-logs/script/elb_mapper.rb
+++ b/aws/emr/cdo-logs/script/elb_mapper.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 # The list of tutorials. Note that relative order matters, e.g., it is important
 # that "starwarsblocks" proceeds "starwars" as the latter will match the regex

--- a/aws/emr/cdo-logs/script/trivial_reducer.rb
+++ b/aws/emr/cdo-logs/script/trivial_reducer.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 # This implements the trivial reducer, e.g., the reducer that emits all inputs
 # without mutation.

--- a/aws/emr/cdo-logs/script/tutorial_mapper.rb
+++ b/aws/emr/cdo-logs/script/tutorial_mapper.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 TUTORIAL = "blockly".freeze
 

--- a/bin/i18n-codeorg/lib/csv-to-yml.rb
+++ b/bin/i18n-codeorg/lib/csv-to-yml.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 require 'csv'
 require 'yaml'

--- a/bin/i18n-codeorg/lib/merge-all-locales.rb
+++ b/bin/i18n-codeorg/lib/merge-all-locales.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 require 'fileutils'
 require 'yaml'


### PR DESCRIPTION
We've [updated the target directory for our Ruby install](https://github.com/code-dot-org/code-dot-org/pull/50661) to `/usr/local/`, so the `/usr/bin` executables are no longer supported. We should always use `env` for our shebangs.