### PR TITLE
[Google Blockly] Add CdoFieldToggle

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1136,14 +1136,18 @@ exports.createJsWrapperBlockCreator = function (
                 this.getSourceBlock().removeInput('flyout_input');
               }
             };
-            const icon = document.createElementNS(SVG_NS, 'tspan');
-            icon.style.fontFamily = 'FontAwesome';
-            icon.textContent = '\uf067'; // plus icon
-            icon.style.color = 'blue';
-            const flyoutToggleButton = new Blockly.FieldButton({
-              value: '',
+            const icon1 = document.createElementNS(SVG_NS, 'tspan');
+            icon1.style.fontFamily = 'FontAwesome';
+            icon1.textContent = '\uf067 '; // plus icon
+            icon1.style.color = 'blue';
+            const icon2 = document.createElementNS(SVG_NS, 'tspan');
+            icon2.style.fontFamily = 'FontAwesome';
+            icon2.textContent = '\uf068 '; // minus icon
+            icon2.style.color = 'blue';
+            const flyoutToggleButton = new Blockly.FieldToggle({
               onClick: toggleFlyout,
-              icon,
+              icon1,
+              icon2,
             });
             this.inputList[0].insertFieldAt(
               0,

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1148,7 +1148,9 @@ exports.createJsWrapperBlockCreator = function (
               onClick: toggleFlyout,
               icon1,
               icon2,
+              displayIcon1: true,
             });
+            // When displayIcon1 is true, flyout is closed. When false, flyout is open. (Information for serialization)
             this.inputList[0].insertFieldAt(
               0,
               flyoutToggleButton,

--- a/apps/src/blockly/addons/cdoFieldToggle.js
+++ b/apps/src/blockly/addons/cdoFieldToggle.js
@@ -8,12 +8,12 @@ import GoogleBlockly from 'blockly/core';
  * @param icon2 SVG <tspan> element - this is the icon that is displayed on the button after the first click.
  */
 export default class CdoFieldToggle extends GoogleBlockly.Field {
-  constructor({onClick, icon1, icon2}) {
+  constructor({onClick, icon1, icon2, displayIcon1}) {
     super();
     this.onClick = onClick;
     this.icon1 = icon1;
     this.icon2 = icon2;
-    this.displayIcon1 = true;
+    this.displayIcon1 = displayIcon1;
     this.SERIALIZABLE = true;
   }
 
@@ -29,7 +29,11 @@ export default class CdoFieldToggle extends GoogleBlockly.Field {
     super.initView();
     this.icon1.style.fill = this.getSourceBlock().style.colourPrimary;
     this.icon2.style.fill = this.getSourceBlock().style.colourPrimary;
-    this.textElement_.appendChild(this.icon1);
+    if (this.displayIcon1) {
+      this.textElement_.appendChild(this.icon1);
+    } else {
+      this.textElement_.appendChild(this.icon2);
+    }
   }
 
   getDisplayText_() {

--- a/apps/src/blockly/addons/cdoFieldToggle.js
+++ b/apps/src/blockly/addons/cdoFieldToggle.js
@@ -1,0 +1,62 @@
+import GoogleBlockly from 'blockly/core';
+
+/**
+ * This is a customized field which the user clicks to toggle between two different states,
+ * for example, displaying or hiding the flyout.
+ * @param onClick The function that handles the field's editor.
+ * @param icon1 SVG <tspan> element - this is the icon that is initially displayed on the button.
+ * @param icon2 SVG <tspan> element - this is the icon that is displayed on the button after the first click.
+ */
+export default class CdoFieldToggle extends GoogleBlockly.Field {
+  constructor({onClick, icon1, icon2}) {
+    super();
+    this.onClick = onClick;
+    this.icon1 = icon1;
+    this.icon2 = icon2;
+    this.displayIcon1 = true;
+    this.SERIALIZABLE = true;
+  }
+
+  static fromJson(options) {
+    return new CdoFieldToggle(options);
+  }
+
+  /**
+   * Create the block UI for this field.
+   * @override
+   */
+  initView() {
+    super.initView();
+    this.icon1.style.fill = this.getSourceBlock().style.colourPrimary;
+    this.icon2.style.fill = this.getSourceBlock().style.colourPrimary;
+    this.textElement_.appendChild(this.icon1);
+  }
+
+  getDisplayText_() {
+    return '';
+  }
+
+  /**
+   * Create an editor for the field.
+   * @override
+   */
+  showEditor_() {
+    if (this.displayIcon1) {
+      this.textElement_.replaceChild(this.icon2, this.icon1);
+    } else {
+      this.textElement_.replaceChild(this.icon1, this.icon2);
+    }
+    this.displayIcon1 = !this.displayIcon1;
+    this.onClick();
+  }
+
+  /**
+   * Contrast background for button with source block
+   * @override
+   */
+  applyColour() {
+    const sourceBlock = this.getSourceBlock();
+    this.icon1.style.fill = sourceBlock.style.colourPrimary;
+    this.icon2.style.fill = sourceBlock.style.colourPrimary;
+  }
+}

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -11,6 +11,7 @@ import * as utils from '@cdo/apps/utils';
 import initializeCdoConstants from './addons/cdoConstants';
 import CdoFieldAngle from './addons/cdoFieldAngle';
 import CdoFieldButton from './addons/cdoFieldButton';
+import CdoFieldToggle from './addons/cdoFieldToggle';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
 import CdoFieldFlyout from './addons/cdoFieldFlyout';
 import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
@@ -246,6 +247,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
 
   // Code.org custom fields
   blocklyWrapper.FieldButton = CdoFieldButton;
+  blocklyWrapper.FieldToggle = CdoFieldToggle;
   blocklyWrapper.FieldImageDropdown = CdoFieldImageDropdown;
 
   blocklyWrapper.blockly_.registry.register(


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Video of flyout after adding `cdoFieldToggle.js`:


https://github.com/code-dot-org/code-dot-org/assets/107423305/f7a57c60-deb4-431a-a6a9-8e26404adcb3

Video of toggle button with different themes:


https://github.com/code-dot-org/code-dot-org/assets/107423305/3a03baf2-1bf7-4920-999e-bc6c4ce1e1be




## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
