### PR TITLE
[Sprite Lab] remove backgroundsTab experiment

### DIFF
--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -111,7 +111,6 @@ export default class SelectStartAnimations extends React.Component {
               onUploadClick={() => console.log('Not supported at this time')}
               playAnimations={false}
               libraryManifest={this.state.levelAnimationsManifest}
-              hideUploadOption
               hideAnimationNames={false}
               navigable
               hideBackgrounds={false}
@@ -129,7 +128,6 @@ export default class SelectStartAnimations extends React.Component {
             onUploadClick={() => console.log('Not supported at this time')}
             playAnimations={false}
             libraryManifest={this.state.libraryManifest}
-            hideUploadOption
             hideAnimationNames={false}
             navigable
             hideBackgrounds={false}

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -44,7 +44,6 @@ class AnimationPicker extends React.Component {
     channelId: PropTypes.string.isRequired,
     allowedExtensions: PropTypes.string,
     libraryManifest: PropTypes.object.isRequired,
-    hideUploadOption: PropTypes.bool.isRequired,
     hideAnimationNames: PropTypes.bool.isRequired,
     navigable: PropTypes.bool.isRequired,
     defaultQuery: PropTypes.object,
@@ -116,7 +115,6 @@ class AnimationPicker extends React.Component {
           onAnimationSelectionComplete={this.props.onAnimationSelectionComplete}
           playAnimations={this.props.playAnimations}
           libraryManifest={this.props.libraryManifest}
-          hideUploadOption={this.props.hideUploadOption}
           hideAnimationNames={this.props.hideAnimationNames}
           navigable={this.props.navigable}
           defaultQuery={this.props.defaultQuery}

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -19,7 +19,6 @@ import {isMobileDevice} from '@cdo/apps/util/browser-detector';
 import {PICKER_TYPE} from './AnimationPicker.jsx';
 import style from './animation-picker-body.module.scss';
 import AnimationUploadButton from './AnimationUploadButton.jsx';
-import experiments from '@cdo/apps/util/experiments';
 
 const MAX_SEARCH_RESULTS = 40;
 
@@ -31,7 +30,6 @@ export default class AnimationPickerBody extends React.Component {
     onAnimationSelectionComplete: PropTypes.func.isRequired,
     playAnimations: PropTypes.bool.isRequired,
     libraryManifest: PropTypes.object.isRequired,
-    hideUploadOption: PropTypes.bool.isRequired,
     hideAnimationNames: PropTypes.bool.isRequired,
     navigable: PropTypes.bool.isRequired,
     defaultQuery: PropTypes.object,
@@ -69,26 +67,6 @@ export default class AnimationPickerBody extends React.Component {
     }
   }
 
-  // Can be safely removed once the 'backgroundsTab' experiment is removed.
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (this.props.defaultQuery !== nextProps.defaultQuery) {
-      const currentPage = 0;
-      const {results, pageCount} = this.searchAssetsWrapper(
-        currentPage,
-        nextProps.defaultQuery
-      );
-      let nextQuery = nextProps.defaultQuery || {
-        categoryQuery: '',
-        searchQuery: '',
-      };
-      this.setState({
-        ...nextQuery,
-        currentPage,
-        results,
-        pageCount,
-      });
-    }
-  }
   searchAssetsWrapper = (page, config = {}) => {
     let {searchQuery, categoryQuery, libraryManifest} = config;
 
@@ -216,7 +194,6 @@ export default class AnimationPickerBody extends React.Component {
     }
     const {searchQuery, categoryQuery, results} = this.state;
     const {
-      hideUploadOption,
       onDrawYourOwnClick,
       onUploadClick,
       onAnimationSelectionComplete,
@@ -225,9 +202,7 @@ export default class AnimationPickerBody extends React.Component {
 
     const searching = searchQuery !== '';
     const inCategory = categoryQuery !== '';
-    const isBackgroundsTab =
-      this.props.pickerType === 'backgrounds' &&
-      experiments.isEnabled(experiments.BACKGROUNDS_AND_UPLOAD);
+    const isBackgroundsTab = this.props.pickerType === 'backgrounds';
     // Display second "Done" button. Useful for mobile, where the original "done" button might not be on screen when
     // animation picker is loaded. 600 pixels is minimum height of the animation picker.
     const shouldDisplaySecondDoneButton = isMobileDevice();
@@ -236,9 +211,6 @@ export default class AnimationPickerBody extends React.Component {
     // OR they are searching but there were no results
     const showDrawAndUploadButtons =
       (!searching && (!inCategory || isBackgroundsTab)) || results.length === 0;
-    // We are showing the upload button if it should be visible per the previous boolean and
-    // hideUploadOption is not set to true.
-    const showingUploadButton = !hideUploadOption && showDrawAndUploadButtons;
 
     return (
       <div style={{marginBottom: 10}}>
@@ -252,7 +224,7 @@ export default class AnimationPickerBody extends React.Component {
         <h1 style={dialogStyles.title}>
           {msg.animationPicker_title({assetType})}
         </h1>
-        {showingUploadButton && (
+        {showDrawAndUploadButtons && (
           <WarningLabel>{msg.animationPicker_warning()}</WarningLabel>
         )}
         <SearchBar
@@ -296,13 +268,11 @@ export default class AnimationPickerBody extends React.Component {
                   icon="pencil"
                   onClick={onDrawYourOwnClick}
                 />
-                {!hideUploadOption && (
-                  <AnimationUploadButton
-                    onUploadClick={onUploadClick}
-                    shouldWarnOnAnimationUpload={shouldWarnOnAnimationUpload}
-                    isBackgroundsTab={isBackgroundsTab}
-                  />
-                )}
+                <AnimationUploadButton
+                  onUploadClick={onUploadClick}
+                  shouldWarnOnAnimationUpload={shouldWarnOnAnimationUpload}
+                  isBackgroundsTab={isBackgroundsTab}
+                />
               </div>
             )}
             {searchQuery === '' &&

--- a/apps/src/p5lab/AnimationTab/AnimationTab.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationTab.jsx
@@ -12,7 +12,6 @@ import PiskelEditor from './PiskelEditor';
 import * as shapes from '../shapes';
 import i18n from '@cdo/locale';
 import {P5LabInterfaceMode, P5LabType} from '../constants.js';
-import experiments from '@cdo/apps/util/experiments';
 /**
  * Root of the animation editor interface mode for GameLab
  */
@@ -21,8 +20,6 @@ class AnimationTab extends React.Component {
     channelId: PropTypes.string,
     onColumnWidthsChange: PropTypes.func.isRequired,
     libraryManifest: PropTypes.object.isRequired,
-    // TODO: When we remove the backgrounds_and_upload experiment we can get rid of hideUploadOption
-    hideUploadOption: PropTypes.bool.isRequired,
     shouldWarnOnAnimationUpload: PropTypes.bool.isRequired,
     hideAnimationNames: PropTypes.bool.isRequired,
     hideBackgrounds: PropTypes.bool.isRequired,
@@ -49,7 +46,6 @@ class AnimationTab extends React.Component {
       defaultQuery,
       hideAnimationNames,
       hideBackgrounds,
-      hideUploadOption,
       interfaceMode,
       labType,
       libraryManifest,
@@ -63,8 +59,7 @@ class AnimationTab extends React.Component {
     }
     const hideCostumes = interfaceMode === P5LabInterfaceMode.BACKGROUND;
     const animationsColumnStyle =
-      labType !== P5LabType.GAMELAB &&
-      experiments.isEnabled(experiments.BACKGROUNDS_AND_UPLOAD)
+      labType !== P5LabType.GAMELAB
         ? styles.animationsColumnSpritelab
         : styles.animationsColumnGamelab;
 
@@ -94,7 +89,6 @@ class AnimationTab extends React.Component {
           <AnimationPicker
             channelId={channelId}
             libraryManifest={libraryManifest}
-            hideUploadOption={hideUploadOption}
             hideAnimationNames={hideAnimationNames}
             navigable={!hideCostumes}
             hideBackgrounds={hideBackgrounds}

--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -88,15 +88,6 @@ class P5LabView extends React.Component {
     });
   }
 
-  shouldHideAnimationUpload() {
-    // Teachers should always be allowed to upload animations.
-    if (this.props.currentUserType === 'teacher') {
-      return false;
-    }
-
-    return this.props.isBlockly;
-  }
-
   // Users of non-Blockly labs should always be allowed to upload animations
   // with no restrictions. Teachers in blockly labs (ie. Sprite Lab) can upload with a warning.
   // When students upload animations in Blockly labs, we disable publish and remix for the project.

--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -24,7 +24,6 @@ import IFrameEmbedOverlay from '@cdo/apps/templates/IFrameEmbedOverlay';
 import VisualizationResizeBar from '@cdo/apps/lib/ui/VisualizationResizeBar';
 import AnimationPicker, {PICKER_TYPE} from './AnimationPicker/AnimationPicker';
 import {getManifest} from '@cdo/apps/assetManagement/animationLibraryApi';
-import experiments from '@cdo/apps/util/experiments';
 
 /**
  * Top-level React wrapper for GameLab
@@ -89,38 +88,20 @@ class P5LabView extends React.Component {
     });
   }
 
-  // TODO: When we remove the backgrounds_and_upload experiment
-  // we can get rid of hideUploadOption
   shouldHideAnimationUpload() {
-    // Teachers should always be allowed to upload animations,
-    // and we are currently enabling it for students under an experiment flag.
-    if (
-      this.props.currentUserType === 'teacher' ||
-      experiments.isEnabled(experiments.BACKGROUNDS_AND_UPLOAD)
-    ) {
+    // Teachers should always be allowed to upload animations.
+    if (this.props.currentUserType === 'teacher') {
       return false;
     }
 
     return this.props.isBlockly;
   }
 
-  // NOTE: this can be simplified to return this.props.blockly once we've removed the backgrounds_and_upload experiment
-  // Users of non-blockly labs should always be allowed to upload animations
-  // with no restrictions. Teachers in blockly labs (ie, sprite lab) can upload with a warning.
-  // If students upload animations we will disable publish and remix.
+  // Users of non-Blockly labs should always be allowed to upload animations
+  // with no restrictions. Teachers in blockly labs (ie. Sprite Lab) can upload with a warning.
+  // When students upload animations in Blockly labs, we disable publish and remix for the project.
   shouldWarnOnAnimationUpload() {
-    if (!this.props.isBlockly) {
-      return false;
-    }
-
-    if (
-      this.props.currentUserType === 'teacher' &&
-      !experiments.isEnabled(experiments.BACKGROUNDS_AND_UPLOAD)
-    ) {
-      return false;
-    }
-
-    return true;
+    return this.props.isBlockly;
   }
 
   renderCodeMode() {
@@ -178,7 +159,6 @@ class P5LabView extends React.Component {
             <AnimationPicker
               channelId={channelId}
               libraryManifest={this.state.libraryManifest}
-              hideUploadOption={this.shouldHideAnimationUpload()}
               shouldWarnOnAnimationUpload={this.shouldWarnOnAnimationUpload()}
               hideAnimationNames={this.props.isBlockly}
               navigable={navigable}
@@ -227,7 +207,6 @@ class P5LabView extends React.Component {
         channelId={this.getChannelId()}
         defaultQuery={defaultQuery}
         libraryManifest={this.state.libraryManifest}
-        hideUploadOption={this.shouldHideAnimationUpload()}
         shouldWarnOnAnimationUpload={this.shouldWarnOnAnimationUpload()}
         hideAnimationNames={this.props.isBlockly}
         hideBackgrounds={this.props.isBlockly && !isBackgroundMode}

--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -12,7 +12,6 @@ import {allowAnimationMode, countAllowedModes} from './stateQueries';
 import PoemSelector from './poetry/PoemSelector';
 import * as utils from '../utils';
 import color from '@cdo/apps/util/color';
-import experiments from '@cdo/apps/util/experiments';
 
 /**
  * Controls above the visualization header, including the code/animation toggle.
@@ -104,25 +103,23 @@ class P5LabVisualizationHeader extends React.Component {
                     : msg.animationMode()}
                 </button>
               )}
-              {allowAnimationMode &&
-                this.props.isBlockly &&
-                experiments.isEnabled(experiments.BACKGROUNDS_AND_UPLOAD) && (
-                  <button
-                    style={{
-                      ...styles.buttonFocus,
-                      // All truncation if the visualize column is very small
-                      // or if translated strings are longer than English.
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                    type="button"
-                    value={P5LabInterfaceMode.BACKGROUND}
-                    id="backgroundMode"
-                  >
-                    {msg.backgroundMode()}
-                  </button>
-                )}
+              {allowAnimationMode && this.props.isBlockly && (
+                <button
+                  style={{
+                    ...styles.buttonFocus,
+                    // All truncation if the visualize column is very small
+                    // or if translated strings are longer than English.
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                  type="button"
+                  value={P5LabInterfaceMode.BACKGROUND}
+                  id="backgroundMode"
+                >
+                  {msg.backgroundMode()}
+                </button>
+              )}
             </ToggleGroup>
           </div>
         )}

--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -107,8 +107,7 @@ class P5LabVisualizationHeader extends React.Component {
                 <button
                   style={{
                     ...styles.buttonFocus,
-                    // All truncation if the visualize column is very small
-                    // or if translated strings are longer than English.
+                    // If the button text is wider than the available space, truncate it.
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -6,10 +6,8 @@ import {TOOLBOX_EDIT_MODE} from '../../constants';
 import {NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
 import {animationSourceUrl} from '../redux/animationList';
 import {changeInterfaceMode} from '../actions';
-import {Goal, showBackground} from '../redux/animationPicker';
 import i18n from '@cdo/locale';
 import spritelabMsg from '@cdo/spritelab/locale';
-import experiments from '@cdo/apps/util/experiments';
 import {parseSoundPathString} from '@cdo/apps/blockly/utils';
 
 function animations(includeBackgrounds) {
@@ -238,25 +236,16 @@ const customInputTypes = {
         getStore().getState().pageConstants &&
         getStore().getState().pageConstants.showAnimationMode
       ) {
-        buttons = experiments.isEnabled(experiments.BACKGROUNDS_AND_UPLOAD)
-          ? [
-              {
-                text: i18n.backgroundMode(),
-                action: () => {
-                  getStore().dispatch(
-                    changeInterfaceMode(P5LabInterfaceMode.BACKGROUND)
-                  );
-                },
-              },
-            ]
-          : [
-              {
-                text: i18n.more(),
-                action: () => {
-                  getStore().dispatch(showBackground(Goal.NEW_ANIMATION));
-                },
-              },
-            ];
+        buttons = [
+          {
+            text: i18n.backgroundMode(),
+            action: () => {
+              getStore().dispatch(
+                changeInterfaceMode(P5LabInterfaceMode.BACKGROUND)
+              );
+            },
+          },
+        ];
       }
       currentInputRow
         .appendField(inputConfig.label)

--- a/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
+++ b/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
@@ -21,7 +21,6 @@ describe('AnimationPickerBody', function () {
     playAnimations: false,
     libraryManifest: testAnimationLibrary,
     categories: CostumeCategories,
-    hideUploadOption: false,
     hideAnimationNames: false,
     navigable: true,
     hideBackgrounds: false,
@@ -38,22 +37,12 @@ describe('AnimationPickerBody', function () {
 
   describe('upload warning', function () {
     it('shows an upload warning if the upload button is visible', function () {
-      const body = shallow(
-        <AnimationPickerBody {...defaultProps} hideUploadOption={false} />
-      );
+      const body = shallow(<AnimationPickerBody {...defaultProps} />);
       const warnings = body.find(WarningLabel);
       expect(warnings).to.have.length(1);
       expect(warnings.children().text()).to.equal(
         msg.animationPicker_warning()
       );
-    });
-
-    it('does not show an upload warning if upload button is hidden', function () {
-      const body = shallow(
-        <AnimationPickerBody {...defaultProps} hideUploadOption={true} />
-      );
-      const warnings = body.find(WarningLabel);
-      expect(warnings).to.have.length(0);
     });
   });
 
@@ -101,14 +90,6 @@ describe('AnimationPickerBody', function () {
       expect(pickerItems.length).to.equal(4);
       const uploadButton = body.find(AnimationUploadButton);
       expect(uploadButton.length).to.equal(1);
-    });
-
-    it('does not show upload button if hideUploadButton', function () {
-      const body = shallow(
-        <AnimationPickerBody {...defaultProps} hideUploadOption={true} />
-      );
-      const uploadButton = body.find(AnimationUploadButton);
-      expect(uploadButton.length).to.equal(0);
     });
 
     it('only shows backgrounds if defaultQuery has categoryQuery backgrounds', function () {


### PR DESCRIPTION
This removes the `backgroundsTab` experiment, making the backgrounds tab and makes uploading of sprite costumes/backgrounds available to all student users.

The experiment was used to control whether certain elements should be created, as well as to initialize a no-longer-needed `hideUploadOption` property (via `shouldHideAnimationUpload()`).

## Manual testing
I checked for key features/changes while signed out as well as signed in with a teacher account. To be sure the experiment wasn't active, I used a Sprite Lab project url that included `?disableExperiments=backgroundsTab`.
The screenshots below all show expected changes and could work as a suitable tour of this feature for anyone who might be new to it.

_Button on `set background to` block reads "Backgrounds" instead of more:_
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/251f6018-6154-462e-8806-71ca43597730)
(Clicking the button opens the Backgrounds tab, rather than directly opening the Backgrounds Library.)

_Tabs for Code/Costumes/Backgrounds are all present above preview area:_
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/76e769f2-5b1a-4994-a645-3e0cf065c199)

_Both animation libraries include a red upload warning and a purple "Upload image" button:_
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/0ae9a5a4-300e-4c36-b7f5-d7abe51bd508)

_Appropriate warning prompts are shown for students as well as teachers:_
Student: ![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/28e35758-d972-41fd-870e-2b121757a9da)
Teacher: ![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/70d96b15-1e7b-4631-a4e6-b331952f0d95)

_Uploaded animations can be used. Student project no longer has a remix button:_
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/42a282f0-df08-4201-98eb-6403e0207298)

_Share dialog explains that publish and remix are disabled:_
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/b75e5d18-597e-4f46-9838-2e6cd247764b)

_Resetting Version History restores Remix button and resets other behavior:_
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/950bd78a-31f3-4124-95cc-b7a1a6ce92e5)



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I believe we can remove two unit tests that were meant to ensure we do not show certain elements when the upload button is meant to be hidden.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
