### PR TITLE
Populate channels_api_secret directly from AWS Secret

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -443,7 +443,7 @@ stub_school_data: false
 
 disable_s3_image_uploads: false
 
-channels_api_secret: <%=poste_secret%>
+channels_api_secret: !Secret
 
 # Whether to prefix bundler commands with 'sudo'.
 # It may be useful to set this false when doing local development on Linux.

--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -8,6 +8,7 @@ dashboard_secret_key_base: not a secret
 
 # needed by storage_id helper
 poste_secret: not a real secret
+channels_api_secret: not a real secret
 
 
 # Engineers need to be able to see raw HTTP error pages so they can debug their feature branch on an adhoc.

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -41,6 +41,7 @@ pusher_app_id:             fake_app_id
 pusher_application_key:    fake_application_key
 pusher_application_secret: fake_application_secret
 poste_secret: not a real secret
+channels_api_secret: not a real secret
 dashboard_devise_pepper: not a pepper!
 dashboard_secret_key_base: not a secret
 

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -20,6 +20,7 @@ pusher_app_id:             fake_app_id
 pusher_application_key:    fake_application_key
 pusher_application_secret: fake_application_secret
 poste_secret: not a real secret
+channels_api_secret: not a real secret
 dashboard_devise_pepper: not a pepper!
 dashboard_secret_key_base: not a secret
 google_maps_api_key: boguskey


### PR DESCRIPTION
Instead of using ERB to populate `CDO.channels_api_secret`, populate it directly from an AWS Secret.
This eliminates the one known (based on log analysis) case where [this secrets/config code path](https://github.com/code-dot-org/code-dot-org/blob/ba2f866519396ee4b11eaf3fc7e80a1a625ceb80/lib/cdo/secrets_config.rb#L156C3-L160) is currently executed, reducing the priority of updating that code path to support Stack Secrets.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

DONE - Use `bin/update_secrets` to populate the `channels_api_secret` value for each major environment type (staging, test, levelbuilder, production, etc.) with the same value that is currently populated in `poste_secret` for each of those environment types.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
