### PR TITLE
Init navigation controller outside of inject

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -332,6 +332,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
   };
   blocklyWrapper.JavaScript = javascriptGenerator;
   blocklyWrapper.navigationController = new NavigationController();
+  // Initialize plugin.
+  blocklyWrapper.navigationController.init();
 
   // Wrap SNAP_RADIUS property, and in the setter make sure we keep SNAP_RADIUS and CONNECTING_SNAP_RADIUS in sync.
   // See https://github.com/google/blockly/issues/2217
@@ -603,8 +605,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
 
     workspace.addChangeListener(onBlockClickDragDelete);
 
-    // Initialize plugin.
-    blocklyWrapper.navigationController.init();
     blocklyWrapper.navigationController.addWorkspace(workspace);
 
     if (!blocklyWrapper.isStartMode && !opt_options.isBlockEditMode) {

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -119,6 +119,14 @@ const BlocklyWrapper = function (blocklyInstance) {
   };
 };
 
+/**
+ * Note that this can only be called once per page load, as this initializes
+ * the navigation controller, and multiple calls to navigationController.init()
+ * will throw an error.
+ *
+ * If this needs to be called multiple times, call Blockly.navigationController.dispose()
+ * before calling this function again.
+ */
 function initializeBlocklyWrapper(blocklyInstance) {
   const blocklyWrapper = new BlocklyWrapper(blocklyInstance);
 

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -124,8 +124,8 @@ const BlocklyWrapper = function (blocklyInstance) {
  * the navigation controller, and multiple calls to navigationController.init()
  * will throw an error.
  *
- * If this needs to be called multiple times, call Blockly.navigationController.dispose()
- * before calling this function again.
+ * If this needs to be called multiple times (for example, in tests), call
+ * Blockly.navigationController.dispose() before calling this function again.
  */
 function initializeBlocklyWrapper(blocklyInstance) {
   const blocklyWrapper = new BlocklyWrapper(blocklyInstance);

--- a/apps/test/unit/blockly/googleBlocklyWrapperTest.js
+++ b/apps/test/unit/blockly/googleBlocklyWrapperTest.js
@@ -11,6 +11,8 @@ describe('Google Blockly Wrapper', () => {
     Blockly = initializeGoogleBlocklyWrapper(GoogleBlockly); // eslint-disable-line no-global-assign
   });
   afterEach(() => {
+    // Dispose navigation controller before initializing the wrapper again.
+    Blockly.navigationController.dispose();
     // Reset Blockly for other tests.
     Blockly = cdoBlockly; // eslint-disable-line no-global-assign
     // Reset context menu for other tests.


### PR DESCRIPTION
Moves the `navigationController.init()` call to the to top level `initializeBlocklyWrapper()` function, and out of `inject()`. This allows `inject()` to be called multiple times, as previously calling `inject()` more than once would throw an error due to the navigation controller already being initialized.

## Links

Slack discussion: https://codedotorg.slack.com/archives/C04TH8400AU/p1688066270812829

## Testing story

Tested locally on a Google Blockly level (Dance Party)