### PR TITLE
Project Beats: report sound library load time

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -2,6 +2,7 @@ import {ResponseValidator} from '@cdo/apps/util/HttpClient';
 import {Key} from '../utils/Notes';
 
 export default class MusicLibrary {
+  name: string;
   groups: FolderGroup[];
   private allowedSounds: Sounds | null;
 
@@ -9,7 +10,8 @@ export default class MusicLibrary {
   private bpm: number | undefined;
   private key: Key | undefined;
 
-  constructor(libraryJson: LibraryJson) {
+  constructor(name: string, libraryJson: LibraryJson) {
+    this.name = name;
     this.groups = libraryJson.groups;
     this.allowedSounds = null;
 

--- a/apps/src/music/player/SamplePlayer.ts
+++ b/apps/src/music/player/SamplePlayer.ts
@@ -1,4 +1,4 @@
-import {logWarning} from '../utils/MusicMetrics';
+import {logWarning, reportLoadTime} from '../utils/MusicMetrics';
 import {Effects} from './interfaces/Effects';
 import MusicLibrary from './MusicLibrary';
 
@@ -72,6 +72,11 @@ export default class SamplePlayer {
       releaseTimeSeconds: secondsPerBeat * RELEASE_DURATION_FACTOR,
       // Use a delay value of a half of a beat
       delayTimeSeconds: secondsPerBeat / 2,
+      reportSoundLibraryLoadTime: (loadTimeMs: number) => {
+        reportLoadTime('SoundLibraryLoadTime', loadTimeMs, [
+          {name: 'Library', value: library.name},
+        ]);
+      },
     });
 
     this.groupPath = library.groups[0].path;

--- a/apps/src/music/player/sound.js
+++ b/apps/src/music/player/sound.js
@@ -1,5 +1,4 @@
 import {fetchSignedCookies} from '@cdo/apps/utils';
-import {reportLoadTime} from '../utils/MusicMetrics';
 import WebAudio from './soundSub';
 
 var soundList = [];
@@ -27,6 +26,7 @@ var audioSystem = null;
  *   {
  *     delayTimeSeconds: number, // Delay time used in the delay effect
  *     releaseTimeSeconds: number // Release time for fading out fixed-duration sounds
+ *     reportSoundLibraryLoadTime: loadTimeMs: number => void // Optional callback to report sound library load time
  *   }
  */
 export function InitSound(desiredSounds, options) {
@@ -35,7 +35,7 @@ export function InitSound(desiredSounds, options) {
   restrictedSoundUrlPath = '/restricted/musiclab/';
   audioSystem = new WebAudio(options);
 
-  LoadSounds(desiredSounds);
+  LoadSounds(desiredSounds, options.reportSoundLibraryLoadTime);
 }
 
 export function LoadSoundFromBuffer(id, buffer) {
@@ -51,7 +51,7 @@ export function GetCurrentAudioTime() {
   return audioSystem?.getCurrentTime();
 }
 
-async function LoadSounds(desiredSounds) {
+async function LoadSounds(desiredSounds, reportSoundLibraryLoadTime) {
   const soundLoadStartTime = Date.now();
   soundList = desiredSounds;
 
@@ -88,7 +88,7 @@ async function LoadSounds(desiredSounds) {
         soundsToLoad--;
         if (soundsToLoad === 0) {
           const loadTimeMs = Date.now() - soundLoadStartTime;
-          reportLoadTime('SoundLibraryLoadTime', loadTimeMs);
+          reportSoundLibraryLoadTime(loadTimeMs);
         }
       }
     );

--- a/apps/src/music/player/soundSub.js
+++ b/apps/src/music/player/soundSub.js
@@ -67,7 +67,7 @@ WebAudio.prototype.getCurrentTime = function () {
   }
 };
 
-WebAudio.prototype.LoadSound = function (url, callback) {
+WebAudio.prototype.LoadSound = function (url, callback, onLoadFinished) {
   var request = new XMLHttpRequest();
   request.open('GET', url, true);
   request.responseType = 'arraybuffer';
@@ -79,13 +79,16 @@ WebAudio.prototype.LoadSound = function (url, callback) {
         request.response,
         function (buffer) {
           callback(buffer);
+          onLoadFinished();
         },
         function (e) {
           logError(e);
+          onLoadFinished();
         }
       );
     } catch (e) {
       logError(e);
+      onLoadFinished();
     }
   };
   request.send();

--- a/apps/src/music/utils/Loader.ts
+++ b/apps/src/music/utils/Loader.ts
@@ -23,19 +23,22 @@ export const loadLibrary = async (
   if (AppConfig.getValue('local-library') === 'true') {
     const localLibraryFilename = 'music-library';
     const localLibrary = require(`@cdo/static/music/${localLibraryFilename}.json`);
-    return new MusicLibrary(localLibrary as LibraryJson);
+    return new MusicLibrary(
+      'local-' + localLibraryFilename,
+      localLibrary as LibraryJson
+    );
   } else {
     // URL param takes precendence over provided library name.
     const libraryParameter = AppConfig.getValue('library') || libraryName;
     const libraryFilename = libraryParameter
-      ? `music-library-${libraryParameter}.json`
-      : 'music-library.json';
+      ? `music-library-${libraryParameter}`
+      : 'music-library';
 
     const libraryJsonResponse = await HttpClient.fetchJson<LibraryJson>(
-      baseUrl + libraryFilename,
+      baseUrl + libraryFilename + '.json',
       {},
       LibraryValidator
     );
-    return new MusicLibrary(libraryJsonResponse.value);
+    return new MusicLibrary(libraryFilename, libraryJsonResponse.value);
   }
 };

--- a/apps/src/music/utils/MusicMetrics.ts
+++ b/apps/src/music/utils/MusicMetrics.ts
@@ -23,13 +23,15 @@ export function logError(message: string | object | Error) {
   MetricsReporter.logError(decorateMessage(message));
 }
 
-export function reportLoadTime(metricName: string, loadTimeMs: number) {
-  MetricsReporter.publishMetric(
-    metricName,
-    loadTimeMs,
-    'Milliseconds',
-    getDimensions()
-  );
+export function reportLoadTime(
+  metricName: string,
+  loadTimeMs: number,
+  dimensions: MetricDimension[] = []
+) {
+  MetricsReporter.publishMetric(metricName, loadTimeMs, 'Milliseconds', [
+    ...dimensions,
+    ...getDimensions(),
+  ]);
 }
 
 /**

--- a/apps/src/music/utils/MusicMetrics.ts
+++ b/apps/src/music/utils/MusicMetrics.ts
@@ -1,4 +1,5 @@
 import MetricsReporter from '@cdo/apps/lib/metrics/MetricsReporter';
+import {MetricDimension} from '@cdo/apps/lib/metrics/types';
 
 /**
  * Logging and reporting functions for Music Lab
@@ -22,6 +23,15 @@ export function logError(message: string | object | Error) {
   MetricsReporter.logError(decorateMessage(message));
 }
 
+export function reportLoadTime(metricName: string, loadTimeMs: number) {
+  MetricsReporter.publishMetric(
+    metricName,
+    loadTimeMs,
+    'Milliseconds',
+    getDimensions()
+  );
+}
+
 /**
  * Decorate log messages with common Music Lab fields
  */
@@ -36,4 +46,13 @@ function decorateMessage(message: string | object): object {
     ...message,
     lab: 'music',
   };
+}
+
+function getDimensions(): MetricDimension[] {
+  return [
+    {
+      name: 'Lab',
+      value: 'music',
+    },
+  ];
 }


### PR DESCRIPTION
Report how long it takes to fully load all sounds in the sound library, even if some failed to load. This will show up in Cloudwatch something like this (this is just from a few test runs on development):

<img width="1205" alt="Screenshot 2023-07-03 at 3 34 40 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/092d9d2c-6606-4ad0-89df-9beeef9620a6">

## Links

https://codedotorg.atlassian.net/browse/SL-916

## Testing story

Tested locally by manually posting metrics to server. Confirmed that load times are reported with the correct dimensions.