### PR TITLE
Add method to get student state from teacher

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2729,11 +2729,11 @@ class User < ApplicationRecord
     return nil unless student?
     return nil unless sections_as_student.any?
 
-    latest_teacher_id = sections_as_student.order("created_at DESC").first.user_id
-    teacher_schools = User.find(latest_teacher_id).user_school_infos
-    return nil unless teacher_schools.any?
+    latest_teacher_id = sections_as_student.order(created_at: :desc).first.user_id
+    latest_teacher_school_info = UserSchoolInfo.where(user_id: latest_teacher_id).order(start_date: :desc).first
+    return nil unless latest_teacher_school_info
 
-    SchoolInfo.find(teacher_schools.order("start_date DESC").first.school_info_id).state
+    latest_teacher_school_info.school_info&.state
   end
 
   # Values for the `child_account_compliance_state` attribute

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2722,6 +2722,20 @@ class User < ApplicationRecord
     end
   end
 
+  # Determine a student' state based on their teacher's state. Used for student
+  # accounts created prior to the addition of the us_state field in June 2023.
+  # For newer accounts, use the us_state field instead.
+  def get_us_state_from_teacher
+    return nil unless student?
+    return nil unless sections_as_student.any?
+
+    latest_teacher_id = sections_as_student.order("created_at DESC").first.user_id
+    teacher_schools = User.find(latest_teacher_id).user_school_infos
+    return nil unless teacher_schools.any?
+
+    SchoolInfo.find(teacher_schools.order("start_date DESC").first.school_info_id).state
+  end
+
   # Values for the `child_account_compliance_state` attribute
   module ChildAccountCompliance
     # The student's account has been used to issue a request to a parent.

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2727,10 +2727,10 @@ class User < ApplicationRecord
   # For newer accounts, use the us_state field instead.
   def teacher_us_state
     return nil unless student?
-    return nil unless sections_as_student.any?
+    latest_student_section = sections_as_student.order(created_at: :desc).first
+    return nil unless latest_student_section
 
-    latest_teacher_id = sections_as_student.order(created_at: :desc).first.user_id
-    latest_teacher_school_info = UserSchoolInfo.where(user_id: latest_teacher_id).order(start_date: :desc).first
+    latest_teacher_school_info = UserSchoolInfo.where(user_id: latest_student_section.user_id).order(start_date: :desc).first
     return nil unless latest_teacher_school_info
 
     latest_teacher_school_info.school_info&.state

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2725,7 +2725,7 @@ class User < ApplicationRecord
   # Determine a student' state based on their teacher's state. Used for student
   # accounts created prior to the addition of the us_state field in June 2023.
   # For newer accounts, use the us_state field instead.
-  def get_us_state_from_teacher
+  def teacher_us_state
     return nil unless student?
     return nil unless sections_as_student.any?
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -573,12 +573,6 @@ FactoryBot.define do
       login_type {'email'}
       grades {['pl']}
     end
-
-    trait :old_section do
-      after :create do |section|
-        section.created_at {Time.now - 1.year}
-      end
-    end
   end
 
   factory :game do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -573,6 +573,12 @@ FactoryBot.define do
       login_type {'email'}
       grades {['pl']}
     end
+
+    trait :old_section do
+      after :create do |section|
+        section.created_at {Time.now - 1.year}
+      end
+    end
   end
 
   factory :game do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4955,7 +4955,7 @@ class UserTest < ActiveSupport::TestCase
     teacher_old = create :teacher, :with_school_info, school_info: school_info_old
 
     section = create :section, user: teacher
-    section_old = create :section, :old_section, user: teacher_old
+    section_old = create :section, created_at: 1.year.ago, user: teacher_old
     student = create(:follower, section: section).student_user
     create :follower, section: section_old, student_user: student
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4932,12 +4932,12 @@ class UserTest < ActiveSupport::TestCase
     section = create :section, user: teacher
     student = create(:follower, section: section).student_user
 
-    assert_equal 'WA', student.get_us_state_from_teacher
+    assert_equal 'WA', student.teacher_us_state
   end
 
   test "returns nil when finding student state from teacher state when the student has no sections" do
     student = create :student
-    assert_nil student.get_us_state_from_teacher
+    assert_nil student.teacher_us_state
   end
 
   test "returns nil when finding student state from teacher state when teacher has no school" do
@@ -4945,7 +4945,7 @@ class UserTest < ActiveSupport::TestCase
     section = create :section, user: teacher
     student = create(:follower, section: section).student_user
 
-    assert_nil student.get_us_state_from_teacher
+    assert_nil student.teacher_us_state
   end
 
   test "when finding student state from teacher state, finds the most recent section" do
@@ -4959,7 +4959,7 @@ class UserTest < ActiveSupport::TestCase
     student = create(:follower, section: section).student_user
     create :follower, section: section_old, student_user: student
 
-    assert_equal 'WA', student.get_us_state_from_teacher
+    assert_equal 'WA', student.teacher_us_state
   end
 
   test "when finding student state from teacher state, finds the most recent school" do
@@ -4970,6 +4970,6 @@ class UserTest < ActiveSupport::TestCase
     section = create :section, user: teacher
     student = create(:follower, section: section).student_user
 
-    assert_equal 'WA', student.get_us_state_from_teacher
+    assert_equal 'WA', student.teacher_us_state
   end
 end


### PR DESCRIPTION
Provides a method to indirectly determine a student's state by looking at the teacher's state from school_info. Since student accounts created before the release of CPA don't have a value populated for `us_state`, this lets us guess with high certainty that they reside in Colorado because they go to school there.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[Subtask](https://codedotorg.atlassian.net/browse/P20-276)
[Main story](https://codedotorg.atlassian.net/browse/P20-62)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
