### PR TITLE
Support view only mode in Music Lab

### DIFF
--- a/apps/src/labs/labRedux.ts
+++ b/apps/src/labs/labRedux.ts
@@ -182,6 +182,11 @@ export const setUpWithoutLevel = createAsyncThunk(
 export const isLabLoading = (state: {lab: LabState}) =>
   state.lab.isLoadingProjectOrLevel || state.lab.isLoading;
 
+// This may depend on more factors, such as share.
+export const isReadOnlyWorkspace = (state: {lab: LabState}) => {
+  return !state.lab.channel?.isOwner;
+};
+
 const labSlice = createSlice({
   name: 'lab',
   initialState,

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -52,9 +52,9 @@ export default class MusicBlocklyWorkspace {
    * @param {*} container HTML element to inject the workspace into
    * @param {*} onBlockSpaceChange callback fired when any block space change events occur
    * @param {*} player reference to a {@link MusicPlayer}
-   * @param {*} toolboxAllowList optional object with allowed toolbox entries
+   * @param {*} isReadOnlyWorkspace is the workspace readonly
    */
-  init(container, onBlockSpaceChange, player, toolboxAllowList) {
+  init(container, onBlockSpaceChange, player, isReadOnlyWorkspace) {
     this.container = container;
 
     Blockly.Extensions.register(
@@ -84,7 +84,7 @@ export default class MusicBlocklyWorkspace {
     Blockly.fieldRegistry.register(FIELD_CHORD_TYPE, FieldChord);
 
     this.workspace = Blockly.inject(container, {
-      toolbox: getToolbox(toolboxAllowList),
+      toolbox: getToolbox(),
       grid: {spacing: 20, length: 0, colour: '#444', snap: true},
       theme: CdoDarkTheme,
       renderer: experiments.isEnabled('zelos')
@@ -94,6 +94,7 @@ export default class MusicBlocklyWorkspace {
       zoom: {
         startScale: experiments.isEnabled('zelos') ? 0.9 : 1,
       },
+      readOnly: isReadOnlyWorkspace,
     });
 
     // Remove two default entries in the toolbox's Functions category that
@@ -398,7 +399,17 @@ export default class MusicBlocklyWorkspace {
   }
 
   updateToolbox(allowList) {
+    if (this.isReadOnly()) {
+      return;
+    }
     const toolbox = getToolbox(allowList);
     this.workspace.updateToolbox(toolbox);
+  }
+
+  isReadOnly() {
+    if (!this.workspace) {
+      return false;
+    }
+    return this.workspace.options.readOnly;
   }
 }

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -399,17 +399,10 @@ export default class MusicBlocklyWorkspace {
   }
 
   updateToolbox(allowList) {
-    if (this.isReadOnly()) {
+    if (!this.workspace || this.workspace.options.readOnly) {
       return;
     }
     const toolbox = getToolbox(allowList);
     this.workspace.updateToolbox(toolbox);
-  }
-
-  isReadOnly() {
-    if (!this.workspace) {
-      return false;
-    }
-    return this.workspace.options.readOnly;
   }
 }

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -45,6 +45,7 @@ import {
   currentLevelIndex,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
 import {
+  isReadOnlyWorkspace,
   setIsLoading,
   setIsPageError,
   setLabReadyForReload,
@@ -117,6 +118,7 @@ class UnconnectedMusicView extends React.Component {
     labReadyForReload: PropTypes.bool,
     setLabReadyForReload: PropTypes.func,
     navigateToNextLevel: PropTypes.func,
+    isReadOnlyWorkspace: PropTypes.bool,
   };
 
   constructor(props) {
@@ -268,7 +270,8 @@ class UnconnectedMusicView extends React.Component {
     this.musicBlocklyWorkspace.init(
       document.getElementById('blockly-div'),
       this.onBlockSpaceChange,
-      this.player
+      this.player,
+      this.props.isReadOnlyWorkspace
     );
     this.player.initialize(this.library);
 
@@ -695,6 +698,7 @@ const MusicView = connect(
     sources: state.lab.sources,
     levelData: state.lab.levelData,
     labReadyForReload: state.lab.labReadyForReload,
+    isReadOnlyWorkspace: isReadOnlyWorkspace(state),
   }),
   dispatch => ({
     setIsPlaying: isPlaying => dispatch(setIsPlaying(isPlaying)),

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -69,7 +69,7 @@ class Ability
     can [:show, :index], DataDoc
 
     # If you can see a level, you can also do these things:
-    can [:embed_level, :get_rubric, :get_serialized_maze, :level_data], Level do |level|
+    can [:embed_level, :get_rubric, :get_serialized_maze, :level_properties], Level do |level|
       can? :read, level
     end
 


### PR DESCRIPTION
This was relatively straightforward since we can read `isOwner` off of the channel which we already load. The `isReadOnlyWorkspace` computation will probably get a little more complex as we support share mode, but it should all be encapsulated in the selector regardless.

Note that currently, when you navigate to an /edit page as a non-owner, or to /view as an owner, the URLs will not change, but the readonly flag will be set accordingly (based on whether the user owns the project). So an /edit URL may still be readonly if the user doesn't own the project, and vice versa for /view. There's a bit of client side code that switches the URL for legacy labs, but I wasn't sure about porting this, since it feels like the server should handle redirecting. Started a [thread](https://codedotorg.slack.com/archives/C044AGTKW3D/p1688428838495339) on slack to discuss, but shouldn't impact this change.

## Links

https://codedotorg.atlassian.net/browse/SL-936

## Testing story

Tested locally.