### PR TITLE
Fix assignment dialog with courses

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -263,7 +263,7 @@ class UnitOverviewTopRow extends React.Component {
               courseVersionId={courseVersionId}
               scriptId={scriptId}
               forceReload={true}
-              isOnCoursePage={false}
+              isAssigningCourse={false}
               isStandAloneUnit={this.props.courseLink === null}
               participantAudience={participantAudience}
             />

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -222,7 +222,7 @@ MultipleSectionsAssigner.propTypes = {
   courseVersionId: PropTypes.number,
   scriptId: PropTypes.number,
   reassignConfirm: PropTypes.func,
-  isAssigningCourse: PropTypes.bool,
+  isAssigningCourse: PropTypes.bool.isRequired,
   isStandAloneUnit: PropTypes.bool,
   participantAudience: PropTypes.string,
   // Redux

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -21,7 +21,7 @@ const MultipleSectionsAssigner = ({
   courseVersionId,
   scriptId,
   reassignConfirm = () => {},
-  isOnCoursePage,
+  isAssigningCourse,
   isStandAloneUnit,
   participantAudience,
   // Redux
@@ -33,7 +33,7 @@ const MultipleSectionsAssigner = ({
   let initialSectionsAssigned = [];
 
   // check to see if this is coming from the UNIT landing page - if so add courses featuring this unit
-  if (!isOnCoursePage) {
+  if (!isAssigningCourse) {
     if (isStandAloneUnit) {
       for (let i = 0; i < sections.length; i++) {
         if (courseVersionId === sections[i].courseVersionId) {
@@ -47,7 +47,7 @@ const MultipleSectionsAssigner = ({
         }
       }
     }
-  } else if (isOnCoursePage) {
+  } else if (isAssigningCourse) {
     // checks to see if this is coming from the COURSE landing page
     for (let i = 0; i < sections.length; i++) {
       if (courseId === sections[i].courseId) {
@@ -83,7 +83,7 @@ const MultipleSectionsAssigner = ({
         s => s.code === currentSectionsAssigned[i].code
       );
       if (needsToBeAssigned) {
-        if (isOnCoursePage) {
+        if (isAssigningCourse) {
           const sectionId = currentSectionsAssigned[i].id;
           assignToSection(
             sectionId,
@@ -106,7 +106,7 @@ const MultipleSectionsAssigner = ({
 
       if (isSectionToBeRemoved) {
         // if on COURSE landing page or a STANDALONE UNIT, unassign entirely
-        isOnCoursePage || isStandAloneUnit
+        isAssigningCourse || isStandAloneUnit
           ? unassignSection(initialSectionsAssigned[i].id, '')
           : assignCourseWithoutUnit(initialSectionsAssigned[i]);
       }
@@ -222,7 +222,7 @@ MultipleSectionsAssigner.propTypes = {
   courseVersionId: PropTypes.number,
   scriptId: PropTypes.number,
   reassignConfirm: PropTypes.func,
-  isOnCoursePage: PropTypes.bool,
+  isAssigningCourse: PropTypes.bool,
   isStandAloneUnit: PropTypes.bool,
   participantAudience: PropTypes.string,
   // Redux

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -110,6 +110,7 @@ const CustomizableCurriculumCatalogCard = ({
   sectionsForDropdown = [],
   isTeacher,
   isSignedOut,
+  courseId,
   ...props
 }) => {
   const [isAssignDialogOpen, setIsAssignDialogOpen] = useState(false);
@@ -128,6 +129,8 @@ const CustomizableCurriculumCatalogCard = ({
           onClose={() => setIsAssignDialogOpen(false)}
           sections={sectionsForDropdown}
           participantAudience="student"
+          isAssigningCourse={!!courseId}
+          courseId={courseId}
           {...props}
         />
       );

--- a/apps/src/templates/teacherDashboard/SectionAssigner.jsx
+++ b/apps/src/templates/teacherDashboard/SectionAssigner.jsx
@@ -16,7 +16,7 @@ class SectionAssigner extends Component {
     courseId: PropTypes.number,
     scriptId: PropTypes.number,
     forceReload: PropTypes.bool,
-    isOnCoursePage: PropTypes.bool,
+    isAssigningCourse: PropTypes.bool,
     isStandAloneUnit: PropTypes.bool,
     participantAudience: PropTypes.string,
     // Redux provided
@@ -55,7 +55,7 @@ class SectionAssigner extends Component {
       selectedSectionId,
       forceReload,
       assignmentName,
-      isOnCoursePage,
+      isAssigningCourse,
       isStandAloneUnit,
       participantAudience,
     } = this.props;
@@ -91,7 +91,7 @@ class SectionAssigner extends Component {
               assignmentName={assignmentName}
               sectionName={selectedSection.name}
               reassignConfirm={this.onReassignConfirm}
-              isOnCoursePage={isOnCoursePage}
+              isAssigningCourse={isAssigningCourse}
               isStandAloneUnit={isStandAloneUnit}
               participantAudience={participantAudience}
             />

--- a/apps/test/unit/templates/MultipleSectionsAssignerTest.js
+++ b/apps/test/unit/templates/MultipleSectionsAssignerTest.js
@@ -24,6 +24,7 @@ describe('MultipleSectionsAssigner', () => {
     assignToSection: assignToSection,
     updateHiddenScript: updateHiddenScript,
     participantAudience: 'student',
+    isAssigningCourse: true,
   };
   const setUp = (overrideProps = {}) => {
     const props = {...defaultProps, ...overrideProps};
@@ -32,7 +33,7 @@ describe('MultipleSectionsAssigner', () => {
 
   it('renders checked and unchecked checkboxes for sections on the UNIT landing page', () => {
     const wrapper = setUp({
-      isOnCoursePage: false,
+      isAssigningCourse: false,
       courseId: assignedCourseANDUnitSection.courseId,
       isStandAloneUnit: false,
       scriptId: assignedCourseANDUnitSection.unitId,
@@ -63,7 +64,7 @@ describe('MultipleSectionsAssigner', () => {
 
   it('renders checked and unchecked checkboxes for sections on the COURSE landing page', () => {
     const wrapper = setUp({
-      isOnCoursePage: true,
+      isAssigningCourse: true,
       courseId: assignedCourseANDUnitSection.courseId,
       isStandAloneUnit: false,
       scriptId: assignedCourseANDUnitSection.unitId,
@@ -112,7 +113,7 @@ describe('MultipleSectionsAssigner', () => {
 
   it('renders checked and unchecked checkboxes for sections on a STAND ALONE landing page', () => {
     const wrapper = setUp({
-      isOnCoursePage: false,
+      isAssigningCourse: false,
       courseId: assigedStandaloneUnitSection.courseId,
       isStandAloneUnit: true,
       scriptId: assigedStandaloneUnitSection.unitId,
@@ -142,7 +143,7 @@ describe('MultipleSectionsAssigner', () => {
 
   it('renders all student sections for a student course', () => {
     const wrapper = setUp({
-      isOnCoursePage: true,
+      isAssigningCourse: true,
       courseId: assignedCourseANDUnitSection.courseId,
       isStandAloneUnit: false,
       scriptId: assignedCourseANDUnitSection.unitId,
@@ -175,7 +176,7 @@ describe('MultipleSectionsAssigner', () => {
 
   it('renders all teacher sections for a teacher course', () => {
     const wrapper = setUp({
-      isOnCoursePage: true,
+      isAssigningCourse: true,
       courseId: assignedCourseANDUnitSection.courseId,
       isStandAloneUnit: false,
       scriptId: assignedCourseANDUnitSection.unitId,
@@ -212,7 +213,7 @@ describe('MultipleSectionsAssigner', () => {
     let reassignConfirm = sinon.fake();
 
     const wrapper = setUp({
-      isOnCoursePage: false,
+      isAssigningCourse: false,
       courseId: assignedCourseANDUnitSection.courseId,
       isStandAloneUnit: false,
       scriptId: assignedCourseANDUnitSection.unitId,
@@ -258,7 +259,7 @@ describe('MultipleSectionsAssigner', () => {
     let updateHiddenScript = sinon.fake();
 
     const wrapper = setUp({
-      isOnCoursePage: false,
+      isAssigningCourse: false,
       courseId: assigedStandaloneUnitSection.courseId,
       isStandAloneUnit: true,
       scriptId: assigedStandaloneUnitSection.unitId,
@@ -301,7 +302,7 @@ describe('MultipleSectionsAssigner', () => {
     let reassignConfirm = sinon.fake();
 
     const wrapper = setUp({
-      isOnCoursePage: false,
+      isAssigningCourse: false,
       courseId: assigedStandaloneUnitSection.courseId,
       isStandAloneUnit: true,
       scriptId: assigedStandaloneUnitSection.unitId,
@@ -344,7 +345,7 @@ describe('MultipleSectionsAssigner', () => {
     let updateHiddenScript = sinon.fake();
 
     const wrapper = setUp({
-      isOnCoursePage: false,
+      isAssigningCourse: false,
       courseId: assignedCourseANDUnitSection.courseId,
       isStandAloneUnit: false,
       scriptId: assignedCourseANDUnitSection.unitId,
@@ -388,7 +389,7 @@ describe('MultipleSectionsAssigner', () => {
     let reassignConfirm = sinon.fake();
 
     const wrapper = setUp({
-      isOnCoursePage: true,
+      isAssigningCourse: true,
       courseId: assignedCourseANDUnitSection.courseId,
       isStandAloneUnit: false,
       scriptId: assignedCourseANDUnitSection.unitId,
@@ -431,7 +432,7 @@ describe('MultipleSectionsAssigner', () => {
     let reassignConfirm = sinon.fake();
 
     const wrapper = setUp({
-      isOnCoursePage: true,
+      isAssigningCourse: true,
       courseId: assignedCourseANDUnitSection.courseId,
       isStandAloneUnit: false,
       scriptId: assignedCourseANDUnitSection.unitId,
@@ -470,7 +471,7 @@ describe('MultipleSectionsAssigner', () => {
 
   it('can select all sections using the `select all` link', () => {
     const wrapper = setUp({
-      isOnCoursePage: false,
+      isAssigningCourse: false,
       courseId: assignedCourseANDUnitSection.courseId,
       isStandAloneUnit: false,
       scriptId: assignedCourseANDUnitSection.unitId,


### PR DESCRIPTION
Dave investigated a fix for a bug https://codedotorg.slack.com/archives/C04540KNGDQ/p1688060803595729, and this PR implements a solution. The bug happens in the following sequence:

Suppose I have these courses assigned to sections:
<img width="779" alt="Screenshot 2023-07-03 at 10 11 33 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/dad6a2e6-0d6a-4426-b4a5-094160f9a0de">

I then go to the catalog page, and when I click on Computer Science A, I see this:
<img width="534" alt="Screenshot 2023-07-03 at 10 10 34 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/ce859582-e46e-4061-823a-ec04a94808a4">

indicating that CSA is already assigned to both sections (it is not). This bug is happening only for UnitGroups, because the CurriculumCatalogCard is not passing in a necessary prop to MultipleSectionAssigner.

I tested this manually. Once I added the fix, I instead saw this on the dialog:
<img width="516" alt="Screenshot 2023-07-03 at 10 17 54 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/f5bb2d80-f747-49b7-ae73-f1d447e1b1cf">

When I assigned one section a "Unit" (aka Script) and another section a "UnitGroup" (aka Course), I have the sections looking like this on the Dashboard:
<img width="787" alt="Screenshot 2023-07-03 at 10 20 49 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/c1a448ea-9d0a-4f67-852f-e825210faef0">

And when I click on the Unit, I see this
<img width="505" alt="Screenshot 2023-07-03 at 10 20 11 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/5c7a2d35-d5fd-4dfb-93b8-14a4842c2932">

And when I click on the UnitGroup, I see this
<img width="528" alt="Screenshot 2023-07-03 at 10 20 18 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/4e5bd79f-3d5b-4079-91c4-d913af4d1fc4">

If I click on an unassigned Unit, I see this
<img width="500" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/b747ab0e-891e-4cd9-9052-c0956999cb84">

And if I click on an unassigned UnitGroup, I see this
<img width="504" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/386abe20-c0c3-4cba-b337-44e271c7e939">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I tested manually (see above). I think this sort of testing makes a lot of sense to do in a UI test, but not a unit test. I'm open to comments pushing for unit tests here, but if we go that way, I'd love to address that in a follow-up PR given that this is time sensitive.

## Deployment strategy

## Follow-up work

Does the `isStandAloneUnit` prop also need to be passed in? If so, how do we know if a unit is standalone or not? Is it always the opposite of a Course or no?

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
