### PR TITLE
Hide 'Assign to Section' button when course is unassignable

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -37,7 +37,6 @@ class UnitOverview extends React.Component {
     courseId: PropTypes.number,
     courseTitle: PropTypes.string,
     courseLink: PropTypes.string,
-    courseAssignable: PropTypes.bool,
     excludeCsfColumnInLegend: PropTypes.bool.isRequired,
     teacherResources: PropTypes.arrayOf(resourceShape),
     studentResources: PropTypes.arrayOf(resourceShape),
@@ -130,7 +129,6 @@ class UnitOverview extends React.Component {
       isProfessionalLearningCourse,
       publishedState,
       participantAudience,
-      courseAssignable,
     } = this.props;
 
     const displayRedirectDialog =
@@ -205,7 +203,6 @@ class UnitOverview extends React.Component {
             courseLink={this.props.courseLink}
             publishedState={publishedState}
             participantAudience={participantAudience}
-            assignable={courseAssignable}
           />
         </div>
         <ProgressTable minimal={false} />

--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -37,6 +37,7 @@ class UnitOverview extends React.Component {
     courseId: PropTypes.number,
     courseTitle: PropTypes.string,
     courseLink: PropTypes.string,
+    courseAssignable: PropTypes.bool,
     excludeCsfColumnInLegend: PropTypes.bool.isRequired,
     teacherResources: PropTypes.arrayOf(resourceShape),
     studentResources: PropTypes.arrayOf(resourceShape),
@@ -129,6 +130,7 @@ class UnitOverview extends React.Component {
       isProfessionalLearningCourse,
       publishedState,
       participantAudience,
+      courseAssignable,
     } = this.props;
 
     const displayRedirectDialog =
@@ -203,6 +205,7 @@ class UnitOverview extends React.Component {
             courseLink={this.props.courseLink}
             publishedState={publishedState}
             participantAudience={participantAudience}
+            assignable={courseAssignable}
           />
         </div>
         <ProgressTable minimal={false} />

--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -49,7 +49,6 @@ class UnitOverviewTopRow extends React.Component {
     publishedState: PropTypes.oneOf(Object.values(PublishedState)),
     courseLink: PropTypes.string,
     participantAudience: PropTypes.string,
-    assignable: PropTypes.bool,
 
     // redux provided
     sectionsForDropdown: PropTypes.arrayOf(sectionForDropdownShape).isRequired,
@@ -143,7 +142,6 @@ class UnitOverviewTopRow extends React.Component {
       isProfessionalLearningCourse,
       publishedState,
       participantAudience,
-      assignable,
     } = this.props;
 
     const pdfDropdownOptions = this.compilePdfDropdownOptions();
@@ -253,29 +251,28 @@ class UnitOverviewTopRow extends React.Component {
             />
           )}
         </div>
-        {!deeperLearningCourse &&
-          viewAs === ViewType.Instructor &&
-          assignable && (
-            <div style={styles.sectionContainer}>
-              <SectionAssigner
-                sections={sectionsForDropdown}
-                selectedSectionId={selectedSectionId}
-                assignmentName={unitTitle}
-                showAssignButton={showAssignButton}
-                courseId={currentCourseId}
-                courseOfferingId={courseOfferingId}
-                courseVersionId={courseVersionId}
-                scriptId={scriptId}
-                forceReload={true}
-                isOnCoursePage={false}
-                isStandAloneUnit={this.props.courseLink === null}
-                participantAudience={participantAudience}
-              />
-              {unitAllowsHiddenLessons && (
-                <BulkLessonVisibilityToggle lessons={unitCalendarLessons} />
-              )}
-            </div>
-          )}
+        {!deeperLearningCourse && viewAs === ViewType.Instructor && (
+          <div style={styles.sectionContainer}>
+            <SectionAssigner
+              sections={sectionsForDropdown}
+              selectedSectionId={selectedSectionId}
+              assignmentName={unitTitle}
+              showAssignButton={showAssignButton}
+              courseId={currentCourseId}
+              courseOfferingId={courseOfferingId}
+              courseVersionId={courseVersionId}
+              scriptId={scriptId}
+              forceReload={true}
+              isOnCoursePage={false}
+              isStandAloneUnit={this.props.courseLink === null}
+              participantAudience={participantAudience}
+            />
+
+            {unitAllowsHiddenLessons && (
+              <BulkLessonVisibilityToggle lessons={unitCalendarLessons} />
+            )}
+          </div>
+        )}
         <div style={isRtl ? styles.left : styles.right}>
           <span>
             <ProgressDetailToggle toggleStudyGroup="unit-overview" />

--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -267,7 +267,6 @@ class UnitOverviewTopRow extends React.Component {
               isStandAloneUnit={this.props.courseLink === null}
               participantAudience={participantAudience}
             />
-
             {unitAllowsHiddenLessons && (
               <BulkLessonVisibilityToggle lessons={unitCalendarLessons} />
             )}

--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -49,6 +49,7 @@ class UnitOverviewTopRow extends React.Component {
     publishedState: PropTypes.oneOf(Object.values(PublishedState)),
     courseLink: PropTypes.string,
     participantAudience: PropTypes.string,
+    assignable: PropTypes.bool,
 
     // redux provided
     sectionsForDropdown: PropTypes.arrayOf(sectionForDropdownShape).isRequired,
@@ -142,6 +143,7 @@ class UnitOverviewTopRow extends React.Component {
       isProfessionalLearningCourse,
       publishedState,
       participantAudience,
+      assignable,
     } = this.props;
 
     const pdfDropdownOptions = this.compilePdfDropdownOptions();
@@ -251,27 +253,29 @@ class UnitOverviewTopRow extends React.Component {
             />
           )}
         </div>
-        {!deeperLearningCourse && viewAs === ViewType.Instructor && (
-          <div style={styles.sectionContainer}>
-            <SectionAssigner
-              sections={sectionsForDropdown}
-              selectedSectionId={selectedSectionId}
-              assignmentName={unitTitle}
-              showAssignButton={showAssignButton}
-              courseId={currentCourseId}
-              courseOfferingId={courseOfferingId}
-              courseVersionId={courseVersionId}
-              scriptId={scriptId}
-              forceReload={true}
-              isOnCoursePage={false}
-              isStandAloneUnit={this.props.courseLink === null}
-              participantAudience={participantAudience}
-            />
-            {unitAllowsHiddenLessons && (
-              <BulkLessonVisibilityToggle lessons={unitCalendarLessons} />
-            )}
-          </div>
-        )}
+        {!deeperLearningCourse &&
+          viewAs === ViewType.Instructor &&
+          assignable && (
+            <div style={styles.sectionContainer}>
+              <SectionAssigner
+                sections={sectionsForDropdown}
+                selectedSectionId={selectedSectionId}
+                assignmentName={unitTitle}
+                showAssignButton={showAssignButton}
+                courseId={currentCourseId}
+                courseOfferingId={courseOfferingId}
+                courseVersionId={courseVersionId}
+                scriptId={scriptId}
+                forceReload={true}
+                isOnCoursePage={false}
+                isStandAloneUnit={this.props.courseLink === null}
+                participantAudience={participantAudience}
+              />
+              {unitAllowsHiddenLessons && (
+                <BulkLessonVisibilityToggle lessons={unitCalendarLessons} />
+              )}
+            </div>
+          )}
         <div style={isRtl ? styles.left : styles.right}>
           <span>
             <ProgressDetailToggle toggleStudyGroup="unit-overview" />

--- a/apps/src/lib/levelbuilder/CourseOfferingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseOfferingEditor.jsx
@@ -30,8 +30,6 @@ const translatedNoneOption = `(${i18n.none()})`;
 const useCourseOffering = initialCourseOffering => {
   const [courseOffering, setCourseOffering] = useState(initialCourseOffering);
   const updateCourseOffering = (key, value) => {
-    console.log('key, value', key, value);
-    console.log('courseOffering', courseOffering);
     setCourseOffering({...courseOffering, [key]: value});
   };
 

--- a/apps/src/lib/levelbuilder/CourseOfferingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseOfferingEditor.jsx
@@ -30,6 +30,8 @@ const translatedNoneOption = `(${i18n.none()})`;
 const useCourseOffering = initialCourseOffering => {
   const [courseOffering, setCourseOffering] = useState(initialCourseOffering);
   const updateCourseOffering = (key, value) => {
+    console.log('key, value', key, value);
+    console.log('courseOffering', courseOffering);
     setCourseOffering({...courseOffering, [key]: value});
   };
 

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -40,15 +40,7 @@ function initPage() {
   const config = JSON.parse(script.dataset.scriptoverview);
 
   const {scriptData, plcBreadcrumb} = config;
-  console.log('scriptData', scriptData);
-  const courseOfferingId = scriptData.courseOfferingId;
-  console.log('courseOfferingId', courseOfferingId);
-  // Get course by courseOfferingId to know if assignable or not.
-  const showAssignButton = false;
-
   const store = getStore();
-  console.log('store', store);
-  console.log('store.getState()', store.getState());
 
   registerReducers({locales});
   store.dispatch(setLocaleCode(scriptData.locale_code));
@@ -125,7 +117,7 @@ function initPage() {
         redirectScriptUrl={scriptData.redirect_script_url}
         versions={scriptData.course_versions}
         courseName={scriptData.course_name}
-        showAssignButton={showAssignButton}
+        showAssignButton={scriptData.showAssignButton}
         isProfessionalLearningCourse={scriptData.isPlCourse}
         userId={scriptData.user_id}
         userType={scriptData.user_type}

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -40,7 +40,15 @@ function initPage() {
   const config = JSON.parse(script.dataset.scriptoverview);
 
   const {scriptData, plcBreadcrumb} = config;
+  console.log('scriptData', scriptData);
+  const courseOfferingId = scriptData.courseOfferingId;
+  console.log('courseOfferingId', courseOfferingId);
+  // Get course by courseOfferingId to know if assignable or not.
+  const courseAssignable = true;
+
   const store = getStore();
+  console.log('store', store);
+  console.log('store.getState()', store.getState());
 
   registerReducers({locales});
   store.dispatch(setLocaleCode(scriptData.locale_code));
@@ -117,6 +125,7 @@ function initPage() {
         redirectScriptUrl={scriptData.redirect_script_url}
         versions={scriptData.course_versions}
         courseName={scriptData.course_name}
+        courseAssignable={courseAssignable}
         showAssignButton={scriptData.show_assign_button}
         isProfessionalLearningCourse={scriptData.isPlCourse}
         userId={scriptData.user_id}

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -44,7 +44,7 @@ function initPage() {
   const courseOfferingId = scriptData.courseOfferingId;
   console.log('courseOfferingId', courseOfferingId);
   // Get course by courseOfferingId to know if assignable or not.
-  const courseAssignable = true;
+  const showAssignButton = false;
 
   const store = getStore();
   console.log('store', store);
@@ -125,8 +125,7 @@ function initPage() {
         redirectScriptUrl={scriptData.redirect_script_url}
         versions={scriptData.course_versions}
         courseName={scriptData.course_name}
-        courseAssignable={courseAssignable}
-        showAssignButton={scriptData.show_assign_button}
+        showAssignButton={showAssignButton}
         isProfessionalLearningCourse={scriptData.isPlCourse}
         userId={scriptData.user_id}
         userType={scriptData.user_type}

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -117,7 +117,7 @@ function initPage() {
         redirectScriptUrl={scriptData.redirect_script_url}
         versions={scriptData.course_versions}
         courseName={scriptData.course_name}
-        showAssignButton={scriptData.showAssignButton}
+        showAssignButton={scriptData.show_assign_button}
         isProfessionalLearningCourse={scriptData.isPlCourse}
         userId={scriptData.user_id}
         userType={scriptData.user_type}

--- a/dashboard/app/models/concerns/curriculum/assignable_course.rb
+++ b/dashboard/app/models/concerns/curriculum/assignable_course.rb
@@ -5,6 +5,7 @@ module Curriculum::AssignableCourse
   extend ActiveSupport::Concern
 
   def course_assignable?(user)
+    return false unless get_course_version&.course_offering&.assignable?
     return false unless can_be_instructor?(user)
     return true if launched?
     return true if pilot? && has_pilot_experiment?(user)

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -214,7 +214,6 @@ class CourseOffering < ApplicationRecord
         display_name: any_versions_launched? ? localized_display_name : localized_display_name + ' *',
         category: category,
         is_featured: is_featured?,
-        assignable: assignable?,
         participant_audience: course_versions.first.content_root.participant_audience,
         course_versions: course_versions.select {|cv| cv.course_assignable?(user)}.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)}.to_h
       }

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -214,6 +214,7 @@ class CourseOffering < ApplicationRecord
         display_name: any_versions_launched? ? localized_display_name : localized_display_name + ' *',
         category: category,
         is_featured: is_featured?,
+        assignable: assignable?,
         participant_audience: course_versions.first.content_root.participant_audience,
         course_versions: course_versions.select {|cv| cv.course_assignable?(user)}.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)}.to_h
       }

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -613,6 +613,12 @@ class UnitGroup < ApplicationRecord
     !!pilot_experiment
   end
 
+  # Wrapper function to help with assignable course logic
+  # @return [CourseVersion]
+  def get_course_version
+    course_version
+  end
+
   def has_pilot_experiment?(user)
     return false unless pilot_experiment
     SingleUserExperiment.enabled?(user: user, experiment_name: pilot_experiment)

--- a/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
+++ b/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
@@ -6,6 +6,7 @@ class AssignableCourseTests < ActiveSupport::TestCase
     @levelbuilder = create :levelbuilder
   end
 
+  #FAILING TEST
   test 'course_assignable? is true if item is launched' do
     launched_course = create(:script, published_state: 'stable')
     assert launched_course.course_assignable?(@teacher)
@@ -22,6 +23,7 @@ class AssignableCourseTests < ActiveSupport::TestCase
     refute pl_course.course_assignable?(@teacher)
   end
 
+  #FAILING TEST
   test 'course_assignable? is true if user has pilot access to item' do
     pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
     pilot_course = create :script, pilot_experiment: 'my-experiment'
@@ -35,6 +37,7 @@ class AssignableCourseTests < ActiveSupport::TestCase
     refute pilot_course.course_assignable?(@teacher)
   end
 
+  #FAILING TEST
   test 'course_assignable? is true if user has editor experiment access' do
     partner_pilot_unit = create :script, pilot_experiment: 'my-experiment', editor_experiment: 'ed-experiment'
     partner = create :teacher, editor_experiment: 'ed-experiment'
@@ -48,6 +51,7 @@ class AssignableCourseTests < ActiveSupport::TestCase
     refute partner_pilot_unit.course_assignable?(@teacher)
   end
 
+  #FAILING TEST
   test 'course_assignable? if levelbuilder and item is in development' do
     in_development_course = create(:script, published_state: 'in_development')
     assert in_development_course.course_assignable?(@levelbuilder)
@@ -58,6 +62,7 @@ class AssignableCourseTests < ActiveSupport::TestCase
     refute in_development_course.course_assignable?(@teacher)
   end
 
+  #FAILING TEST
   test 'course_assignable? if levelbuilder and item is beta' do
     in_development_course = create(:script, published_state: 'beta')
     assert in_development_course.course_assignable?(@levelbuilder)

--- a/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
+++ b/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
@@ -6,70 +6,76 @@ class AssignableCourseTests < ActiveSupport::TestCase
     @levelbuilder = create :levelbuilder
   end
 
-  #FAILING TEST
   test 'course_assignable? is true if item is launched' do
-    launched_course = create(:script, published_state: 'stable')
+    launched_course = create(:course_version, :with_unit).content_root
+    launched_course.update!(published_state: 'stable')
     assert launched_course.course_assignable?(@teacher)
   end
 
   test 'course_assignable? is false if published state is beta' do
-    beta_course = create(:script, published_state: 'beta')
+    beta_course = create(:course_version, :with_unit).content_root
+    beta_course.update!(published_state: 'beta')
     refute beta_course.course_assignable?(@teacher)
   end
 
   test 'course_assignable? is false if can not be instructor of course' do
-    pl_course = create :script, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher
+    pl_course = create(:course_version, :with_unit).content_root
+    pl_course.update!(instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
 
     refute pl_course.course_assignable?(@teacher)
   end
 
-  #FAILING TEST
   test 'course_assignable? is true if user has pilot access to item' do
     pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
-    pilot_course = create :script, pilot_experiment: 'my-experiment'
+    pilot_course = create(:course_version, :with_unit).content_root
+    pilot_course.update!(pilot_experiment: 'my-experiment')
 
     assert pilot_course.course_assignable?(pilot_teacher)
   end
 
   test 'course_assignable? is false if user does not have pilot access to item' do
-    pilot_course = create :script, pilot_experiment: 'my-experiment'
+    pilot_course = create(:course_version, :with_unit).content_root
+    pilot_course.update!(pilot_experiment: 'my-experiment')
 
     refute pilot_course.course_assignable?(@teacher)
   end
 
-  #FAILING TEST
   test 'course_assignable? is true if user has editor experiment access' do
-    partner_pilot_unit = create :script, pilot_experiment: 'my-experiment', editor_experiment: 'ed-experiment'
+    partner_pilot_unit = create(:course_version, :with_unit).content_root
+    partner_pilot_unit.update!(pilot_experiment: 'my-experiment', editor_experiment: 'ed-experiment')
     partner = create :teacher, editor_experiment: 'ed-experiment'
 
     assert partner_pilot_unit.course_assignable?(partner)
   end
 
   test 'course_assignable? is false if user does not have editor experiment access' do
-    partner_pilot_unit = create :script, pilot_experiment: 'my-experiment', editor_experiment: 'ed-experiment'
+    partner_pilot_unit = create(:course_version, :with_unit).content_root
+    partner_pilot_unit.update!(pilot_experiment: 'my-experiment', editor_experiment: 'ed-experiment')
 
     refute partner_pilot_unit.course_assignable?(@teacher)
   end
 
-  #FAILING TEST
   test 'course_assignable? if levelbuilder and item is in development' do
-    in_development_course = create(:script, published_state: 'in_development')
+    in_development_course = create(:course_version, :with_unit).content_root
+    in_development_course.update!(published_state: 'in_development')
     assert in_development_course.course_assignable?(@levelbuilder)
   end
 
   test 'course_assignable? is false if not a levelbuilder and item is in development' do
-    in_development_course = create(:script, published_state: 'in_development')
+    in_development_course = create(:course_version, :with_unit).content_root
+    in_development_course.update!(published_state: 'in_development')
     refute in_development_course.course_assignable?(@teacher)
   end
 
-  #FAILING TEST
   test 'course_assignable? if levelbuilder and item is beta' do
-    in_development_course = create(:script, published_state: 'beta')
+    in_development_course = create(:course_version, :with_unit).content_root
+    in_development_course.update!(published_state: 'beta')
     assert in_development_course.course_assignable?(@levelbuilder)
   end
 
   test 'course_assignable? is false if not a levelbuilder and item is beta' do
-    in_development_course = create(:script, published_state: 'beta')
+    in_development_course = create(:course_version, :with_unit).content_root
+    in_development_course.update!(published_state: 'in_development')
     refute in_development_course.course_assignable?(@teacher)
   end
 end

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -1148,6 +1148,7 @@ class UnitTest < ActiveSupport::TestCase
     assert_equal 'foo-2018', course_versions.values[1][:name]
   end
 
+  #FAILING TEST
   test 'summarize includes show assign button' do
     unit = create(:script, name: 'script', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview)
     teacher = create(:teacher)

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -1148,9 +1148,9 @@ class UnitTest < ActiveSupport::TestCase
     assert_equal 'foo-2018', course_versions.values[1][:name]
   end
 
-  #FAILING TEST
   test 'summarize includes show assign button' do
-    unit = create(:script, name: 'script', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview)
+    unit = create(:course_version, :with_unit).content_root
+    unit.update!(name: 'script', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview)
     teacher = create(:teacher)
 
     # No user, show_assign_button set to false


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR hides the 'Assign to sections' button on the unit overview page when a course is not `assignable`.
`assignable` is a property of a `course_offering`. 

<details>

<summary>Background context on `course_version`</summary>

`course_version` is the 'link' between a [`unit`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/unit.rb) or [`unit_group`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/unit_group.rb) and [`course_offering`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/course_offering.rb). 

Below is a simplified visualization of the relationships among these models:

![Curriculum version models](https://github.com/code-dot-org/code-dot-org/assets/107423305/6098b15a-22b0-437a-9ebb-90070cd559b1)

</details>


I updated the definition of `course_assignable?` in `assignable_course.rb` to check that the `course_version.course_offering.assignable` is `true`. I then updated unit tests in `assignable_course_test.rb` and `unit_test.rb` to ensure each course had a `course_version`. Thanks to @bethanyaconnor for her help with this task!

BEFORE UPDATE:

<img width="1254" alt="Screen Shot 2023-07-05 at 12 42 24 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/5bbef3d1-d541-416f-a143-7f1731c7d4c9">   
   

AFTER UPDATE:

<img width="1284" alt="Screen Shot 2023-07-05 at 3 13 32 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/4cca0a2e-a841-459b-b462-184345b09b16">




## Links
[jira ticket](https://codedotorg.atlassian.net/browse/SL-938)
[Slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1688396596254339)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I tested locally to ensure both standalone units and courses with a collection of units (such as CS Principles) behave as expected, i.e., when the 'assignable' checkbox is unchecked, the 'Assign to sections' button is hidden.

AFTER UPDATE - video of CS in Algebra after 'assignable' checkbox is unchecked:

https://github.com/code-dot-org/code-dot-org/assets/107423305/d615b54d-b067-446f-8122-1ca249dd4ac1

AFTER UPDATE - video of CS Principles after 'assignable' checkbox is unchecked.

https://github.com/code-dot-org/code-dot-org/assets/107423305/f4aff9ae-dab7-4465-93d9-ba678be79888


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
When a section is already assigned to CS in Algebra, ‘Find a course’ is displayed instead of 'CS in Algebra' which is misleading. 

Example is the 2021-22 1st period section in screenshot below:

![Find_a_course](https://github.com/code-dot-org/code-dot-org/assets/107423305/c48e43af-557a-4171-8b05-d36efbc9a0b4)



[jira ticket](https://codedotorg.atlassian.net/browse/SL-955) for this.

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
