### PR TITLE
Run Tests Without `Dir.chdir`

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -25,58 +25,56 @@ namespace :test do
   end
 
   timed_task_with_logging :regular_ui do
-    Dir.chdir(dashboard_dir('test/ui')) do
-      ChatClient.log 'Running <b>dashboard</b> UI tests...'
-      failed_browser_count = RakeUtils.system_with_chat_logging(
-        'bundle', 'exec', './runner.rb',
-        '-d', CDO.site_host('studio.code.org'),
-        '-p', CDO.site_host('code.org'),
-        '--db', # Ensure features that require database access are run even if the server name isn't "test"
-        '--parallel', '120',
-        '--magic_retry',
-        '--with-status-page',
-        '--fail_fast',
-        '--priority 0'
-      )
-      if failed_browser_count == 0
-        message = '┬──┬ ﻿ノ( ゜-゜ノ) UI tests for <b>dashboard</b> succeeded.'
-        ChatClient.log message
-        ChatClient.message 'server operations', message, color: 'green'
-      else
-        message = "(╯°□°）╯︵ ┻━┻ UI tests for <b>dashboard</b> failed on #{failed_browser_count} browser(s)."
-        ChatClient.log message, color: 'red'
-        ChatClient.message 'server operations', message, color: 'red', notify: 1
-        raise "UI tests failed"
-      end
+    ChatClient.log 'Running <b>dashboard</b> UI tests...'
+    failed_browser_count = RakeUtils.system_with_chat_logging(
+      "cd #{dashboard_dir('test/ui')} &&",
+      'bundle', 'exec', './runner.rb',
+      '-d', CDO.site_host('studio.code.org'),
+      '-p', CDO.site_host('code.org'),
+      '--db', # Ensure features that require database access are run even if the server name isn't "test"
+      '--parallel', '120',
+      '--magic_retry',
+      '--with-status-page',
+      '--fail_fast',
+      '--priority 0'
+    )
+    if failed_browser_count == 0
+      message = '┬──┬ ﻿ノ( ゜-゜ノ) UI tests for <b>dashboard</b> succeeded.'
+      ChatClient.log message
+      ChatClient.message 'server operations', message, color: 'green'
+    else
+      message = "(╯°□°）╯︵ ┻━┻ UI tests for <b>dashboard</b> failed on #{failed_browser_count} browser(s)."
+      ChatClient.log message, color: 'red'
+      ChatClient.message 'server operations', message, color: 'red', notify: 1
+      raise "UI tests failed"
     end
   end
 
   timed_task_with_logging :eyes_ui do
-    Dir.chdir(dashboard_dir('test/ui')) do
-      ChatClient.log 'Running <b>dashboard</b> UI visual tests...'
-      eyes_features = `find features/ -name "*.feature" | xargs grep -lr '@eyes'`.split("\n")
-      failed_browser_count = RakeUtils.system_with_chat_logging(
-        'bundle', 'exec', './runner.rb',
-        '-c', 'Chrome,iPhone',
-        '-d', CDO.site_host('studio.code.org'),
-        '-p', CDO.site_host('code.org'),
-        '--db', # Ensure features that require database access are run even if the server name isn't "test"
-        '--eyes',
-        '--magic_retry',
-        '--with-status-page',
-        '-f', eyes_features.join(","),
-        '--parallel', (eyes_features.count * 2).to_s
-      )
-      if failed_browser_count == 0
-        message = '⊙‿⊙ Eyes tests for <b>dashboard</b> succeeded, no changes detected.'
-        ChatClient.log message
-        ChatClient.message 'server operations', message, color: 'green'
-      else
-        message = 'ಠ_ಠ Eyes tests for <b>dashboard</b> failed. See <a href="https://eyes.applitools.com/app/sessions/">the console</a> for results or to modify baselines.'
-        ChatClient.log message, color: 'red'
-        ChatClient.message 'server operations', message, color: 'red', notify: 1
-        raise "Eyes tests failed"
-      end
+    ChatClient.log 'Running <b>dashboard</b> UI visual tests...'
+    eyes_features = `find #{dashboard_dir('test/ui/features')} -name "*.feature" | xargs grep -lr '@eyes'`.split("\n")
+    failed_browser_count = RakeUtils.system_with_chat_logging(
+      "cd #{dashboard_dir('test/ui')} &&",
+      'bundle', 'exec', './runner.rb',
+      '-c', 'Chrome,iPhone',
+      '-d', CDO.site_host('studio.code.org'),
+      '-p', CDO.site_host('code.org'),
+      '--db', # Ensure features that require database access are run even if the server name isn't "test"
+      '--eyes',
+      '--magic_retry',
+      '--with-status-page',
+      '-f', eyes_features.join(","),
+      '--parallel', (eyes_features.count * 2).to_s
+    )
+    if failed_browser_count == 0
+      message = '⊙‿⊙ Eyes tests for <b>dashboard</b> succeeded, no changes detected.'
+      ChatClient.log message
+      ChatClient.message 'server operations', message, color: 'green'
+    else
+      message = 'ಠ_ಠ Eyes tests for <b>dashboard</b> failed. See <a href="https://eyes.applitools.com/app/sessions/">the console</a> for results or to modify baselines.'
+      ChatClient.log message, color: 'red'
+      ChatClient.message 'server operations', message, color: 'red', notify: 1
+      raise "Eyes tests failed"
     end
   end
 


### PR DESCRIPTION
`Dir.chdir` is inherently thread-unsafe, which is a problem for us because the two rake tasks we have which use it also get run in parallel threads: https://github.com/code-dot-org/code-dot-org/blob/e0aa3b37133f99a70f7ff0dffaad9e93da35e286/lib/rake/test.rake#L88-L94

This hasn't harmed us so far because although one of the two calls to `Dir.chdir` will "override" the other, they're both targeting the same directory so in practice the overridden one will continue to work just fine.

However, Ruby starting in 3.0 will be much more proactive about preventing the user from making this call in the first place and the `test:ui_all` Rake task will begin failing in that version with `conflicting chdir during another chdir block`. Fortunately, we don't actually need to change the working directory at the *Ruby* level, we just want to change the directory from which the child process we're kicking off is executed, which we can do with a simple `cd` in the child process itself.

I recommend reviewing [with whitespace changes disabled](https://github.com/code-dot-org/code-dot-org/pull/52619/files?w=1)

## Links

- https://coderscat.com/ruby-change-current-working-directory/
- https://bugs.ruby-lang.org/issues/9785
- https://bugs.ruby-lang.org/issues/15661

## Testing story

Verified locally that with this change (plus a tweak to have each test suite run only a single arbitrarily-chosen test rather than the entire test suite), we are successfully able to run `bundle exec rake test:ui_all` on Ruby 3.0