### PR TITLE
P20-285: Create unit tests for shared functions i18n sync-in

### DIFF
--- a/bin/i18n/resources/dashboard/shared_functions.rb
+++ b/bin/i18n/resources/dashboard/shared_functions.rb
@@ -1,0 +1,29 @@
+require 'json'
+
+require_relative '../../../../dashboard/config/environment'
+require_relative '../../i18n_script_utils'
+
+module I18n
+  module Resources
+    module Dashboard
+      module SharedFunctions
+        I18N_SOURCE_FILE_PATH = CDO.dir(File.join(I18N_SOURCE_DIR, 'dashboard/shared_functions.yml')).freeze
+
+        def self.sync_in
+          puts 'Preparing shared functions'
+
+          # TODO: Refactor shared_functions request and data collection
+          #   1. Select data in batches of 1k records
+          #   2. Optimize data collection
+          shared_functions = SharedBlocklyFunction.where(level_type: 'GamelabJr').pluck(:name)
+          hash = {}
+          shared_functions.sort.each do |func|
+            hash[func] = func
+          end
+
+          File.write(I18N_SOURCE_FILE_PATH, I18nScriptUtils.to_crowdin_yaml({'en' => {'data' => {'shared_functions' => hash}}}))
+        end
+      end
+    end
+  end
+end

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -25,7 +25,7 @@ module I18n
       localize_level_and_project_content
       localize_block_content
       I18n::Resources::Apps::Animations.sync_in
-      localize_shared_functions
+      I18n::Resources::Dashboard::SharedFunctions.sync_in
       I18n::Resources::Dashboard::CourseOfferings.sync_in
       localize_standards
       localize_docs
@@ -624,17 +624,6 @@ module I18n
       end
 
       File.write("dashboard/config/locales/blocks.en.yml", I18nScriptUtils.to_crowdin_yaml({"en" => {"data" => {"blocks" => blocks}}}))
-    end
-
-    def self.localize_shared_functions
-      puts "Preparing shared functions"
-
-      shared_functions = SharedBlocklyFunction.where(level_type: 'GamelabJr').pluck(:name)
-      hash = {}
-      shared_functions.sort.each do |func|
-        hash[func] = func
-      end
-      File.write("i18n/locales/source/dashboard/shared_functions.yml", I18nScriptUtils.to_crowdin_yaml({"en" => {"data" => {"shared_functions" => hash}}}))
     end
 
     def self.select_redactable(i18n_strings)

--- a/bin/test/i18n/resources/dashboard/test_shared_functions.rb
+++ b/bin/test/i18n/resources/dashboard/test_shared_functions.rb
@@ -1,0 +1,36 @@
+require_relative '../../../test_helper'
+require_relative '../../../../i18n/resources/dashboard/shared_functions'
+
+class I18n::Resources::Dashboard::SharedFunctionsTest < Minitest::Test
+  def test_sync_in
+    expected_shared_functions_data = {
+      'en' => {
+        'data' => {
+          'shared_functions' => {
+            'shared-function-1' => 'shared-function-1',
+            'shared-function-2' => 'shared-function-2'
+          }
+        }
+      }
+    }
+    expected_sync_in_result_file_path = CDO.dir('i18n/locales/source/dashboard/shared_functions.yml')
+    expected_sync_in_result_file_data = 'expected_sync_in_result_file_data'
+
+    I18nScriptUtils.stubs(:to_crowdin_yaml).with(expected_shared_functions_data).returns(expected_sync_in_result_file_data)
+    SharedBlocklyFunction.any_instance.stubs(:write_file)
+
+    SharedBlocklyFunction.transaction do
+      SharedBlocklyFunction.delete_all
+
+      FactoryBot.create(:shared_blockly_function, level_type: 'GamelabJr', name: 'shared-function-2')
+      FactoryBot.create(:shared_blockly_function, level_type: 'Unexpected', name: 'unexpected')
+      FactoryBot.create(:shared_blockly_function, level_type: 'GamelabJr', name: 'shared-function-1')
+
+      File.expects(:write).with(expected_sync_in_result_file_path, expected_sync_in_result_file_data).once
+
+      I18n::Resources::Dashboard::SharedFunctions.sync_in
+    ensure
+      raise ActiveRecord::Rollback
+    end
+  end
+end

--- a/bin/test/i18n/test_sync-in.rb
+++ b/bin/test/i18n/test_sync-in.rb
@@ -10,7 +10,7 @@ class I18n::SyncInTest < Minitest::Test
     I18n::SyncIn.expects(:localize_level_and_project_content).in_sequence(exec_seq)
     I18n::SyncIn.expects(:localize_block_content).in_sequence(exec_seq)
     I18n::Resources::Apps::Animations.expects(:sync_in).in_sequence(exec_seq)
-    I18n::SyncIn.expects(:localize_shared_functions).in_sequence(exec_seq)
+    I18n::Resources::Dashboard::SharedFunctions.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Dashboard::CourseOfferings.expects(:sync_in).in_sequence(exec_seq)
     I18n::SyncIn.expects(:localize_standards).in_sequence(exec_seq)
     I18n::SyncIn.expects(:localize_docs).in_sequence(exec_seq)


### PR DESCRIPTION
This PR does two things:

1. Refactors the `localize_shared_functions` method into a module  `I18n::Resources::Dashboard::SharedFunctions`.
2. Crate unit tests for the  `I18n::Resources::Dashboard::SharedFunctions` module.

## Links
- jira ticket: [P20-285](https://codedotorg.atlassian.net/browse/P20-285)

## Sync-in
<img width="1488" alt="Screenshot 2023-07-13 at 18 52 28" src="https://github.com/code-dot-org/code-dot-org/assets/66776217/1e42bf9d-759b-458b-ba3b-63f49cfb13be">