### PR TITLE
Add text to assign dialog when assigning from Curriculum

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -348,6 +348,7 @@
   "chooseSection": "Choose your section",
   "chooseSectionsPrompt": "Which section(s) do you want to assign \"{assignmentName}\" to?",
   "chooseSectionsDirections": "When you assign a curriculum to a section, that curriculum will be the first thing students see upon signing in. Changing the assigned curriculum will never affect students progress on other curriculum.",
+  "chooseSectionsDirectionsOnCatalog": "When you assign a curriculum to a section, that curriculum will be the first thing students see upon signing in. Changing the assigned curriculum will never affect students progress on other curriculum. Note: The most recent recommended version of the curriculum will be assigned to your course when you assign from the Curriculum Catalog.",
   "chooseTable": "Choose a table",
   "chromebook": "Chromebook",
   "className": "Class Name",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -348,7 +348,7 @@
   "chooseSection": "Choose your section",
   "chooseSectionsPrompt": "Which section(s) do you want to assign \"{assignmentName}\" to?",
   "chooseSectionsDirections": "When you assign a curriculum to a section, that curriculum will be the first thing students see upon signing in. Changing the assigned curriculum will never affect students progress on other curriculum.",
-  "chooseSectionsDirectionsOnCatalog": "When you assign a curriculum to a section, that curriculum will be the first thing students see upon signing in. Changing the assigned curriculum will never affect students progress on other curriculum. Note: The most recent recommended version of the curriculum will be assigned to your course when you assign from the Curriculum Catalog.",
+  "chooseSectionsDirectionsOnCatalog": "When you assign a curriculum to a section, that curriculum will be the first thing students see upon signing in. Changing the assigned curriculum will never affect students progress on other curriculum. Note: The most recent recommended version of the curriculum will be assigned to your section when you assign from the Curriculum Catalog.",
   "chooseTable": "Choose a table",
   "chromebook": "Chromebook",
   "className": "Class Name",

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -25,6 +25,7 @@ const MultipleSectionsAssigner = ({
   isStandAloneUnit,
   participantAudience,
   onAssignSuccess,
+  sectionDirections = i18n.chooseSectionsDirections(),
   // Redux
   sections,
   unassignSection,
@@ -192,7 +193,7 @@ const MultipleSectionsAssigner = ({
       >
         {i18n.chooseSectionsPrompt({assignmentName})}
       </div>
-      <div style={styles.content}>{i18n.chooseSectionsDirections()}</div>
+      <div style={styles.content}>{sectionDirections}</div>
       <div style={styles.header} className="uitest-confirm-assignment-dialog">
         {i18n.yourSectionsList()}
       </div>
@@ -251,6 +252,7 @@ MultipleSectionsAssigner.propTypes = {
   isStandAloneUnit: PropTypes.bool,
   participantAudience: PropTypes.string,
   onAssignSuccess: PropTypes.func,
+  sectionDirections: PropTypes.string,
   // Redux
   sections: PropTypes.arrayOf(sectionForDropdownShape).isRequired,
   unassignSection: PropTypes.func.isRequired,

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -259,6 +259,7 @@ const CurriculumCatalog = ({
                 key,
                 image,
                 display_name,
+                display_name_with_year,
                 grade_levels,
                 duration,
                 school_subject,
@@ -274,6 +275,7 @@ const CurriculumCatalog = ({
                 <CurriculumCatalogCard
                   key={key}
                   courseDisplayName={display_name}
+                  courseDisplayNameWithYear={display_name_with_year}
                   imageSrc={image || undefined}
                   duration={duration}
                   gradesArray={grade_levels.split(',')}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -136,6 +136,7 @@ const CustomizableCurriculumCatalogCard = ({
           onAssignSuccess={onAssignSuccess}
           isAssigningCourse={!!courseId}
           courseId={courseId}
+          sectionDirections={i18n.chooseSectionsDirectionsOnCatalog()}
           {...props}
         />
       );

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -73,6 +73,7 @@ const CurriculumCatalogCard = ({
 
 CurriculumCatalogCard.propTypes = {
   courseDisplayName: PropTypes.string.isRequired,
+  courseDisplayNameWithYear: PropTypes.string.isRequired,
   duration: PropTypes.oneOf(Object.keys(translatedCourseOfferingDurations))
     .isRequired,
   gradesArray: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -99,6 +100,7 @@ const CustomizableCurriculumCatalogCard = ({
   assignButtonDescription,
   assignButtonText,
   courseDisplayName,
+  courseDisplayNameWithYear,
   duration,
   gradeRange,
   imageAltText,
@@ -129,7 +131,7 @@ const CustomizableCurriculumCatalogCard = ({
     } else if (isTeacher && sectionsForDropdown.length > 0) {
       return (
         <MultipleSectionsAssigner
-          assignmentName={courseDisplayName}
+          assignmentName={courseDisplayNameWithYear}
           onClose={() => setIsAssignDialogOpen(false)}
           sections={sectionsForDropdown}
           participantAudience="student"
@@ -224,6 +226,7 @@ const CustomizableCurriculumCatalogCard = ({
 
 CustomizableCurriculumCatalogCard.propTypes = {
   courseDisplayName: PropTypes.string.isRequired,
+  courseDisplayNameWithYear: PropTypes.string.isRequired,
   duration: PropTypes.string.isRequired,
   gradeRange: PropTypes.string.isRequired,
   imageSrc: PropTypes.string.isRequired,

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
@@ -17,6 +17,7 @@ const Template = args => (
 
 const defaultArgs = {
   courseDisplayName: 'Computer Science Principles',
+  courseDisplayNameWithYear: 'Computer Science Principles (22-23)',
   duration: 'school_year',
   gradesArray: ['1', '2', '3', '4'],
   topics: ['programming', 'artificial_intelligence', 'art_and_design'],

--- a/apps/src/templates/curriculumCatalog/curriculumCatalogShapes.jsx
+++ b/apps/src/templates/curriculumCatalog/curriculumCatalogShapes.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 export const curriculumDataShape = PropTypes.shape({
   key: PropTypes.string.isRequired,
   display_name: PropTypes.string.isRequired,
+  display_name_with_year: PropTypes.string.isRequired,
   grade_levels: PropTypes.string,
   image: PropTypes.string,
   cs_topic: PropTypes.string,

--- a/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTestHelper.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTestHelper.jsx
@@ -2,6 +2,7 @@
 const makerCurriculum = {
   key: 'devices',
   display_name: 'Creating Apps for Devices',
+  display_name_with_year: 'Creating Apps for Devices (2022)',
   grade_levels: '6,7,8,9,10,11,12',
   image: 'devices.png',
   duration: 'week',
@@ -13,6 +14,7 @@ const makerCurriculum = {
 const countingCurriculum = {
   key: 'counting-csc',
   display_name: 'Computer Science Connections',
+  display_name_with_year: 'Computer Science Connections (2023)',
   grade_levels: '3,4,5',
   image: 'csc.png',
   duration: 'lesson',
@@ -26,6 +28,7 @@ const countingCurriculum = {
 const poemArtCurriculum = {
   key: 'poem-art',
   display_name: 'Poem Art',
+  display_name_with_year: 'Poem Art (2017)',
   grade_levels: '2,3,4,5,6,7,8,9,10,11,12',
   image: null,
   duration: 'lesson',
@@ -39,6 +42,7 @@ const poemArtCurriculum = {
 const danceUnpluggedCurriculum = {
   key: 'dance-unplugged',
   display_name: 'Hour of Code - Dance Party - Unplugged',
+  display_name_with_year: 'Hour of Code - Dance Party - Unplugged (2018)',
   grade_levels: '2,3,4,5,6,7,8',
   image: null,
   duration: 'lesson',
@@ -52,6 +56,7 @@ const danceUnpluggedCurriculum = {
 const course1Curriculum = {
   key: 'course1',
   display_name: 'Course 1',
+  display_name_with_year: 'Course 1 (2012)',
   grade_levels: 'K,1',
   image: null,
   duration: 'lesson',
@@ -65,6 +70,7 @@ const course1Curriculum = {
 const course2Curriculum = {
   key: 'course2',
   display_name: 'Course 2',
+  display_name_with_year: 'Course 2 (2012)',
   grade_levels: '2,3,4,5',
   image: 'course2.png',
   duration: 'lesson',
@@ -78,6 +84,7 @@ const course2Curriculum = {
 const course3Curriculum = {
   key: 'course3',
   display_name: 'Course 3',
+  display_name_with_year: 'Course 3 (2012)',
   grade_levels: '3,4,5',
   image: 'course3.png',
   duration: 'lesson',
@@ -91,6 +98,7 @@ const course3Curriculum = {
 const course4Curriculum = {
   key: 'course4',
   display_name: 'Course 4',
+  display_name_with_year: 'Course 4 (2012)',
   grade_levels: '4,5',
   image: 'course4.png',
   duration: 'lesson',
@@ -104,6 +112,7 @@ const course4Curriculum = {
 const noGradesCurriculum = {
   key: 'no-grades',
   display_name: 'No Grades',
+  display_name_with_year: 'No Grade (2012)',
   grade_levels: null,
   image: 'grades.png',
   duration: 'lesson',
@@ -117,6 +126,7 @@ const noGradesCurriculum = {
 const noPathCurriculum = {
   key: 'no-path',
   display_name: 'No Path',
+  display_name_with_year: 'No Path (2012)',
   grade_levels: 'K,1',
   image: 'grades.png',
   duration: 'month',

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -55,6 +55,7 @@ describe('CurriculumCatalogCard', () => {
     store = getStore();
     defaultProps = {
       courseDisplayName: 'AI for Oceans',
+      courseDisplayNameWithYear: 'AI for Oceans (2022)',
       duration: 'quarter',
       gradesArray: ['4', '5', '6', '7', '8'],
       isEnglish: true,
@@ -263,7 +264,7 @@ describe('CurriculumCatalogCard', () => {
     });
   });
 
-  it('clicking Assign button as a teacher with sections shows dialog with sections and catalog-specific text', () => {
+  it('clicking Assign button as a teacher with sections shows dialog with sections and catalog-specific text with year', () => {
     store.dispatch(setSections(sections));
     renderCurriculumCard({
       ...defaultProps,
@@ -283,6 +284,7 @@ describe('CurriculumCatalogCard', () => {
     fireEvent.click(assignButton);
     sections.forEach(section => screen.getByText(section.name));
     screen.getByText('The most recent recommended version', {exact: false});
+    screen.getByRole('heading', defaultProps.courseDisplayNameWithYear);
   });
 
   it('clicking Assign button as a teacher without sections shows dialog to create section', () => {

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -263,7 +263,7 @@ describe('CurriculumCatalogCard', () => {
     });
   });
 
-  it('clicking Assign button as a teacher with sections shows sections', () => {
+  it('clicking Assign button as a teacher with sections shows dialog with sections and catalog-specific text', () => {
     store.dispatch(setSections(sections));
     renderCurriculumCard({
       ...defaultProps,
@@ -282,6 +282,7 @@ describe('CurriculumCatalogCard', () => {
     );
     fireEvent.click(assignButton);
     sections.forEach(section => screen.getByText(section.name));
+    screen.getByText('The most recent recommended version', {exact: false});
   });
 
   it('clicking Assign button as a teacher without sections shows dialog to create section', () => {

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -109,6 +109,11 @@ class CourseOffering < ApplicationRecord
     latest_published_version(locale_code).content_root.link
   end
 
+  def display_name_with_year(locale_code = 'en-us')
+    return localized_display_name unless latest_published_version(locale_code)
+    latest_published_version(locale_code).content_root.localized_assignment_family_title
+  end
+
   def course_id
     return unless latest_published_version&.content_root_type == 'UnitGroup'
     latest_published_version.content_root.id
@@ -275,6 +280,7 @@ class CourseOffering < ApplicationRecord
     {
       key: key,
       display_name: display_name,
+      display_name_with_year: display_name_with_year(locale_code),
       grade_levels: grade_levels,
       duration: duration,
       image: image,

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -72,6 +72,7 @@ class CourseVersion < ApplicationRecord
   delegate :can_view_version?, to: :content_root, allow_nil: true
   delegate :included_in_units?, to: :content_root, allow_nil: true
   delegate :link, to: :content_root, allow_nil: false
+  delegate :localized_assignment_family_title, to: :content_root, allow_nil: false
 
   # Seeding method for creating / updating / deleting the CourseVersion for the given
   # potential content root, i.e. a Unit or UnitGroup.


### PR DESCRIPTION
Does two things:
1) Adds `Note: The most recent recommended version of the curriculum will be assigned to your section when you assign from the Curriculum Catalog.` to the directions in the MultipleSectionsAssigner when coming from the Catalog page.
2) Includes the version year in the `MultipleSectionsAssigner`. This change does _not_ change the card title on the catalog page.
See https://codedotorg.slack.com/archives/C04540KNGDQ/p1688573148864529 for more context.

Now looks like
<img width="495" alt="Screenshot 2023-07-05 at 1 29 42 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/81f376aa-d3b3-49e3-a05b-aa0062e93dfd">

While the catalog card still looks like
<img width="245" alt="Screenshot 2023-07-05 at 1 29 33 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/4e9ad1e5-638b-4a42-bfbe-7b7fdf6139d1">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
