### PR TITLE
Fix Violations of and Reenable `Rails/Pick`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -200,11 +200,6 @@ Rails/I18nLocaleTexts:
 Rails/Output:
   Enabled: false
 
-# Offense count: 4
-# This cop supports unsafe auto-correction (--auto-correct-all).
-Rails/Pick:
-  Enabled: false
-
 # Offense count: 49
 # This cop supports safe auto-correction (--auto-correct).
 Rails/Pluck:

--- a/dashboard/app/controllers/admin_reports_controller.rb
+++ b/dashboard/app/controllers/admin_reports_controller.rb
@@ -36,7 +36,7 @@ class AdminReportsController < ApplicationController
 
           # Determine whether the level is a multi question, replacing the
           # numerical answer with its corresponding text if so.
-          level_info = Level.where(id: level_id).pluck(:type, :properties).first
+          level_info = Level.where(id: level_id).pick(:type, :properties)
           next unless level_info && level_info[0] == 'Multi' && !level_info[1].empty?
           level_answers = level_info[1]["answers"]
           @responses[level_id].each do |response|

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
@@ -122,7 +122,7 @@ module Api::V1::Pd
       csf_workshop = create :csf_workshop,
         started_at:  Time.now.utc - 1.day,
         ended_at: Time.now.utc - 1.hour
-      facilitator_id = csf_workshop.facilitators.pluck(:id).first
+      facilitator_id = csf_workshop.facilitators.pick(:id)
       create_list :csf_intro_post_workshop_submission, 1, :answers_low, pd_workshop_id: csf_workshop.id
       create_list :csf_intro_post_workshop_submission, 5, :answers_high, pd_workshop_id: csf_workshop.id
 
@@ -157,7 +157,7 @@ module Api::V1::Pd
       response = JSON.parse(@response.body, symbolize_names: true)
 
       overall_facilitator_rollup_facilitator = response[:workshop_rollups][:facilitator][:overall_facilitator]
-      csf_workshop_1_facilitator = csf_workshop_1.facilitators.pluck(:id).first.to_s.to_sym
+      csf_workshop_1_facilitator = csf_workshop_1.facilitators.pick(:id).to_s.to_sym
       assert_equal 5, overall_facilitator_rollup_facilitator[csf_workshop_1_facilitator][:response_count]
     end
 

--- a/dashboard/test/lib/pd/foorm/rollup_creator_test.rb
+++ b/dashboard/test/lib/pd/foorm/rollup_creator_test.rb
@@ -136,7 +136,7 @@ module Pd::Foorm
       rollup_configuration = JSON.parse(File.read('test/fixtures/rollup_config.json'), symbolize_names: true)
       questions_to_summarize = rollup_configuration[:'CS Fundamentals']
       workshop = create :csf_workshop
-      @facilitator_id = workshop.facilitators.pluck(:id).first
+      @facilitator_id = workshop.facilitators.pick(:id)
       @facilitators = {@facilitator_id => "name"}
       create :csf_intro_post_facilitator_workshop_submission,
         :answers_low,


### PR DESCRIPTION
> This cop enforces the use of `pick` over `pluck(…).first`.
>
> Using `pluck` followed by `first` creates an intermediate array, which `pick` avoids. When called on an Active Record relation, `pick` adds a limit to the query so that only one value is fetched from the database.

Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Rails/Pick`

## Links

- https://docs.rubocop.org/rubocop-rails/cops_rails.html#railspick
- https://www.rubydoc.info/gems/rubocop-rails/2.8.1/RuboCop/Cop/Rails/Pick

## Testing story

This fix is safe to apply automatically in Rails 6.1, which we are on: https://docs.rubocop.org/rubocop-rails/cops_rails.html#safety-21

Given that, I'm comfortable relying entirely on existing CI tests for this one.