### PR TITLE
Fix Violations of and Reenable `Performance/CollectionLiteralInLoop`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -148,11 +148,6 @@ Naming/MethodParameterName:
 Naming/VariableNumber:
   Enabled: false
 
-# Offense count: 41
-# Configuration parameters: MinSize.
-Performance/CollectionLiteralInLoop:
-  Enabled: false
-
 # Offense count: 61
 # This cop supports safe auto-correction (--auto-correct).
 Performance/Detect:

--- a/bin/create-release
+++ b/bin/create-release
@@ -30,10 +30,11 @@ def git_generate_changelog
     merge_commit_pattern.match(change) || squash_merge_pattern.match(change)
   end
 
+  # ignore merges from staging and test, which represent standard
+  # deploy operations
+  standard_deploy_branches = ['staging', 'test']
   relevant_matches = matches.select do |match|
-    # ignore merges from staging and test, which represent standard
-    # deploy operations
-    !match.nil? && (!match.names.include?('branch') || !['staging', 'test'].include?(match['branch']))
+    !match.nil? && (!match.names.include?('branch') || !standard_deploy_branches.include?(match['branch']))
   end
 
   items = relevant_matches.map do |match|

--- a/bin/cron/delete_twilio_data
+++ b/bin/cron/delete_twilio_data
@@ -19,6 +19,7 @@ def main
   # every five minutes. We further backtrack a minute for rounding error.
   date_to_delete = Time.now - ((60 + 5 + 1) * 60)
 
+  in_process_statuses = %w(accepted queued sending sent SENT receiving)
   @client.messages.list(
     date_sent: date_to_delete.strftime('%F'),
     page_size: 1000
@@ -28,7 +29,7 @@ def main
     # another execution of this script.
     # Per customer ticket #712102, it is also an error to delete a message
     # in state sent, despite not seeing public documentation of this.
-    if %w(accepted queued sending sent SENT receiving).include? message.status
+    if in_process_statuses.include? message.status
       next
     end
 

--- a/bin/grep-applab-source
+++ b/bin/grep-applab-source
@@ -9,6 +9,8 @@ MAX_THREADS = 200
 # Must be a multiple of MAX_THREADS.
 LOG_INCREMENT = 1000
 
+HEADERS = %w{owner_storage_id match project_url}
+
 if ARGV.length < 2 || ARGV.length.odd?
   warn "usage: #{$0} <regex1> <output1>.tsv [<regex2> <output2>.tsv] ..."
   exit(1)
@@ -31,7 +33,7 @@ end
 commands = ARGV.map(&:to_s).map(&:strip).each_slice(2).to_a.map do |regex, filename|
   # print tsv headers
   File.open(filename, 'w') do |file|
-    file << (%w{owner_storage_id match project_url}.join("\t") + "\n")
+    file << (HEADERS.join("\t") + "\n")
   end
 
   # construct regex

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -398,10 +398,11 @@ module I18n
 
       if level.is_a? BubbleChoice
         i18n_strings["sublevels"] = {}
+        # Block categories, variables, and parameters are handled differently below and are generally covered by the script levels
+        ignored_types = %w[block_categories variable_names parameter_names]
         level.sublevels.map do |sublevel|
           i18n_strings["sublevels"][sublevel.name] = get_i18n_strings sublevel
-          # Block categories, variables, and parameters are handled differently below and are generally covered by the script levels
-          %w[block_categories variable_names parameter_names].each do |type|
+          ignored_types.each do |type|
             i18n_strings["sublevels"][sublevel.name].delete(type) if i18n_strings["sublevels"][sublevel.name].key? type
           end
         end

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -152,6 +152,13 @@ def restore_redacted_files
 
   puts "Restoring redacted files in #{locales.count} locales, parallelized between #{Parallel.processor_count / 2} processes"
 
+  # Prepare some collection literals
+  app_types_with_link = %w(applab gamelab weblab)
+  resource_and_vocab_paths = [
+    'i18n/locales/original/dashboard/scripts.yml',
+    'i18n/locales/original/dashboard/courses.yml'
+  ]
+
   Parallel.each(locales, in_processes: (Parallel.processor_count / 2)) do |prop|
     locale = prop[:locale_s]
     next if locale == 'en-US'
@@ -176,10 +183,7 @@ def restore_redacted_files
       else
         # Everything else is differentiated only by the plugins used
         plugins = []
-        if [
-          'i18n/locales/original/dashboard/scripts.yml',
-          'i18n/locales/original/dashboard/courses.yml'
-        ].include? original_path
+        if resource_and_vocab_paths.include? original_path
           plugins << 'resourceLink'
           plugins << 'vocabularyDefinition'
         elsif original_path.starts_with? "i18n/locales/original/curriculum_content"
@@ -188,7 +192,7 @@ def restore_redacted_files
           plugins << 'visualCodeBlock'
           plugins << 'link'
           plugins << 'resourceLink'
-        elsif %w(applab gamelab weblab).include?(File.basename(original_path, '.json'))
+        elsif app_types_with_link.include?(File.basename(original_path, '.json'))
           plugins << 'link'
         end
         RedactRestoreUtils.restore(original_path, translated_path, translated_path, plugins)
@@ -488,7 +492,7 @@ def distribute_translations(upload_manifests)
       relative_dir = File.dirname(relative_path)
       name = File.basename(loc_file, ".*")
       # TODO: Remove the ai.md exception when ai.md files are deleted from crowdin
-      next if %w[ai].include? name # ai.md file has been substituted by ai.haml
+      next if name == "ai" # ai.md file has been substituted by ai.haml
       destination = File.join(destination_dir, relative_dir, "#{name}.#{locale}.md.partial")
       FileUtils.mkdir_p(File.dirname(destination))
       FileUtils.mv(loc_file, destination)

--- a/bin/oneoff/backup_translations.rb
+++ b/bin/oneoff/backup_translations.rb
@@ -24,8 +24,9 @@ puts 'Moving content'
 file_count = 0
 script = 'poem-art'
 
+non_locale_i18n_directories = ['i18n/locales/original', 'i18n/locales/source', 'i18n/locales/en-US']
 Dir.glob("i18n/locales/**").each do |directory|
-  next if ['i18n/locales/original', 'i18n/locales/source', 'i18n/locales/en-US'].include? directory
+  next if non_locale_i18n_directories.include? directory
   file = File.join(directory, "/course_content/other/#{script}.json")
   locale = directory.delete_prefix('i18n/locales/')
 

--- a/bin/oneoff/generate_legacy_survey_summaries.rb
+++ b/bin/oneoff/generate_legacy_survey_summaries.rb
@@ -124,6 +124,7 @@ def snapshot_summer_workshops_from_jotform(course)
 
   survey_reports = {}
 
+  only_facilitator_questions_responses = [false, true]
   facilitators.each do |id, f|
     all_their_workshops = Pd::Workshop.facilitated_by(f)
     all_their_completed_workshops = all_their_workshops.where(course: course, subject: subject).in_state(Pd::Workshop::STATE_ENDED)
@@ -132,7 +133,7 @@ def snapshot_summer_workshops_from_jotform(course)
 
     unless all_their_completed_workshops.empty?
       # Do workshop rollups, then facilitator rollups.
-      [false, true].each do |only_facilitator_questions|
+      only_facilitator_questions_responses.each do |only_facilitator_questions|
         rollup = report_facilitator_rollup(id, all_their_completed_workshops.first, only_facilitator_questions)
 
         key = "facilitator_#{id}_all_ws"

--- a/bin/oneoff/geocode-mailing-list-nyc
+++ b/bin/oneoff/geocode-mailing-list-nyc
@@ -8,6 +8,7 @@ FORMS = PEGASUS_DB[:forms]
 
 def main
   #['nyc-admins', 'nyc-parents', 'nyc-teachers'].each do |group|
+  nyc_cities = ['bronx', 'brooklyn', 'manhattan', 'queens', 'new york']
   ['nyc-teachers'].each do |group|
     CSV.foreach("#{group}.csv", headers: true) do |row|
       if row['city'].to_s.empty?
@@ -29,7 +30,7 @@ def main
         end
       end
 
-      next unless ['bronx', 'brooklyn', 'manhattan', 'queens', 'new york'].include?(row['city'].to_s.downcase)
+      next unless nyc_cities.include?(row['city'].to_s.downcase)
 
       puts CSV.generate_line([row['email'], row['name'], row['city'], row['state'], row['country']])
     end

--- a/bin/oneoff/send_facilitator_decision_emails
+++ b/bin/oneoff/send_facilitator_decision_emails
@@ -4,12 +4,12 @@ require_relative '../../dashboard/config/environment'
 
 ActiveRecord::Base.transaction do
   applications_emailed = []
+  decision_entry_types = ['declined_email', 'waitlisted_email']
   puts "Sending decision emails for locked declined/waitlisted facilitator 1920 applications..."
   Pd::Application::Facilitator1920Application.find_each do |application|
     if application.locked? && Pd::Application::Facilitator1920Application::AUTO_EMAIL_STATUSES.include?(application.status)
       log = application.sanitize_status_timestamp_change_log
-
-      if log.select {|entry| ['declined_email', 'waitlisted_email'].include? entry[:title]}.empty?
+      if log.select {|entry| decision_entry_types.include? entry[:title]}.empty?
         application.emails.unsent.destroy_all
         application.queue_email(application.status)
         applications_emailed << "id: #{application.id}, status: #{application.status}"

--- a/bin/oneoff/set_course_audiences.rb
+++ b/bin/oneoff/set_course_audiences.rb
@@ -14,6 +14,7 @@ def set_course_audiences
     next if script.unit_group
 
     # rubocop:disable Style/WordArray
+    # rubocop:disable Performance/CollectionLiteralInLoop
     script.instructor_audience = if ['csd1-dlp-18', 'csd2-dlp-18', 'csd3-dlp-18', 'csd4-dlp-18', 'csd5-dlp-18',
                                      'csd6-dlp-18', 'csp1-dlp-18', 'csp2-dlp-18', 'csp3-dlp-18', 'csp4-dlp-18',
                                      'csp5-dlp-18', 'csp-create-dlp-18', 'csp-explore-dlp-18', 'csp-novice-18',
@@ -44,6 +45,7 @@ def set_course_audiences
                                     Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
                                   end
     # rubocop:enable Style/WordArray
+    # rubocop:enable Performance/CollectionLiteralInLoop
 
     script.update!(skip_name_format_validation: true)
     script.write_script_json
@@ -51,13 +53,13 @@ def set_course_audiences
 
   UnitGroup.all.each do |course|
     # default is instructor_audience teacher and participant_audience student so only need to update unit groups we want something else
-    next unless ['self-paced-pl-csp-2021'].include?(course.name)
+    next unless course.name == 'self-paced-pl-csp-2021'
 
-    course.instructor_audience = if ['self-paced-pl-csp-2021'].include?(course.name)
+    course.instructor_audience = if course.name == 'self-paced-pl-csp-2021'
                                    Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.universal_instructor
                                  end
 
-    course.participant_audience = if ['self-paced-pl-csp-2021'].include?(course.name)
+    course.participant_audience = if course.name == 'self-paced-pl-csp-2021'
                                     Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher
                                   end
 

--- a/bin/oneoff/set_instruction_type.rb
+++ b/bin/oneoff/set_instruction_type.rb
@@ -12,11 +12,12 @@ require_relative '../../dashboard/config/environment'
 def set_instruction_type
   raise unless Rails.application.config.levelbuilder_mode
 
+  self_paced_units = ['self-paced-pl-csd5-2021', 'self-paced-pl-csd6-2021', 'self-paced-pl-csd7-2021', 'self-paced-pl-csd8-2021']
   Unit.all.each do |script|
     # scripts in unit_groups get their instruction type from their unit group
     next if script.unit_group
 
-    script.instruction_type = if ['self-paced-pl-csd5-2021', 'self-paced-pl-csd6-2021', 'self-paced-pl-csd7-2021', 'self-paced-pl-csd8-2021'].include?(script.name)
+    script.instruction_type = if self_paced_units.include?(script.name)
                                 'self_paced'
                               else
                                 'teacher_led'
@@ -25,9 +26,10 @@ def set_instruction_type
     script.write_script_json
   end
 
+  self_paced_unit_groups = ['self-paced-pl-csp-2021', 'self-paced-pl-csd-2021']
   UnitGroup.all.each do |course|
     # default is teacher_led so only need to update unit groups we want to be self_paced
-    next unless ['self-paced-pl-csp-2021', 'self-paced-pl-csd-2021'].include?(course.name)
+    next unless self_paced_unit_groups.include?(course.name)
 
     course.instruction_type = 'self_paced'
     course.save!

--- a/cookbooks/cdo-apps/recipes/stop.rb
+++ b/cookbooks/cdo-apps/recipes/stop.rb
@@ -3,12 +3,12 @@
 # Use ruby_block to apply after all other notifications.
 ruby_block 'stop services' do
   block {}
-  %w(
-    pegasus
-    dashboard
-    nginx
-  ).each do |service|
-    %i(stop disable).each do |action|
+
+  services = %w(pegasus dashboard nginx)
+  actions = %i(stop disable)
+
+  services.each do |service|
+    actions.each do |action|
       notifies action, "service[#{service}]"
     end
   end

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -178,7 +178,8 @@ class ApiController < ApplicationController
     updates = params.require(:updates)
     updates.to_a.each do |item|
       # Convert string-boolean parameters to boolean
-      %i(locked readonly_answers).each {|val| item[val] = JSONValue.value(item[val])}
+      item[:locked] = JSONValue.value(item[:locked])
+      item[:readonly_answers] = JSONValue.value(item[:readonly_answers])
 
       user_level_data = item[:user_level_data]
       if user_level_data[:user_id].nil? || user_level_data[:level_id].nil? || user_level_data[:script_id].nil?

--- a/dashboard/app/controllers/regional_partners_controller.rb
+++ b/dashboard/app/controllers/regional_partners_controller.rb
@@ -54,9 +54,12 @@ class RegionalPartnersController < ApplicationController
   # PATCH /regional_partners/:id
   def update
     update_params = regional_partner_params.to_h
-    %w(csd csp).each do |course|
-      %w(facilitator).each do |role|
-        %w(open close).each do |state|
+    courses = %w(csd csp)
+    roles = %w(facilitator)
+    states = %w(open close)
+    courses.each do |course|
+      roles.each do |role|
+        states.each do |state|
           key = "apps_#{state}_date_#{course}_#{role}".to_sym
           # Do a date validation.  An exception will result if invalid.
           Date.parse(regional_partner_params[key]) if regional_partner_params[key].presence

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -439,8 +439,9 @@ module UsersHelper
   def percent_complete_total(unit, user = current_user)
     summary = summarize_user_progress(unit, user)
     levels = unit.script_levels.map(&:level)
+    complete_statuses = %w(perfect passed)
     completed = levels.count do |l|
-      sum = summary[:progress][l.id]; sum && %w(perfect passed).include?(sum[:status])
+      sum = summary[:progress][l.id]; sum && complete_statuses.include?(sum[:status])
     end
     (100.0 * completed / levels.count).round(2)
   end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -123,6 +123,7 @@ class BubbleChoice < DSLDefined
   # @return [Array]
   def summarize_sublevels(script_level: nil, user_id: nil, should_localize: false)
     summary = []
+    localized_properties = %i[display_name short_instructions long_instructions]
     sublevels.each_with_index do |level, index|
       level_info = level.summary_for_lesson_plans.symbolize_keys
 
@@ -164,7 +165,7 @@ class BubbleChoice < DSLDefined
       end
 
       if should_localize
-        %i[display_name short_instructions long_instructions].each do |property|
+        localized_properties.each do |property|
           localized_value = I18n.t(level.name, scope: [:data, property], default: nil, smart: true)
           level_info[property] = localized_value unless localized_value.nil?
         end

--- a/dashboard/app/models/pd/application/principal_approval_application.rb
+++ b/dashboard/app/models/pd/application/principal_approval_application.rb
@@ -65,13 +65,14 @@ module Pd::Application
     end
 
     def underrepresented_minority_percent
+      underrepresented_minority_groups = [
+        :black,
+        :hispanic,
+        :pacific_islander,
+        :american_indian
+      ]
       sanitized_form_data_hash.select do |k, _|
-        [
-          :black,
-          :hispanic,
-          :pacific_islander,
-          :american_indian
-        ].include? k
+        underrepresented_minority_groups.include? k
       end.values.sum(&:to_f)
     end
 

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -927,6 +927,7 @@ module Pd::Application
       principal_application = Pd::Application::PrincipalApprovalApplication.where(application_guid: application_guid).first
       principal_answers = principal_application&.csv_data
       school_stats = get_latest_school_stats(school_id)
+      simple_columns = [:title_i_status, :students_total, :urm_percent]
       CSV.generate do |csv|
         row = []
         CSV_COLUMNS[:teacher].each do |k|
@@ -947,7 +948,7 @@ module Pd::Application
         end
         CSV_COLUMNS[:nces].each do |k|
           if school_stats
-            if [:title_i_status, :students_total, :urm_percent].include? k
+            if simple_columns.include? k
               row.push(school_stats[k] || school_stats.try(k) || "")
             elsif k == :rural_status
               row.push(school_stats.rural_school?)

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -713,7 +713,7 @@ class ScriptLevel < ApplicationRecord
         when GamelabJr
           send("#{level.standalone_app_name_or_default}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
         when Artist
-          artist_type = ['elsa', 'anna'].include?(level.skin) ? 'frozen' : 'artist'
+          artist_type = (level.skin == 'elsa' || level.skin == 'anna') ? 'frozen' : 'artist'
           send("#{artist_type}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
         when Studio # playlab
           send("#{'playlab'}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -66,9 +66,10 @@ class LevelLoader
 
       # activerecord-import (with MySQL, anyway) doesn't save associated
       # models, so we've got to do this manually.
+      immutable_lcd_columns = %i{id level_id created_at}
       changed_lcds = changed_levels.filter_map(&:level_concept_difficulty)
       lcd_update_columns = LevelConceptDifficulty.columns.map(&:name).map(&:to_sym).
-          reject {|column| %i{id level_id created_at}.include? column}
+        reject {|column| immutable_lcd_columns.include? column}
       LevelConceptDifficulty.import! changed_lcds, on_duplicate_key_update: lcd_update_columns
 
       # activerecord-import doesn't trigger before_save and before_create hooks
@@ -81,8 +82,9 @@ class LevelLoader
       end
 
       # Bulk-import changed levels.
+      immutable_level_columns = %i(id name created_at)
       update_columns = Level.columns.map(&:name).map(&:to_sym).
-        reject {|column| %i(id name created_at).include? column}
+        reject {|column| immutable_level_columns.include? column}
       Level.import! changed_levels, on_duplicate_key_update: update_columns
 
       # now we want to run some after_save callbacks, which didn't get run when

--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -285,6 +285,7 @@ module ScriptConstants
     # next prefix based on constant mapping, then add the year to the recommended prefix.
     # Example: coursea-2019 becomes prefix: coursea, year: 2019.
     # coursea maps to courseb, so return courseb-2019.
+    applab_courses = %w(coursef express)
     CSF_COURSE_PATTERNS.each do |r|
       match_data = r.match(course_name)
       next unless match_data
@@ -292,7 +293,7 @@ module ScriptConstants
       prefix = match_data[1]
       year = match_data[2]
 
-      return "applab-intro" if %w(coursef express).include?(prefix)
+      return "applab-intro" if applab_courses.include?(prefix)
 
       prefix_mapping = {
         "coursea" => "courseb",

--- a/dashboard/lib/single_sign_on.rb
+++ b/dashboard/lib/single_sign_on.rb
@@ -54,10 +54,11 @@ class SingleSignOn
     decoded = Base64.decode64(parsed["sso"])
     decoded_hash = Rack::Utils.parse_query(decoded)
 
+    valid_bool_values = %w(true false)
     ACCESSORS.each do |k|
       val = decoded_hash[k.to_s]
       if BOOLS.include? k
-        val = ["true", "false"].include?(val) ? val == "true" : nil
+        val = valid_bool_values.include?(val) ? val == "true" : nil
       end
       sso.send("#{k}=", val)
     end

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -216,7 +216,15 @@ module Pd::Application
     end
 
     test 'get_first_selected_workshop multiple local workshops' do
-      workshops = (1..3).map {|i| create :workshop, num_sessions: 2, sessions_from: Time.zone.today + i, location_address: %w(tba TBA tba)[i - 1]}
+      addresses = %w(tba TBA tba)
+      workshops = (1..3).map do |i|
+        create(
+          :workshop,
+          num_sessions: 2,
+          sessions_from: Time.zone.today + i,
+          location_address: addresses[i - 1]
+        )
+      end
 
       application = create :pd_teacher_application, form_data_hash: (
       build(:pd_teacher_application_hash, :with_multiple_workshops,

--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -105,12 +105,12 @@ module AWS
         loop do
           sleep 1
           change_set = cfn.describe_change_set(change_set_name: change_set_id)
-          break unless %w(CREATE_PENDING CREATE_IN_PROGRESS).include?(change_set.status)
+          break unless change_set.status == "CREATE_PENDING" || change_set.status == "CREATE_IN_PROGRESS"
         end
         change_set.changes.each do |change|
           c = change.resource_change
           str = "#{c.action} #{c.logical_resource_id} [#{c.resource_type}] #{c.scope.join(', ')}"
-          str += " Replacement: #{c.replacement}" if %w(True Conditional).include?(c.replacement)
+          str += " Replacement: #{c.replacement}" if c.replacement == "True" || c.replacement == "Conditional"
           str += " (#{c.details.map {|d| d.target.name}.join(', ')})" if c.details.any?
           log.info str unless options[:quiet]
         end

--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -98,6 +98,7 @@ module LessonImportHelper
 
   def self.create_lesson_vocabularies(cb_vocab, course_version_id)
     return [] if cb_vocab.blank?
+    detailed_courses = %w(csd csp)
     cb_vocab.map do |cb_vocabulary|
       raise unless cb_vocabulary['word']
       key = cb_vocabulary['word'].downcase.tr(" ", "_")
@@ -106,8 +107,9 @@ module LessonImportHelper
         key: key
       )
       vocab.word = cb_vocabulary['word']
+      course_key = CourseVersion.find(course_version_id).course_offering.key
       vocab.definition =
-        if ['csd', 'csp'].include? CourseVersion.find(course_version_id).course_offering.key
+        if detailed_courses.include?(course_key)
           cb_vocabulary['detailDef']
         else
           cb_vocabulary['simpleDef']
@@ -163,6 +165,7 @@ module LessonImportHelper
 
     sections = []
     name = ''
+    valid_prefixes = [1, 2]
     sorted_matches.each do |match|
       case match[:type]
       when 'tip'
@@ -180,7 +183,7 @@ module LessonImportHelper
         pullthrough_match = match[:match]
         # If the syntax takes the form of [code-studio], [code-studio 1-<length>], or [code-studio 2-<length>],
         # add the level activity sections here.
-        if pullthrough_match[1].blank? || ([1, 2].include?(pullthrough_match[1]) && levels.length == pullthrough_match[2].to_i)
+        if pullthrough_match[1].blank? || (valid_prefixes.include?(pullthrough_match[1]) && levels.length == pullthrough_match[2].to_i)
           level_sections = create_activity_sections_by_progression(levels, lesson_activity_id)
           sections += level_sections
           levels.clear

--- a/lib/rake/stack.rake
+++ b/lib/rake/stack.rake
@@ -49,12 +49,15 @@ Note: Consumes AWS resources until `adhoc:stop` is called.'
   end
 
   # Managed resource stacks other than the Code.org application.
-  %I(vpc iam ami data lambda alerting).each do |stack|
+  simple_stacks = %I(lambda alerting)
+  rack_stacks = %I(ami data)
+  other_stacks = %I(vpc iam)
+  (other_stacks + rack_stacks + simple_stacks).each do |stack|
     namespace stack do
       timed_task_with_logging :environment do
         stack_name = ENV['STACK_NAME']
-        stack_name ||= stack.to_s if [:lambda, :alerting].include? stack
-        stack_name ||= "#{stack.upcase}#{"-#{rack_env}" if [:ami, :data].include? stack}"
+        stack_name ||= stack.to_s if simple_stacks.include?(stack)
+        stack_name ||= "#{stack.upcase}#{"-#{rack_env}" if rack_stacks.include?(stack)}"
 
         Dir.chdir aws_dir('cloudformation')
         require 'cdo/aws/cloud_formation'

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -470,7 +470,7 @@ class Homepage
   end
 
   def self.get_video(request)
-    video = get_actions(request).find {|a| ["video", "video_thumbnail"].include? a[:type]}
+    video = get_actions(request).find {|a| a[:type] == "video" || a[:type] == "video_thumbnail"}
 
     if video
       {
@@ -512,7 +512,7 @@ class Homepage
       # celeb, stat, non-celeb, stat, celeb, stat, non-celeb, stat, celeb, stat,
       # etc.
       heroes.shuffle!
-      heroes_nonceleb = heroes.select {|hero| ["student", "teacher"].include? hero[:type]}
+      heroes_nonceleb = heroes.select {|hero| hero[:type] == "student" || hero[:type] == "teacher"}
       heroes_celeb = heroes.select {|hero| hero[:type] == "celeb"}
       heroes_stat = heroes.select {|hero| hero[:type] == "stat"}
       heroes_arranged =


### PR DESCRIPTION
> Identifies places where Array and Hash literals are used within loops. It is better to extract them into a local variable or constant to avoid unnecessary allocations on each iteration.

All fixes applied manually, using my own subjective best judgement. Some of them involved minor reorganizations, but most changes are minimal. In one case, I added an ignore directive rather than a fix to an one oneoff executable.

Note that one advantage of putting these literals in a variable is that without an intentionally crafted name, the "why" behind the collection isn't always clear. I've attempted to give each of the new variables an accurate and informative name, but for many of them my best attempt is still just a guess. I welcome suggestions on how any of them could be improved!


## Links

- https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancecollectionliteralinloop
- https://msp-greg.github.io/rubocop-performance/RuboCop/Cop/Performance/CollectionLiteralInLoop.html

## Testing story

Relying entirely on existing tests to verify that none of these change affect existing functionality.