### PR TITLE
P20-287: Create unit tests for course offerings i18n sync-in

### DIFF
--- a/bin/i18n/resources/dashboard/course_offerings.rb
+++ b/bin/i18n/resources/dashboard/course_offerings.rb
@@ -1,0 +1,31 @@
+require 'json'
+
+require_relative '../../../../dashboard/config/environment'
+require_relative '../../i18n_script_utils'
+
+module I18n
+  module Resources
+    module Dashboard
+      module CourseOfferings
+        SYNC_IN_FILE_PATH = CDO.dir(File.join(I18N_SOURCE_DIR, 'dashboard/course_offerings.json')).freeze
+
+        # Aggregate every CourseOffering record's `key` as the translation key, and
+        # each record's `display_name` as the translation string.
+        def self.sync_in
+          puts 'Preparing course offerings'
+
+          course_offerings = {}
+
+          # TODO: Refactor course_offerings data collection
+          #   1. Select data in batches of 1k records
+          #   2. Fix data sorting
+          CourseOffering.all.sort.each do |co|
+            course_offerings[co.key] = co.display_name
+          end
+
+          File.write(SYNC_IN_FILE_PATH, JSON.pretty_generate(course_offerings))
+        end
+      end
+    end
+  end
+end

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -15,6 +15,8 @@ require_relative 'i18n_script_utils'
 require_relative 'redact_restore_utils'
 require_relative '../animation_assets/manifest_builder'
 
+Dir[File.expand_path('../resources/**/*.rb', __FILE__)].sort.each {|file| require file}
+
 module I18n
   module SyncIn
     def self.perform
@@ -25,7 +27,7 @@ module I18n
       localize_block_content
       localize_animation_library
       localize_shared_functions
-      localize_course_offerings
+      I18n::Resources::Dashboard::CourseOfferings.sync_in
       localize_standards
       localize_docs
       puts "Copying source files"
@@ -643,22 +645,6 @@ module I18n
         hash[func] = func
       end
       File.write("i18n/locales/source/dashboard/shared_functions.yml", I18nScriptUtils.to_crowdin_yaml({"en" => {"data" => {"shared_functions" => hash}}}))
-    end
-
-    # Aggregate every CourseOffering record's `key` as the translation key, and
-    # each record's `display_name` as the translation string.
-    def self.localize_course_offerings
-      puts "Preparing course offerings"
-
-      hash = {}
-      CourseOffering.all.sort.each do |co|
-        hash[co.key] = co.display_name
-      end
-      write_dashboard_json('course_offerings', hash)
-    end
-
-    def self.write_dashboard_json(location, hash)
-      File.write(File.join(I18N_SOURCE_DIR, "dashboard/#{location}.json"), JSON.pretty_generate(hash))
     end
 
     def self.select_redactable(i18n_strings)

--- a/bin/test/i18n/resources/dashboard/test_course_offerings.rb
+++ b/bin/test/i18n/resources/dashboard/test_course_offerings.rb
@@ -1,0 +1,22 @@
+require_relative '../../../test_helper'
+require_relative '../../../../i18n/resources/dashboard/course_offerings'
+
+class I18n::Resources::Dashboard::CourseOfferingsTest < Minitest::Test
+  def test_sync_in
+    CourseOffering.transaction do
+      CourseOffering.delete_all
+
+      FactoryBot.create(:course_offering, key: 'course-offering-key-2', display_name: 'course-offering-name-2')
+      FactoryBot.create(:course_offering, key: 'course-offering-key-1', display_name: 'course-offering-name-1')
+
+      File.expects(:write).with(
+        CDO.dir('i18n/locales/source/dashboard/course_offerings.json'),
+        %Q[{\n  "course-offering-key-2": "course-offering-name-2",\n  "course-offering-key-1": "course-offering-name-1"\n}]
+      ).once
+
+      I18n::Resources::Dashboard::CourseOfferings.sync_in
+    ensure
+      raise ActiveRecord::Rollback
+    end
+  end
+end

--- a/bin/test/i18n/test_sync-in.rb
+++ b/bin/test/i18n/test_sync-in.rb
@@ -11,7 +11,7 @@ class I18n::SyncInTest < Minitest::Test
     I18n::SyncIn.expects(:localize_block_content).in_sequence(exec_seq)
     I18n::SyncIn.expects(:localize_animation_library).in_sequence(exec_seq)
     I18n::SyncIn.expects(:localize_shared_functions).in_sequence(exec_seq)
-    I18n::SyncIn.expects(:localize_course_offerings).in_sequence(exec_seq)
+    I18n::Resources::Dashboard::CourseOfferings.expects(:sync_in).in_sequence(exec_seq)
     I18n::SyncIn.expects(:localize_standards).in_sequence(exec_seq)
     I18n::SyncIn.expects(:localize_docs).in_sequence(exec_seq)
     I18nScriptUtils.expects(:run_bash_script).with('bin/i18n-codeorg/in.sh').in_sequence(exec_seq)


### PR DESCRIPTION
This PR does two things:
1. Refactors the `localize_course_offerings` method into a module `I18n::Resources::Dashboard::CourseOfferings`.
2. Crate unit tests for the `I18n::Resources::Dashboard::CourseOfferings` module.

## Links
- jira ticket: [P20-287](https://codedotorg.atlassian.net/browse/P20-287)

## Sync-in
<img width="1619" alt="Screenshot 2023-07-10 at 22 37 16" src="https://github.com/code-dot-org/code-dot-org/assets/66776217/1f18edbd-0877-426a-9c23-9e450e462cbb">

<img width="1025" alt="Screenshot 2023-07-10 at 22 39 28" src="https://github.com/code-dot-org/code-dot-org/assets/66776217/d2aace4a-31d5-4b4e-99bc-909cf2705104">