### PR TITLE
Change Curriculum back to Course in header

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -357,7 +357,7 @@ en:
       finished_hoc: "I finished!"
       sign_in_to_save: 'Sign in to save progress'
       my_dashboard: "My Dashboard"
-      course_catalog: "Curriculum Catalog"
+      course_catalog: "Course Catalog"
       project_gallery: "Projects"
       sections: "Sections"
       help_support: "Help and support"

--- a/dashboard/test/ui/features/foundations/header.feature
+++ b/dashboard/test/ui/features/foundations/header.feature
@@ -23,7 +23,7 @@ Scenario: Student in English should see 2 header links
   Given I create a student named "Sally Student" and go home
   And I wait to see ".headerlinks"
   And I see "#header-student-courses"
-  And element "#header-student-courses" contains text "Curriculum Catalog"
+  And element "#header-student-courses" contains text "Course Catalog"
   And I see "#header-student-projects"
   And element "#header-student-projects" contains text "Projects"
 
@@ -33,7 +33,7 @@ Scenario: Teacher in English should see 5 header links
   And I see "#header-teacher-home"
   And element "#header-teacher-home" contains text "My Dashboard"
   And I see "#header-teacher-courses"
-  And element "#header-teacher-courses" contains text "Curriculum Catalog"
+  And element "#header-teacher-courses" contains text "Course Catalog"
   And I see "#header-teacher-projects"
   And element "#header-teacher-projects" contains text "Projects"
   And I see "#header-teacher-professional-learning"


### PR DESCRIPTION
Updates https://github.com/code-dot-org/code-dot-org/pull/52605 to use "Course Catalog" instead of "Curriculum Catalog," but keeps the path at `/catalog`.

If we go this route, we'll also need to update the string here https://docs.google.com/spreadsheets/d/1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU/edit#gid=0

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
