### PR TITLE
Update PL section button spacing on new Teach page

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/teach-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/teach-styles.scss
@@ -54,7 +54,16 @@ section.pl-offerings {
     }
 
     .flex-container {
-      gap: 2rem;
+      gap: 1.5rem;
+      flex-direction: column;
+
+      &.self-paced-english {
+        gap: 1.3rem;
+
+        @media screen and (max-width: $width-md) {
+          gap: 0;
+        }
+      }
     }
 
     img {

--- a/pegasus/sites.v3/code.org/views/teach_page_pl_list_forums.haml
+++ b/pegasus/sites.v3/code.org/views/teach_page_pl_list_forums.haml
@@ -1,4 +1,4 @@
-%div.flex-container.justify-center.align-content-baseline.wrap
+%div.flex-container.align-content-baseline.wrap
   %figure
     %img{src: "/images/teach-page-pl-offerings-forums.png", alt: ""}
   .content-wrapper

--- a/pegasus/sites.v3/code.org/views/teach_page_pl_list_self_paced.haml
+++ b/pegasus/sites.v3/code.org/views/teach_page_pl_list_self_paced.haml
@@ -1,9 +1,23 @@
-%div.flex-container.justify-center.align-content-baseline.wrap
+%div.flex-container.align-content-baseline.wrap
   %figure
     %img{src: "/images/teach-page-pl-offerings-self-paced.png", alt: ""}
-  .content-wrapper
-    %h3.heading-sm
-      =hoc_s(:teach_page_pl_offerings_list_heading_self_paced)
-    %p=hoc_s(:teach_page_pl_offerings_list_desc_self_paced)
-    %a.link-button{href: "/educate/professional-development-online"}
-      =hoc_s(:call_to_action_find_self_paced_modules)
+  -# Align the buttons at the bottom of the sections for English.
+  -# Allow non-English buttons to flow with the preceding paragraph
+  -# due to a greater chance for varying paragraph heights.
+  - if request.language == "en"
+    .flex-container.flex-space-between.self-paced-english
+      .content-wrapper
+        %h3.heading-sm
+          =hoc_s(:teach_page_pl_offerings_list_heading_self_paced)
+        %p=hoc_s(:teach_page_pl_offerings_list_desc_self_paced)
+      .content-footer
+        %a.link-button{href: "/educate/professional-development-online"}
+          =hoc_s(:call_to_action_find_self_paced_modules)
+  - else
+    .content-wrapper
+      %h3.heading-sm
+        =hoc_s(:teach_page_pl_offerings_list_heading_self_paced)
+      %p=hoc_s(:teach_page_pl_offerings_list_desc_self_paced)
+      %a.link-button{href: "/educate/professional-development-online"}
+        =hoc_s(:call_to_action_find_self_paced_modules)
+

--- a/pegasus/sites.v3/code.org/views/teach_page_pl_list_workshops.haml
+++ b/pegasus/sites.v3/code.org/views/teach_page_pl_list_workshops.haml
@@ -1,4 +1,4 @@
-%div.flex-container.justify-center.align-content-baseline.wrap
+%div.flex-container.align-content-baseline.wrap
   %figure
     %img{src: "/images/teach-page-pl-offerings-workshops.png", alt: ""}
   .content-wrapper


### PR DESCRIPTION
Adjust the button alignment in the PL section on https://code.org/teach page for English vs. non-English
- **English:** align buttons to the bottom of the section
- **Non-English:** allow buttons to flow with the preceding paragraph due to a greater chance for varying paragraph heights.
- Maintained responsive styles

**Jira ticket:** [ACQ-705](https://codedotorg.atlassian.net/browse/ACQ-705)

----

### English
<img width="1081" alt="English" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/1f7e130d-7449-44ba-9e3a-587678496e24">

### Non-English
<img width="1117" alt="Non-English" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/655f5790-f440-47a6-ae4a-379fd1ce0641">