### PR TITLE
Add v2 course offerings fields

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -2,22 +2,27 @@
 #
 # Table name: course_offerings
 #
-#  id                   :integer          not null, primary key
-#  key                  :string(255)      not null
-#  display_name         :string(255)      not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  category             :string(255)      default("other"), not null
-#  is_featured          :boolean          default(FALSE), not null
-#  assignable           :boolean          default(TRUE), not null
-#  curriculum_type      :string(255)
-#  marketing_initiative :string(255)
-#  grade_levels         :string(255)
-#  header               :string(255)
-#  image                :string(255)
-#  cs_topic             :string(255)
-#  school_subject       :string(255)
-#  device_compatibility :string(255)
+#  id                               :integer          not null, primary key
+#  key                              :string(255)      not null
+#  display_name                     :string(255)      not null
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  category                         :string(255)      default("other"), not null
+#  is_featured                      :boolean          default(FALSE), not null
+#  assignable                       :boolean          default(TRUE), not null
+#  curriculum_type                  :string(255)
+#  marketing_initiative             :string(255)
+#  grade_levels                     :string(255)
+#  header                           :string(255)
+#  image                            :string(255)
+#  cs_topic                         :string(255)
+#  school_subject                   :string(255)
+#  device_compatibility             :string(255)
+#  description                      :string(255)
+#  self_paced_professional_learning :string(255)
+#  professional_learning_program    :string(255)
+#  video                            :string(255)
+#  published_date                   :datetime
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20230705195726_add_description_self_paced_professional_learning_professional_learning_program_video_published_date_to_course_offerings.rb
+++ b/dashboard/db/migrate/20230705195726_add_description_self_paced_professional_learning_professional_learning_program_video_published_date_to_course_offerings.rb
@@ -1,0 +1,9 @@
+class AddDescriptionSelfPacedProfessionalLearningProfessionLearningProgramVideoPublishedDateToCourseOfferings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :course_offerings, :description, :string
+    add_column :course_offerings, :self_paced_professional_learning, :string
+    add_column :course_offerings, :professional_learning_program, :string
+    add_column :course_offerings, :video, :string
+    add_column :course_offerings, :published_date, :datetime
+  end
+end

--- a/dashboard/db/migrate/20230705195726_add_description_self_paced_professional_learning_professional_learning_program_video_published_date_to_course_offerings.rb
+++ b/dashboard/db/migrate/20230705195726_add_description_self_paced_professional_learning_professional_learning_program_video_published_date_to_course_offerings.rb
@@ -1,4 +1,4 @@
-class AddDescriptionSelfPacedProfessionalLearningProfessionLearningProgramVideoPublishedDateToCourseOfferings < ActiveRecord::Migration[6.1]
+class AddDescriptionSelfPacedProfessionalLearningProfessionalLearningProgramVideoPublishedDateToCourseOfferings < ActiveRecord::Migration[6.1]
   def change
     add_column :course_offerings, :description, :string
     add_column :course_offerings, :self_paced_professional_learning, :string

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_09_220913) do
+ActiveRecord::Schema.define(version: 2023_07_05_195726) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -409,6 +409,11 @@ ActiveRecord::Schema.define(version: 2023_06_09_220913) do
     t.string "cs_topic"
     t.string "school_subject"
     t.string "device_compatibility"
+    t.string "description"
+    t.string "self_paced_professional_learning"
+    t.string "professional_learning_program"
+    t.string "video"
+    t.datetime "published_date"
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 


### PR DESCRIPTION
Adds 5 new fields to the course offering model: ```description```, ```self_paced_professional_learning```, ```professional_learning_program```, ```video```, and ```published_date```. These fields will be used for the curriculum catalog expanded card (v2).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-653)







## Follow-up work
I'll create the pull request for updating the serialization test and the pull request for serializing the new fields using ```CourseOffering.all.each(&:write_serialization) ```




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
