### PR TITLE
Music: move global blockly setup to separate function

### DIFF
--- a/apps/src/Globals.d.ts
+++ b/apps/src/Globals.d.ts
@@ -13,3 +13,10 @@ declare const IN_UNIT_TEST: boolean;
 declare const IN_STORYBOOK: boolean;
 declare const PISKEL_DEVELOPMENT_MODE: string;
 declare const DEBUG_MINIFIED: number;
+
+// Declare the type for the global Blockly object, set by the Blockly wrapper.
+// The intersection type is needed as the Blockly wrapper provides additional
+// functions and properties not present in Google Blockly. If/when these are
+// converted to TypeScript, this type can be narrowed.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const Blockly: typeof import('blockly') & Record<string, any>;

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -1,34 +1,17 @@
 import CustomMarshalingInterpreter from '../../lib/tools/jsinterpreter/CustomMarshalingInterpreter';
 import {BlockTypes} from './blockTypes';
-import {MUSIC_BLOCKS} from './musicBlocks';
 import CdoDarkTheme from '@cdo/apps/blockly/themes/cdoDark';
 import {getToolbox} from './toolbox';
-import FieldSounds from './FieldSounds';
-import FieldPattern from './FieldPattern';
 import {getBlockMode} from '../appConfig';
 import {BlockMode} from '../constants';
 import {
-  DEFAULT_TRACK_NAME_EXTENSION,
-  DOCS_BASE_URL,
-  DYNAMIC_TRIGGER_EXTENSION,
-  FIELD_CHORD_TYPE,
-  FIELD_PATTERN_TYPE,
-  FIELD_SOUNDS_TYPE,
   FIELD_TRIGGER_START_NAME,
-  PLAY_MULTI_MUTATOR,
   TriggerStart,
   TRIGGER_FIELD,
 } from './constants';
-import {
-  dynamicTriggerExtension,
-  getDefaultTrackNameExtension,
-  playMultiMutator,
-} from './extensions';
 import experiments from '@cdo/apps/util/experiments';
 import {GeneratorHelpersSimple2} from './blocks/simple2';
-import FieldChord from './FieldChord';
 import {Renderers} from '@cdo/apps/blockly/constants';
-import musicI18n from '../locale';
 import {logError, logWarning} from '../utils/MusicMetrics';
 
 /**
@@ -51,37 +34,14 @@ export default class MusicBlocklyWorkspace {
    * Initialize the Blockly workspace
    * @param {*} container HTML element to inject the workspace into
    * @param {*} onBlockSpaceChange callback fired when any block space change events occur
-   * @param {*} player reference to a {@link MusicPlayer}
    * @param {*} isReadOnlyWorkspace is the workspace readonly
    */
-  init(container, onBlockSpaceChange, player, isReadOnlyWorkspace) {
-    this.container = container;
-
-    Blockly.Extensions.register(
-      DYNAMIC_TRIGGER_EXTENSION,
-      dynamicTriggerExtension
-    );
-
-    Blockly.Extensions.register(
-      DEFAULT_TRACK_NAME_EXTENSION,
-      getDefaultTrackNameExtension(player)
-    );
-
-    Blockly.Extensions.registerMutator(PLAY_MULTI_MUTATOR, playMultiMutator);
-
-    for (let blockType of Object.keys(MUSIC_BLOCKS)) {
-      Blockly.Blocks[blockType] = {
-        init: function () {
-          this.jsonInit(MUSIC_BLOCKS[blockType].definition);
-        },
-      };
-
-      Blockly.JavaScript[blockType] = MUSIC_BLOCKS[blockType].generator;
+  init(container, onBlockSpaceChange, isReadOnlyWorkspace) {
+    if (this.workspace) {
+      this.workspace.dispose();
     }
 
-    Blockly.fieldRegistry.register(FIELD_SOUNDS_TYPE, FieldSounds);
-    Blockly.fieldRegistry.register(FIELD_PATTERN_TYPE, FieldPattern);
-    Blockly.fieldRegistry.register(FIELD_CHORD_TYPE, FieldChord);
+    this.container = container;
 
     this.workspace = Blockly.inject(container, {
       toolbox: getToolbox(),
@@ -97,30 +57,9 @@ export default class MusicBlocklyWorkspace {
       readOnly: isReadOnlyWorkspace,
     });
 
-    // Remove two default entries in the toolbox's Functions category that
-    // we don't want.
-    delete Blockly.Blocks.procedures_defreturn;
-    delete Blockly.Blocks.procedures_ifreturn;
-
-    // Rename the new function placeholder text for Music Lab specifically.
-    Blockly.Msg['PROCEDURES_DEFNORETURN_PROCEDURE'] =
-      musicI18n.blockly_functionNamePlaceholder();
-
-    // Wrap the create function block's init function in a function that
-    // sets the block's help URL to the appropriate entry in the Music Lab
-    // docs, and calls the original init function if present.
-    const functionBlock = Blockly.Blocks.procedures_defnoreturn;
-    functionBlock.initOriginal = functionBlock.init;
-    functionBlock.init = function () {
-      this.setHelpUrl(DOCS_BASE_URL + 'create_function');
-      this.initOriginal?.();
-    };
-
-    Blockly.setInfiniteLoopTrap();
-
     this.resizeBlockly();
 
-    Blockly.addChangeListener(Blockly.mainBlockSpace, onBlockSpaceChange);
+    this.workspace.addChangeListener(onBlockSpaceChange);
 
     this.workspace.registerButtonCallback('createVariableHandler', button => {
       Blockly.Variables.createVariableButtonHandler(

--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -1,0 +1,78 @@
+import {
+  DEFAULT_TRACK_NAME_EXTENSION,
+  DOCS_BASE_URL,
+  DYNAMIC_TRIGGER_EXTENSION,
+  FIELD_CHORD_TYPE,
+  FIELD_PATTERN_TYPE,
+  FIELD_SOUNDS_TYPE,
+  PLAY_MULTI_MUTATOR,
+} from './constants';
+import {
+  dynamicTriggerExtension,
+  getDefaultTrackNameExtension,
+  playMultiMutator,
+} from './extensions';
+import FieldChord from './FieldChord';
+import FieldPattern from './FieldPattern';
+import FieldSounds from './FieldSounds';
+import {MUSIC_BLOCKS} from './musicBlocks';
+import musicI18n from '../locale';
+import {BlockConfig} from './types';
+
+/**
+ * Set up the global Blockly environment for Music Lab. This should
+ * only be called once per page load, as it configures the global
+ * Blockly state.
+ */
+export function setUpBlocklyForMusicLab() {
+  Blockly.Extensions.register(
+    DYNAMIC_TRIGGER_EXTENSION,
+    dynamicTriggerExtension
+  );
+
+  Blockly.Extensions.register(
+    DEFAULT_TRACK_NAME_EXTENSION,
+    getDefaultTrackNameExtension()
+  );
+
+  Blockly.Extensions.registerMutator(PLAY_MULTI_MUTATOR, playMultiMutator);
+
+  // Needed for TypeScript to recognize the type of the MUSIC_BLOCKS. Remove
+  // after converting musicBlocks to TypeScript.
+  const typedMusicBlocks = MUSIC_BLOCKS as {[key: string]: BlockConfig};
+  for (const blockType of Object.keys(typedMusicBlocks)) {
+    const blockConfig = typedMusicBlocks[blockType] as BlockConfig;
+    Blockly.Blocks[blockType] = {
+      init: function () {
+        this.jsonInit(blockConfig.definition);
+      },
+    };
+
+    Blockly.JavaScript[blockType] = blockConfig.generator;
+  }
+
+  Blockly.fieldRegistry.register(FIELD_SOUNDS_TYPE, FieldSounds);
+  Blockly.fieldRegistry.register(FIELD_PATTERN_TYPE, FieldPattern);
+  Blockly.fieldRegistry.register(FIELD_CHORD_TYPE, FieldChord);
+
+  // Remove two default entries in the toolbox's Functions category that
+  // we don't want.
+  delete Blockly.Blocks.procedures_defreturn;
+  delete Blockly.Blocks.procedures_ifreturn;
+
+  // Rename the new function placeholder text for Music Lab specifically.
+  Blockly.Msg['PROCEDURES_DEFNORETURN_PROCEDURE'] =
+    musicI18n.blockly_functionNamePlaceholder();
+
+  // Wrap the create function block's init function in a function that
+  // sets the block's help URL to the appropriate entry in the Music Lab
+  // docs, and calls the original init function if present.
+  const functionBlock = Blockly.Blocks.procedures_defnoreturn;
+  functionBlock.initOriginal = functionBlock.init;
+  functionBlock.init = function () {
+    this.setHelpUrl(DOCS_BASE_URL + 'create_function');
+    this.initOriginal?.();
+  };
+
+  Blockly.setInfiniteLoopTrap();
+}

--- a/apps/src/music/blockly/types.ts
+++ b/apps/src/music/blockly/types.ts
@@ -1,0 +1,8 @@
+import {Block} from 'blockly';
+
+// Configuration data for a block.
+export interface BlockConfig {
+  // TODO: specify structure of definition as this is used more
+  definition: object;
+  generator: (block: Block) => string;
+}

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -64,6 +64,7 @@ import UpdateTimer from './UpdateTimer';
 import ValidatorProvider from '@cdo/apps/lab2/progress/ValidatorProvider';
 import {Key} from '../utils/Notes';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {setUpBlocklyForMusicLab} from '../blockly/setup';
 
 /**
  * Top-level container for Music Lab. Manages all views on the page as well as the
@@ -156,6 +157,7 @@ class UnconnectedMusicView extends React.Component {
 
     // Music Lab currently does not support share and remix
     header.showHeaderForProjectBacked({showShareAndRemix: false});
+    setUpBlocklyForMusicLab();
   }
 
   componentDidMount() {
@@ -270,7 +272,6 @@ class UnconnectedMusicView extends React.Component {
     this.musicBlocklyWorkspace.init(
       document.getElementById('blockly-div'),
       this.onBlockSpaceChange,
-      this.player,
       this.props.isReadOnlyWorkspace
     );
     this.player.initialize(this.library);


### PR DESCRIPTION
Moves all Music Lab global Blockly setup out of MusicBlocklyWorkspace and into a separate function, meant to be called only once per page load. This allows MusicBlocklyWorkspace#init() to be called multiple times if needed, which is useful if we decide to unmount MusicView when switching between a music and non-music level without reloads.

## Testing story

Tested locally, confirmed no behavior changes. Tested that calling init() multiple times doesn't throw any errors and the reference to the correct workspace is maintained.