### PR TITLE
Add logging for save failures to Projects client

### DIFF
--- a/apps/src/lab2/projects/channelsApi.ts
+++ b/apps/src/lab2/projects/channelsApi.ts
@@ -16,11 +16,12 @@ export async function get(channelId: string): Promise<Channel> {
 }
 
 export async function update(channel: Channel): Promise<Response> {
-  return fetch(`${rootUrl}/${channel.id}`, {
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-    },
-    method: 'POST',
-    body: JSON.stringify(channel),
-  });
+  return HttpClient.post(
+    `${rootUrl}/${channel.id}`,
+    JSON.stringify(channel),
+    false,
+    {
+      'Content-Type': 'application/json; charset=UTF-8',
+    }
+  );
 }


### PR DESCRIPTION
Adds logging for save failures to the ProjectManager, as part of adding overall logging to the new lab2 projects/level system.

## Links

Part of https://codedotorg.atlassian.net/browse/SL-804

## Testing story

Tested locally; confirmed errors are caught and logged, and listeners are still notified.