### PR TITLE
Redirect to appropriate edit/view page for standalone lab2 projects

### DIFF
--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -431,6 +431,7 @@ class ProjectsControllerTest < ActionController::TestCase
 
     get :show, params: {path: "/projects/music/#{channel_id}/view", key: 'music', channel_id: channel_id, readonly: true}
     assert_response :redirect
+    assert_redirected_to "/projects/music/#{channel_id}/edit"
   end
 
   test 'on lab2 levels navigating to /edit redirects to /view if user is not project owner' do
@@ -439,5 +440,6 @@ class ProjectsControllerTest < ActionController::TestCase
 
     get :edit, params: {path: "/projects/music/#{channel_id}/edit", key: 'music', channel_id: channel_id}
     assert_response :redirect
+    assert_redirected_to "/projects/music/#{channel_id}/view"
   end
 end

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -424,4 +424,20 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_response :success
     assert_not_nil @response.body['channel']
   end
+
+  test 'on lab2 levels navigating to /view redirects to /edit if user is project owner' do
+    channel_id = '12345'
+    Projects.any_instance.stubs(:get).returns({isOwner: true})
+
+    get :show, params: {path: "/projects/music/#{channel_id}/view", key: 'music', channel_id: channel_id, readonly: true}
+    assert_response :redirect
+  end
+
+  test 'on lab2 levels navigating to /edit redirects to /view if user is not project owner' do
+    channel_id = '12345'
+    Projects.any_instance.stubs(:get).returns({isOwner: false})
+
+    get :edit, params: {path: "/projects/music/#{channel_id}/edit", key: 'music', channel_id: channel_id}
+    assert_response :redirect
+  end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -786,6 +786,11 @@ FactoryBot.define do
     level_num {'custom'}
   end
 
+  factory :music, parent: :level, class: Music do
+    game {Game.music}
+    level_num {'custom'}
+  end
+
   factory :block do
     transient do
       sequence(:index)


### PR DESCRIPTION
For standalone lab2 projects, this change redirects to the appropriate /edit or /view page, based on of the user is the owner of the project. 

For legacy labs, this is handled on the front end, here: https://github.com/code-dot-org/code-dot-org/blob/bcf2d0d5a12cc1a8526a960cf7a0fd9f35ba0ac1/apps/src/code-studio/initApp/project.js#L2061

But this didn't feel like the correct approach for new labs, as it's modifying the URL on the front end and mutating data handed down by the server (in this case app options). Since we know if the user is the project owner on the back end already, we can handle the redirect there, and front end code doesn't need to worry about determining where to redirect.

Note that the URL doesn't actually have any effect on whether the project is readonly; this is determined by the "isOwner" value on the project, which we fetch from the server separately.

https://github.com/code-dot-org/code-dot-org/assets/85528507/b2c9530e-f1c0-49cb-9006-9f5b842e6160

## Testing story

Tested locally + unit tests.