### PR TITLE
Revert "Revert "Run Tests Without `Dir.chdir`""

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -52,7 +52,7 @@ namespace :test do
 
   timed_task_with_logging :eyes_ui do
     ChatClient.log 'Running <b>dashboard</b> UI visual tests...'
-    eyes_features = `find #{dashboard_dir('test/ui/features')} -name "*.feature" | xargs grep -lr '@eyes'`.split("\n")
+    eyes_features = `cd #{dashboard_dir('test/ui')} && find features/ -name "*.feature" | xargs grep -lr '@eyes'`.split("\n")
     failed_browser_count = RakeUtils.system_with_chat_logging(
       "cd #{dashboard_dir('test/ui')} &&",
       'bundle', 'exec', './runner.rb',

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -25,58 +25,56 @@ namespace :test do
   end
 
   timed_task_with_logging :regular_ui do
-    Dir.chdir(dashboard_dir('test/ui')) do
-      ChatClient.log 'Running <b>dashboard</b> UI tests...'
-      failed_browser_count = RakeUtils.system_with_chat_logging(
-        'bundle', 'exec', './runner.rb',
-        '-d', CDO.site_host('studio.code.org'),
-        '-p', CDO.site_host('code.org'),
-        '--db', # Ensure features that require database access are run even if the server name isn't "test"
-        '--parallel', '120',
-        '--magic_retry',
-        '--with-status-page',
-        '--fail_fast',
-        '--priority 0'
-      )
-      if failed_browser_count == 0
-        message = '┬──┬ ﻿ノ( ゜-゜ノ) UI tests for <b>dashboard</b> succeeded.'
-        ChatClient.log message
-        ChatClient.message 'server operations', message, color: 'green'
-      else
-        message = "(╯°□°）╯︵ ┻━┻ UI tests for <b>dashboard</b> failed on #{failed_browser_count} browser(s)."
-        ChatClient.log message, color: 'red'
-        ChatClient.message 'server operations', message, color: 'red', notify: 1
-        raise "UI tests failed"
-      end
+    ChatClient.log 'Running <b>dashboard</b> UI tests...'
+    failed_browser_count = RakeUtils.system_with_chat_logging(
+      "cd #{dashboard_dir('test/ui')} &&",
+      'bundle', 'exec', './runner.rb',
+      '-d', CDO.site_host('studio.code.org'),
+      '-p', CDO.site_host('code.org'),
+      '--db', # Ensure features that require database access are run even if the server name isn't "test"
+      '--parallel', '120',
+      '--magic_retry',
+      '--with-status-page',
+      '--fail_fast',
+      '--priority 0'
+    )
+    if failed_browser_count == 0
+      message = '┬──┬ ﻿ノ( ゜-゜ノ) UI tests for <b>dashboard</b> succeeded.'
+      ChatClient.log message
+      ChatClient.message 'server operations', message, color: 'green'
+    else
+      message = "(╯°□°）╯︵ ┻━┻ UI tests for <b>dashboard</b> failed on #{failed_browser_count} browser(s)."
+      ChatClient.log message, color: 'red'
+      ChatClient.message 'server operations', message, color: 'red', notify: 1
+      raise "UI tests failed"
     end
   end
 
   timed_task_with_logging :eyes_ui do
-    Dir.chdir(dashboard_dir('test/ui')) do
-      ChatClient.log 'Running <b>dashboard</b> UI visual tests...'
-      eyes_features = `find features/ -name "*.feature" | xargs grep -lr '@eyes'`.split("\n")
-      failed_browser_count = RakeUtils.system_with_chat_logging(
-        'bundle', 'exec', './runner.rb',
-        '-c', 'Chrome,iPhone',
-        '-d', CDO.site_host('studio.code.org'),
-        '-p', CDO.site_host('code.org'),
-        '--db', # Ensure features that require database access are run even if the server name isn't "test"
-        '--eyes',
-        '--magic_retry',
-        '--with-status-page',
-        '-f', eyes_features.join(","),
-        '--parallel', (eyes_features.count * 2).to_s
-      )
-      if failed_browser_count == 0
-        message = '⊙‿⊙ Eyes tests for <b>dashboard</b> succeeded, no changes detected.'
-        ChatClient.log message
-        ChatClient.message 'server operations', message, color: 'green'
-      else
-        message = 'ಠ_ಠ Eyes tests for <b>dashboard</b> failed. See <a href="https://eyes.applitools.com/app/sessions/">the console</a> for results or to modify baselines.'
-        ChatClient.log message, color: 'red'
-        ChatClient.message 'server operations', message, color: 'red', notify: 1
-        raise "Eyes tests failed"
-      end
+    ChatClient.log 'Running <b>dashboard</b> UI visual tests...'
+    eyes_features = `find #{dashboard_dir('test/ui/features')} -name "*.feature" | xargs grep -lr '@eyes'`.split("\n")
+    failed_browser_count = RakeUtils.system_with_chat_logging(
+      "cd #{dashboard_dir('test/ui')} &&",
+      'bundle', 'exec', './runner.rb',
+      '-c', 'Chrome,iPhone',
+      '-d', CDO.site_host('studio.code.org'),
+      '-p', CDO.site_host('code.org'),
+      '--db', # Ensure features that require database access are run even if the server name isn't "test"
+      '--eyes',
+      '--magic_retry',
+      '--with-status-page',
+      '-f', eyes_features.join(","),
+      '--parallel', (eyes_features.count * 2).to_s
+    )
+    if failed_browser_count == 0
+      message = '⊙‿⊙ Eyes tests for <b>dashboard</b> succeeded, no changes detected.'
+      ChatClient.log message
+      ChatClient.message 'server operations', message, color: 'green'
+    else
+      message = 'ಠ_ಠ Eyes tests for <b>dashboard</b> failed. See <a href="https://eyes.applitools.com/app/sessions/">the console</a> for results or to modify baselines.'
+      ChatClient.log message, color: 'red'
+      ChatClient.message 'server operations', message, color: 'red', notify: 1
+      raise "Eyes tests failed"
     end
   end
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#52659, restoring https://github.com/code-dot-org/code-dot-org/pull/52619

The first attempt broke the Eyes test status page because for Eyes tests we started calling `runner.rb` with a full path to the feature like `bundle exec ./runner.rb -f /home/ubuntu/test/dashboard/test/ui/features/acquisition_products/pd/workshop_dashboard.feature` rather than a relative path like `bundle exec ./runner.rb -f features/acquisition_products/pd/workshop_dashboard.feature`. The tests themselves just care about finding the right file for each feature, so they worked just fine; the test status page cares about the actual string used to identify the feature, so it broke.

I'm also working on a longer-term fix [here](https://github.com/code-dot-org/code-dot-org/pull/52665) to make `runner.rb` (and the test status page) more flexible about where it's being called from, but in the meantime the easy fix is to just implement the manual `cd` in a way that preserves the original syntax.

As with the original PR, I recommend reviewing [with whitespace changes ignored](https://github.com/code-dot-org/code-dot-org/pull/52668/files?w=1)

## Testing Story

Verified that running `rake test:eyes_ui` locally now calls `runner.rb` with relative rather than absolute file names:

```
[~/code-dot-org (revert-52659-revert-52619-run-tests-without-dir-chdir)]$ bundle exec rake test:eyes_ui
GetSecretValue: development/cdo/slack_bot_token
Flushing Cdo::Metrics::Buffer, waiting Infinity seconds
cd /home/elijah/projects/work/code-dot-org/dashboard/test/ui && bundle exec ./runner.rb -c Chrome,iPhone -d localhost-studio.code.org:3000 -p localhost.code.org:3000 --db --eyes --magic_retry --with-status-page -f features/star_labs/spritelab/eyes.feature,features/star_labs/applab/eyes1.feature,features/star_labs/applab/eyes2.feature,features/star_labs/applab/eyes4.feature,features/star_labs/applab/tooltips.feature,features/star_labs/applab/eyes3.feature,features/star_labs/angle_helper.feature,features/star_labs/unused_blocks.feature,features/star_labs/artist_autorun.feature,features/star_labs/public_key_cryptography/eyes.feature,features/star_labs/mobile_portait.feature,features/star_labs/craft/dialogs.feature,features/star_labs/contract_editor.feature,features/star_labs/algebra.feature,features/star_labs/gamelab/eyes.feature,features/teacher_tools/submittable_eyes.feature,features/teacher_tools/level_types/curriculum_reference.feature,features/teacher_tools/level_types/free_response_contained_levels.feature,features/teacher_tools/level_types/multiple_choice_contained_levels.feature,features/teacher_tools/below_visualization.feature,features/teacher_tools/level_video.feature,features/teacher_tools/lesson_show.feature,features/teacher_tools/send_lesson.feature,features/teacher_tools/lesson_lock_retake.feature,features/teacher_tools/level_summary.feature,features/teacher_tools/teacher_lesson_plan.feature,features/teacher_tools/teacher_dashboard/teacher_dashboard.feature,features/teacher_tools/teacher_dashboard/progress_tab_views_eyes.feature,features/teacher_tools/hidden_scripts_eyes.feature,features/teacher_tools/level_completion.feature,features/teacher_tools/instructions/top_instructions.feature,features/teacher_tools/instructions/csp_top_instructions_eyes.feature,features/teacher_tools/instructions/feedback_tab_eyes.feature,features/teacher_tools/instructions/teacher_only_markdown.feature,features/teacher_tools/hidden_stages_eyes.feature,features/teacher_tools/lesson_lock.feature,features/teacher_tools/courses_eyes.feature,features/teacher_tools/student_not_started_level_warning.feature,features/teacher_tools/projects/projects.feature,features/teacher_tools/teacher_student_toggle.feature,features/teacher_tools/video/videoplayer_eyes.feature,features/initial_page_views3.feature,features/initial_page_views.feature,features/javalab/javalab_demo_mode.feature,features/javalab/console_only.feature,features/javalab/prompter.feature,features/javalab/theater.feature,features/javalab/code_review_scenarios.feature,features/javalab/neighborhood.feature,features/initial_page_views2.feature,features/initial_page_views_csf.feature,features/other_sites.feature,features/acquisition_products/pd/workshop_certificates.feature,features/acquisition_products/pd/daily_survey_results.feature,features/acquisition_products/pd/workshop_dashboard.feature,features/acquisition_products/pd/dashboard_view.feature,features/acquisition_products/pd/teacher_application.feature,features/acquisition_products/pd/teacher_application_dashboard.feature,features/eyes.feature,features/hour_of_code/hour_of_code_finish.feature,features/hour_of_code/hoc_batch_certificates.feature,features/hour_of_code/tutorial_landing_pages.feature,features/hour_of_code/hour_of_code_dot_com.feature,features/xteam/cookie_banner.feature,features/xteam/race_interstitial.feature,features/foundations/footer.feature,features/foundations/markdown_rendering.feature --parallel 134
```