### PR TITLE
Fix centered text on tablet and mobile on Teach page resources section

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/teach-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/teach-styles.scss
@@ -43,6 +43,12 @@ section.free-curriculum {
   }
 }
 
+section.resources {
+  h2, p.desc {
+    text-align: center;
+  }
+}
+
 section.pl-offerings {
 
   .grid-container {

--- a/pegasus/sites.v3/code.org/public/teach.haml
+++ b/pegasus/sites.v3/code.org/public/teach.haml
@@ -117,7 +117,7 @@ theme: responsive_full_width
         %a.link-button{href: CDO.studio_url("/catalog?grade=grade_10&grade=grade_11&grade=grade_12&grade=grade_9")}
           =hoc_s(:grade_level_label_high)
 
-%section.resources.bg-neutral-light.centered
+%section.resources.bg-neutral-light
   .wrapper
     = view :resources_tabs
 

--- a/pegasus/sites.v3/code.org/views/resources_tabs.haml
+++ b/pegasus/sites.v3/code.org/views/resources_tabs.haml
@@ -2,7 +2,8 @@
 -# "design-system-pegasus.scss" stylesheet.
 
 %h2=hoc_s(:resources_tabs_heading)
-%p=hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
+%p.desc
+  =hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
 
 -# Shows tabs UI on desktop
 .resources-tabs.show-desktop


### PR DESCRIPTION
Fix responsive centered text on the Resources tabs on https://code.org/teach
- Only an issue on the Teach page — other pages using this partial are ok
- Works w/ LTR and RTL languages

### Before (Tablet)
<img width="786" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/2c4e3dfc-980d-44f6-9c09-5e610d6714ee">

### After (Tablet)
<img width="782" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/b379d13d-42c6-49ee-951c-1b5f8d0ffd36">
