### PR TITLE
Music: fix playback warning

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -506,15 +506,17 @@ class UnconnectedMusicView extends React.Component {
   };
 
   stopSong = () => {
-    if (this.props.isPlaying) {
-      this.player.stopSong();
-      this.playingTriggers = [];
-
-      this.executeCompiledSong();
-
-      this.props.setIsPlaying(false);
-      this.props.setCurrentPlayheadPosition(0);
+    if (!this.props.isPlaying) {
+      return;
     }
+
+    this.player.stopSong();
+    this.playingTriggers = [];
+
+    this.executeCompiledSong();
+
+    this.props.setIsPlaying(false);
+    this.props.setCurrentPlayheadPosition(0);
   };
 
   onFeedbackClicked = () => {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -506,13 +506,15 @@ class UnconnectedMusicView extends React.Component {
   };
 
   stopSong = () => {
-    this.player.stopSong();
-    this.playingTriggers = [];
+    if (this.props.isPlaying) {
+      this.player.stopSong();
+      this.playingTriggers = [];
 
-    this.executeCompiledSong();
+      this.executeCompiledSong();
 
-    this.props.setIsPlaying(false);
-    this.props.setCurrentPlayheadPosition(0);
+      this.props.setIsPlaying(false);
+      this.props.setCurrentPlayheadPosition(0);
+    }
   };
 
   onFeedbackClicked = () => {


### PR DESCRIPTION
This fixes a codepath which resulted in [this](https://github.com/code-dot-org/code-dot-org/blob/f653bcb75e8dc063059facad825d8d8d1d8d1bb0/apps/src/music/blockly/MusicBlocklyWorkspace.js#L290) warning: `executeCompiledSong called before compileSong.`

It seems to be the result of a race condition when switching to a music level from a non-music one.  In a repro case, the page is loaded on a video level, and then the level is switched to a music one.  [`componentDidUpdate`](https://github.com/code-dot-org/code-dot-org/blob/f653bcb75e8dc063059facad825d8d8d1d8d1bb0/apps/src/music/views/MusicView.jsx#L177) fires, and [`stopSong`](https://github.com/code-dot-org/code-dot-org/blob/f653bcb75e8dc063059facad825d8d8d1d8d1bb0/apps/src/music/views/MusicView.jsx#L194) is called, and part of stopping a song is to [re-execute](https://github.com/code-dot-org/code-dot-org/blob/f653bcb75e8dc063059facad825d8d8d1d8d1bb0/apps/src/music/views/MusicView.jsx#L498) the compiled code, except there isn't any compiled code yet.  A little while afterwards, [`onBlockSpaceChange`](https://github.com/code-dot-org/code-dot-org/blob/f653bcb75e8dc063059facad825d8d8d1d8d1bb0/apps/src/music/views/MusicView.jsx#L360) fires, and the song is [compiled](https://github.com/code-dot-org/code-dot-org/blob/f653bcb75e8dc063059facad825d8d8d1d8d1bb0/apps/src/music/views/MusicView.jsx#L378).

It turns out we don't need to do anything when a song is stopped if it isn't playing, which removes the unnecessary attempt to execute the song in this repro.
