### PR TITLE
Clarify latest year on curriculum catalog card

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -259,7 +259,7 @@ const CurriculumCatalog = ({
                 key,
                 image,
                 display_name,
-                display_name_with_year,
+                display_name_with_latest_year,
                 grade_levels,
                 duration,
                 school_subject,
@@ -275,7 +275,7 @@ const CurriculumCatalog = ({
                 <CurriculumCatalogCard
                   key={key}
                   courseDisplayName={display_name}
-                  courseDisplayNameWithYear={display_name_with_year}
+                  courseDisplayNameWithYear={display_name_with_latest_year}
                   imageSrc={image || undefined}
                   duration={duration}
                   gradesArray={grade_levels.split(',')}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -275,7 +275,9 @@ const CurriculumCatalog = ({
                 <CurriculumCatalogCard
                   key={key}
                   courseDisplayName={display_name}
-                  courseDisplayNameWithYear={display_name_with_latest_year}
+                  courseDisplayNameWithLatestYear={
+                    display_name_with_latest_year
+                  }
                   imageSrc={image || undefined}
                   duration={duration}
                   gradesArray={grade_levels.split(',')}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -73,7 +73,7 @@ const CurriculumCatalogCard = ({
 
 CurriculumCatalogCard.propTypes = {
   courseDisplayName: PropTypes.string.isRequired,
-  courseDisplayNameWithYear: PropTypes.string.isRequired,
+  courseDisplayNameWithLatestYear: PropTypes.string.isRequired,
   duration: PropTypes.oneOf(Object.keys(translatedCourseOfferingDurations))
     .isRequired,
   gradesArray: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -100,7 +100,7 @@ const CustomizableCurriculumCatalogCard = ({
   assignButtonDescription,
   assignButtonText,
   courseDisplayName,
-  courseDisplayNameWithYear,
+  courseDisplayNameWithLatestYear,
   duration,
   gradeRange,
   imageAltText,
@@ -131,7 +131,7 @@ const CustomizableCurriculumCatalogCard = ({
     } else if (isTeacher && sectionsForDropdown.length > 0) {
       return (
         <MultipleSectionsAssigner
-          assignmentName={courseDisplayNameWithYear}
+          assignmentName={courseDisplayNameWithLatestYear}
           onClose={() => setIsAssignDialogOpen(false)}
           sections={sectionsForDropdown}
           participantAudience="student"
@@ -226,7 +226,7 @@ const CustomizableCurriculumCatalogCard = ({
 
 CustomizableCurriculumCatalogCard.propTypes = {
   courseDisplayName: PropTypes.string.isRequired,
-  courseDisplayNameWithYear: PropTypes.string.isRequired,
+  courseDisplayNameWithLatestYear: PropTypes.string.isRequired,
   duration: PropTypes.string.isRequired,
   gradeRange: PropTypes.string.isRequired,
   imageSrc: PropTypes.string.isRequired,

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
@@ -17,7 +17,7 @@ const Template = args => (
 
 const defaultArgs = {
   courseDisplayName: 'Computer Science Principles',
-  courseDisplayNameWithYear: 'Computer Science Principles (22-23)',
+  courseDisplayNameWithLatestYear: 'Computer Science Principles (22-23)',
   duration: 'school_year',
   gradesArray: ['1', '2', '3', '4'],
   topics: ['programming', 'artificial_intelligence', 'art_and_design'],

--- a/apps/src/templates/curriculumCatalog/curriculumCatalogShapes.jsx
+++ b/apps/src/templates/curriculumCatalog/curriculumCatalogShapes.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 export const curriculumDataShape = PropTypes.shape({
   key: PropTypes.string.isRequired,
   display_name: PropTypes.string.isRequired,
-  display_name_with_year: PropTypes.string.isRequired,
+  display_name_with_latest_year: PropTypes.string.isRequired,
   grade_levels: PropTypes.string,
   image: PropTypes.string,
   cs_topic: PropTypes.string,

--- a/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTestHelper.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTestHelper.jsx
@@ -2,7 +2,7 @@
 const makerCurriculum = {
   key: 'devices',
   display_name: 'Creating Apps for Devices',
-  display_name_with_year: 'Creating Apps for Devices (2022)',
+  display_name_with_latest_year: 'Creating Apps for Devices (2022)',
   grade_levels: '6,7,8,9,10,11,12',
   image: 'devices.png',
   duration: 'week',
@@ -14,7 +14,7 @@ const makerCurriculum = {
 const countingCurriculum = {
   key: 'counting-csc',
   display_name: 'Computer Science Connections',
-  display_name_with_year: 'Computer Science Connections (2023)',
+  display_name_with_latest_year: 'Computer Science Connections (2023)',
   grade_levels: '3,4,5',
   image: 'csc.png',
   duration: 'lesson',
@@ -28,7 +28,7 @@ const countingCurriculum = {
 const poemArtCurriculum = {
   key: 'poem-art',
   display_name: 'Poem Art',
-  display_name_with_year: 'Poem Art (2017)',
+  display_name_with_latest_year: 'Poem Art (2017)',
   grade_levels: '2,3,4,5,6,7,8,9,10,11,12',
   image: null,
   duration: 'lesson',
@@ -42,7 +42,8 @@ const poemArtCurriculum = {
 const danceUnpluggedCurriculum = {
   key: 'dance-unplugged',
   display_name: 'Hour of Code - Dance Party - Unplugged',
-  display_name_with_year: 'Hour of Code - Dance Party - Unplugged (2018)',
+  display_name_with_latest_year:
+    'Hour of Code - Dance Party - Unplugged (2018)',
   grade_levels: '2,3,4,5,6,7,8',
   image: null,
   duration: 'lesson',
@@ -56,7 +57,7 @@ const danceUnpluggedCurriculum = {
 const course1Curriculum = {
   key: 'course1',
   display_name: 'Course 1',
-  display_name_with_year: 'Course 1 (2012)',
+  display_name_with_latest_year: 'Course 1 (2012)',
   grade_levels: 'K,1',
   image: null,
   duration: 'lesson',
@@ -70,7 +71,7 @@ const course1Curriculum = {
 const course2Curriculum = {
   key: 'course2',
   display_name: 'Course 2',
-  display_name_with_year: 'Course 2 (2012)',
+  display_name_with_latest_year: 'Course 2 (2012)',
   grade_levels: '2,3,4,5',
   image: 'course2.png',
   duration: 'lesson',
@@ -84,7 +85,7 @@ const course2Curriculum = {
 const course3Curriculum = {
   key: 'course3',
   display_name: 'Course 3',
-  display_name_with_year: 'Course 3 (2012)',
+  display_name_with_latest_year: 'Course 3 (2012)',
   grade_levels: '3,4,5',
   image: 'course3.png',
   duration: 'lesson',
@@ -98,7 +99,7 @@ const course3Curriculum = {
 const course4Curriculum = {
   key: 'course4',
   display_name: 'Course 4',
-  display_name_with_year: 'Course 4 (2012)',
+  display_name_with_latest_year: 'Course 4 (2012)',
   grade_levels: '4,5',
   image: 'course4.png',
   duration: 'lesson',
@@ -112,7 +113,7 @@ const course4Curriculum = {
 const noGradesCurriculum = {
   key: 'no-grades',
   display_name: 'No Grades',
-  display_name_with_year: 'No Grade (2012)',
+  display_name_with_latest_year: 'No Grade (2012)',
   grade_levels: null,
   image: 'grades.png',
   duration: 'lesson',
@@ -126,7 +127,7 @@ const noGradesCurriculum = {
 const noPathCurriculum = {
   key: 'no-path',
   display_name: 'No Path',
-  display_name_with_year: 'No Path (2012)',
+  display_name_with_latest_year: 'No Path (2012)',
   grade_levels: 'K,1',
   image: 'grades.png',
   duration: 'month',

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {fireEvent, render, screen} from '@testing-library/react';
+import {within} from '@testing-library/dom';
 import {pull} from 'lodash';
 import {expect} from '../../../util/reconfiguredChai';
 import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
@@ -55,7 +56,7 @@ describe('CurriculumCatalogCard', () => {
     store = getStore();
     defaultProps = {
       courseDisplayName: 'AI for Oceans',
-      courseDisplayNameWithYear: 'AI for Oceans (2022)',
+      courseDisplayNameWithLatestYear: 'AI for Oceans (2022)',
       duration: 'quarter',
       gradesArray: ['4', '5', '6', '7', '8'],
       isEnglish: true,
@@ -283,8 +284,12 @@ describe('CurriculumCatalogCard', () => {
     );
     fireEvent.click(assignButton);
     sections.forEach(section => screen.getByText(section.name));
-    screen.getByText('The most recent recommended version', {exact: false});
-    screen.getByText(defaultProps.courseDisplayNameWithYear, {exact: false});
+    screen.getByText(defaultProps.courseDisplayNameWithLatestYear, {
+      exact: false,
+    });
+    screen.getByText('The most recent recommended version', {
+      exact: false,
+    });
   });
 
   it('clicking Assign button as a teacher without sections shows dialog to create section', () => {

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {fireEvent, render, screen} from '@testing-library/react';
-import {within} from '@testing-library/dom';
 import {pull} from 'lodash';
 import {expect} from '../../../util/reconfiguredChai';
 import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -109,7 +109,7 @@ class CourseOffering < ApplicationRecord
     latest_published_version(locale_code).content_root.link
   end
 
-  def display_name_with_year(locale_code = 'en-us')
+  def display_name_with_latest_year(locale_code = 'en-us')
     return localized_display_name unless latest_published_version(locale_code)
     latest_published_version(locale_code).content_root.localized_assignment_family_title
   end
@@ -280,7 +280,7 @@ class CourseOffering < ApplicationRecord
     {
       key: key,
       display_name: display_name,
-      display_name_with_year: display_name_with_year(locale_code),
+      display_name_with_latest_year: display_name_with_latest_year(locale_code),
       grade_levels: grade_levels,
       duration: duration,
       image: image,


### PR DESCRIPTION
Makes it clear that the course display name with year on the curriculum catalog card is the *latest* year. This is a follow-up from https://github.com/code-dot-org/code-dot-org/pull/52626. I did a find-and-replace for these strings.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
