### PR TITLE
Music: sound loading progress bar

### DIFF
--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -39,7 +39,10 @@ export default class MusicPlayer {
    * Initializes the MusicPlayer and {@link SamplePlayer} with the music library.
    * Playback cannot start until the player is initialized.
    */
-  initialize(library: MusicLibrary) {
+  initialize(
+    library: MusicLibrary,
+    updateLoadProgress: (value: number) => void
+  ) {
     this.library = library;
 
     // Set key and BPM from library if present
@@ -52,7 +55,7 @@ export default class MusicPlayer {
       this.key = this.validateKey(libraryKey);
     }
 
-    this.samplePlayer.initialize(library, this.bpm);
+    this.samplePlayer.initialize(library, this.bpm, updateLoadProgress);
   }
 
   /**

--- a/apps/src/music/player/SamplePlayer.ts
+++ b/apps/src/music/player/SamplePlayer.ts
@@ -46,7 +46,11 @@ export default class SamplePlayer {
     this.groupPath = '';
   }
 
-  initialize(library: MusicLibrary, bpm: number) {
+  initialize(
+    library: MusicLibrary,
+    bpm: number,
+    updateLoadProgress: (value: number) => void
+  ) {
     const soundList = library.groups
       .map(group => {
         return group.folders.map(folder => {
@@ -77,6 +81,7 @@ export default class SamplePlayer {
           {name: 'Library', value: library.name},
         ]);
       },
+      updateLoadProgress: updateLoadProgress,
     });
 
     this.groupPath = library.groups[0].path;

--- a/apps/src/music/player/sound.js
+++ b/apps/src/music/player/sound.js
@@ -26,6 +26,7 @@ var audioSystem = null;
  *   {
  *     delayTimeSeconds: number, // Delay time used in the delay effect
  *     releaseTimeSeconds: number // Release time for fading out fixed-duration sounds
+ *     updateLoadProgress: progress: number => void // Callback to report loading progress
  *     reportSoundLibraryLoadTime: loadTimeMs: number => void // Optional callback to report sound library load time
  *   }
  */
@@ -35,7 +36,11 @@ export function InitSound(desiredSounds, options) {
   restrictedSoundUrlPath = '/restricted/musiclab/';
   audioSystem = new WebAudio(options);
 
-  LoadSounds(desiredSounds, options.reportSoundLibraryLoadTime);
+  LoadSounds(
+    desiredSounds,
+    options.updateLoadProgress,
+    options.reportSoundLibraryLoadTime
+  );
 }
 
 export function LoadSoundFromBuffer(id, buffer) {
@@ -51,7 +56,11 @@ export function GetCurrentAudioTime() {
   return audioSystem?.getCurrentTime();
 }
 
-async function LoadSounds(desiredSounds, reportSoundLibraryLoadTime) {
+async function LoadSounds(
+  desiredSounds,
+  updateLoadProgress,
+  reportSoundLibraryLoadTime
+) {
   const soundLoadStartTime = Date.now();
   soundList = desiredSounds;
 
@@ -90,6 +99,9 @@ async function LoadSounds(desiredSounds, reportSoundLibraryLoadTime) {
           const loadTimeMs = Date.now() - soundLoadStartTime;
           reportSoundLibraryLoadTime(loadTimeMs);
         }
+        updateLoadProgress(
+          (soundList.length - soundsToLoad) / soundList.length
+        );
       }
     );
   }

--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -41,7 +41,9 @@ export interface MusicState {
   playbackEvents: PlaybackEvent[];
   /** The current last measure of the song */
   lastMeasure: number;
-  /** The current sound loading progress */
+  /** The current sound loading progress, from 0-1 inclusive, representing the
+   * number of sounds loaded out of the total number of sounds to load.
+   */
   soundLoadingProgress: number;
 }
 

--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -1,9 +1,5 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 import {PlaybackEvent} from '../player/interfaces/PlaybackEvent';
-import {
-  initialValidationState,
-  ValidationState,
-} from '@cdo/apps/lab2/progress/ProgressManager';
 
 const registerReducers = require('@cdo/apps/redux').registerReducers;
 
@@ -45,6 +41,8 @@ export interface MusicState {
   playbackEvents: PlaybackEvent[];
   /** The current last measure of the song */
   lastMeasure: number;
+  /** The current sound loading progress */
+  soundLoadingProgress: number;
 }
 
 const initialState: MusicState = {
@@ -58,6 +56,7 @@ const initialState: MusicState = {
   isBeatPadShowing: true,
   playbackEvents: [],
   lastMeasure: 0,
+  soundLoadingProgress: 0,
 };
 
 const musicSlice = createSlice({
@@ -141,6 +140,9 @@ const musicSlice = createSlice({
       state.playbackEvents.push(...action.payload.events);
       state.lastMeasure = action.payload.lastMeasure;
     },
+    setSoundLoadingProgress: (state, action: PayloadAction<number>) => {
+      state.soundLoadingProgress = action.payload;
+    },
   },
 });
 
@@ -189,4 +191,5 @@ export const {
   toggleBeatPad,
   clearPlaybackEvents,
   addPlaybackEvents,
+  setSoundLoadingProgress,
 } = musicSlice.actions;

--- a/apps/src/music/views/Controls.jsx
+++ b/apps/src/music/views/Controls.jsx
@@ -10,6 +10,27 @@ import {useDispatch, useSelector} from 'react-redux';
 import {hideBeatPad, showBeatPad} from '../redux/musicRedux';
 import commonI18n from '@cdo/locale';
 
+const LoadingProgress = () => {
+  const progressValue = useSelector(state => state.music.soundLoadingProgress);
+
+  if (progressValue >= 1) {
+    return null;
+  }
+
+  return (
+    <div id="loading-progress" className={moduleStyles.loadingProgress}>
+      <div
+        className={moduleStyles.loadingProgressFill}
+        style={{
+          width: `${progressValue * 100}%`,
+        }}
+      >
+        &nbsp;
+      </div>
+    </div>
+  );
+};
+
 /**
  * Renders the playback controls bar, including the play/pause button, show/hide beat pad button,
  * and show/hide instructions button.
@@ -66,6 +87,7 @@ const Controls = ({setPlaying, playTrigger, hasTrigger}) => {
         </button>
       </div>
       {isBeatPadShowing && renderBeatPad()}
+      <LoadingProgress />
     </div>
   );
 };

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -30,6 +30,7 @@ import {
   addPlaybackEvents,
   clearPlaybackEvents,
   getCurrentlyPlayingBlockIds,
+  setSoundLoadingProgress,
 } from '../redux/musicRedux';
 import KeyHandler from './KeyHandler';
 import {
@@ -119,6 +120,7 @@ class UnconnectedMusicView extends React.Component {
     setLabReadyForReload: PropTypes.func,
     navigateToNextLevel: PropTypes.func,
     isReadOnlyWorkspace: PropTypes.bool,
+    updateLoadProgress: PropTypes.func,
   };
 
   constructor(props) {
@@ -274,7 +276,7 @@ class UnconnectedMusicView extends React.Component {
       this.onBlockSpaceChange,
       this.props.isReadOnlyWorkspace
     );
-    this.player.initialize(this.library);
+    this.player.initialize(this.library, this.props.updateLoadProgress);
 
     this.setState({
       loadedLibrary: true,
@@ -717,6 +719,7 @@ const MusicView = connect(
     setLabReadyForReload: labReadyForReload =>
       dispatch(setLabReadyForReload(labReadyForReload)),
     navigateToNextLevel: () => dispatch(navigateToNextLevel()),
+    updateLoadProgress: value => dispatch(setSoundLoadingProgress(value)),
   })
 )(UnconnectedMusicView);
 

--- a/apps/src/music/views/controls.module.scss
+++ b/apps/src/music/views/controls.module.scss
@@ -76,3 +76,19 @@
   font-size: 14px;
   padding: 0 8px;
 }
+
+.loadingProgress {
+  width: 100%;
+  height: 5px;
+  background-color: $neutral_dark80;
+  position: relative;
+  margin-top: auto;
+  border-radius: 4px;
+  overflow: hidden;
+
+  .loadingProgressFill {
+    height: 5px;
+    background-color: $neutral_dark60;
+    position: absolute;
+  }
+}


### PR DESCRIPTION
This adds a subtle progress bar for the sound loading in Music Lab.  This doesn't need be a permanent feature, but while we are still loading sounds in the background after the main lab is up and running, it should help give us an intuitive idea about how long this is taking in different situations.  (We are analyzing reported metrics for this, too.)

https://github.com/code-dot-org/code-dot-org/assets/2205926/985d6fad-19f6-4864-b70f-6f0e1c830b85

Coded on the Amtrak to Portland!
