### PR TITLE
Skip safari for now on teacher application UI test

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
@@ -1,5 +1,6 @@
 @dashboard_db_access
 @no_mobile
+@no_safari
 
 Feature: Teacher Application
 


### PR DESCRIPTION
Our teacher application test is getting extremely flakey. The first attempt (https://github.com/code-dot-org/code-dot-org/pull/52211) wasn't successful. At this point, it looks like Safari is the main culprit –– this PR disables the Safari test until we can prioritize more time to properly fix it.

<img width="456" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/395d4d8c-def2-47fd-a237-cffbefd29ac0">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
