### PR TITLE
Add Lab2Wrapper to ProjectBeats

### DIFF
--- a/apps/src/music/views/ProjectBeats.tsx
+++ b/apps/src/music/views/ProjectBeats.tsx
@@ -3,6 +3,7 @@ import Lab2Wrapper from '@cdo/apps/lab2/views/Lab2Wrapper';
 import {getStore} from '@cdo/apps/redux';
 import React from 'react';
 import {Provider} from 'react-redux';
+import {logError} from '../utils/MusicMetrics';
 import MusicView from './MusicView';
 
 /**
@@ -15,7 +16,9 @@ const ProjectBeats: React.FunctionComponent<{channelId: string}> = ({
 }) => {
   return (
     <Provider store={getStore()}>
-      <Lab2Wrapper>
+      <Lab2Wrapper
+        onError={(error, componentStack) => logError({error, componentStack})}
+      >
         <ProjectContainer channelId={channelId}>
           <MusicView inIncubator={true} />
         </ProjectContainer>

--- a/apps/src/music/views/ProjectBeats.tsx
+++ b/apps/src/music/views/ProjectBeats.tsx
@@ -1,0 +1,27 @@
+import ProjectContainer from '@cdo/apps/lab2/projects/ProjectContainer';
+import Lab2Wrapper from '@cdo/apps/lab2/views/Lab2Wrapper';
+import {getStore} from '@cdo/apps/redux';
+import React from 'react';
+import {Provider} from 'react-redux';
+import MusicView from './MusicView';
+
+/**
+ * Renders the "Project Beats" Music Lab experience, presented only on the Incubator page.
+ * All other Music Lab experiences (script levels, single levels, standalone projects)
+ * are presented via the Lab2 entrypoint.
+ */
+const ProjectBeats: React.FunctionComponent<{channelId: string}> = ({
+  channelId,
+}) => {
+  return (
+    <Provider store={getStore()}>
+      <Lab2Wrapper>
+        <ProjectContainer channelId={channelId}>
+          <MusicView inIncubator={true} />
+        </ProjectContainer>
+      </Lab2Wrapper>
+    </Provider>
+  );
+};
+
+export default ProjectBeats;

--- a/apps/src/sites/studio/pages/musiclab/index.js
+++ b/apps/src/sites/studio/pages/musiclab/index.js
@@ -1,31 +1,14 @@
 import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {Provider} from 'react-redux';
-import {getStore} from '@cdo/apps/redux';
-import MusicLabView from '@cdo/apps/music/views/MusicView';
-import ProjectContainer from '@cdo/apps/lab2/projects/ProjectContainer';
-import ErrorBoundary from '@cdo/apps/lab2/ErrorBoundary';
-import {logError} from '@cdo/apps/music/utils/MusicMetrics';
-import {ErrorFallbackPage} from '@cdo/apps/lab2/views/Lab2Wrapper';
+import ProjectBeats from '@cdo/apps/music/views/ProjectBeats';
 
 $(document).ready(function () {
   const channelId = document.querySelector('script[data-channelid]').dataset
     .channelid;
 
   ReactDOM.render(
-    <ErrorBoundary
-      fallback={<ErrorFallbackPage />}
-      onError={(error, componentStack) =>
-        logError({error: error.toString(), componentStack})
-      }
-    >
-      <Provider store={getStore()}>
-        <ProjectContainer channelId={channelId}>
-          <MusicLabView channelId={channelId} inIncubator={true} />
-        </ProjectContainer>
-      </Provider>
-    </ErrorBoundary>,
+    <ProjectBeats channelId={channelId} />,
     document.getElementById('musiclab-container')
   );
 });


### PR DESCRIPTION
Adds the Lab2Wrapper to the /projectbeats page, which brings in all the nice loading and error UI, and prevents unwanted clicks from going through while loading is in progress. Also split the Project Beats UI into a separate react view just for easier management and so we could use typescript

## Links

https://codedotorg.atlassian.net/browse/SL-977

## Testing story

Tested locally. Couldn't perform any actions (play, start over, trigger) until page had fully loaded