### PR TITLE
[Google Blockly] Add CdoFieldFlyout and CdoBlockFlyout

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -245,6 +245,7 @@
     "@blockly/keyboard-navigation": "0.3.6",
     "@blockly/plugin-cross-tab-copy-paste": "^2.0.7",
     "@blockly/plugin-scroll-options": "~3.0.3",
+    "@blockly/renderer-inline-row-separators": "^0.2.13",
     "@blockly/theme-dark": "^4.0.3",
     "@blockly/theme-highcontrast": "^3.0.3",
     "@code-dot-org/johnny-five": "2.1.0-cdo.3",

--- a/apps/src/blockly/addons/cdoBlockFlyout.js
+++ b/apps/src/blockly/addons/cdoBlockFlyout.js
@@ -1,5 +1,6 @@
 import GoogleBlockly from 'blockly/core';
 
+const svgPaths = GoogleBlockly.utils.svgPaths;
 export default class CdoBlockFlyout extends GoogleBlockly.HorizontalFlyout {
   /**
    * This is a customized flyout class that extends the HorizontalFlyout class.
@@ -12,6 +13,7 @@ export default class CdoBlockFlyout extends GoogleBlockly.HorizontalFlyout {
     this.horizontalLayout_ = true;
     this.minWidth_ = workspaceOptions.minWidth || this.minWidth_;
     this.maxWidth_ = workspaceOptions.maxWidth || this.maxWidth_;
+    this.flyoutBlockPadding = 18;
   }
 
   autoClose = false;
@@ -87,7 +89,8 @@ export default class CdoBlockFlyout extends GoogleBlockly.HorizontalFlyout {
     const topBlockWidth = this.sourceBlock_.svgGroup_
       .querySelector('path')
       .getBoundingClientRect().width;
-    this.width_ = Math.max(this.width_, topBlockWidth - 36);
+    const blockWidthMinusPadding = topBlockWidth - this.flyoutBlockPadding * 2;
+    this.width_ = Math.max(this.width_, blockWidthMinusPadding);
     this.setBackgroundPath_(this.width_, this.height_);
     this.position();
   }
@@ -114,70 +117,56 @@ export default class CdoBlockFlyout extends GoogleBlockly.HorizontalFlyout {
    * Position the flyout.
    */
   position() {
-    this.isVisible() && this.positionAt_(this.width_, this.height_, 0, 0);
+    this.isVisible() &&
+      this.positionAt_(
+        this.width_,
+        this.height_,
+        this.RTL ? -this.flyoutBlockPadding : 0,
+        0
+      );
   }
 
   /**
    * Create and set the path for the visible boundaries of the flyout.
    *
-   * @param width The width of the flyout, not including the rounded corners.
-   * @param height The height of the flyout, not including rounded corners.
+   * @param {number} width The width of the flyout, not including the rounded corners.
+   * @param {number} height The height of the flyout, not including rounded corners.
    */
   setBackgroundPath_(width, height) {
-    const svgPaths = GoogleBlockly.utils.svgPaths;
-    let path = svgPaths.moveTo(
-      this.RTL ? width : 0,
-      this.toolboxPosition_ === Blockly.TOOLBOX_AT_TOP ? 0 : this.CORNER_RADIUS
-    );
-
-    path += svgPaths.curve('a', [
+    const path = [];
+    const cornerEndPositions = [
+      svgPaths.point(this.CORNER_RADIUS, -this.CORNER_RADIUS),
       svgPaths.point(this.CORNER_RADIUS, this.CORNER_RADIUS),
-      this.RTL ? ' 0 0 0 ' : ' 0 0 1 ',
-      svgPaths.point(
-        this.RTL ? -this.CORNER_RADIUS : this.CORNER_RADIUS,
-        -this.CORNER_RADIUS
-      ),
-    ]);
+      svgPaths.point(-this.CORNER_RADIUS, this.CORNER_RADIUS),
+      svgPaths.point(-this.CORNER_RADIUS, -this.CORNER_RADIUS),
+    ];
+    path.push(svgPaths.moveTo(0, this.CORNER_RADIUS));
 
-    path += svgPaths.lineOnAxis('h', this.RTL ? -width : width);
+    path.push(this.createCornerPath(cornerEndPositions[0]));
+    path.push(svgPaths.lineOnAxis('h', width));
+    path.push(this.createCornerPath(cornerEndPositions[1]));
+    path.push(svgPaths.lineOnAxis('v', height));
+    path.push(this.createCornerPath(cornerEndPositions[2]));
+    path.push(svgPaths.lineOnAxis('h', -width));
+    path.push(this.createCornerPath(cornerEndPositions[3]));
+    path.push('z');
 
-    path += svgPaths.curve('a', [
-      svgPaths.point(this.CORNER_RADIUS, this.CORNER_RADIUS),
-      this.RTL ? ' 0 0 0 ' : ' 0 0 1 ',
-      svgPaths.point(
-        this.RTL ? -this.CORNER_RADIUS : this.CORNER_RADIUS,
-        this.CORNER_RADIUS
-      ),
-    ]);
-
-    path += svgPaths.lineOnAxis('v', height);
-
-    path += svgPaths.curve('a', [
-      svgPaths.point(this.CORNER_RADIUS, this.CORNER_RADIUS),
-      this.RTL ? ' 0 0 0 ' : ' 0 0 1 ',
-      svgPaths.point(
-        this.RTL ? this.CORNER_RADIUS : -this.CORNER_RADIUS,
-        this.CORNER_RADIUS
-      ),
-    ]);
-
-    path += svgPaths.lineOnAxis('h', this.RTL ? width : -width);
-
-    path += svgPaths.curve('a', [
-      svgPaths.point(this.CORNER_RADIUS, this.CORNER_RADIUS),
-      this.RTL ? ' 0 0 0 ' : ' 0 0 1 ',
-      svgPaths.point(
-        this.RTL ? this.CORNER_RADIUS : -this.CORNER_RADIUS,
-        -this.CORNER_RADIUS
-      ),
-    ]);
-
-    path += 'z';
-
-    this.svgClipPath_.setAttribute('d', path);
-    this.svgBackground_.setAttribute('d', path);
+    this.svgClipPath_.setAttribute('d', path.join(''));
+    this.svgBackground_.setAttribute('d', path.join(''));
   }
 
+  /**
+   * Creates an SVG arc path command string based on the corner radius
+   * of the flyout background.
+   *
+   * @param {string} cornerEndPosition - The endpoint of the arc path.
+   *     It should be in the format 'dx,dy' representing the relative
+   *     coordinates from the current position, ex. (8,-8).
+   * @returns {string} The SVG arc path command string, ex. 'a 8 8 0,0,1 8,-8'
+   */
+  createCornerPath(cornerEndPosition) {
+    return svgPaths.arc('a', '0,0,1', this.CORNER_RADIUS, cornerEndPosition);
+  }
   /**
    * Attach this field to a block.
    *

--- a/apps/src/blockly/addons/cdoBlockFlyout.js
+++ b/apps/src/blockly/addons/cdoBlockFlyout.js
@@ -1,0 +1,212 @@
+import GoogleBlockly from 'blockly/core';
+
+export default class CdoBlockFlyout extends GoogleBlockly.HorizontalFlyout {
+  /**
+   * This is a customized flyout class that extends the HorizontalFlyout class.
+   * This flyout is intended to be place inside of a block's FieldFlyout.
+   *
+   * @param {Object} workspaceOptions - The options for constructing the class.
+   */
+  constructor(workspaceOptions) {
+    super(workspaceOptions);
+    this.horizontalLayout_ = !0;
+    this.minWidth_ = workspaceOptions.minWidth || this.minWidth_;
+    this.maxWidth_ = workspaceOptions.maxWidth || this.maxWidth_;
+  }
+
+  autoClose = false;
+  minWidth_ = 0;
+  maxWidth_ = 1000;
+
+  /**
+   * @returns True if this flyout may be scrolled with a scrollbar or
+   *     by dragging.
+   */
+  isScrollable() {
+    return false;
+  }
+
+  /**
+   * Creates the flyout's DOM.  Only needs to be called once.  The flyout can
+   * either exist as its own SVG element or be a g element nested inside a
+   * separate SVG element.
+   *
+   * @param tagName The type of tag to
+   *     put the flyout in. This should be <svg> or <g>.
+   * @returns The flyout's SVG group.
+   */
+  createDom(tagName) {
+    super.createDom(tagName);
+    tagName =
+      'flyoutClip' +
+      Blockly.utils.idGenerator.genUid().replace(/([\(\)])/g, '');
+    let definitions = Blockly.utils.dom.createSvgElement(
+      'defs',
+      {},
+      this.svgGroup_
+    );
+    definitions = Blockly.utils.dom.createSvgElement(
+      'clipPath',
+      {
+        id: tagName,
+      },
+      definitions
+    );
+    this.svgClipPath_ = Blockly.utils.dom.createSvgElement(
+      'path',
+      {},
+      definitions
+    );
+    this.svgGroup_.setAttribute('clip-path', 'url(#' + tagName + ')');
+    this.svgGroup_.classList.add('blockFieldFlyout');
+    return this.svgGroup_;
+  }
+
+  /**
+   * Initializes the flyout.
+   *
+   * @param targetWorkspace The workspace in which to
+   *     create new blocks.
+   */
+  init(targetWorkspace) {
+    super.init(targetWorkspace);
+    this.targetWorkspace_ = targetWorkspace;
+  }
+
+  /**
+   * Compute height of flyout.  Position mat under each block.
+   * For RTL: Lay out the blocks right-aligned.
+   */
+  reflowInternal_() {
+    this.height_ = 0;
+    this.width_ = 0;
+    const topBlocks = this.workspace_.getTopBlocks(false);
+    for (let i = 0, block; (block = topBlocks[i]); i++) {
+      const blockHW = block.getHeightWidth();
+      this.updateHeight_(blockHW.height);
+      this.updateWidth_(blockHW.width);
+      if (this.rectMap_.has(block)) {
+        this.moveRectToBlock_(this.rectMap_.get(block), block);
+      }
+    }
+    // We need to set the flyout width based on the block itself, excluding children.
+    // Using block.getHeightWidth() would include blocks connected to input and next
+    // connections, which could make the flyout wider than the block that contains it.
+    const topBlockWidth = this.sourceBlock_.svgGroup_
+      .querySelector('path')
+      .getBoundingClientRect().width;
+    this.width_ = Math.max(this.width_, topBlockWidth - 36);
+    this.setBackgroundPath_(this.width_, this.height_);
+    this.position();
+  }
+
+  /** Update the flyout height based on the new block height.
+   *
+   * @param {number} newHeight - The new block height.
+   * @private
+   */
+  updateHeight_(newHeight) {
+    this.height_ = Math.max(this.height_, newHeight);
+  }
+  /**
+   * Update the flyout width based on the new block width.
+   *
+   * @param {number} newWidth - The new block width.
+   * @private
+   */
+  updateWidth_(newWidth) {
+    this.width_ += newWidth + this.GAP_X;
+  }
+
+  /**
+   * Position the flyout.
+   */
+  position() {
+    this.isVisible() && this.positionAt_(this.width_, this.height_, 0, 0);
+  }
+
+  /**
+   * Create and set the path for the visible boundaries of the flyout.
+   *
+   * @param width The width of the flyout, not including the rounded corners.
+   * @param height The height of the flyout, not including rounded corners.
+   */
+  setBackgroundPath_(width, height) {
+    const svgPaths = GoogleBlockly.utils.svgPaths;
+    let path = svgPaths.moveTo(
+      this.RTL ? width : 0,
+      this.toolboxPosition_ === Blockly.TOOLBOX_AT_TOP ? 0 : this.CORNER_RADIUS
+    );
+
+    path += svgPaths.curve('a', [
+      svgPaths.point(this.CORNER_RADIUS, this.CORNER_RADIUS),
+      this.RTL ? ' 0 0 0 ' : ' 0 0 1 ',
+      svgPaths.point(
+        this.RTL ? -this.CORNER_RADIUS : this.CORNER_RADIUS,
+        -this.CORNER_RADIUS
+      ),
+    ]);
+
+    path += svgPaths.lineOnAxis('h', this.RTL ? -width : width);
+
+    path += svgPaths.curve('a', [
+      svgPaths.point(this.CORNER_RADIUS, this.CORNER_RADIUS),
+      this.RTL ? ' 0 0 0 ' : ' 0 0 1 ',
+      svgPaths.point(
+        this.RTL ? -this.CORNER_RADIUS : this.CORNER_RADIUS,
+        this.CORNER_RADIUS
+      ),
+    ]);
+
+    path += svgPaths.lineOnAxis('v', height);
+
+    path += svgPaths.curve('a', [
+      svgPaths.point(this.CORNER_RADIUS, this.CORNER_RADIUS),
+      this.RTL ? ' 0 0 0 ' : ' 0 0 1 ',
+      svgPaths.point(
+        this.RTL ? this.CORNER_RADIUS : -this.CORNER_RADIUS,
+        this.CORNER_RADIUS
+      ),
+    ]);
+
+    path += svgPaths.lineOnAxis('h', this.RTL ? width : -width);
+
+    path += svgPaths.curve('a', [
+      svgPaths.point(this.CORNER_RADIUS, this.CORNER_RADIUS),
+      this.RTL ? ' 0 0 0 ' : ' 0 0 1 ',
+      svgPaths.point(
+        this.RTL ? this.CORNER_RADIUS : -this.CORNER_RADIUS,
+        -this.CORNER_RADIUS
+      ),
+    ]);
+
+    path += 'z';
+
+    this.svgClipPath_.setAttribute('d', path);
+    this.svgBackground_.setAttribute('d', path);
+  }
+
+  /**
+   * Attach this field to a block.
+   *
+   * @param block The block containing this field.
+   */
+  setSourceBlock_(block) {
+    this.sourceBlock_ = block;
+  }
+
+  /**
+   * Returns whether the provided block or bubble would be deleted if dropped on
+   * this area. Mini-toolboxes should never be used to delete blocks.
+   * The original method checks if the element is deletable and is always called
+   * before onDragEnter/onDragOver/onDragExit.
+   *
+   * @param element The block or bubble currently being dragged.
+   * @param couldConnect Whether the element could could connect to another.
+   * @returns Whether the element provided would be deleted if dropped on this
+   *     area.
+   */
+  wouldDelete(element, _couldConnect) {
+    return false;
+  }
+}

--- a/apps/src/blockly/addons/cdoBlockFlyout.js
+++ b/apps/src/blockly/addons/cdoBlockFlyout.js
@@ -3,13 +3,13 @@ import GoogleBlockly from 'blockly/core';
 export default class CdoBlockFlyout extends GoogleBlockly.HorizontalFlyout {
   /**
    * This is a customized flyout class that extends the HorizontalFlyout class.
-   * This flyout is intended to be place inside of a block's FieldFlyout.
+   * This flyout is intended to be placed inside of a block's FieldFlyout.
    *
    * @param {Object} workspaceOptions - The options for constructing the class.
    */
   constructor(workspaceOptions) {
     super(workspaceOptions);
-    this.horizontalLayout_ = !0;
+    this.horizontalLayout_ = true;
     this.minWidth_ = workspaceOptions.minWidth || this.minWidth_;
     this.maxWidth_ = workspaceOptions.maxWidth || this.maxWidth_;
   }
@@ -70,14 +70,17 @@ export default class CdoBlockFlyout extends GoogleBlockly.HorizontalFlyout {
     this.height_ = 0;
     this.width_ = 0;
     const topBlocks = this.workspace_.getTopBlocks(false);
-    for (let i = 0, block; (block = topBlocks[i]); i++) {
+    topBlocks.forEach(block => {
       const blockHW = block.getHeightWidth();
       this.updateHeight_(blockHW.height);
       this.updateWidth_(blockHW.width);
+
       if (this.rectMap_.has(block)) {
-        this.moveRectToBlock_(this.rectMap_.get(block), block);
+        const rect = this.rectMap_.get(block);
+        this.moveRectToBlock_(rect, block);
       }
-    }
+    });
+
     // We need to set the flyout width based on the block itself, excluding children.
     // Using block.getHeightWidth() would include blocks connected to input and next
     // connections, which could make the flyout wider than the block that contains it.

--- a/apps/src/blockly/addons/cdoBlockFlyout.js
+++ b/apps/src/blockly/addons/cdoBlockFlyout.js
@@ -63,17 +63,6 @@ export default class CdoBlockFlyout extends GoogleBlockly.HorizontalFlyout {
   }
 
   /**
-   * Initializes the flyout.
-   *
-   * @param targetWorkspace The workspace in which to
-   *     create new blocks.
-   */
-  init(targetWorkspace) {
-    super.init(targetWorkspace);
-    this.targetWorkspace_ = targetWorkspace;
-  }
-
-  /**
    * Compute height of flyout.  Position mat under each block.
    * For RTL: Lay out the blocks right-aligned.
    */

--- a/apps/src/blockly/addons/cdoFieldFlyout.js
+++ b/apps/src/blockly/addons/cdoFieldFlyout.js
@@ -1,0 +1,135 @@
+import GoogleBlockly from 'blockly/core';
+import CdoBlockFlyout from './cdoBlockFlyout';
+
+export default class CdoFieldFlyout extends GoogleBlockly.Field {
+  /**
+   * @param value The initial value of the field.
+   * @param {Object} opt_config A map of options used to configure the field.
+   *    Refer to the individual field's documentation for a list of properties
+   * this parameter supports.
+   */
+  constructor(value, opt_config) {
+    super(value);
+    this.configure_(opt_config);
+  }
+
+  /**
+   * Construct a FieldFlyout from a JSON arg object.
+   *
+   * @param {Object} options A JSON object with options.
+   * @returns {CdoFieldFlyout} The new field instance.
+   */
+  static fromJson(options) {
+    return new CdoFieldFlyout(options.flyoutKey, options);
+  }
+
+  EDITABLE = false;
+  CURSOR = 'default';
+
+  /**
+   * Process the configuration map passed to the field.
+   *
+   * @param {Object} [config] A map of options used to configure the field.
+   */
+  configure_(config) {
+    if (config) {
+      this.minWidth_ = config.minWidth;
+      this.maxWidth_ = config.maxWidth;
+    }
+  }
+
+  /**
+   * Create the block UI for this field.
+   */
+  initView() {
+    this.workspace_ = this.getSourceBlock().workspace;
+    this.flyout_ = new CdoBlockFlyout({
+      ...Blockly.getMainWorkspace().options,
+      disabledPatternId: this.workspace_.options.disabledPatternId,
+      parentWorkspace: this.workspace_,
+      RTL: this.workspace_.RTL,
+      minWidth: this.minWidth_,
+      maxWidth: this.maxWidth_,
+    });
+    this.flyout_.setSourceBlock_(this.getSourceBlock());
+    this.fieldGroup_.appendChild(this.flyout_.createDom('g'));
+  }
+
+  /**
+   * This is the Blockly hook to create an editor for the field.
+   */
+  showEditor_() {
+    this.setFlyoutVisible(!this.isFlyoutVisible());
+  }
+
+  /**
+   * Returns the height and width of the field.
+   *
+   * This should *in general* be the only place render_ gets called from.
+   *
+   * @returns {Blockly.utils.Size} Height and width.
+   */
+  getSize() {
+    if (!this.isVisible()) {
+      return new Blockly.utils.Size(0, 0);
+    }
+    // Normally, Blockly skips rendering fields unless we've notified the
+    // rendering system that they've changed (this.isDirty_), but in this
+    // case, we want to always re-render / resize the field so that it
+    // matches the width of the block.
+    this.render_();
+
+    if (this.visible_ && this.size_.width === 0) {
+      // If the field is not visible the width will be 0 as well, one of the
+      // problems with the old system.
+      this.render_();
+    }
+
+    return this.size_;
+  }
+  /**
+   * Used by getSize() to move/resize any DOM elements, and get the new size.
+   *
+   * All rendering that has an effect on the size/shape of the block should be
+   * done here, and should be triggered by getSize().
+   */
+  render_() {
+    this.showEditor_();
+    const fieldGroupBBox = this.fieldGroup_.getBBox();
+    if (this.flyout_.isVisible()) {
+      this.size_ = new Blockly.utils.Size(
+        this.flyout_.getWidth(),
+        fieldGroupBBox.height
+      );
+    } else {
+      this.size_ = new Blockly.utils.Size(
+        fieldGroupBBox.width,
+        fieldGroupBBox.height
+      );
+    }
+  }
+
+  /**
+   * Show or hide the flyout, then re-render it.
+   *
+   * @param {boolean} isVisible Whether or not the flyout should be shown.
+   */
+  setFlyoutVisible(isVisible) {
+    if (!this.flyout_.targetWorkspace_) {
+      this.flyout_.init(this.workspace_);
+    }
+    isVisible
+      ? this.flyout_.show(`flyout_${this.sourceBlock_.type}`)
+      : this.flyout_.hide();
+    this.forceRerender();
+  }
+
+  /**
+   * Is this field's flyout visible?
+   *
+   * @returns True if visible.
+   */
+  isFlyoutVisible() {
+    return this.flyout_.isVisible();
+  }
+}

--- a/apps/src/blockly/addons/cdoFieldFlyout.js
+++ b/apps/src/blockly/addons/cdoFieldFlyout.js
@@ -6,8 +6,11 @@ export default class CdoFieldFlyout extends GoogleBlockly.Field {
    * This is a customized class that extends Blockly's Field class.
    * This field depends on `CdoBlockFlyout`, which is used to create a flyout
    * of blocks. We colloquially refer to this as a block's "mini-toolbox".
-   * @param value The initial value of the field.
-   * @param {Object} opt_config A map of options used to configure the field.
+   *
+   * @param {string} value - The initial value of the field.
+   * @param {Object} [opt_config] - A map of options used to configure the field.
+   * @param {number} [opt_config.minWidth] - The minimum width of the field.
+   * @param {number} [opt_config.maxWidth] - The maximum width of the field.
    */
   constructor(value, opt_config) {
     super(value);
@@ -30,7 +33,9 @@ export default class CdoFieldFlyout extends GoogleBlockly.Field {
   /**
    * Process the configuration map passed to the field.
    *
-   * @param {Object} [config] A map of options used to configure the field.
+   * @param {Object} [config] - A map of options used to configure the field.
+   * @param {number} [config.minWidth] - The minimum width of the field.
+   * @param {number} [config.maxWidth] - The maximum width of the field.
    */
   configure_(config) {
     if (config) {

--- a/apps/src/blockly/addons/cdoFieldFlyout.js
+++ b/apps/src/blockly/addons/cdoFieldFlyout.js
@@ -115,7 +115,7 @@ export default class CdoFieldFlyout extends GoogleBlockly.Field {
    * @param {boolean} isVisible Whether or not the flyout should be shown.
    */
   setFlyoutVisible(isVisible) {
-    if (!this.flyout_.targetWorkspace_) {
+    if (!this.flyout_.targetWorkspace) {
       this.flyout_.init(this.workspace_);
     }
     isVisible

--- a/apps/src/blockly/addons/cdoFieldFlyout.js
+++ b/apps/src/blockly/addons/cdoFieldFlyout.js
@@ -3,10 +3,11 @@ import CdoBlockFlyout from './cdoBlockFlyout';
 
 export default class CdoFieldFlyout extends GoogleBlockly.Field {
   /**
+   * This is a customized class that extends Blockly's Field class.
+   * This field depends on `CdoBlockFlyout`, which is used to create a flyout
+   * of blocks. We colloquially refer to this as a block's "mini-toolbox".
    * @param value The initial value of the field.
    * @param {Object} opt_config A map of options used to configure the field.
-   *    Refer to the individual field's documentation for a list of properties
-   * this parameter supports.
    */
   constructor(value, opt_config) {
     super(value);

--- a/apps/src/blockly/addons/cdoRendererThrasos.js
+++ b/apps/src/blockly/addons/cdoRendererThrasos.js
@@ -1,7 +1,9 @@
 import GoogleBlockly from 'blockly/core';
 import CdoPathObject from './cdoPathObjectThrasos';
 import CdoConstantsProvider from './cdoConstantsProvider';
-export default class CdoRendererThrasos extends GoogleBlockly.thrasos.Renderer {
+import {addInlineRowSeparators} from '@blockly/renderer-inline-row-separators';
+
+export class CdoRendererThrasosBase extends GoogleBlockly.thrasos.Renderer {
   /**
    * @override
    * Use our PathObject class instead of the default. Our PathObject has
@@ -20,3 +22,8 @@ export default class CdoRendererThrasos extends GoogleBlockly.thrasos.Renderer {
     return new CdoConstantsProvider();
   };
 }
+
+export const CdoRendererThrasos = addInlineRowSeparators(
+  CdoRendererThrasosBase,
+  GoogleBlockly.thrasos.RenderInfo
+);

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -13,6 +13,7 @@ import CdoFieldAngle from './addons/cdoFieldAngle';
 import CdoFieldButton from './addons/cdoFieldButton';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
 import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
+import CdoFieldFlyout from './addons/cdoFieldFlyout';
 import CdoFieldMultilineInput from './addons/cdoFieldMultilineInput';
 import CdoFieldNumber from './addons/cdoFieldNumber';
 import CdoFieldTextInput from './addons/cdoFieldTextInput';
@@ -21,7 +22,7 @@ import FunctionEditor from './addons/functionEditor';
 import initializeGenerator from './addons/cdoGenerator';
 import CdoMetricsManager from './addons/cdoMetricsManager';
 import CdoRendererGeras from './addons/cdoRendererGeras';
-import CdoRendererThrasos from './addons/cdoRendererThrasos';
+import {CdoRendererThrasos} from './addons/cdoRendererThrasos';
 import CdoRendererZelos from './addons/cdoRendererZelos';
 import CdoTheme from './themes/cdoTheme';
 import CdoDarkTheme from './themes/cdoDark';
@@ -244,6 +245,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
     ['field_number', 'FieldNumber', CdoFieldNumber],
     ['field_angle', 'FieldAngle', CdoFieldAngle],
     ['field_multilinetext', 'FieldMultilineInput', CdoFieldMultilineInput],
+    ['field_flyout', 'FieldFlyout', CdoFieldFlyout],
   ];
   blocklyWrapper.overrideFields(fieldOverrides);
 

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1345,6 +1345,11 @@
   resolved "https://registry.yarnpkg.com/@blockly/plugin-scroll-options/-/plugin-scroll-options-3.0.3.tgz#71fddcb58a1a4e8e145e1c0e6ffc21d15adab951"
   integrity sha512-UxArVgFn/D23TKtW6CM3rPc9r7qzx/XnKmZZANPqOvNB3X1PdZbm8+EGHocdzZbcUqq+g+Xjb+O4PfkT0kfqag==
 
+"@blockly/renderer-inline-row-separators@^0.2.13":
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/@blockly/renderer-inline-row-separators/-/renderer-inline-row-separators-0.2.14.tgz#41bd8f56c28719e25df323f196a4ec7722071d73"
+  integrity sha512-nmVPDtMaLBWLDktQv7pPK9wEpYheNmPjwP+0uZqJYzE7u3A4CFZ0szxc/0Uxo4TeFYpoLok2lYQQWRwdMO/aXw==
+
 "@blockly/theme-dark@^4.0.3":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@blockly/theme-dark/-/theme-dark-4.0.3.tgz#7457f91d93157804bd661a699dae9ba673061010"


### PR DESCRIPTION
## Overview
This PR adds `CdoFieldFlyout` a new customized field for Google Blockly labs. This field creates a horizontal flyout (`CdoBlockFlyout`) that we colloquially refer to as a "mini-toolbox".
Note that this PR doesn't change any existing functionality on the site today. Rather, it makes the new field and flyout type available in preparation for the work to support mini-toolbox blocks that are found in Sprite Lab.
Therefore, testing of these new classes was done primarily in [alternate draft branch](https://github.com/code-dot-org/code-dot-org/compare/mike/spritelab-minitoolbox-blocks) that fully implements both, as well as a [new toggle field](https://github.com/code-dot-org/code-dot-org/pull/52708) that is also up for review.

## Background
Fields are used to define most UI elements on a block. Examples of fields include string labels, images, inputs for literal data such as strings and numbers, and rich editors like date pickers and angle pickers.
- More info on the [anatomy of a field](https://developers.google.com/blockly/guides/create-custom-blocks/fields/anatomy-of-a-field).
- More info on [creating custom fields](https://developers.google.com/blockly/guides/create-custom-blocks/fields/customizing-fields/overview).
The custom field `CdoFieldFlyout` can be thought of as a container for a flyout UI (`CdoBlockFlyout`). While our standard toolboxes use a customized version of Blockly's Vertical Flyout (blocks arranged vertically), the mini-toolbox will use a custom version of the Horizontal Flyout.
The flyout field field needs to be positioned at the bottom of the block on its row. It also needs to be entirely collapsible, controlled by a toggle button on the top row of the block.
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/ba5488bf-b966-497e-aa52-ca263cb6a412)
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/f55fa85f-7d80-4395-9b04-d76193542039)
(Above screenshots were taken from the draft branch mentioned above, which implements both new field types and the new flyout.)

## Process
* For the Blockly Summit in 2019, @BeksOmega from the Blockly team created a proof-of-concept for a block containing a toggle-able flyout: http://bekawestberg.me/projects/blockly-summit-2019-demo/ Unfortunately, the source code for this experiment feature was lost.
<img width="234" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/4d22e994-153d-4552-8116-e7e4ea657477">

* In May of this year, @bencodeorg reverse-engineered the features from Beka's Blockly Playground by [copying the minified source code into our repo](https://github.com/code-dot-org/code-dot-org/commit/225769a5559389c5447ef7f19a61c1354d552138) and refactoring it to use [modern JS classes](https://github.com/code-dot-org/code-dot-org/commit/480f9c656584a46b0da061551beb4915ecf7336b).
* Ben and I collaborated on some initial steps to get the copied/refactored code working, including copying over variable labels that I sourced from the core Blockly repo. We first got a basic block to render, then focused on getting the expected blocks to render in the flyout. This required defining some temporary blocks that use the new field and callback functions (which determine the blocks to populate the flyout with). Eventually, we would need to support dynamically adding these fields to _any_ block as part of the block-creating flow in `block_utils.js`. See this massive snippet for details (j/k, don't actually try to read this): https://github.com/code-dot-org/code-dot-org/blob/e6a7540e7dbbe6029b00506c08d3ded184705ad0/apps/src/block_utils.js#L860-L1277)

* As Ben was departing for parental leave, I took lead on the project in June. To get the blocks into alignment with how they appear in Sprite Lab today, I had to make significant modifications to the new field:
  * We needed to force the flyout field to be on its own row, below any other fields/inputs. Unfortunately, this isn't supported with core Blockly. Fortunately, a plugin exists that allows use dummy inputs as row separators: https://github.com/google/blockly-samples/tree/master/plugins/renderer-inline-row-separators This plugin was used to modify our Thrasos renderer so that it can render the blocks as we'd expect.
  * Instead of the field including an "arrow" symbol that controlled opening/closing the flyout, we needed it to work with a separate button with custom UI. Initially I considered re-using `CdoFieldButton`, but after discussing with Beka, we opted for a brand new field instead. @fisher-alice wrote the new field `CdoFieldToggle` which I then pulled into my draft branch. 
  * Once the two fields were connected and operating properly, a lot of bug fixing took place. In some cases, the code we had copied over was trying to do things in outdated or redundant ways. We also had some custom CDO functionality to consider. 
    * For example, when dragging blocks on a workspace, we hide the contents of the main toolbox (and show a trashcan sprite). We didn't want to hide the contents of block flyouts.

## Next Steps
* Add `CdoFieldToggle` to the wrapper (https://github.com/code-dot-org/code-dot-org/pull/52708)
* Add `CdoFieldFlyout` and `CdoBlockFlyout` to the wrapper (this PR)
* Move complex Blockly-version-specific logic out of block_utils (https://github.com/code-dot-org/code-dot-org/pull/52715)
* Implement `CdoFieldToggle` and `CdoFieldFlyout` to add support for mini-toolbox blocks when using Google Blockly (draft: https://github.com/code-dot-org/code-dot-org/pull/52700/files)


## Links

https://codedotorg.atlassian.net/browse/SL-793

## Testing story

This field was implemented and tested as part of a larger feature [branch](https://github.com/code-dot-org/code-dot-org/pull/mike/spritelab-minitoolbox-blocks) which adds Google Blockly support for three Sprite Lab blocks.
