### PR TITLE
[Google Blockly] Remove undesired options from context menu

### DIFF
--- a/apps/src/blockly/addons/contextMenu.js
+++ b/apps/src/blockly/addons/contextMenu.js
@@ -297,6 +297,10 @@ function unregisterDefaultOptions() {
   // This needs to be wrapped in a try for now because our GoogleBlocklyWrapperTest.js
   // is not correctly cleaning up its state.
   try {
+    GoogleBlockly.ContextMenuRegistry.registry.unregister(
+      'blockCollapseExpand'
+    );
+    GoogleBlockly.ContextMenuRegistry.registry.unregister('blockInline');
     // cleanUp() doesn't currently account for immovable blocks.
     GoogleBlockly.ContextMenuRegistry.registry.unregister('cleanWorkspace');
     GoogleBlockly.ContextMenuRegistry.registry.unregister('collapseWorkspace');


### PR DESCRIPTION
Removes the context menu options “External Inputs” and “Collapse Block”. 

![image (155)](https://github.com/code-dot-org/code-dot-org/assets/43474485/9c4bd015-c679-4d12-92d7-fc848ffd181b)
The teal blocks in the screenshot are all the same block. The first block has external inputs (as opposed to inline inputs), and the second block is collapsed. These options are only available in Google Blockly (e.g. Poetry/Dance right now). 

Supporting these options was adding complexity to the Sprite Lab migration, so I checked in with the curriculum team about them. They weren't really aware of them, but suggested it was a good idea to remove them. [[Slack thread](https://codedotorg.slack.com/archives/C02GRH2PYB1/p1688666954541649)]
Amy BW says, _"We've never used 'External Inputs' or 'Collapse Block'.  I wouldn't want it for the student view. I'm not sure we'd use it as curriculum writers either"._
Katie Frank said, _"The feature looks more confusing than it’s worth for both students and curriculum writers."_



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
