### PR TITLE
Migrations and models for LearningGoal and LearningGoalEvidenceLevel

### DIFF
--- a/dashboard/app/models/learning_goal.rb
+++ b/dashboard/app/models/learning_goal.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: learning_goals
+#
+#  id            :bigint           not null, primary key
+#  position      :integer
+#  lesson_id     :integer
+#  level_id      :integer
+#  learning_goal :string(255)
+#  ai_enabled    :boolean
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+class LearningGoal < ApplicationRecord
+end

--- a/dashboard/app/models/learning_goal_evidence_level.rb
+++ b/dashboard/app/models/learning_goal_evidence_level.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: learning_goal_evidence_levels
+#
+#  id                  :bigint           not null, primary key
+#  learning_goal_id    :integer
+#  understanding       :integer
+#  teacher_description :text(65535)
+#  ai_prompt           :text(65535)
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+class LearningGoalEvidenceLevel < ApplicationRecord
+end

--- a/dashboard/db/migrate/20230710181031_create_learning_goal_evidence_levels.rb
+++ b/dashboard/db/migrate/20230710181031_create_learning_goal_evidence_levels.rb
@@ -1,0 +1,13 @@
+class CreateLearningGoalEvidenceLevels < ActiveRecord::Migration[6.1]
+  def change
+    create_table :learning_goal_evidence_levels do |t|
+      t.integer :id
+      t.integer :learning_goal_id
+      t.integer :understanding
+      t.text :teacher_description
+      t.text :ai_prompt
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/migrate/20230710184729_create_learning_goals.rb
+++ b/dashboard/db/migrate/20230710184729_create_learning_goals.rb
@@ -1,0 +1,13 @@
+class CreateLearningGoals < ActiveRecord::Migration[6.1]
+  def change
+    create_table :learning_goals do |t|
+      t.integer :position
+      t.integer :lesson_id
+      t.integer :level_id
+      t.string :learning_goal
+      t.boolean :ai_enabled
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_05_195726) do
+ActiveRecord::Schema.define(version: 2023_07_10_184729) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -620,6 +620,25 @@ ActiveRecord::Schema.define(version: 2023_07_05_195726) do
     t.datetime "updated_at", null: false
     t.index ["script_id", "level_id"], name: "index_hint_view_requests_on_script_id_and_level_id"
     t.index ["user_id"], name: "index_hint_view_requests_on_user_id"
+  end
+
+  create_table "learning_goal_evidence_levels", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+    t.integer "learning_goal_id"
+    t.integer "understanding"
+    t.text "teacher_description"
+    t.text "ai_prompt"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "learning_goals", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+    t.integer "position"
+    t.integer "lesson_id"
+    t.integer "level_id"
+    t.string "learning_goal"
+    t.boolean "ai_enabled"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "lesson_activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Adds tables for `LearningGoal` and `LearningGoalEvidenceLevel` based on the [tech spec](https://docs.google.com/document/d/1saBTPhEywbH1pF5ePPW9qehFDa7dGQpm3RfcUZ0QpV8/edit). Indexes will be added later -- create [this task](https://codedotorg.atlassian.net/browse/AITT-77) to track that.