### PR TITLE
Add UI tests for Catalog assign button

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -33,8 +33,8 @@ Feature: Curriculum Catalog Page
     And I get redirected to "/users/sign_in?user_return_to=/catalog" via "dashboard"
 
   Scenario: Signed-in student is redirected to help page when clicking Assign
-    Given I create a student named "Student Sam"
-    Then I am on "http://studio.code.org/catalog"
+    Given I am on "http://studio.code.org/catalog"
+    And I am a student
     And I wait until element "h4:contains(AI for Oceans)" is visible
 
     Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"

--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -30,7 +30,7 @@ Feature: Curriculum Catalog Page
     Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"
     And I wait until element "h3:contains(Sign in or create account to assign a curriculum)" is visible
     Then I click selector "a:contains(Sign in or create account)"
-    And I wait until I am on "https://studio.code.org/users/sign_in?user_return_to=/catalog" via "nothing"
+    And I wait until I am on "https://studio.code.org/users/sign_in?user_return_to=/catalog"
 
   Scenario: Signed-in student is redirected to help page when clicking Assign
     Given I create a student named "Student Sam"

--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -30,7 +30,7 @@ Feature: Curriculum Catalog Page
     Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"
     And I wait until element "h3:contains(Sign in or create account to assign a curriculum)" is visible
     Then I click selector "a:contains(Sign in or create account)"
-    And I wait until I am on "https://studio.code.org/users/sign_in?user_return_to=/catalog"
+    And I wait until element "h2:contains(Have an account already? Sign in)" is visible
 
   Scenario: Signed-in student is redirected to help page when clicking Assign
     Given I create a student named "Student Sam"

--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -20,3 +20,34 @@ Feature: Curriculum Catalog Page
     And I wait until element "h5:contains(No matching curricula)" is visible
     And I see no difference for "Curriculum Catalog: No Offerings"
     And I close my eyes
+
+  # Assign button scenarios
+
+  Scenario: Signed-out user is redirected to sign-in page when clicking Assign
+    Given I am on "http://studio.code.org/catalog"
+    And I wait until element "h4:contains(AI for Oceans)" is visible
+
+    Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"
+    And I wait until element "h3:contains(Sign in or create account to assign a curriculum)" is visible
+    Then I click selector "a:contains(Sign in or create account)"
+    And I get redirected to "/users/sign_in?user_return_to=/catalog" via "dashboard"
+
+  Scenario: Signed-in student is redirected to help page when clicking Assign
+    Given I create a student named "Student Sam"
+    Then I am on "http://studio.code.org/catalog"
+    And I wait until element "h4:contains(AI for Oceans)" is visible
+
+    Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"
+    And I wait until element "h3:contains(Use a teacher account to assign a curriculum)" is visible
+    Then I click selector "a:contains(Learn how to update account type)"
+    And check that the URL matches "https://support.code.org/hc/en-us/articles/360023222371-How-can-I-change-my-account-type-from-student-to-teacher-or-vice-versa"
+
+  Scenario: Signed-in teacher without sections is prompted to created sections when clicking Assign
+    Given I create a teacher named "Teacher Tom"
+    Then I am on "http://studio.code.org/catalog"
+    And I wait until element "h4:contains(AI for Oceans)" is visible
+
+    Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"
+    And I wait until element "h3:contains(Create class section to assign a curriculum)" is visible
+    Then I click selector "a:contains(Create Section)"
+    And I wait to see a modal containing text "Create a new section"

--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -30,11 +30,11 @@ Feature: Curriculum Catalog Page
     Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"
     And I wait until element "h3:contains(Sign in or create account to assign a curriculum)" is visible
     Then I click selector "a:contains(Sign in or create account)"
-    And I get redirected to "/users/sign_in?user_return_to=/catalog" via "dashboard"
+    And I wait until I am on "https://studio.code.org/users/sign_in?user_return_to=/catalog" via "nothing"
 
   Scenario: Signed-in student is redirected to help page when clicking Assign
+    Given I create a student named "Student Sam"
     Given I am on "http://studio.code.org/catalog"
-    And I am a student
     And I wait until element "h4:contains(AI for Oceans)" is visible
 
     Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"
@@ -50,4 +50,4 @@ Feature: Curriculum Catalog Page
     Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"
     And I wait until element "h3:contains(Create class section to assign a curriculum)" is visible
     Then I click selector "a:contains(Create Section)"
-    And I wait to see a modal containing text "Create a new section"
+    And I wait until element "h3:contains(Create a new section)" is visible


### PR DESCRIPTION
Adds UI tests in the curriculum catalog for three scenarios:
- signed-in teacher without sections
- signed-in student
- signed-out user

Still need to add:
- signed-in teacher with sections assigning unit
- signed-in teacher with sections assigning course
- non-English user

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
