### PR TITLE
Lab2: Remove variables source validation

### DIFF
--- a/apps/src/lab2/responseValidators.ts
+++ b/apps/src/lab2/responseValidators.ts
@@ -15,9 +15,5 @@ export const SourceResponseValidator: ResponseValidator<
     throw new Error('Missing required field: blocks');
   }
 
-  if (blocklySource.variables === undefined) {
-    throw new Error('Missing required field: variables');
-  }
-
   return projectSources;
 };


### PR DESCRIPTION
We don't need to block loading on variables not existing, as we no longer use variables. We found this issue in our error log review.

## Links
- [slack discussion](https://codedotorg.slack.com/archives/C04TH8400AU/p1689029047974369)
- jira: [SL-975](https://codedotorg.atlassian.net/browse/SL-975)

## Testing story
Tested locally that a project that previously failed to load now loads.

## Follow-up work
We have a potential follow up to default to start sources if we do not have blocks instead of failing to load. This load failure is also not friendly--the page just fails to load code, with no error to the user or option to start over. I created a [follow up task](https://codedotorg.atlassian.net/browse/SL-981) to track this.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
