### PR TITLE
Migrations for Rubric, LearningGoal, and LearningGoalEvidenceLevel models

### DIFF
--- a/dashboard/app/models/learning_goal.rb
+++ b/dashboard/app/models/learning_goal.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: learning_goals
+#
+#  id            :bigint           not null, primary key
+#  key           :string(255)
+#  position      :integer
+#  rubric_id     :integer
+#  learning_goal :string(255)
+#  ai_enabled    :boolean
+#  tips          :text(65535)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+class LearningGoal < ApplicationRecord
+end

--- a/dashboard/app/models/learning_goal_evidence_level.rb
+++ b/dashboard/app/models/learning_goal_evidence_level.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: learning_goal_evidence_levels
+#
+#  id                  :bigint           not null, primary key
+#  learning_goal_id    :integer
+#  understanding       :integer
+#  teacher_description :text(65535)
+#  ai_prompt           :text(65535)
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+class LearningGoalEvidenceLevel < ApplicationRecord
+end

--- a/dashboard/app/models/rubric.rb
+++ b/dashboard/app/models/rubric.rb
@@ -1,0 +1,12 @@
+# == Schema Information
+#
+# Table name: rubrics
+#
+#  id         :bigint           not null, primary key
+#  lesson_id  :integer
+#  level_id   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Rubric < ApplicationRecord
+end

--- a/dashboard/db/migrate/20230711174932_create_rubrics.rb
+++ b/dashboard/db/migrate/20230711174932_create_rubrics.rb
@@ -1,0 +1,10 @@
+class CreateRubrics < ActiveRecord::Migration[6.1]
+  def change
+    create_table :rubrics do |t|
+      t.integer :lesson_id
+      t.integer :level_id
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/migrate/20230711175139_create_learning_goals.rb
+++ b/dashboard/db/migrate/20230711175139_create_learning_goals.rb
@@ -1,0 +1,14 @@
+class CreateLearningGoals < ActiveRecord::Migration[6.1]
+  def change
+    create_table :learning_goals do |t|
+      t.string :key
+      t.integer :position
+      t.integer :rubric_id
+      t.string :learning_goal
+      t.boolean :ai_enabled
+      t.text :tips
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/migrate/20230711175151_create_learning_goal_evidence_levels.rb
+++ b/dashboard/db/migrate/20230711175151_create_learning_goal_evidence_levels.rb
@@ -1,0 +1,12 @@
+class CreateLearningGoalEvidenceLevels < ActiveRecord::Migration[6.1]
+  def change
+    create_table :learning_goal_evidence_levels do |t|
+      t.integer :learning_goal_id
+      t.integer :understanding
+      t.text :teacher_description
+      t.text :ai_prompt
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_10_182706) do
+ActiveRecord::Schema.define(version: 2023_07_11_175151) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -633,6 +633,26 @@ ActiveRecord::Schema.define(version: 2023_07_10_182706) do
     t.integer "understanding"
     t.text "feedback"
     t.text "context"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "learning_goal_evidence_levels", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+    t.integer "learning_goal_id"
+    t.integer "understanding"
+    t.text "teacher_description"
+    t.text "ai_prompt"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "learning_goals", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+    t.string "key"
+    t.integer "position"
+    t.integer "rubric_id"
+    t.string "learning_goal"
+    t.boolean "ai_enabled"
+    t.text "tips"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -1594,6 +1614,13 @@ ActiveRecord::Schema.define(version: 2023_07_10_182706) do
     t.integer "course_version_id", null: false
     t.index ["course_version_id", "key"], name: "index_resources_on_course_version_id_and_key", unique: true
     t.index ["name", "url"], name: "index_resources_on_name_and_url", type: :fulltext
+  end
+
+  create_table "rubrics", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+    t.integer "lesson_id"
+    t.integer "level_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "school_districts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
A couple changes from the [tech spec](https://docs.google.com/document/d/1saBTPhEywbH1pF5ePPW9qehFDa7dGQpm3RfcUZ0QpV8/edit):
1. The addition of a `Rubric` model that stores a lesson and level id and subsequently removing those columns from `LearningGoal`
2. A `key` column for `LearningGoal`. This is necessary because of the way we move content from levelbuilder to production and the fact that `LearningGoal` ids cannot change once created (as `LearningGoalEvaluation`, a table with user data, uses those ids)

I created a [task](https://codedotorg.atlassian.net/browse/AITT-77) to add indexes to these tables as a follow-up.