### PR TITLE
Music: small entrypoint cleanup

### DIFF
--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -67,8 +67,6 @@
         = render partial: "levels/#{@level.class.to_s.underscore}"
       - unless @level.is_a?(StandaloneVideo) || @level.properties['hide_reference_area']
         = render partial: 'levels/reference_area'
-    - elsif @game.app == Game::MUSIC
-      = render partial: 'levels/music'
     - else
       = render partial: 'levels/blockly'
 


### PR DESCRIPTION
I missed removing a final reference to Music in `levels/show`. All Music lab levels now go through the lab2 entrypoint, and the music entrypoint doesn't exist anymore, so this should be removed.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
