### PR TITLE
Music: support default sound in music library

### DIFF
--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -14,7 +14,10 @@ const FIELD_PADDING = 2;
  */
 class FieldSounds extends GoogleBlockly.Field {
   constructor(options) {
-    super(options.currentValue);
+    const currentValue =
+      options.currentValue || options.getLibrary().getDefaultSound();
+
+    super(currentValue);
 
     this.options = options;
     this.playingPreview = null;

--- a/apps/src/music/blockly/fields.js
+++ b/apps/src/music/blockly/fields.js
@@ -1,6 +1,6 @@
 // Common field definitions used across multiple music blocks
 
-import {DEFAULT_SOUND, DEFAULT_PATTERN, DEFAULT_CHORD} from '../constants';
+import {DEFAULT_PATTERN, DEFAULT_CHORD} from '../constants';
 import Globals from '../globals';
 import musicI18n from '../locale';
 import {
@@ -20,7 +20,7 @@ export const fieldSoundsDefinition = {
   playPreview: (id, onStop) => {
     Globals.getPlayer().previewSound(id, onStop);
   },
-  currentValue: DEFAULT_SOUND,
+  currentValue: null,
 };
 
 export const fieldPatternDefinition = {

--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -15,7 +15,6 @@ import {
 import FieldChord from './FieldChord';
 import FieldPattern from './FieldPattern';
 import FieldSounds from './FieldSounds';
-import {BlockTypes} from './blockTypes';
 import {MUSIC_BLOCKS} from './musicBlocks';
 import musicI18n from '../locale';
 import {BlockConfig} from './types';
@@ -25,7 +24,7 @@ import {BlockConfig} from './types';
  * only be called once per page load, as it configures the global
  * Blockly state.
  */
-export function setUpBlocklyForMusicLab(defaultSound: string | undefined) {
+export function setUpBlocklyForMusicLab() {
   Blockly.Extensions.register(
     DYNAMIC_TRIGGER_EXTENSION,
     dynamicTriggerExtension
@@ -43,15 +42,6 @@ export function setUpBlocklyForMusicLab(defaultSound: string | undefined) {
   const typedMusicBlocks = MUSIC_BLOCKS as {[key: string]: BlockConfig};
   for (const blockType of Object.keys(typedMusicBlocks)) {
     const blockConfig = typedMusicBlocks[blockType] as BlockConfig;
-
-    // Patch up the default sound if the library provides one.
-    if (
-      blockType === BlockTypes.PLAY_SOUND_AT_CURRENT_LOCATION_SIMPLE2 &&
-      defaultSound
-    ) {
-      blockConfig.definition.args0[0].currentValue = defaultSound;
-    }
-
     Blockly.Blocks[blockType] = {
       init: function () {
         this.jsonInit(blockConfig.definition);

--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -15,6 +15,7 @@ import {
 import FieldChord from './FieldChord';
 import FieldPattern from './FieldPattern';
 import FieldSounds from './FieldSounds';
+import {BlockTypes} from './blockTypes';
 import {MUSIC_BLOCKS} from './musicBlocks';
 import musicI18n from '../locale';
 import {BlockConfig} from './types';
@@ -24,7 +25,7 @@ import {BlockConfig} from './types';
  * only be called once per page load, as it configures the global
  * Blockly state.
  */
-export function setUpBlocklyForMusicLab() {
+export function setUpBlocklyForMusicLab(defaultSound: string | undefined) {
   Blockly.Extensions.register(
     DYNAMIC_TRIGGER_EXTENSION,
     dynamicTriggerExtension
@@ -42,6 +43,15 @@ export function setUpBlocklyForMusicLab() {
   const typedMusicBlocks = MUSIC_BLOCKS as {[key: string]: BlockConfig};
   for (const blockType of Object.keys(typedMusicBlocks)) {
     const blockConfig = typedMusicBlocks[blockType] as BlockConfig;
+
+    // Patch up the default sound in case the library provides one.
+    if (
+      blockType === BlockTypes.PLAY_SOUND_AT_CURRENT_LOCATION_SIMPLE2 &&
+      defaultSound
+    ) {
+      blockConfig.definition.args0[0].currentValue = defaultSound;
+    }
+
     Blockly.Blocks[blockType] = {
       init: function () {
         this.jsonInit(blockConfig.definition);

--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -44,7 +44,7 @@ export function setUpBlocklyForMusicLab(defaultSound: string | undefined) {
   for (const blockType of Object.keys(typedMusicBlocks)) {
     const blockConfig = typedMusicBlocks[blockType] as BlockConfig;
 
-    // Patch up the default sound in case the library provides one.
+    // Patch up the default sound if the library provides one.
     if (
       blockType === BlockTypes.PLAY_SOUND_AT_CURRENT_LOCATION_SIMPLE2 &&
       defaultSound

--- a/apps/src/music/blockly/types.ts
+++ b/apps/src/music/blockly/types.ts
@@ -3,6 +3,6 @@ import {Block} from 'blockly';
 // Configuration data for a block.
 export interface BlockConfig {
   // TODO: specify structure of definition as this is used more
-  definition: {args0: {currentValue: string}[]};
+  definition: object;
   generator: (block: Block) => string;
 }

--- a/apps/src/music/blockly/types.ts
+++ b/apps/src/music/blockly/types.ts
@@ -3,6 +3,6 @@ import {Block} from 'blockly';
 // Configuration data for a block.
 export interface BlockConfig {
   // TODO: specify structure of definition as this is used more
-  definition: object;
+  definition: {args0: {currentValue: string}[]};
   generator: (block: Block) => string;
 }

--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -39,8 +39,6 @@ export const BlockMode = {
   TRACKS: 'Tracks',
 };
 
-export const DEFAULT_SOUND = 'beats/groovy_beat';
-
 // For reference, events look like this:
 // events: [{src: 'sound_1', tick: 3}]
 export const DEFAULT_PATTERN = {

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -25,6 +25,11 @@ export default class MusicLibrary {
     }
   }
 
+  getDefaultSound(): string | undefined {
+    const firstGroup: FolderGroup = this.groups[0];
+    return firstGroup?.defaultSound;
+  }
+
   getSoundForId(id: string): SoundData | null {
     const splitId = id.split('/');
     const path = splitId[0];
@@ -150,6 +155,7 @@ interface FolderGroup {
   path: string;
   bpm?: number;
   key?: string;
+  defaultSound?: string;
   folders: SoundFolder[];
 }
 

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -27,7 +27,13 @@ export default class MusicLibrary {
 
   getDefaultSound(): string | undefined {
     const firstGroup: FolderGroup = this.groups[0];
-    return firstGroup?.defaultSound;
+
+    // The fallback is the first non-instrument/kit folder's first sound.
+    const firstFolder = firstGroup?.folders.find(group => !group.type);
+    const firstSoundFullPath = `${firstFolder?.path}/${firstFolder?.sounds[0].src}`;
+
+    // Return the specified default sound or the fallback sound.
+    return firstGroup?.defaultSound || firstSoundFullPath;
   }
 
   getSoundForId(id: string): SoundData | null {

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -28,12 +28,14 @@ export default class MusicLibrary {
   getDefaultSound(): string | undefined {
     const firstGroup: FolderGroup = this.groups[0];
 
+    // Return the specified default sound if there is one.
+    if (firstGroup?.defaultSound) {
+      return firstGroup?.defaultSound;
+    }
+
     // The fallback is the first non-instrument/kit folder's first sound.
     const firstFolder = firstGroup?.folders.find(group => !group.type);
-    const firstSoundFullPath = `${firstFolder?.path}/${firstFolder?.sounds[0].src}`;
-
-    // Return the specified default sound or the fallback sound.
-    return firstGroup?.defaultSound || firstSoundFullPath;
+    return `${firstFolder?.path}/${firstFolder?.sounds[0].src}`;
   }
 
   getSoundForId(id: string): SoundData | null {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -161,6 +161,7 @@ class UnconnectedMusicView extends React.Component {
 
     // Music Lab currently does not support share and remix
     header.showHeaderForProjectBacked({showShareAndRemix: false});
+    setUpBlocklyForMusicLab();
   }
 
   componentDidMount() {
@@ -271,8 +272,6 @@ class UnconnectedMusicView extends React.Component {
 
     Globals.setLibrary(this.library);
     Globals.setPlayer(this.player);
-
-    setUpBlocklyForMusicLab(this.library.getDefaultSound());
 
     this.musicBlocklyWorkspace.init(
       document.getElementById('blockly-div'),

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -161,7 +161,6 @@ class UnconnectedMusicView extends React.Component {
 
     // Music Lab currently does not support share and remix
     header.showHeaderForProjectBacked({showShareAndRemix: false});
-    setUpBlocklyForMusicLab();
   }
 
   componentDidMount() {
@@ -272,6 +271,8 @@ class UnconnectedMusicView extends React.Component {
 
     Globals.setLibrary(this.library);
     Globals.setPlayer(this.player);
+
+    setUpBlocklyForMusicLab(this.library.getDefaultSound());
 
     this.musicBlocklyWorkspace.init(
       document.getElementById('blockly-div'),

--- a/apps/static/music/music-library.json
+++ b/apps/static/music/music-library.json
@@ -5,7 +5,7 @@
       "name": "All",
       "imageSrc": "all.png",
       "path": "all-by-type",
-      "defaultSound": "beats/disco_beat",
+      "defaultSound": "beats/groovy_alternate_beat",
       "folders": [
         {
           "name": "Piano",

--- a/apps/static/music/music-library.json
+++ b/apps/static/music/music-library.json
@@ -5,6 +5,7 @@
       "name": "All",
       "imageSrc": "all.png",
       "path": "all-by-type",
+      "defaultSound": "beats/disco_beat",
       "folders": [
         {
           "name": "Piano",


### PR DESCRIPTION
This adds support for an optional `defaultSound` in the music library which will be used as the default sound for the `play` block.  If this value isn't provided, the default sound is now the first non-instrument/kit folder's first sound.
