### PR TITLE
Pin Ruby to 3.0.5 in Gemfiles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source 'https://rubygems.org'
 
-# Temporarily support both Ruby 2.7 and 3.0 until we've fully transitioned from
-# the former to the latter
-# TODO infra: pin us to ruby 3 once all persistent managed servers get updated
-ruby '>= 2.7', '< 3.1'
+ruby '3.0.5'
 
 # Ruby 2.7 no longer includes some libraries by default; install
 # the ones we need here

--- a/cookbooks/Gemfile
+++ b/cookbooks/Gemfile
@@ -1,9 +1,6 @@
 source 'https://rubygems.org'
 
-# Temporarily support both Ruby 2.7 and 3.0 until we've fully transitioned from
-# the former to the latter
-# TODO infra: pin us to ruby 3 once all persistent managed servers get updated
-ruby '>= 2.7', '< 3.1'
+ruby '3.0.5'
 
 gem 'berkshelf'
 gem 'chef', '17.6.18'


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/52617

Now that all our persistent servers have been updated to that version, we no longer need to continue to support our last version.