### PR TITLE
Music: improve Web Audio error handling

### DIFF
--- a/apps/src/music/player/soundSub.js
+++ b/apps/src/music/player/soundSub.js
@@ -54,8 +54,7 @@ function WebAudio(options) {
       'Web Audio API is not supported in this browser',
       e
     );
-    audioContext = null;
-    return;
+    throw e;
   }
 
   soundEffects = new SoundEffects(audioContext, delayTimeSeconds);
@@ -85,12 +84,18 @@ WebAudio.prototype.LoadSound = function (url, callback, onLoadFinished) {
           onLoadFinished();
         },
         function (e) {
-          Lab2MetricsReporter.logError('Error decoding audio data', e);
+          Lab2MetricsReporter.logError(
+            {name: 'Error decoding audio data', url: url},
+            e
+          );
           onLoadFinished();
         }
       );
     } catch (e) {
-      Lab2MetricsReporter.logError('Error decoding audio data', e);
+      Lab2MetricsReporter.logError(
+        {name: 'Error decoding audio data', url: url},
+        e
+      );
       onLoadFinished();
     }
   };

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -277,7 +277,15 @@ class UnconnectedMusicView extends React.Component {
       this.onBlockSpaceChange,
       this.props.isReadOnlyWorkspace
     );
-    this.player.initialize(this.library, this.props.updateLoadProgress);
+    try {
+      this.player.initialize(this.library, this.props.updateLoadProgress);
+    } catch (error) {
+      this.props.setPageError({
+        errorMessage: 'Error initializing music player',
+        error,
+      });
+      return;
+    }
 
     this.setState({
       loadedLibrary: true,


### PR DESCRIPTION
This makes a couple small changes to hopefully improve Web Audio error handling.

- If we have issues decoding audio, we'll now log the audio file URL, which might help identify the issue more quickly.
- If we aren't able to initialize the Web Audio audio context and it throws, we'll re-throw the error all the way back to `MusicView` which will catch it, and show the sad bee.
  - We have been seeing occasional batches of `TypeError: null is not an object (evaluating 's.decodeAudioData')` in our logs, and one way I've reproed this is by simulating the throw here.  Our new handling will still record the failure to initialize the audio context, which is the real issue, while avoiding all of these subsequent errors from being logged.
 