### PR TITLE
Comment out step to generate curriculum PDFs

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -97,12 +97,12 @@ namespace :build do
           RakeUtils.git_push
         end
 
-        if rack_env?(:staging)
+        # if rack_env?(:staging)
           # This step will only complete successfully if we succeed in
           # generating all curriculum PDFs.
-          ChatClient.log "Generating missing pdfs..."
-          RakeUtils.rake_stream_output 'curriculum_pdfs:generate_missing_pdfs'
-        end
+        #  ChatClient.log "Generating missing pdfs..."
+        #  RakeUtils.rake_stream_output 'curriculum_pdfs:generate_missing_pdfs'
+        # end
       end
 
       # Skip asset precompile in development.


### PR DESCRIPTION
This step is failing due to the Ruby 3 upgrade. To give us time to debug, while unblocking staging, temporarily pausing PDF generation. This PR should be reverted when the error is solved.