### PR TITLE
Lab2: Get app name from level properties

### DIFF
--- a/apps/src/lab2/Lab2MetricsReporter.ts
+++ b/apps/src/lab2/Lab2MetricsReporter.ts
@@ -6,7 +6,7 @@ import {MetricDimension} from '@cdo/apps/lib/metrics/types';
  */
 interface ReportingProperties {
   channelId?: string;
-  projectType?: string;
+  appName?: string;
   currentLevelId?: string;
   scriptId?: number;
 }
@@ -83,10 +83,10 @@ class Lab2MetricsReporter {
    */
   private getCommonDimensions(): MetricDimension[] {
     const dimensions = [];
-    if (this.commonProperties.projectType) {
+    if (this.commonProperties.appName) {
       dimensions.push({
-        name: 'ProjectType',
-        value: this.commonProperties.projectType,
+        name: 'AppName',
+        value: this.commonProperties.appName,
       });
     }
     return dimensions;

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -11,6 +11,7 @@ import {
   ThunkDispatch,
 } from '@reduxjs/toolkit';
 import {
+  AppName,
   Channel,
   LevelData,
   LevelProperties,
@@ -60,6 +61,7 @@ export interface LabState {
   // Validation status for the current level. This is used by the progress system to determine
   // what instructions to display and if the user has satisfied the validation conditions, if present.
   validationState: ValidationState;
+  appName: AppName | undefined;
 }
 
 const initialState: LabState = {
@@ -73,6 +75,7 @@ const initialState: LabState = {
   hideShareAndRemix: true,
   isProjectLevel: false,
   validationState: {...initialValidationState},
+  appName: undefined,
 };
 
 // Thunks
@@ -238,6 +241,9 @@ const labSlice = createSlice({
     setValidationState(state, action: PayloadAction<ValidationState>) {
       state.validationState = {...action.payload};
     },
+    setAppName(state, action: PayloadAction<AppName | undefined>) {
+      state.appName = action.payload;
+    },
   },
   extraReducers: builder => {
     builder.addCase(setUpWithLevel.fulfilled, state => {
@@ -340,11 +346,13 @@ function setProjectAndLevelData(
       /* defaultValue*/ false
     );
     dispatch(setIsProjectLevel(isProjectLevel));
+    dispatch(setAppName(levelProperties.appName));
   } else {
     // set default values to clear out any previous values
     dispatch(setLevelData(undefined));
     dispatch(setHideShareAndRemix(true));
     dispatch(setIsProjectLevel(false));
+    dispatch(setAppName(undefined));
   }
   dispatch(setLabReadyForReload(true));
 }
@@ -371,14 +379,18 @@ export const {
   setIsLoading,
   setPageError,
   clearPageError,
-  setChannel,
-  setSources,
-  setLevelData,
   setLabReadyForReload,
   setValidationState,
 } = labSlice.actions;
 
 // These should not be set outside of the lab slice.
-const {setHideShareAndRemix, setIsProjectLevel} = labSlice.actions;
+const {
+  setHideShareAndRemix,
+  setIsProjectLevel,
+  setAppName,
+  setChannel,
+  setSources,
+  setLevelData,
+} = labSlice.actions;
 
 export default labSlice.reducer;

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -91,6 +91,7 @@ export interface LevelProperties {
   // disabled flag for specific exceptions.
   disableProjects?: 'true' | 'false';
   levelData: LevelData;
+  appName: AppName;
 }
 
 // Level configuration data used by project-backed labs that don't require
@@ -171,7 +172,8 @@ export type AppName =
   | 'studio'
   | 'bounce'
   | 'poetry'
-  | 'spritelab';
+  | 'spritelab'
+  | 'standalone_video';
 
 export type StandaloneAppName =
   | 'spritelab'

--- a/apps/src/lab2/views/Lab2.tsx
+++ b/apps/src/lab2/views/Lab2.tsx
@@ -6,116 +6,20 @@
 // allows level switching between those levels without a page reload.
 
 import React from 'react';
-import {Provider, useSelector} from 'react-redux';
+import {Provider} from 'react-redux';
 import {getStore} from '@cdo/apps/redux';
-import {levelsForLessonId} from '@cdo/apps/code-studio/progressReduxSelectors';
-import {ProgressState} from '@cdo/apps/code-studio/progressRedux';
-import {LevelWithProgress} from '@cdo/apps/types/progressTypes';
-import {
-  getProjectType,
-  getStandaloneProjectId,
-} from '@cdo/apps/lab2/projects/utils';
+import {getStandaloneProjectId} from '@cdo/apps/lab2/projects/utils';
 import Lab2Wrapper from './Lab2Wrapper';
 import ProjectContainer from '../projects/ProjectContainer';
-import ProgressContainer from '../progress/ProgressContainer';
-import StandaloneVideo from '@cdo/apps/standaloneVideo/StandaloneVideo';
-import MusicView from '@cdo/apps/music/views/MusicView';
 import MetricsAdapter from './MetricsAdapter';
-
-interface AppProperties {
-  name: string;
-  usesChannel: boolean;
-  backgroundMode: boolean;
-  node: React.ReactNode;
-}
-
-const appsProperties: AppProperties[] = [
-  {
-    name: 'music',
-    usesChannel: true,
-    backgroundMode: true,
-    node: <MusicView />,
-  },
-  {
-    name: 'standalone_video',
-    usesChannel: false,
-    backgroundMode: false,
-    node: <StandaloneVideo />,
-  },
-];
+import LabRenderer from './LabRenderer';
 
 const Lab2: React.FunctionComponent = () => {
-  const currentLessonLevels = useSelector((state: {progress: ProgressState}) =>
-    levelsForLessonId(state.progress, state.progress.currentLessonId)
-  );
-  let currentLessonAppProperties: AppProperties[];
-  let currentAppName: string;
-
-  if (currentLessonLevels) {
-    currentAppName = currentLessonLevels.find(
-      (level: LevelWithProgress) => level.isCurrentLevel
-    ).app;
-    const currentLessonAppNames: string[] = Array.from(
-      new Set(currentLessonLevels.map((level: LevelWithProgress) => level.app))
-    );
-    currentLessonAppProperties = appsProperties.filter(appProperties =>
-      currentLessonAppNames.includes(appProperties.name)
-    );
-  } else {
-    // If we don't have a lesson, we are either on a /project or /level page.
-    // The app type will have been sent via the server.
-    currentAppName = getProjectType();
-    currentLessonAppProperties = appsProperties.filter(
-      appProperties => appProperties.name === currentAppName
-    );
-  }
-
-  const currentAppProperties: AppProperties | undefined = appsProperties.find(
-    appProperties => appProperties.name === currentAppName
-  );
-
-  const channelId: string | undefined = currentAppProperties?.usesChannel
-    ? getStandaloneProjectId()
-    : undefined;
-
   return (
     <Lab2Wrapper>
       <MetricsAdapter />
-      <ProjectContainer channelId={channelId}>
-        {currentLessonAppProperties.map(appProperty => {
-          return (
-            <ProgressContainer
-              key={appProperty.name}
-              appType={appProperty.name}
-            >
-              {appProperty.backgroundMode && (
-                <div
-                  id={`lab2-${appProperty.name}`}
-                  style={{
-                    width: '100%',
-                    height: '100%',
-                    visibility:
-                      currentAppName === appProperty.name
-                        ? 'visible'
-                        : 'hidden',
-                  }}
-                >
-                  {appProperty.node}
-                </div>
-              )}
-
-              {!appProperty.backgroundMode &&
-                appProperty.name === currentAppName && (
-                  <div
-                    id={`lab2-${appProperty.name}`}
-                    style={{width: '100%', height: '100%'}}
-                  >
-                    {appProperty.node}
-                  </div>
-                )}
-            </ProgressContainer>
-          );
-        })}
+      <ProjectContainer channelId={getStandaloneProjectId()}>
+        <LabRenderer />
       </ProjectContainer>
     </Lab2Wrapper>
   );

--- a/apps/src/lab2/views/Lab2.tsx
+++ b/apps/src/lab2/views/Lab2.tsx
@@ -10,7 +10,7 @@ import {getStandaloneProjectId} from '@cdo/apps/lab2/projects/utils';
 import Lab2Wrapper from './Lab2Wrapper';
 import ProjectContainer from '../projects/ProjectContainer';
 import MetricsAdapter from './MetricsAdapter';
-import LabRenderer from './LabRenderer';
+import LabViewsRenderer from './LabViewsRenderer';
 
 const Lab2: React.FunctionComponent = () => {
   return (
@@ -18,7 +18,7 @@ const Lab2: React.FunctionComponent = () => {
       <Lab2Wrapper>
         <MetricsAdapter />
         <ProjectContainer channelId={getStandaloneProjectId()}>
-          <LabRenderer />
+          <LabViewsRenderer />
         </ProjectContainer>
       </Lab2Wrapper>
     </Provider>

--- a/apps/src/lab2/views/Lab2.tsx
+++ b/apps/src/lab2/views/Lab2.tsx
@@ -1,10 +1,8 @@
-// Lab2
-//
-// A React component used for a ScriptLevel that uses Lab2.  It examines the
-// set of levels in the current lesson, determines the set of apps they use,
-// and instantiates a React component for each app that it supports.  This
-// allows level switching between those levels without a page reload.
-
+/**
+ * Lab2
+ *
+ * The top-level component that houses all Lab2 framework components.
+ */
 import React from 'react';
 import {Provider} from 'react-redux';
 import {getStore} from '@cdo/apps/redux';
@@ -16,21 +14,15 @@ import LabRenderer from './LabRenderer';
 
 const Lab2: React.FunctionComponent = () => {
   return (
-    <Lab2Wrapper>
-      <MetricsAdapter />
-      <ProjectContainer channelId={getStandaloneProjectId()}>
-        <LabRenderer />
-      </ProjectContainer>
-    </Lab2Wrapper>
-  );
-};
-
-const Lab2WithProvider: React.FunctionComponent = () => {
-  return (
     <Provider store={getStore()}>
-      <Lab2 />
+      <Lab2Wrapper>
+        <MetricsAdapter />
+        <ProjectContainer channelId={getStandaloneProjectId()}>
+          <LabRenderer />
+        </ProjectContainer>
+      </Lab2Wrapper>
     </Provider>
   );
 };
 
-export default Lab2WithProvider;
+export default Lab2;

--- a/apps/src/lab2/views/LabRenderer.tsx
+++ b/apps/src/lab2/views/LabRenderer.tsx
@@ -13,8 +13,6 @@ import {AppName} from '../types';
 
 // Configuration for how a Lab should be rendered
 interface AppProperties {
-  /** Whether this Lab uses projects (channels) */
-  usesChannel: boolean;
   /**
    * Whether this lab should remain rendered in the background once mounted.
    * If true, the lab will always be present in the tree, but will be hidden
@@ -28,12 +26,10 @@ interface AppProperties {
 
 const appsProperties: {[appName in AppName]?: AppProperties} = {
   music: {
-    usesChannel: true,
     backgroundMode: true,
     node: <MusicView />,
   },
   standalone_video: {
-    usesChannel: false,
     backgroundMode: false,
     node: <StandaloneVideo />,
   },

--- a/apps/src/lab2/views/LabRenderer.tsx
+++ b/apps/src/lab2/views/LabRenderer.tsx
@@ -1,0 +1,91 @@
+import MusicView from '@cdo/apps/music/views/MusicView';
+import StandaloneVideo from '@cdo/apps/standaloneVideo/StandaloneVideo';
+import React from 'react';
+import {useSelector} from 'react-redux';
+import {LabState} from '../lab2Redux';
+import ProgressContainer from '../progress/ProgressContainer';
+import {AppName} from '../types';
+
+interface AppProperties {
+  usesChannel: boolean;
+  backgroundMode: boolean;
+  node: React.ReactNode;
+}
+
+const appsProperties: {[appName in AppName]?: AppProperties} = {
+  music: {
+    usesChannel: true,
+    backgroundMode: true,
+    node: <MusicView />,
+  },
+  standalone_video: {
+    usesChannel: false,
+    backgroundMode: false,
+    node: <StandaloneVideo />,
+  },
+};
+
+const LabRenderer: React.FunctionComponent = () => {
+  const currentAppName = useSelector(
+    (state: {lab: LabState}) => state.lab.appName
+  );
+
+  // TODO: Instead of rendering all known apps, render only visited apps.
+  // This will require refactoring logic around the labReadyForReload flag.
+  const appsToRender = Object.keys(appsProperties) as AppName[];
+  return (
+    <>
+      {appsToRender.map(appName => {
+        const properties = appsProperties[appName];
+        if (!properties) {
+          console.warn("Don't know how to render app: " + appName);
+          return null;
+        }
+
+        return (
+          <ProgressContainer key={appName} appType={appName}>
+            {properties.backgroundMode && (
+              <VisibilityContainer
+                appName={appName}
+                visible={currentAppName === appName}
+              >
+                {properties.node}
+              </VisibilityContainer>
+            )}
+
+            {!properties.backgroundMode && currentAppName === appName && (
+              <VisibilityContainer appName={appName} visible={true}>
+                {properties.node}
+              </VisibilityContainer>
+            )}
+          </ProgressContainer>
+        );
+      })}
+    </>
+  );
+};
+
+interface VisibilityContainerProps {
+  appName: AppName;
+  visible: boolean;
+  children: React.ReactNode;
+}
+
+const VisibilityContainer: React.FunctionComponent<
+  VisibilityContainerProps
+> = ({appName, visible, children}) => {
+  return (
+    <div
+      id={`lab2-${appName}`}
+      style={{
+        width: '100%',
+        height: '100%',
+        visibility: visible ? 'visible' : 'hidden',
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default LabRenderer;

--- a/apps/src/lab2/views/LabRenderer.tsx
+++ b/apps/src/lab2/views/LabRenderer.tsx
@@ -1,3 +1,8 @@
+/**
+ * Configuration and management for rendering Lab views in Lab2, based on the
+ * currently active Lab (determined by the current app name). This
+ * helps facilitate level-switching between labs without page reloads.
+ */
 import MusicView from '@cdo/apps/music/views/MusicView';
 import StandaloneVideo from '@cdo/apps/standaloneVideo/StandaloneVideo';
 import React from 'react';
@@ -6,9 +11,18 @@ import {LabState} from '../lab2Redux';
 import ProgressContainer from '../progress/ProgressContainer';
 import {AppName} from '../types';
 
+// Configuration for how a Lab should be rendered
 interface AppProperties {
+  /** Whether this Lab uses projects (channels) */
   usesChannel: boolean;
+  /**
+   * Whether this lab should remain rendered in the background once mounted.
+   * If true, the lab will always be present in the tree, but will be hidden
+   * via visibility: hidden when not active. If false, the lab will only
+   * be rendered in the tree when active.
+   */
   backgroundMode: boolean;
+  /** React View for the Lab */
   node: React.ReactNode;
 }
 
@@ -33,6 +47,12 @@ const LabRenderer: React.FunctionComponent = () => {
   // TODO: Instead of rendering all known apps, render only visited apps.
   // This will require refactoring logic around the labReadyForReload flag.
   const appsToRender = Object.keys(appsProperties) as AppName[];
+
+  // Iterate through appsToRender and render Lab views for each. If
+  // backgroundMode is true, the Lab view will always be rendered, but
+  // visibility will be toggled based on whether the app is active. If
+  // backgroundMode is false, the Lab view will only be rendered when the
+  // app is active.
   return (
     <>
       {appsToRender.map(appName => {

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -35,7 +35,7 @@ const appsProperties: {[appName in AppName]?: AppProperties} = {
   },
 };
 
-const LabRenderer: React.FunctionComponent = () => {
+const LabViewsRenderer: React.FunctionComponent = () => {
   const currentAppName = useSelector(
     (state: {lab: LabState}) => state.lab.appName
   );
@@ -104,4 +104,4 @@ const VisibilityContainer: React.FunctionComponent<
   );
 };
 
-export default LabRenderer;
+export default LabViewsRenderer;

--- a/apps/src/lab2/views/MetricsAdapter.tsx
+++ b/apps/src/lab2/views/MetricsAdapter.tsx
@@ -12,9 +12,7 @@ const MetricsAdapter: React.FunctionComponent = () => {
   const channelId = useSelector(
     (state: {lab: LabState}) => state.lab.channel?.id
   );
-  const projectType = useSelector(
-    (state: {lab: LabState}) => state.lab.channel?.projectType
-  );
+  const appName = useSelector((state: {lab: LabState}) => state.lab.appName);
   const currentLevelId = useSelector(
     (state: {progress: ProgressState}) =>
       state.progress.currentLevelId || undefined
@@ -41,8 +39,8 @@ const MetricsAdapter: React.FunctionComponent = () => {
   }, [channelId]);
 
   useEffect(() => {
-    Lab2MetricsReporter.updateProperties({projectType});
-  }, [projectType]);
+    Lab2MetricsReporter.updateProperties({appName});
+  }, [appName]);
 
   useEffect(() => {
     if (pageError) {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -121,6 +121,7 @@ class UnconnectedMusicView extends React.Component {
     navigateToNextLevel: PropTypes.func,
     isReadOnlyWorkspace: PropTypes.bool,
     updateLoadProgress: PropTypes.func,
+    appName: PropTypes.string,
   };
 
   constructor(props) {
@@ -217,30 +218,41 @@ class UnconnectedMusicView extends React.Component {
     // If we just finished loading the lab, then we need to update the
     // sources and level data.
     if (!prevProps.labReadyForReload && this.props.labReadyForReload) {
-      // Load and initialize the library and player if not done already.
-      // Read the library name first from level data, or from the project
-      // sources if not present on the level. If there is no library name
-      // specified on the level or sources, we will fallback to loading the
-      // default library.
-      let libraryName = this.props.levelData?.library;
-      if (!libraryName && this.props.sources?.labConfig?.music) {
-        libraryName = this.props.sources.labConfig.music.library;
-      }
-      await this.loadAndInitializePlayer(libraryName);
-
-      if (this.getStartSources() || this.props.sources) {
-        let codeToLoad = this.getStartSources();
-        if (this.props.sources?.source) {
-          codeToLoad = JSON.parse(this.props.sources.source);
+      // Only load if the current app is music.
+      if (this.props.appName === 'music') {
+        // Load and initialize the library and player if not done already.
+        // Read the library name first from level data, or from the project
+        // sources if not present on the level. If there is no library name
+        // specified on the level or sources, we will fallback to loading the
+        // default library.
+        let libraryName = this.props.levelData?.library;
+        if (!libraryName && this.props.sources?.labConfig?.music) {
+          libraryName = this.props.sources.labConfig.music.library;
         }
-        this.loadCode(codeToLoad);
-      }
+        await this.loadAndInitializePlayer(libraryName);
 
-      // Update components with level-specific data
-      if (this.props.levelData) {
-        this.musicBlocklyWorkspace.updateToolbox(this.props.levelData.toolbox);
-        this.library.setAllowedSounds(this.props.levelData.sounds);
-        this.props.setShowInstructions(!!this.props.levelData.text);
+        this.musicBlocklyWorkspace.init(
+          document.getElementById('blockly-div'),
+          this.onBlockSpaceChange,
+          this.props.isReadOnlyWorkspace
+        );
+
+        if (this.getStartSources() || this.props.sources) {
+          let codeToLoad = this.getStartSources();
+          if (this.props.sources?.source) {
+            codeToLoad = JSON.parse(this.props.sources.source);
+          }
+          this.loadCode(codeToLoad);
+        }
+
+        // Update components with level-specific data
+        if (this.props.levelData) {
+          this.musicBlocklyWorkspace.updateToolbox(
+            this.props.levelData.toolbox
+          );
+          this.library.setAllowedSounds(this.props.levelData.sounds);
+          this.props.setShowInstructions(!!this.props.levelData.text);
+        }
       }
 
       this.props.setLabReadyForReload(false);
@@ -272,11 +284,6 @@ class UnconnectedMusicView extends React.Component {
     Globals.setLibrary(this.library);
     Globals.setPlayer(this.player);
 
-    this.musicBlocklyWorkspace.init(
-      document.getElementById('blockly-div'),
-      this.onBlockSpaceChange,
-      this.props.isReadOnlyWorkspace
-    );
     this.player.initialize(this.library, this.props.updateLoadProgress);
 
     this.setState({
@@ -702,6 +709,7 @@ const MusicView = connect(
     levelData: state.lab.levelData,
     labReadyForReload: state.lab.labReadyForReload,
     isReadOnlyWorkspace: isReadOnlyWorkspace(state),
+    appName: state.lab.appName,
   }),
   dispatch => ({
     setIsPlaying: isPlaying => dispatch(setIsPlaying(isPlaying)),

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -813,6 +813,7 @@ class Level < ApplicationRecord
     properties_camelized = properties.camelize_keys
     properties_camelized[:levelData] = video if video
     properties_camelized[:type] = type
+    properties_camelized[:appName] = game&.app
     properties_camelized
   end
 

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -83,7 +83,7 @@ class LevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", appName: "maze"}, body)
+    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze"}, body)
   end
 
   test "should get filtered levels with just page param" do

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -83,7 +83,7 @@ class LevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze"}, body)
+    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", appName: "maze"}, body)
   end
 
   test "should get filtered levels with just page param" do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -104,7 +104,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze"}, body)
+    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze"}, body)
   end
 
   test 'should show script level for csp1-2020 lockable lesson with lesson plan' do


### PR DESCRIPTION
Get the current app name as a part of the level properties JSON response, rather than from app options or current lesson. This reduces some complexity for how we determine the current app type and is useful for metrics reporting as previously we were getting the app name from the channel, which wouldn't work for levels without a project (like StandaloneVideo).

I moved the lab rendering/switching logic into a separate, inner component; currently, this component just renders all available app types (currently only music and video) but a good optimization would be to only load an app once we've visited a level that uses it for the first time. In order to do this though, we'd have to update some logic around the labReadyForReload flag, which we've discussed on Slack [here](https://codedotorg.slack.com/archives/C044AGTKW3D/p1689204256395099). I'll follow up with a change to address this as per the discussions in that thread. Currently, since we load all apps at once, we don't have any issues with the flag because MusicView automatically manages it (even though the current level may not be a music level).

## Testing story

Tested locally + unit tests.