### PR TITLE
Add indexes to rubric tables

### DIFF
--- a/dashboard/app/models/learning_goal.rb
+++ b/dashboard/app/models/learning_goal.rb
@@ -12,5 +12,9 @@
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #
+# Indexes
+#
+#  index_learning_goals_on_rubric_id_and_key  (rubric_id,key) UNIQUE
+#
 class LearningGoal < ApplicationRecord
 end

--- a/dashboard/app/models/learning_goal.rb
+++ b/dashboard/app/models/learning_goal.rb
@@ -3,9 +3,9 @@
 # Table name: learning_goals
 #
 #  id            :bigint           not null, primary key
-#  key           :string(255)
+#  key           :string(255)      not null
 #  position      :integer
-#  rubric_id     :integer
+#  rubric_id     :integer          not null
 #  learning_goal :string(255)
 #  ai_enabled    :boolean
 #  tips          :text(65535)

--- a/dashboard/app/models/learning_goal_evidence_level.rb
+++ b/dashboard/app/models/learning_goal_evidence_level.rb
@@ -3,8 +3,8 @@
 # Table name: learning_goal_evidence_levels
 #
 #  id                  :bigint           not null, primary key
-#  learning_goal_id    :integer
-#  understanding       :integer
+#  learning_goal_id    :integer          not null
+#  understanding       :integer          not null
 #  teacher_description :text(65535)
 #  ai_prompt           :text(65535)
 #  created_at          :datetime         not null

--- a/dashboard/app/models/learning_goal_evidence_level.rb
+++ b/dashboard/app/models/learning_goal_evidence_level.rb
@@ -10,5 +10,9 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #
+# Indexes
+#
+#  index_learning_goal_evidence_levels_on_lg_id_and_understanding  (learning_goal_id,understanding) UNIQUE
+#
 class LearningGoalEvidenceLevel < ApplicationRecord
 end

--- a/dashboard/app/models/rubric.rb
+++ b/dashboard/app/models/rubric.rb
@@ -3,15 +3,14 @@
 # Table name: rubrics
 #
 #  id         :bigint           not null, primary key
-#  lesson_id  :integer
-#  level_id   :integer
+#  lesson_id  :integer          not null
+#  level_id   :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
 # Indexes
 #
-#  index_rubrics_on_lesson_id  (lesson_id) UNIQUE
-#  index_rubrics_on_level_id   (level_id)
+#  index_rubrics_on_lesson_id_and_level_id  (lesson_id,level_id) UNIQUE
 #
 class Rubric < ApplicationRecord
 end

--- a/dashboard/app/models/rubric.rb
+++ b/dashboard/app/models/rubric.rb
@@ -11,6 +11,7 @@
 # Indexes
 #
 #  index_rubrics_on_lesson_id  (lesson_id) UNIQUE
+#  index_rubrics_on_level_id   (level_id)
 #
 class Rubric < ApplicationRecord
 end

--- a/dashboard/app/models/rubric.rb
+++ b/dashboard/app/models/rubric.rb
@@ -8,5 +8,9 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
+# Indexes
+#
+#  index_rubrics_on_lesson_id  (lesson_id) UNIQUE
+#
 class Rubric < ApplicationRecord
 end

--- a/dashboard/db/migrate/20230713141627_add_indexes_to_rubric_tables.rb
+++ b/dashboard/db/migrate/20230713141627_add_indexes_to_rubric_tables.rb
@@ -1,0 +1,7 @@
+class AddIndexesToRubricTables < ActiveRecord::Migration[6.1]
+  def change
+    add_index :rubrics, :lesson_id, unique: true
+    add_index :learning_goals, [:rubric_id, :key], unique: true
+    add_index :learning_goal_evidence_levels, [:learning_goal_id, :understanding], unique: true, name: 'index_learning_goal_evidence_levels_on_lg_id_and_understanding'
+  end
+end

--- a/dashboard/db/migrate/20230713141627_add_indexes_to_rubric_tables.rb
+++ b/dashboard/db/migrate/20230713141627_add_indexes_to_rubric_tables.rb
@@ -1,8 +1,14 @@
 class AddIndexesToRubricTables < ActiveRecord::Migration[6.1]
   def change
-    add_index :rubrics, :lesson_id, unique: true
-    add_index :rubrics, :level_id
+    add_index :rubrics, [:lesson_id, :level_id], unique: true
     add_index :learning_goals, [:rubric_id, :key], unique: true
     add_index :learning_goal_evidence_levels, [:learning_goal_id, :understanding], unique: true, name: 'index_learning_goal_evidence_levels_on_lg_id_and_understanding'
+
+    change_column_null :rubrics, :lesson_id, false
+    change_column_null :rubrics, :level_id, false
+    change_column_null :learning_goals, :rubric_id, false
+    change_column_null :learning_goals, :key, false
+    change_column_null :learning_goal_evidence_levels, :learning_goal_id, false
+    change_column_null :learning_goal_evidence_levels, :understanding, false
   end
 end

--- a/dashboard/db/migrate/20230713141627_add_indexes_to_rubric_tables.rb
+++ b/dashboard/db/migrate/20230713141627_add_indexes_to_rubric_tables.rb
@@ -1,6 +1,7 @@
 class AddIndexesToRubricTables < ActiveRecord::Migration[6.1]
   def change
     add_index :rubrics, :lesson_id, unique: true
+    add_index :rubrics, :level_id
     add_index :learning_goals, [:rubric_id, :key], unique: true
     add_index :learning_goal_evidence_levels, [:learning_goal_id, :understanding], unique: true, name: 'index_learning_goal_evidence_levels_on_lg_id_and_understanding'
   end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1624,6 +1624,7 @@ ActiveRecord::Schema.define(version: 2023_07_13_141627) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["lesson_id"], name: "index_rubrics_on_lesson_id", unique: true
+    t.index ["level_id"], name: "index_rubrics_on_level_id"
   end
 
   create_table "school_districts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_11_175151) do
+ActiveRecord::Schema.define(version: 2023_07_13_141627) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -644,6 +644,7 @@ ActiveRecord::Schema.define(version: 2023_07_11_175151) do
     t.text "ai_prompt"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["learning_goal_id", "understanding"], name: "index_learning_goal_evidence_levels_on_lg_id_and_understanding", unique: true
   end
 
   create_table "learning_goals", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
@@ -655,6 +656,7 @@ ActiveRecord::Schema.define(version: 2023_07_11_175151) do
     t.text "tips"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["rubric_id", "key"], name: "index_learning_goals_on_rubric_id_and_key", unique: true
   end
 
   create_table "lesson_activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
@@ -1621,6 +1623,7 @@ ActiveRecord::Schema.define(version: 2023_07_11_175151) do
     t.integer "level_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["lesson_id"], name: "index_rubrics_on_lesson_id", unique: true
   end
 
   create_table "school_districts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -638,8 +638,8 @@ ActiveRecord::Schema.define(version: 2023_07_13_141627) do
   end
 
   create_table "learning_goal_evidence_levels", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
-    t.integer "learning_goal_id"
-    t.integer "understanding"
+    t.integer "learning_goal_id", null: false
+    t.integer "understanding", null: false
     t.text "teacher_description"
     t.text "ai_prompt"
     t.datetime "created_at", precision: 6, null: false
@@ -648,9 +648,9 @@ ActiveRecord::Schema.define(version: 2023_07_13_141627) do
   end
 
   create_table "learning_goals", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
-    t.string "key"
+    t.string "key", null: false
     t.integer "position"
-    t.integer "rubric_id"
+    t.integer "rubric_id", null: false
     t.string "learning_goal"
     t.boolean "ai_enabled"
     t.text "tips"
@@ -1619,12 +1619,11 @@ ActiveRecord::Schema.define(version: 2023_07_13_141627) do
   end
 
   create_table "rubrics", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
-    t.integer "lesson_id"
-    t.integer "level_id"
+    t.integer "lesson_id", null: false
+    t.integer "level_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["lesson_id"], name: "index_rubrics_on_lesson_id", unique: true
-    t.index ["level_id"], name: "index_rubrics_on_level_id"
+    t.index ["lesson_id", "level_id"], name: "index_rubrics_on_lesson_id_and_level_id", unique: true
   end
 
   create_table "school_districts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Adds some indexes to the rubric tables! We'll still need to add some for `learning_goal_evaluations` but I wanted to wait until we start using that data and have a better sense of what indexes we need.