### PR TITLE
Rubric model assocations

### DIFF
--- a/dashboard/app/models/learning_goal.rb
+++ b/dashboard/app/models/learning_goal.rb
@@ -13,4 +13,6 @@
 #  updated_at    :datetime         not null
 #
 class LearningGoal < ApplicationRecord
+  belongs_to :rubric
+  has_many :learning_goal_evidence_levels, dependent: :destroy
 end

--- a/dashboard/app/models/learning_goal_evaluation.rb
+++ b/dashboard/app/models/learning_goal_evaluation.rb
@@ -17,4 +17,5 @@
 #  updated_at       :datetime         not null
 #
 class LearningGoalEvaluation < ApplicationRecord
+  belongs_to :learning_goal
 end

--- a/dashboard/app/models/learning_goal_evidence_level.rb
+++ b/dashboard/app/models/learning_goal_evidence_level.rb
@@ -11,4 +11,5 @@
 #  updated_at          :datetime         not null
 #
 class LearningGoalEvidenceLevel < ApplicationRecord
+  belongs_to :learning_goal
 end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -57,6 +57,8 @@ class Lesson < ApplicationRecord
   has_many :lessons_opportunity_standards,  dependent: :destroy
   has_many :opportunity_standards, through: :lessons_opportunity_standards, source: :standard
 
+  has_one :rubric, dependent: :destroy
+
   self.table_name = 'stages'
 
   serialized_attrs %w(

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -38,6 +38,7 @@ class Level < ApplicationRecord
   has_one :level_concept_difficulty, dependent: :destroy
   has_many :level_sources
   has_many :hint_view_requests
+  has_many :rubrics, dependent: :destroy
 
   before_validation :strip_name
   before_destroy :remove_empty_script_levels

--- a/dashboard/app/models/rubric.rb
+++ b/dashboard/app/models/rubric.rb
@@ -9,4 +9,7 @@
 #  updated_at :datetime         not null
 #
 class Rubric < ApplicationRecord
+  has_many :learning_goals, -> {order(:position)}, dependent: :destroy
+  belongs_to :level
+  belongs_to :lesson
 end


### PR DESCRIPTION
Codifying my understanding of the model relations -- please comment if these don't seem right. I want to get these right before we go too much farther!

This understanding comes both from [the tech spec](https://docs.google.com/document/d/1saBTPhEywbH1pF5ePPW9qehFDa7dGQpm3RfcUZ0QpV8/edit#heading=h.on8ieiafsjyw) and [this slack conversation](https://codedotorg.slack.com/archives/C050HE4QDHR/p1688406272872309) (apologies for this being in a private channel!).

The associations codified here are:
1. A `Rubric` belongs to a `Lesson` and a `Level`. (We may, in the future, need to know the unit, but that can be derived through lesson.)
2. A `Rubric` has many `LearningGoal` and, inversely, a `LearningGoal` belongs to a `Rubric`.
3. A `LearningGoal` has many `LearningGoalEvidenceLevel` and, inversely, a `LearningGoalEvidenceLevel` belongs to a `LearningGoal`.
4. A `LearningGoalEvaluation` belongs to a `LearningGoal`. It will also have some associations with users in the future, but I haven't added those in this PR, preferring to focus only on the rubric side.