### PR TITLE
Fix sign in from catalog page Amplitude event to maintain accessibility

### DIFF
--- a/apps/src/sites/studio/pages/devise/sessions/new.js
+++ b/apps/src/sites/studio/pages/devise/sessions/new.js
@@ -17,4 +17,10 @@ $(document).ready(() => {
   document.getElementById('user_signup').addEventListener('click', () => {
     analyticsReporter.sendEvent(EVENTS.SIGN_UP_STARTED_EVENT);
   });
+
+  if (window.location.href.includes('user_return_to=/catalog')) {
+    analyticsReporter.sendEvent(
+      EVENTS.CURRICULUM_CATALOG_SIGN_IN_CLICKED_IN_ASSIGN_DIALOG
+    );
+  }
 });

--- a/apps/src/templates/curriculumCatalog/noSectionsToAssignDialogs.jsx
+++ b/apps/src/templates/curriculumCatalog/noSectionsToAssignDialogs.jsx
@@ -5,8 +5,6 @@ import Button from '@cdo/apps/templates/Button';
 import AccessibleDialog from '@cdo/apps/templates/AccessibleDialog';
 import Typography from '@cdo/apps/componentLibrary/typography';
 import style from './no_sections_to_assign_dialog.module.scss';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 const signInURL = `/users/sign_in?user_return_to=${location.pathname}`;
 const upgradeAccountArticleURL =
@@ -14,12 +12,6 @@ const upgradeAccountArticleURL =
 const setUpStudentSectionsURL =
   window.location.origin +
   '/home?openAddSectionDialog=true&participantType=student';
-const handleSignInOrCreateAccountClick = () => {
-  analyticsReporter.sendEvent(
-    EVENTS.CURRICULUM_CATALOG_SIGN_IN_CLICKED_IN_ASSIGN_DIALOG
-  );
-  window.location.href = signInURL;
-};
 
 export const SignInToAssignSectionsDialog = ({onClose}) => (
   <NoSectionsToAssignBaseDialog
@@ -27,7 +19,7 @@ export const SignInToAssignSectionsDialog = ({onClose}) => (
     helpText={i18n.signInToAssignHelpText()}
     onClose={onClose}
     buttonText={i18n.signInOrCreateAccount()}
-    onClick={handleSignInOrCreateAccountClick}
+    href={signInURL}
   />
 );
 


### PR DESCRIPTION
This PR responds to @megcrenshaw 's [comment](https://github.com/code-dot-org/code-dot-org/pull/52652#discussion_r1262809931) on the previous Amplitude events PR for the Curriculum Catalog page. Instead of modifying the button to take an `onClick` over an `href`, this event checks the URL of the sign-in page to see if it was from the catalog page.

This will also help with the consistency of the event since we've had problems in the past of trying to log an event right before a redirect and the event not actually logging, so by having the event log upon reaching the desired page we should see more consistency.

### Event is logged when coming from the Curriculum Catalog page
![Catalog_sign_in_event](https://github.com/code-dot-org/code-dot-org/assets/56283563/c9bc4e2e-0643-48bb-bf4a-885e75a8189e)

### Event is not logged when just visitng the sign-in page
![Catalog_sign_in_event_not](https://github.com/code-dot-org/code-dot-org/assets/56283563/d13928bf-b03f-4c23-ad38-8c8156b3d4f6)

## Links
Github discussion: [here](https://github.com/code-dot-org/code-dot-org/pull/52652#discussion_r1262809931)
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-714&assignee=60d62161f65054006980bd71)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
