### PR TITLE
Add publish and unpublish to Lab2 ProjectManager

### DIFF
--- a/apps/src/lab2/projects/ChannelsStore.ts
+++ b/apps/src/lab2/projects/ChannelsStore.ts
@@ -15,6 +15,10 @@ export interface ChannelsStore {
   save: (channel: Channel) => Promise<Response>;
 
   redirectToRemix: (channel: Channel) => void;
+
+  publish: (channel: Channel) => Promise<Response>;
+
+  unpublish: (channel: Channel) => Promise<Response>;
 }
 
 // Note: We don't need to actually save a channel for local storage.
@@ -42,6 +46,16 @@ export class LocalChannelsStore implements ChannelsStore {
   redirectToRemix() {
     // Remix is not supported for local storage.
   }
+
+  publish() {
+    // Publishing is not supported for local storage.
+    return Promise.resolve(new Response(''));
+  }
+
+  unpublish() {
+    // Unpublishing is not supported for local storage.
+    return Promise.resolve(new Response(''));
+  }
 }
 
 export class RemoteChannelsStore implements ChannelsStore {
@@ -62,5 +76,13 @@ export class RemoteChannelsStore implements ChannelsStore {
 
   redirectToRemix(channel: Channel) {
     projectsApi.redirectToRemix(channel.id, channel.projectType);
+  }
+
+  publish(channel: Channel) {
+    return channelsApi.publish(channel);
+  }
+
+  unpublish(channel: Channel) {
+    return channelsApi.unpublish(channel);
   }
 }

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -195,6 +195,20 @@ export default class ProjectManager {
     this.channelsStore.redirectToRemix(this.lastChannel);
   }
 
+  /**
+   * Publish the current channel.
+   */
+  publish() {
+    this.publishHelper(true);
+  }
+
+  /**
+   * Unpublish the current channel.
+   */
+  unpublish() {
+    this.publishHelper(false);
+  }
+
   addSaveSuccessListener(
     listener: (channel: Channel, sources: ProjectSources) => void
   ) {
@@ -376,6 +390,28 @@ export default class ProjectManager {
     const error = new Error(errorMessage);
     Lab2MetricsReporter.logError(errorMessage, error);
     throw error;
+  }
+
+  /**
+   * Helper for publish and unpublish methods, since they are so similar.
+   * Either publishes or unpublishes lastChannel, depending on the publish parameter.
+   * If this ProjectManager has been destroyed, or we're missing a channel, this method
+   * will throw an error.
+   * @param publish true if we should publish, false is we should unpublish
+   * @returns a Promise that resolves when the publish/unpublish is complete
+   */
+  private async publishHelper(publish: boolean) {
+    const actionType = publish ? 'publish' : 'unpublish';
+    this.throwErrorIfDestroyed(actionType);
+    if (!this.lastChannel || !this.lastChannel.projectType) {
+      this.logAndThrowError(`Cannot ${actionType} without channel`);
+      return;
+    }
+    if (publish) {
+      return this.channelsStore.publish(this.lastChannel);
+    } else {
+      return this.channelsStore.unpublish(this.lastChannel);
+    }
   }
 
   // LISTENERS

--- a/apps/src/lab2/projects/channelsApi.ts
+++ b/apps/src/lab2/projects/channelsApi.ts
@@ -25,3 +25,15 @@ export async function update(channel: Channel): Promise<Response> {
     }
   );
 }
+
+export async function publish(channel: Channel): Promise<Response> {
+  return HttpClient.post(
+    `${rootUrl}/${channel.id}/publish/${channel.projectType}`,
+    '',
+    false
+  );
+}
+
+export async function unpublish(channel: Channel): Promise<Response> {
+  return HttpClient.post(`${rootUrl}/${channel.id}/unpublish`, '', false);
+}


### PR DESCRIPTION
Expose publish and unpublish api in the Lab2 ProjectManager. This is not currently used anywhere, but gets us closer to feature parity with the legacy system. We don't currently enable publish in Music Lab because we don't want Music Lab projects in the gallery at this point.

## Links

- jira ticket: [SL-806](https://codedotorg.atlassian.net/browse/SL-806)

## Testing story
Tested locally in Music Lab by manually calling publish and unpublish. With these changes Music Lab cannot be published as it is not in the list of [publishable project types](https://github.com/code-dot-org/code-dot-org/blob/cda236aa5f89c0a5a24107e7ad2dc3f09dd9c92c/lib/cdo/shared_constants.rb#L79), so I also temporarily added it to that list while testing. 


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
