### PR TITLE
Redirect share URL to edit/view for Lab2 projects

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -550,14 +550,17 @@ class ProjectsController < ApplicationController
   # Redirect to the correct view/edit page for Lab2 projects. If a project owner is on a /view
   # page, redirect to /edit. If a non-owner is on an /edit page, redirect to /view.
   # For legacy (non-Lab2) labs, this is handled on the front-end.
+  # We will also redirect away from share URLs to the correct view/edit page as Lab2 does not
+  # yet support separate share pages.
   private def redirect_edit_view_for_lab2
     return nil unless @level.uses_lab2?
 
     project = Projects.new(get_storage_id).get(params[:channel_id])
     is_owner = project[:isOwner]
+    sharing = params[:iframe_embed] == true || params[:share] == true
 
-    return redirect_to "/projects/#{params[:key]}/#{params[:channel_id]}/edit" if is_owner && request.path.ends_with?('/view')
-    return redirect_to "/projects/#{params[:key]}/#{params[:channel_id]}/view" if !is_owner && request.path.ends_with?('/edit')
+    return redirect_to "/projects/#{params[:key]}/#{params[:channel_id]}/edit" if is_owner && (sharing || request.path.ends_with?('/view'))
+    return redirect_to "/projects/#{params[:key]}/#{params[:channel_id]}/view" if !is_owner && (sharing || request.path.ends_with?('/edit'))
   end
 
   # Automatically catch authorization exceptions on any methods in this controller

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -474,7 +474,7 @@ class ProjectsControllerTest < ActionController::TestCase
     channel_id = '12345'
     Projects.any_instance.stubs(:get).returns({isOwner: false})
 
-    get :edit, params: {path: "/projects/music/#{channel_id}", key: 'music', channel_id: channel_id, iframe_embed: true}
+    get :edit, params: {path: "/projects/music/#{channel_id}/embed", key: 'music', channel_id: channel_id, iframe_embed: true}
     assert_response :redirect
     assert_redirected_to "/projects/music/#{channel_id}/view"
   end

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -442,4 +442,40 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_response :redirect
     assert_redirected_to "/projects/music/#{channel_id}/view"
   end
+
+  test 'on lab2 levels navigating to a share URL redirects to /edit if user is project owner' do
+    channel_id = '12345'
+    Projects.any_instance.stubs(:get).returns({isOwner: true})
+
+    get :show, params: {path: "/projects/music/#{channel_id}", key: 'music', channel_id: channel_id, share: true}
+    assert_response :redirect
+    assert_redirected_to "/projects/music/#{channel_id}/edit"
+  end
+
+  test 'on lab2 levels navigating to a share URL redirects to /view if user is not project owner' do
+    channel_id = '12345'
+    Projects.any_instance.stubs(:get).returns({isOwner: false})
+
+    get :edit, params: {path: "/projects/music/#{channel_id}", key: 'music', channel_id: channel_id, share: true}
+    assert_response :redirect
+    assert_redirected_to "/projects/music/#{channel_id}/view"
+  end
+
+  test 'on lab2 levels navigating to an embed URL redirects to /edit if user is project owner' do
+    channel_id = '12345'
+    Projects.any_instance.stubs(:get).returns({isOwner: true})
+
+    get :show, params: {path: "/projects/music/#{channel_id}/embed", key: 'music', channel_id: channel_id, iframe_embed: true}
+    assert_response :redirect
+    assert_redirected_to "/projects/music/#{channel_id}/edit"
+  end
+
+  test 'on lab2 levels navigating to an embed URL redirects to /view if user is not project owner' do
+    channel_id = '12345'
+    Projects.any_instance.stubs(:get).returns({isOwner: false})
+
+    get :edit, params: {path: "/projects/music/#{channel_id}", key: 'music', channel_id: channel_id, iframe_embed: true}
+    assert_response :redirect
+    assert_redirected_to "/projects/music/#{channel_id}/view"
+  end
 end


### PR DESCRIPTION
Redirects share (projects/\<channel\>) and embed (projects/\<channel\>/embed) to /view or /edit, based on whether the user is the project owner for Lab2 projects specifically. Share/embed URLs are currently not supported for Lab2, and in the case of Music Lab, we currently won't be building a standalone share experience different from going to the /view link.

## Links

https://codedotorg.atlassian.net/browse/SL-990

## Testing story

Tested locally + unit