### PR TITLE
Revert "Revert "Add UI tests for Catalog assign button""

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -20,3 +20,34 @@ Feature: Curriculum Catalog Page
     And I wait until element "h5:contains(No matching curricula)" is visible
     And I see no difference for "Curriculum Catalog: No Offerings"
     And I close my eyes
+
+  # Assign button scenarios
+
+  Scenario: Signed-out user is redirected to sign-in page when clicking Assign
+    Given I am on "http://studio.code.org/catalog"
+    And I wait until element "h4:contains(AI for Oceans)" is visible
+
+    Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"
+    And I wait until element "h3:contains(Sign in or create account to assign a curriculum)" is visible
+    Then I click selector "a:contains(Sign in or create account)"
+    And I wait until element "h2:contains(Have an account already? Sign in)" is visible
+
+  Scenario: Signed-in student is redirected to help page when clicking Assign
+    Given I create a student named "Student Sam"
+    Given I am on "http://studio.code.org/catalog"
+    And I wait until element "h4:contains(AI for Oceans)" is visible
+
+    Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"
+    And I wait until element "h3:contains(Use a teacher account to assign a curriculum)" is visible
+    Then I click selector "a:contains(Learn how to update account type)"
+    And check that the URL matches "https://support.code.org/hc/en-us/articles/360023222371-How-can-I-change-my-account-type-from-student-to-teacher-or-vice-versa"
+
+  Scenario: Signed-in teacher without sections is prompted to created sections when clicking Assign
+    Given I create a teacher named "Teacher Tom"
+    Then I am on "http://studio.code.org/catalog"
+    And I wait until element "h4:contains(AI for Oceans)" is visible
+
+    Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"
+    And I wait until element "h3:contains(Create class section to assign a curriculum)" is visible
+    Then I click selector "a:contains(Create Section)"
+    And I wait until element "h3:contains(Create a new section)" is visible


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#52763, restoring https://github.com/code-dot-org/code-dot-org/pull/52726.

When this was originally merged in, it caused errors on staging due to another [recently-merged PR](https://github.com/code-dot-org/code-dot-org/pull/52652#discussion_r1262809931) which changed an anchor tag into a button tag. The tag is now back as an anchor tag, thanks to [this PR](https://github.com/code-dot-org/code-dot-org/pull/52781), so this is safe to restore.