### PR TITLE
kaitie/added button started container for rubric pages

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -770,6 +770,8 @@ describe('entry tests', () => {
       './src/sites/studio/pages/reference_guides/edit_all.js',
     'programming_expressions/index':
       './src/sites/studio/pages/programming_expressions/index.js',
+    'rubrics/new': './src/sites/studio/pages/rubrics/new.js',
+    'rubrics/edit': './src/sites/studio/pages/rubrics/edit.js',
     'sections/new': './src/sites/studio/pages/sections/new.js',
     'sections/edit': './src/sites/studio/pages/sections/edit.js',
     'scripts/edit': './src/sites/studio/pages/scripts/edit.js',

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
@@ -145,17 +145,28 @@ class ActivitiesEditor extends Component {
             allowMajorCurriculumChanges={allowMajorCurriculumChanges}
           />
         ))}
-        {this.props.hasLessonPlan && (
+        <div>
+          {this.props.hasLessonPlan && (
+            <button
+              onMouseDown={this.handleAddActivity}
+              className="btn add-activity"
+              style={styles.addActivity}
+              type="button"
+            >
+              <i style={{marginRight: 7}} className="fa fa-plus-circle" />
+              Activity
+            </button>
+          )}
           <button
-            onMouseDown={this.handleAddActivity}
-            className="btn add-activity"
+            onMouseDown={console.log('clicked')}
+            className="btn add-rubric"
             style={styles.addActivity}
             type="button"
           >
             <i style={{marginRight: 7}} className="fa fa-plus-circle" />
-            Activity
+            Add Rubric
           </button>
-        )}
+        </div>
         <input
           type="hidden"
           name="activities"

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
@@ -157,15 +157,14 @@ class ActivitiesEditor extends Component {
               Activity
             </button>
           )}
-          <button
-            onMouseDown={console.log('clicked')}
+          <a
             className="btn add-rubric"
-            style={styles.addActivity}
-            type="button"
+            style={styles.addRubric}
+            href="https://levelbuilder-studio.code.org/rubrics/new"
           >
             <i style={{marginRight: 7}} className="fa fa-plus-circle" />
             Add Rubric
-          </button>
+          </a>
         </div>
         <input
           type="hidden"
@@ -187,6 +186,14 @@ const styles = {
     background: color.cyan,
     border: `1px solid ${color.cyan}`,
     boxShadow: 'none',
+  },
+  addRubric: {
+    fontSize: 14,
+    color: 'white',
+    background: color.cyan,
+    border: `1px solid ${color.cyan}`,
+    boxShadow: 'none',
+    margin: `5px 5px 0px`,
   },
 };
 

--- a/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function RubricsContainer(props) {
+  return (
+    <div>
+      <h1>Rubrics Container</h1>
+    </div>
+  );
+}

--- a/apps/src/sites/studio/pages/rubrics/edit.js
+++ b/apps/src/sites/studio/pages/rubrics/edit.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import RubricsContainer from '@cdo/apps/lib/levelbuilder/rubrics/RubricsContainer';
+
+// Note that I will need to pass some data in here (perhaps the id of the rubric)
+// Currently, this URL will work http://localhost-studio.code.org:3000/rubrics/12/edit
+$(document).ready(() => {
+  ReactDOM.render(<RubricsContainer />, document.getElementById('form'));
+});

--- a/apps/src/sites/studio/pages/rubrics/new.js
+++ b/apps/src/sites/studio/pages/rubrics/new.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import RubricsContainer from '@cdo/apps/lib/levelbuilder/rubrics/RubricsContainer';
+
+$(document).ready(() => {
+  ReactDOM.render(<RubricsContainer />, document.getElementById('form'));
+});

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitiesEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitiesEditorTest.jsx
@@ -19,7 +19,7 @@ describe('ActivitiesEditor', () => {
 
   it('renders default props', () => {
     const wrapper = shallow(<ActivitiesEditor {...defaultProps} />);
-    expect(wrapper.find('button').length).to.equal(2);
+    expect(wrapper.find('button').length).to.equal(1);
     expect(wrapper.find('ActivityCardAndPreview').length).to.equal(1);
 
     const hiddenInputs = wrapper.find('input[type="hidden"]');
@@ -30,7 +30,7 @@ describe('ActivitiesEditor', () => {
     const wrapper = shallow(
       <ActivitiesEditor {...defaultProps} hasLessonPlan={false} />
     );
-    expect(wrapper.find('button').length).to.equal(1);
+    expect(wrapper.find('button').length).to.equal(0);
     expect(wrapper.find('ActivityCardAndPreview').length).to.equal(1);
 
     const hiddenInputs = wrapper.find('input[type="hidden"]');
@@ -39,7 +39,7 @@ describe('ActivitiesEditor', () => {
 
   it('adds activity when activity button pressed', () => {
     const wrapper = shallow(<ActivitiesEditor {...defaultProps} />);
-    expect(wrapper.find('button').length).to.equal(2);
+    expect(wrapper.find('button').length).to.equal(1);
 
     const button = wrapper.find('button').at(0);
     expect(button.text()).to.include('Activity');

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitiesEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitiesEditorTest.jsx
@@ -19,29 +19,29 @@ describe('ActivitiesEditor', () => {
 
   it('renders default props', () => {
     const wrapper = shallow(<ActivitiesEditor {...defaultProps} />);
-    expect(wrapper.find('button').length).to.equal(1);
+    expect(wrapper.find('button').length).to.equal(2);
     expect(wrapper.find('ActivityCardAndPreview').length).to.equal(1);
 
     const hiddenInputs = wrapper.find('input[type="hidden"]');
     expect(hiddenInputs.length, 'hidden input').to.equal(1);
   });
 
-  it('renders without button if hasLessonPlan false', () => {
+  it('renders without activity button if hasLessonPlan false', () => {
     const wrapper = shallow(
       <ActivitiesEditor {...defaultProps} hasLessonPlan={false} />
     );
-    expect(wrapper.find('button').length).to.equal(0);
+    expect(wrapper.find('button').length).to.equal(1);
     expect(wrapper.find('ActivityCardAndPreview').length).to.equal(1);
 
     const hiddenInputs = wrapper.find('input[type="hidden"]');
     expect(hiddenInputs.length, 'hidden input').to.equal(1);
   });
 
-  it('adds activity when button pressed', () => {
+  it('adds activity when activity button pressed', () => {
     const wrapper = shallow(<ActivitiesEditor {...defaultProps} />);
-    expect(wrapper.find('button').length).to.equal(1);
+    expect(wrapper.find('button').length).to.equal(2);
 
-    const button = wrapper.find('button');
+    const button = wrapper.find('button').at(0);
     expect(button.text()).to.include('Activity');
     button.simulate('mouseDown');
     expect(addActivity).to.have.been.calledWith(

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -1,0 +1,7 @@
+class RubricsController < ApplicationController
+  def edit
+  end
+
+  def new
+  end
+end

--- a/dashboard/app/views/rubrics/edit.html.haml
+++ b/dashboard/app/views/rubrics/edit.html.haml
@@ -1,0 +1,3 @@
+%script{src: webpack_asset_path('js/rubrics/edit.js')}
+
+#form

--- a/dashboard/app/views/rubrics/new.html.haml
+++ b/dashboard/app/views/rubrics/new.html.haml
@@ -1,0 +1,3 @@
+%script{src: webpack_asset_path('js/rubrics/new.js')}
+
+#form

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -334,7 +334,7 @@ Dashboard::Application.routes.draw do
       end
     end
 
-    resources :rubrics, only: [:edit, :new], param: 'key'
+    resources :rubrics, only: [:edit, :new]
 
     resources :course_offerings, only: [:edit, :update], param: 'key' do
       collection do

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -334,6 +334,8 @@ Dashboard::Application.routes.draw do
       end
     end
 
+    resources :rubrics, only: [:edit, :new], param: 'key'
+
     resources :course_offerings, only: [:edit, :update], param: 'key' do
       collection do
         get 'quick_assign_course_offerings'


### PR DESCRIPTION
I am looking for some feedback on the Curriculum Writer Experience start of things before I get too far.   This PR is just a first step in getting the full experience up and running.  This...

**1. Adds a button to the "lesson edit page"**

<img width="261" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/217614bd-c9bc-4d67-ad9a-755f57b51517">

Future work:  Make the button work.  AND, if time, make the button say "edit rubric" or "add rubric" depending if there is an existing rubric or not. 
Feedback needed on: Location of the button - is this what we expect?

**2. Creates the "new rubric" page (http://localhost-studio.code.org:3000/rubrics/new)**
Future work:  Add the content to the page as well as make it functional.

**3. Creates the "edit rubric" page (http://localhost-studio.code.org:3000/rubrics/15/edit)**
Future work: Add content to the page, make it functional, and pass in the correct rubric ID to the URL

## Links

[AITT-59](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?selectedIssue=AITT-59)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

See above for follow-up work.  Additionally, we need to restrict this URL to level-builder access only. 

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
