### PR TITLE
Music: project page background color

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -385,6 +385,8 @@ class ProjectsController < ApplicationController
       blocklyVersion: params[:blocklyVersion]
     )
 
+    @body_classes = @level.properties['background']
+
     if [Game::ARTIST, Game::SPRITELAB, Game::POETRY].include? @game.app
       @project_image = CDO.studio_url "/v3/files/#{@view_options['channel']}/.metadata/thumbnail.png", 'https:'
     end

--- a/dashboard/config/scripts/levels/New Music Lab Project.level
+++ b/dashboard/config/scripts/levels/New Music Lab Project.level
@@ -5,6 +5,7 @@
   "created_at": "2023-06-22T01:38:42.000Z",
   "level_num": "custom",
   "user_id": 4,
+  "background": "music-black",
   "properties": {
     "is_project_level": "true",
     "encrypted": "false",


### PR DESCRIPTION
Music Lab pages under `/projects/music/` now have the proper background color.