### PR TITLE
Music: drag blocks over toolbox

### DIFF
--- a/apps/style/lab2/style.scss
+++ b/apps/style/lab2/style.scss
@@ -1,1 +1,1 @@
-/* This file is currently empty. */
+@import "../blockly";

--- a/dashboard/app/views/levels/_lab2.html.haml
+++ b/dashboard/app/views/levels/_lab2.html.haml
@@ -7,3 +7,4 @@
   %script{src: webpack_asset_path('js/googleblockly.js')}
   %script{src: webpack_asset_path('js/common.js')}
   %script{src: webpack_asset_path("js/lab2.js"), data: {appoptions: app_options.to_json}}
+  %link{href: asset_path("css/lab2.css"), rel: 'stylesheet', type: 'text/css'}


### PR DESCRIPTION
Dragging a block out of the workspace and back to the toolbox, to be deleted, now takes the block over the toolbox, rather than under it.  This uses an existing styling override we've used in other labs.
