### PR TITLE
Music: highlight randomly playing sound

### DIFF
--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -159,7 +159,11 @@ export const getCurrentlyPlayingBlockIds = (state: {
     const currentlyPlaying =
       currentPlayheadPosition !== 0 &&
       currentPlayheadPosition >= playbackEvent.when &&
-      currentPlayheadPosition < playbackEvent.when + playbackEvent.length;
+      currentPlayheadPosition < playbackEvent.when + playbackEvent.length &&
+      !(
+        playbackEvent.skipContext?.insideRandom &&
+        playbackEvent.skipContext?.skipSound
+      );
 
     if (currentlyPlaying) {
       playingBlockIds.push(playbackEvent.blockId);


### PR DESCRIPTION
Now, when playing a random sound out of several inside a "play random" block, we only highlight that sound's block.

### before

<img width="578" alt="Screenshot 2023-07-15 at 9 08 34 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/eec2a67b-36e8-42e0-860f-6d4377af48ab">

### after

<img width="578" alt="Screenshot 2023-07-15 at 9 05 35 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/2b116d0e-dbe3-4102-8f03-740a27d9c6dc">
