### PR TITLE
[LTI] Validate LtiResourceLink

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -79,7 +79,7 @@ class LtiV1Controller < ApplicationController
 
     if jwt_verifier.verify_jwt
       message_type = decoded_jwt[:'https://purl.imsglobal.org/spec/lti/claim/message_type']
-      return unauthorized_status unless message_type == 'LtiResourceLinkRequest'
+      return error_status unless message_type == 'LtiResourceLinkRequest'
 
       target_link_uri = decoded_jwt[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri']
       redirect_to target_link_uri
@@ -101,6 +101,10 @@ class LtiV1Controller < ApplicationController
 
   def unauthorized_status
     render(status: :unauthorized, json: {error: 'Unauthorized'})
+  end
+
+  def error_status
+    render(status: :not_acceptable, json: {error: 'Only LtiResourceLink is supported right now'})
   end
 
   def create_state_and_nonce

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -79,7 +79,7 @@ class LtiV1Controller < ApplicationController
 
     if jwt_verifier.verify_jwt
       message_type = decoded_jwt[:'https://purl.imsglobal.org/spec/lti/claim/message_type']
-      return error_status unless message_type == 'LtiResourceLinkRequest'
+      return wrong_resource_type unless message_type == 'LtiResourceLinkRequest'
 
       target_link_uri = decoded_jwt[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri']
       redirect_to target_link_uri
@@ -103,7 +103,7 @@ class LtiV1Controller < ApplicationController
     render(status: :unauthorized, json: {error: 'Unauthorized'})
   end
 
-  def error_status
+  def wrong_resource_type
     render(status: :not_acceptable, json: {error: 'Only LtiResourceLink is supported right now'})
   end
 

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -78,6 +78,9 @@ class LtiV1Controller < ApplicationController
     jwt_verifier = JwtVerifier.new(decoded_jwt, integration)
 
     if jwt_verifier.verify_jwt
+      message_type = decoded_jwt[:'https://purl.imsglobal.org/spec/lti/claim/message_type']
+      return unauthorized_status unless message_type == 'LtiResourceLinkRequest'
+
       target_link_uri = decoded_jwt[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri']
       redirect_to target_link_uri
     else

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -45,7 +45,8 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
       iat: 1.day.ago.to_i,
       iss: @integration.issuer,
       nonce: @nonce,
-      'https://purl.imsglobal.org/spec/lti/claim/target_link_uri': target_link_uri
+      'https://purl.imsglobal.org/spec/lti/claim/target_link_uri': target_link_uri,
+      'https://purl.imsglobal.org/spec/lti/claim/message_type': 'LtiResourceLinkRequest'
     }
   end
 
@@ -156,6 +157,14 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   test 'auth - error raised for issued at time in future' do
     payload = get_valid_payload
     payload[:iat] = 3.days.from_now.to_i
+    jwt = create_jwt(payload)
+    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
+    assert_response :unauthorized
+  end
+
+  test 'auth - LTI Resource Type wrong' do
+    payload = get_valid_payload
+    payload['https://purl.imsglobal.org/spec/lti/claim/message_type'] = 'file'
     jwt = create_jwt(payload)
     post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
     assert_response :unauthorized

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -164,10 +164,11 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
   test 'auth - LTI Resource Type wrong' do
     payload = get_valid_payload
-    payload['https://purl.imsglobal.org/spec/lti/claim/message_type'] = 'file'
+    payload[:'https://purl.imsglobal.org/spec/lti/claim/message_type'] = 'file'
+    LtiV1Controller.any_instance.stubs(:get_decoded_jwt).returns payload
     jwt = create_jwt(payload)
     post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
-    assert_response :unauthorized
+    assert_response :not_acceptable
   end
 
   test 'auth - error raised in decoding jwt' do


### PR DESCRIPTION
Followup to the Auth controller to only allow requests with `LtiResourceLink` type.

https://codedotorg.atlassian.net/browse/P20-105

## Tests

```
➜  dashboard git:(elf-p20-105-resource-type) ✗ bundle exec spring testunit ./test/controllers/lti_v1_controller_test.rb
Running via Spring preloader in process 7551
Running via Spring preloader in process 7563
Finished seed:check_migrations (less than 1 second)
Finished seed:videos (less than 1 second)
Finished seed:games (less than 1 second)
Finished seed:concepts (less than 1 second)
done
Finished seed:secret_words (less than 1 second)
done
Finished seed:secret_pictures (less than 1 second)
Finished seed:school_districts (less than 1 second)
Finished seed:schools (less than 1 second)
Finished seed:standards (7 seconds)
Finished seed:foorms (1 second)
Finished seed:import_pegasus_data (less than 1 second)
Finished seed:test (less than 1 second)
Started with run options --seed 61002

  19/19: [===================================================================================================================================================================] 100% Time: 00:00:11, Time: 00:00:11

Finished in 13.20957s
19 tests, 26 assertions, 0 failures, 0 errors, 0 skips
```

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
