### PR TITLE
GA4: fix track event on dashboard

### DIFF
--- a/apps/src/lib/util/GoogleAnalyticsReporter.js
+++ b/apps/src/lib/util/GoogleAnalyticsReporter.js
@@ -145,10 +145,10 @@ class GoogleAnalyticsReporter {
    * Public function exposed to track custom events in Google Analytics
    */
   trackEvent(category_value, action_name, dimensions) {
-    if (this.isGoogleAnalyticsUniversalEnabled) {
+    if (googleAnalyticsReporter.isGoogleAnalyticsUniversalEnabled) {
       ga('send', 'event', category_value, action_name, dimensions);
     }
-    if (this.isGoogleAnalytics4Enabled) {
+    if (googleAnalyticsReporter.isGoogleAnalytics4Enabled) {
       gtag('event', action_name, {
         eventCategory: category_value,
         dimensions,


### PR DESCRIPTION
Proposed follow-up to https://github.com/code-dot-org/code-dot-org/pull/52094.

As noted in the comment [here](https://github.com/code-dot-org/code-dot-org/pull/52094/files#r1265607875), `this` is `Window`, but should actually be the singleton instance of `GoogleAnalyticsReporter` provided by `googleAnalyticsReporter`.