### PR TITLE
[i18n] update crontab -lc -> -l -c

### DIFF
--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -23,13 +23,13 @@ HOME=/home/ubuntu
 # Note that the CI_ONLY_BUILD environment variable is necessary; the server is
 # not set up to actually serve a version of the website, and it will fail to
 # build correctly if not thus restricted.
-0 */4 * * * BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && CI_ONLY_BUILD=true bundle exec ./bin/cronjob ./aws/ci_build >>/tmp/cronlog 2>&1"
+0 */4 * * * BASH_ENV=~/.bashrc bash -l -c "cd /home/ubuntu/code-dot-org && CI_ONLY_BUILD=true bundle exec ./bin/cronjob ./aws/ci_build >>/tmp/cronlog 2>&1"
 
 # Run the I18n Sync!
 # Sync is scheduled for 12:30 AM PST every Monday; run around midnight so the
 # sync is hopefully finished by start of day on Monday, offset by 30 minutes so
 # we don't conflict with the ci_build which runs on the hour.
-30 8 * * MON BASH_ENV=~/.bashrc bash -lc "(cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1"
+30 8 * * MON BASH_ENV=~/.bashrc bash -l -c "(cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1"
 
 # Run the sync down periodically throughout the week. Specifically:
 # - Run it every 4 hours. This is a somewhat arbitrarily-chosen frequency
@@ -39,14 +39,14 @@ HOME=/home/ubuntu
 # - Run it every day except Monday. This is done so we don't conflict with the
 #   full sync, and also because we expect to spend Monday verifiying the
 #   results of the full sync.
-# 30 */4 * * SUN,TUE-SAT BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
+# 30 */4 * * SUN,TUE-SAT BASH_ENV=~/.bashrc bash -l -c "cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
 
 # Periodically check to see if the I18n Sync PRs have been merged and attempt
 # to return to staging.
-0 */1 * * * BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
+0 */1 * * * BASH_ENV=~/.bashrc bash -l -c "cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
 
 # Update string translation status to Redshift
-0 0 * * * BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
+0 0 * * * BASH_ENV=~/.bashrc bash -l -c "cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
 
 # Run the Crowdin translation validator tool
-# 30 0 * * * BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && (bundle exec bin/i18n/translation_monitor/run_crowdin_validator.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
+# 30 0 * * * BASH_ENV=~/.bashrc bash -l -c "cd /home/ubuntu/code-dot-org && (bundle exec bin/i18n/translation_monitor/run_crowdin_validator.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"


### PR DESCRIPTION
As the i18n / Platform point person, I'm looking at i18n sync and it seems like the cronjob still isn't running

Looked at  https://github.com/code-dot-org/code-dot-org/pull/52369 and it seems like maybe the `l` and `c` flags need to be separated (since `c` takes an argument).

🤷  seems like a YOLO update, but it's broken right now, so we've only got upside.
