### PR TITLE
Javalab: make copy of sources before modifying

### DIFF
--- a/apps/src/javalab/redux/editorRedux.ts
+++ b/apps/src/javalab/redux/editorRedux.ts
@@ -119,8 +119,9 @@ const javalabEditorSlice = createSlice({
             action.payload.sources,
             action.payload.isEditingStartSources
           );
+        const sources = _.cloneDeep(action.payload.sources);
         const updatedSources = updateAllSourceFileOrders(
-          action.payload.sources,
+          sources,
           fileMetadata,
           orderedTabKeys
         );


### PR DESCRIPTION
We received a Zendesk report of a user not being able to reset their progress on [this level](https://studio.code.org/s/csa3-2023/lessons/4/levels/6/sublevel/4). Error looked like this:

![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/03e32603-6b08-4500-b68c-c63c478ab8f0)

I was able to reproduce when viewing the level for the first time and trying to reset my progress, although I didn't consistently repro after refreshing the page.

I believe the root cause is directly modifying an object that we should be cloning (a set of `sources` provided [here](https://github.com/code-dot-org/code-dot-org/blob/f7984f353d419fed2e87776d6a0d255e335aa57d/apps/src/javalab/Javalab.js#L478-L481)).

I've updated our code here to clone the object before modifying it. This is similar to what we do here when calling the same function (although in the existing case, we're working with redux state directly rather than an action):

https://github.com/code-dot-org/code-dot-org/blob/f7984f353d419fed2e87776d6a0d255e335aa57d/apps/src/javalab/redux/editorRedux.ts#L188-L190

## Links

- zendesk ticket: [link](https://codeorg.zendesk.com/agent/tickets/451187)

## Testing story

I was able to repro consistently with fresh accounts visiting the level linked above, then immediately trying to reset my version history. I was not able to repro this issue following the same steps (with a new account) after this change.