### PR TITLE
Lab2: update lab loading logic

### DIFF
--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -234,11 +234,13 @@ const labSlice = createSlice({
     onLevelChange(
       state,
       action: PayloadAction<{
+        channel?: Channel;
         appName?: AppName;
         levelData?: LevelData;
         initialSources?: ProjectSources;
       }>
     ) {
+      state.channel = action.payload.channel;
       state.appName = action.payload.appName;
       state.levelData = action.payload.levelData;
       state.initialSources = action.payload.initialSources;
@@ -330,7 +332,6 @@ function setProjectAndLevelData(
     return;
   }
   const {channel, initialSources, levelProperties} = data;
-  dispatch(setChannel(channel));
   if (levelProperties) {
     const hideShareAndRemix = convertOptionalStringToBoolean(
       levelProperties.hideShareAndRemix,
@@ -353,6 +354,7 @@ function setProjectAndLevelData(
     onLevelChange({
       appName: levelProperties?.appName,
       levelData: levelProperties?.levelData,
+      channel,
       initialSources,
     })
   );

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -49,13 +49,11 @@ export interface LabState {
     | undefined;
   // channel for the current project, or undefined if there is no current project.
   channel: Channel | undefined;
-  // last saved source for the current project, or undefined if we have not loaded or saved yet.
-  sources: ProjectSources | undefined;
+  // Initial sources for the current level, as loaded from the server. Subsequent changes to sources
+  // while the project is being edited are managed by the Lab and Project Manager directly.
+  initialSources: ProjectSources | undefined;
   // Level data for the current level
   levelData: LevelData | undefined;
-  // Whether the lab is ready for a reload.  This is used to manage the case where multiple loads
-  // happen in a row, and we only want to reload the lab when we are done.
-  labReadyForReload: boolean;
   hideShareAndRemix: boolean;
   isProjectLevel: boolean;
   // Validation status for the current level. This is used by the progress system to determine
@@ -69,9 +67,8 @@ const initialState: LabState = {
   isLoading: false,
   pageError: undefined,
   channel: undefined,
-  sources: undefined,
+  initialSources: undefined,
   levelData: undefined,
-  labReadyForReload: false,
   hideShareAndRemix: true,
   isProjectLevel: false,
   validationState: {...initialValidationState},
@@ -147,7 +144,7 @@ export const setUpWithLevel = createAsyncThunk(
       thunkAPI.dispatch
     );
     setProjectAndLevelData(
-      {sources, channel, levelProperties},
+      {initialSources: sources, channel, levelProperties},
       thunkAPI.signal.aborted,
       thunkAPI.dispatch
     );
@@ -178,7 +175,7 @@ export const setUpWithoutLevel = createAsyncThunk(
       thunkAPI.dispatch
     );
     setProjectAndLevelData(
-      {sources, channel},
+      {initialSources: sources, channel},
       thunkAPI.signal.aborted,
       thunkAPI.dispatch
     );
@@ -223,15 +220,6 @@ const labSlice = createSlice({
     setChannel(state, action: PayloadAction<Channel | undefined>) {
       state.channel = action.payload;
     },
-    setSources(state, action: PayloadAction<ProjectSources | undefined>) {
-      state.sources = action.payload;
-    },
-    setLevelData(state, action: PayloadAction<LevelData | undefined>) {
-      state.levelData = action.payload;
-    },
-    setLabReadyForReload(state, action: PayloadAction<boolean>) {
-      state.labReadyForReload = action.payload;
-    },
     setHideShareAndRemix(state, action: PayloadAction<boolean>) {
       state.hideShareAndRemix = action.payload;
     },
@@ -241,8 +229,19 @@ const labSlice = createSlice({
     setValidationState(state, action: PayloadAction<ValidationState>) {
       state.validationState = {...action.payload};
     },
-    setAppName(state, action: PayloadAction<AppName | undefined>) {
-      state.appName = action.payload;
+    // Update the level data and initial sources simultaneously when the level changes.
+    // These fields are updated together so that labs receive all updates at once.
+    onLevelChange(
+      state,
+      action: PayloadAction<{
+        appName?: AppName;
+        levelData?: LevelData;
+        initialSources?: ProjectSources;
+      }>
+    ) {
+      state.appName = action.payload.appName;
+      state.levelData = action.payload.levelData;
+      state.initialSources = action.payload.initialSources;
     },
   },
   extraReducers: builder => {
@@ -296,9 +295,8 @@ async function setUpAndLoadProject(
   projectManager.addSaveStartListener(() =>
     dispatch(setProjectUpdatedSaving())
   );
-  projectManager.addSaveSuccessListener((channel, source) => {
+  projectManager.addSaveSuccessListener(channel => {
     dispatch(setProjectUpdatedAt(channel.updatedAt));
-    dispatch(setSources(source));
     dispatch(setChannel(channel));
   });
   projectManager.addSaveNoopListener(channel => {
@@ -321,7 +319,7 @@ async function setUpAndLoadProject(
 function setProjectAndLevelData(
   data: {
     channel?: Channel;
-    sources?: ProjectSources;
+    initialSources?: ProjectSources;
     levelProperties?: LevelProperties;
   },
   aborted: boolean,
@@ -331,11 +329,9 @@ function setProjectAndLevelData(
   if (aborted) {
     return;
   }
-  const {channel, sources, levelProperties} = data;
+  const {channel, initialSources, levelProperties} = data;
   dispatch(setChannel(channel));
-  dispatch(setSources(sources));
   if (levelProperties) {
-    dispatch(setLevelData(levelProperties.levelData));
     const hideShareAndRemix = convertOptionalStringToBoolean(
       levelProperties.hideShareAndRemix,
       /* defaultValue*/ true
@@ -346,15 +342,20 @@ function setProjectAndLevelData(
       /* defaultValue*/ false
     );
     dispatch(setIsProjectLevel(isProjectLevel));
-    dispatch(setAppName(levelProperties.appName));
   } else {
     // set default values to clear out any previous values
-    dispatch(setLevelData(undefined));
     dispatch(setHideShareAndRemix(true));
     dispatch(setIsProjectLevel(false));
-    dispatch(setAppName(undefined));
   }
-  dispatch(setLabReadyForReload(true));
+  // Dispatch level change last so labs can react to the new level data
+  // and new initial sources at once.
+  dispatch(
+    onLevelChange({
+      appName: levelProperties?.appName,
+      levelData: levelProperties?.levelData,
+      initialSources,
+    })
+  );
 }
 
 async function loadLevelProperties(
@@ -375,22 +376,11 @@ async function cleanUpProjectManager() {
   Lab2Registry.getInstance().clearProjectManager();
 }
 
-export const {
-  setIsLoading,
-  setPageError,
-  clearPageError,
-  setLabReadyForReload,
-  setValidationState,
-} = labSlice.actions;
+export const {setIsLoading, setPageError, clearPageError, setValidationState} =
+  labSlice.actions;
 
 // These should not be set outside of the lab slice.
-const {
-  setHideShareAndRemix,
-  setIsProjectLevel,
-  setAppName,
-  setChannel,
-  setSources,
-  setLevelData,
-} = labSlice.actions;
+const {setHideShareAndRemix, setIsProjectLevel, setChannel, onLevelChange} =
+  labSlice.actions;
 
 export default labSlice.reducer;

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -5,11 +5,13 @@
  */
 import MusicView from '@cdo/apps/music/views/MusicView';
 import StandaloneVideo from '@cdo/apps/standaloneVideo/StandaloneVideo';
-import React from 'react';
+import classNames from 'classnames';
+import React, {useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 import {LabState} from '../lab2Redux';
 import ProgressContainer from '../progress/ProgressContainer';
 import {AppName} from '../types';
+import moduleStyles from './lab-views-renderer.module.scss';
 
 // Configuration for how a Lab should be rendered
 interface AppProperties {
@@ -40,9 +42,14 @@ const LabViewsRenderer: React.FunctionComponent = () => {
     (state: {lab: LabState}) => state.lab.appName
   );
 
-  // TODO: Instead of rendering all known apps, render only visited apps.
-  // This will require refactoring logic around the labReadyForReload flag.
-  const appsToRender = Object.keys(appsProperties) as AppName[];
+  const [appsToRender, setAppsToRender] = useState<AppName[]>([]);
+
+  // When navigating to a new app type, add it to the list of apps to render.
+  useEffect(() => {
+    if (currentAppName && !appsToRender.includes(currentAppName)) {
+      setAppsToRender([...appsToRender, currentAppName]);
+    }
+  }, [currentAppName, appsToRender]);
 
   // Iterate through appsToRender and render Lab views for each. If
   // backgroundMode is true, the Lab view will always be rendered, but
@@ -93,11 +100,10 @@ const VisibilityContainer: React.FunctionComponent<
   return (
     <div
       id={`lab2-${appName}`}
-      style={{
-        width: '100%',
-        height: '100%',
-        visibility: visible ? 'visible' : 'hidden',
-      }}
+      className={classNames(
+        moduleStyles.visibilityContainer,
+        visible && moduleStyles.visible
+      )}
     >
       {children}
     </div>

--- a/apps/src/lab2/views/lab-views-renderer.module.scss
+++ b/apps/src/lab2/views/lab-views-renderer.module.scss
@@ -1,0 +1,10 @@
+.visibilityContainer {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  visibility: hidden;
+
+  &.visible {
+    visibility: visible;
+  }
+}

--- a/apps/src/music/types.ts
+++ b/apps/src/music/types.ts
@@ -13,10 +13,11 @@ export type MusicLocale = {
 
 // TODO: Use this interface when converting MusicView to TypeScript
 export interface MusicLevelData extends ProjectLevelData {
-  toolbox: {
-    [key: string]: string;
+  toolbox?: {
+    [key: string]: string[];
   };
-  sounds: {
-    [key: string]: string;
+  sounds?: {
+    [key: string]: string[];
   };
+  library?: string;
 }

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -65,6 +65,7 @@ import ValidatorProvider from '@cdo/apps/lab2/progress/ValidatorProvider';
 import {Key} from '../utils/Notes';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {setUpBlocklyForMusicLab} from '../blockly/setup';
+import {isEqual} from 'lodash';
 
 /**
  * Top-level container for Music Lab. Manages all views on the page as well as the
@@ -113,7 +114,7 @@ class UnconnectedMusicView extends React.Component {
     setProjectUpdatedError: PropTypes.func,
     setIsLoading: PropTypes.func,
     setPageError: PropTypes.func,
-    sources: PropTypes.object,
+    initialSources: PropTypes.object,
     levelData: PropTypes.object,
     labReadyForReload: PropTypes.bool,
     setLabReadyForReload: PropTypes.func,
@@ -175,6 +176,10 @@ class UnconnectedMusicView extends React.Component {
     window.addEventListener('beforeunload', event => {
       this.analyticsReporter.endSession();
     });
+
+    if (this.props.appName === 'music' || this.props.inIncubator) {
+      this.onLevelLoad(this.props.levelData, this.props.initialSources);
+    }
   }
 
   async componentDidUpdate(prevProps) {
@@ -212,47 +217,45 @@ class UnconnectedMusicView extends React.Component {
       this.updateHighlightedBlocks();
     }
 
-    // If we just finished loading the lab, then we need to update the
-    // sources and level data.
-    if (!prevProps.labReadyForReload && this.props.labReadyForReload) {
-      // Only load if the current app is music or we are on the Incubator page.
-      if (this.props.appName === 'music' || this.props.inIncubator) {
-        // Load and initialize the library and player if not done already.
-        // Read the library name first from level data, or from the project
-        // sources if not present on the level. If there is no library name
-        // specified on the level or sources, we will fallback to loading the
-        // default library.
-        let libraryName = this.props.levelData?.library;
-        if (!libraryName && this.props.sources?.labConfig?.music) {
-          libraryName = this.props.sources.labConfig.music.library;
-        }
-        await this.loadAndInitializePlayer(libraryName);
+    // Update components with new level data and new initial sources when
+    // the level changes.
+    if (
+      (!isEqual(prevProps.levelData, this.props.levelData) ||
+        !isEqual(prevProps.initialSources, this.props.initialSources)) &&
+      (this.props.appName === 'music' || this.props.inIncubator)
+    ) {
+      this.onLevelLoad(this.props.levelData, this.props.initialSources);
+    }
+  }
 
-        this.musicBlocklyWorkspace.init(
-          document.getElementById('blockly-div'),
-          this.onBlockSpaceChange,
-          this.props.isReadOnlyWorkspace
-        );
+  async onLevelLoad(levelData, initialSources) {
+    // Load and initialize the library and player if not done already.
+    // Read the library name first from level data, or from the project
+    // sources if not present on the level. If there is no library name
+    // specified on the level or sources, we will fallback to loading the
+    // default library.
+    let libraryName = levelData?.library;
+    if (!libraryName && initialSources?.labConfig?.music) {
+      libraryName = initialSources.labConfig.music.library;
+    }
+    await this.loadAndInitializePlayer(libraryName);
 
-        if (this.getStartSources() || this.props.sources) {
-          let codeToLoad = this.getStartSources();
-          if (this.props.sources?.source) {
-            codeToLoad = JSON.parse(this.props.sources.source);
-          }
-          this.loadCode(codeToLoad);
-        }
+    this.musicBlocklyWorkspace.init(
+      document.getElementById('blockly-div'),
+      this.onBlockSpaceChange,
+      this.props.isReadOnlyWorkspace
+    );
 
-        // Update components with level-specific data
-        if (this.props.levelData) {
-          this.musicBlocklyWorkspace.updateToolbox(
-            this.props.levelData.toolbox
-          );
-          this.library.setAllowedSounds(this.props.levelData.sounds);
-          this.props.setShowInstructions(!!this.props.levelData.text);
-        }
+    this.musicBlocklyWorkspace.updateToolbox(levelData?.toolbox);
+    this.library.setAllowedSounds(levelData?.sounds);
+    this.props.setShowInstructions(!!levelData?.text);
+
+    if (this.getStartSources() || initialSources) {
+      let codeToLoad = this.getStartSources();
+      if (initialSources?.source) {
+        codeToLoad = JSON.parse(initialSources.source);
       }
-
-      this.props.setLabReadyForReload(false);
+      this.loadCode(codeToLoad);
     }
   }
 
@@ -710,7 +713,7 @@ const MusicView = connect(
     isHeadersShowing: state.music.isHeadersShowing,
     currentScriptId: state.progress.scriptId,
     currentlyPlayingBlockIds: getCurrentlyPlayingBlockIds(state),
-    sources: state.lab.sources,
+    initialSources: state.lab.initialSources,
     levelData: state.lab.levelData,
     labReadyForReload: state.lab.labReadyForReload,
     isReadOnlyWorkspace: isReadOnlyWorkspace(state),

--- a/apps/src/music/views/ProjectBeats.tsx
+++ b/apps/src/music/views/ProjectBeats.tsx
@@ -32,9 +32,11 @@ export default ProjectBeats;
 // Defers loading MusicView until the channel has been loaded. This ensures
 // that all project data has been loaded before mounting MusicView.
 const DeferredMusicView: React.FunctionComponent = () => {
-  const channel = useSelector((state: {lab: LabState}) => state.lab.channel);
+  const channelLoaded = useSelector(
+    (state: {lab: LabState}) => !!state.lab.channel
+  );
 
-  if (!channel) {
+  if (!channelLoaded) {
     return null;
   }
 

--- a/apps/src/music/views/ProjectBeats.tsx
+++ b/apps/src/music/views/ProjectBeats.tsx
@@ -1,9 +1,10 @@
+import {LabState} from '@cdo/apps/lab2/lab2Redux';
 import ProjectContainer from '@cdo/apps/lab2/projects/ProjectContainer';
 import Lab2Wrapper from '@cdo/apps/lab2/views/Lab2Wrapper';
 import MetricsAdapter from '@cdo/apps/lab2/views/MetricsAdapter';
 import {getStore} from '@cdo/apps/redux';
 import React from 'react';
-import {Provider} from 'react-redux';
+import {Provider, useSelector} from 'react-redux';
 import MusicView from './MusicView';
 
 /**
@@ -19,7 +20,7 @@ const ProjectBeats: React.FunctionComponent<{channelId: string}> = ({
       <Lab2Wrapper>
         <MetricsAdapter />
         <ProjectContainer channelId={channelId}>
-          <MusicView inIncubator={true} />
+          <DeferredMusicView />
         </ProjectContainer>
       </Lab2Wrapper>
     </Provider>
@@ -27,3 +28,15 @@ const ProjectBeats: React.FunctionComponent<{channelId: string}> = ({
 };
 
 export default ProjectBeats;
+
+// Defers loading MusicView until the channel has been loaded. This ensures
+// that all project data has been loaded before mounting MusicView.
+const DeferredMusicView: React.FunctionComponent = () => {
+  const channel = useSelector((state: {lab: LabState}) => state.lab.channel);
+
+  if (!channel) {
+    return null;
+  }
+
+  return <MusicView inIncubator={true} />;
+};

--- a/apps/src/standaloneVideo/StandaloneVideo.tsx
+++ b/apps/src/standaloneVideo/StandaloneVideo.tsx
@@ -5,7 +5,7 @@
 // they will get an older-style level implemented with a HAML page and some
 // non-React JS code.
 
-import React from 'react';
+import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import Video from './Video';
@@ -20,9 +20,22 @@ import styles from './video.module.scss';
 
 const StandaloneVideo: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
-  const levelVideo: VideoLevelData = useSelector(
+  const levelData = useSelector(
     (state: {lab: LabState}) => state.lab.levelData
-  ) as VideoLevelData;
+  );
+  const currentAppName = useSelector(
+    (state: {lab: LabState}) => state.lab.appName
+  );
+
+  const [levelVideo, setLevelVideo] = React.useState<VideoLevelData | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (currentAppName === 'standalone_video' && levelData) {
+      setLevelVideo(levelData as VideoLevelData);
+    }
+  }, [currentAppName, levelData]);
 
   const nextButtonPressed = () => {
     const appType = 'standalone_video';


### PR DESCRIPTION
Last bit of refactoring around lab loading and removing the labReadyForReload flag, as discussed a bit in this [thread](https://codedotorg.slack.com/archives/C044AGTKW3D/p1689204256395099).

Changes here are:
- Removal of the labReadyForReload flag
- Lab sources in lab2redux have been renamed initialSources, meant to represent the state of the initial sources fetched from the server on level load.
- On level change, after all level and project data has been loaded, the level data, initial sources, and app name are all updated at once via one redux action. This means that labs receive these updates in the same update pass and only receive them once all level/project loading is complete.

Some background: the main motivation for doing this is just to establish a clear pattern for newer labs as we start onboarding more labs into Lab2. In its current state, everything does work fine; but this just happens to work because Music Lab and Standalone Video have no common level data fields, and are both rendered at the same time. However, since Standalone Video doesn't manually reset the labReadyForReload flag, we could have ended up in some out of sync state, especially if we deferred rendering Music Lab. We discussed how it would be ideal for labs to manage as little state themselves as possible, so with this change the idea is that labs just need to listen for initial sources and/or level data updates and process them accordingly. Since these are only updated once per level change, and within the same redux action, labs should be able to just trust that whenever they receive updates, they are safe to process and overwrite any current state.

## Testing story

Tested locally in all the things (script levels with Music and Standalone Video), single levels for Music and Standalone Video, Music Lab standalone, and Project Beats.