### PR TITLE
Sort i18n JSON props during sync-out

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -262,8 +262,7 @@ def sort_and_sanitize(hash)
   hash.sort_by {|key, _| key}.each_with_object({}) do |(key, value), result|
     case value
     when Hash
-      sorted_value = sort_and_sanitize(value)
-      result[key] = sorted_value unless sorted_value.nil? || sorted_value.empty?
+      result[key] = sort_and_sanitize(value) unless sorted_value.empty?
     when Array
       result[key] = value.filter_map {|v| v.is_a?(Hash) ? sort_and_sanitize(v) : v}
     when String

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -39,7 +39,7 @@ def sync_out(upload_manifests=false)
   I18nScriptUtils.with_synchronous_stdout do
     I18nScriptUtils.run_standalone_script "dashboard/scripts/update_tts_i18n_static_messages.rb"
   end
-  clean_up_sync_out(CROWDIN_TEST_PROJECTS)
+  clean_up_sync_out(CROWDIN_PROJECTS)
   puts "Sync out completed successfully"
 rescue => exception
   puts "Sync out failed from the error: #{exception}"
@@ -80,7 +80,7 @@ end
 #  "/dashboard/base.yml", "/blockly-mooc/maze.json",
 #  "/course_content/2018/coursea-2018.json", etc.
 def file_changed?(locale, file)
-  @change_datas ||= CROWDIN_TEST_PROJECTS.map do |_project_identifier, project_options|
+  @change_datas ||= CROWDIN_PROJECTS.map do |_project_identifier, project_options|
     unless File.exist?(project_options[:files_to_sync_out_json])
       raise <<~ERR
         File not found #{project_options[:files_to_sync_out_json]}.
@@ -393,7 +393,6 @@ def distribute_translations(upload_manifests)
     locale = prop[:locale_s]
     locale_dir = File.join("i18n/locales", locale)
     next if locale == 'en-US'
-    next unless %w[es-ES es-MX].include?(locale)
     next unless File.directory?(locale_dir)
 
     ### Dashboard

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -260,12 +260,13 @@ end
 
 def sort_and_sanitize(hash)
   hash.sort_by {|key, _| key}.each_with_object({}) do |(key, value), result|
-    if value.is_a? Hash
+    case value
+    when Hash
       sorted_value = sort_and_sanitize(value)
       result[key] = sorted_value unless sorted_value.nil? || sorted_value.empty?
-    elsif value.is_a? Array
+    when Array
       result[key] = value.filter_map {|v| v.is_a?(Hash) ? sort_and_sanitize(v) : v}
-    elsif value.is_a? String
+    when String
       result[key] = value.gsub(/\\r/, "\r")
     else
       result[key] = value unless value.nil?


### PR DESCRIPTION
After the Ruby 3.0.5 upgrade, the sync-out created a very large PR because the JSON props for synced-out files were re-ordered. This adds a new function to sort the keys in the translations hash first before writing the JSON.

Since a function was already present that iterates the hash to sanitize certain strings and remove nil values, I added that logic into the sort function so that we do not need to traverse the hash an extra time.

## Links
[JIRA ticket](https://codedotorg.atlassian.net/browse/P20-304)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
