### PR TITLE
Music/Lab2: make error log structure more consistent

### DIFF
--- a/apps/src/lab2/Lab2MetricsReporter.ts
+++ b/apps/src/lab2/Lab2MetricsReporter.ts
@@ -35,10 +35,11 @@ class Lab2MetricsReporter {
     MetricsReporter.logWarning(this.decorateMessage(message));
   }
 
-  public logError(errorMessage: string | object, error?: Error) {
+  public logError(errorMessage: string, error?: Error, details?: object) {
     const message = {
       errorMessage,
       error: error?.stack || error?.message,
+      details,
     };
     MetricsReporter.logError(this.decorateMessage(message));
   }

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -45,6 +45,7 @@ export interface LabState {
     | {
         errorMessage: string;
         error?: Error;
+        details?: object;
       }
     | undefined;
   // channel for the current project, or undefined if there is no current project.
@@ -213,6 +214,7 @@ const labSlice = createSlice({
       action: PayloadAction<{
         errorMessage: string;
         error?: Error;
+        details?: object;
       }>
     ) {
       state.pageError = action.payload;

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -32,10 +32,9 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
     <ErrorBoundary
       fallback={<ErrorFallbackPage />}
       onError={(error, componentStack) =>
-        Lab2MetricsReporter.logError(
-          {name: 'Uncaught React Error', componentStack},
-          error
-        )
+        Lab2MetricsReporter.logError('Uncaught React Error', error, {
+          componentStack,
+        })
       }
     >
       <div

--- a/apps/src/lab2/views/MetricsAdapter.tsx
+++ b/apps/src/lab2/views/MetricsAdapter.tsx
@@ -44,7 +44,11 @@ const MetricsAdapter: React.FunctionComponent = () => {
 
   useEffect(() => {
     if (pageError) {
-      Lab2MetricsReporter.logError(pageError.errorMessage, pageError.error);
+      Lab2MetricsReporter.logError(
+        pageError.errorMessage,
+        pageError.error,
+        pageError.details
+      );
     }
   }, [pageError]);
 

--- a/apps/src/music/player/soundSub.js
+++ b/apps/src/music/player/soundSub.js
@@ -84,18 +84,12 @@ WebAudio.prototype.LoadSound = function (url, callback, onLoadFinished) {
           onLoadFinished();
         },
         function (e) {
-          Lab2MetricsReporter.logError(
-            {name: 'Error decoding audio data', url: url},
-            e
-          );
+          Lab2MetricsReporter.logError('Error decoding audio data', e, {url});
           onLoadFinished();
         }
       );
     } catch (e) {
-      Lab2MetricsReporter.logError(
-        {name: 'Error decoding audio data', url: url},
-        e
-      );
+      Lab2MetricsReporter.logError('Error decoding audio data', e, {url});
       onLoadFinished();
     }
   };

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -268,7 +268,11 @@ class UnconnectedMusicView extends React.Component {
     try {
       this.library = await loadLibrary(libraryName);
     } catch (error) {
-      this.props.setPageError({errorMessage: 'Error loading library', error});
+      this.props.setPageError({
+        errorMessage: 'Error loading library',
+        error,
+        details: {libraryName},
+      });
       return;
     }
 
@@ -287,6 +291,7 @@ class UnconnectedMusicView extends React.Component {
       this.props.setPageError({
         errorMessage: 'Error initializing music player',
         error,
+        details: {libraryName},
       });
       return;
     }

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -271,7 +271,7 @@ class UnconnectedMusicView extends React.Component {
       this.props.setPageError({
         errorMessage: 'Error loading library',
         error,
-        details: {libraryName},
+        details: {libraryName: libraryName || 'default'},
       });
       return;
     }
@@ -291,7 +291,7 @@ class UnconnectedMusicView extends React.Component {
       this.props.setPageError({
         errorMessage: 'Error initializing music player',
         error,
-        details: {libraryName},
+        details: {libraryName: libraryName || 'default'},
       });
       return;
     }


### PR DESCRIPTION
A bit of standardization for the structure of error logs in Lab2 metrics reporting. Previously, we were allowing the errorMessage field to be either a string or a plain object, which made it more difficult to group by error message and search for the right field. With this change, errorMessage must be a string, and we can provide an optional details object with additional context. This way we can more clearly bucketize by errorMessage and know which keys to look for.

Example log ("errorMessage" is a general descriptor, and "details" has additional context, in this case the URL):

<img width="1061" alt="Screenshot 2023-07-17 at 2 51 13 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/4d18e456-255f-4a3e-bdd1-a2dc4969166d">


## Links

https://codedotorg.atlassian.net/browse/SL-986

## Testing story

Tested locally by posting metrics to the dev log stream.