### PR TITLE
Update privacy links in CPA emails

### DIFF
--- a/dashboard/app/views/parent_mailer/parent_permission_confirmation.html.haml
+++ b/dashboard/app/views/parent_mailer/parent_permission_confirmation.html.haml
@@ -5,7 +5,7 @@
   Thank you for approving your child's use of a Code.org® account (or adding a personal login to an existing Code.org account used in school).  By approving your child's account, you agree to the Code.org
   %a{href:"https://code.org/tos"}Terms of Service
   and
-  %a{href:"https://code.org/privacy"}Privacy Policy.
+  %a{href:"https://code.org/privacy-nov2021#protecting-childrens-privacy"}Privacy Policy.
 
 %p
   You can revoke your consent at any time by emailing us at
@@ -17,7 +17,7 @@
 
 %p
   We do not sell data or exploit it for financial gain. We do not sell ads.  We do not store student email addresses in a retrievable format.  For more information on Code.org accounts for children under 13 years old, please see our <u>Children's Privacy Notice</u>, which is part of our full
-  %a{href:"https://code.org/privacy"}Privacy Policy.
+  %a{href:"https://code.org/privacy-nov2021#protecting-childrens-privacy"}Privacy Policy.
 
 %p
   Thank you for allowing your child to learn with us.

--- a/dashboard/app/views/parent_mailer/parent_permission_reminder.html.haml
+++ b/dashboard/app/views/parent_mailer/parent_permission_reminder.html.haml
@@ -15,13 +15,13 @@
 
 %p
   We do not sell data or exploit it for financial gain. We do not sell ads.  We do not store student email addresses in a retrievable format.  For more information on Code.org accounts for children under 13 years old, please see our <u>Children's Privacy Notice</u>, which is part of our full
-  %a{href:"https://code.org/privacy"}Privacy Policy.
+  %a{href:"https://code.org/privacy-nov2021#protecting-childrens-privacy"}Privacy Policy.
 
 %p
   By approving your child's account, you agree to the Code.org
   %a{href:"https://code.org/tos"}Terms of Service
   and
-  %a{href:"https://code.org/privacy"}Privacy Policy.
+  %a{href:"https://code.org/privacy-nov2021#protecting-childrens-privacy"}Privacy Policy.
   You may withdraw your consent and delete the child's account at any time by contacting us at
   %a{href:"mailto:support@code.org"}support@code.org
   from your email address receiving this notice.  Your email address will not be used or disclosed by Code.org for any other purpose unless you provide a separate consent.

--- a/dashboard/app/views/parent_mailer/parent_permission_request.html.haml
+++ b/dashboard/app/views/parent_mailer/parent_permission_request.html.haml
@@ -12,13 +12,13 @@
 
 %p
   We do not sell data or exploit it for financial gain. We do not sell ads.  We do not store student email addresses in a retrievable format.  For more information on Code.org accounts for children under 13 years old, please see our <u>Children's Privacy Notice</u>, which is part of our full
-  %a{href:"https://code.org/privacy"}Privacy Policy.
+  %a{href:"https://code.org/privacy-nov2021#protecting-childrens-privacy"}Privacy Policy.
 
 %p
   By approving your child's account, you agree to the Code.org
   %a{href:"https://code.org/tos"}Terms of Service
   and
-  %a{href:"https://code.org/privacy"}Privacy Policy.
+  %a{href:"https://code.org/privacy-nov2021#protecting-childrens-privacy"}Privacy Policy.
   You may withdraw your consent and delete the child's account at any time by contacting us at
   %a{href:"mailto:support@code.org"}support@code.org
   from your email address receiving this notice.  Your email address will not be used or disclosed by Code.org for any other purpose unless you provide a separate consent.


### PR DESCRIPTION
The original CPA emails contained outdated links to the privacy policy. This changes the links to point to the "protecting children's privacy" section of the nov2021 revised policy.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[JIRA ticket](https://codedotorg.atlassian.net/browse/P20-297)
[Google doc discussion](https://docs.google.com/document/d/1Ml15JK6mcZBHgiBRc-Cpj11yZ53Gu8gD2tnNLVwfzGM/edit?disco=AAAA0crvlGY)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
