### PR TITLE
Fix Forward: Fix Database Client Configuration Settings

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -515,9 +515,9 @@ redshift_password:
 devinternal_db_writer: !Secret
 
 # Until we have a better configuration setting service, use AWS Secrets Manager to store these non-secret values.
-db_cluster_id: !StackSecret
-db_proxy_reporting_endpoint: !StackSecret
-db_writer_endpoint: !StackSecret
+db_cluster_id: !Secret
+db_proxy_reporting_endpoint: !Secret
+db_writer_endpoint: !Secret
 # FOLLOW ON: Transition from the above naming convention to the `db_endpoint_[type]` convention below.
 db_endpoint_writer: PLACEHOLDER
 db_endpoint_proxy_writer: PLACEHOLDER
@@ -526,13 +526,13 @@ db_endpoint_proxy_reporting: PLACEHOLDER
 
 # Database credentials (username & password) are stored in an AWS Secret in a JSON format required by RDS Proxy:
 # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-setup.html#rds-proxy-secrets-arns
-db_credential_admin: !StackSecret
+db_credential_admin: {"username":"PLACEHOLDER", "password":"PLACEHOLDER"}
 db_admin_user: master
 db_admin_password: !Secret
-db_credential_writer: !StackSecret
+db_credential_writer: {"username":"PLACEHOLDER", "password":"PLACEHOLDER"}
 db_writer_user: application-writer
 db_writer_password: !Secret
-db_credential_reader: !StackSecret
+db_credential_reader: {"username":"PLACEHOLDER", "password":"PLACEHOLDER"}
 db_reader_user: readonly
 db_reader_password: !Secret
 


### PR DESCRIPTION
Fix Forward for #50253 which can't be applied to existing ("managed") systems because those systems pull the new `CDO` configuration settings and attempt to re-start the Ruby web application servers before updating the CloudFormation template that creates the AWS Secrets used to populate some of those CDO configuration settings. For config settings that are already being used, revert back to populating them from environment-type secrets (`!Secret`) and for config settings not used yet by any code, give them placeholder values.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
