### PR TITLE
Fix Forward: Re-provision old Secrets for Database Configuration

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -131,6 +131,27 @@
       Description: 'Publish RDS Proxy Reporting Endpoint to the application configuration setting CDO.db_proxy_reporting_endpoint'
       Name: !Sub "CfnStack/${AWS::StackName}/db_proxy_reporting_endpoint"
       SecretString: !GetAtt ReportingDBProxyEndpoint.Endpoint
+  # Continue publishing the old Secrets that apply to all deployments with the same environment type
+  # Until the configuration settings cutover in a future change from `!Secret` to the `!StackSecret` created above.
+  DEPRECATEDDBClusterIDConfig:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: 'Publish Database Cluster ID to application configuration setting CDO.db_cluster_id'
+      Name: '<%=environment%>/cdo/db_cluster_id'
+      SecretString: <%=rack_env?(:production) ? "'#{PRODUCTION_DB_CLUSTER_ID}'" : '!Ref AuroraCluster'%>
+  DEPRECATEDDBWriterEndpointConfig:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: 'Publish Database Cluster Writer Endpoint to application configuration setting CDO.db_writer_endpoint'
+      Name: '<%=environment%>/cdo/db_writer_endpoint'
+      # Publish a placeholder string for production. We set the value of the Secret manually in production.
+      SecretString: <%=rack_env?(:production) ? 'PLACEHOLDER' : '!GetAtt AuroraCluster.Endpoint.Address'%>
+  DEPRECATEDDBProxyReportingEndpointConfig:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: 'Publish RDS Proxy Reporting Endpoint to the application configuration setting CDO.db_proxy_reporting_endpoint'
+      Name: '<%=environment%>/cdo/db_proxy_reporting_endpoint'
+      SecretString: !GetAtt ReportingDBProxyEndpoint.Endpoint
 
 # We don't provision these in production via CloudFormation ... yet!
 <% unless rack_env?(:production)%>


### PR DESCRIPTION
Fix forward for #52853 which was a fix forward for #50253 

There was a circular dependency between the `CDO.` configuration settings that had switched to using the new `!StackSecret` and the CloudFormation template changes to create those new Stack-specific secrets.

Staging and Test both have the new Stack Specific Secrets now, and no longer have the environment-type secrets, but three  `CDO.` entries are expecting the old Secrets to still be there. Re-create those old Secrets.


## Testing story

`bundle exec rake stack:validate RAILS_ENV=adhoc VERBOSE=yup DATABASE=YeahWeNeedRDS`

## Deployment strategy

## Follow-up work

Once this change has been deployed to all managed environments, follow up with a change to start using the new `!StackSecret` and delete the deprecated Secrets.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
