### PR TITLE
Seed/serialize rubrics from levelbuilder to other environments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -613,13 +613,14 @@ GEM
       webfinger (>= 1.0.1)
     orm_adapter (0.5.0)
     os (1.1.4)
-    parallel (1.12.1)
+    parallel (1.23.0)
     parallel_tests (2.27.0)
       parallel
     paranoia (2.5.3)
       activerecord (>= 5.1, < 7.1)
-    parser (3.1.2.0)
+    parser (3.2.2.3)
       ast (~> 2.4.1)
+      racc
     pdf-reader (2.9.2)
       Ascii85 (~> 1.0)
       afm (~> 0.2.1)
@@ -695,7 +696,7 @@ GEM
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     raindrops (0.20.0)
     rake (12.3.3)
     rambling-trie (2.3.1)
@@ -707,7 +708,7 @@ GEM
       json
     redcarpet (3.5.1)
     redis (3.3.3)
-    regexp_parser (2.4.0)
+    regexp_parser (2.8.1)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -743,17 +744,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (1.28.0)
+    rubocop (1.52.1)
+      json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.2.2.3)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.17.0, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.17.0)
-      parser (>= 3.1.1.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -765,7 +767,7 @@ GEM
       rubocop (>= 1.0.0)
     ruby-openid (2.9.2)
     ruby-prof (0.15.9)
-    ruby-progressbar (1.11.0)
+    ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
     ruby_dig (0.0.2)
@@ -819,7 +821,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.11)
     sshkit (1.20.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -867,7 +868,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
-    unicode-display_width (2.1.0)
+    unicode-display_width (2.4.2)
     unicode_utils (1.4.0)
     uri (0.12.1)
     user_agent_parser (2.3.0)
@@ -1049,7 +1050,7 @@ DEPENDENCIES
   rinku
   rmagick (~> 4.2.5)
   rspec
-  rubocop (= 1.28)
+  rubocop (~> 1.28)
   rubocop-performance
   rubocop-rails
   rubocop-rails-accessibility
@@ -1071,7 +1072,6 @@ DEPENDENCIES
   spring-commands-testunit
   sprockets!
   sprockets-rails (= 3.3.0)
-  sqlite3
   sshkit
   stringex (~> 2.5.2)
   thin

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -613,14 +613,13 @@ GEM
       webfinger (>= 1.0.1)
     orm_adapter (0.5.0)
     os (1.1.4)
-    parallel (1.23.0)
+    parallel (1.12.1)
     parallel_tests (2.27.0)
       parallel
     paranoia (2.5.3)
       activerecord (>= 5.1, < 7.1)
-    parser (3.2.2.3)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
-      racc
     pdf-reader (2.9.2)
       Ascii85 (~> 1.0)
       afm (~> 0.2.1)
@@ -696,7 +695,7 @@ GEM
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
-    rainbow (3.1.1)
+    rainbow (3.0.0)
     raindrops (0.20.0)
     rake (12.3.3)
     rambling-trie (2.3.1)
@@ -708,7 +707,7 @@ GEM
       json
     redcarpet (3.5.1)
     redis (3.3.3)
-    regexp_parser (2.8.1)
+    regexp_parser (2.4.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -744,18 +743,17 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (1.52.1)
-      json (~> 2.3)
+    rubocop (1.28.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.3)
+      parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.29.0)
-      parser (>= 3.2.1.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.17.0)
+      parser (>= 3.1.1.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -767,7 +765,7 @@ GEM
       rubocop (>= 1.0.0)
     ruby-openid (2.9.2)
     ruby-prof (0.15.9)
-    ruby-progressbar (1.13.0)
+    ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
     ruby_dig (0.0.2)
@@ -821,6 +819,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.11)
     sshkit (1.20.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -868,7 +867,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
-    unicode-display_width (2.4.2)
+    unicode-display_width (2.1.0)
     unicode_utils (1.4.0)
     uri (0.12.1)
     user_agent_parser (2.3.0)
@@ -1050,7 +1049,7 @@ DEPENDENCIES
   rinku
   rmagick (~> 4.2.5)
   rspec
-  rubocop (~> 1.28)
+  rubocop (= 1.28)
   rubocop-performance
   rubocop-rails
   rubocop-rails-accessibility
@@ -1072,6 +1071,7 @@ DEPENDENCIES
   spring-commands-testunit
   sprockets!
   sprockets-rails (= 3.3.0)
+  sqlite3
   sshkit
   stringex (~> 2.5.2)
   thin

--- a/dashboard/app/models/learning_goal.rb
+++ b/dashboard/app/models/learning_goal.rb
@@ -19,4 +19,13 @@
 class LearningGoal < ApplicationRecord
   belongs_to :rubric
   has_many :learning_goal_evidence_levels, dependent: :destroy
+
+  def seeding_key(seed_context)
+    my_rubric = seed_context.rubrics.find {|r| r.id == rubric_id}
+    my_key = {
+      key: key
+    }
+    rubric_seeding_key = my_rubric.seeding_key(seed_context)
+    my_key.merge!(rubric_seeding_key) {|key, _, _| raise "Duplicate key when generating seeding_key: #{key}"}
+  end
 end

--- a/dashboard/app/models/learning_goal.rb
+++ b/dashboard/app/models/learning_goal.rb
@@ -23,7 +23,7 @@ class LearningGoal < ApplicationRecord
   def seeding_key(seed_context)
     my_rubric = seed_context.rubrics.find {|r| r.id == rubric_id}
     my_key = {
-      key: key
+      'learning_goal.key': key
     }
     rubric_seeding_key = my_rubric.seeding_key(seed_context)
     my_key.merge!(rubric_seeding_key) {|key, _, _| raise "Duplicate key when generating seeding_key: #{key}"}

--- a/dashboard/app/models/learning_goal_evidence_level.rb
+++ b/dashboard/app/models/learning_goal_evidence_level.rb
@@ -16,4 +16,13 @@
 #
 class LearningGoalEvidenceLevel < ApplicationRecord
   belongs_to :learning_goal
+
+  def seeding_key(seed_context)
+    my_learning_goal = seed_context.learning_goals.find {|lg| lg.id == learning_goal_id}
+    my_key = {
+      understanding: understanding
+    }
+    learning_goal_seeding_key = my_learning_goal.seeding_key(seed_context)
+    my_key.merge!(learning_goal_seeding_key) {|key, _, _| raise "Duplicate key when generating seeding_key: #{key}"}
+  end
 end

--- a/dashboard/app/models/rubric.rb
+++ b/dashboard/app/models/rubric.rb
@@ -16,4 +16,9 @@ class Rubric < ApplicationRecord
   has_many :learning_goals, -> {order(:position)}, dependent: :destroy
   belongs_to :level
   belongs_to :lesson
+
+  def seeding_key(seed_context)
+    my_lesson = seed_context.lessons.find {|l| l.id == lesson_id}
+    my_lesson.seeding_key(seed_context)
+  end
 end

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -122,6 +122,7 @@ class Unit < ApplicationRecord
             :vocabularies,
             :programming_expressions,
             :objectives,
+            {rubric: {learning_goals: :learning_goal_evidence_levels}},
             :standards,
             :opportunity_standards
           ]

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -21,7 +21,7 @@ module Services
       :resources, :lessons_resources, :scripts_resources, :scripts_student_resources,
       :vocabularies, :lessons_vocabularies, :programming_environments,
       :programming_expressions, :lessons_programming_expressions, :objectives, :frameworks,
-      :standards, :lessons_standards, :lessons_opportunity_standards, keyword_init: true
+      :standards, :lessons_standards, :lessons_opportunity_standards, :rubrics, :learning_goals, :learning_goal_evidence_levels, keyword_init: true
     )
 
     # Produces a JSON representation of the given Unit and all objects under it in its "tree", in a format specifically
@@ -72,6 +72,10 @@ module Services
 
       objectives = script.lessons.map(&:objectives).flatten.sort_by(&:key)
 
+      rubrics = script.lessons.map(&:rubric).flatten
+      learning_goals = rubrics.map(&:learning_goals).flatten.sort_by(&:key)
+      learning_goal_evidence_levels = learning_goals.map(&:learning_goal_evidence_levels).flatten.sort_by(&:understanding)
+
       seed_context = SeedContext.new(
         script: script,
         lesson_groups: script.lesson_groups,
@@ -94,7 +98,9 @@ module Services
         frameworks: frameworks,
         standards: standards,
         lessons_standards: lessons_standards,
-        lessons_opportunity_standards: lessons_opportunity_standards
+        lessons_opportunity_standards: lessons_opportunity_standards,
+        rubrics: rubrics,
+        learning_goals: learning_goals
       )
       scope = {seed_context: seed_context}
 
@@ -116,6 +122,9 @@ module Services
         objectives: objectives.map {|o| ScriptSeed::ObjectiveSerializer.new(o, scope: scope).as_json},
         lessons_standards: lessons_standards.map {|ls| ScriptSeed::LessonsStandardSerializer.new(ls, scope: scope).as_json},
         lessons_opportunity_standards: lessons_opportunity_standards.map {|ls| ScriptSeed::LessonsOpportunityStandardSerializer.new(ls, scope: scope).as_json},
+        rubrics: rubrics.map {|r| ScriptSeed::RubricSerializer.new(r, scope: scope).as_json},
+        learning_goals: learning_goals.map {|lg| ScriptSeed::LearningGoalSerializer.new(lg, scope: scope).as_json},
+        learning_goal_evidence_levels: learning_goal_evidence_levels.map {|lgel| ScriptSeed::LearningGoalEvidenceLevelSerializer.new(lgel, scope: scope).as_json},
       }
       JSON.pretty_generate(data) + "\n"
     end
@@ -197,6 +206,9 @@ module Services
       objectives_data = data['objectives']
       lessons_standards_data = data['lessons_standards'] || []
       lessons_opportunity_standards_data = data['lessons_opportunity_standards'] || []
+      rubrics_data = data['rubrics'] || []
+      learning_goals_data = data['learning_goals'] || []
+      learning_goals_evidence_levels_data = data['learning_goal_evidence_levels'] || []
       seed_context = SeedContext.new
 
       Unit.transaction do
@@ -244,6 +256,10 @@ module Services
         seed_context.standards = Standard.all
         seed_context.lessons_standards = import_lessons_standards(lessons_standards_data, seed_context)
         seed_context.lessons_opportunity_standards = import_lessons_opportunity_standards(lessons_opportunity_standards_data, seed_context)
+
+        seed_context.rubrics = import_rubrics(rubrics_data, seed_context)
+        seed_context.learning_goals = import_learning_goals(learning_goals_data, seed_context)
+        seed_context.learning_goal_evidence_levels = import_learning_goals_evidence_levels(learning_goals_evidence_levels_data, seed_context)
 
         # generate_plc_objects must be run after lessons are added.
         seed_context.script.generate_plc_objects
@@ -671,6 +687,57 @@ module Services
       LessonsOpportunityStandard.joins(:lesson).where('stages.script_id' => seed_context.script.id)
     end
 
+    def self.import_rubrics(rubrics_data, seed_context)
+      rubrics_to_import = rubrics_data.map do |rubric_data|
+        lesson = seed_context.lessons.find {|l| l.key == rubric_data['seeding_key']['lesson.key']}
+        raise 'No lesson found' if lesson.nil?
+
+        level = lesson.levels.find {|l| l.name == rubric_data['level_name']}
+
+        rubric_attrs = rubric_data.except('seeding_key', 'level_name')
+        rubric_attrs['lesson_id'] = lesson.id
+        rubric_attrs['level_id'] = level&.id if level
+        Rubric.new(rubric_attrs)
+      end
+
+      existing_rubrics = Rubric.joins(:lesson).where('stages.script_id' => seed_context.script.id)
+      destroy_outdated_objects(Rubric, existing_rubrics, rubrics_to_import, seed_context)
+      Rubric.import! rubrics_to_import, on_duplicate_key_update: get_columns(Rubric)
+      Rubric.joins(:lesson).where('stages.script_id' => seed_context.script.id)
+    end
+
+    def self.import_learning_goals(learning_goals_data, seed_context)
+      learning_goals_to_import = learning_goals_data.map do |learning_goal_data|
+        rubric = seed_context.lessons.find {|l| l.key == learning_goal_data['seeding_key']['lesson.key']}.rubric
+        raise 'No rubric found' if rubric.nil?
+
+        learning_goal_attrs = learning_goal_data.except('seeding_key')
+        learning_goal_attrs['rubric_id'] = rubric.id
+        LearningGoal.new(learning_goal_attrs)
+      end
+
+      existing_learning_goals = LearningGoal.joins(:rubric).where('rubrics.lesson_id' => seed_context.lessons.pluck(:id))
+      destroy_outdated_objects(LearningGoal, existing_learning_goals, learning_goals_to_import, seed_context)
+      LearningGoal.import! learning_goals_to_import, on_duplicate_key_update: get_columns(LearningGoal)
+      LearningGoal.joins(:rubric).where('rubrics.lesson_id' => seed_context.lessons.pluck(:id))
+    end
+
+    def self.import_learning_goals_evidence_levels(learning_goal_evidence_levels_data, seed_context)
+      learning_goals_evidence_levels_to_import = learning_goal_evidence_levels_data.map do |learning_goal_evidence_level_data|
+        learning_goal = seed_context.learning_goals.find {|lg| lg.key == learning_goal_evidence_level_data['seeding_key']['learning_goal.key']}
+        raise 'No learning goal found' if learning_goal.nil?
+
+        learning_goal_evidence_level_attrs = learning_goal_evidence_level_data.except('seeding_key')
+        learning_goal_evidence_level_attrs['learning_goal_id'] = learning_goal.id
+        LearningGoalEvidenceLevel.new(learning_goal_evidence_level_attrs)
+      end
+
+      existing_learning_goals_evidence_levels = LearningGoalEvidenceLevel.joins(:learning_goal).where('learning_goals.rubric_id' => seed_context.rubrics.pluck(:id))
+      destroy_outdated_objects(LearningGoalEvidenceLevel, existing_learning_goals_evidence_levels, learning_goals_evidence_levels_to_import, seed_context)
+      LearningGoalEvidenceLevel.import! learning_goals_evidence_levels_to_import, on_duplicate_key_update: get_columns(LearningGoalEvidenceLevel)
+      LearningGoalEvidenceLevel.joins(:learning_goal).where('learning_goals.rubric_id' => seed_context.rubrics.pluck(:id))
+    end
+
     def self.destroy_outdated_objects(model_class, all_objects, imported_objects, seed_context)
       objects_to_keep_by_seeding_key = imported_objects.index_by {|o| o.seeding_key(seed_context)}
       should_keep = all_objects.group_by {|o| objects_to_keep_by_seeding_key.include?(o.seeding_key(seed_context))}
@@ -910,6 +977,34 @@ module Services
 
     class LessonsOpportunityStandardSerializer < ActiveModel::Serializer
       attributes :seeding_key
+
+      def seeding_key
+        object.seeding_key(@scope[:seed_context])
+      end
+    end
+
+    class RubricSerializer < ActiveModel::Serializer
+      attributes :level_name, :seeding_key
+
+      def level_name
+        object.level&.name
+      end
+
+      def seeding_key
+        object.seeding_key(@scope[:seed_context])
+      end
+    end
+
+    class LearningGoalSerializer < ActiveModel::Serializer
+      attributes :key, :position, :learning_goal, :ai_enabled, :tips, :seeding_key
+
+      def seeding_key
+        object.seeding_key(@scope[:seed_context])
+      end
+    end
+
+    class LearningGoalEvidenceLevelSerializer < ActiveModel::Serializer
+      attributes :understanding, :teacher_description, :ai_prompt, :seeding_key
 
       def seeding_key
         object.seeding_key(@scope[:seed_context])

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -54,6 +54,7 @@ module Services
       # in a manner that will be stable across environments.
       sort_context = SeedContext.new(
         script: script,
+        lesson_groups: script.lesson_groups,
         lessons: script.lessons,
         resources: resources,
         frameworks: frameworks,
@@ -72,7 +73,7 @@ module Services
 
       objectives = script.lessons.map(&:objectives).flatten.sort_by(&:key)
 
-      rubrics = script.lessons.map(&:rubric).flatten
+      rubrics = script.lessons.filter_map(&:rubric).sort_by {|r| r.seeding_key(sort_context).to_json}
       learning_goals = rubrics.map(&:learning_goals).flatten.sort_by(&:key)
       learning_goal_evidence_levels = learning_goals.map(&:learning_goal_evidence_levels).flatten.sort_by(&:understanding)
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1761,6 +1761,7 @@ FactoryBot.define do
 
   factory :rubric do
     association :lesson
+    association :level
   end
 
   factory :learning_goal do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1758,4 +1758,21 @@ FactoryBot.define do
       user {create :young_student, :with_parent_permission}
     end
   end
+
+  factory :rubric do
+    association :lesson
+  end
+
+  factory :learning_goal do
+    sequence(:key) {|n| "lg_#{n}"}
+    position {0}
+    learning_goal {"Test Learning Goal"}
+    ai_enabled {false}
+  end
+
+  factory :learning_goal_evidence_level do
+    association :learning_goal
+    understanding {0}
+    teacher_description {"Description for teacher"}
+  end
 end

--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -1055,5 +1055,101 @@
         "opportunity_standard.shortcode": "test-serialize-seeding-json-lg-1-l-2-opportunity-standard-2"
       }
     }
+  ],
+  "rubrics": [
+    {
+      "level_name": "test-serialize-seeding-json_blockly_1",
+      "seeding_key": {
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
+        "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
+        "script.name": "test-serialize-seeding-json-script"
+      }
+    },
+    {
+      "level_name": "test-serialize-seeding-json_blockly_9",
+      "seeding_key": {
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
+        "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
+        "script.name": "test-serialize-seeding-json-script"
+      }
+    }
+  ],
+  "learning_goals": [
+    {
+      "key": "test-serialize-seeding-json-lg-1-l-1-learning-goal-1",
+      "position": 0,
+      "learning_goal": "Test Learning Goal",
+      "ai_enabled": false,
+      "tips": null,
+      "seeding_key": {
+        "learning_goal.key": "test-serialize-seeding-json-lg-1-l-1-learning-goal-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
+        "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
+        "script.name": "test-serialize-seeding-json-script"
+      }
+    },
+    {
+      "key": "test-serialize-seeding-json-lg-1-l-2-learning-goal-1",
+      "position": 0,
+      "learning_goal": "Test Learning Goal",
+      "ai_enabled": false,
+      "tips": null,
+      "seeding_key": {
+        "learning_goal.key": "test-serialize-seeding-json-lg-1-l-2-learning-goal-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
+        "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
+        "script.name": "test-serialize-seeding-json-script"
+      }
+    }
+  ],
+  "learning_goal_evidence_levels": [
+    {
+      "understanding": 1,
+      "teacher_description": "Description for teacher",
+      "ai_prompt": null,
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "test-serialize-seeding-json-lg-1-l-1-learning-goal-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
+        "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
+        "script.name": "test-serialize-seeding-json-script"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "Description for teacher",
+      "ai_prompt": null,
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "test-serialize-seeding-json-lg-1-l-2-learning-goal-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
+        "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
+        "script.name": "test-serialize-seeding-json-script"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Description for teacher",
+      "ai_prompt": null,
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "test-serialize-seeding-json-lg-1-l-1-learning-goal-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
+        "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
+        "script.name": "test-serialize-seeding-json-script"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Description for teacher",
+      "ai_prompt": null,
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "test-serialize-seeding-json-lg-1-l-2-learning-goal-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
+        "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
+        "script.name": "test-serialize-seeding-json-script"
+      }
+    }
   ]
 }

--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -1058,7 +1058,7 @@
   ],
   "rubrics": [
     {
-      "level_name": "test-serialize-seeding-json_blockly_1",
+      "level_name": "test-serialize-seeding-json_blockly_8",
       "seeding_key": {
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -1066,7 +1066,7 @@
       }
     },
     {
-      "level_name": "test-serialize-seeding-json_blockly_9",
+      "level_name": "test-serialize-seeding-json_blockly_16",
       "seeding_key": {
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -68,7 +68,7 @@ module Services
       #   4 queries to set up course offering and course version
       #   34 queries - two for each model, + one extra query each for Lessons,
       #     LessonActivities, ActivitySections, ScriptLevels, LevelsScriptLevels,
-      #     Resources, and Vocabulary.
+      #     Resources, Vocabulary, Rubric, LearningGoal, and LearningGoalEvidenceLevel.
       #     These 2-3 queries per model are to (1) delete old entries, (2) import
       #     new/updated entries, and then (3) fetch the result for use by the next
       #     layer down in the hierarchy.

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -1545,7 +1545,7 @@ module Services
 
         next if lesson.levels.empty?
         (1..num_rubrics_per_lesson).each do |_r|
-          rubric = create :rubric, lesson: lesson, level: lesson.levels.first
+          rubric = create :rubric, lesson: lesson, level: lesson.levels.last
           (1..num_learning_goals_per_rubric).each do |lg|
             learning_goal = create :learning_goal, rubric: rubric, key: "#{lesson.name}-learning-goal-#{lg}"
             (1..num_learning_goal_evidence_levels_per_learning_goal).each do |lge|


### PR DESCRIPTION
This PR serializes rubrics into script_json files and adds the logic to seed from them as well. My thinking is that rubrics are associated directly with lessons and should be serialized alongside them in those files.

This PR is on the large side but a fair amount of that is boiler plate. You can see what the serialized rubrics will look like in [the test file](https://github.com/code-dot-org/code-dot-org/pull/52864/files#diff-572af6870e7c3d4e07ac7e45f8eb58e36c4018ec9fabf83cfbdfa8cde3c9bccc).

Let me know if this approach doesn't make sense or I should look into another approach! I did consider new config files for these rubrics but realized that I would still be keying off the lesson, in which case I should just add to the script_json files.

This PR doesn't hook write_script_json to be called on rubric save so that will be follow up work, either by me or @kobryan0619 as she works on the edit experience on levelbuilder.

