### PR TITLE
Added Fixed Positioning of filters on curriculum catalog

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -389,58 +389,60 @@ const CurriculumCatalog = ({
           </button>
         </div>
       )}
-      <div className={style.catalogFiltersContainer}>
-        <Heading6 className={style.catalogFiltersRowLabel}>
-          {i18n.filterBy()}
-        </Heading6>
-        {Object.keys(filterTypes).map(filterKey => (
-          <CheckboxDropdown
-            key={filterKey}
-            name={filterKey}
-            label={filterTypes[filterKey].label}
-            allOptions={filterTypes[filterKey].options}
-            checkedOptions={appliedFilters[filterKey]}
-            onChange={e => handleSelect(e, filterKey)}
-            handleSelectAll={() => handleSelectAllOfFilter(filterKey)}
-            handleClearAll={() => handleClearAllOfFilter(filterKey)}
-          />
-        ))}
-        <Button
-          id="clear-filters"
-          className={style.catalogClearFiltersButton}
-          type="button"
-          onClick={handleClear}
-          text={i18n.clearFilters()}
-          styleAsText
-          color={Button.ButtonColor.brandSecondaryDefault}
-        />
-      </div>
-      {!isEnglish && (
-        <div className={style.catalogLanguageFilterRow}>
-          <div className={style.catalogLanguageFilterRowNumAvailable}>
-            <BodyTwoText>
-              {i18n.numCurriculaAvailableInLanguage({
-                numCurricula: numFilteredTranslatedCurricula,
-                language: languageNativeName,
-              })}
-            </BodyTwoText>
-            <FontAwesome
-              icon="language"
-              className="fa-solid"
-              title={i18n.courseInYourLanguage()}
+      <div className={style.fixedFiltersTop}>
+        <div className={style.catalogFiltersContainer}>
+          <Heading6 className={style.catalogFiltersRowLabel}>
+            {i18n.filterBy()}
+          </Heading6>
+          {Object.keys(filterTypes).map(filterKey => (
+            <CheckboxDropdown
+              key={filterKey}
+              name={filterKey}
+              label={filterTypes[filterKey].label}
+              allOptions={filterTypes[filterKey].options}
+              checkedOptions={appliedFilters[filterKey]}
+              onChange={e => handleSelect(e, filterKey)}
+              handleSelectAll={() => handleSelectAllOfFilter(filterKey)}
+              handleClearAll={() => handleClearAllOfFilter(filterKey)}
             />
-          </div>
-          <Toggle
-            name="filterTranslatedToggle"
-            label={i18n.onlyShowCurriculaInLanguage({
-              language: languageNativeName,
-            })}
-            size="m"
-            checked={appliedFilters['translated']}
-            onChange={e => handleToggleLanguageFilter(e.target.checked)}
+          ))}
+          <Button
+            id="clear-filters"
+            className={style.catalogClearFiltersButton}
+            type="button"
+            onClick={handleClear}
+            text={i18n.clearFilters()}
+            styleAsText
+            color={Button.ButtonColor.brandSecondaryDefault}
           />
         </div>
-      )}
+        {!isEnglish && (
+          <div className={style.catalogLanguageFilterRow}>
+            <div className={style.catalogLanguageFilterRowNumAvailable}>
+              <BodyTwoText>
+                {i18n.numCurriculaAvailableInLanguage({
+                  numCurricula: numFilteredTranslatedCurricula,
+                  language: languageNativeName,
+                })}
+              </BodyTwoText>
+              <FontAwesome
+                icon="language"
+                className="fa-solid"
+                title={i18n.courseInYourLanguage()}
+              />
+            </div>
+            <Toggle
+              name="filterTranslatedToggle"
+              label={i18n.onlyShowCurriculaInLanguage({
+                language: languageNativeName,
+              })}
+              size="m"
+              checked={appliedFilters['translated']}
+              onChange={e => handleToggleLanguageFilter(e.target.checked)}
+            />
+          </div>
+        )}
+      </div>
       <div className={style.catalogContentContainer}>
         {renderSearchResults()}
       </div>

--- a/apps/style/code-studio/curriculum_catalog_container.module.scss
+++ b/apps/style/code-studio/curriculum_catalog_container.module.scss
@@ -1,4 +1,4 @@
-@use "color.scss";
+@use 'color.scss';
 
 .catalogFiltersContainer {
   display: flex;
@@ -104,4 +104,11 @@ button.catalogClearFiltersButton {
 .assignSuccessMessage {
   margin: 16px;
   color: color.$bootstrap_success_text;
+}
+
+.fixedFiltersTop {
+  position: sticky;
+  top: 0;
+  background-color: white;
+  padding: 4px 0;
 }

--- a/apps/style/code-studio/curriculum_catalog_container.module.scss
+++ b/apps/style/code-studio/curriculum_catalog_container.module.scss
@@ -112,5 +112,4 @@ button.catalogClearFiltersButton {
   position: sticky;
   top: 0;
   background-color: white;
-  //padding: 1em 0;
 }

--- a/apps/style/code-studio/curriculum_catalog_container.module.scss
+++ b/apps/style/code-studio/curriculum_catalog_container.module.scss
@@ -110,5 +110,4 @@ button.catalogClearFiltersButton {
   position: sticky;
   top: 0;
   background-color: white;
-  padding: 4px 0;
 }

--- a/apps/style/code-studio/curriculum_catalog_container.module.scss
+++ b/apps/style/code-studio/curriculum_catalog_container.module.scss
@@ -5,7 +5,8 @@
   align-items: baseline;
   gap: 16px;
   max-width: 60em;
-  margin: 1em auto;
+  margin: 0 auto;
+  padding: 1em 0;
 
   button {
     margin: 0;
@@ -16,7 +17,8 @@
   display: flex;
   justify-content: space-between;
   max-width: 60em;
-  margin: 1em auto;
+  margin: 0 auto;
+  padding: 0 0 1em 0;
 
   p {
     margin: 1em 0;
@@ -44,7 +46,7 @@ button.catalogClearFiltersButton {
 
 .catalogContentContainer {
   max-width: 60em;
-  margin: 1em auto;
+  margin: 0 auto 1em auto;
 }
 
 .catalogContentCards {
@@ -110,4 +112,5 @@ button.catalogClearFiltersButton {
   position: sticky;
   top: 0;
   background-color: white;
+  //padding: 1em 0;
 }


### PR DESCRIPTION
Filters will stay at the top of the page when scrolling through the curriculum catalog. Language filter will also stick if shown.

### Regular Filters
https://github.com/code-dot-org/code-dot-org/assets/137838584/424b4c0f-9df1-46b7-a62e-eeeb9aa6ba4b


### Regular and Language Filters
https://github.com/code-dot-org/code-dot-org/assets/137838584/f0c82fc4-ca73-484a-a0fb-d85f67912a63




## Links



- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-717)


## Testing story

Local testing







## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
