### PR TITLE
Deflake teacher application dashboard eyes tests: always show RP dropdown

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/summary.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/summary.jsx
@@ -22,7 +22,6 @@ export const removeIncompleteApplications = data =>
 export class Summary extends React.Component {
   static propTypes = {
     regionalPartnerFilter: RegionalPartnerPropType.isRequired,
-    showRegionalPartnerDropdown: PropTypes.bool,
     isWorkshopAdmin: PropTypes.bool,
   };
 
@@ -59,12 +58,9 @@ export class Summary extends React.Component {
     this.abortLoad();
     this.setState({loading: true});
 
-    let url = '/api/v1/pd/applications';
-    if (this.props.showRegionalPartnerDropdown) {
-      url += `?${$.param({
-        regional_partner_value: regionalPartnerFilter.value,
-      })}`;
-    }
+    let url = `/api/v1/pd/applications?${$.param({
+      regional_partner_value: regionalPartnerFilter.value,
+    })}`;
 
     this.loadRequest = $.ajax({
       method: 'GET',
@@ -88,7 +84,7 @@ export class Summary extends React.Component {
       <div>
         <ApplicantSearch />
         {this.props.isWorkshopAdmin && <AdminNavigationButtons />}
-        {this.props.showRegionalPartnerDropdown && <RegionalPartnerDropdown />}
+        <RegionalPartnerDropdown />
         <h1>{this.props.regionalPartnerFilter.label}</h1>
         <Row>
           <Col sm={6}>
@@ -130,7 +126,5 @@ export default connect(state => {
   return {
     regionalPartnerFilter: state.regionalPartners.regionalPartnerFilter,
     isWorkshopAdmin,
-    showRegionalPartnerDropdown:
-      isWorkshopAdmin || state.regionalPartners.regionalPartners.length > 1,
   };
 })(Summary);

--- a/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
@@ -58,16 +58,17 @@ describe('Summary', () => {
   it('Generates 3 tables in 1 rows after hearing from server', () => {
     let server = sinon.fakeServer.create();
 
-    server.respondWith('GET', '/api/v1/pd/applications', [
-      200,
-      {'Content-Type': 'application/json'},
-      JSON.stringify(data),
-    ]);
+    server.respondWith(
+      'GET',
+      '/api/v1/pd/applications?regional_partner_value=1',
+      [200, {'Content-Type': 'application/json'}, JSON.stringify(data)]
+    );
 
     let summary = createSummary();
 
     server.respond();
     summary.update();
+
     const rows = summary.find(Row);
     expect(rows).to.have.length(1);
     expect(rows.at(0).children()).to.have.length(3);


### PR DESCRIPTION
Issue: Eyes tests for teacher application dashboard are flaky as there is a dependency on the number of RPs in the system to either show or hide the RP filtering dropdown. As a result when previous test setup/cleanup fails, it results in the test getting flaky.

Fix: Updating the UI to always show the RP filtering dropdown. In production, the filter will be always visible as we will never be in a state where number of RPs is zero

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

JIRA https://codedotorg.atlassian.net/browse/ACQ-620?atlOrigin=eyJpIjoiYjNhMDU0NDcwMTcwNDU5Zjk2YTgzYzk3ZTU4ZmJkMjkiLCJwIjoiaiJ9

## Testing story

Manually validated in local environment that the drop down shows even when all RPs are deleted from the backend.

## Deployment strategy

Rolls out as part of regular DTP

## Follow-up work

Enable the flaky eyes test once this is rolled out and update baselines as needed

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
