### PR TITLE
Install i18n dependencies only in test env

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -316,7 +316,7 @@ discourse_sso_secret:
 ### Application configuration defaults
 
 # Installs bin/i18n dependencies
-build_i18n: true
+build_i18n: false
 
 i18n_backend:
 cache:

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -34,6 +34,9 @@ stub_school_data: true
 daemon: true
 use_pusher: <%=!ci_test%>
 
+# Install i18n dependencies for i18n tests
+build_i18n: true
+
 # Since channel ids are derived from user id and other sequential integer ids
 # use a new S3 sources directory for each Test Build to prevent a UI test
 # from inadvertently using a channel id from a previous Test Build.


### PR DESCRIPTION
We need to install i18n dependencies for i18n tests.
We run the tests only in drone and the test env, so there is no reason to install them in every envs.
Especially since `npm` isn't available in the production env.