### PR TITLE
Lab2/Music: require app name for labs without level

### DIFF
--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -152,7 +152,7 @@ export const setUpWithLevel = createAsyncThunk(
   }
 );
 
-// Given a channel id as the payload, set up the lab for that channel id.
+// Given a channel id and app name as the payload, set up the lab for that channel id.
 // This consists of cleaning up the existing project manager (if applicable), then
 // creating a project manager and loading the project data.
 // This method is used for loading a lab that is not associated with a level
@@ -160,13 +160,13 @@ export const setUpWithLevel = createAsyncThunk(
 // If we get an aborted signal, we will exit early.
 export const setUpWithoutLevel = createAsyncThunk(
   'lab/setUpWithoutLevel',
-  async (payload: string, thunkAPI) => {
+  async (payload: {channelId: string; appName: AppName}, thunkAPI) => {
     await cleanUpProjectManager();
 
     // Create the new project manager.
     const projectManager = ProjectManagerFactory.getProjectManager(
       ProjectManagerStorageType.REMOTE,
-      payload
+      payload.channelId
     );
     Lab2Registry.getInstance().setProjectManager(projectManager);
 
@@ -176,7 +176,11 @@ export const setUpWithoutLevel = createAsyncThunk(
       thunkAPI.dispatch
     );
     setProjectAndLevelData(
-      {initialSources: sources, channel},
+      {
+        initialSources: sources,
+        channel,
+        levelProperties: {appName: payload.appName},
+      },
       thunkAPI.signal.aborted,
       thunkAPI.dispatch
     );

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -13,10 +13,12 @@ import {getLevelPropertiesPath} from '@cdo/apps/code-studio/progressReduxSelecto
 import {ProgressState} from '@cdo/apps/code-studio/progressRedux';
 import header from '@cdo/apps/code-studio/header';
 import {clearHeader} from '@cdo/apps/code-studio/headerRedux';
+import {AppName} from '../types';
 
 const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
   children,
   channelId,
+  appName,
 }) => {
   const currentLevelId = useSelector(
     (state: {progress: ProgressState}) => state.progress.currentLevelId
@@ -62,18 +64,29 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
           channelId,
         })
       );
-    } else if (channelId) {
+    } else if (channelId && appName) {
       // Otherwise, if we have a channel id, set up the lab using the channel id.
       // This path should only be used for lab pages that don't have a level, such as
-      // /projectbeats.
-      promise = dispatch(setUpWithoutLevel(channelId));
+      // /projectbeats. App name also must be provided if using this path.
+      promise = dispatch(setUpWithoutLevel({channelId, appName}));
+    } else if (channelId || appName) {
+      console.warn(
+        'If loading a lab without a level, channel ID and app name must both be provided'
+      );
     }
     return () => {
       // If we have an early return, we will abort the promise in progress.
       // An early return could happen if the level is changed mid-load.
       promise.abort();
     };
-  }, [channelId, currentLevelId, scriptId, levelPropertiesPath, dispatch]);
+  }, [
+    channelId,
+    appName,
+    currentLevelId,
+    scriptId,
+    levelPropertiesPath,
+    dispatch,
+  ]);
 
   useEffect(() => {
     window.addEventListener('beforeunload', event => {
@@ -133,7 +146,13 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
 
 interface ProjectContainerProps {
   children: React.ReactNode;
+  /** Channel ID for the project, if already known. Used for standalone projects and projects without levels. */
   channelId?: string;
+  /**
+   * App name for the lab that will be displayed, used only for projects without levels. Must be provided
+   * if loading a lab without a level.
+   */
+  appName?: AppName;
 }
 
 export default ProjectContainer;

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -90,7 +90,7 @@ export interface LevelProperties {
   // the only labs we support have projects enabled, it's easier to make this a
   // disabled flag for specific exceptions.
   disableProjects?: 'true' | 'false';
-  levelData: LevelData;
+  levelData?: LevelData;
   appName: AppName;
 }
 

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -177,7 +177,7 @@ class UnconnectedMusicView extends React.Component {
       this.analyticsReporter.endSession();
     });
 
-    if (this.props.appName === 'music' || this.props.inIncubator) {
+    if (this.props.appName === 'music') {
       this.onLevelLoad(this.props.levelData, this.props.initialSources);
     }
   }
@@ -222,7 +222,7 @@ class UnconnectedMusicView extends React.Component {
     if (
       (!isEqual(prevProps.levelData, this.props.levelData) ||
         !isEqual(prevProps.initialSources, this.props.initialSources)) &&
-      (this.props.appName === 'music' || this.props.inIncubator)
+      this.props.appName === 'music'
     ) {
       this.onLevelLoad(this.props.levelData, this.props.initialSources);
     }

--- a/apps/src/music/views/ProjectBeats.tsx
+++ b/apps/src/music/views/ProjectBeats.tsx
@@ -19,7 +19,7 @@ const ProjectBeats: React.FunctionComponent<{channelId: string}> = ({
     <Provider store={getStore()}>
       <Lab2Wrapper>
         <MetricsAdapter />
-        <ProjectContainer channelId={channelId}>
+        <ProjectContainer channelId={channelId} appName={'music'}>
           <DeferredMusicView />
         </ProjectContainer>
       </Lab2Wrapper>


### PR DESCRIPTION
Require an app name to be passed to ProjectContainer, if displaying a lab without a level. This helps make lab code more consistent since labs can make the same assumptions about the app name being set, even when it's not retrieved from level properties.

There's a different direction we could go here, which is to set the app name manually within music lab code, as currently the project beats page is the only page that loads a lab without a level. In that case, we'd be limiting the scope of this path further to only work for project beats, which could be a good thing if we want to encourage future labs to always have a level if possible. However, in [discussing this on Slack](https://codedotorg.slack.com/archives/C044AGTKW3D/p1689701858375869), there seem to be benefits to leaving this path open for future labs for the sake of prototyping and experimentation, so I opted to build support for this directly into Lab2 rather than within music lab code.

Note: the immediate reason for adding this change is that on project beats, the app name ("music") was not getting reported, since it wasn't set by the level.

## Testing story

Tested locally on /projectbeats, allthethings, standalone, and single levels