### PR TITLE
Music: Remove dynamic trigger extension and dummy input

### DIFF
--- a/apps/src/blockly/addons/cdoRendererThrasos.js
+++ b/apps/src/blockly/addons/cdoRendererThrasos.js
@@ -3,7 +3,7 @@ import CdoPathObject from './cdoPathObjectThrasos';
 import CdoConstantsProvider from './cdoConstantsProvider';
 import {addInlineRowSeparators} from '@blockly/renderer-inline-row-separators';
 
-export class CdoRendererThrasos extends GoogleBlockly.thrasos.Renderer {
+export class CdoRendererThrasosBase extends GoogleBlockly.thrasos.Renderer {
   /**
    * @override
    * Use our PathObject class instead of the default. Our PathObject has
@@ -23,8 +23,7 @@ export class CdoRendererThrasos extends GoogleBlockly.thrasos.Renderer {
   };
 }
 
-// Create a separate version of the renderer that includes inline row separators.
-export const CdoRendererThrasosIRS = addInlineRowSeparators(
-  CdoRendererThrasos,
+export const CdoRendererThrasos = addInlineRowSeparators(
+  CdoRendererThrasosBase,
   GoogleBlockly.thrasos.RenderInfo
 );

--- a/apps/src/blockly/constants.js
+++ b/apps/src/blockly/constants.js
@@ -30,10 +30,8 @@ export const Themes = {
 export const Renderers = {
   GERAS: 'cdo_renderer_geras',
   THRASOS: 'cdo_renderer_thrasos',
-  THRASOS_IRS: 'cdo_renderer_thrasos_irs',
   ZELOS: 'cdo_renderer_zelos',
-  // The default renderer includes inline row separators.
-  DEFAULT: 'cdo_renderer_thrasos_irs',
+  DEFAULT: 'cdo_renderer_thrasos',
 };
 
 // Used for custom field type ClampedNumber(,)

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -23,10 +23,7 @@ import FunctionEditor from './addons/functionEditor';
 import initializeGenerator from './addons/cdoGenerator';
 import CdoMetricsManager from './addons/cdoMetricsManager';
 import CdoRendererGeras from './addons/cdoRendererGeras';
-import {
-  CdoRendererThrasos,
-  CdoRendererThrasosIRS,
-} from './addons/cdoRendererThrasos';
+import {CdoRendererThrasos} from './addons/cdoRendererThrasos';
 import CdoRendererZelos from './addons/cdoRendererZelos';
 import CdoTheme from './themes/cdoTheme';
 import CdoDarkTheme from './themes/cdoDark';
@@ -281,12 +278,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
     blocklyWrapper.blockly_.registry.Type.RENDERER,
     Renderers.THRASOS,
     CdoRendererThrasos,
-    true /* opt_allowOverrides */
-  );
-  blocklyWrapper.blockly_.registry.register(
-    blocklyWrapper.blockly_.registry.Type.RENDERER,
-    Renderers.THRASOS_IRS,
-    CdoRendererThrasosIRS,
     true /* opt_allowOverrides */
   );
   blocklyWrapper.blockly_.registry.register(

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -49,7 +49,7 @@ export default class MusicBlocklyWorkspace {
       theme: CdoDarkTheme,
       renderer: experiments.isEnabled('zelos')
         ? Renderers.ZELOS
-        : Renderers.THRASOS,
+        : Renderers.DEFAULT,
       noFunctionBlockFrame: true,
       zoom: {
         startScale: experiments.isEnabled('zelos') ? 0.9 : 1,

--- a/apps/src/music/blockly/blocks/events.js
+++ b/apps/src/music/blockly/blocks/events.js
@@ -1,6 +1,6 @@
 import {BlockTypes} from '../blockTypes';
-import {TRIGGER_FIELD} from '../constants';
 import musicI18n from '../../locale';
+import {fieldTriggerDefinition} from '../fields';
 
 export const whenRun = {
   definition: {
@@ -21,10 +21,7 @@ export const triggeredAt = {
     style: 'event_blocks',
     message0: musicI18n.blockly_blockTriggeredAt({trigger: '%1', time: '%2'}),
     args0: [
-      {
-        type: 'input_dummy',
-        name: TRIGGER_FIELD,
-      },
+      fieldTriggerDefinition,
       {
         type: 'field_variable',
         name: 'var',
@@ -34,7 +31,6 @@ export const triggeredAt = {
     inputsInline: true,
     nextStatement: null,
     tooltip: musicI18n.blockly_blockTriggeredAtTooltip(),
-    extensions: ['dynamic_trigger_extension'],
   },
   generator: ctx => {
     const varName = Blockly.JavaScript.nameDB_.getName(
@@ -51,17 +47,11 @@ export const triggeredAtSimple = {
   definition: {
     type: BlockTypes.TRIGGERED_AT_SIMPLE,
     message0: musicI18n.blockly_blockTriggered({trigger: '%1'}),
-    args0: [
-      {
-        type: 'input_dummy',
-        name: TRIGGER_FIELD,
-      },
-    ],
+    args0: [fieldTriggerDefinition],
     inputsInline: true,
     nextStatement: null,
     style: 'event_blocks',
     tooltip: musicI18n.blockly_blockTriggeredTooltip(),
-    extensions: ['dynamic_trigger_extension'],
   },
   generator: ctx => {
     const varName = Blockly.JavaScript.nameDB_.getDistinctName(

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -1,7 +1,6 @@
 import {BlockTypes} from '../blockTypes';
 import {
   TRIGGER_FIELD,
-  DYNAMIC_TRIGGER_EXTENSION,
   FIELD_SOUNDS_NAME,
   FIELD_PATTERN_NAME,
   FIELD_REST_DURATION_NAME,
@@ -17,6 +16,7 @@ import {
   fieldPatternDefinition,
   fieldRestDurationDefinition,
   fieldChordDefinition,
+  fieldTriggerDefinition,
 } from '../fields';
 import {getCodeForSingleBlock} from '../blockUtils';
 import musicI18n from '../../locale';
@@ -98,10 +98,7 @@ export const triggeredAtSimple2 = {
     type: BlockTypes.TRIGGERED_AT_SIMPLE2,
     message0: musicI18n.blockly_blockTriggered({trigger: '%1', when: '%2'}),
     args0: [
-      {
-        type: 'input_dummy',
-        name: TRIGGER_FIELD,
-      },
+      fieldTriggerDefinition,
       {
         type: 'field_dropdown',
         name: FIELD_TRIGGER_START_NAME,
@@ -125,7 +122,6 @@ export const triggeredAtSimple2 = {
     nextStatement: null,
     style: 'event_blocks',
     tooltip: musicI18n.blockly_blockTriggeredTooltip(),
-    extensions: [DYNAMIC_TRIGGER_EXTENSION],
     helpUrl: DOCS_BASE_URL + 'trigger',
   },
   generator: block =>

--- a/apps/src/music/blockly/blocks/tracks.js
+++ b/apps/src/music/blockly/blocks/tracks.js
@@ -1,16 +1,14 @@
 import {BlockTypes} from '../blockTypes';
 import {
   DEFAULT_TRACK_NAME_EXTENSION,
-  DYNAMIC_TRIGGER_EXTENSION,
   EXTRA_SOUND_INPUT_PREFIX,
   FIELD_REST_DURATION_NAME,
   PLAY_MULTI_MUTATOR,
   PRIMARY_SOUND_INPUT_NAME,
   SOUND_VALUE_TYPE,
   TRACK_NAME_FIELD,
-  TRIGGER_FIELD,
 } from '../constants';
-import {fieldRestDurationDefinition} from '../fields';
+import {fieldRestDurationDefinition, fieldTriggerDefinition} from '../fields';
 import musicI18n from '../../locale';
 
 const getCurrentTrackId = ctx => {
@@ -106,17 +104,14 @@ export const newTrackOnTrigger = {
         name: TRACK_NAME_FIELD,
         text: 'my track',
       },
-      {
-        type: 'input_dummy',
-        name: TRIGGER_FIELD,
-      },
+      fieldTriggerDefinition,
     ],
     inputsInline: true,
     nextStatement: null,
     style: 'event_blocks',
     tooltip: musicI18n.blockly_blockNewTrackOnTriggerTooltip(),
     helpUrl: '',
-    extensions: [DEFAULT_TRACK_NAME_EXTENSION, DYNAMIC_TRIGGER_EXTENSION],
+    extensions: [DEFAULT_TRACK_NAME_EXTENSION],
   },
   generator: ctx => {
     return `Sequencer.createTrack("${

--- a/apps/src/music/blockly/constants.js
+++ b/apps/src/music/blockly/constants.js
@@ -1,6 +1,5 @@
 // Extensions & Mutator Names
 
-export const DYNAMIC_TRIGGER_EXTENSION = 'dynamic_trigger_extension';
 export const DEFAULT_TRACK_NAME_EXTENSION = 'default_track_name_extension';
 export const PLAY_MULTI_MUTATOR = 'play_multi_mutator';
 

--- a/apps/src/music/blockly/extensions.js
+++ b/apps/src/music/blockly/extensions.js
@@ -1,4 +1,3 @@
-import {Triggers} from '../constants';
 import {BlockTypes} from './blockTypes';
 import {
   EXTRA_SOUND_INPUT_PREFIX,
@@ -7,15 +6,6 @@ import {
   SOUND_VALUE_TYPE,
   TRACK_NAME_FIELD,
 } from './constants';
-
-export const dynamicTriggerExtension = function () {
-  this.getInput('trigger').appendField(
-    new Blockly.FieldDropdown(function () {
-      return Triggers.map(trigger => [trigger.dropdownLabel, trigger.id]);
-    }),
-    'trigger'
-  );
-};
 
 export const getDefaultTrackNameExtension = player =>
   function () {

--- a/apps/src/music/blockly/fields.js
+++ b/apps/src/music/blockly/fields.js
@@ -1,6 +1,6 @@
 // Common field definitions used across multiple music blocks
 
-import {DEFAULT_PATTERN, DEFAULT_CHORD} from '../constants';
+import {DEFAULT_PATTERN, DEFAULT_CHORD, Triggers} from '../constants';
 import Globals from '../globals';
 import musicI18n from '../locale';
 import {
@@ -11,6 +11,7 @@ import {
   FIELD_PATTERN_TYPE,
   FIELD_CHORD_TYPE,
   FIELD_CHORD_NAME,
+  TRIGGER_FIELD,
 } from './constants';
 
 export const fieldSoundsDefinition = {
@@ -66,4 +67,10 @@ export const fieldRestDurationDefinition = {
     [musicI18n.blockly_fieldRestOneMeasure(), '1'],
     [musicI18n.blockly_fieldRestMeasures({num: 2}), '2'],
   ],
+};
+
+export const fieldTriggerDefinition = {
+  type: 'field_dropdown',
+  name: TRIGGER_FIELD,
+  options: Triggers.map(trigger => [trigger.dropdownLabel, trigger.id]),
 };

--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -1,17 +1,12 @@
 import {
   DEFAULT_TRACK_NAME_EXTENSION,
   DOCS_BASE_URL,
-  DYNAMIC_TRIGGER_EXTENSION,
   FIELD_CHORD_TYPE,
   FIELD_PATTERN_TYPE,
   FIELD_SOUNDS_TYPE,
   PLAY_MULTI_MUTATOR,
 } from './constants';
-import {
-  dynamicTriggerExtension,
-  getDefaultTrackNameExtension,
-  playMultiMutator,
-} from './extensions';
+import {getDefaultTrackNameExtension, playMultiMutator} from './extensions';
 import FieldChord from './FieldChord';
 import FieldPattern from './FieldPattern';
 import FieldSounds from './FieldSounds';
@@ -25,11 +20,6 @@ import {BlockConfig} from './types';
  * Blockly state.
  */
 export function setUpBlocklyForMusicLab() {
-  Blockly.Extensions.register(
-    DYNAMIC_TRIGGER_EXTENSION,
-    dynamicTriggerExtension
-  );
-
   Blockly.Extensions.register(
     DEFAULT_TRACK_NAME_EXTENSION,
     getDefaultTrackNameExtension()


### PR DESCRIPTION
Due to an [update](https://github.com/code-dot-org/code-dot-org/pull/52842) in our default renderer, we had an issue where trigger blocks were getting split into multiple lines since they were using dummy inputs. Seems like we don't actually need the dummy inputs or the dynamic extension anymore, as we know all of our triggers ahead of time, so this change removes those which corrects the appearance of the blocks.

See [slack thread](https://codedotorg.slack.com/archives/C04TH8400AU/p1689641875315419) for more context (thanks @mikeharv for helping us figure this out!)

Before:

![Screenshot 2023-07-18 at 3 38 04 PM](https://github.com/code-dot-org/code-dot-org/assets/85528507/9b1f523c-98d4-4542-8cc4-5a5ec08c9f3e)

After:

![Screenshot 2023-07-18 at 3 38 12 PM](https://github.com/code-dot-org/code-dot-org/assets/85528507/217e6fcf-56f3-467a-b6bc-1e32f0c425fe)

## Testing story

Tested locally.