### PR TITLE
Fix Violations of and Reenable `Lint/OrAssignmentToConstant`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -103,11 +103,6 @@ Lint/MixedRegexpCaptureTypes:
 Lint/NoReturnInBeginEndBlocks:
   Enabled: false
 
-# Offense count: 2
-# This cop supports unsafe auto-correction (--auto-correct-all).
-Lint/OrAssignmentToConstant:
-  Enabled: false
-
 # Offense count: 10
 # This cop supports unsafe auto-correction (--auto-correct-all).
 # Configuration parameters: AllowedImplicitNamespaces.

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -322,4 +322,4 @@ module Cdo
     end
   end
 end
-CDO ||= Cdo::Impl.instance
+CDO = Cdo::Impl.instance

--- a/lib/cdo/rack/deflater.rb
+++ b/lib/cdo/rack/deflater.rb
@@ -107,8 +107,6 @@ module Rack
     end
 
     class DeflateStream
-      # TODO: The `||=` is used below instead of `=` so as to avoid a constant redefinition warning.
-      # Fix this, so that direct assignment can be used.
       DEFLATE_ARGS = [
         Zlib::DEFAULT_COMPRESSION,
         # drop the zlib header which causes both Safari and IE to choke

--- a/lib/cdo/rack/deflater.rb
+++ b/lib/cdo/rack/deflater.rb
@@ -109,7 +109,7 @@ module Rack
     class DeflateStream
       # TODO: The `||=` is used below instead of `=` so as to avoid a constant redefinition warning.
       # Fix this, so that direct assignment can be used.
-      DEFLATE_ARGS ||= [
+      DEFLATE_ARGS = [
         Zlib::DEFAULT_COMPRESSION,
         # drop the zlib header which causes both Safari and IE to choke
         -Zlib::MAX_WBITS,


### PR DESCRIPTION
> Checks for unintended or-assignment to a constant.
>
> Constants should always be assigned in the same location. And its value should always be the same. If constants are assigned in multiple locations, the result may vary depending on the order of `require`.

Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Lint/OrAssignmentToConstant`

This may well be a Chesterton's Fence situation, because in neither case is it clear to me why we are using conditional assignment for these constants in the first place. I couldn't find any other attempts to initialize these values in the codebase, or any scenario in which the conditional case of these conditional assignments would be used. I can't think of any reason why there would be, either, for the reasons pointed out in the description of the cop itself; I think it's likely these are just oversights, but want to call out that I'm not certain about that.

## Links

- https://docs.rubocop.org/rubocop/cops_lint.html#lintorassignmenttoconstant
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/OrAssignmentToConstant