### PR TITLE
Revert "Reenable storybook deploy as part of staging apps build"

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -25,11 +25,6 @@ namespace :build do
       npm_target = CDO.optimize_webpack_assets ? 'build:dist' : 'build'
       RakeUtils.system "npm run #{npm_target}"
       File.write(commit_hash, calculate_apps_commit_hash)
-
-      if rack_env?(:staging)
-        ChatClient.log 'Deploying <b>storybook</b>...'
-        RakeUtils.system 'npm run storybook:deploy'
-      end
     end
   end
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#52821

Staging build failed at this step -- reverting until I can investigate further. Build logs here:

https://s3.console.aws.amazon.com/s3/object/cdo-build-logs?prefix=staging/20230718T234416%2B0000