### PR TITLE
Add focus state to carousel pagination

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -788,6 +788,10 @@ form {
       &.selected {
         background: $brand_primary_default;
       }
+
+      &:focus {
+        @include focus-outline;
+      }
     }
   }
 }


### PR DESCRIPTION
Adding focus state styles to the carousel pagination dots for better keyboard navigation accessibility.

- An example can be seen on https://code.org/10years

**Jira ticket:** [ACQ-707](https://codedotorg.atlassian.net/browse/ACQ-707)

----

https://github.com/code-dot-org/code-dot-org/assets/9256643/bc9143c4-deab-49e2-8695-2044d65c367d


