### PR TITLE
Music: make sure workspace is initialized

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -86,6 +86,10 @@ export default class MusicBlocklyWorkspace {
    * @param {*} scope Global scope to provide the execution runtime
    */
   compileSong(scope) {
+    if (!this.workspace) {
+      Lab2MetricsReporter.logWarning('workspace not initialized.');
+      return;
+    }
     Blockly.getGenerator().init(this.workspace);
 
     this.compiledEvents = {};
@@ -290,10 +294,18 @@ export default class MusicBlocklyWorkspace {
   }
 
   getCode() {
+    if (!this.workspace) {
+      Lab2MetricsReporter.logWarning('workspace not initialized.');
+      return {};
+    }
     return Blockly.serialization.workspaces.save(this.workspace);
   }
 
   getAllBlocks() {
+    if (!this.workspace) {
+      Lab2MetricsReporter.logWarning('workspace not initialized.');
+      return [];
+    }
     return this.workspace.getAllBlocks();
   }
 
@@ -328,6 +340,10 @@ export default class MusicBlocklyWorkspace {
 
   // Load the workspace with the given code.
   loadCode(code) {
+    if (!this.workspace) {
+      Lab2MetricsReporter.logWarning('workspace not initialized.');
+      return;
+    }
     Blockly.serialization.workspaces.load(code, this.workspace);
   }
 


### PR DESCRIPTION
Speculative fix for a few bugs we've been seeing where the blockly workspace is referenced before being initialized. Worth noting that these bugs have actually mostly disappeared as of ~6/30, but this helps prevent any future bugs in case we end up in similar race conditions again.