### PR TITLE
Revert "Revert "Reenable storybook deploy as part of staging apps build""

### DIFF
--- a/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx
@@ -4,6 +4,8 @@ import i18n from '@cdo/locale';
 import FontAwesome from '../FontAwesome';
 import color from '@cdo/apps/util/color';
 import StudentGroup from './StudentGroup';
+// todo: remove this!
+// comment to force apps build in staging build
 
 export default function CodeReviewGroup({
   droppableId,

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -25,6 +25,11 @@ namespace :build do
       npm_target = CDO.optimize_webpack_assets ? 'build:dist' : 'build'
       RakeUtils.system "npm run #{npm_target}"
       File.write(commit_hash, calculate_apps_commit_hash)
+
+      if rack_env?(:staging)
+        ChatClient.log 'Deploying <b>storybook</b>...'
+        RakeUtils.system 'npm run storybook:deploy'
+      end
     end
   end
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#52884

Bringing this back without changes, as I think the error we observed was caused by an invalid symlink on the staging machine. I've removed the offending symlink there, so would like to merge this again and see what happens. More detail in [this Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1689269206156649).