### PR TITLE
Adding Kosovo to country and partner list

### DIFF
--- a/dashboard/app/models/pd/international_opt_in.rb
+++ b/dashboard/app/models/pd/international_opt_in.rb
@@ -81,7 +81,7 @@ class Pd::InternationalOptIn < ApplicationRecord
 
   def self.options
     entry_keys = {
-      schoolCountry: %w(australia barbados belize brazil canada chile colombia dominican_republic india indonesia israel jamaica kenya malaysia maldives mexico mongolia new_zealand paraguay portugal slovakia south_korea spain thailand trinidad_and_tobago uzbekistan vietnam),
+      schoolCountry: %w(australia barbados belize brazil canada chile colombia dominican_republic india indonesia israel jamaica kenya kosovo malaysia maldives mexico mongolia new_zealand paraguay portugal slovakia south_korea spain thailand trinidad_and_tobago uzbekistan vietnam),
       workshopCourse: %w(csf_af csf_express csd csp csa other not_applicable),
       emailOptIn: %w(opt_in_yes opt_in_no),
       legalOptIn: %w(opt_in_yes opt_in_no)

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1214,6 +1214,7 @@ en:
         israel: 'Israel'
         jamaica: 'Jamaica'
         kenya: 'Kenya'
+        kosovo: 'Kosovo'
         malaysia: 'Malaysia'
         maldives: 'Maldives'
         mexico: 'Mexico'

--- a/dashboard/lib/international_opt_in_people.rb
+++ b/dashboard/lib/international_opt_in_people.rb
@@ -20,6 +20,7 @@ module InternationalOptInPeople
     israel: ["Wix.com"],
     jamaica: ["The Trust for the Americas"],
     kenya: ["STEAMLabs Africa"],
+    kosovo: ["SHPIQ"],
     malaysia: ["Malaysia Digital Economy Corporation"],
     maldives: ["Women in Tech Maldives"],
     mexico: ["Cuantrix"],


### PR DESCRIPTION
We have a new international partner in Kosovo.
We need to add the new partner to the International Workshop attendance form.

This PR adds:
- Kosovo to `international_opt_in.rb`
- Kosovo partner to `international_opt_in_people.rb`
- Kosovo key and value to `en.yml`

## Links
- [IPD Dashboard Data](https://docs.google.com/spreadsheets/d/1rYMWWgbYrSlepdLLz4uQNk9750tGtgOi/edit#gid=1461703672)
- Jira: [P20-320](https://codedotorg.atlassian.net/browse/P20-320)

## Testing story
- link: http://
![Screenshot 2023-07-20 at 17 04 04](https://github.com/code-dot-org/code-dot-org/assets/66776217/bf95bd7b-6d5f-4353-ba91-0502f6e8b750)
localhost-studio.code.org:3000/pd/international_workshop

## Follow-up work


## Privacy
No privacy concerns

## Security
No security concerns

## Caching
No caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
