### PR TITLE
Fix Curriculum Catalog Eyes Test Typo

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -27,7 +27,7 @@ Feature: Curriculum Catalog Page
   Scenario: Signed-out user sees the curriculum catalog with offerings and can filter
     Given I am on "http://studio.code.org/catalog/lang/es"
     Then I wait until I am on "http://studio.code.org/catalog?lang=es"
-    And I open my eyes to test "Curriculum Catalog in Spansih"
+    And I open my eyes to test "Curriculum Catalog in Spanish"
     Then I wait until element "#topic-dropdown" is visible
     And I wait until element "h4:contains(Inteligencia Artificial para Océanos)" is visible
     And I see no difference for "Curriculum Catalog: All Offerings in Spanish"


### PR DESCRIPTION
Fixes a typo in the curriculum catalog eyes test file from [a recent PR](https://github.com/code-dot-org/code-dot-org/pull/52895).

## Links
PR this fixes the typo from: [here](https://github.com/code-dot-org/code-dot-org/pull/52895)

## Testing story
Passing drone build.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
