### PR TITLE
Fall back when no recommended course version

### DIFF
--- a/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
@@ -100,7 +100,7 @@ function updateSectionCourse(updateCourse, course) {
   if (courseVersionId === undefined) {
     const stableVersions = Object.values(courseVersions)
       .filter(version => version.is_stable)
-      .sort(cv => -cv.key);
+      .sort(version => -version.key);
     console.log(stableVersions);
     courseVersionId = stableVersions[0]?.id;
   }

--- a/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
@@ -96,6 +96,14 @@ function updateSectionCourse(updateCourse, course) {
     )?.id;
   }
 
+  // If no recommended version, fall back to the most recent stable version.
+  if (courseVersionId === undefined) {
+    const stableVersions = Object.values(courseVersions).filter(
+      version => version.is_stable
+    );
+    courseVersionId = stableVersions[stableVersions.length - 1]?.id;
+  }
+
   const courseVersion = courseVersions[courseVersionId];
   const isStandaloneUnit = courseVersion.type === 'Unit';
 

--- a/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
@@ -98,10 +98,11 @@ function updateSectionCourse(updateCourse, course) {
 
   // If no recommended version, fall back to the most recent stable version.
   if (courseVersionId === undefined) {
-    const stableVersions = Object.values(courseVersions).filter(
-      version => version.is_stable
-    );
-    courseVersionId = stableVersions[stableVersions.length - 1]?.id;
+    const stableVersions = Object.values(courseVersions)
+      .filter(version => version.is_stable)
+      .sort(cv => -cv.key);
+    console.log(stableVersions);
+    courseVersionId = stableVersions[0]?.id;
   }
 
   const courseVersion = courseVersions[courseVersionId];

--- a/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
@@ -101,7 +101,6 @@ function updateSectionCourse(updateCourse, course) {
     const stableVersions = Object.values(courseVersions)
       .filter(version => version.is_stable)
       .sort(version => -version.key);
-    console.log(stableVersions);
     courseVersionId = stableVersions[0]?.id;
   }
 

--- a/apps/test/unit/templates/sectionsRefresh/CourseOfferingsTestData.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CourseOfferingsTestData.jsx
@@ -811,3 +811,97 @@ export const plCourseOfferings = {
     ],
   },
 };
+
+export const noRecommendedVersionsOfferings = {
+  high: {
+    Course: {
+      'Year Long': [
+        {
+          id: 73,
+          key: 'csa',
+          display_name: 'Computer Science A',
+          course_versions: [
+            [
+              373,
+              {
+                id: 373,
+                key: '2022',
+                version_year: '22-23',
+                content_root_id: 32,
+                name: 'Informática A (22-23)',
+                path: '/courses/csa-2022',
+                type: 'UnitGroup',
+                is_stable: true,
+                is_recommended: false,
+                locales: ['English'],
+                units: {
+                  173: {
+                    id: 173,
+                    name: "Programación Orientada a Objetos ('22-'23)",
+                    path: '/s/csa1-2022',
+                    lesson_extras_available: false,
+                    text_to_speech_enabled: true,
+                    position: 1,
+                    requires_verified_instructor: true,
+                  },
+                },
+              },
+            ],
+            [
+              377,
+              {
+                id: 377,
+                key: '2020',
+                version_year: '',
+                content_root_id: 36,
+                name: 'Piloto de CSA',
+                path: '/courses/csa-pilot',
+                type: 'UnitGroup',
+                is_stable: false,
+                is_recommended: false,
+                locales: ['English'],
+                units: {
+                  177: {
+                    id: 177,
+                    name: 'Programación Orientada a Objetos *',
+                    path: '/s/csa1-pilot',
+                    lesson_extras_available: false,
+                    text_to_speech_enabled: false,
+                    position: 1,
+                    requires_verified_instructor: true,
+                  },
+                },
+              },
+            ],
+            [
+              775,
+              {
+                id: 775,
+                key: '2023',
+                version_year: '23-24',
+                content_root_id: 62,
+                name: 'Informática A (23-24)',
+                path: '/courses/csa-2023',
+                type: 'UnitGroup',
+                is_stable: false,
+                is_recommended: false,
+                locales: ['English'],
+                units: {
+                  174: {
+                    id: 174,
+                    name: 'Programación Orientada a Objetos *',
+                    path: '/s/csa1-2023',
+                    lesson_extras_available: false,
+                    text_to_speech_enabled: false,
+                    position: 1,
+                    requires_verified_instructor: true,
+                  },
+                },
+              },
+            ],
+          ],
+        },
+      ],
+    },
+  },
+};

--- a/apps/test/unit/templates/sectionsRefresh/CourseOfferingsTestData.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CourseOfferingsTestData.jsx
@@ -822,6 +822,32 @@ export const noRecommendedVersionsOfferings = {
           display_name: 'Computer Science A',
           course_versions: [
             [
+              370,
+              {
+                id: 370,
+                key: '2019',
+                version_year: '19-20',
+                content_root_id: 32,
+                name: 'Informática A (19-20)',
+                path: '/courses/csa-2019',
+                type: 'UnitGroup',
+                is_stable: true,
+                is_recommended: false,
+                locales: ['English'],
+                units: {
+                  173: {
+                    id: 173,
+                    name: "Programación Orientada a Objetos ('19-'20)",
+                    path: '/s/csa1-2019',
+                    lesson_extras_available: false,
+                    text_to_speech_enabled: true,
+                    position: 1,
+                    requires_verified_instructor: true,
+                  },
+                },
+              },
+            ],
+            [
               373,
               {
                 id: 373,

--- a/apps/test/unit/templates/sectionsRefresh/QuickAssignTableTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/QuickAssignTableTest.jsx
@@ -7,6 +7,7 @@ import {MARKETING_AUDIENCE} from '@cdo/apps/templates/sectionsRefresh/Curriculum
 import {
   elementarySchoolCourseOffering,
   highSchoolCourseOfferings,
+  noRecommendedVersionsOfferings,
 } from './CourseOfferingsTestData';
 import i18n from '@cdo/locale';
 
@@ -56,6 +57,21 @@ describe('QuickAssignTable', () => {
       target: {value: 'Computer Science A', checked: true},
     });
     expect(updateSpy).to.have.been.called;
+  });
+
+  it('correctly falls back when a course has no recommended version', () => {
+    const updateSpy = sinon.spy();
+    const wrapper = setUpMount({
+      updateCourse: updateSpy,
+      courseOfferings: noRecommendedVersionsOfferings,
+    });
+
+    const radio = wrapper.find('input');
+    expect(updateSpy).not.to.have.been.called;
+    radio.simulate('change', {
+      target: {value: 'Computer Science A', checked: true},
+    });
+    expect(updateSpy).to.have.been.calledWith(sinon.match({versionId: 373}));
   });
 
   it('automatically checks correct radio button if course is already assigned', () => {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

When there are no recommended course versions for a given selection, the section setup flow was raising an exception and not allowing certain courses to be assigned. Instead, we should fall back to the most recent stable course version. (Thanks Bethany for knowing what that behavior should be.)

![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/e80df678-6046-4a83-b494-123464fc0f06)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- jira ticket: [TEACH-622](https://codedotorg.atlassian.net/browse/TEACH-622)


