### PR TITLE
Fixes a flaky CPA test.

### DIFF
--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -15,7 +15,10 @@ Feature: Policy Compliance and Parental Permission
     Then element "#lockout-submit" is enabled
 
     # Ensure that we are now "pending"
+    And I take note of the current loaded page
     When I press "lockout-submit"
+    Then I wait until I am on a different page than I noted before
+
     Then I wait to see "#lockout-panel-form"
     And element "#permission-status" contains text "Pending"
 
@@ -56,7 +59,9 @@ Feature: Policy Compliance and Parental Permission
     And element "#permission-status" contains text "Pending"
 
     # Perform a "resend"
+    And I take note of the current loaded page
     When I press "lockout-resend"
+    Then I wait until I am on a different page than I noted before
     Then I wait to see "#lockout-panel-form"
 
   Scenario: New under 13 account should be able to send a different email
@@ -74,7 +79,10 @@ Feature: Policy Compliance and Parental Permission
     Then element "#lockout-submit" is enabled
 
     # Ensure that we are now "pending"
+    And I take note of the current loaded page
     When I press "lockout-submit"
+    Then I wait until I am on a different page than I noted before
+
     Then I wait to see "#lockout-panel-form"
     And element "#permission-status" contains text "Pending"
 
@@ -84,6 +92,9 @@ Feature: Policy Compliance and Parental Permission
     Then element "#lockout-submit" is enabled
 
     # Ensure that the new email was used
+    And I take note of the current loaded page
     When I press "lockout-submit"
+    Then I wait until I am on a different page than I noted before
+
     Then I wait to see "#lockout-panel-form"
     And element "#parent-email" has value "parent2@example.com"

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -48,7 +48,10 @@ Feature: Policy Compliance and Parental Permission
     Then element "#lockout-submit" is enabled
 
     # Ensure that we are now "pending"
+    And I take note of the current loaded page
     When I press "lockout-submit"
+    Then I wait until I am on a different page than I noted before
+
     Then I wait to see "#lockout-panel-form"
     And element "#permission-status" contains text "Pending"
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -98,6 +98,20 @@ Given /^I am on "([^"]*)"$/ do |url|
   navigate_to replace_hostname(url)
 end
 
+And /^I take note of the current loaded page$/ do
+  # Remember this page
+  @current_page_body = @browser.find_element(:css, 'body')
+end
+
+Then /^I wait until I am on a different page than I noted before$/ do
+  # When we've seen a page before, look for a different page
+  if @current_page_body
+    wait_until do
+      @current_page_body != @browser.find_element(:css, 'body')
+    end
+  end
+end
+
 When /^I wait to see (?:an? )?"([.#])([^"]*)"$/ do |selector_symbol, name|
   selection_criteria = selector_symbol == '#' ? {id: name} : {class: name}
   wait_until {!@browser.find_elements(selection_criteria).empty?}


### PR DESCRIPTION
Simply, the flakiness is because the form redirects back to itself which confuses the UI tests since they may race to read the screen before the refresh.

Adds a UI test step that can detect when a page was reloaded. This is needed because the test in question loads the same page at the same URL. Checking for the URL or an element on the page is not good enough since it would be ambiguous between the original page and the reloaded page. There is no other way to wait until the text being checked could possibly be updated, that I can tell, in our existing test helpers.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
- jira ticket: [P20-388](https://codedotorg.atlassian.net/browse/P20-388)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
