### PR TITLE
Add method to regenerate PDFs for specified units

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -138,6 +138,8 @@ module Services
             any_pdf_generated = true
           end
 
+          # Generating resource PDFs is currently broken
+          # See https://codedotorg.atlassian.net/browse/TEACH-601
           #if should_generate_resource_pdf?(script)
           #  puts "Regenerating Unit Resources PDF for #{script.name}"
           #  generate_script_resources_pdf(script, dir)
@@ -170,6 +172,8 @@ module Services
             any_pdf_generated = true
           end
 
+          # Generating resource PDFs is currently broken
+          # See https://codedotorg.atlassian.net/browse/TEACH-601
           #if !script_resources_pdf_exists_for?(script) && should_generate_resource_pdf?(script)
           #  puts "Generating missing Unit Resources PDF for #{script.name}"
           #  generate_script_resources_pdf(script, dir)

--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -121,6 +121,37 @@ module Services
       end
     end
 
+    def self.regenerate_pdfs(scripts)
+      scripts.each do |script|
+        Dir.mktmpdir("pdf_generation") do |dir|
+          any_pdf_generated = false
+
+          script.lessons.select(&:has_lesson_plan).each do |lesson|
+            puts "Regenerating Lesson PDFs for #{lesson.key} (from #{script.name})"
+            generate_lesson_pdf(lesson, dir)
+            any_pdf_generated = true
+          end
+
+          if should_generate_overview_pdf?(script)
+            puts "Regenerating Unit Overview PDF for #{script.name}"
+            generate_script_overview_pdf(script, dir)
+            any_pdf_generated = true
+          end
+
+          #if should_generate_resource_pdf?(script)
+          #  puts "Regenerating Unit Resources PDF for #{script.name}"
+          #  generate_script_resources_pdf(script, dir)
+          #  any_pdf_generated = true
+          #end
+
+          if any_pdf_generated
+            puts "Uploading generated PDFs to S3"
+            upload_generated_pdfs_to_s3(dir)
+          end
+        end
+      end
+    end
+
     def self.generate_missing_pdfs
       get_pdf_enabled_scripts.each do |script|
         Dir.mktmpdir("pdf_generation") do |dir|
@@ -139,11 +170,11 @@ module Services
             any_pdf_generated = true
           end
 
-          if !script_resources_pdf_exists_for?(script) && should_generate_resource_pdf?(script)
-            puts "Generating missing Unit Resources PDF for #{script.name}"
-            generate_script_resources_pdf(script, dir)
-            any_pdf_generated = true
-          end
+          #if !script_resources_pdf_exists_for?(script) && should_generate_resource_pdf?(script)
+          #  puts "Generating missing Unit Resources PDF for #{script.name}"
+          #  generate_script_resources_pdf(script, dir)
+          #  any_pdf_generated = true
+          #end
 
           if any_pdf_generated
             puts "Generated all missing PDFs for #{script.name}; uploading results to S3"

--- a/dashboard/lib/services/curriculum_pdfs/script_overview.rb
+++ b/dashboard/lib/services/curriculum_pdfs/script_overview.rb
@@ -61,7 +61,7 @@ module Services
           pdfs << script_path
 
           # Include PDF for the lesson in our set of PDFs to merge.
-          script.lessons.each do |lesson|
+          script.lessons.select(&:has_lesson_plan).each do |lesson|
             ChatClient.log("Finding/generating PDF for #{lesson.key.inspect}") if DEBUG
             # 1. If we already have a version of the PDF on the local
             #    filesystem, grab it from there.

--- a/dashboard/test/lib/services/curriculum_pdfs/script_overview_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs/script_overview_test.rb
@@ -56,12 +56,12 @@ class Services::CurriculumPdfs::ScriptOverviewTest < ActiveSupport::TestCase
       PDF.expects(:merge_local_pdfs).with {|_output, *input| input.length == 1}
       Services::CurriculumPdfs.generate_script_overview_pdf(script, tmpdir)
 
-      lesson_group.lessons << create(:lesson, script: script)
+      lesson_group.lessons << create(:lesson, script: script, has_lesson_plan: true)
       script.reload
       PDF.expects(:merge_local_pdfs).with {|_output, *input| input.length == 2}
       Services::CurriculumPdfs.generate_script_overview_pdf(script, tmpdir)
 
-      lesson_group.lessons << create(:lesson, script: script)
+      lesson_group.lessons << create(:lesson, script: script, has_lesson_plan: true)
       script.reload
       PDF.expects(:merge_local_pdfs).with {|_output, *input| input.length == 3}
       Services::CurriculumPdfs.generate_script_overview_pdf(script, tmpdir)


### PR DESCRIPTION
This PR does three things:
1. (the biggest one) adds a method to regenerate PDFs for specified units. We used to have something that could do this but I think it was lost in a refactor somewhere. In cases where the PDF is corrupted in some way, I find it very useful to have a method to do this. I did pretty much copy and adjust the code from `generate_missing_pdfs` -- I can't see a good way to reduce code duplication here but open to suggestions!
2. Commented out resource PDF generation in both `generate_missing_pdfs` and `regenerate_pdfs`. This was broken by the Ruby 3 upgrade and is tracked [here](https://codedotorg.atlassian.net/browse/TEACH-601).
3. Fixed a minor bug where we were inserting a page in the script overview PDF when there were lessons without lesson plans. You can see this by going to https://studio.code.org/s/csd3-2022, printing lesson plans, and scrolling to the bottom of the PDF. Lesson 1 is inserted as the second to last lesson in the place of a lesson plan-less lesson. 