### PR TITLE
Fix empty objects in sync-out JSON

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -266,7 +266,9 @@ def sort_and_sanitize(hash)
   hash.sort_by {|key, _| key}.each_with_object({}) do |(key, value), result|
     case value
     when Hash
-      result[key] = sort_and_sanitize(value) unless value.empty?
+      # ensure we always call sort_and_sanitize on the hash to avoid top-level empty objects
+      sorted_hash = sort_and_sanitize(value)
+      result[key] = sorted_hash unless sorted_hash.empty?
     when Array
       result[key] = value.filter_map {|v| v.is_a?(Hash) ? sort_and_sanitize(v) : v}
     when String


### PR DESCRIPTION
The sort_and_sanitize function in the sync-out script was leaving behind empty objects, causing some files to be larger than they should be.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
