### PR TITLE
Fix block pool rendering bug

### DIFF
--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -166,10 +166,7 @@ function updateBlockPreview() {
   });
   const block = `<block type="${blockName}" />`;
   Blockly.mainBlockSpace.clear();
-  Blockly.cdoUtils.loadBlocksToWorkspace(
-    Blockly.mainBlockSpace,
-    Blockly.Xml.domToText(block)
-  );
+  Blockly.cdoUtils.loadBlocksToWorkspace(Blockly.mainBlockSpace, block);
   Blockly.addChangeListener(Blockly.mainBlockSpace, onBlockSpaceChange);
 }
 


### PR DESCRIPTION
We were unnecessarily calling `domToText` on a string, when we can just pass the string in. This was causing blocks to not render in the block pool editor.


## Testing story
Tested locally, before the fix blocks didn't render, now they do.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
