### PR TITLE
Fix Violations of and Reenable `Rails/AssertNot`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,13 @@ Layout/SpaceInsideHashLiteralBraces:
 Naming/RescuedExceptionsVariableName:
   PreferredName: exception
 
+# This Cop by default uses a custom Include directive which in our
+# project would also include pegasus
+# see https://github.com/rubocop/rubocop-rails/blob/d81af275bba3d06e30156596c2c057cf68f8272b/config/default.yml#L213C11-L213C11
+Rails/AssertNot:
+  Include:
+    - dashboard/**/test/**/*
+
 Rails/Date:
   EnforcedStyle: strict
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -157,13 +157,6 @@ Performance/MethodObjectAsBlock:
 Rails/ApplicationMailer:
   Enabled: false
 
-# Offense count: 21
-# This cop supports safe auto-correction (--auto-correct).
-# Configuration parameters: Include.
-# Include: **/test/**/*
-Rails/AssertNot:
-  Enabled: false
-
 # Offense count: 472
 # This cop supports unsafe auto-correction (--auto-correct-all).
 # Configuration parameters: Whitelist, AllowedMethods, AllowedReceivers.

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -24,7 +24,7 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
 
   test 'a post request to using_text_mode updates using_text_mode' do
     sign_in(@user)
-    assert !@user.using_text_mode
+    assert_not @user.using_text_mode
     post :post_using_text_mode, params: {user_id: 'me', using_text_mode: 'true'}
     assert_response :success
     response = JSON.parse(@response.body)
@@ -57,7 +57,7 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
 
   test 'a post request to mute_music updates mute_music' do
     sign_in(@user)
-    assert !@user.mute_music
+    assert_not @user.mute_music
     post :post_mute_music, params: {user_id: 'me', mute_music: 'true'}
     assert_response :success
     response = JSON.parse(@response.body)
@@ -90,7 +90,7 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
 
   test 'a post request to display_theme updates display_theme' do
     sign_in(@user)
-    assert !@user.display_theme
+    assert_not @user.display_theme
     post :update_display_theme, params: {user_id: 'me', display_theme: 'dark'}
     assert_response :success
     response = JSON.parse(@response.body)

--- a/dashboard/test/controllers/code_reviews_controller_test.rb
+++ b/dashboard/test/controllers/code_reviews_controller_test.rb
@@ -95,7 +95,7 @@ class CodeReviewsControllerTest < ActionController::TestCase
 
   test 'update fails when trying to re-open a closed review' do
     code_review = create :code_review, user_id: @project_owner.id, closed_at: DateTime.now
-    assert !code_review.open?
+    assert_not code_review.open?
 
     patch :update, params: {
       id: code_review.id,

--- a/dashboard/test/helpers/application_helper_test.rb
+++ b/dashboard/test/helpers/application_helper_test.rb
@@ -65,7 +65,7 @@ class ApplicationHelperTest < ActionView::TestCase
         )
       )
     end
-    assert(!browser.cdo_unsupported?)
+    assert_not(browser.cdo_unsupported?)
   end
 
   test "chrome 34 detected" do

--- a/dashboard/test/lib/certificate_image_test.rb
+++ b/dashboard/test/lib/certificate_image_test.rb
@@ -13,10 +13,10 @@ class CertificateImageTest < ActiveSupport::TestCase
     assert CertificateImage.prefilled_title_course?('mee_empathy')
     assert CertificateImage.prefilled_title_course?('mee_timecraft')
     assert CertificateImage.prefilled_title_course?('mee_estate')
-    assert !CertificateImage.prefilled_title_course?('course1')
-    assert !CertificateImage.prefilled_title_course?('course2')
-    assert !CertificateImage.prefilled_title_course?('course3')
-    assert !CertificateImage.prefilled_title_course?('course4')
+    assert_not CertificateImage.prefilled_title_course?('course1')
+    assert_not CertificateImage.prefilled_title_course?('course2')
+    assert_not CertificateImage.prefilled_title_course?('course3')
+    assert_not CertificateImage.prefilled_title_course?('course4')
   end
 
   def test_course_templates

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3690,7 +3690,7 @@ class UserTest < ActiveSupport::TestCase
   test 'new users require a password if no authentication provided' do
     assert_raises(ActiveRecord::RecordInvalid) do
       user = create :user, password: nil
-      assert !user.errors[:password].empty?
+      assert_not user.errors[:password].empty?
     end
   end
 

--- a/pegasus/test/test_csv.rb
+++ b/pegasus/test/test_csv.rb
@@ -30,7 +30,7 @@ class CSVTest < Minitest::Test
                  state_cs_t hs_t count_t higher_ed_t)
     columns.each do |column_name|
       column = state_policy_csv.first.find_index(column_name)
-      assert !column.nil?, "cdo-state-promote.csv missing column #{column_name}"
+      assert_not column.nil?, "cdo-state-promote.csv missing column #{column_name}"
     end
   end
 end

--- a/pegasus/test/test_csv.rb
+++ b/pegasus/test/test_csv.rb
@@ -30,7 +30,7 @@ class CSVTest < Minitest::Test
                  state_cs_t hs_t count_t higher_ed_t)
     columns.each do |column_name|
       column = state_policy_csv.first.find_index(column_name)
-      assert_not column.nil?, "cdo-state-promote.csv missing column #{column_name}"
+      assert !column.nil?, "cdo-state-promote.csv missing column #{column_name}"
     end
   end
 end

--- a/pegasus/test/test_curriculum_course.rb
+++ b/pegasus/test/test_curriculum_course.rb
@@ -16,14 +16,14 @@ class CurriculumCourseTest < Minitest::Test
       assert(@course.valid_lesson_directory_name('1'))
       assert(@course.valid_lesson_directory_name('6-2'))
       assert(@course.valid_lesson_directory_name('.go_ahead_process_me'))
-      assert(!@course.valid_lesson_directory_name('.'))
-      assert(!@course.valid_lesson_directory_name('..'))
-      assert(!@course.valid_lesson_directory_name('_dont_parse_me'))
+      assert_not(@course.valid_lesson_directory_name('.'))
+      assert_not(@course.valid_lesson_directory_name('..'))
+      assert_not(@course.valid_lesson_directory_name('_dont_parse_me'))
     end
 
     it 'should verify directory existence' do
       assert(@course.valid_lesson_directory?('1')) # exists for course1
-      assert(!@course.valid_lesson_directory?('999')) # does not
+      assert_not(@course.valid_lesson_directory?('999')) # does not
     end
 
     it 'should get empty array for units when no units' do
@@ -48,7 +48,7 @@ class CurriculumCourseTest < Minitest::Test
 
       it 'should recognize that it has units' do
         assert(@course_with_units.has_units?)
-        assert(!@course_without_units.has_units?)
+        assert_not(@course_without_units.has_units?)
       end
 
       it 'should get lesson numbers when there are unit numbers' do
@@ -60,11 +60,11 @@ class CurriculumCourseTest < Minitest::Test
 
       it 'should determine whether lessons are in unit' do
         assert(@course_with_units.lesson_in_unit?('3-5', '3'))
-        assert(!@course_with_units.lesson_in_unit?('3-5', '4'))
+        assert_not(@course_with_units.lesson_in_unit?('3-5', '4'))
       end
 
       it 'should get all lessons' do
-        assert(!@course_with_units.get_lessons.empty?)
+        assert_not(@course_with_units.get_lessons.empty?)
         assert(@course_with_units.get_lessons.first.is_a?(CurriculumCourse::Lesson))
       end
     end

--- a/pegasus/test/test_curriculum_course.rb
+++ b/pegasus/test/test_curriculum_course.rb
@@ -16,14 +16,14 @@ class CurriculumCourseTest < Minitest::Test
       assert(@course.valid_lesson_directory_name('1'))
       assert(@course.valid_lesson_directory_name('6-2'))
       assert(@course.valid_lesson_directory_name('.go_ahead_process_me'))
-      assert_not(@course.valid_lesson_directory_name('.'))
-      assert_not(@course.valid_lesson_directory_name('..'))
-      assert_not(@course.valid_lesson_directory_name('_dont_parse_me'))
+      assert(!@course.valid_lesson_directory_name('.'))
+      assert(!@course.valid_lesson_directory_name('..'))
+      assert(!@course.valid_lesson_directory_name('_dont_parse_me'))
     end
 
     it 'should verify directory existence' do
       assert(@course.valid_lesson_directory?('1')) # exists for course1
-      assert_not(@course.valid_lesson_directory?('999')) # does not
+      assert(!@course.valid_lesson_directory?('999')) # does not
     end
 
     it 'should get empty array for units when no units' do
@@ -48,7 +48,7 @@ class CurriculumCourseTest < Minitest::Test
 
       it 'should recognize that it has units' do
         assert(@course_with_units.has_units?)
-        assert_not(@course_without_units.has_units?)
+        assert(!@course_without_units.has_units?)
       end
 
       it 'should get lesson numbers when there are unit numbers' do
@@ -60,11 +60,11 @@ class CurriculumCourseTest < Minitest::Test
 
       it 'should determine whether lessons are in unit' do
         assert(@course_with_units.lesson_in_unit?('3-5', '3'))
-        assert_not(@course_with_units.lesson_in_unit?('3-5', '4'))
+        assert(!@course_with_units.lesson_in_unit?('3-5', '4'))
       end
 
       it 'should get all lessons' do
-        assert_not(@course_with_units.get_lessons.empty?)
+        assert(!@course_with_units.get_lessons.empty?)
         assert(@course_with_units.get_lessons.first.is_a?(CurriculumCourse::Lesson))
       end
     end

--- a/pegasus/test/test_object.rb
+++ b/pegasus/test/test_object.rb
@@ -8,8 +8,8 @@ class ObjectTest < Minitest::Test
     assert [].nil_or_empty?
     assert ({}).nil_or_empty?
 
-    assert !('a'.nil_or_empty?)
-    assert !([1].nil_or_empty?)
-    assert !(({a: 1}).nil_or_empty?)
+    assert_not('a'.nil_or_empty?)
+    assert_not([1].nil_or_empty?)
+    assert_not(({a: 1}).nil_or_empty?)
   end
 end

--- a/pegasus/test/test_object.rb
+++ b/pegasus/test/test_object.rb
@@ -8,8 +8,8 @@ class ObjectTest < Minitest::Test
     assert [].nil_or_empty?
     assert ({}).nil_or_empty?
 
-    assert_not('a'.nil_or_empty?)
-    assert_not([1].nil_or_empty?)
-    assert_not(({a: 1}).nil_or_empty?)
+    assert !('a'.nil_or_empty?)
+    assert !([1].nil_or_empty?)
+    assert !(({a: 1}).nil_or_empty?)
   end
 end


### PR DESCRIPTION
This one's pretty straightforward:

> Use `assert_not` instead of `assert !`.

Fix applied automatically with `bundle exec rubocop --autocorrect --only Rails/AssertNot`

I did have to add an explicit `Include` directive to prevent this Cop from warning us about Pegasus tests, for which `assert_not` is not defined.

## Links

- https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsassertnot
- https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/AssertNot