### PR TITLE
Fix Violations of and Reenable `Style/ClassEqualityComparison`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -233,13 +233,6 @@ Security/MarshalLoad:
 Style/AccessModifierDeclarations:
   Enabled: false
 
-# Offense count: 27
-# This cop supports safe auto-correction (--auto-correct).
-# Configuration parameters: IgnoredMethods.
-# IgnoredMethods: ==, equal?, eql?
-Style/ClassEqualityComparison:
-  Enabled: false
-
 # Offense count: 151
 Style/ClassVars:
   Enabled: false

--- a/bin/aws_access
+++ b/bin/aws_access
@@ -13,7 +13,7 @@ module Aws
   end
 end
 
-unless (provider = Aws::STS::Client.new.config.credentials).class == Aws::Google
+unless (provider = Aws::STS::Client.new.config.credentials).instance_of?(Aws::Google)
   puts "WARNING: AWS is currently using #{provider}, not Google credentials."
 end
 

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -190,17 +190,17 @@ class Foorm::Form < ApplicationRecord
   def self.validate_choices(choices, question_name)
     choice_values = Set.new
     choices.each do |choice|
-      if choice.class == Hash && choice.key?(:value) && choice.key?(:text)
+      if choice.instance_of?(Hash) && choice.key?(:value) && choice.key?(:text)
         if choice_values.include?(choice[:value])
           raise InvalidFoormConfigurationError, "Duplicate choice value #{choice[:value]} in question #{question_name}."
         end
         choice_values.add(choice[:value])
-      elsif choice.class == Hash
+      elsif choice.instance_of?(Hash)
         unless choice.key?(:value)
           error_msg = "Foorm configuration contains question '#{question_name}' without a  value for a choice. Choice text is '#{choice[:text]}'."
           raise InvalidFoormConfigurationError, error_msg
         end
-      elsif choice.class == String
+      elsif choice.instance_of?(String)
         error_msg = "Foorm configuration contains question '#{question_name}' without key-value choice. Choice is '#{choice}'."
         raise InvalidFoormConfigurationError,  error_msg
       end

--- a/dashboard/app/models/plc/course_unit.rb
+++ b/dashboard/app/models/plc/course_unit.rb
@@ -32,7 +32,7 @@ class Plc::CourseUnit < ApplicationRecord
   end
 
   def has_evaluation?
-    script.levels.where(type: 'LevelGroup').flat_map(&:levels).any? {|level| level.class == EvaluationMulti}
+    script.levels.where(type: 'LevelGroup').flat_map(&:levels).any? {|level| level.instance_of?(EvaluationMulti)}
   end
 
   def deprecated?
@@ -40,7 +40,7 @@ class Plc::CourseUnit < ApplicationRecord
   end
 
   def determine_preferred_learning_modules(user)
-    evaluation_level = script.levels.reverse.find {|level| level.class == LevelGroup}
+    evaluation_level = script.levels.reverse.find {|level| level.instance_of?(LevelGroup)}
 
     level_source = user.last_attempt(evaluation_level).try(:level_source)
     return [] if level_source.nil?

--- a/dashboard/legacy/middleware/channels_api.rb
+++ b/dashboard/legacy/middleware/channels_api.rb
@@ -178,7 +178,7 @@ class ChannelsApi < Sinatra::Base
     begin
       value = Projects.new(get_storage_id).update(id, value, request.ip, locale: request.locale, project_type: project_type)
     rescue ArgumentError, OpenSSL::Cipher::CipherError, ProfanityPrivacyError, Projects::ValidationError => exception
-      if exception.class == ProfanityPrivacyError
+      if exception.instance_of?(ProfanityPrivacyError)
         dont_cache
         status 422
         content_type :json

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -417,7 +417,7 @@ class FilesApi < Sinatra::Base
       begin
         share_failure = ShareFiltering.find_failure(body, request.locale)
       rescue StandardError => exception
-        return file_too_large(endpoint) if exception.class == WebPurify::TextTooLongError
+        return file_too_large(endpoint) if exception.instance_of?(WebPurify::TextTooLongError)
         details = exception.message.empty? ? nil : exception.message
         return json_bad_request(details)
       end

--- a/dashboard/lib/pd/foorm/foorm_parser.rb
+++ b/dashboard/lib/pd/foorm/foorm_parser.rb
@@ -154,9 +154,9 @@ module Pd::Foorm
     def self.flatten_choices(choices)
       choices_obj = {}
       choices.each do |choice_hash|
-        if choice_hash.class == Hash && choice_hash.key?(:value) && choice_hash.key?(:text)
+        if choice_hash.instance_of?(Hash) && choice_hash.key?(:value) && choice_hash.key?(:text)
           choices_obj[choice_hash[:value]] = fill_question_placeholders(choice_hash[:text])
-        elsif choice_hash.class == String
+        elsif choice_hash.instance_of?(String)
           choices_obj[choice_hash] = fill_question_placeholders(choice_hash)
           Honeybadger.notify(
             "Foorm configuration contains question without key-value choice. Choice is '#{choice_hash}'. Please update the survey configuration."

--- a/lib/forms/pegasus_form_errors.rb
+++ b/lib/forms/pegasus_form_errors.rb
@@ -4,7 +4,7 @@ class FormError < ArgumentError
   def self.detect_errors(data)
     errors = {}
     data.each_pair do |key, value|
-      errors[key] = [value.message] if value.class == FieldError
+      errors[key] = [value.message] if value.instance_of?(FieldError)
     end
     errors
   end

--- a/lib/forms/pegasus_form_validation.rb
+++ b/lib/forms/pegasus_form_validation.rb
@@ -7,7 +7,7 @@ require_relative '../cdo/geocoder'
 
 module PegasusFormValidation
   private def csv_multivalue(value)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     begin
       CSV.parse_line(value.to_s) || []
     rescue
@@ -16,13 +16,13 @@ module PegasusFormValidation
   end
 
   private def default_if_empty(value, default_value)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     return default_value if value.blank?
     value
   end
 
   private def downcased(value)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     if value.is_a?(Enumerable)
       value.map {|i| i.to_s.downcase}
     else
@@ -31,13 +31,13 @@ module PegasusFormValidation
   end
 
   private def enum(value, allowed)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     return FieldError.new(value, :invalid) unless allowed.include?(value)
     value
   end
 
   private def integer(value)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     return nil if value.blank?
 
     s_value = value.to_s.strip
@@ -48,20 +48,20 @@ module PegasusFormValidation
   end
 
   private def nil_if_empty(value)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     return nil if value.blank?
     value
   end
 
   private def required(value)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     return value if value.is_a? Integer
     return FieldError.new(value, :required) if value.blank?
     value
   end
 
   private def stripped(value)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     if value.is_a?(Enumerable)
       value.map {|i| i.to_s.strip}
     else
@@ -70,13 +70,13 @@ module PegasusFormValidation
   end
 
   private def uploaded_file(value)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     return nil if value.blank?
     AWS::S3.upload_to_bucket('cdo-form-uploads', value[:filename], File.open(value[:tempfile]))
   end
 
   private def email_address(value)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     email = downcased stripped value
     return nil if email.blank?
     return FieldError.new(value, :invalid) unless ValidatesEmailFormatOf.validate_email_format(email).nil?
@@ -84,7 +84,7 @@ module PegasusFormValidation
   end
 
   private def zip_code(value)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     value = stripped value
     return nil if value.blank?
 
@@ -95,13 +95,13 @@ module PegasusFormValidation
   end
 
   private def confirm_match(value, value2)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     return FieldError.new(value, :mismatch) if value != value2
     value
   end
 
   private def us_phone_number(value)
-    return value if value.class == FieldError
+    return value if value.instance_of?(FieldError)
     value = stripped value
     return nil if value.blank?
     return FieldError.new(value, :invalid) unless RegexpUtils.us_phone_number?(value)
@@ -112,9 +112,9 @@ module PegasusFormValidation
     errors = {}
 
     data.each_pair do |key, value|
-      if value.class == FieldError
+      if value.instance_of?(FieldError)
         errors[key] = [value.message]
-      elsif value.class == Hash
+      elsif value.instance_of?(Hash)
         suberrors = data_to_errors(value)
         suberrors.each_pair do |subkey, subvalue|
           newkey = "#{key}[#{subkey}]".to_sym

--- a/pegasus/forms/petition.rb
+++ b/pegasus/forms/petition.rb
@@ -13,8 +13,8 @@ class Petition < Form
     # Though this should have been done client-side, we do this server-side
     # for redundancy.
     if age < 16
-      result[:email_s] = 'anonymous@code.org' unless result[:email_s].class == FieldError
-      result[:name_s] = nil unless result[:name_s].class == FieldError
+      result[:email_s] = 'anonymous@code.org' unless result[:email_s].instance_of?(FieldError)
+      result[:name_s] = nil unless result[:name_s].instance_of?(FieldError)
     end
 
     result.merge! get_location(data[:zip_code_or_country_s].to_s.strip)


### PR DESCRIPTION
> Enforces the use of `Object#instance_of?` instead of class comparison for equality. `==`, `equal?`, and `eql?` custom method definitions are allowed by default. These are customizable with `AllowedMethods` option.

Fix applied automatically with `bundle exec rubocop --autocorrect-all --only Style/ClassEqualityComparison`

This is one of those rare `Style/` Cops that seems unambiguously good to me; I'm curious to hear if others have any preference for any of these alternatives over `instance_of?`.

## Links

- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ClassEqualityComparison
- https://docs.rubocop.org/rubocop/cops_style.html#styleclassequalitycomparison