### PR TITLE
Revert "Revert "Restoring PL section setup ui tests""

### DIFF
--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -171,7 +171,7 @@ export default function SectionsSetUpContainer({
       : null;
 
     const computedGrades =
-      participantType === 'teacher' ? ['pl'] : section.grade;
+      participantType === 'student' ? section.grade : ['pl'];
 
     const section_data = {
       login_type: loginType,

--- a/dashboard/test/ui/config/course_offerings/ui-test-teacher-pl-course.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-teacher-pl-course.json
@@ -3,5 +3,9 @@
   "display_name": "Teacher PL Course",
   "category": "pl_other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": "Professional Learning",
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": "summer_workshops_612"
 }

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -1,8 +1,6 @@
 @no_mobile
 Feature: Professional learning Sections
 
-  @skip
-  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Create new professional learning section as levelbuilder
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -21,13 +19,15 @@ Feature: Professional learning Sections
     And element ".uitest-facilitator-type" is visible
     When I select facilitator participant type
 
-    # Edit Section Form
-    Then I wait to see "#uitest-section-name"
-    And I press keys "My Section of Teachers" for element "#uitest-section-name"
-    Then I wait to see "#uitest-assignment-family"
-    When I select the "ui-test-teacher-pl-course" option in dropdown "uitest-assignment-family"
-    And I press the save button to create a new section
-    And I wait for the dialog to close using jQuery
+    # New Section details
+    Then I wait to see "#sections-set-up-container"
+    And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
+    And I wait until element "button:contains(Professional Learning)" is visible
+    # TODO TEACH-592: Seed PL courses so we can test course assignment
+    # And I click selector "button:contains(Professional Learning)"
+    # And I press the first "input[name='Teacher PL Course']" element
+    And I press the first "#uitest-save-section-changes" element
+    And I wait until element "#classroom-sections" is visible
 
     # Professional Learning Sections Table
     Then I should see the professional learning section table
@@ -35,8 +35,6 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
-  @skip
-  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Create new professional learning section as universal instructor
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -55,13 +53,12 @@ Feature: Professional learning Sections
     And element ".uitest-facilitator-type" is visible
     When I select facilitator participant type
 
-    # Edit Section Form
-    Then I wait to see "#uitest-section-name"
-    And I press keys "My Section of Teachers" for element "#uitest-section-name"
-    Then I wait to see "#uitest-assignment-family"
-    When I select the "ui-test-teacher-pl-course" option in dropdown "uitest-assignment-family"
-    And I press the save button to create a new section
-    And I wait for the dialog to close using jQuery
+    # New Section details
+    Then I wait to see "#sections-set-up-container"
+    And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
+    And I wait until element "button:contains(Professional Learning)" is visible
+    And I press the first "#uitest-save-section-changes" element
+    And I wait until element "#classroom-sections" is visible
 
     # Professional Learning Sections Table
     Then I should see the professional learning section table
@@ -69,8 +66,6 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
-  @skip
-  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Create new professional learning section as plc reviewer
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -89,13 +84,12 @@ Feature: Professional learning Sections
     And element ".uitest-facilitator-type" is visible
     When I select facilitator participant type
 
-    # Edit Section Form
-    Then I wait to see "#uitest-section-name"
-    And I press keys "My Section of Teachers" for element "#uitest-section-name"
-    Then I wait to see "#uitest-assignment-family"
-    When I select the "ui-test-facilitator-pl-course" option in dropdown "uitest-assignment-family"
-    And I press the save button to create a new section
-    And I wait for the dialog to close using jQuery
+    # New Section details
+    Then I wait to see "#sections-set-up-container"
+    And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
+    And I wait until element "button:contains(Professional Learning)" is visible
+    And I press the first "#uitest-save-section-changes" element
+    And I wait until element "#classroom-sections" is visible
 
     # Professional Learning Sections Table
     Then I should see the professional learning section table
@@ -103,8 +97,6 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
-  @skip
-  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Create new professional learning section as facilitator
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -123,13 +115,12 @@ Feature: Professional learning Sections
     And element ".uitest-facilitator-type" is not visible
     When I select teacher participant type
 
-    # Edit Section Form
-    Then I wait to see "#uitest-section-name"
-    And I press keys "My Section of Teachers" for element "#uitest-section-name"
-    Then I wait to see "#uitest-assignment-family"
-    When I select the "ui-test-teacher-pl-course" option in dropdown "uitest-assignment-family"
-    And I press the save button to create a new section
-    And I wait for the dialog to close using jQuery
+    # New Section details
+    Then I wait to see "#sections-set-up-container"
+    And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
+    And I wait until element "button:contains(Professional Learning)" is visible
+    And I press the first "#uitest-save-section-changes" element
+    And I wait until element "#classroom-sections" is visible
 
     # Professional Learning Sections Table
     Then I should see the professional learning section table
@@ -137,8 +128,6 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
-  @skip
-  # TODO TEACH-509: Reenable with new section setup flow
   Scenario: Teacher can not create professional learning section
     Given I create a teacher named "Teacher"
     And I sign in as "Teacher" and go home
@@ -149,8 +138,7 @@ Feature: Professional learning Sections
 
     # Participant Type Picker Does Not Show
     Then I should see the new section dialog
-    Then I select email login
-    Then I wait to see "#uitest-section-name"
+    And element ".uitest-teacher-type" is not visible
 
   Scenario: Teacher tries to join professional learning section for teachers
     Given I create an authorized teacher-associated student named "Sally"

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -36,8 +36,8 @@ Feature: Professional learning Sections
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
   Scenario: Create new professional learning section as universal instructor
-    Given I create an authorized teacher-associated student named "Sally"
-    When I sign in as "Teacher_Sally" and go home
+    Given I create an authorized teacher-associated student named "Maggie"
+    When I sign in as "Teacher_Maggie" and go home
     And I get universal instructor access
     And I reload the page
 
@@ -67,8 +67,8 @@ Feature: Professional learning Sections
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
   Scenario: Create new professional learning section as plc reviewer
-    Given I create an authorized teacher-associated student named "Sally"
-    When I sign in as "Teacher_Sally" and go home
+    Given I create an authorized teacher-associated student named "Arity"
+    When I sign in as "Teacher_Arity" and go home
     And I get plc reviewer access
     And I reload the page
 
@@ -98,8 +98,8 @@ Feature: Professional learning Sections
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
   Scenario: Create new professional learning section as facilitator
-    Given I create an authorized teacher-associated student named "Sally"
-    When I sign in as "Teacher_Sally" and go home
+    Given I create an authorized teacher-associated student named "Colin"
+    When I sign in as "Teacher_Colin" and go home
     And I get facilitator access
     And I reload the page
 
@@ -141,8 +141,8 @@ Feature: Professional learning Sections
     And element ".uitest-teacher-type" is not visible
 
   Scenario: Teacher tries to join professional learning section for teachers
-    Given I create an authorized teacher-associated student named "Sally"
-    When I sign in as "Teacher_Sally" and go home
+    Given I create an authorized teacher-associated student named "Bri"
+    When I sign in as "Teacher_Bri" and go home
     And I get universal instructor access
     And I create a new teacher section and go home
 
@@ -156,8 +156,8 @@ Feature: Professional learning Sections
     Then the professional learning joined sections table should have 1 row
 
   Scenario: Teacher tries to join professional learning section for facilitators
-    Given I create an authorized teacher-associated student named "Sally"
-    When I sign in as "Teacher_Sally" and go home
+    Given I create an authorized teacher-associated student named "Kelly"
+    When I sign in as "Teacher_Kelly" and go home
     And I get universal instructor access
     And I create a new facilitator section and go home
 
@@ -172,8 +172,8 @@ Feature: Professional learning Sections
     And element ".announcement-notification" contains text matching "You do not have the permissions to join section"
 
   Scenario: Facilitator tries to join professional learning section for teachers
-    Given I create an authorized teacher-associated student named "Sally"
-    When I sign in as "Teacher_Sally" and go home
+    Given I create an authorized teacher-associated student named "Gilly"
+    When I sign in as "Teacher_Gilly" and go home
     And I get universal instructor access
     And I create a new teacher section and go home
 
@@ -189,8 +189,8 @@ Feature: Professional learning Sections
     Then the professional learning joined sections table should have 1 row
 
   Scenario: Facilitator tries to join professional learning section for facilitators
-    Given I create an authorized teacher-associated student named "Sally"
-    When I sign in as "Teacher_Sally" and go home
+    Given I create an authorized teacher-associated student named "Sarah"
+    When I sign in as "Teacher_Sarah" and go home
     And I get universal instructor access
     And I create a new facilitator section and go home
 
@@ -206,8 +206,8 @@ Feature: Professional learning Sections
     Then the professional learning joined sections table should have 1 row
 
   Scenario: Universal Instructor tries to join professional learning section for teachers
-    Given I create an authorized teacher-associated student named "Sally"
-    When I sign in as "Teacher_Sally" and go home
+    Given I create an authorized teacher-associated student named "Lauren"
+    When I sign in as "Teacher_Lauren" and go home
     And I get universal instructor access
     And I create a new teacher section and go home
 
@@ -223,8 +223,8 @@ Feature: Professional learning Sections
     Then the professional learning joined sections table should have 1 row
 
   Scenario: Universal Instructor tries to join professional learning section for facilitators
-    Given I create an authorized teacher-associated student named "Sally"
-    When I sign in as "Teacher_Sally" and go home
+    Given I create an authorized teacher-associated student named "Syd"
+    When I sign in as "Teacher_Syd" and go home
     And I get universal instructor access
     And I create a new facilitator section and go home
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#52548

This PR hopefully gets the rest of the PL Sections tests running again. I believe based on a saucelabs investigation that these tests weren't running properly because it kept creating the same teacher associated student. This pr updates their names to prevent any sort of bugginess between tests. See screenshot below.

<img width="1043" alt="Screenshot 2023-07-20 at 3 45 15 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/268f841a-7f1a-47bb-bbde-9f62b35bf050">


## Links


- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-555