### PR TITLE
Music: support flyout toolbox

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -36,7 +36,7 @@ export default class MusicBlocklyWorkspace {
    * @param {*} onBlockSpaceChange callback fired when any block space change events occur
    * @param {*} isReadOnlyWorkspace is the workspace readonly
    * @param {*} toolboxAllowList object defining allowed toolbox entries
-   * @param {*} isReadOnlyWorkspace is the toolbox simple, without categories
+   * @param {*} simpleToolbox is the toolbox simple, without categories
    *
    */
   init(

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -35,27 +35,20 @@ export default class MusicBlocklyWorkspace {
    * @param {*} container HTML element to inject the workspace into
    * @param {*} onBlockSpaceChange callback fired when any block space change events occur
    * @param {*} isReadOnlyWorkspace is the workspace readonly
-   * @param {*} toolboxAllowList object defining allowed toolbox entries
-   * @param {*} simpleToolbox is the toolbox simple, without categories
+   * @param {*} toolbox information about the toolbox
    *
    */
-  init(
-    container,
-    onBlockSpaceChange,
-    isReadOnlyWorkspace,
-    toolboxAllowList,
-    simpleToolbox
-  ) {
+  init(container, onBlockSpaceChange, isReadOnlyWorkspace, toolbox) {
     if (this.workspace) {
       this.workspace.dispose();
     }
 
     this.container = container;
 
-    const toolbox = getToolbox(toolboxAllowList, simpleToolbox);
+    const toolboxBlocks = getToolbox(toolbox);
 
     this.workspace = Blockly.inject(container, {
-      toolbox: toolbox,
+      toolbox: toolboxBlocks,
       grid: {spacing: 20, length: 0, colour: '#444', snap: true},
       theme: CdoDarkTheme,
       renderer: experiments.isEnabled('zelos')

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -35,16 +35,27 @@ export default class MusicBlocklyWorkspace {
    * @param {*} container HTML element to inject the workspace into
    * @param {*} onBlockSpaceChange callback fired when any block space change events occur
    * @param {*} isReadOnlyWorkspace is the workspace readonly
+   * @param {*} toolboxAllowList object defining allowed toolbox entries
+   * @param {*} isReadOnlyWorkspace is the toolbox simple, without categories
+   *
    */
-  init(container, onBlockSpaceChange, isReadOnlyWorkspace) {
+  init(
+    container,
+    onBlockSpaceChange,
+    isReadOnlyWorkspace,
+    toolboxAllowList,
+    simpleToolbox
+  ) {
     if (this.workspace) {
       this.workspace.dispose();
     }
 
     this.container = container;
 
+    const toolbox = getToolbox(toolboxAllowList, simpleToolbox);
+
     this.workspace = Blockly.inject(container, {
-      toolbox: getToolbox(),
+      toolbox: toolbox,
       grid: {spacing: 20, length: 0, colour: '#444', snap: true},
       theme: CdoDarkTheme,
       renderer: experiments.isEnabled('zelos')
@@ -353,13 +364,5 @@ export default class MusicBlocklyWorkspace {
     } catch (e) {
       Lab2MetricsReporter.logError('Error running user generated code', e);
     }
-  }
-
-  updateToolbox(allowList) {
-    if (!this.workspace || this.workspace.options.readOnly) {
-      return;
-    }
-    const toolbox = getToolbox(allowList);
-    this.workspace.updateToolbox(toolbox);
   }
 }

--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -305,7 +305,7 @@ const toolboxBlocks = {
 
 function generateToolbox(categoryBlocksMap, options) {
   const toolbox = {
-    kind: options?.simpleToolbox ? 'flyoutToolbox' : 'categoryToolbox',
+    kind: options?.type === 'flyout' ? 'flyoutToolbox' : 'categoryToolbox',
     contents: [],
   };
 
@@ -330,7 +330,7 @@ function generateToolbox(categoryBlocksMap, options) {
       categoryContents.push(toolboxBlocks[blockName]);
     }
 
-    if (options?.simpleToolbox) {
+    if (options?.type === 'flyout') {
       toolbox.contents = toolbox.contents.concat(categoryContents);
     } else {
       toolbox.contents.push({
@@ -383,7 +383,7 @@ function getCategoryName(category) {
   return categoryTypeToLocalizedName[category];
 }
 
-export function getToolbox(allowList, simpleToolbox) {
+export function getToolbox(toolbox) {
   switch (getBlockMode()) {
     case BlockMode.SIMPLE:
       return generateToolbox({
@@ -449,7 +449,11 @@ export function getToolbox(allowList, simpleToolbox) {
             BlockTypes.SET_DELAY_EFFECT_AT_CURRENT_LOCATION_SIMPLE2,
           ],
         },
-        {includeFunctions: true, allowList, simpleToolbox}
+        {
+          includeFunctions: true,
+          allowList: toolbox?.blocks,
+          type: toolbox?.type,
+        }
       );
   }
 }

--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -305,7 +305,7 @@ const toolboxBlocks = {
 
 function generateToolbox(categoryBlocksMap, options) {
   const toolbox = {
-    kind: 'categoryToolbox',
+    kind: options?.simpleToolbox ? 'flyoutToolbox' : 'categoryToolbox',
     contents: [],
   };
 
@@ -330,12 +330,16 @@ function generateToolbox(categoryBlocksMap, options) {
       categoryContents.push(toolboxBlocks[blockName]);
     }
 
-    toolbox.contents.push({
-      kind: 'category',
-      name: getCategoryName(category),
-      cssConfig: baseCategoryCssConfig,
-      contents: categoryContents,
-    });
+    if (options?.simpleToolbox) {
+      toolbox.contents = toolbox.contents.concat(categoryContents);
+    } else {
+      toolbox.contents.push({
+        kind: 'category',
+        name: getCategoryName(category),
+        cssConfig: baseCategoryCssConfig,
+        contents: categoryContents,
+      });
+    }
   }
 
   if (options?.includeVariables) {
@@ -379,7 +383,7 @@ function getCategoryName(category) {
   return categoryTypeToLocalizedName[category];
 }
 
-export function getToolbox(allowList) {
+export function getToolbox(allowList, simpleToolbox) {
   switch (getBlockMode()) {
     case BlockMode.SIMPLE:
       return generateToolbox({
@@ -445,7 +449,7 @@ export function getToolbox(allowList) {
             BlockTypes.SET_DELAY_EFFECT_AT_CURRENT_LOCATION_SIMPLE2,
           ],
         },
-        {includeFunctions: true, allowList}
+        {includeFunctions: true, allowList, simpleToolbox}
       );
   }
 }

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -243,10 +243,11 @@ class UnconnectedMusicView extends React.Component {
     this.musicBlocklyWorkspace.init(
       document.getElementById('blockly-div'),
       this.onBlockSpaceChange,
-      this.props.isReadOnlyWorkspace
+      this.props.isReadOnlyWorkspace,
+      levelData?.toolbox,
+      levelData?.simpleToolbox
     );
 
-    this.musicBlocklyWorkspace.updateToolbox(levelData?.toolbox);
     this.library.setAllowedSounds(levelData?.sounds);
     this.props.setShowInstructions(!!levelData?.text);
 

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -244,8 +244,7 @@ class UnconnectedMusicView extends React.Component {
       document.getElementById('blockly-div'),
       this.onBlockSpaceChange,
       this.props.isReadOnlyWorkspace,
-      levelData?.toolbox,
-      levelData?.simpleToolbox
+      levelData?.toolbox
     );
 
     this.library.setAllowedSounds(levelData?.sounds);

--- a/dashboard/config/scripts/levels/Music Level 1.level
+++ b/dashboard/config/scripts/levels/Music Level 1.level
@@ -7,9 +7,11 @@
     "level_data": {
       "text": "First, please play one sound.",
       "toolbox": {
-        "Play": ["play_sound_at_current_location_simple2"]
+        "blocks": {
+          "Play": ["play_sound_at_current_location_simple2"]
+        },
+        "type": "flyout"
       },
-      "simpleToolbox": true,
       "sounds": {
         "beats": ["disco_beat", "reggaeton_beat"]
       },

--- a/dashboard/config/scripts/levels/Music Level 1.level
+++ b/dashboard/config/scripts/levels/Music Level 1.level
@@ -9,6 +9,7 @@
       "toolbox": {
         "Play": ["play_sound_at_current_location_simple2"]
       },
+      "simpleToolbox": true,
       "sounds": {
         "beats": ["disco_beat", "reggaeton_beat"]
       },

--- a/dashboard/config/scripts/levels/Music Level 2.level
+++ b/dashboard/config/scripts/levels/Music Level 2.level
@@ -10,6 +10,7 @@
         "Play": ["play_sound_at_current_location_simple2"],
         "Control": ["play_sounds_together"]
       },
+      "simpleToolbox": true,
       "sounds": {
         "beats": ["cafe_beat", "reggaeton_beat"],
         "leads": ["lucky_guitar", "picked_guitar"]

--- a/dashboard/config/scripts/levels/Music Level 2.level
+++ b/dashboard/config/scripts/levels/Music Level 2.level
@@ -7,10 +7,12 @@
     "level_data": {
       "text": "Second, please play three sounds at the same time.",
       "toolbox": {
-        "Play": ["play_sound_at_current_location_simple2"],
-        "Control": ["play_sounds_together"]
+        "blocks": {
+          "Play": ["play_sound_at_current_location_simple2"],
+          "Control": ["play_sounds_together"]
+        },
+        "type": "flyout"
       },
-      "simpleToolbox": true,
       "sounds": {
         "beats": ["cafe_beat", "reggaeton_beat"],
         "leads": ["lucky_guitar", "picked_guitar"]

--- a/dashboard/config/scripts/levels/Music Level 3.level
+++ b/dashboard/config/scripts/levels/Music Level 3.level
@@ -10,7 +10,7 @@
       "startSources": {
         "blocks": {
           "languageVersion": 0,
-          "blocks": [{"type": "when_run_simple2", "deletable": false, "movable": false, "x": 36, "y": 36}]
+          "blocks": [{"id": "when-run-block", "type": "when_run_simple2", "deletable": false, "movable": false, "x": 36, "y": 36}]
         },
         "variables": [{"name": "currentTime"}, {"name": "i"}]
       }

--- a/dashboard/config/scripts/levels/hoc-amazon - music lab - 1.level
+++ b/dashboard/config/scripts/levels/hoc-amazon - music lab - 1.level
@@ -11,9 +11,11 @@
     "level_data": {
       "text": "First, please play one sound.",
       "toolbox": {
-        "Play": [
-          "play_sound_at_current_location_simple2"
-        ]
+        "blocks": {
+          "Play": [
+            "play_sound_at_current_location_simple2"
+          ]
+        }
       },
       "sounds": {
         "beats": [

--- a/dashboard/config/scripts/levels/hoc-amazon - music lab - 2.level
+++ b/dashboard/config/scripts/levels/hoc-amazon - music lab - 2.level
@@ -11,12 +11,14 @@
     "level_data": {
       "text": "Second, please play three sounds at the same time.",
       "toolbox": {
-        "Play": [
-          "play_sound_at_current_location_simple2"
-        ],
-        "Control": [
-          "play_sounds_together"
-        ]
+        "blocks": {
+          "Play": [
+            "play_sound_at_current_location_simple2"
+          ],
+          "Control": [
+            "play_sounds_together"
+          ]
+        }
       },
       "sounds": {
         "beats": [

--- a/dashboard/config/scripts/levels/music_lab_2023_2.level
+++ b/dashboard/config/scripts/levels/music_lab_2023_2.level
@@ -31,9 +31,11 @@
         ]
       },
       "toolbox": {
-        "Play": [
-          "play_sound_at_current_location_simple2"
-        ]
+        "blocks": {
+          "Play": [
+            "play_sound_at_current_location_simple2"
+          ]
+        }
       },
       "text": "Let’s lay down a beat!\n## Do This\n1. Snap a `play`(#7435b2) block under the `when run`(#fca401) block, and click on the sound name to open the Sound Library. The Sound Library has all the sounds you can choose from for remixing this song. We're making a beat, so pick something with the little drum icon next to it.\n2. Hit the `Run`(#fca401) button to take a listen.",
       "validations": [

--- a/dashboard/config/scripts/levels/music_lab_2023_3.level
+++ b/dashboard/config/scripts/levels/music_lab_2023_3.level
@@ -11,12 +11,14 @@
       "library": "happy",
       "text": "#Loop It\nIt's common to take a beat and repeat it, sometimes for the rest of a song. But songs can get pretty long, so we'd need a ton of blocks if we added them one by one! Thankfully, repeating things is also common in code. In the `Control`(#999999) category of the toolbox, you'll find the `repeat`(#f218a2) block. Anything you put inside it will be repeated the number of times set by the block. \n## Do This\nUse this block to repeat the sounds that make up your beat a few times. You should notice the beat repeats the same number of times you set in the loop!",
       "toolbox": {
-        "Play": [
-          "play_sound_at_current_location_simple2"
-        ],
-        "Control": [
-          "repeat_simple2"
-        ]
+        "blocks": {
+          "Play": [
+            "play_sound_at_current_location_simple2"
+          ],
+          "Control": [
+            "repeat_simple2"
+          ]
+        }
       },
       "validations": [
         {

--- a/dashboard/config/scripts/levels/music_lab_2023_4.level
+++ b/dashboard/config/scripts/levels/music_lab_2023_4.level
@@ -126,15 +126,17 @@
         }
       },
       "toolbox": {
-        "Play": [
-          "play_sound_at_current_location_simple2"
-        ],
-        "Control": [
-          "repeat_simple2"
-        ],
-        "Functions": [
-          "procedures_defnoreturn"
-        ]
+        "blocks": {
+          "Play": [
+            "play_sound_at_current_location_simple2"
+          ],
+          "Control": [
+            "repeat_simple2"
+          ],
+          "Functions": [
+            "procedures_defnoreturn"
+          ]
+        }
       },
       "validations": [
         {

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
@@ -27,5 +27,5 @@ Scenario Outline: Dragging play sound block
 
 Examples:
   | url                                                       | test_name               |
-  | http://studio.code.org/s/allthethings/lessons/46/levels/2 | music lab script level  |
+  | http://studio.code.org/s/allthethings/lessons/46/levels/4 | music lab script level  |
   | http://studio.code.org/projectbeats?show-video=false      | music lab incubator     |


### PR DESCRIPTION
This adds support for an optional Music Lab level property, `"type": "flyout"`, which will show a [toolbox](https://developers.google.com/blockly/guides/configure/web/toolbox) with all blocks shown all the time, without categories.  

It seems this could be helpful in early levels in a progression, when only a few blocks will be available.

The toolbox section of the level data has been changed a little, to have separate `"blocks"` and optional `"type"` entries.

### flyout toolbox

<img width="1242" alt="Screenshot 2023-07-21 at 12 43 38 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/135fc7b5-2ec1-47f3-8dfa-2abe6335ba6d">

### categories toolbox (default)

<img width="1242" alt="Screenshot 2023-07-21 at 12 43 43 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/4020ef6d-bf80-4b12-b8ff-19c162651f00">


