### PR TITLE
Music: update timeline function boundaries

### DIFF
--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -147,7 +147,7 @@ export const playSoundAtCurrentLocationSimple2 = {
   generator: block =>
     `Sequencer.playSound("${block.getFieldValue(FIELD_SOUNDS_NAME)}", "${
       block.id
-    }");`,
+    }");\n`,
 };
 
 export const playPatternAtCurrentLocationSimple2 = {

--- a/apps/src/music/player/interfaces/FunctionEvents.ts
+++ b/apps/src/music/player/interfaces/FunctionEvents.ts
@@ -1,0 +1,16 @@
+import {PlaybackEvent} from './PlaybackEvent';
+
+/**
+ * This is very similar to {@link FunctionContext}, but also contains
+ * all playback events that occur in the function. This model will be
+ * useful for timeline rendering, but as of now is only used within this
+ * class.
+ */
+export interface FunctionEvents {
+  name: string;
+  uniqueInvocationId: number;
+  playbackEvents: PlaybackEvent[];
+  calledFunctionIds: number[];
+  startMeasure: number;
+  endMeasure: number;
+}

--- a/apps/src/music/player/interfaces/FunctionEvents.ts
+++ b/apps/src/music/player/interfaces/FunctionEvents.ts
@@ -2,9 +2,7 @@ import {PlaybackEvent} from './PlaybackEvent';
 
 /**
  * This is very similar to {@link FunctionContext}, but also contains
- * all playback events that occur in the function. This model will be
- * useful for timeline rendering, but as of now is only used within this
- * class.
+ * all playback events that occur in the function.
  */
 export interface FunctionEvents {
   name: string;

--- a/apps/src/music/player/sequencer/Simple2Sequencer.ts
+++ b/apps/src/music/player/sequencer/Simple2Sequencer.ts
@@ -133,10 +133,13 @@ export default class Simple2Sequencer extends Sequencer {
     const lastFunctionId = this.functionStack.pop();
     if (lastFunctionId !== undefined) {
       this.functionMap[lastFunctionId].endMeasure = this.getCurrentMeasure();
-      // Add the called function to the list of functions that its caller called.
-      this.functionMap[
-        this.functionStack[this.functionStack.length - 1]
-      ].calledFunctionIds.push(lastFunctionId);
+
+      if (this.functionStack.length > 0) {
+        // Add the called function to the list of functions that its caller called.
+        this.functionMap[
+          this.functionStack[this.functionStack.length - 1]
+        ].calledFunctionIds.push(lastFunctionId);
+      }
     }
 
     this.effectsStack.pop();
@@ -291,18 +294,6 @@ export default class Simple2Sequencer extends Sequencer {
     currentFunction.playbackEvents.push(event);
     this.updateMeasureForPlayByLength(event.length);
   }
-
-  /*
-  private addNewFunctionCall(functionName: string){
-    const currentFunctionId = this.getCurrentFunctionId();
-    if (currentFunctionId === null) {
-      Lab2MetricsReporter.logWarning('Invalid state: no current function ID');
-      return;
-    }
-    const currentFunction = this.functionMap[currentFunctionId];
-
-    currentFunction.calledFunctionIds.push(functionName);
-  }*/
 
   // Internal helper to get the entry at the top of the stack, or null
   // if the stack is empty.

--- a/apps/src/music/player/sequencer/Simple2Sequencer.ts
+++ b/apps/src/music/player/sequencer/Simple2Sequencer.ts
@@ -4,6 +4,7 @@ import {ChordEvent, ChordEventValue} from '../interfaces/ChordEvent';
 import {Effects, EffectValue} from '../interfaces/Effects';
 import {PatternEvent, PatternEventValue} from '../interfaces/PatternEvent';
 import {PlaybackEvent} from '../interfaces/PlaybackEvent';
+import {FunctionEvents} from '../interfaces/FunctionEvents';
 import {SkipContext} from '../interfaces/SkipContext';
 import {SoundEvent} from '../interfaces/SoundEvent';
 import MusicLibrary from '../MusicLibrary';
@@ -13,20 +14,6 @@ interface SequenceFrame {
   measure: number;
   together: boolean;
   lastMeasures: number[];
-}
-
-/**
- * This is very similar to {@link FunctionContext}, but also contains
- * all playback events that occur in the function. This model will be
- * useful for timeline rendering, but as of now is only used within this
- * class.
- */
-interface FunctionEvents {
-  name: string;
-  uniqueInvocationId: number;
-  playbackEvents: PlaybackEvent[];
-  startMeasure: number;
-  endMeasure: number;
 }
 
 interface SkipFrame {
@@ -128,6 +115,7 @@ export default class Simple2Sequencer extends Sequencer {
       startMeasure: this.getCurrentMeasure(),
       endMeasure: this.getCurrentMeasure(),
       playbackEvents: [],
+      calledFunctionIds: [],
     };
 
     this.functionStack.push(uniqueId);
@@ -145,6 +133,10 @@ export default class Simple2Sequencer extends Sequencer {
     const lastFunctionId = this.functionStack.pop();
     if (lastFunctionId !== undefined) {
       this.functionMap[lastFunctionId].endMeasure = this.getCurrentMeasure();
+      // Add the called function to the list of functions that its caller called.
+      this.functionMap[
+        this.functionStack[this.functionStack.length - 1]
+      ].calledFunctionIds.push(lastFunctionId);
     }
 
     this.effectsStack.pop();
@@ -299,6 +291,18 @@ export default class Simple2Sequencer extends Sequencer {
     currentFunction.playbackEvents.push(event);
     this.updateMeasureForPlayByLength(event.length);
   }
+
+  /*
+  private addNewFunctionCall(functionName: string){
+    const currentFunctionId = this.getCurrentFunctionId();
+    if (currentFunctionId === null) {
+      Lab2MetricsReporter.logWarning('Invalid state: no current function ID');
+      return;
+    }
+    const currentFunction = this.functionMap[currentFunctionId];
+
+    currentFunction.calledFunctionIds.push(functionName);
+  }*/
 
   // Internal helper to get the entry at the top of the stack, or null
   // if the stack is empty.

--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -1,6 +1,7 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 import {MIN_NUM_MEASURES} from '../constants';
 import {PlaybackEvent} from '../player/interfaces/PlaybackEvent';
+import {FunctionEvents} from '../player/interfaces/FunctionEvents';
 
 const registerReducers = require('@cdo/apps/redux').registerReducers;
 
@@ -40,6 +41,8 @@ export interface MusicState {
   isBeatPadShowing: boolean;
   /** The current list of playback events */
   playbackEvents: PlaybackEvent[];
+  /** The current ordered functions */
+  orderedFunctions: FunctionEvents[];
   /** The current last measure of the song */
   lastMeasure: number;
   /** The current sound loading progress, from 0-1 inclusive, representing the
@@ -60,6 +63,7 @@ const initialState: MusicState = {
   isHeadersShowing: true,
   isBeatPadShowing: true,
   playbackEvents: [],
+  orderedFunctions: [],
   lastMeasure: 0,
   soundLoadingProgress: 0,
   startingPlayheadPosition: 1,
@@ -139,12 +143,21 @@ const musicSlice = createSlice({
       state.playbackEvents = [];
       state.lastMeasure = 0;
     },
+    clearOrderedFunctions: state => {
+      state.orderedFunctions = [];
+    },
     addPlaybackEvents: (
       state,
       action: PayloadAction<{events: PlaybackEvent[]; lastMeasure: number}>
     ) => {
       state.playbackEvents.push(...action.payload.events);
       state.lastMeasure = action.payload.lastMeasure;
+    },
+    addOrderedFunctions: (
+      state,
+      action: PayloadAction<{orderedFunctions: FunctionEvents[]}>
+    ) => {
+      state.orderedFunctions.push(...action.payload.orderedFunctions);
     },
     setSoundLoadingProgress: (state, action: PayloadAction<number>) => {
       state.soundLoadingProgress = action.payload;
@@ -218,7 +231,9 @@ export const {
   hideBeatPad,
   toggleBeatPad,
   clearPlaybackEvents,
+  clearOrderedFunctions,
   addPlaybackEvents,
+  addOrderedFunctions,
   setSoundLoadingProgress,
   setStartPlayheadPosition,
   moveStartPlayheadPositionForward,

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -29,7 +29,9 @@ import {
   setInstructionsPosition,
   InstructionsPositions,
   addPlaybackEvents,
+  addOrderedFunctions,
   clearPlaybackEvents,
+  clearOrderedFunctions,
   getCurrentlyPlayingBlockIds,
   setSoundLoadingProgress,
 } from '../redux/musicRedux';
@@ -104,7 +106,9 @@ class UnconnectedMusicView extends React.Component {
     setInstructionsPosition: PropTypes.func,
     navigateToLevelId: PropTypes.func,
     clearPlaybackEvents: PropTypes.func,
+    clearOrderedFunctions: PropTypes.func,
     addPlaybackEvents: PropTypes.func,
+    addOrderedFunctions: PropTypes.func,
     currentlyPlayingBlockIds: PropTypes.array,
     isHeadersShowing: PropTypes.bool,
     sendSuccessReport: PropTypes.func,
@@ -457,6 +461,9 @@ class UnconnectedMusicView extends React.Component {
       events: playbackEvents,
       lastMeasure: this.sequencer.getLastMeasure(),
     });
+    this.props.addOrderedFunctions({
+      orderedFunctions: this.sequencer.getOrderedFunctions(),
+    });
     this.player.playEvents(playbackEvents);
 
     this.playingTriggers.push({
@@ -475,12 +482,16 @@ class UnconnectedMusicView extends React.Component {
   executeCompiledSong = () => {
     // Clear the events list because it will be populated next.
     this.props.clearPlaybackEvents();
+    this.props.clearOrderedFunctions();
 
     this.sequencer.clear();
     this.musicBlocklyWorkspace.executeCompiledSong(this.playingTriggers);
     this.props.addPlaybackEvents({
       events: this.sequencer.getPlaybackEvents(),
       lastMeasure: this.sequencer.getLastMeasure(),
+    });
+    this.props.addOrderedFunctions({
+      orderedFunctions: this.sequencer.getOrderedFunctions(),
     });
   };
 
@@ -746,8 +757,11 @@ const MusicView = connect(
       dispatch(setInstructionsPosition(instructionsPosition)),
     navigateToLevelId: levelId => dispatch(navigateToLevelId(levelId)),
     clearPlaybackEvents: () => dispatch(clearPlaybackEvents()),
+    clearOrderedFunctions: () => dispatch(clearOrderedFunctions()),
     addPlaybackEvents: playbackEvents =>
       dispatch(addPlaybackEvents(playbackEvents)),
+    addOrderedFunctions: orderedFunctions =>
+      dispatch(addOrderedFunctions(orderedFunctions)),
     sendSuccessReport: appType => dispatch(sendSuccessReport(appType)),
     setProjectUpdatedSaving: () => dispatch(setProjectUpdatedSaving()),
     setProjectUpdatedAt: updatedAt => dispatch(setProjectUpdatedAt(updatedAt)),

--- a/apps/src/music/views/TimelineSimple2Events.jsx
+++ b/apps/src/music/views/TimelineSimple2Events.jsx
@@ -153,7 +153,8 @@ const TimelineSimple2Events = ({
             key={index}
             style={{
               position: 'absolute',
-              backgroundColor: 'rgba(255 255 255 / 0.12)',
+              backgroundColor:
+                index === 0 ? 'rgba(0 0 0 / 0)' : 'rgba(255 255 255 / 0.12)',
               borderRadius: 8,
               left: paddingOffset + (uniqueFunction.left - 1) * barWidth,
               width: (uniqueFunction.right - uniqueFunction.left) * barWidth,

--- a/apps/src/music/views/TimelineSimple2Events.jsx
+++ b/apps/src/music/views/TimelineSimple2Events.jsx
@@ -54,8 +54,8 @@ const TimelineSimple2Events = ({
   });
 
   function getFunctionBounds(orderedFunction) {
-    let left = 100000,
-      top = 100000,
+    let left = Number.MAX_SAFE_INTEGER,
+      top = Number.MAX_SAFE_INTEGER,
       right = 0,
       bottom = 0;
 


### PR DESCRIPTION
This updates the Music Lab timeline rendering of function boundaries, so that each function's boundary includes sounds generated by functions it calls.  It also removes the boundary from the outermost `when run`.

<img width="1531" alt="Screenshot 2023-07-22 at 8 12 12 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/25679be4-dc03-4a89-8d4b-d2636b890bd0">
