### PR TITLE
Lab2: show error message under sad bee

### DIFF
--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -93,6 +93,7 @@
 
   .pageErrorContainer {
     background-color: rgba(0 0 0 / 0.5);
+    color: $neutral_dark;
     position: absolute;
     width: 100%;
     height: 100%;
@@ -108,13 +109,17 @@
       background-color: $neutral_light;
       border-radius: 5px;
       padding: 20px;
+      text-align: center;
 
-      .pageErrorImage {
+      &Image {
         width: 120px;
         display: block;
-        margin: 0 auto;
-        margin-top: 2px;
-        margin-bottom: 15px;
+        margin: 2px auto 15px auto;
+      }
+
+      &Message {
+        color: $neutral_dark70;
+        margin-top: 10px;
       }
     }
   }

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -25,8 +25,7 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
   const isPageError: boolean = useSelector(hasPageError);
   const errorMessage: string | undefined = useSelector(
     (state: {lab: LabState}) =>
-      state?.lab?.pageError?.errorMessage ||
-      state?.lab?.pageError?.error?.message
+      state.lab.pageError?.errorMessage || state.lab.pageError?.error?.message
   );
   const overlayStyle: string = isLoading
     ? moduleStyles.showingBlock
@@ -76,7 +75,7 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
 };
 
 export interface ErrorUIProps {
-  message?: string | undefined;
+  message?: string;
 }
 
 export const ErrorUI: React.FunctionComponent<ErrorUIProps> = ({message}) => (

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -11,7 +11,7 @@ import {useSelector} from 'react-redux';
 import classNames from 'classnames';
 import moduleStyles from './Lab2Wrapper.module.scss';
 import ErrorBoundary from '../ErrorBoundary';
-import {isLabLoading, hasPageError} from '../lab2Redux';
+import {LabState, isLabLoading, hasPageError} from '../lab2Redux';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import Lab2MetricsReporter from '../Lab2MetricsReporter';
 const i18n = require('@cdo/locale');
@@ -23,7 +23,11 @@ export interface Lab2WrapperProps {
 const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
   const isLoading: boolean = useSelector(isLabLoading);
   const isPageError: boolean = useSelector(hasPageError);
-
+  const errorMessage: string | undefined = useSelector(
+    (state: {lab: LabState}) =>
+      state?.lab?.pageError?.errorMessage ||
+      state?.lab?.pageError?.error?.message
+  );
   const overlayStyle: string = isLoading
     ? moduleStyles.showingBlock
     : moduleStyles.fadeInBlock;
@@ -65,20 +69,27 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
           )}
         </div>
 
-        {isPageError && <ErrorUI />}
+        {isPageError && <ErrorUI message={errorMessage} />}
       </div>
     </ErrorBoundary>
   );
 };
 
-export const ErrorUI = () => (
+export interface ErrorUIProps {
+  message?: string | undefined;
+}
+
+export const ErrorUI: React.FunctionComponent<ErrorUIProps> = ({message}) => (
   <div id="page-error-container" className={moduleStyles.pageErrorContainer}>
     <div id="page-error" className={moduleStyles.pageError}>
       <img
         className={moduleStyles.pageErrorImage}
         src="/shared/images/sad-bee-avatar.png"
       />
-      {i18n.loadingError()}
+      <div>{i18n.loadingError()}</div>
+      {message && (
+        <div className={moduleStyles.pageErrorMessage}>({message})</div>
+      )}
     </div>
   </div>
 );


### PR DESCRIPTION
Just an idea to show the readable error message, if there is one, under the sad bee, for Lab2 errors.

<img width="1498" alt="Screenshot 2023-07-22 at 9 36 04 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/ef5ade53-c455-4345-a430-db3553835ee4">
