### PR TITLE
Music: update small footer styling

### DIFF
--- a/apps/src/music/views/controls.module.scss
+++ b/apps/src/music/views/controls.module.scss
@@ -45,6 +45,7 @@
     flex: 2;
     background-color: #fca401;
     color: $neutral_light;
+    margin: 0;
 
     .text {
       padding-left: 10px;
@@ -72,7 +73,7 @@
   height: 5px;
   background-color: $neutral_dark80;
   position: relative;
-  margin-top: auto;
+  margin-top: 15px;
   border-radius: 4px;
   overflow: hidden;
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -829,6 +829,48 @@ $small-footer-standard-width: 400px;
   border-top: initial;
 }
 
+/* Custom styling for the locale & copyright buttons and the copyright flyout,
+ * for Music Lab.
+ */
+.music-black {
+  #page-small-footer {
+    user-select: none;
+
+    .small-footer-base {
+      margin-left: 10px;
+    }
+
+    .i18n-dropdown-container, .copyright-link {
+      height: 26px;
+      box-sizing: border-box;
+      border: solid 1px $neutral_dark40;
+    }
+
+    .copyright-button {
+      user-select: none;
+
+      .copyright-link {
+        width: 26px;
+      }
+    }
+
+    .i18n-dropdown-container, .globe-icon, #locale, .copyright-link {
+      background-color: initial;
+      color: $neutral_dark40;
+    }
+
+    #copyright-flyout {
+      border: solid 1px $neutral_dark40;
+      box-sizing: border-box;
+    }
+
+    #copyright-flyout, #copyright-scroll-area {
+      background-color: $neutral_dark;
+      color: $neutral_light;
+    }
+  }
+}
+
 .header_separator {
   padding-left: 2px;
   margin-bottom: -18px;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -862,6 +862,17 @@ $small-footer-standard-width: 400px;
     #copyright-flyout {
       border: solid 1px $neutral_dark40;
       box-sizing: border-box;
+
+      h4, a:link {
+        color: $neutral_dark50;
+      }
+
+      img {
+        background-color: $neutral_light;
+        border-radius: 4px;
+        padding: 4px;
+        margin-bottom: 6px;
+      }
     }
 
     #copyright-flyout, #copyright-scroll-area {


### PR DESCRIPTION
Update the small footer styling for Music Lab.

### Updated footer

<img width="1279" alt="Screenshot 2023-07-23 at 10 48 42 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/91a10505-7c70-48b0-afb7-d55bb6d2f71a">

### With copyright flyout open

<img width="1279" alt="Screenshot 2023-07-23 at 10 58 43 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/b384c054-6590-415f-9804-59cfbcf6e4c0">

