### PR TITLE
Reenable curriculum PDF generation

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -97,12 +97,12 @@ namespace :build do
           RakeUtils.git_push
         end
 
-        # if rack_env?(:staging)
-        #  This step will only complete successfully if we succeed in
-        #  generating all curriculum PDFs.
-        #  ChatClient.log "Generating missing pdfs..."
-        #  RakeUtils.rake_stream_output 'curriculum_pdfs:generate_missing_pdfs'
-        # end
+        if rack_env?(:staging)
+          # This step will only complete successfully if we succeed in
+          # generating all curriculum PDFs.
+          ChatClient.log "Generating missing pdfs..."
+          RakeUtils.rake_stream_output 'curriculum_pdfs:generate_missing_pdfs'
+        end
       end
 
       # Skip asset precompile in development.


### PR DESCRIPTION
Effectively a revert of https://github.com/code-dot-org/code-dot-org/pull/52774 (there were some linter errors with that PR so I couldn't do a clean revert). Ruby 3 only broke resource pdf generation so we can turn PDF generation back on as those lines were commented out in #52923.

I've generated PDFs on staging since #52923 was merged so I believe this PR is safe, but I'm still planning on merging it at a time when it won't delay the DTP.