### PR TITLE
Make MultipleSectionsAssigner 'Select all' button accessible

### DIFF
--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {connect} from 'react-redux';
-import classnames from 'classnames';
 
 import i18n from '@cdo/locale';
 import Button from '@cdo/apps/templates/Button';
@@ -222,15 +221,12 @@ const MultipleSectionsAssigner = ({
                 )
             )}
         </div>
-        <a
-          className={classnames(
-            moduleStyle.selectAllOptions,
-            'select-all-sections'
-          )}
+        <Button
+          text={i18n.selectAll()}
           onClick={selectAllHandler}
-        >
-          {i18n.selectAll()}
-        </a>
+          styleAsText
+          color={Button.ButtonColor.brandSecondaryDefault}
+        />
       </div>
 
       <div className={moduleStyle.buttonContainer}>

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -222,6 +222,7 @@ const MultipleSectionsAssigner = ({
             )}
         </div>
         <Button
+          id="select-all-sections"
           text={i18n.selectAll()}
           onClick={selectAllHandler}
           styleAsText

--- a/apps/src/templates/multiple-sections-assigner.module.scss
+++ b/apps/src/templates/multiple-sections-assigner.module.scss
@@ -39,12 +39,6 @@
   margin-bottom: 0;
 }
 
-.selectAllOptions {
-  font-family: 'Gotham 5r', sans-serif;
-  font-size: 16px;
-  cursor: pointer;
-}
-
 .buttonContainer {
   display: flex;
   justify-content: space-between;

--- a/apps/test/unit/templates/MultipleSectionsAssignerTest.js
+++ b/apps/test/unit/templates/MultipleSectionsAssignerTest.js
@@ -455,7 +455,7 @@ describe('MultipleSectionsAssigner', () => {
       scriptId: assignedCourseANDUnitSection.unitId,
     });
 
-    wrapper.find('.select-all-sections').simulate('click');
+    wrapper.find('#select-all-sections').simulate('click');
     const allSections = wrapper.find('Checkbox');
     for (let i = 0; i < allSections.length; i++) {
       expect(allSections.at(i).props().checked).to.be.true;


### PR DESCRIPTION
In the `MultipleSectionsAssigner`, "Select All" is currently an anchor tag which is not accessible, as the functionality is a button. This PR switches it over to being a button so that it's tab-navigable:

### Previous behavior as an anchor tag
https://github.com/code-dot-org/code-dot-org/assets/56283563/2d476379-9a2c-4100-8fc3-8b31eb7191b6

### New behavior as a button
https://github.com/code-dot-org/code-dot-org/assets/56283563/5447b8c4-feff-44e6-bec3-14bba294d411

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-642&assignee=60d62161f65054006980bd71)

## Testing story
Updated unit tests and passing drone build.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
