### PR TITLE
fix forward for pl sections tests

### DIFF
--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -195,10 +195,7 @@ Then /^I should see the student section table$/ do
 end
 
 Then /^I should see the professional learning section table$/ do
-  steps <<-GHERKIN
-    Given I scroll the ".uitest-owned-pl-sections" element into view
-    Then I see ".uitest-owned-pl-sections"
-  GHERKIN
+  steps 'Then I see ".uitest-owned-pl-sections"'
 end
 
 Then /^I should see the professional learning joined sections table$/ do

--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -195,7 +195,10 @@ Then /^I should see the student section table$/ do
 end
 
 Then /^I should see the professional learning section table$/ do
-  steps 'Then I see ".uitest-owned-pl-sections"'
+  steps <<-GHERKIN
+    Given I scroll the ".uitest-owned-pl-sections" element into view
+    Then I see ".uitest-owned-pl-sections"
+  GHERKIN
 end
 
 Then /^I should see the professional learning joined sections table$/ do

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -27,7 +27,7 @@ Feature: Professional learning Sections
     # And I click selector "button:contains(Professional Learning)"
     # And I press the first "input[name='Teacher PL Course']" element
     And I press the first "#uitest-save-section-changes" element
-    And I wait until element "#classroom-sections" is visible
+    And I wait until element ".uitest-owned-pl-sections" is visible
 
     # Professional Learning Sections Table
     Then I should see the professional learning section table
@@ -58,7 +58,7 @@ Feature: Professional learning Sections
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
     And I press the first "#uitest-save-section-changes" element
-    And I wait until element "#classroom-sections" is visible
+    And I wait until element ".uitest-owned-pl-sections" is visible
 
     # Professional Learning Sections Table
     Then I should see the professional learning section table
@@ -89,7 +89,7 @@ Feature: Professional learning Sections
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
     And I press the first "#uitest-save-section-changes" element
-    And I wait until element "#classroom-sections" is visible
+    And I wait until element ".uitest-owned-pl-sections" is visible
 
     # Professional Learning Sections Table
     Then I should see the professional learning section table
@@ -120,7 +120,7 @@ Feature: Professional learning Sections
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
     And I press the first "#uitest-save-section-changes" element
-    And I wait until element "#classroom-sections" is visible
+    And I wait until element ".uitest-owned-pl-sections" is visible
 
     # Professional Learning Sections Table
     Then I should see the professional learning section table


### PR DESCRIPTION
After investigating the failures of the pl sections ui tests on safari, the tests failed because the pl table isn't in view. This changes the element the test waits for to the table instead of the container, to ensure it's actually loaded before 'seeing' it.

<img width="1036" alt="Screenshot 2023-07-24 at 12 05 02 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/efd10875-e38a-4e67-acd2-c331f1c804a3">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
