### PR TITLE
Fix lab2 project saving bug

### DIFF
--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -25,10 +25,7 @@ export default class ProjectManager {
   private readonly saveInterval: number = 30 * 1000; // 30 seconds
   private saveInProgress = false;
   private saveQueued = false;
-  private saveSuccessListeners: ((
-    channel: Channel,
-    sources: ProjectSources
-  ) => void)[] = [];
+  private saveSuccessListeners: ((channel: Channel) => void)[] = [];
   private saveNoopListeners: ((channel?: Channel) => void)[] = [];
   private saveFailListeners: ((error: Error) => void)[] = [];
   private saveStartListeners: (() => void)[] = [];
@@ -220,9 +217,7 @@ export default class ProjectManager {
     this.publishHelper(false);
   }
 
-  addSaveSuccessListener(
-    listener: (channel: Channel, sources: ProjectSources) => void
-  ) {
+  addSaveSuccessListener(listener: (channel: Channel) => void) {
     this.saveSuccessListeners.push(listener);
   }
 
@@ -257,11 +252,7 @@ export default class ProjectManager {
     // We can't save without a last channel or last source.
     // We also know we don't need to save if we don't have sources to save
     // or a channel to save.
-    if (
-      !this.lastChannel ||
-      !this.lastSource ||
-      !(this.sourcesToSave || this.channelToSave)
-    ) {
+    if (!this.lastChannel || !(this.sourcesToSave || this.channelToSave)) {
       this.executeSaveNoopListeners(this.lastChannel);
       return;
     }
@@ -315,10 +306,7 @@ export default class ProjectManager {
 
     this.saveInProgress = false;
     this.channelToSave = undefined;
-    this.executeSaveSuccessListeners(
-      this.lastChannel,
-      JSON.parse(this.lastSource) as ProjectSources
-    );
+    this.executeSaveSuccessListeners(this.lastChannel);
     this.initialSaveComplete = true;
   }
 
@@ -450,11 +438,8 @@ export default class ProjectManager {
   }
 
   // LISTENERS
-  private executeSaveSuccessListeners(
-    channel: Channel,
-    sources: ProjectSources
-  ) {
-    this.saveSuccessListeners.forEach(listener => listener(channel, sources));
+  private executeSaveSuccessListeners(channel: Channel) {
+    this.saveSuccessListeners.forEach(listener => listener(channel));
   }
 
   private executeSaveNoopListeners(channel?: Channel) {

--- a/apps/test/unit/lab2/projects/ProjectManagerTest.ts
+++ b/apps/test/unit/lab2/projects/ProjectManagerTest.ts
@@ -188,6 +188,7 @@ describe('ProjectManager', () => {
   });
 
   it('can still save if initial load returned a 404', async () => {
+    // Error message will contain a 404 if sources store encountered a 404.
     sourcesStore.load.throws(new Error('404'));
     const projectManager = new ProjectManager(
       sourcesStore,


### PR DESCRIPTION
I introduced a bug where a new project couldn't save because we were checking for the existence of `this.lastSources` unnecessarily. The reason I added the check was so we could ensure we could send sources in the save success listener, but in [this PR](https://github.com/code-dot-org/code-dot-org/pull/52845) we stopped using the returned sources in the listener. Therefore, I updated the listener to only expect to receive a channel, not channel and sources.

## Links
- [slack discussion](https://codedotorg.slack.com/archives/C044AGTKW3D/p1690227030023399)

## Testing story
Tested that after this change you can save a new project, and added a unit test for this scenario.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
