### PR TITLE
Configure chatbot fields, intructions on AI chat levels

### DIFF
--- a/dashboard/app/models/levels/aichat.rb
+++ b/dashboard/app/models/levels/aichat.rb
@@ -24,14 +24,11 @@
 #  index_levels_on_name       (name)
 #
 
-# TODO: Update this level to account for the params we actually need.
 class Aichat < Level
   serialized_attrs %w(
-    project_template_level_name
-    start_sources
-    hide_share_and_remix
-    is_project_level
-    submittable
+    system_prompt
+    bot_title
+    bot_description
   )
 
   def self.create_from_level_builder(params, level_params)

--- a/dashboard/app/views/levels/editors/_aichat.html.haml
+++ b/dashboard/app/views/levels/editors/_aichat.html.haml
@@ -1,3 +1,3 @@
 = render partial: 'levels/editors/fields/aichat_fields', locals: {f: f}
-
+= render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_aichat_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_aichat_fields.html.haml
@@ -1,1 +1,13 @@
-%h1 Aichat Fields
+%h1.control-legend{data: {toggle: "collapse", target: "#ai-chat"}}
+  AI Chat
+
+#ai-chat.in.collapse
+  = f.label :bot_title, 'Bot Title'
+  %p Short title for bot that will be shown to students with each message (eg, "History Bot").
+  = f.text_field :bot_title
+  = f.label :bot_description, 'Bot Description'
+  %p Student-facing description of the bot that students will interact with.
+  = f.text_area :bot_description, placeholder: '', rows: 2, class:"input-block-level"
+  = f.label :system_prompt, 'System Prompt'
+  %p Bot-facing prompt used to specify behavior of chatbot.
+  = f.text_area :system_prompt, placeholder: '', rows: 4, class:"input-block-level"

--- a/dashboard/app/views/levels/editors/fields/_instructions.haml
+++ b/dashboard/app/views/levels/editors/fields/_instructions.haml
@@ -2,6 +2,6 @@
   Instructions
 
 #instructions.in.collapse
-  = render partial: 'levels/editors/fields/short_instructions', locals: {f: f} unless (@level.is_a?(Applab) || @level.instance_of?(Gamelab) || @level.is_a?(Weblab) || @level.is_a?(ExternalLink) || @level.is_a?(FreeResponse) || @level.is_a?(FrequencyAnalysis) || @level.is_a?(PublicKeyCryptography)|| @level.is_a?(Vigenere) || @level.is_a?(Javalab))
+  = render partial: 'levels/editors/fields/short_instructions', locals: {f: f} unless (@level.is_a?(Applab) || @level.instance_of?(Gamelab) || @level.is_a?(Weblab) || @level.is_a?(ExternalLink) || @level.is_a?(FreeResponse) || @level.is_a?(FrequencyAnalysis) || @level.is_a?(PublicKeyCryptography)|| @level.is_a?(Vigenere) || @level.is_a?(Javalab)) || @level.is_a?(Aichat)
   = render partial: 'levels/editors/fields/long_instructions', locals: {f: f}
   = render partial: 'levels/editors/fields/tts', locals: {f: f} unless @level.is_a?(ExternalLink) || @level.is_a?(FreeResponse) || @level.is_a?(Widget)

--- a/dashboard/app/views/levels/editors/fields/_tts.haml
+++ b/dashboard/app/views/levels/editors/fields/_tts.haml
@@ -4,7 +4,7 @@
   #tts-error.alert.alert-error{style: "display: none"}
     #alert-content
   .row
-    - unless (@level.is_a?(Applab) || @level.instance_of?(Gamelab) || @level.is_a?(Weblab) || @level.is_a?(Javalab))
+    - unless (@level.is_a?(Applab) || @level.instance_of?(Gamelab) || @level.is_a?(Weblab) || @level.is_a?(Javalab)) || @level.is_a?(Aichat)
       .span6
         %h5 Short Instructions
         = f.text_area :tts_short_instructions_override, placeholder: '', rows: 4, class:"input-block-level"


### PR DESCRIPTION
Allows levelbuilders to edit/store configuration for `aichat` levels -- a system prompt, student-facing description, and a bot title.

<img width="500" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/d07336fe-1244-491a-8dc1-926d2ed0c818">

I also added the ability for levelbuilders to edit long instructions, which I believe is the set of instructions we'd want to be able to edit (I referred to [this Javalab PR](https://github.com/code-dot-org/code-dot-org/pull/39631)). I also checked in with Amy to see if there were any additional fields we'd want to have, which she didn't think were necessary at the moment.

I excluded the image upload aspect of this feature from this PR -- after chatting with Amy, it sounds like there is a bit of uncertainty about how we'll configure chatbot avatars (ie, will the design team need to manage avatars for each chatbot?) We can add this at a later date if needed.

## Links

- jira ticket: [SL-996](https://codedotorg.atlassian.net/browse/SL-996)

## Testing story

Tested manually that editing these fields were a) available on revisiting the edit page, b) cloned when I cloned the level, and c) were stored to the level config file as expected:

![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/bea5b342-577a-4416-8434-71f6e78c61ed)