### PR TITLE
Lab2: default to empty sources if validation fails

### DIFF
--- a/apps/src/lab2/responseValidators.ts
+++ b/apps/src/lab2/responseValidators.ts
@@ -6,14 +6,30 @@ export const SourceResponseValidator: ResponseValidator<
 > = response => {
   const projectSources = response as ProjectSources;
   if (!projectSources.source) {
-    throw new Error('Missing required field: source');
+    throw new ValidationError('Missing required field: source');
   }
 
   // Currently only Blockly JSON sources are supported.
-  const blocklySource = JSON.parse(projectSources.source) as BlocklySource;
+  let blocklySource;
+  try {
+    blocklySource = JSON.parse(projectSources.source) as BlocklySource;
+  } catch (e) {
+    throw new ValidationError('Error parsing JSON: ' + e);
+  }
   if (blocklySource.blocks === undefined) {
-    throw new Error('Missing required field: blocks');
+    throw new ValidationError('Missing required field: blocks');
   }
 
   return projectSources;
 };
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+
+    // Needed for TypeScript to register this class correctly in ES5
+    // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, ValidationError.prototype);
+  }
+}


### PR DESCRIPTION
If loading sources fails due to validation error, we'll log a warning and default to empty sources, rather than throwing and showing an error page. This situation is common especially on dev environments where user ID/storage ID collisions can result in incompatible code loading on music lab projects.

Example warning log for when this occurs:
<img width="1388" alt="Screenshot 2023-07-24 at 1 50 04 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/53425ceb-4d41-4ac9-b90f-ecd9c273b258">

## Links

https://codedotorg.atlassian.net/browse/SL-981

## Testing story

Tested locally.