### PR TITLE
Revert "Revert "[AI Chat] Add Open AI backend controller""

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -592,3 +592,7 @@ cdo_amplitude_api_key:
 
 # API Key for doublethedonation.com
 ddconf_api_key: !Secret
+
+# Credentials for OpenAI API
+openai_chat_api_key: !Secret
+openai_org_id: !Secret

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -594,5 +594,5 @@ cdo_amplitude_api_key:
 ddconf_api_key: !Secret
 
 # Credentials for OpenAI API
-openai_chat_api_key: !Secret
-openai_org_id: !Secret
+openai_chat_completion_api_key: !Secret
+openai_chat_completion_org_id: !Secret

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -71,3 +71,6 @@ redshift_password: !Secret
 redshift_username: !Secret
 
 slack_bot_token: !Secret
+
+openai_chat_completion_api_key: ''
+openai_chat_completion_org_id: ''

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -73,4 +73,3 @@ redshift_username: !Secret
 slack_bot_token: !Secret
 
 openai_chat_completion_api_key: ''
-openai_chat_completion_org_id: ''

--- a/dashboard/app/controllers/openai_chat_controller.rb
+++ b/dashboard/app/controllers/openai_chat_controller.rb
@@ -14,13 +14,7 @@ class OpenaiChatController < ApplicationController
     return render(status: chat_completion_return_message[:status], json: chat_completion_return_message[:json])
   end
 
-  private def has_required_messages_param?
-    begin
-      params.require([:messages])
-    rescue ActionController::ParameterMissing
-      return false
-    end
-
-    true
+  def has_required_messages_param?
+    params[:messages].present?
   end
 end

--- a/dashboard/app/controllers/openai_chat_controller.rb
+++ b/dashboard/app/controllers/openai_chat_controller.rb
@@ -1,0 +1,26 @@
+class OpenaiChatController < ApplicationController
+  include OpenaiChatHelper
+  authorize_resource class: false
+
+  # POST /openai/chat_completion
+  def chat_completion
+    unless has_required_messages_param?
+      return render(status: :bad_request, json: {})
+    end
+
+    messages = params[:messages]
+    response = OpenaiChatHelper.request_chat_completion(messages)
+    chat_completion_return_message = OpenaiChatHelper.get_chat_completion_response_message(response)
+    return render(status: chat_completion_return_message[:status], json: chat_completion_return_message[:json])
+  end
+
+  private def has_required_messages_param?
+    begin
+      params.require([:messages])
+    rescue ActionController::ParameterMissing
+      return false
+    end
+
+    true
+  end
+end

--- a/dashboard/app/helpers/openai_chat_helper.rb
+++ b/dashboard/app/helpers/openai_chat_helper.rb
@@ -1,7 +1,7 @@
 module OpenaiChatHelper
   OPEN_AI_URL = "https://api.openai.com/v1/chat/completions"
-  OPENAI_CHAT_API_KEY = CDO.openai_chat_api_key
-  CODE_ORG_ID = CDO.openai_org_id
+  OPENAI_CHAT_COMPLETION_API_KEY = CDO.openai_chat_completion_api_key
+  CODE_ORG_ID = CDO.openai_chat_completion_org_id
   TEMPERATURE = 0
   GPT_MODEL = 'gpt-3.5-turbo'
 
@@ -9,7 +9,7 @@ module OpenaiChatHelper
     # Set up the API endpoint URL and request headers
     headers = {
       "Content-Type" => "application/json",
-      "Authorization" => "Bearer #{OPENAI_CHAT_API_KEY}",
+      "Authorization" => "Bearer #{OPENAI_CHAT_COMPLETION_API_KEY}",
       "OpenAI-Organization" => CODE_ORG_ID
     }
 

--- a/dashboard/app/helpers/openai_chat_helper.rb
+++ b/dashboard/app/helpers/openai_chat_helper.rb
@@ -1,0 +1,37 @@
+module OpenaiChatHelper
+  OPEN_AI_URL = "https://api.openai.com/v1/chat/completions"
+  OPENAI_CHAT_API_KEY = CDO.openai_chat_api_key
+  CODE_ORG_ID = CDO.openai_org_id
+  TEMPERATURE = 0
+  GPT_MODEL = 'gpt-3.5-turbo'
+
+  def self.request_chat_completion(messages)
+    # Set up the API endpoint URL and request headers
+    headers = {
+      "Content-Type" => "application/json",
+      "Authorization" => "Bearer #{OPENAI_CHAT_API_KEY}",
+      "OpenAI-Organization" => CODE_ORG_ID
+    }
+
+    data = {
+      model: GPT_MODEL,
+      temperature: TEMPERATURE,
+      messages: messages
+    }
+
+    HTTParty.post(
+      OPEN_AI_URL,
+      headers: headers,
+      body: data.to_json,
+      open_timeout: DCDO.get('openai_http_open_timeout', 5),
+      read_timeout: DCDO.get('openai_http_read_timeout', 5)
+    )
+  end
+
+  def self.get_chat_completion_response_message(response)
+    # Parse the response JSON and return the chat response message and status
+    response_body = JSON.parse(response.body)
+    response_body = response_body['choices'][0]['message'] if response.code == 200
+    return {status: response.code, json: response_body}
+  end
+end

--- a/dashboard/app/helpers/openai_chat_helper.rb
+++ b/dashboard/app/helpers/openai_chat_helper.rb
@@ -1,7 +1,6 @@
 module OpenaiChatHelper
   OPEN_AI_URL = "https://api.openai.com/v1/chat/completions"
   OPENAI_CHAT_COMPLETION_API_KEY = CDO.openai_chat_completion_api_key
-  CODE_ORG_ID = CDO.openai_chat_completion_org_id
   TEMPERATURE = 0
   GPT_MODEL = 'gpt-3.5-turbo'
 
@@ -9,9 +8,9 @@ module OpenaiChatHelper
     # Set up the API endpoint URL and request headers
     headers = {
       "Content-Type" => "application/json",
-      "Authorization" => "Bearer #{OPENAI_CHAT_COMPLETION_API_KEY}",
-      "OpenAI-Organization" => CODE_ORG_ID
+      "Authorization" => "Bearer #{OPENAI_CHAT_COMPLETION_API_KEY}"
     }
+    headers["OpenAI-Organization"] = CDO.openai_chat_completion_org_id if CDO.openai_chat_completion_org_id
 
     data = {
       model: GPT_MODEL,

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -62,8 +62,7 @@ class Ability
       Foorm::Library,
       Foorm::LibraryQuestion,
       :javabuilder_session,
-      CodeReview,
-      :openai_chat
+      CodeReview
     ]
     cannot :index, Level
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -62,7 +62,8 @@ class Ability
       Foorm::Library,
       Foorm::LibraryQuestion,
       :javabuilder_session,
-      CodeReview
+      CodeReview,
+      :openai_chat
     ]
     cannot :index, Level
 
@@ -280,6 +281,10 @@ class Ability
         can :index, :peer_review_submissions
         can :dashboard, :peer_reviews
         can :report_csv, :peer_review_submissions
+      end
+
+      if user.permission?(UserPermission::AI_CHAT_ACCESS)
+        can :chat_completion, :openai_chat
       end
     end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1061,6 +1061,8 @@ Dashboard::Application.routes.draw do
 
     get '/get_token', to: 'authenticity_token#get_token'
 
+    post '/openai/chat_completion', to: 'openai_chat#chat_completion'
+
     # Policy Compliance
     get '/policy_compliance/child_account_consent/', to:
       'policy_compliance#child_account_consent'

--- a/dashboard/test/controllers/openai_chat_controller_test.rb
+++ b/dashboard/test/controllers/openai_chat_controller_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class OpenaiChatControllerTest < ActionController::TestCase
+  setup do
+    response = Net::HTTPResponse.new(nil, '200', nil)
+    OpenaiChatHelper.stubs(:request_chat_completion).returns(response)
+    OpenaiChatHelper.stubs(:get_chat_completion_response_message).returns({status: 200, json: {}})
+  end
+
+  # User without ai_chat_access is unable to access the chat completion endpoint
+  test_user_gets_response_for :chat_completion,
+  user: :levelbuilder,
+  method: :post,
+  params: {messages: [{role: "user", content: "Say this is a test!"}]},
+  response: :forbidden
+
+  # With ai_chat_access, a post request without a messages param returns a bad request
+  test_user_gets_response_for :chat_completion,
+  user: :ai_chat_access,
+  method: :post,
+  params: {},
+  response: :bad_request
+
+  # With ai_chat_access, a post request with a messages param returns a success
+  test_user_gets_response_for :chat_completion,
+  user: :ai_chat_access,
+  method: :post,
+  params: {messages: [{role: "user", content: "Say this is a test!"}]},
+  response: :success
+end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -156,6 +156,12 @@ FactoryBot.define do
           authorized_teacher.save
         end
       end
+      factory :ai_chat_access do
+        after(:create) do |ai_chat_access|
+          ai_chat_access.permission = UserPermission::AI_CHAT_ACCESS
+          ai_chat_access.save
+        end
+      end
       factory :facilitator do
         transient do
           course {nil}

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -933,6 +933,16 @@ class AbilityTest < ActiveSupport::TestCase
     refute Ability.new(program_manager).can? :destroy, incomplete_application
   end
 
+  test 'users with AI_CHAT_ACCESS can access Open AI chat completion endpoint' do
+    ai_chat_access_user = create :ai_chat_access
+    assert Ability.new(ai_chat_access_user).can? :chat_completion, :openai_chat
+  end
+
+  test 'user without AI_CHAT_ACCESS cannot access Open AI chat completion endpoint' do
+    levelbuilder = create :levelbuilder
+    refute Ability.new(levelbuilder).can? :chat_completion, :openai_chat
+  end
+
   private
 
   def put_students_in_section_and_code_review_group(students, section)

--- a/dashboard/test/models/concerns/user_permission_grantee_test.rb
+++ b/dashboard/test/models/concerns/user_permission_grantee_test.rb
@@ -123,6 +123,13 @@ class UserPermissionGranteeTest < ActiveSupport::TestCase
     assert user.workshop_organizer?
   end
 
+  test 'ai_chat_access?' do
+    user = create :teacher
+    refute user.ai_chat_access?
+    user.permission = UserPermission::AI_CHAT_ACCESS
+    assert user.ai_chat_access?
+  end
+
   test 'grant admin permission logs to infrasecurity' do
     teacher = create :teacher, :google_sso_provider, password: nil
 


### PR DESCRIPTION
This PR reverts code-dot-org/code-dot-org#52973 which reverted code-dot-org/code-dot-org#52759 which added the Open AI backend controller. The original PR was reverted because the API keys and org ID had not been added to AWS secrets. 

This PR renames the keys and org ID since there will be more than one Code.org Open AI production account to be able to gather metrics based on project (teacher-tools vs student-learning). The keys and org ID have been added to AWS secrets. `openai_chat_completion_api_key` is assigned to a default (invalid) value in  `development.yml.erb` to prevent a developer's local server from failing.