### PR TITLE
P20-317: Create unit tests for courses i18n sync-in

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -26,7 +26,6 @@ cp_in $orig_dir/restricted.en.yml $loc_dir/restricted.yml
 cp_in $orig_dir/scripts.en.yml $loc_dir/scripts.yml
 cp_in $orig_dir/slides.en.yml $loc_dir/slides.yml
 cp_in $orig_dir/unplugged.en.yml $loc_dir/unplugged.yml
-cp_in $orig_dir/courses.en.yml $loc_dir/courses.yml
 
 ### Blockly Core
 

--- a/bin/i18n/resources/dashboard/courses.rb
+++ b/bin/i18n/resources/dashboard/courses.rb
@@ -1,0 +1,71 @@
+require 'fileutils'
+require 'json'
+
+require_relative '../../i18n_script_utils'
+require_relative '../../redact_restore_utils'
+
+module I18n
+  module Resources
+    module Dashboard
+      module Courses
+        I18N_SOURCE_FILE_PATH = CDO.dir(File.join(I18N_SOURCE_DIR, 'dashboard/courses.yml')).freeze
+
+        # Merging dashboard/config/courses/*.course with courses.yml
+        # These files contain resources used by UnitGroup (used in the landing pages of full courses).
+        # https://studio.code.org/courses/csd-2021
+        # All other resources used in Unit come from scrip_json files (used in the landing pages for each Unit).
+        # https://studio.code.org/s/csd1-2021
+        def self.sync_in
+          puts 'Preparing dashboard courses'
+
+          # Currently, csd is the only fully translatable course that has resources in this directory
+          translatable_courses = %w(csd)
+          resources = {}
+          Dir[CDO.dir('dashboard/config/courses/*.course')].each do |file|
+            course_json = JSON.load_file(file)
+            course_properties = course_json['properties']
+
+            next if course_json['resources'].empty?
+            next unless translatable_courses.include?(course_properties['family_name'])
+
+            course_json['resources'].each do |resource|
+              # resoruce.rb uses Services::GloballyUniqueIdentifiers.build_resource_key to create resource keys as follow
+              # resource.key / resource.course_version.course_offering.key / resource.course_version.key
+              # resource_key is used to localize the resources.
+              resource_key = [resource['key'], course_properties['family_name'], course_properties['version_year']].join('/')
+              resources.store(resource_key, {'name' => resource['name'], 'url' => resource['url']})
+            end
+          end
+
+          FileUtils.mkdir_p(File.dirname(I18N_SOURCE_FILE_PATH))
+          # `dashboard/config/locales/blocks.en.yml` updates automatically from levelbuilder content
+          FileUtils.cp(CDO.dir('dashboard/config/locales/courses.en.yml'), I18N_SOURCE_FILE_PATH)
+
+          courses_yaml = YAML.load_file(I18N_SOURCE_FILE_PATH)
+          courses_data = courses_yaml.dig('en', 'data')
+          # Merging resources if courses already contain resources
+          courses_data['resources'] ? courses_data['resources'].merge!(resources) : courses_data.store('resources', resources)
+
+          File.write(I18N_SOURCE_FILE_PATH, I18nScriptUtils.to_crowdin_yaml(courses_yaml))
+
+          puts 'Redacting dashboard courses'
+          # Save the original data, for restoration
+          original = I18N_SOURCE_FILE_PATH.sub('source', 'original')
+          FileUtils.mkdir_p(File.dirname(original))
+          FileUtils.cp(I18N_SOURCE_FILE_PATH, original)
+
+          # Redact the specific subset of fields within each script that we care about.
+          data = YAML.load_file(I18N_SOURCE_FILE_PATH)
+          data['en']['data']['course']['name'].values.each do |datum|
+            markdown_data = datum.slice('description', 'student_description', 'description_student', 'description_teacher')
+            redacted_data = RedactRestoreUtils.redact_data(markdown_data, %w[resourceLink vocabularyDefinition], 'md')
+            datum.merge!(redacted_data)
+          end
+
+          # Overwrite source file with redacted data
+          File.write(I18N_SOURCE_FILE_PATH, I18nScriptUtils.to_crowdin_yaml(data))
+        end
+      end
+    end
+  end
+end

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -30,12 +30,12 @@ module I18n
       I18n::Resources::Dashboard::Standards.sync_in
       I18n::Resources::Dashboard::Docs.sync_in
       I18n::Resources::Apps::ExternalSources.sync_in
+      I18n::Resources::Dashboard::Courses.sync_in
       I18n::Resources::Apps::Labs.sync_in
       puts "Copying source files"
       I18nScriptUtils.run_bash_script "bin/i18n-codeorg/in.sh"
-      localize_course_resources
       redact_level_content
-      redact_script_and_course_content
+      redact_script
       localize_markdown_content
       puts "Sync in completed successfully"
     rescue => exception
@@ -377,49 +377,6 @@ module I18n
       end
     end
 
-    # Merging dashboard/config/courses/*.course with courses.yml
-    # These files contain resources used by UnitGroup (used in the landing pages of full courses).
-    # https://studio.code.org/courses/csd-2021
-    # All other resources used in Unit come from scrip_json files (used in the landing pages for each Unit).
-    # https://studio.code.org/s/csd1-2021
-    def self.localize_course_resources
-      puts "Preparing course resources"
-
-      # Currently, csd is the only fully translatable course that has resources in this directory
-      translatable_courses = %w(csd)
-      resources = {}
-      Dir.glob(File.join('dashboard', 'config', 'courses', '*.course')).each do |file|
-        course_json = JSON.parse(File.read(file))
-        course_properties = course_json['properties']
-        next unless translatable_courses.include?(course_properties['family_name'])
-
-        course_resources = course_json['resources']
-        next if course_resources.empty?
-        course_resources.each do |resource|
-          # resoruce.rb uses Services::GloballyUniqueIdentifiers.build_resource_key to create resource keys as follow
-          # resource.key / resource.course_version.course_offering.key / resource.course_version.key
-          # resource_key is used to localize the resources.
-          resource_key = [resource['key'], course_properties['family_name'], course_properties['version_year']].join('/')
-          resources.store(resource_key, {'name' => resource['name'], 'url' => resource['url']})
-        end
-      end
-      courses_source = File.join(I18N_SOURCE_DIR, 'dashboard', 'courses.yml')
-      courses_yaml = YAML.load_file(courses_source)
-      courses_data = courses_yaml['en']['data']
-      # Merging resources if courses already contain resources
-      courses_data['resources'] ? courses_data['resources'].merge!(resources) : courses_data.store('resources', resources)
-      File.write(courses_source, I18nScriptUtils.to_crowdin_yaml(courses_yaml))
-    end
-
-    def self.localize_animation_library
-      spritelab_animation_source_file = "#{I18N_SOURCE_DIR}/animations/spritelab_animation_library.json"
-      FileUtils.mkdir_p(File.dirname(spritelab_animation_source_file))
-      File.open(spritelab_animation_source_file, "w") do |file|
-        animation_strings = ManifestBuilder.new({spritelab: true, quiet: true}).get_animation_strings
-        file.write(JSON.pretty_generate(animation_strings))
-      end
-    end
-
     def self.select_redactable(i18n_strings)
       redactable_content = %w(
         authored_hints
@@ -471,11 +428,11 @@ module I18n
       end
     end
 
-    def self.redact_script_and_course_content
+    def self.redact_script
       plugins = %w(resourceLink vocabularyDefinition)
       fields = %w(description student_description description_student description_teacher)
 
-      %w(script course).each do |type|
+      %w(script).each do |type|
         puts "Redacting #{type} content"
         source = File.join(I18N_SOURCE_DIR, "dashboard/#{type}s.yml")
 

--- a/bin/test/i18n/resources/dashboard/test_courses.rb
+++ b/bin/test/i18n/resources/dashboard/test_courses.rb
@@ -1,0 +1,171 @@
+require_relative '../../../test_helper'
+require_relative '../../../../i18n/resources/dashboard/courses'
+
+class I18n::Resources::Dashboard::CoursesTest < Minitest::Test
+  def test_sync_in
+    exec_seq = sequence('execution')
+
+    expected_i18n_source_file_path = CDO.dir('i18n/locales/source/dashboard/courses.yml')
+    expected_i18n_source_file_data = {
+      'en' => {
+        'data' => {
+          'course' => {
+            'name' => {
+              'valid_course_csd' => {
+                'assignment_family_title' => 'valid_course_csd -> assignment_family_title',
+                'title'                   => 'valid_course_csd -> title',
+                'version_title'           => 'valid_course_csd -> version_title',
+                'description'             => 'valid_course_csd -> description',
+                'student_description'     => 'valid_course_csd -> student_description',
+                'description_student'     => 'valid_course_csd -> description_student',
+                'description_teacher'     => 'valid_course_csd -> description_teacher',
+                'description_short'       => 'valid_course_csd -> description_short'
+              }
+            }
+          },
+          'resources' => {
+            'resource_1_key/csd/1970' => {
+              'name' => 'Resource 1',
+              'url' => '/courses/course-1/resources'
+            }
+          }
+        }
+      }
+    }
+
+    expected_redaction_data = {
+      'description'         => 'valid_course_csd -> description',
+      'student_description' => 'valid_course_csd -> student_description',
+      'description_student' => 'valid_course_csd -> description_student',
+      'description_teacher' => 'valid_course_csd -> description_teacher',
+    }
+    expected_redacted_data = {
+      'description'         => 'redacted -> description',
+      'student_description' => 'redacted -> student_description',
+      'description_student' => 'redacted -> description_student',
+      'description_teacher' => 'redacted -> description_teacher',
+    }
+    expected_redacted_i18n_source_data = {
+      'en' => {
+        'data' => {
+          'course' => {
+            'name' => {
+              'valid_course_csd' => {
+                'assignment_family_title' => 'valid_course_csd -> assignment_family_title',
+                'title'                   => 'valid_course_csd -> title',
+                'version_title'           => 'valid_course_csd -> version_title',
+                'description_short'       => 'valid_course_csd -> description_short',
+                **expected_redacted_data
+              }
+            }
+          },
+          'resources' => {
+            'resource_1_key/csd/1970' => {
+              'name' => 'Resource 1',
+              'url' => '/courses/course-1/resources'
+            }
+          }
+        }
+      }
+    }
+
+    Dir.stubs(:[]).with(CDO.dir('dashboard/config/courses/*.course')).returns(%w[invalid_course_csd_without_resources invalid_course_not_csd valid_course_csd])
+    JSON.stubs(:load_file).with('invalid_course_csd_without_resources').returns(invalid_course_csd_without_resources_data)
+    JSON.stubs(:load_file).with('invalid_course_not_csd').returns(invalid_course_not_csd_data)
+    JSON.stubs(:load_file).with('valid_course_csd').returns(valid_course_csd_data)
+    YAML.stubs(:load_file).with(expected_i18n_source_file_path).returns(i18n_source_data_without_resources, expected_i18n_source_file_data)
+
+    # Preparation of the i18n source file
+    FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/dashboard')).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with(CDO.dir('dashboard/config/locales/courses.en.yml'), expected_i18n_source_file_path).in_sequence(exec_seq)
+    I18nScriptUtils.expects(:to_crowdin_yaml).with(expected_i18n_source_file_data).returns('expected_i18n_source_file_data').in_sequence(exec_seq)
+    File.expects(:write).with(expected_i18n_source_file_path, 'expected_i18n_source_file_data').in_sequence(exec_seq)
+
+    # Redaction of the i18n source file
+    FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/original/dashboard')).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with(expected_i18n_source_file_path, CDO.dir('i18n/locales/original/dashboard/courses.yml')).in_sequence(exec_seq)
+    RedactRestoreUtils.expects(:redact_data).with(expected_redaction_data, %w[resourceLink vocabularyDefinition], 'md').returns(expected_redacted_data).in_sequence(exec_seq)
+    I18nScriptUtils.expects(:to_crowdin_yaml).with(expected_redacted_i18n_source_data).returns('expected_redacted_i18n_source_yaml_data').in_sequence(exec_seq)
+    File.expects(:write).with(expected_i18n_source_file_path, 'expected_redacted_i18n_source_yaml_data').in_sequence(exec_seq)
+
+    I18n::Resources::Dashboard::Courses.sync_in
+  end
+
+  private
+
+  def invalid_course_csd_without_resources_data
+    {
+      'name' => 'invalid_course_csd_without_resources',
+      'properties' => {
+        'family_name' => 'csd'
+      },
+      'resources' => []
+    }
+  end
+
+  def invalid_course_not_csd_data
+    {
+      'name' => 'invalid_course_not_csd',
+      'properties' => {
+        'family_name' => 'not_csd'
+      },
+      'resources' => [
+        'name' => 'invalid_course_not_csd -> resources -> name'
+      ]
+    }
+  end
+
+  def valid_course_csd_data
+    {
+      'name' => 'valid_course_csd',
+      'script_names' => %w[script_name_1 script_name_2],
+      'published_state' => 'stable',
+      'instruction_type' => 'teacher_led',
+      'participant_audience' => 'student',
+      'instructor_audience' => 'teacher',
+      'properties' => {
+        'family_name' => 'csd',
+        'has_numbered_units' => true,
+        'has_verified_resources' => true,
+        'version_year' => '1970'
+      },
+      'resources' => [
+        {
+          'name' => 'Resource 1',
+          'url' => '/courses/course-1/resources',
+          'key' => 'resource_1_key',
+          'properties' => {
+            'is_rollup' => true
+          },
+          'seeding_key' => {
+            'resource.key' => 'seeding_key_resource_key_1'
+          }
+        }
+      ],
+      'student_resources' => []
+    }
+  end
+
+  def i18n_source_data_without_resources
+    {
+      'en' => {
+        'data' => {
+          'course' => {
+            'name' => {
+              'valid_course_csd' => {
+                'assignment_family_title' => 'valid_course_csd -> assignment_family_title',
+                'title'                   => 'valid_course_csd -> title',
+                'version_title'           => 'valid_course_csd -> version_title',
+                'description'             => 'valid_course_csd -> description',
+                'student_description'     => 'valid_course_csd -> student_description',
+                'description_student'     => 'valid_course_csd -> description_student',
+                'description_teacher'     => 'valid_course_csd -> description_teacher',
+                'description_short'       => 'valid_course_csd -> description_short'
+              }
+            }
+          }
+        }
+      }
+    }
+  end
+end

--- a/bin/test/i18n/test_redact_restore_utils.rb
+++ b/bin/test/i18n/test_redact_restore_utils.rb
@@ -76,4 +76,11 @@ class RedactRestoreUtilsTest < Minitest::Test
 
     assert_equal expected_result, RedactRestoreUtils.redact_data(raw_redact_data, %w[resourceLink])
   end
+
+  def test_redaction_of_data_with_vocabulary_definition_plugin
+    raw_redact_data = {'valid' => '[v test/example/1]', 'invalid' => '[v test/example]'}
+    expected_result = {'valid' => '[test][0]', 'invalid' => '[v test/example]'}
+
+    assert_equal expected_result, RedactRestoreUtils.redact_data(raw_redact_data, %w[vocabularyDefinition])
+  end
 end

--- a/bin/test/i18n/test_sync-in.rb
+++ b/bin/test/i18n/test_sync-in.rb
@@ -15,11 +15,11 @@ class I18n::SyncInTest < Minitest::Test
     I18n::Resources::Dashboard::Standards.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Dashboard::Docs.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Apps::ExternalSources.expects(:sync_in).in_sequence(exec_seq)
+    I18n::Resources::Dashboard::Courses.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Apps::Labs.expects(:sync_in).in_sequence(exec_seq)
     I18nScriptUtils.expects(:run_bash_script).with('bin/i18n-codeorg/in.sh').in_sequence(exec_seq)
-    I18n::SyncIn.expects(:localize_course_resources).in_sequence(exec_seq)
     I18n::SyncIn.expects(:redact_level_content).in_sequence(exec_seq)
-    I18n::SyncIn.expects(:redact_script_and_course_content).in_sequence(exec_seq)
+    I18n::SyncIn.expects(:redact_script).in_sequence(exec_seq)
     I18n::SyncIn.expects(:localize_markdown_content).in_sequence(exec_seq)
 
     I18n::SyncIn.perform


### PR DESCRIPTION
1. Moved `I18n::SyncIn.localize_course_resources` and `I18n::SyncIn.redact_course_content` to `I18n::Resources::Dashboard::Courses.sync_in`
2. Created a unit test for `I18n::Resources::Dashboard::Courses.sync_in`

## Links
- jira ticket: [P20-317](https://codedotorg.atlassian.net/browse/P20-317)

## Sync-in
![Screenshot 2023-07-26 at 13 42 38](https://github.com/code-dot-org/code-dot-org/assets/66776217/1ecff380-05f7-4d11-830d-8f5dfc9cebe6)

![Screenshot 2023-07-26 at 13 43 39](https://github.com/code-dot-org/code-dot-org/assets/66776217/483dd91f-c211-496e-8077-9e0636feb38d)
