### PR TITLE
P20-325: Create unit tests for labs (blockly-mooc) i18n sync-in

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -28,19 +28,6 @@ cp_in $orig_dir/slides.en.yml $loc_dir/slides.yml
 cp_in $orig_dir/unplugged.en.yml $loc_dir/unplugged.yml
 cp_in $orig_dir/courses.en.yml $loc_dir/courses.yml
 
-### Apps
-
-orig_dir=apps/i18n
-loc_dir=i18n/locales/source/blockly-mooc
-mkdir -p $loc_dir
-
-# Copy JSON files.
-for file in $(find $orig_dir -name 'en_us.json'); do
-  relname=${file#$orig_dir}
-  cp_in $file $loc_dir${relname%/en_us.json}.json
-done
-
-
 ### Blockly Core
 
 orig_dir=apps/node_modules/@code-dot-org/blockly/i18n/locales/en-US

--- a/bin/i18n/resources/apps/labs.rb
+++ b/bin/i18n/resources/apps/labs.rb
@@ -1,0 +1,39 @@
+require 'fileutils'
+require 'json'
+
+require_relative '../../i18n_script_utils'
+require_relative '../../redact_restore_utils'
+
+module I18n
+  module Resources
+    module Apps
+      module Labs
+        I18N_SOURCE_DIR_PATH = CDO.dir(File.join(I18N_SOURCE_DIR, 'blockly-mooc')).freeze
+
+        def self.sync_in
+          puts 'Preparing *labs files'
+          FileUtils.mkdir_p(I18N_SOURCE_DIR_PATH)
+
+          Dir[CDO.dir('apps/i18n/**/en_us.json')].each do |filepath|
+            FileUtils.cp(filepath, File.join(I18N_SOURCE_DIR_PATH, "#{filepath.split('/')[-2]}.json"))
+          end
+
+          puts 'Redacting *labs content'
+          # Only CSD labs are redacted, since other labs were already part of the i18n pipeline and redaction would edit
+          # strings existing in crowdin already
+          redactable_labs = %w[applab gamelab weblab]
+
+          redactable_labs.each do |lab_name|
+            source_path = File.join(I18N_SOURCE_DIR_PATH, "#{lab_name}.json")
+            backup_path = source_path.sub('source', 'original')
+
+            FileUtils.mkdir_p(File.dirname(backup_path))
+            FileUtils.cp(source_path, backup_path)
+
+            RedactRestoreUtils.redact(source_path, source_path, %w[link])
+          end
+        end
+      end
+    end
+  end
+end

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -30,12 +30,12 @@ module I18n
       I18n::Resources::Dashboard::Standards.sync_in
       I18n::Resources::Dashboard::Docs.sync_in
       I18n::Resources::Apps::ExternalSources.sync_in
+      I18n::Resources::Apps::Labs.sync_in
       puts "Copying source files"
       I18nScriptUtils.run_bash_script "bin/i18n-codeorg/in.sh"
       localize_course_resources
       redact_level_content
       redact_script_and_course_content
-      redact_labs_content
       localize_markdown_content
       puts "Sync in completed successfully"
     rescue => exception
@@ -468,23 +468,6 @@ module I18n
 
       Dir.glob(File.join(I18N_SOURCE_DIR, "course_content/**/*.json")).each do |source_path|
         redact_level_file(source_path)
-      end
-    end
-
-    # These files are synced in using the `bin/i18n-codeorg/in.sh` script.
-    def self.redact_labs_content
-      puts "Redacting *labs content"
-
-      # Only CSD labs are redacted, since other labs were already part of the i18n pipeline and redaction would edit
-      # strings existing in crowdin already
-      redactable_labs = %w(applab gamelab weblab)
-
-      redactable_labs.each do |lab_name|
-        source_path = File.join(I18N_SOURCE_DIR, "blockly-mooc", lab_name + ".json")
-        backup_path = source_path.sub("source", "original")
-        FileUtils.mkdir_p(File.dirname(backup_path))
-        FileUtils.cp(source_path, backup_path)
-        RedactRestoreUtils.redact(source_path, source_path, ['link'])
       end
     end
 

--- a/bin/test/i18n/resources/apps/test_labs.rb
+++ b/bin/test/i18n/resources/apps/test_labs.rb
@@ -1,0 +1,30 @@
+require_relative '../../../test_helper'
+require_relative '../../../../i18n/resources/apps/labs'
+
+class I18n::Resources::Apps::LabsTest < Minitest::Test
+  def test_sync_in
+    exec_seq = sequence('execution')
+
+    # Preparation of i18n source files
+    FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/blockly-mooc')).in_sequence(exec_seq)
+    Dir.expects(:[]).with(CDO.dir('apps/i18n/**/en_us.json')).returns(['apps/i18n/expected_lab/en_us.json']).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with('apps/i18n/expected_lab/en_us.json', CDO.dir('i18n/locales/source/blockly-mooc/expected_lab.json')).in_sequence(exec_seq)
+
+    # Redaction of applab i18n source file
+    FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/original/blockly-mooc')).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with(CDO.dir('i18n/locales/source/blockly-mooc/applab.json'), CDO.dir('i18n/locales/original/blockly-mooc/applab.json')).in_sequence(exec_seq)
+    RedactRestoreUtils.expects(:redact).with(CDO.dir('i18n/locales/source/blockly-mooc/applab.json'), CDO.dir('i18n/locales/source/blockly-mooc/applab.json'), %w[link]).in_sequence(exec_seq)
+
+    # Redaction of gamelab i18n source file
+    FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/original/blockly-mooc')).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with(CDO.dir('i18n/locales/source/blockly-mooc/gamelab.json'), CDO.dir('i18n/locales/original/blockly-mooc/gamelab.json')).in_sequence(exec_seq)
+    RedactRestoreUtils.expects(:redact).with(CDO.dir('i18n/locales/source/blockly-mooc/gamelab.json'), CDO.dir('i18n/locales/source/blockly-mooc/gamelab.json'), %w[link]).in_sequence(exec_seq)
+
+    # Redaction of weblab i18n source file
+    FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/original/blockly-mooc')).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with(CDO.dir('i18n/locales/source/blockly-mooc/weblab.json'), CDO.dir('i18n/locales/original/blockly-mooc/weblab.json')).in_sequence(exec_seq)
+    RedactRestoreUtils.expects(:redact).with(CDO.dir('i18n/locales/source/blockly-mooc/weblab.json'), CDO.dir('i18n/locales/source/blockly-mooc/weblab.json'), %w[link]).in_sequence(exec_seq)
+
+    I18n::Resources::Apps::Labs.sync_in
+  end
+end

--- a/bin/test/i18n/test_sync-in.rb
+++ b/bin/test/i18n/test_sync-in.rb
@@ -15,11 +15,11 @@ class I18n::SyncInTest < Minitest::Test
     I18n::Resources::Dashboard::Standards.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Dashboard::Docs.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Apps::ExternalSources.expects(:sync_in).in_sequence(exec_seq)
+    I18n::Resources::Apps::Labs.expects(:sync_in).in_sequence(exec_seq)
     I18nScriptUtils.expects(:run_bash_script).with('bin/i18n-codeorg/in.sh').in_sequence(exec_seq)
     I18n::SyncIn.expects(:localize_course_resources).in_sequence(exec_seq)
     I18n::SyncIn.expects(:redact_level_content).in_sequence(exec_seq)
     I18n::SyncIn.expects(:redact_script_and_course_content).in_sequence(exec_seq)
-    I18n::SyncIn.expects(:redact_labs_content).in_sequence(exec_seq)
     I18n::SyncIn.expects(:localize_markdown_content).in_sequence(exec_seq)
 
     I18n::SyncIn.perform


### PR DESCRIPTION
1. Moved `I18n::SyncIn.redact_labs_content ` to `I18n::Resources::Dashboard::Labs.sync_in`.
2. Created unit tests for the `I18n::Resources::Apps::Labs` module.

## Links
- jira ticket: [P20-325](https://codedotorg.atlassian.net/browse/P20-325)

## Sync-in
![Screenshot 2023-07-25 at 15 20 47](https://github.com/code-dot-org/code-dot-org/assets/66776217/fa848a09-d97f-48ad-a170-c81c0035fb3a)

![Screenshot 2023-07-25 at 15 24 13](https://github.com/code-dot-org/code-dot-org/assets/66776217/5cb6ed48-44af-4b6e-b9de-2b5f715044e6)
