### PR TITLE
Fix course version dropdown sort function

### DIFF
--- a/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
@@ -100,7 +100,7 @@ function updateSectionCourse(updateCourse, course) {
   if (courseVersionId === undefined) {
     const stableVersions = Object.values(courseVersions)
       .filter(version => version.is_stable)
-      .sort(version => -version.key);
+      .sort((a, b) => b.key - a.key);
     courseVersionId = stableVersions[0]?.id;
   }
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Followup to #52919. Fixes a bug that caused the course versions to be sorted in the opposite direction for the purposes of selecting the default version, on Firefox. This results in the default course version (when there is no recommended version) being set to the oldest stable version, instead of the newest.

![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/d61ef660-9af3-4685-a323-f8bdf560ea65)

The correct syntax for a [JS sort function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) is `(a, b) => ...`, and I was only passing in a single parameter. For some browser implementation reason, this worked fine in my testing on Chrome and in our unit tests, but fails on Firefox. I caught it when checking on staging/prod today. Unfortunately, I still can't test on Firefox locally because it doesn't seem to be possible to get it to switch languages away from English.

## Links


- jira ticket: [TEACH-622](https://codedotorg.atlassian.net/browse/TEACH-622)


## Testing story

In a debugger breakpoint on staging, with Firefox, I ran the minified code:

```js
Object.values(o).filter((function (e) {
  return e.is_stable
})).sort((function (e) {
  return - e.key
}))
```

It returned the objects in the opposite order from what I expected. I ran the same code on Chrome, and got the expected order. Then I changed the code to use two variables, and ran it in Firefox again:

```js
Object.values(o).filter((function (e) {
  return e.is_stable
})).sort((function (a, b) {
  return b.key - a.key
}))
```

I did the same on Chrome. Both browsers returned the same, expected results.