### PR TITLE
Music: internal gallery

### DIFF
--- a/dashboard/app/controllers/musiclab_controller.rb
+++ b/dashboard/app/controllers/musiclab_controller.rb
@@ -39,6 +39,11 @@ class MusiclabController < ApplicationController
     view_options(full_width: true, responsive_content: true, no_padding_container: true)
   end
 
+  def gallery
+    view_options(full_width: true, responsive_content: true, no_padding_container: true)
+    @channel_ids = Project.where(project_type: "music").last(50).map {|project| JSON.parse(project.value)["id"]}.compact_blank
+  end
+
   # TODO: This is a temporary addition to serve the analytics API key
   # specifically for Music Lab. When we start using Amplitude for other
   # applications, we should create a dedicated controller/util that serves

--- a/dashboard/app/controllers/musiclab_controller.rb
+++ b/dashboard/app/controllers/musiclab_controller.rb
@@ -40,6 +40,10 @@ class MusiclabController < ApplicationController
   end
 
   def gallery
+    unless current_user&.admin?
+      render :no_access
+    end
+
     view_options(full_width: true, responsive_content: true, no_padding_container: true)
     @channel_ids = Project.where(project_type: "music").last(50).map {|project| JSON.parse(project.value)["id"]}.compact_blank
   end

--- a/dashboard/app/views/musiclab/gallery.html.haml
+++ b/dashboard/app/views/musiclab/gallery.html.haml
@@ -1,0 +1,16 @@
+:css
+  .gallery {
+    max-width: 970px;
+    margin: 0px auto 80px;
+  }
+
+.gallery
+  %h1 Internal Music Gallery
+  Recently-saved music projects
+  %br/
+  %br/
+  .entries
+    - @channel_ids.each do |channel_id|
+      .entry
+        %a{href: "/projects/music/#{channel_id}"}
+          = channel_id

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -41,6 +41,7 @@ Dashboard::Application.routes.draw do
     get "/musiclab", to: redirect("/projectbeats", status: 302)
     get "/projectbeats", to: "musiclab#index"
     get "/musiclab/menu", to: "musiclab#menu"
+    get "/musiclab/gallery", to: "musiclab#gallery"
     get "/musiclab/analytics_key", to: "musiclab#get_analytics_key"
 
     resources :activity_hints, only: [:update]


### PR DESCRIPTION
A very simple gallery for admin users only, which lists the last 50 `"music"` projects saved, with a link to view each.  Designed for internal use so we can peruse content currently being created.  Accessible at https://studio.code.org/musiclab/gallery.

<img width="1083" alt="Screenshot 2023-07-25 at 9 58 43 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/1dce3210-e71f-41f9-bbbf-b14c042fe783">
