### PR TITLE
Update styling for dialog to accomodate different screen sizes

### DIFF
--- a/apps/src/templates/accessible-dialogue.module.scss
+++ b/apps/src/templates/accessible-dialogue.module.scss
@@ -20,4 +20,5 @@
   background-color: #fff;
   border-radius: 4px;
   padding: 1rem;
+  overflow: scroll;
 };

--- a/apps/src/templates/curriculumCatalog/no_sections_to_assign_dialog.module.scss
+++ b/apps/src/templates/curriculumCatalog/no_sections_to_assign_dialog.module.scss
@@ -17,7 +17,19 @@
 }
 
 .lowerContainer {
-  margin-top: auto;
+  // screen sizes larger than mobile
+  @media screen and (min-width: $width-sm) {
+    margin-top: auto;
+  }
+
+  // mobile screen sizes
+  @media screen and (max-width: $width-sm) {
+    margin-top: 1em;
+
+    hr {
+      display: none;
+    }
+  }
 }
 
 .buttonContainer {
@@ -34,10 +46,6 @@
     margin-top: 1em;
     justify-content: center;
     flex-direction: column-reverse;
-
-    hr {
-      display: none;
-    }
 
     button,
     a,

--- a/apps/src/templates/curriculumCatalog/no_sections_to_assign_dialog.module.scss
+++ b/apps/src/templates/curriculumCatalog/no_sections_to_assign_dialog.module.scss
@@ -31,13 +31,14 @@
 
   // mobile screen sizes
   @media screen and (max-width: $width-sm) {
+    margin-top: 1em;
+    justify-content: center;
+    flex-direction: column-reverse;
+
     hr {
       display: none;
     }
 
-    margin-top: 1em;
-    justify-content: center;
-    flex-direction: column-reverse;
     button,
     a,
     a:link,

--- a/apps/src/templates/curriculumCatalog/no_sections_to_assign_dialog.module.scss
+++ b/apps/src/templates/curriculumCatalog/no_sections_to_assign_dialog.module.scss
@@ -1,7 +1,8 @@
 @import "color.scss";
+@import "breakpoints";
 
 .dialogContainer {
-  height: 18rem;
+  min-height: 18rem;
   display: flex;
   flex-flow: column;
 
@@ -21,7 +22,18 @@
 
 .buttonContainer {
   display: flex;
-  justify-content: space-between;
+  flex-flow: wrap;
+  gap: 1em;
+
+  // screen sizes larger than mobile
+  @media screen and (min-width: $width-sm) {
+    justify-content: space-between;
+  }
+
+  // mobile screen sizes
+  @media screen and (max-width: $width-sm) {
+    justify-content: center;
+  }
 
   button,
   a,

--- a/apps/src/templates/curriculumCatalog/no_sections_to_assign_dialog.module.scss
+++ b/apps/src/templates/curriculumCatalog/no_sections_to_assign_dialog.module.scss
@@ -22,7 +22,6 @@
 
 .buttonContainer {
   display: flex;
-  flex-flow: wrap;
   gap: 1em;
 
   // screen sizes larger than mobile
@@ -32,7 +31,21 @@
 
   // mobile screen sizes
   @media screen and (max-width: $width-sm) {
+    hr {
+      display: none;
+    }
+
+    margin-top: 1em;
     justify-content: center;
+    flex-direction: column-reverse;
+    button,
+    a,
+    a:link,
+    a:visited {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+    }
   }
 
   button,


### PR DESCRIPTION
Updates the styling for dialogs on mobile:

<img width="271" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/fa29b19a-ae1b-4427-80d5-60d50f57099f">

**Demo on different screen sizes:**

https://github.com/code-dot-org/code-dot-org/assets/9142121/4dd31caa-247b-404a-82d8-475109ba69ab

**Old version:**

<img width="167" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/aa4f291f-873d-4977-91b3-77f6155a483b">



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
