### PR TITLE
Music: tweak undo/redo button sizing

### DIFF
--- a/apps/src/music/views/panelContainer.module.scss
+++ b/apps/src/music/views/panelContainer.module.scss
@@ -9,7 +9,7 @@
   position: relative;
 
   .panelContainerHeader {
-    min-height: 28px;
+    min-height: 30px;
     background-color: $neutral_dark80;
     border-bottom: solid $default-spacing $dark_black;
     position: relative;
@@ -26,11 +26,11 @@
       }
 
       &Right {
-        right: 10px;
+        right: 4px;
       }
 
       &Left {
-        left: 10px;
+        left: 4px;
       }
     }
   }

--- a/apps/src/music/views/undo-redo-buttons.module.scss
+++ b/apps/src/music/views/undo-redo-buttons.module.scss
@@ -10,13 +10,13 @@
   background-color: $neutral_dark;
   color: $neutral_light;
   display: flex;
-  height: 20px;
+  height: 24px;
+  width: 24px;
   font-size: 13px;
   justify-content: center;
   align-items: center;
   border-radius: 3px;
   margin: 2px;
-  padding: 5px;
   transition: opacity 0.2s ease;
 
   &Disabled {


### PR DESCRIPTION
Forgot to include this small tweak in https://github.com/code-dot-org/code-dot-org/pull/52949 which updates the sizing of the undo/redo buttons and header to the sizes specified by @markabarrett (32px header and 24px buttons).

<img width="1512" alt="Screenshot 2023-07-25 at 2 02 08 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/595d6181-ab93-494b-9e6f-b628c7047e91">
