### PR TITLE
P20-318: Create unit tests for markdown i18n sync-in

### DIFF
--- a/bin/i18n/resources/pegasus/markdown.rb
+++ b/bin/i18n/resources/pegasus/markdown.rb
@@ -1,0 +1,64 @@
+require 'fileutils'
+require 'json'
+
+require_relative '../../i18n_script_utils'
+
+module I18n
+  module Resources
+    module Pegasus
+      module Markdown
+        I18N_SOURCE_DIR_PATH = CDO.dir(File.join(I18N_SOURCE_DIR, 'markdown/public')).freeze
+
+        def self.sync_in
+          markdown_files_to_localize = %w[
+            public/athome.md.partial
+            public/break.md.partial
+            public/coldplay.md.partial
+            public/csforgood.md
+            public/curriculum/unplugged.md.partial
+            public/educate/csc.md.partial
+            public/educate/curriculum/csf-transition-guide.md
+            public/educate/it.md
+            public/helloworld.md.partial
+            public/hourofcode/artist.md.partial
+            public/hourofcode/flappy.md.partial
+            public/hourofcode/frozen.md.partial
+            public/hourofcode/hourofcode.md.partial
+            public/hourofcode/infinity.md.partial
+            public/hourofcode/mc.md.partial
+            public/hourofcode/playlab.md.partial
+            public/hourofcode/starwars.md.partial
+            public/hourofcode/unplugged-conditionals-with-cards.md.partial
+            public/international/about.md.partial
+            public/poetry.md.partial
+            views/hoc2022_create_activities.md.partial
+            views/hoc2022_play_activities.md.partial
+            views/hoc2022_explore_activities.md.partial
+          ]
+
+          markdown_files_to_localize.each do |filepath|
+            full_filepath = CDO.dir(File.join('pegasus/sites.v3/code.org', filepath))
+
+            unless File.exist?(full_filepath)
+              puts "#{filepath} does not exist"
+              next
+            end
+
+            # Remove the .partial if it exists
+            source_path = File.join(I18N_SOURCE_DIR_PATH, File.dirname(filepath), File.basename(filepath, '.partial'))
+            # TODO: refactor dir structure
+            source_path = source_path.sub('public/public/', 'public/')
+
+            FileUtils.mkdir_p(File.dirname(source_path))
+            FileUtils.cp(full_filepath, source_path)
+
+            header, content, _line = Documents.new.helpers.parse_yaml_header(source_path)
+
+            I18nScriptUtils.sanitize_header!(header)
+            I18nScriptUtils.write_markdown_with_header(content, header, source_path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -32,11 +32,11 @@ module I18n
       I18n::Resources::Apps::ExternalSources.sync_in
       I18n::Resources::Dashboard::Courses.sync_in
       I18n::Resources::Apps::Labs.sync_in
+      I18n::Resources::Pegasus::Markdown.sync_in
       puts "Copying source files"
       I18nScriptUtils.run_bash_script "bin/i18n-codeorg/in.sh"
       redact_level_content
       redact_script
-      localize_markdown_content
       puts "Sync in completed successfully"
     rescue => exception
       puts "Sync in failed from the error: #{exception}"
@@ -451,53 +451,6 @@ module I18n
 
         # Overwrite source file with redacted data
         File.write(source, I18nScriptUtils.to_crowdin_yaml(data))
-      end
-    end
-
-    def self.localize_markdown_content
-      markdown_files_to_localize = %w[
-        athome.md.partial
-        break.md.partial
-        coldplay.md.partial
-        csforgood.md
-        curriculum/unplugged.md.partial
-        educate/csc.md.partial
-        educate/curriculum/csf-transition-guide.md
-        educate/it.md
-        helloworld.md.partial
-        hourofcode/artist.md.partial
-        hourofcode/flappy.md.partial
-        hourofcode/frozen.md.partial
-        hourofcode/hourofcode.md.partial
-        hourofcode/infinity.md.partial
-        hourofcode/mc.md.partial
-        hourofcode/playlab.md.partial
-        hourofcode/starwars.md.partial
-        hourofcode/unplugged-conditionals-with-cards.md.partial
-        international/about.md.partial
-        poetry.md.partial
-        ../views/hoc2022_create_activities.md.partial
-        ../views/hoc2022_play_activities.md.partial
-        ../views/hoc2022_explore_activities.md.partial
-      ]
-      markdown_files_to_localize.each do |path|
-        original_path = File.join('pegasus/sites.v3/code.org/public', path)
-        original_path_exists = File.exist?(original_path)
-        puts "#{original_path} does not exist" unless original_path_exists
-        next unless original_path_exists
-        # This reforms the `../` relative paths so they appear as though they are
-        # within the `public` path. This is a legacy solution to keep things clean
-        # when viewed by the translators in crowdin.
-        path = path[3...] if path.start_with? "../"
-        # Remove the .partial if it exists
-        source_path = File.join(I18N_SOURCE_DIR, 'markdown/public', File.dirname(path), File.basename(path, '.partial'))
-        FileUtils.mkdir_p(File.dirname(source_path))
-        FileUtils.cp(original_path, source_path)
-      end
-      Dir.glob(File.join(I18N_SOURCE_DIR, "markdown/**/*.md")).each do |path|
-        header, content, _line = Documents.new.helpers.parse_yaml_header(path)
-        I18nScriptUtils.sanitize_header!(header)
-        I18nScriptUtils.write_markdown_with_header(content, header, path)
       end
     end
   end

--- a/bin/test/i18n/resources/pegasus/test_markdown.rb
+++ b/bin/test/i18n/resources/pegasus/test_markdown.rb
@@ -1,0 +1,77 @@
+require_relative '../../../test_helper'
+require_relative '../../../../i18n/resources/pegasus/markdown'
+
+class I18n::Resources::Pegasus::MarkdownTest < Minitest::Test
+  def test_sync_in
+    exec_seq = sequence('execution')
+
+    Documents.stubs(new: stub(helpers: stub))
+
+    expected_sync_in_file_paths.each do |expected_original_file_path, expected_i18n_source_path|
+      FileUtils.expects(:mkdir_p).with(File.dirname(expected_i18n_source_path)).in_sequence(exec_seq)
+      FileUtils.expects(:cp).with(expected_original_file_path, expected_i18n_source_path).in_sequence(exec_seq)
+
+      Documents.new.helpers.expects(:parse_yaml_header).with(expected_i18n_source_path).returns(%w[expected_header expected_content expected_line]).in_sequence(exec_seq)
+
+      I18nScriptUtils.expects(:sanitize_header!).with('expected_header').in_sequence(exec_seq)
+      I18nScriptUtils.expects(:write_markdown_with_header).with('expected_content', 'expected_header', expected_i18n_source_path).in_sequence(exec_seq)
+    end
+
+    I18n::Resources::Pegasus::Markdown.sync_in
+  end
+
+  private
+
+  def expected_sync_in_file_paths
+    [
+      [
+        CDO.dir('pegasus/sites.v3/code.org/public/athome.md.partial'),
+        CDO.dir('i18n/locales/source/markdown/public/athome.md')
+      ],
+      [
+        CDO.dir('pegasus/sites.v3/code.org/public/break.md.partial'),
+        CDO.dir('i18n/locales/source/markdown/public/break.md')
+      ],
+      [
+        CDO.dir('pegasus/sites.v3/code.org/public/coldplay.md.partial'),
+        CDO.dir('i18n/locales/source/markdown/public/coldplay.md')
+      ],
+      [
+        CDO.dir('pegasus/sites.v3/code.org/public/curriculum/unplugged.md.partial'),
+        CDO.dir('i18n/locales/source/markdown/public/curriculum/unplugged.md')
+      ],
+      [
+        CDO.dir('pegasus/sites.v3/code.org/public/educate/curriculum/csf-transition-guide.md'),
+        CDO.dir('i18n/locales/source/markdown/public/educate/curriculum/csf-transition-guide.md')
+      ],
+      [
+        CDO.dir('pegasus/sites.v3/code.org/public/educate/it.md'),
+        CDO.dir('i18n/locales/source/markdown/public/educate/it.md')
+      ],
+      [
+        CDO.dir('pegasus/sites.v3/code.org/public/helloworld.md.partial'),
+        CDO.dir('i18n/locales/source/markdown/public/helloworld.md')
+      ],
+      [
+        CDO.dir('pegasus/sites.v3/code.org/public/international/about.md.partial'),
+        CDO.dir('i18n/locales/source/markdown/public/international/about.md')
+      ],
+      [
+        CDO.dir('pegasus/sites.v3/code.org/public/poetry.md.partial'),
+        CDO.dir('i18n/locales/source/markdown/public/poetry.md')
+      ],
+      [
+        CDO.dir('pegasus/sites.v3/code.org/views/hoc2022_create_activities.md.partial'),
+        CDO.dir('i18n/locales/source/markdown/public/views/hoc2022_create_activities.md')
+      ],
+      [
+        CDO.dir('pegasus/sites.v3/code.org/views/hoc2022_play_activities.md.partial'),
+        CDO.dir('i18n/locales/source/markdown/public/views/hoc2022_play_activities.md')
+      ],
+      [
+        CDO.dir('pegasus/sites.v3/code.org/views/hoc2022_explore_activities.md.partial'),
+        CDO.dir('i18n/locales/source/markdown/public/views/hoc2022_explore_activities.md')
+      ],
+    ]
+  end
+end

--- a/bin/test/i18n/test_i18n_script_utils.rb
+++ b/bin/test/i18n/test_i18n_script_utils.rb
@@ -5,4 +5,45 @@ class I18nScriptUtilsTest < Minitest::Test
   def test_to_crowdin_yaml
     assert_equal "---\n:en:\n  test: \"#example\"\n  'yes': 'y'\n", I18nScriptUtils.to_crowdin_yaml({en: {'test' => '#example', 'yes' => 'y'}})
   end
+
+  def test_header_sanitization
+    header = {'title' => 'Expects only title', 'invalid' => 'Unexpected header'}
+
+    I18nScriptUtils.sanitize_header!(header)
+
+    assert_equal({'title' => 'Expects only title'}, header)
+  end
+
+  def test_markdown_with_header_writing
+    exec_seq = sequence('execution')
+
+    expected_markdown = 'expected_markdown'
+    expected_header   = {'expected' => 'header'}
+    expected_filepath = 'expected_filepath'
+    expected_file     = stub('expected_file')
+
+    File.expects(:open).with(expected_filepath, 'w').yields(expected_file).in_sequence(exec_seq)
+    I18nScriptUtils.expects(:to_crowdin_yaml).with(expected_header).returns('expected_header_crowdin_yaml').in_sequence(exec_seq)
+    expected_file.expects(:write).with('expected_header_crowdin_yaml').in_sequence(exec_seq)
+    expected_file.expects(:write).with("---\n\n").in_sequence(exec_seq)
+    expected_file.expects(:write).with(expected_markdown).in_sequence(exec_seq)
+
+    I18nScriptUtils.write_markdown_with_header(expected_markdown, expected_header, expected_filepath)
+  end
+
+  def test_markdown_with_header_writing_when_header_is_empty
+    exec_seq = sequence('execution')
+
+    expected_markdown = 'expected_markdown'
+    expected_header   = {}
+    expected_filepath = 'expected_filepath'
+    expected_file     = stub('expected_file')
+
+    File.expects(:open).with(expected_filepath, 'w').yields(expected_file).in_sequence(exec_seq)
+    I18nScriptUtils.expects(:to_crowdin_yaml).with(expected_header).never
+    expected_file.expects(:write).with("---\n\n").never
+    expected_file.expects(:write).with(expected_markdown).in_sequence(exec_seq)
+
+    I18nScriptUtils.write_markdown_with_header(expected_markdown, expected_header, expected_filepath)
+  end
 end

--- a/bin/test/i18n/test_sync-in.rb
+++ b/bin/test/i18n/test_sync-in.rb
@@ -17,10 +17,10 @@ class I18n::SyncInTest < Minitest::Test
     I18n::Resources::Apps::ExternalSources.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Dashboard::Courses.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Apps::Labs.expects(:sync_in).in_sequence(exec_seq)
+    I18n::Resources::Pegasus::Markdown.expects(:sync_in).in_sequence(exec_seq)
     I18nScriptUtils.expects(:run_bash_script).with('bin/i18n-codeorg/in.sh').in_sequence(exec_seq)
     I18n::SyncIn.expects(:redact_level_content).in_sequence(exec_seq)
     I18n::SyncIn.expects(:redact_script).in_sequence(exec_seq)
-    I18n::SyncIn.expects(:localize_markdown_content).in_sequence(exec_seq)
 
     I18n::SyncIn.perform
   end

--- a/pegasus/test/test_router.rb
+++ b/pegasus/test/test_router.rb
@@ -114,4 +114,14 @@ class RouterTest < Minitest::Test
     refute_match "<title>1,2,3</title>", resp.body
     assert_match "<title>&lt;%= (1..3).to_a.join(&#39;,&#39;).inspect %&gt;</title>", resp.body
   end
+
+  def test_parsing_yaml_header
+    fixture_path = File.join(__dir__, 'fixtures/sites/code.org/public/div_brackets.md')
+
+    yaml_header, content, lines_count = app.helpers.parse_yaml_header(fixture_path)
+
+    assert_equal({'x' => 'y'}, yaml_header)
+    assert_equal("### HELLO\n\n[class]\n\n[#id]\n\nTesting div-brackets.\n\n[/#id]\n\n[/class]\n", content)
+    assert_equal(6, lines_count)
+  end
 end


### PR DESCRIPTION
1. Moved `I18n::SyncIn.localize_markdown_content ` to `I18n::Resources::Pegasus::Markdown.sync_in`
2. Created a unit test for `I18n::Resources::Pegasus::Markdown.sync_in`
3. Created a unit test for `Documents.new.helpers.parse_yaml_header`
4. Created a unit test for `I18nScriptUtils.sanitize_header!`
5. Created unit tests for `I18nScriptUtils.write_markdown_with_header`

## Links
- jira ticket: [P20-318](https://codedotorg.atlassian.net/browse/P20-318)

## Sync-in
![Screenshot 2023-07-26 at 14 43 35](https://github.com/code-dot-org/code-dot-org/assets/66776217/90a178f4-c3c4-49fe-83ff-c2ce873145ca)

![Screenshot 2023-07-26 at 14 44 04](https://github.com/code-dot-org/code-dot-org/assets/66776217/581405e5-cff6-4f01-9d6a-6afdac34d398)