### PR TITLE
P20-325: Move Labs files copying from in.sh to I18n::Resources::Apps::Labs.sync_in

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -40,9 +40,6 @@ for file in $(find $orig_dir -name '*.json'); do
   cp_in $file $loc_dir$relname
 done
 
-### Oceans tutorial
-cp_in apps/node_modules/@code-dot-org/ml-activities/i18n/oceans.json i18n/locales/source/blockly-mooc/fish.json
-
 ### Pegasus
 
 orig_dir=pegasus/cache/i18n

--- a/bin/i18n/resources/apps/labs.rb
+++ b/bin/i18n/resources/apps/labs.rb
@@ -14,6 +14,8 @@ module I18n
           puts 'Preparing *labs files'
           FileUtils.mkdir_p(I18N_SOURCE_DIR_PATH)
 
+          FileUtils.cp(CDO.dir('apps/node_modules/@code-dot-org/ml-activities/i18n/oceans.json'), File.join(I18N_SOURCE_DIR_PATH, 'fish.json'))
+
           Dir[CDO.dir('apps/i18n/**/en_us.json')].each do |filepath|
             FileUtils.cp(filepath, File.join(I18N_SOURCE_DIR_PATH, "#{filepath.split('/')[-2]}.json"))
           end

--- a/bin/test/i18n/resources/apps/test_labs.rb
+++ b/bin/test/i18n/resources/apps/test_labs.rb
@@ -7,6 +7,7 @@ class I18n::Resources::Apps::LabsTest < Minitest::Test
 
     # Preparation of i18n source files
     FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/blockly-mooc')).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with(CDO.dir('apps/node_modules/@code-dot-org/ml-activities/i18n/oceans.json'), CDO.dir('i18n/locales/source/blockly-mooc/fish.json')).in_sequence(exec_seq)
     Dir.expects(:[]).with(CDO.dir('apps/i18n/**/en_us.json')).returns(['apps/i18n/expected_lab/en_us.json']).in_sequence(exec_seq)
     FileUtils.expects(:cp).with('apps/i18n/expected_lab/en_us.json', CDO.dir('i18n/locales/source/blockly-mooc/expected_lab.json')).in_sequence(exec_seq)
 


### PR DESCRIPTION
1. Moved `apps/node_modules/@code-dot-org/ml-activities/i18n/oceans.json` copying to `I18n::Resources::Apps::Labs.sync_in` to `I18n::Resources::Dashboard::Courses.sync_in`.
2. Updated the `I18n::Resources::Apps::Labs.sync_in` unit test.

## Links
- jira ticket: [P20-325](https://codedotorg.atlassian.net/browse/P20-325)
