### PR TITLE
[i18n-dev] update crontab

### DIFF
--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -15,7 +15,7 @@
 #
 # Where can I ask a question about this config?
 # Reach out to the #i18n slack channel.
-
+PATH=/home/ubuntu/.rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 HOME=/home/ubuntu
 
 # Run a CI Build to update the server from staging. We do this primarily to
@@ -23,13 +23,13 @@ HOME=/home/ubuntu
 # Note that the CI_ONLY_BUILD environment variable is necessary; the server is
 # not set up to actually serve a version of the website, and it will fail to
 # build correctly if not thus restricted.
-0 */4 * * * BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && CI_ONLY_BUILD=true bundle exec ./bin/cronjob ./aws/ci_build >>/tmp/cronlog 2>&1"
+0 */4 * * * bash -l -c "cd /home/ubuntu/code-dot-org && CI_ONLY_BUILD=true bundle exec ./bin/cronjob ./aws/ci_build >>/tmp/cronlog 2>&1"
 
 # Run the I18n Sync!
 # Sync is scheduled for 12:30 AM PST every Monday; run around midnight so the
 # sync is hopefully finished by start of day on Monday, offset by 30 minutes so
 # we don't conflict with the ci_build which runs on the hour.
-30 8 * * MON BASH_ENV=~/.bashrc bash -lc "(cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1"
+30 8 * * MON bash -l -c "(cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1"
 
 # Run the sync down periodically throughout the week. Specifically:
 # - Run it every 4 hours. This is a somewhat arbitrarily-chosen frequency
@@ -39,14 +39,14 @@ HOME=/home/ubuntu
 # - Run it every day except Monday. This is done so we don't conflict with the
 #   full sync, and also because we expect to spend Monday verifiying the
 #   results of the full sync.
-# 30 */4 * * SUN,TUE-SAT BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
+# 30 */4 * * SUN,TUE-SAT bash -l -c "cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
 
 # Periodically check to see if the I18n Sync PRs have been merged and attempt
 # to return to staging.
-0 */1 * * * BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
+0 */1 * * * bash -l -c "cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
 
 # Update string translation status to Redshift
-0 0 * * * BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
+0 0 * * * bash -l -c "cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
 
 # Run the Crowdin translation validator tool
-# 30 0 * * * BASH_ENV=~/.bashrc bash -lc "cd /home/ubuntu/code-dot-org && (bundle exec bin/i18n/translation_monitor/run_crowdin_validator.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"
+# 30 0 * * * bash -l -c "cd /home/ubuntu/code-dot-org && (bundle exec bin/i18n/translation_monitor/run_crowdin_validator.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error"

--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -15,7 +15,7 @@
 #
 # Where can I ask a question about this config?
 # Reach out to the #i18n slack channel.
-PATH=/home/ubuntu/.rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+PATH=/home/ubuntu/.rbenv/shims:/home/ubuntu/.nvm/versions/node/v18.16.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 HOME=/home/ubuntu
 
 # Run a CI Build to update the server from staging. We do this primarily to


### PR DESCRIPTION
I've been iterating on fixing the crontab on the i18n-dev server, this is the crontab that is currently on the server, so checking in the changes.

You can edit the crontab directly on the server with `crontab -e`

I think this will overwrite the local changes when chef runs.

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
