### PR TITLE
Update setProperty in Applab text areas

### DIFF
--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -231,7 +231,7 @@ export default {
   onPropertyChange: function (element, name, value) {
     switch (name) {
       case 'value':
-        element.innerHTML = value;
+        element.innerHTML = utils.escapeText(value);
         break;
       default:
         return false;
@@ -242,7 +242,7 @@ export default {
   readProperty: function (element, name) {
     switch (name) {
       case 'value':
-        return element.innerHTML;
+        return utils.unescapeText(element.innerHTML);
       default:
         throw `unknown property name ${name}`;
     }

--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -231,7 +231,7 @@ export default {
   onPropertyChange: function (element, name, value) {
     switch (name) {
       case 'value':
-        element.innerHTML = utils.escapeText(value);
+        element.innerHTML = utils.escapeHtml(value);
         break;
       default:
         return false;
@@ -242,7 +242,7 @@ export default {
   readProperty: function (element, name) {
     switch (name) {
       case 'value':
-        return utils.unescapeText(element.innerHTML);
+        return utils.unescapeHtml(element.innerHTML);
       default:
         throw `unknown property name ${name}`;
     }

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -115,6 +115,25 @@ export function escapeHtml(unsafe) {
 }
 
 /**
+ * Reverses escaped HTML into its original form.
+ * List of special characters is taken from
+ * https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html.
+ * @param {string} safe - The string to unescape.
+ * @returns {string} Unescaped string. Returns an empty string if input is null or undefined.
+ */
+export function unescapeHtml(safe) {
+  return safe
+    ? safe
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&#47;/g, '/')
+    : '';
+}
+
+/**
  * Version of modulo which, unlike javascript's `%` operator,
  * will always return a positive remainder.
  * @param number

--- a/apps/test/unit/applab/designModeTest.js
+++ b/apps/test/unit/applab/designModeTest.js
@@ -172,6 +172,18 @@ describe('setProperty and read Property', () => {
       expect(text_area.innerHTML).to.equal('Gamma Delta');
       expect(dropdown.value).to.equal('Epsilon Zeta');
     });
+
+    it('Escapes HTML in text area', () => {
+      designMode.updateProperty(
+        text_area,
+        'value',
+        '<script>alert("hi")</script>'
+      );
+      expect(text_area.innerHTML).to.equal(
+        '&lt;script&gt;alert("hi")&lt;/script&gt;'
+      );
+    });
+
     it('Sets the expected value for dropdowns, text area, and text input', () => {
       designMode.updateProperty(text_input, 'value', 'Iota Kappa');
       designMode.updateProperty(text_area, 'value', 'Lambda Mu');
@@ -181,6 +193,7 @@ describe('setProperty and read Property', () => {
       expect(text_area.innerHTML).to.equal('Lambda Mu');
       expect(dropdown.value).to.equal('Eta Theta');
     });
+
     it('Uses the asset timestamp in the source path for pictures', () => {
       designMode.updateProperty(picture, 'picture', 'picture.jpg', 123456);
       expect(picture.src).to.contain('picture.jpg?t=123456');
@@ -208,6 +221,13 @@ describe('setProperty and read Property', () => {
       );
       expect(designMode.readProperty(dropdown, 'value')).to.equal(
         'Epsilon Zeta'
+      );
+    });
+
+    it('unescapes HTML in text area', () => {
+      text_area.innerHTML = '&lt;script&gt;alert("hi")&lt;/script&gt;';
+      expect(designMode.readProperty(text_area, 'value')).to.equal(
+        '<script>alert("hi")</script>'
       );
     });
   });


### PR DESCRIPTION
More discussion/details in [this Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1690221230623569). In that thread, I've added a screenshot of the manual testing I did locally.

I also checked in with the curriculum team to see if they thought this change might affect students/curricululum, which they did not. More detail in [this thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1690404692673569).

I'll give our support team a heads up about this change as well, in case they get inquiries from users who were using this feature in ways we didn't intend to explicitly support.

## Links

- jira ticket: [BC-44](https://codedotorg.atlassian.net/browse/BC-44)

## Testing story

Added new unit tests to cover this change.