### PR TITLE
P20-316: Move copying of external oceans.json from in.sh

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -39,9 +39,6 @@ for file in $(find $orig_dir -name '*.json'); do
   cp_in $file $loc_dir$relname
 done
 
-### Oceans tutorial
-cp_in apps/node_modules/@code-dot-org/ml-activities/i18n/oceans.json i18n/locales/source/blockly-mooc/fish.json
-
 ### Pegasus
 
 orig_dir=pegasus/cache/i18n

--- a/bin/i18n/resources/apps/external_sources.rb
+++ b/bin/i18n/resources/apps/external_sources.rb
@@ -14,6 +14,12 @@ module I18n
 
           FileUtils.mkdir_p(I18N_SOURCE_DIR_PATH)
 
+          # Preparing Oceans tutorial
+          # TODO: move the file to the `external-sources` folder instead of `blockly-mooc`
+          labs_dir = CDO.dir(File.join(I18N_SOURCE_DIR, 'blockly-mooc'))
+          FileUtils.mkdir_p(labs_dir)
+          FileUtils.cp(CDO.dir('apps/node_modules/@code-dot-org/ml-activities/i18n/oceans.json'), File.join(labs_dir, 'fish.json'))
+
           # ml-playground (AI Lab) files
 
           # Preparing AI Lab UI Strings

--- a/bin/test/i18n/resources/apps/test_external_sources.rb
+++ b/bin/test/i18n/resources/apps/test_external_sources.rb
@@ -7,6 +7,10 @@ class I18n::Resources::Apps::ExternalSourcesTest < Minitest::Test
 
     FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/external-sources')).in_sequence(exec_seq)
 
+    expected_labs_dir = CDO.dir('i18n/locales/source/blockly-mooc')
+    FileUtils.expects(:mkdir_p).with(expected_labs_dir).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with(CDO.dir('apps/node_modules/@code-dot-org/ml-activities/i18n/oceans.json'), File.join(expected_labs_dir, 'fish.json')).in_sequence(exec_seq)
+
     expected_ml_playground_dir = CDO.dir('i18n/locales/source/external-sources/ml-playground')
     FileUtils.expects(:mkdir_p).with(expected_ml_playground_dir).in_sequence(exec_seq)
     FileUtils.expects(:cp).with(CDO.dir('apps/node_modules/@code-dot-org/ml-playground/i18n/mlPlayground.json'), expected_ml_playground_dir).in_sequence(exec_seq)


### PR DESCRIPTION
1. Moved `apps/node_modules/@code-dot-org/ml-activities/i18n/oceans.json` copying to `I18n::Resources::Apps::Labs.sync_in` to `I18n::Resources::Apps::ExternalSources.sync_in`.
2. Updated the `I18n::Resources::Apps::ExternalSources.sync_in` unit test.

## Links
- jira ticket: [P20-316](https://codedotorg.atlassian.net/browse/P20-316)