### PR TITLE
updated Crowdin upload success message in sync-up

### DIFF
--- a/bin/i18n/sync-up.rb
+++ b/bin/i18n/sync-up.rb
@@ -18,7 +18,7 @@ def sync_up
         while line = stdout.gets
           # skip lines detailing individual file upload, unless that file
           # resulted in an unexpected response
-          next if line.start_with?("File ") && line.end_with?("OK\n", "SKIPPED\n")
+          next if line.start_with?("✔️  File")
 
           puts line
         end


### PR DESCRIPTION
This might be silly, but Corwdin changed the upload success message their API returned at some point (speculatively in Version 2 of their CLI client)

Previously, when a file was successfully (or skipped) uploaded to Crowdin the following message was returned:
`File 'path_to/my_file.yml'-\ - OK` or `File 'path_to/my_file.yml'| - SKIPPED`
![image](https://github.com/code-dot-org/code-dot-org/assets/66776217/c9098845-dc9b-405f-81f4-78b95ff7304c)

Now the message is the following:
`:heavy_check_mark:  File 'path_to/my_file.json'`
![image](https://github.com/code-dot-org/code-dot-org/assets/66776217/be8d1b8e-b8c4-4b08-a3a5-607adad805c8)

This PR just updates the expected message so we skip the expected behavior lines and logging only an unexpected response.

## Testing Story
No more annoying messages!!
![image](https://github.com/code-dot-org/code-dot-org/assets/66776217/51171b68-7b64-4cc3-af9a-3882894df398)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [X] Tests provide adequate coverage
- [X] Privacy and Security impacts have been assessed
- [X] Code is well-commented
- [X] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Pull Request is labeled appropriately
- [X] Follow-up work items (including potential tech debt) are tracked and linked
