### PR TITLE
P20-324: Create unit tests for scripts i18n sync-in

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -23,7 +23,6 @@ cp_in $orig_dir/en.yml $loc_dir/base.yml
 cp_in $orig_dir/data.en.yml $loc_dir/data.yml
 cp_in $orig_dir/devise.en.yml $loc_dir/devise.yml
 cp_in $orig_dir/restricted.en.yml $loc_dir/restricted.yml
-cp_in $orig_dir/scripts.en.yml $loc_dir/scripts.yml
 cp_in $orig_dir/slides.en.yml $loc_dir/slides.yml
 cp_in $orig_dir/unplugged.en.yml $loc_dir/unplugged.yml
 

--- a/bin/i18n/resources/dashboard/scripts.rb
+++ b/bin/i18n/resources/dashboard/scripts.rb
@@ -1,0 +1,39 @@
+require 'fileutils'
+require 'json'
+
+require_relative '../../i18n_script_utils'
+require_relative '../../redact_restore_utils'
+
+module I18n
+  module Resources
+    module Dashboard
+      module Scripts
+        I18N_SOURCE_FILE_PATH = CDO.dir(File.join(I18N_SOURCE_DIR, 'dashboard/scripts.yml')).freeze
+
+        def self.sync_in
+          puts 'Preparing dashboard scripts'
+          FileUtils.mkdir_p(File.dirname(I18N_SOURCE_FILE_PATH))
+          # `dashboard/config/locales/blocks.en.yml` updates automatically from levelbuilder content
+          FileUtils.cp(CDO.dir('dashboard/config/locales/scripts.en.yml'), I18N_SOURCE_FILE_PATH)
+
+          puts 'Redacting dashboard scripts'
+          # Save the original data, for restoration
+          original = I18N_SOURCE_FILE_PATH.sub('source', 'original')
+          FileUtils.mkdir_p(File.dirname(original))
+          FileUtils.cp(I18N_SOURCE_FILE_PATH, original)
+
+          # Redact the specific subset of fields within each script that we care about.
+          data = YAML.load_file(I18N_SOURCE_FILE_PATH)
+          data['en']['data']['script']['name'].values.each do |datum|
+            markdown_data = datum.slice('description', 'student_description', 'description_student', 'description_teacher')
+            redacted_data = RedactRestoreUtils.redact_data(markdown_data, %w[resourceLink vocabularyDefinition], 'md')
+            datum.merge!(redacted_data)
+          end
+
+          # Overwrite source file with redacted data
+          File.write(I18N_SOURCE_FILE_PATH, I18nScriptUtils.to_crowdin_yaml(data))
+        end
+      end
+    end
+  end
+end

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -30,13 +30,13 @@ module I18n
       I18n::Resources::Dashboard::Standards.sync_in
       I18n::Resources::Dashboard::Docs.sync_in
       I18n::Resources::Apps::ExternalSources.sync_in
+      I18n::Resources::Dashboard::Scripts.sync_in
       I18n::Resources::Dashboard::Courses.sync_in
       I18n::Resources::Apps::Labs.sync_in
       I18n::Resources::Pegasus::Markdown.sync_in
       puts "Copying source files"
       I18nScriptUtils.run_bash_script "bin/i18n-codeorg/in.sh"
       redact_level_content
-      redact_script
       puts "Sync in completed successfully"
     rescue => exception
       puts "Sync in failed from the error: #{exception}"
@@ -425,32 +425,6 @@ module I18n
 
       Dir.glob(File.join(I18N_SOURCE_DIR, "course_content/**/*.json")).each do |source_path|
         redact_level_file(source_path)
-      end
-    end
-
-    def self.redact_script
-      plugins = %w(resourceLink vocabularyDefinition)
-      fields = %w(description student_description description_student description_teacher)
-
-      %w(script).each do |type|
-        puts "Redacting #{type} content"
-        source = File.join(I18N_SOURCE_DIR, "dashboard/#{type}s.yml")
-
-        # Save the original data, for restoration
-        original = source.sub("source", "original")
-        FileUtils.mkdir_p(File.dirname(original))
-        FileUtils.cp(source, original)
-
-        # Redact the specific subset of fields within each script that we care about.
-        data = YAML.load_file(source)
-        data['en']['data'][type]['name'].values.each do |datum|
-          markdown_data = datum.slice(*fields)
-          redacted_data = RedactRestoreUtils.redact_data(markdown_data, plugins, 'md')
-          datum.merge!(redacted_data)
-        end
-
-        # Overwrite source file with redacted data
-        File.write(source, I18nScriptUtils.to_crowdin_yaml(data))
       end
     end
   end

--- a/bin/test/i18n/resources/dashboard/test_scripts.rb
+++ b/bin/test/i18n/resources/dashboard/test_scripts.rb
@@ -1,0 +1,86 @@
+require_relative '../../../test_helper'
+require_relative '../../../../i18n/resources/dashboard/scripts'
+
+class I18n::Resources::Dashboard::ScriptsTest < Minitest::Test
+  def test_sync_in
+    exec_seq = sequence('execution')
+
+    expected_i18n_source_file_path = CDO.dir('i18n/locales/source/dashboard/scripts.yml')
+    expected_i18n_source_file_data = {
+      'en' => {
+        'data' => {
+          'script' => {
+            'name' => {
+              'csd' => {
+                'assignment_family_title' => 'csd -> assignment_family_title',
+                'title'                   => 'csd -> title',
+                'version_title'           => 'csd -> version_title',
+                'description'             => 'csd -> description',
+                'student_description'     => 'csd -> student_description',
+                'description_student'     => 'csd -> description_student',
+                'description_teacher'     => 'csd -> description_teacher',
+                'description_short'       => 'csd -> description_short'
+              }
+            }
+          },
+          'resources' => {
+            'resource_1_key/csd/1970' => {
+              'name' => 'Resource 1',
+              'url' => '/courses/course-1/resources'
+            }
+          }
+        }
+      }
+    }
+
+    expected_redaction_data = {
+      'description'         => 'csd -> description',
+      'student_description' => 'csd -> student_description',
+      'description_student' => 'csd -> description_student',
+      'description_teacher' => 'csd -> description_teacher',
+    }
+    expected_redacted_data = {
+      'description'         => 'redacted -> description',
+      'student_description' => 'redacted -> student_description',
+      'description_student' => 'redacted -> description_student',
+      'description_teacher' => 'redacted -> description_teacher',
+    }
+    expected_redacted_i18n_source_data = {
+      'en' => {
+        'data' => {
+          'script' => {
+            'name' => {
+              'csd' => {
+                'assignment_family_title' => 'csd -> assignment_family_title',
+                'title'                   => 'csd -> title',
+                'version_title'           => 'csd -> version_title',
+                'description_short'       => 'csd -> description_short',
+                **expected_redacted_data
+              }
+            }
+          },
+          'resources' => {
+            'resource_1_key/csd/1970' => {
+              'name' => 'Resource 1',
+              'url' => '/courses/course-1/resources'
+            }
+          }
+        }
+      }
+    }
+
+    # Preparation of the i18n source file
+    FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/dashboard')).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with(CDO.dir('dashboard/config/locales/scripts.en.yml'), expected_i18n_source_file_path).in_sequence(exec_seq)
+
+    # Redaction of the i18n source file
+    FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/original/dashboard')).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with(expected_i18n_source_file_path, CDO.dir('i18n/locales/original/dashboard/scripts.yml')).in_sequence(exec_seq)
+    YAML.expects(:load_file).with(expected_i18n_source_file_path).returns(expected_i18n_source_file_data).in_sequence(exec_seq)
+    RedactRestoreUtils.expects(:redact_data).with(expected_redaction_data, %w[resourceLink vocabularyDefinition], 'md').returns(expected_redacted_data).in_sequence(exec_seq)
+    I18nScriptUtils.expects(:to_crowdin_yaml).with(expected_redacted_i18n_source_data).returns('expected_redacted_i18n_source_yaml_data').in_sequence(exec_seq)
+    File.expects(:write).with(expected_i18n_source_file_path, 'expected_redacted_i18n_source_yaml_data').in_sequence(exec_seq)
+
+    I18n::Resources::Dashboard::Scripts.sync_in
+  end
+end

--- a/bin/test/i18n/test_sync-in.rb
+++ b/bin/test/i18n/test_sync-in.rb
@@ -15,12 +15,12 @@ class I18n::SyncInTest < Minitest::Test
     I18n::Resources::Dashboard::Standards.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Dashboard::Docs.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Apps::ExternalSources.expects(:sync_in).in_sequence(exec_seq)
+    I18n::Resources::Dashboard::Scripts.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Dashboard::Courses.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Apps::Labs.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Pegasus::Markdown.expects(:sync_in).in_sequence(exec_seq)
     I18nScriptUtils.expects(:run_bash_script).with('bin/i18n-codeorg/in.sh').in_sequence(exec_seq)
     I18n::SyncIn.expects(:redact_level_content).in_sequence(exec_seq)
-    I18n::SyncIn.expects(:redact_script).in_sequence(exec_seq)
 
     I18n::SyncIn.perform
   end


### PR DESCRIPTION
1. Moved `I18n::SyncIn.redact_script_content` to `I18n::Resources::Dashboard::Scripts.sync_in`
2. Created a unit test for `I18n::Resources::Dashboard::Scripts.sync_in`

## Links
- jira ticket: [P20-324](https://codedotorg.atlassian.net/browse/P20-324)

## Sync-in
![image](https://github.com/code-dot-org/code-dot-org/assets/66776217/1ed7f7b0-8ea7-4462-b8d9-0767eff0a7a7)

![Screenshot 2023-07-27 at 14 09 18](https://github.com/code-dot-org/code-dot-org/assets/66776217/0f8491e1-7743-400c-b6c7-7875af0b1c3e)