### PR TITLE
P20-328: Create unit tests for hourofcode i18n sync-in

### DIFF
--- a/bin/i18n/hoc_sync_utils.rb
+++ b/bin/i18n/hoc_sync_utils.rb
@@ -7,31 +7,6 @@ require 'fileutils'
 require 'tempfile'
 
 class HocSyncUtils
-  # Pulls in all strings that need to be translated for HourOfCode.com. Pulls
-  # source files from pegasus/sites.v3/hourofcode.com and collects them to a
-  # single source folder i18n/locales/source.
-  def self.sync_in
-    puts "Preparing Hour of Code content"
-    orig_dir = "pegasus/sites.v3/hourofcode.com/public"
-    dest_dir = File.join(I18N_SOURCE_DIR, "hourofcode")
-
-    # Copy the file containing developer-added strings
-    FileUtils.mkdir_p(dest_dir)
-    FileUtils.cp("pegasus/sites.v3/hourofcode.com/i18n/en.yml", dest_dir)
-
-    # Copy the markdown files representing individual page content
-    Dir.glob(File.join(orig_dir, "**/*.{md,md.partial}")).each do |file|
-      dest = file.sub(orig_dir, dest_dir)
-      if File.extname(dest) == '.partial'
-        dest = File.join(File.dirname(dest), File.basename(dest, '.partial'))
-      end
-
-      FileUtils.mkdir_p(File.dirname(dest))
-      FileUtils.cp(file, dest)
-      sanitize_hoc_file(dest)
-    end
-  end
-
   def self.sync_out
     rename_yml_to_locale
     copy_from_i18n_source_to_hoc
@@ -87,19 +62,6 @@ class HocSyncUtils
         FileUtils.cp(source_path, File.join(dest_dir, dest_name))
       end
     end
-  end
-
-  # YAML headers can include a lot of things we don't want translators to mess
-  # with or worry about; layout, navigation settings, social media tags, etc.
-  # However, they also include things like page titles that we DO want
-  # translators to be able to translate, so we can't ignore them completely.
-  # Instead, here we reduce the headers down to contain only the keys we care
-  # about and then in the out step we reinflate the received headers with the
-  # values from the original source.
-  def self.sanitize_hoc_file(path)
-    header, content, _line = Documents.new.helpers.parse_yaml_header(path)
-    I18nScriptUtils.sanitize_header!(header)
-    I18nScriptUtils.write_markdown_with_header(content, header, path)
   end
 
   # In the sync in, we slice the YAML headers of the files we upload to crowdin

--- a/bin/i18n/resources/pegasus/hourofcode.rb
+++ b/bin/i18n/resources/pegasus/hourofcode.rb
@@ -1,0 +1,49 @@
+require 'fileutils'
+
+require_relative '../../i18n_script_utils'
+
+module I18n
+  module Resources
+    module Pegasus
+      module HourOfCode
+        I18N_SOURCE_DIR_PATH = CDO.dir(File.join(I18N_SOURCE_DIR, 'hourofcode')).freeze
+
+        # Pulls in all strings that need to be translated for HourOfCode.com. Pulls
+        # source files from pegasus/sites.v3/hourofcode.com and collects them to a
+        # single source folder i18n/locales/source.
+        def self.sync_in
+          puts 'Preparing Hour of Code content'
+
+          orig_dir = CDO.dir('pegasus/sites.v3/hourofcode.com/public')
+
+          # Copy the file containing developer-added strings
+          FileUtils.mkdir_p(I18N_SOURCE_DIR_PATH)
+          FileUtils.cp(CDO.dir('pegasus/sites.v3/hourofcode.com/i18n/en.yml'), I18N_SOURCE_DIR_PATH)
+
+          # Copy the markdown files representing individual page content
+          Dir[File.join(orig_dir, '**/*.{md,md.partial}')].each do |file|
+            dest = file.sub(orig_dir, I18N_SOURCE_DIR_PATH)
+
+            if File.extname(dest) == '.partial'
+              dest = File.join(File.dirname(dest), File.basename(dest, '.partial'))
+            end
+
+            FileUtils.mkdir_p(File.dirname(dest))
+            FileUtils.cp(file, dest)
+
+            # YAML headers can include a lot of things we don't want translators to mess
+            # with or worry about; layout, navigation settings, social media tags, etc.
+            # However, they also include things like page titles that we DO want
+            # translators to be able to translate, so we can't ignore them completely.
+            # Instead, here we reduce the headers down to contain only the keys we care
+            # about and then in the out step we reinflate the received headers with the
+            # values from the original source.
+            header, content, _line = ::Documents.new.helpers.parse_yaml_header(dest)
+            I18nScriptUtils.sanitize_header!(header)
+            I18nScriptUtils.write_markdown_with_header(content, header, dest)
+          end
+        end
+      end
+    end
+  end
+end

--- a/bin/i18n/resources/pegasus/markdown.rb
+++ b/bin/i18n/resources/pegasus/markdown.rb
@@ -1,7 +1,6 @@
 require 'fileutils'
 require 'json'
 
-require_relative '../../../../pegasus/router'
 require_relative '../../i18n_script_utils'
 
 module I18n

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -10,7 +10,6 @@ require 'fileutils'
 require 'json'
 require 'digest/md5'
 
-require_relative 'hoc_sync_utils'
 require_relative 'i18n_script_utils'
 require_relative 'redact_restore_utils'
 
@@ -21,7 +20,7 @@ module I18n
     def self.perform
       puts "Sync in starting"
       Services::I18n::CurriculumSyncUtils.sync_in
-      HocSyncUtils.sync_in
+      I18n::Resources::Pegasus::HourOfCode.sync_in
       localize_level_and_project_content
       I18n::Resources::Dashboard::Blocks.sync_in
       I18n::Resources::Apps::Animations.sync_in

--- a/bin/test/i18n/resources/pegasus/test_hourofcode.rb
+++ b/bin/test/i18n/resources/pegasus/test_hourofcode.rb
@@ -1,0 +1,40 @@
+require_relative '../../../test_helper'
+require_relative '../../../../i18n/resources/pegasus/hourofcode'
+
+class I18n::Resources::Pegasus::HourOfCodeTest < Minitest::Test
+  def setup
+    ::Documents.stubs(new: stub(helpers: stub))
+  end
+
+  def test_sync_in
+    exec_seq = sequence('execution')
+
+    expected_i18n_source_dir = CDO.dir('i18n/locales/source/hourofcode')
+
+    FileUtils.expects(:mkdir_p).with(expected_i18n_source_dir).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with(CDO.dir('pegasus/sites.v3/hourofcode.com/i18n/en.yml'), expected_i18n_source_dir).in_sequence(exec_seq)
+
+    Dir.expects(:[]).with(CDO.dir('pegasus/sites.v3/hourofcode.com/public/**/*.{md,md.partial}')).returns(
+      [
+        CDO.dir('pegasus/sites.v3/hourofcode.com/public/expected1.md'),
+        CDO.dir('pegasus/sites.v3/hourofcode.com/public/expected2.md.partial')
+      ]
+    ).in_sequence(exec_seq)
+
+    expected_i18n_source_file1_path = CDO.dir('i18n/locales/source/hourofcode/expected1.md')
+    FileUtils.expects(:mkdir_p).with(expected_i18n_source_dir).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with(CDO.dir('pegasus/sites.v3/hourofcode.com/public/expected1.md'), expected_i18n_source_file1_path).in_sequence(exec_seq)
+    ::Documents.new.helpers.expects(:parse_yaml_header).with(expected_i18n_source_file1_path).returns(%w[expected_header expected_content expected_line]).in_sequence(exec_seq)
+    I18nScriptUtils.expects(:sanitize_header!).with('expected_header').in_sequence(exec_seq)
+    I18nScriptUtils.expects(:write_markdown_with_header).with('expected_content', 'expected_header', expected_i18n_source_file1_path).in_sequence(exec_seq)
+
+    expected_i18n_source_file2_path = CDO.dir('i18n/locales/source/hourofcode/expected2.md')
+    FileUtils.expects(:mkdir_p).with(expected_i18n_source_dir).in_sequence(exec_seq)
+    FileUtils.expects(:cp).with(CDO.dir('pegasus/sites.v3/hourofcode.com/public/expected2.md.partial'), expected_i18n_source_file2_path).in_sequence(exec_seq)
+    ::Documents.new.helpers.expects(:parse_yaml_header).with(expected_i18n_source_file2_path).returns(%w[expected_header expected_content expected_line]).in_sequence(exec_seq)
+    I18nScriptUtils.expects(:sanitize_header!).with('expected_header').in_sequence(exec_seq)
+    I18nScriptUtils.expects(:write_markdown_with_header).with('expected_content', 'expected_header', expected_i18n_source_file2_path).in_sequence(exec_seq)
+
+    I18n::Resources::Pegasus::HourOfCode.sync_in
+  end
+end

--- a/bin/test/i18n/test_sync-in.rb
+++ b/bin/test/i18n/test_sync-in.rb
@@ -6,7 +6,7 @@ class I18n::SyncInTest < Minitest::Test
     exec_seq = sequence('execution')
 
     Services::I18n::CurriculumSyncUtils.expects(:sync_in).in_sequence(exec_seq)
-    HocSyncUtils.expects(:sync_in).in_sequence(exec_seq)
+    I18n::Resources::Pegasus::HourOfCode.expects(:sync_in).in_sequence(exec_seq)
     I18n::SyncIn.expects(:localize_level_and_project_content).in_sequence(exec_seq)
     I18n::Resources::Dashboard::Blocks.expects(:sync_in).in_sequence(exec_seq)
     I18n::Resources::Apps::Animations.expects(:sync_in).in_sequence(exec_seq)


### PR DESCRIPTION
1. Moved `HocSyncUtils.sync_in` to `I18n::Resources::Pegasus::Hourofcode.sync_in`
2. Created a unit test for `I18n::Resources::Pegasus::Hourofcode.sync_in`

## Links
- jira ticket: [P20-328](https://codedotorg.atlassian.net/browse/P20-328)
## Sync-in
![Screenshot 2023-07-28 at 13 44 41](https://github.com/code-dot-org/code-dot-org/assets/66776217/2502ab91-8442-4f9f-91ce-025b3bf363b4)

![Screenshot 2023-07-28 at 13 45 03](https://github.com/code-dot-org/code-dot-org/assets/66776217/b2f3a8ba-d7e7-41b1-97ff-c02f76c9fa82)