### PR TITLE
Collapse checkbox dropdowns on the Curriculum Catalog page when 'Escape' is pressed

### DIFF
--- a/apps/src/templates/CheckboxDropdown.jsx
+++ b/apps/src/templates/CheckboxDropdown.jsx
@@ -28,8 +28,15 @@ const CheckboxDropdown = ({
     handleClearAll(name);
   }, [name, handleClearAll]);
 
+  // Collapse dropdown if 'Escape' is pressed
+  const onKeyDown = e => {
+    if (e.keyCode === 27) {
+      e.currentTarget.classList.remove('open');
+    }
+  };
+
   return (
-    <div id={`${name}-dropdown`} className="dropdown">
+    <div id={`${name}-dropdown`} className="dropdown" onKeyDown={onKeyDown}>
       <button
         id={`${name}-dropdown-button`}
         type="button"


### PR DESCRIPTION
Currently on the Curriculum Catalog page, the checkbox dropdowns are not fully tab-navigable in an expected way since hitting 'Escape' does not collapse the dropdowns, and it will actually just expand/collapse them when selecting the root of the dropdown. With this PR, pressing 'Escape' collapses the dropdown the user is navigating if it is expanded.

### Demo only using tab navigation and pressing 'Escape' to close the dropdowns
https://github.com/code-dot-org/code-dot-org/assets/56283563/6a5ff713-35ee-43b4-83e3-bad46b48de8c

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-637&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and drone build.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
