### PR TITLE
Use scss module for styling Header Banner

### DIFF
--- a/apps/src/templates/HeaderBanner.jsx
+++ b/apps/src/templates/HeaderBanner.jsx
@@ -13,17 +13,28 @@ export default class HeaderBanner extends React.Component {
     headingText: PropTypes.string,
     subHeadingText: PropTypes.string,
     description: PropTypes.string,
-    short: PropTypes.bool,
+    children: PropTypes.node,
     backgroundUrl: PropTypes.string.isRequired,
+    backgroundImageStyling: PropTypes.object,
     imageUrl: PropTypes.string,
+    imgStyling: PropTypes.object,
   };
 
   render() {
-    const {headingText, subHeadingText, description, backgroundUrl, imageUrl} =
-      this.props;
+    const {
+      headingText,
+      subHeadingText,
+      description,
+      children,
+      backgroundUrl,
+      backgroundImageStyling,
+      imageUrl,
+      imgStyling,
+    } = this.props;
 
     const backgroundImageStyle = {
       backgroundImage: `url(${backgroundUrl})`,
+      ...backgroundImageStyling,
     };
 
     return (
@@ -43,10 +54,11 @@ export default class HeaderBanner extends React.Component {
                 {description}
               </Typography>
             )}
+            {children}
           </div>
           {imageUrl && (
             <figure>
-              <img src={imageUrl} alt="" />
+              <img src={imageUrl} style={imgStyling} alt="" />
             </figure>
           )}
         </div>

--- a/apps/src/templates/HeaderBanner.jsx
+++ b/apps/src/templates/HeaderBanner.jsx
@@ -5,169 +5,52 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import color from '../util/color';
-import {connect} from 'react-redux';
-import styleConstants from '@cdo/apps/styleConstants';
+import Typography from '@cdo/apps/componentLibrary/typography';
+import style from './header-banner.module.scss';
 
-class HeaderBanner extends React.Component {
+export default class HeaderBanner extends React.Component {
   static propTypes = {
     headingText: PropTypes.string,
     subHeadingText: PropTypes.string,
     description: PropTypes.string,
-    children: PropTypes.node,
     short: PropTypes.bool,
-    responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']).isRequired,
     backgroundUrl: PropTypes.string.isRequired,
     imageUrl: PropTypes.string,
   };
 
   render() {
-    const {
-      short,
-      headingText,
-      subHeadingText,
-      description,
-      responsiveSize,
-      backgroundUrl,
-      imageUrl,
-    } = this.props;
+    const {headingText, subHeadingText, description, backgroundUrl, imageUrl} =
+      this.props;
 
-    let headerBannerContainerStyle,
-      headingStyle,
-      subHeadingStyle,
-      descriptionStyle;
-
-    const isSmallScreen = responsiveSize === 'xs';
-    headerBannerContainerStyle = short
-      ? styles.headerBannerContainerShort
-      : styles.headerBannerContainer;
-    headingStyle = short ? styles.bannerHeadingShort : styles.bannerHeading;
-    if (isSmallScreen) {
-      subHeadingStyle = styles.bannerSubHeadingResponsive;
-      descriptionStyle = styles.bannerDescriptionResponsive;
-    } else {
-      subHeadingStyle = styles.bannerSubHeading;
-      descriptionStyle = styles.bannerDescription;
-    }
-
-    const headerBannerStyle = {
+    const backgroundImageStyle = {
       backgroundImage: `url(${backgroundUrl})`,
     };
 
-    const bannerContentImageStyle = short
-      ? styles.bannerContentImageShort
-      : styles.bannerContentImage;
-
-    if (isSmallScreen) {
-      return (
-        <div>
-          <div id={'header-banner'} style={headerBannerStyle}>
-            <div
-              className={'bannerContentContainer'}
-              style={headerBannerContainerStyle}
-            >
-              <div className={'bannerContent'}>
-                <h1 style={headingStyle}>{headingText}</h1>
-              </div>
-            </div>
-          </div>
-          <div id={'header-banner-overflow'}>
-            <div className={'bannerContent'}>
-              {subHeadingText && (
-                <div style={subHeadingStyle}>{subHeadingText}</div>
-              )}
-              {description && <div style={descriptionStyle}>{description}</div>}
-              {this.props.children && (
-                <div className={'children'}>{this.props.children}</div>
-              )}
-            </div>
-          </div>
-        </div>
-      );
-    } else {
-      return (
-        <div id={'header-banner'} style={headerBannerStyle}>
-          <div
-            className={'bannerContentContainer'}
-            style={headerBannerContainerStyle}
-          >
-            <div className={'bannerContent'}>
-              <h1 style={headingStyle}>{headingText}</h1>
-              {subHeadingText && (
-                <div style={subHeadingStyle}>{subHeadingText}</div>
-              )}
-              {description && <div style={descriptionStyle}>{description}</div>}
-              {this.props.children && (
-                <div className={'children'}>{this.props.children}</div>
-              )}
-            </div>
-            {imageUrl && (
-              <img style={bannerContentImageStyle} src={imageUrl} alt="" />
+    return (
+      <div style={backgroundImageStyle} className={style.banner}>
+        <div className={style.contentWrapper}>
+          <div className={style.textWrapper}>
+            <Typography semanticTag="h1" visualAppearance="heading-xxl">
+              {headingText}
+            </Typography>
+            {subHeadingText && (
+              <Typography semanticTag="p" visualAppearance="body-one">
+                {subHeadingText}
+              </Typography>
+            )}
+            {description && (
+              <Typography semanticTag="p" visualAppearance="body-one">
+                {description}
+              </Typography>
             )}
           </div>
+          {imageUrl && (
+            <figure>
+              <img src={imageUrl} alt="" />
+            </figure>
+          )}
         </div>
-      );
-    }
+      </div>
+    );
   }
 }
-
-const styles = {
-  headerBannerContainer: {
-    minHeight: 260,
-    maxWidth: styleConstants['content-width'],
-  },
-  headerBannerContainerShort: {
-    minHeight: 140,
-    maxWidth: styleConstants['content-width'],
-  },
-  bannerHeading: {
-    fontFamily: '"Barlow Semi Condensed Semibold", sans-serif',
-    color: color.white,
-    fontSize: 48,
-    marginBottom: 0,
-  },
-  bannerHeadingShort: {
-    fontFamily: '"Barlow Semi Condensed Semibold", sans-serif',
-    color: color.white,
-    fontSize: 48,
-    marginBottom: 0,
-  },
-  bannerSubHeading: {
-    fontFamily: '"Gotham 4r", sans-serif',
-    color: color.white,
-    fontSize: 16,
-    lineHeight: '21px',
-    marginTop: 16,
-  },
-  bannerSubHeadingResponsive: {
-    fontFamily: '"Gotham 4r", sans-serif',
-    color: color.dark_charcoal,
-    fontSize: 16,
-    lineHeight: '21px',
-    marginTop: 16,
-  },
-  bannerDescription: {
-    fontFamily: '"Gotham 4r", sans-serif',
-    color: color.white,
-    fontSize: 16,
-    lineHeight: '21px',
-    marginTop: 16,
-  },
-  bannerDescriptionResponsive: {
-    fontFamily: '"Gotham 4r", sans-serif',
-    color: color.dark_charcoal,
-    fontSize: 16,
-    lineHeight: '21px',
-    marginTop: 16,
-  },
-  bannerContentImage: {
-    maxHeight: 260,
-  },
-  bannerContentImageShort: {
-    maxHeight: 140,
-  },
-};
-
-export default connect(state => ({
-  responsiveSize: state.responsive.responsiveSize,
-}))(HeaderBanner);

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -376,7 +376,6 @@ const CurriculumCatalog = ({
       <HeaderBanner
         headingText={i18n.curriculumCatalogHeaderTitle()}
         subHeadingText={i18n.curriculumCatalogHeaderSubtitle()}
-        short={false}
         backgroundUrl={CourseCatalogBannerBackground}
         imageUrl={CourseCatalogIllustration01}
       />

--- a/apps/src/templates/header-banner.module.scss
+++ b/apps/src/templates/header-banner.module.scss
@@ -5,23 +5,24 @@
   // background-image is passed in via the `style` attribute
   background-size: cover;
   position: relative;
-  overflow: hidden;
   padding: 2rem 1rem;
   box-sizing: border-box;
 }
 
 .contentWrapper {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   max-width: 960px;
+  min-height: 100px;
   margin: 0 auto;
 
   figure {
     @media screen and (min-width: $width-sm) {
       width: 25%;
       margin: 0 auto;
+      display: flex;
+      justify-content: end;
     }
 
     @media screen and (max-width: $width-sm) {
@@ -39,16 +40,15 @@
     width: 100%;
   }
 
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   position: relative;
   z-index: 1;
 
   h1, p {
     color: white;
-  }
-
-  p {
     margin-bottom: 0;
-    color: white;
   }
 }
 

--- a/apps/src/templates/header-banner.module.scss
+++ b/apps/src/templates/header-banner.module.scss
@@ -7,6 +7,14 @@
   position: relative;
   padding: 2rem 1rem;
   box-sizing: border-box;
+
+  /*
+    The banner background image leaves an open space for text on the left. Therefore, in Right-to-Left languages, the
+    banner needs to be flipped horizontally so the background image empty space is on the right.
+   */
+  html[dir="rtl"] & {
+    transform: scaleX(-1);
+  }
 }
 
 .contentWrapper {
@@ -16,6 +24,14 @@
   max-width: 960px;
   min-height: 100px;
   margin: 0 auto;
+
+  /*
+    Since the whole banner was flipped horizontally, we need to un-flip all the content in the header so that the text
+    and layout are not backwards
+   */
+  html[dir="rtl"] & {
+    transform: scaleX(-1);
+  }
 
   figure {
     @media screen and (min-width: $width-sm) {

--- a/apps/src/templates/header-banner.module.scss
+++ b/apps/src/templates/header-banner.module.scss
@@ -1,0 +1,56 @@
+@import "breakpoints";
+@import "typography";
+
+.banner {
+  // background-image is passed in via the `style` attribute
+  background-size: cover;
+  position: relative;
+  overflow: hidden;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+}
+
+.contentWrapper {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 960px;
+  margin: 0 auto;
+
+  figure {
+    @media screen and (min-width: $width-sm) {
+      width: 25%;
+      margin: 0 auto;
+    }
+
+    @media screen and (max-width: $width-sm) {
+      display: none
+    }
+  }
+}
+
+.textWrapper {
+  @media screen and (min-width: $width-sm) {
+    width: 60%;
+  }
+
+  @media screen and (max-width: $width-sm) {
+    width: 100%;
+  }
+
+  position: relative;
+  z-index: 1;
+
+  h1, p {
+    color: white;
+  }
+
+  p {
+    margin-bottom: 0;
+    color: white;
+  }
+}
+
+
+

--- a/apps/src/templates/projects/ProjectHeader.jsx
+++ b/apps/src/templates/projects/ProjectHeader.jsx
@@ -20,12 +20,12 @@ export default class ProjectHeader extends React.Component {
     return (
       <div>
         <HeaderBanner
-          short={true}
           headingText={i18n.projects()}
           subHeadingText={i18n.projectsSubHeadingMillions({
             project_count: this.props.projectCount,
           })}
           backgroundUrl={backgroundUrl}
+          backgroundImageStyling={{backgroundPosition: '90% 40%'}}
         />
         <div className={'container main'}>
           {this.props.showDeprecatedCalcAndEvalWarning && (

--- a/apps/src/templates/studioHomepages/Courses.jsx
+++ b/apps/src/templates/studioHomepages/Courses.jsx
@@ -60,7 +60,6 @@ class Courses extends Component {
           headingText={headingText}
           subHeadingText={subHeadingText}
           description={description}
-          short={!isSignedOut}
           backgroundUrl={backgroundUrl}
         >
           {isSignedOut && (
@@ -109,6 +108,7 @@ const styles = {
     borderColor: color.white,
     color: color.neutral_dark,
     fontFamily: `"Gotham 5r", sans-serif`,
+    width: 'fit-content',
   },
 };
 

--- a/apps/src/templates/studioHomepages/Courses.jsx
+++ b/apps/src/templates/studioHomepages/Courses.jsx
@@ -61,6 +61,7 @@ class Courses extends Component {
           subHeadingText={subHeadingText}
           description={description}
           backgroundUrl={backgroundUrl}
+          backgroundImageStyling={{backgroundPosition: '40% 40%'}}
         >
           {isSignedOut && (
             <Button

--- a/apps/src/templates/studioHomepages/Incubator.jsx
+++ b/apps/src/templates/studioHomepages/Incubator.jsx
@@ -11,7 +11,7 @@ class Incubator extends Component {
           subHeadingText="Try something new"
           backgroundUrl="/shared/images/banners/banner-incubator.png"
           imageUrl="/shared/images/banners/banner-incubator-image.png"
-          short={true}
+          imgStyling={{maxHeight: '160px'}}
         />
         <div className="main" style={{maxWidth: 970, margin: '0 auto'}}>
           <div style={{margin: '40px 0'}}>

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -50,6 +50,7 @@ export default class StudentHomepage extends Component {
         <HeaderBanner
           headingText={i18n.homepageHeading()}
           backgroundUrl={backgroundUrl}
+          backgroundImageStyling={{backgroundPosition: '90% 30%'}}
         />
         <div className={'container main'}>
           <ProtectedStatefulDiv ref="flashes" />

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -49,7 +49,6 @@ export default class StudentHomepage extends Component {
       <div>
         <HeaderBanner
           headingText={i18n.homepageHeading()}
-          short={true}
           backgroundUrl={backgroundUrl}
         />
         <div className={'container main'}>

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -173,7 +173,6 @@ export const UnconnectedTeacherHomepage = ({
     <div>
       <HeaderBanner
         headingText={i18n.homepageHeading()}
-        short={true}
         backgroundUrl={backgroundUrl}
       />
       <div className={'container main'}>

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -174,6 +174,7 @@ export const UnconnectedTeacherHomepage = ({
       <HeaderBanner
         headingText={i18n.homepageHeading()}
         backgroundUrl={backgroundUrl}
+        backgroundImageStyling={{backgroundPosition: '90% 30%'}}
       />
       <div className={'container main'}>
         <ProtectedStatefulDiv ref={flashes} />

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -18,14 +18,12 @@ describe('Courses', () => {
     it('shows a short banner when signed in', () => {
       const wrapper = shallow(<Courses {...TEST_PROPS} isSignedOut={false} />);
       const header = wrapper.find(HeaderBanner);
-      assert.isTrue(header.prop('short'));
       assert.isUndefined(header.prop('description'));
     });
 
     it('shows a long banner when signed out', () => {
       const wrapper = shallow(<Courses {...TEST_PROPS} isSignedOut={true} />);
       const header = wrapper.find(HeaderBanner);
-      assert.isFalse(header.prop('short'));
       assert.isString(header.prop('description'));
     });
   });

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -24,9 +24,7 @@ describe('StudentHomepage', () => {
   it('shows a Header Banner that says My Dashboard', () => {
     const wrapper = shallow(<StudentHomepage {...TEST_PROPS} />);
     const headerBanner = wrapper.find(HeaderBanner);
-    assert.deepEqual(headerBanner.props(), {
-      headingText: 'My Dashboard',
-    });
+    expect(headerBanner.props().headingText).to.equal('My Dashboard');
   });
 
   it('references a ProtectedStatefulDiv for flashes', () => {

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -21,13 +21,11 @@ describe('StudentHomepage', () => {
     showVerifiedTeacherWarning: false,
   };
 
-  it('shows a non-extended Header Banner that says My Dashboard', () => {
+  it('shows a Header Banner that says My Dashboard', () => {
     const wrapper = shallow(<StudentHomepage {...TEST_PROPS} />);
     const headerBanner = wrapper.find(HeaderBanner);
     assert.deepEqual(headerBanner.props(), {
       headingText: 'My Dashboard',
-      short: true,
-      backgroundUrl: '/shared/images/banners/teacher-homepage-hero.jpg',
     });
   });
 

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -52,13 +52,11 @@ describe('TeacherHomepage', () => {
     sessionStorage.getItem.restore();
   });
 
-  it('shows a non-extended Header Banner that says My Dashboard', () => {
+  it('shows a Header Banner that says My Dashboard', () => {
     const wrapper = setUp();
-    const headerBanner = wrapper.find('Connect(HeaderBanner)');
+    const headerBanner = wrapper.find('HeaderBanner');
     assert.deepEqual(headerBanner.props(), {
       headingText: 'My Dashboard',
-      short: true,
-      backgroundUrl: '/shared/images/banners/teacher-homepage-hero.jpg',
     });
   });
 

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -55,9 +55,7 @@ describe('TeacherHomepage', () => {
   it('shows a Header Banner that says My Dashboard', () => {
     const wrapper = setUp();
     const headerBanner = wrapper.find('HeaderBanner');
-    assert.deepEqual(headerBanner.props(), {
-      headingText: 'My Dashboard',
-    });
+    expect(headerBanner.props().headingText).to.equal('My Dashboard');
   });
 
   it('renders 2 ProtectedStatefulDivs', () => {

--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -18,7 +18,7 @@ Scenario: School Info Confirmation Dialog
   # Teacher account is created with partial school info
   Given I create a teacher named "Teacher_Chuba" and go home
    # Wait for homepage to load before reloading the page.
-  Then I wait until element "#header-banner" is visible
+  Then I wait until element "h1" contains text "My Dashboard"
   # The date of the teacher's account is updated to 7 days ago to simulate time travel
   # This enables the condition (see school_info_interstitial helper.rb) that checks
   # the age of the account to determine when to show the school info interstitial.

--- a/dashboard/test/ui/features/teacher_tools/projects/public_project_gallery_signed_out.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/public_project_gallery_signed_out.feature
@@ -4,7 +4,7 @@ Background:
   Given I am on "http://studio.code.org/projects/public"
 
 Scenario: Public Gallery Shows Expected Elements
-  Then I wait until element "#header-banner" is visible
+  Then I wait until element "h1" contains text "Projects"
   Then I wait until element "#uitest-public-projects" is visible
 
 Scenario: Public Gallery Shows Expected Project Types


### PR DESCRIPTION
The original ask was to ensure that, on mobile, the text that is part of the header banner on Desktop stays inside the banner on mobile, rather than dropping below the banner.

There are 6 pages that use HeaderBanner:
<img width="836" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/85f3704a-b641-4260-9e61-5e8df8213b02">

I refactored the HeaderBanner component in a few ways:
1) I used Kelby's pattern on Pegasus as a guide (see https://github.com/code-dot-org/code-dot-org/pull/50929#issuecomment-1483014088)
2) I removed the `short` prop, instead opting for dynamic styling based on content. This is what the `short` prop was doing:
https://github.com/code-dot-org/code-dot-org/blob/de6ff638edb7ac5e06bb5dd2e0c5c34bbcb24c74/apps/src/templates/HeaderBanner.jsx#L12-L59
The ProjectHeader, the Courses banner (if not signed out), the Incubator, the StudentHomepage, and the TeacherHomepage all had the `short` prop set to `true`. See screenshots for the styling updates.
3) I also removed the responsiveSize prop, opting instead for media queries to determine styling in SCSS (also part of Kelby's styling mentioned in 1).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story (Screenshots)

Here are the screenshots for what's changed. I was *not* striving for parity, but rather ensuring responsiveness + readability of text for all header banners.

**Catalog**
<img width="1295" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/0ecc43cf-d29a-45f2-a4ea-2aa53c1932bc">
<img width="223" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/36ef1de8-48af-43d0-9039-e137b80f17a5">

Local:
<img width="1431" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/7bfed748-f008-400a-bf0e-2cf13b5ae1fa">
<img width="232" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/21d6d1e5-4d4b-44f4-af89-c867fdd55b3f">

--

**Projects**
<img width="1294" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/a27bcf27-c7d4-478e-8580-4d801f685209">
<img width="382" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/267395a4-b897-4a6f-a8bf-1a1cbb98813f">

Local:
<img width="1426" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/3b9a243f-3036-4ac7-9c73-36266b82a88e">
<img width="193" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/f9144558-ae73-44cd-8617-7cbb1f43a858">

--

**Courses (Signed Out)**
<img width="1294" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/73ed1acc-68fc-4ead-8b66-2827f1191ab4">
<img width="236" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/823acede-ab64-434a-abf6-64132d0390f1">

Local:
<img width="1435" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/30470152-8262-4bc6-8603-d3fde1380fb8">
<img width="499" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/4601e0df-b9cf-4fc1-aea9-c63a51d75948">

--

**Courses (Signed In)**
<img width="1190" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/85d58033-653c-41eb-89fe-539a64122c54">
<img width="513" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/23663065-9c49-48c3-b351-007e502e0942">

Local:
<img width="1173" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/15013dfd-9822-4c14-9329-20984a029212">
<img width="510" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/3dbe1d3e-abde-4b6e-96a3-2bca5fafb187">

--

**Incubator**
<img width="1283" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/13c9c048-caf4-4970-ae13-fcb15ae066b0">
<img width="218" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/284c8374-55fe-487a-905d-fa7fd253feae">

Local:
<img width="1436" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/02cfdfd2-04aa-4583-83ff-a1b0cd428733">
<img width="499" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/6d3afa74-f6f0-4edc-8c6f-0b951f28d989">

--

**Teacher Homepage**
<img width="1244" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/0a4b6d14-b908-4630-b55e-89ce3a966907">
<img width="500" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/6aa24e93-d92e-4ef5-b74c-f9c24d855258">

Local:
<img width="1174" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/007714c7-3b54-4734-9fa2-3a48c8faf33d">
<img width="500" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/39af19d5-b73e-45cf-93fc-3bc5d264e884">

--

**Student Homepage**
<img width="1168" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/81aa9d9c-78c4-459e-a8d8-2b54d954e544">
<img width="499" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/cf19998c-2e5b-44ae-b8d0-5bfea3725e76">

Local:
<img width="1241" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/621fe80c-5d5a-4d24-8803-611afb6f4eee">
<img width="507" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/2af52dc7-6bf9-407f-9c01-9139540a0910">

RTL:

<img width="1435" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/66abdb28-f863-4778-a8cf-fb1b746ec788">
<img width="1435" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/168d5a5c-4fb1-45d2-8902-49d23db832f8">
<img width="217" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/5e9eb12c-0eff-467d-87eb-bd42110e7bbf">
<img width="218" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/bda25c9e-1956-4911-b75f-61d3f56850ef">
<img width="1040" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/a059047b-30e8-44ba-a91f-03258933180a">


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
