### PR TITLE
Improved visibility on collapse button in Java Lab Preview Pane

### DIFF
--- a/apps/src/code-studio/components/AdvancedShareOptions.jsx
+++ b/apps/src/code-studio/components/AdvancedShareOptions.jsx
@@ -38,12 +38,6 @@ const style = {
     color: color.neutral_dark,
     fontFamily: "'Gotham 5r', sans-serif",
   },
-  warningp: {
-    fontSize: 'inherit',
-    lineHeight: 'inherit',
-    color: color.red,
-    fontFamily: "'Gotham 5r', sans-serif",
-  },
   bold: {
     fontFamily: "'Gotham 7r', sans-serif",
   },
@@ -135,7 +129,6 @@ class AdvancedShareOptions extends React.Component {
     return (
       <div>
         <p style={style.p}>{i18n.shareEmbedDescription()}</p>
-        <p style={style.warningp}>{i18n.shareEmbedWarning()}</p>
         <textarea
           type="text"
           onClick={e => e.target.select()}

--- a/apps/src/code-studio/components/AdvancedShareOptions.jsx
+++ b/apps/src/code-studio/components/AdvancedShareOptions.jsx
@@ -38,6 +38,12 @@ const style = {
     color: color.neutral_dark,
     fontFamily: "'Gotham 5r', sans-serif",
   },
+  warningp: {
+    fontSize: 'inherit',
+    lineHeight: 'inherit',
+    color: color.red,
+    fontFamily: "'Gotham 5r', sans-serif",
+  },
   bold: {
     fontFamily: "'Gotham 7r', sans-serif",
   },
@@ -129,6 +135,7 @@ class AdvancedShareOptions extends React.Component {
     return (
       <div>
         <p style={style.p}>{i18n.shareEmbedDescription()}</p>
+        <p style={style.warningp}>{i18n.shareEmbedWarning()}</p>
         <textarea
           type="text"
           onClick={e => e.target.select()}

--- a/apps/src/javalab/PreviewPaneHeader.jsx
+++ b/apps/src/javalab/PreviewPaneHeader.jsx
@@ -8,6 +8,7 @@ import PaneHeader, {
 } from '@cdo/apps/templates/PaneHeader';
 import CollapserIcon from '@cdo/apps/templates/CollapserIcon';
 import {RecordingFileType} from '../code-studio/components/recorders';
+import {white} from '../util/color';
 
 export default function PreviewPaneHeader({
   isCollapsed,
@@ -22,7 +23,12 @@ export default function PreviewPaneHeader({
       <PaneSection className={'pane-header-section pane-header-section-left'}>
         <PaneButton
           headerHasFocus
-          icon={<CollapserIcon isCollapsed={isCollapsed} />}
+          icon={
+            <CollapserIcon
+              isCollapsed={isCollapsed}
+              style={styles.previewPaneCollapserIcon}
+            />
+          }
           onClick={toggleVisualizationCollapsed}
           label=""
           isRtl={false}
@@ -89,5 +95,8 @@ const styles = {
     ':hover': {
       backgroundColor: 'transparent',
     },
+  },
+  previewPaneCollapserIcon: {
+    color: white,
   },
 };

--- a/apps/src/javalab/PreviewPaneHeader.jsx
+++ b/apps/src/javalab/PreviewPaneHeader.jsx
@@ -8,7 +8,7 @@ import PaneHeader, {
 } from '@cdo/apps/templates/PaneHeader';
 import CollapserIcon from '@cdo/apps/templates/CollapserIcon';
 import {RecordingFileType} from '../code-studio/components/recorders';
-import {white} from '../util/color';
+import color from '@cdo/apps/util/color';
 
 export default function PreviewPaneHeader({
   isCollapsed,
@@ -26,7 +26,7 @@ export default function PreviewPaneHeader({
           icon={
             <CollapserIcon
               isCollapsed={isCollapsed}
-              style={styles.previewPaneCollapserIcon}
+              style={styles.collapserIcon}
             />
           }
           onClick={toggleVisualizationCollapsed}
@@ -96,7 +96,7 @@ const styles = {
       backgroundColor: 'transparent',
     },
   },
-  previewPaneCollapserIcon: {
-    color: white,
+  collapserIcon: {
+    color: color.white,
   },
 };


### PR DESCRIPTION
## Summary
Updated the color of Java Lab Preview Pane Collapse Button to white in order for it to be more visible. 
Before:
![image](https://github.com/code-dot-org/code-dot-org/assets/31292421/9e9b1767-3bf6-4deb-ba49-057eab751f0a)
After:
![image](https://github.com/code-dot-org/code-dot-org/assets/31292421/23660633-c406-4cb9-b3ec-bf2b9d14a4a5)

## Links
- jira ticket: [https://codedotorg.atlassian.net/browse/SL-1006]()

## Testing story
Manual tests to see whether the color visibly changed. Ensured that the collapse button on the instruction panel above remained the original color. 

See photo: 
![image](https://github.com/code-dot-org/code-dot-org/assets/31292421/1c981149-1807-4eb9-9f61-17c7f1c4c489)

## Privacy
This change does not involve the collection, use, or sharing of both new and existing Personal Data. 

## PR Checklist
- [] Tests provide adequate coverage
- [] Privacy and Security impacts have been assessed
- [] Code is well-commented
- [] New features are translatable or updates will not break translations
- [] Relevant documentation has been added or updated
- [] User impact is well-understood and desirable
- [] Pull Request is labeled appropriately
- [] Follow-up work items (including potential tech debt) are tracked and linked
