### PR TITLE
Reenable storybook deploy as part of staging apps build, attempt #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ npm-debug.log
 /apps/src/applab/sharedApplabGoalBlocks.js
 /apps/src/p5lab/gamelab/sharedGamelabBlocks.js
 /apps/src/styleConstants.js
+/apps/storybook-deploy
 /apps/test/entry-tests.js
 /apps/test/interpreter/test-results-new*.json
 /apps/yarn-error.log

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx
@@ -4,8 +4,6 @@ import i18n from '@cdo/locale';
 import FontAwesome from '../FontAwesome';
 import color from '@cdo/apps/util/color';
 import StudentGroup from './StudentGroup';
-// todo: remove this!
-// comment to force apps build in staging build
 
 export default function CodeReviewGroup({
   droppableId,

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx
@@ -4,6 +4,8 @@ import i18n from '@cdo/locale';
 import FontAwesome from '../FontAwesome';
 import color from '@cdo/apps/util/color';
 import StudentGroup from './StudentGroup';
+// todo: remove this!
+// comment to force apps build in staging build
 
 export default function CodeReviewGroup({
   droppableId,

--- a/apps/stylelint.config.js
+++ b/apps/stylelint.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  ignoreFiles: ['./build/**/*.scss'],
+  ignoreFiles: ['./build/**/*.scss', './storybook-deploy/*'],
   extends: ['stylelint-config-standard', 'stylelint-config-standard-scss'],
   rules: {
     'media-feature-range-notation': 'prefix',

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -25,6 +25,11 @@ namespace :build do
       npm_target = CDO.optimize_webpack_assets ? 'build:dist' : 'build'
       RakeUtils.system "npm run #{npm_target}"
       File.write(commit_hash, calculate_apps_commit_hash)
+
+      if rack_env?(:staging)
+        ChatClient.log 'Deploying <b>storybook</b>...'
+        RakeUtils.system 'npm run storybook:deploy'
+      end
     end
   end
 

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -3,7 +3,10 @@ require 'cdo/chat_client'
 require 'cdo/rake_utils'
 require 'cdo/git_utils'
 require lib_dir 'cdo/data/logging/rake_task_event_logger'
+require 'dynamic_config/dcdo'
+
 include TimedTaskWithLogging
+
 namespace :build do
   desc 'Builds apps.'
   timed_task_with_logging :apps do
@@ -26,7 +29,7 @@ namespace :build do
       RakeUtils.system "npm run #{npm_target}"
       File.write(commit_hash, calculate_apps_commit_hash)
 
-      if rack_env?(:staging)
+      if rack_env?(:staging) && DCDO.get('deploy_storybook', false)
         ChatClient.log 'Deploying <b>storybook</b>...'
         RakeUtils.system 'npm run storybook:deploy'
       end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#52934

Attempt no. 2 surfaced another broken symlink issue, which should be fixed by this PR: https://github.com/code-dot-org/code-dot-org/pull/52998

The code included here is the same as what was reviewed in this initial attempt to reenable storybook deploy in [this PR](https://github.com/code-dot-org/code-dot-org/pull/52821), with the addition of: 
- gitignore and ignore scss lint on the `storybook-deploy` directory -- this directory should be deleted at the end of the storybook deploy script, but in case we error out before the delete step happens, we avoid a whole host of slack notifications for linting errors
- add DCDO flag to control the storybook deploy, so I can have a faster iteration time when working on this (eg, if there are issues that can be resolved without a code change, like a bad symlink on the staging machine).

## Testing story

I ran `bundle exec rake build:apps` locally with and without the DCDO flag set (and the staging flag removed), and saw the appropriate behavior (ie, storybook built when it was enabled, and did not when it was not enabled).