### PR TITLE
P20 314/get access token

### DIFF
--- a/dashboard/app/controllers/oauth_jwks_controller.rb
+++ b/dashboard/app/controllers/oauth_jwks_controller.rb
@@ -1,10 +1,20 @@
 require 'jwt'
 require 'json'
 
+include LtiAccessTokenHelper
+
 class OauthJwksController < ApplicationController
   # GET /oauth/jwks
   def jwks
     jwks_data = CDO.jwks_data
     render json: jwks_data
+  end
+
+  # TEMP: Use this endpoint to invoke the get_access_token. You can configure your
+  # local LTI Integration client_id
+  def access_token
+    access_token = get_access_token("10000000000001", "https://canvas.instructure.com")
+    p access_token
+    render json: access_token
   end
 end

--- a/dashboard/app/controllers/oauth_jwks_controller.rb
+++ b/dashboard/app/controllers/oauth_jwks_controller.rb
@@ -1,7 +1,7 @@
 require 'jwt'
 require 'json'
 
-include LtiAccessTokenHelper
+include LtiAccessToken
 
 class OauthJwksController < ApplicationController
   # GET /oauth/jwks
@@ -10,7 +10,8 @@ class OauthJwksController < ApplicationController
     render json: jwks_data
   end
 
-  # TEMP: Use this endpoint to invoke the get_access_token. You can configure your
+  # TEMP: Remove before merging.
+  # Use this endpoint to invoke the get_access_token. You can configure your
   # local LTI Integration client_id
   def access_token
     access_token = get_access_token("10000000000003", "https://canvas.instructure.com")

--- a/dashboard/app/controllers/oauth_jwks_controller.rb
+++ b/dashboard/app/controllers/oauth_jwks_controller.rb
@@ -13,7 +13,7 @@ class OauthJwksController < ApplicationController
   # TEMP: Use this endpoint to invoke the get_access_token. You can configure your
   # local LTI Integration client_id
   def access_token
-    access_token = get_access_token("10000000000001", "https://canvas.instructure.com")
+    access_token = get_access_token("10000000000003", "https://canvas.instructure.com")
     p access_token
     render json: access_token
   end

--- a/dashboard/app/helpers/lti_access_token_helper.rb
+++ b/dashboard/app/helpers/lti_access_token_helper.rb
@@ -41,14 +41,17 @@ module LtiAccessTokenHelper
       scope: 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem https://purl.imsglobal.org/spec/lti-ags/scope/result/read',
     }
 
+    p query
+
     res = HTTParty.post(access_token_url, query: query, headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
     # get access_token and exp from response
-    access_token = res.body[:access_token]
-    exp = res.body[:expires_in]
+    # access_token = res.body[:access_token]
+    # exp = res.body[:expires_in]
 
-    # cache access_token, set expiration
-    CDO.shared_cache.write(cache_key, access_token, expires_in: exp)
+    # # cache access_token, set expiration
+    # CDO.shared_cache.write(cache_key, access_token, expires_in: exp)
 
-    return access_token
+    # return access_token
+    return res.body
   end
 end

--- a/dashboard/app/helpers/lti_access_token_helper.rb
+++ b/dashboard/app/helpers/lti_access_token_helper.rb
@@ -1,8 +1,8 @@
-module LtiAccessToken
+module LtiAccessTokenHelper
   NAMESPACE = "lti_v1_controller".freeze
 
   # client_id and issuer are present in the id_token we cache or store as a cookie from the LTI launch
-  def self.get_access_token(client_id, issuer)
+  def get_access_token(client_id, issuer)
     cache_key = "#{NAMESPACE}/#{client_id}-#{issuer}"
 
     # check for valid access token
@@ -15,9 +15,9 @@ module LtiAccessToken
 
     # assemble JWT payload
     jwt_payload = {
-      iss: 'studio.code.org',
-      sub: integration[:issuer],
-      aud: [access_token_url],
+      iss: CDO.studio_url('', CDO.default_scheme),
+      sub: client_id,
+      aud: access_token_url,
       iat: Time.now.to_i,
       # this can be short, since the JWT will be validated as part of the access_token request handshake. Start at 5 minutes, reduce it if we feel like it.
       exp: (5).minutes.from_now.to_i,
@@ -34,23 +34,19 @@ module LtiAccessToken
     pri = OpenSSL::PKey::RSA.new(private_key)
     jwt = JWT.encode(jwt_payload, pri, 'RS256', kid: kid)
 
-    # format request body (must be url form encoded)
-    req_access_token_url = URI(access_token_url)
-    req_access_token_url.query = {
+    query = {
       grant_type: 'client_credentials',
       client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
       client_assertion: jwt,
       scope: 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem https://purl.imsglobal.org/spec/lti-ags/scope/result/read',
-    }.to_query
+    }
 
-    # POST request to access_token_url
-    res = HTTParty.post(req_access_token_url.to_s)
+    res = HTTParty.post(access_token_url, query: query, headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
     # get access_token and exp from response
     access_token = res.body[:access_token]
-    exp = res.body[:exp]
+    exp = res.body[:expires_in]
 
     # cache access_token, set expiration
-    # TODO: need to convert exp probably
     CDO.shared_cache.write(cache_key, access_token, expires_in: exp)
 
     return access_token

--- a/dashboard/app/helpers/lti_access_token_helper.rb
+++ b/dashboard/app/helpers/lti_access_token_helper.rb
@@ -1,0 +1,58 @@
+module LtiAccessToken
+  NAMESPACE = "lti_v1_controller".freeze
+
+  # client_id and issuer are present in the id_token we cache or store as a cookie from the LTI launch
+  def self.get_access_token(client_id, issuer)
+    cache_key = "#{NAMESPACE}/#{client_id}-#{issuer}"
+
+    # check for valid access token
+    access_token = CDO.shared_cache.read(cache_key)
+    return access_token if access_token
+
+    # get access_token_url for this LTI Integration
+    integration = LtiIntegration.find_by(client_id: client_id, issuer: issuer)
+    access_token_url = integration[:access_token_url]
+
+    # assemble JWT payload
+    jwt_payload = {
+      iss: 'studio.code.org',
+      sub: integration[:issuer],
+      aud: [access_token_url],
+      iat: Time.now.to_i,
+      # this can be short, since the JWT will be validated as part of the access_token request handshake. Start at 5 minutes, reduce it if we feel like it.
+      exp: (5).minutes.from_now.to_i,
+      jti: SecureRandom.alphanumeric(10),
+    }
+
+    # get private key and kid TODO: figure out a more elegant way to tranform to hash from JSON, can it be a one liner?
+    private_key_json = CDO.jwk_private_key_data
+    private_key_hash = private_key_json.transform_keys(&:to_sym)
+    private_key = private_key_hash[:private_key]
+    kid = private_key_hash[:kid]
+
+    # sign JWT
+    pri = OpenSSL::PKey::RSA.new(private_key)
+    jwt = JWT.encode(jwt_payload, pri, 'RS256', kid: kid)
+
+    # format request body (must be url form encoded)
+    req_access_token_url = URI(access_token_url)
+    req_access_token_url.query = {
+      grant_type: 'client_credentials',
+      client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+      client_assertion: jwt,
+      scope: 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem https://purl.imsglobal.org/spec/lti-ags/scope/result/read',
+    }.to_query
+
+    # POST request to access_token_url
+    res = HTTParty.post(req_access_token_url.to_s)
+    # get access_token and exp from response
+    access_token = res.body[:access_token]
+    exp = res.body[:exp]
+
+    # cache access_token, set expiration
+    # TODO: need to convert exp probably
+    CDO.shared_cache.write(cache_key, access_token, expires_in: exp)
+
+    return access_token
+  end
+end

--- a/dashboard/app/helpers/lti_access_token_helper.rb
+++ b/dashboard/app/helpers/lti_access_token_helper.rb
@@ -20,7 +20,7 @@ module LtiAccessTokenHelper
       aud: access_token_url,
       iat: Time.now.to_i,
       # this can be short, since the JWT will be validated as part of the access_token request handshake. Start at 5 minutes, reduce it if we feel like it.
-      exp: (5).minutes.from_now.to_i,
+      exp: (15).minutes.from_now.to_i,
       jti: SecureRandom.alphanumeric(10),
     }
 
@@ -38,20 +38,23 @@ module LtiAccessTokenHelper
       grant_type: 'client_credentials',
       client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
       client_assertion: jwt,
-      scope: 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem https://purl.imsglobal.org/spec/lti-ags/scope/result/read',
+      # specify scopes, there are additional optional scopes available
+      scope: 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem',
     }
 
-    p query
-
     res = HTTParty.post(access_token_url, query: query, headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
-    # get access_token and exp from response
-    # access_token = res.body[:access_token]
-    # exp = res.body[:expires_in]
 
-    # # cache access_token, set expiration
-    # CDO.shared_cache.write(cache_key, access_token, expires_in: exp)
+    # get access_token and exp from response
+    token_response = JSON.parse(res.body)
+    access_token = token_response[:access_token]
+    exp = token_response[:expires_in]
+
+    # cache access_token, set expiration
+    CDO.shared_cache.write(cache_key, access_token, expires_in: exp)
 
     # return access_token
+
+    #TEMP put here for deving
     return res.body
   end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -602,6 +602,7 @@ Dashboard::Application.routes.draw do
 
     # OAuth endpoints
     get '/oauth/jwks', to: 'oauth_jwks#jwks'
+    get '/oauth/access_token', to: 'oauth_jwks#access_token'
 
     get '/notes/:key', to: 'notes#index'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -598,6 +598,7 @@ Dashboard::Application.routes.draw do
 
     # LTI API endpoints
     match '/lti/v1/login(/:platform_id)', to: 'lti_v1#login', via: [:get, :post]
+    # TEMP: Remvoe before merging
     post '/lti/v1/authenticate', to: 'lti_v1#authenticate'
 
     # OAuth endpoints

--- a/dashboard/lib/lti_access_token.rb
+++ b/dashboard/lib/lti_access_token.rb
@@ -1,4 +1,4 @@
-module LtiAccessTokenHelper
+module LtiAccessToken
   NAMESPACE = "lti_v1_controller".freeze
 
   # client_id and issuer are present in the id_token we cache or store as a cookie from the LTI launch
@@ -45,16 +45,13 @@ module LtiAccessTokenHelper
     res = HTTParty.post(access_token_url, query: query, headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
 
     # get access_token and exp from response
-    token_response = JSON.parse(res.body)
+    token_response = JSON.parse(res.body).transform_keys(&:to_sym)
     access_token = token_response[:access_token]
     exp = token_response[:expires_in]
 
     # cache access_token, set expiration
     CDO.shared_cache.write(cache_key, access_token, expires_in: exp)
 
-    # return access_token
-
-    #TEMP put here for deving
-    return res.body
+    return access_token
   end
 end


### PR DESCRIPTION
This is a WIP feature that adds a helper method `get_access_token`, which will request an access_token from an LMS. [See spec](https://docs.google.com/document/d/1tTwAF40cnn2oUvK2CmRO-a5qYXkCR5rR5gBJS2-zV_U/edit#heading=h.lmushxao8hm).

Currently hitting this error when requesting an access while running CDO and Canvas locally: `{"error":"invalid_request","error_description":"JWS signature invalid."}`.

I confirmed the signature of the JWT is valid, using JWT.io.

**UPDATE:**
Canvas doesn't seem to like a JWKS url. I can get this to work locally when I paste the public key object (not the full JWKS keys array, just the single public key object) in the Canvas configuration.

![Screenshot 2023-08-01 at 3 46 44 PM](https://github.com/code-dot-org/code-dot-org/assets/8847422/3800704f-1067-432a-9504-abbbd54d05c3)

**UPDATE 2:** I'm pretty sure this is because of how the Canvas docker is running. When I `curl http://127.0.0.1:3000/oauth/jwks` from inside the Canvas web docker container, I get a connection refused.

Digging into this more, this is due to how the Canvas docker-compose is set up. The web container is linked to the redis and postgress container. This is setting up networking between those containers, and isn't using the host network, so it can't reach a locally running service running outside those linked containers.

The reason that LTI launches still work, is because the LTI handshake uses redirects in the browser, so Canvas isn't directly calling my instance of Code.org running locally. Going through this access_token request flow is the first time Canvas is trying to call a code.org endpoint, specifically the JWKS url, and can't reach it.

Looking at fixes to get around this networking issue:

* https://phillbarber.blogspot.com/2015/02/connect-docker-to-service-on-parent-host.html
* https://blog.michaelhamrah.com/2014/06/accessing-the-docker-host-server-within-a-container/

**UPDATE 3:**

I'm able to curl the JWKS endpoint from inside the Canvas web container. Here's how:

* In your terminal, run `docker run -it alpine /bin/sh`. This will pull down an alpine image, start it, and put you in a shell. From here, run `ping docker.for.mac.localhost` (`ping host.docker.internal` also works). This should resolve to an IP address, for me it's 192.168.65.2
* Exit that container, and open a terminal in the Canvas web container (pro tip, if you're running docker for mac, click on the container name (web-1 for me), then click on the terminal tab at the top.
* Run `curl 192.168.65.2:3000/oauth/jwks`. This should return the JWKS object.

So it is networking, need to figure out a solid solution to get around this problem.

**TODO:**
This get_access_token method should probably be moved to dashboard/lib/get_access_token instead of in the controller helpers.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
