### PR TITLE
Use readable scss class names locally

### DIFF
--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -190,7 +190,17 @@ var baseConfig = {
         test: /\.scss$/,
         use: [
           {loader: 'style-loader'},
-          {loader: 'css-loader', options: {modules: {auto: true}}},
+          {
+            loader: 'css-loader',
+            options: {
+              modules: {
+                auto: true,
+                localIdentName: process.env.DEV
+                  ? '[path][name]__[local]'
+                  : '[hash:base64]',
+              },
+            },
+          },
           {
             loader: 'sass-loader',
             options: {


### PR DESCRIPTION
Working with @AfifahK on a css change in Javalab, I was reminded of how unreadable our SCSS class names are locally. I remembered Maddie mentioning last summer that we could configure more readable class names locally ([thread here](https://codedotorg.slack.com/archives/C03MZ259SUU/p1660075127199999?thread_ts=1660074793.327699&cid=C03MZ259SUU)).

This PR implements the configuration suggested in the css-loader docs here:
https://github.com/webpack-contrib/css-loader/blob/master/README.md#localidentname

Before:

<img width="1095" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/4054c132-19ac-4015-aca1-7522a6739f21">

After:

<img width="1093" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/77082338-dd1e-4402-a911-e9812a5264d8">