### PR TITLE
Project Beats: make when run block undeletable and immovable

### DIFF
--- a/apps/static/music/startSourcesSimple2.json
+++ b/apps/static/music/startSourcesSimple2.json
@@ -1,7 +1,15 @@
 {
   "blocks": {
     "languageVersion": 0,
-    "blocks": [{"id": "when-run-block", "type": "when_run_simple2", "x": 30, "y": 30}]
-  },
-  "variables": [{"name": "currentTime"}, {"name": "i"}]
+    "blocks": [
+      {
+        "id": "when-run-block",
+        "type": "when_run_simple2",
+        "deletable": false,
+        "movable": false,
+        "x": 30,
+        "y": 30
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Make the starting "when run" block undeletable and immovable on Project Beats

## Testing story

Tested locally on /projectbeats