### PR TITLE
Factor out filter component on Curriculum Catalog page

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -1,162 +1,17 @@
-import React, {useState, useEffect, useCallback} from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {curriculumDataShape} from './curriculumCatalogShapes';
 import i18n from '@cdo/locale';
 import style from '../../../style/code-studio/curriculum_catalog_container.module.scss';
-import {queryParams, updateQueryParam} from '../../code-studio/utils';
 import HeaderBanner from '../HeaderBanner';
 import CourseCatalogBannerBackground from '../../../static/curriculum_catalog/course-catalog-banner-bg.png';
 import CourseCatalogIllustration01 from '../../../static/curriculum_catalog/course-catalog-illustration-01.png';
 import CourseCatalogNoSearchResultPenguin from '../../../static/curriculum_catalog/course-catalog-no-search-result-penguin.png';
-import Toggle from '../../componentLibrary/toggle/Toggle.tsx';
-import Button from '@cdo/apps/templates/Button';
-import {
-  Heading5,
-  Heading6,
-  BodyTwoText,
-} from '@cdo/apps/componentLibrary/typography';
-import CheckboxDropdown from '../CheckboxDropdown';
+import {Heading5, BodyTwoText} from '@cdo/apps/componentLibrary/typography';
+import CurriculumCatalogFilters from './CurriculumCatalogFilters';
 import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
-import {
-  translatedCourseOfferingCsTopics,
-  translatedInterdisciplinary,
-  translatedCourseOfferingDeviceTypes,
-  translatedCourseOfferingDurations,
-  translatedGradeLevels,
-  gradeLevelsMap,
-} from '../teacherDashboard/CourseOfferingHelpers';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
-
-const filterTypes = {
-  grade: {
-    name: 'grade',
-    label: i18n.grade(),
-    options: translatedGradeLevels,
-  },
-  duration: {
-    name: 'duration',
-    label: i18n.duration(),
-    options: translatedCourseOfferingDurations,
-  },
-  topic: {
-    name: 'topic',
-    label: i18n.topic(),
-    options: {
-      ...translatedInterdisciplinary,
-      ...translatedCourseOfferingCsTopics,
-    },
-  },
-  device: {
-    name: 'device',
-    label: i18n.device(),
-    options: translatedCourseOfferingDeviceTypes,
-  },
-};
-
-const getEmptyFilters = () => {
-  let filters = {translated: false};
-  Object.keys(filterTypes).forEach(filterKey => {
-    filters[filterKey] = [];
-  });
-  return filters;
-};
-
-// Filters out invalid values for the given filter key.
-const getValidParamValues = (filterKey, paramValues) => {
-  if (!Array.isArray(paramValues)) {
-    paramValues = [paramValues];
-  }
-  return paramValues.filter(paramValue => {
-    return Object.keys(filterTypes[filterKey].options).includes(paramValue);
-  });
-};
-
-// Returns initial filter states based on URL parameters (returns empty filters if
-// no relevant parameters in the URL).
-const getInitialFilterStates = () => {
-  const filterTypeKeys = Object.keys(filterTypes);
-  const urlParams = queryParams();
-
-  let filters = getEmptyFilters();
-  Object.keys(urlParams).forEach(paramKey => {
-    if (filterTypeKeys.includes(paramKey)) {
-      filters[paramKey] = getValidParamValues(paramKey, urlParams[paramKey]);
-    } else if (paramKey === 'translated') {
-      filters['translated'] = urlParams[paramKey] === 'true';
-    }
-  });
-  return filters;
-};
-
-// Returns whether the given curriculum matches the checked grade level filters.
-const filterByGradeLevel = (curriculum, gradeFilters) => {
-  if (gradeFilters.length > 0) {
-    if (!curriculum.grade_levels) {
-      return false;
-    } else {
-      const curriculumGradeLevels = curriculum.grade_levels.split(',');
-      const supportsFilteredGradeLevel = gradeFilters.some(grade =>
-        curriculumGradeLevels.includes(gradeLevelsMap[grade])
-      );
-      if (!supportsFilteredGradeLevel) {
-        return false;
-      }
-    }
-  }
-  return true;
-};
-
-// Returns whether the given curriculum matches the checked duration filters.
-const filterByDuration = (curriculum, durationFilters) => {
-  return (
-    durationFilters.length === 0 ||
-    durationFilters.includes(curriculum.duration)
-  );
-};
-
-// Returns whether the given curriculum matches the checked topic filters.
-// (Note: the Interdisciplinary topic will show any course that has been tagged
-// with a school subject (e.g. Math, Science, etc.))
-const filterByTopic = (curriculum, topicFilters) => {
-  if (topicFilters.length > 0) {
-    if (!curriculum.cs_topic) {
-      return false;
-    } else {
-      // Handle main CS topics
-      const curriculumTopics = curriculum.cs_topic.split(',');
-      const supportsFilteredTopics = topicFilters.some(topic =>
-        curriculumTopics.includes(topic)
-      );
-      // Handle case of Interdisciplinary topic
-      const hasAndSupportsInterdisciplinary =
-        topicFilters.includes('interdisciplinary') && curriculum.school_subject;
-      if (!supportsFilteredTopics && !hasAndSupportsInterdisciplinary) {
-        return false;
-      }
-    }
-  }
-  return true;
-};
-
-// Returns whether the given curriculum matches the checked device filters.
-const filterByDevice = (curriculum, deviceFilters) => {
-  if (deviceFilters.length > 0) {
-    if (!curriculum.device_compatibility) {
-      return false;
-    } else {
-      const curriculumDevComp = JSON.parse(curriculum.device_compatibility);
-      const supportsFilteredDevice = deviceFilters.some(
-        device => curriculumDevComp[device] === 'ideal'
-      );
-      if (!supportsFilteredDevice) {
-        return false;
-      }
-    }
-  }
-  return true;
-};
 
 const CurriculumCatalog = ({
   curriculaData,
@@ -165,116 +20,9 @@ const CurriculumCatalog = ({
   ...props
 }) => {
   const [filteredCurricula, setFilteredCurricula] = useState(curriculaData);
-  const [numFilteredTranslatedCurricula, setNumFilteredTranslatedCurricula] =
-    useState(
-      filteredCurricula.filter(curriculum => curriculum.is_translated).length
-    );
-  const [appliedFilters, setAppliedFilters] = useState(
-    getInitialFilterStates()
-  );
   const [assignSuccessMessage, setAssignSuccessMessage] = useState('');
   const [showAssignSuccessMessage, setShowAssignSuccessMessage] =
     useState(false);
-
-  // Filters out any Curriculum Catalog Cards of courses that do not match the filter criteria.
-  useEffect(() => {
-    const newFilteredCurricula = curriculaData.filter(
-      curriculum =>
-        filterByGradeLevel(curriculum, appliedFilters['grade']) &&
-        filterByDuration(curriculum, appliedFilters['duration']) &&
-        filterByTopic(curriculum, appliedFilters['topic']) &&
-        filterByDevice(curriculum, appliedFilters['device']) &&
-        (!appliedFilters['translated'] || curriculum.is_translated)
-    );
-    const newNumFilteredTranslatedCurricula = newFilteredCurricula.filter(
-      curriculum => curriculum.is_translated
-    ).length;
-
-    setNumFilteredTranslatedCurricula(newNumFilteredTranslatedCurricula);
-    setFilteredCurricula(newFilteredCurricula);
-
-    if (newFilteredCurricula.length === 0) {
-      analyticsReporter.sendEvent(
-        EVENTS.CURRICULUM_CATALOG_NO_AVAILABLE_CURRICULA_EVENT,
-        {
-          filters_selected: JSON.stringify(appliedFilters),
-        }
-      );
-    }
-  }, [curriculaData, appliedFilters]);
-
-  // Handles updating the given filter and the URL parameters.
-  const handleUpdateFilter = (filterKey, values) => {
-    let newFilters = {...appliedFilters};
-    newFilters[filterKey] = values;
-    setAppliedFilters(newFilters);
-
-    const valuesParam =
-      values.length > 0 || filterKey === 'translated' ? values : undefined;
-    updateQueryParam(filterKey, valuesParam, true);
-  };
-
-  // Selects the given value in the given filter.
-  const handleSelect = (event, filterKey) => {
-    const value = event.target.value;
-    const isChecked = event.target.checked;
-
-    let updatedFilters;
-    if (isChecked) {
-      // Add checked item into applied filters
-      updatedFilters = [...appliedFilters[filterKey], value];
-    } else {
-      // Remove unchecked item from applied filters
-      updatedFilters = appliedFilters[filterKey].filter(item => item !== value);
-    }
-    handleUpdateFilter(filterKey, updatedFilters);
-
-    analyticsReporter.sendEvent(
-      EVENTS.CURRICULUM_CATALOG_DROPDOWN_FILTER_SELECTED_EVENT,
-      {
-        filter_category: filterKey,
-        filter_name: value,
-      }
-    );
-  };
-
-  // Selects all options within the given filter.
-  const handleSelectAllOfFilter = filterKey => {
-    handleUpdateFilter(filterKey, Object.keys(filterTypes[filterKey].options));
-    analyticsReporter.sendEvent(
-      EVENTS.CURRICULUM_CATALOG_DROPDOWN_FILTER_SELECTED_EVENT,
-      {
-        filter_category: filterKey,
-        filter_name: Object.keys(filterTypes[filterKey].options).toString(),
-      }
-    );
-  };
-
-  const handleToggleLanguageFilter = isToggled => {
-    handleUpdateFilter('translated', isToggled);
-    analyticsReporter.sendEvent(
-      EVENTS.CURRICULUM_CATALOG_TOGGLE_LANGUAGE_FILTER_EVENT,
-      {
-        toggle_setting: isToggled,
-      }
-    );
-  };
-
-  // Clears all filter selections.
-  const handleClear = useCallback(() => {
-    setAppliedFilters(getEmptyFilters());
-    Object.keys(filterTypes).forEach(filterKey =>
-      updateQueryParam(filterKey, undefined, false)
-    );
-    if (!isEnglish) {
-      updateQueryParam('translated', undefined, false);
-    }
-  }, [isEnglish]);
-
-  // Clears selections within the given filter.
-  const handleClearAllOfFilter = filterKey => {
-    handleUpdateFilter(filterKey, []);
-  };
 
   const handleAssignSuccess = assignmentData => {
     setAssignSuccessMessage(
@@ -394,60 +142,13 @@ const CurriculumCatalog = ({
           </button>
         </div>
       )}
-      <div className={style.fixedFiltersTop}>
-        <div className={style.catalogFiltersContainer}>
-          <Heading6 className={style.catalogFiltersRowLabel}>
-            {i18n.filterBy()}
-          </Heading6>
-          {Object.keys(filterTypes).map(filterKey => (
-            <CheckboxDropdown
-              key={filterKey}
-              name={filterKey}
-              label={filterTypes[filterKey].label}
-              allOptions={filterTypes[filterKey].options}
-              checkedOptions={appliedFilters[filterKey]}
-              onChange={e => handleSelect(e, filterKey)}
-              handleSelectAll={() => handleSelectAllOfFilter(filterKey)}
-              handleClearAll={() => handleClearAllOfFilter(filterKey)}
-            />
-          ))}
-          <Button
-            id="clear-filters"
-            className={style.catalogClearFiltersButton}
-            type="button"
-            onClick={handleClear}
-            text={i18n.clearFilters()}
-            styleAsText
-            color={Button.ButtonColor.brandSecondaryDefault}
-          />
-        </div>
-        {!isEnglish && (
-          <div className={style.catalogLanguageFilterRow}>
-            <div className={style.catalogLanguageFilterRowNumAvailable}>
-              <BodyTwoText>
-                {i18n.numCurriculaAvailableInLanguage({
-                  numCurricula: numFilteredTranslatedCurricula,
-                  language: languageNativeName,
-                })}
-              </BodyTwoText>
-              <FontAwesome
-                icon="language"
-                className="fa-solid"
-                title={i18n.courseInYourLanguage()}
-              />
-            </div>
-            <Toggle
-              name="filterTranslatedToggle"
-              label={i18n.onlyShowCurriculaInLanguage({
-                language: languageNativeName,
-              })}
-              size="m"
-              checked={appliedFilters['translated']}
-              onChange={e => handleToggleLanguageFilter(e.target.checked)}
-            />
-          </div>
-        )}
-      </div>
+      <CurriculumCatalogFilters
+        curriculaData={curriculaData}
+        filteredCurricula={filteredCurricula}
+        setFilteredCurricula={setFilteredCurricula}
+        isEnglish={isEnglish}
+        languageNativeName={languageNativeName}
+      />
       <div className={style.catalogContentContainer}>
         {renderSearchResults()}
       </div>

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogFilters.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogFilters.jsx
@@ -1,0 +1,333 @@
+import React, {useState, useEffect, useCallback} from 'react';
+import PropTypes from 'prop-types';
+import i18n from '@cdo/locale';
+import {queryParams, updateQueryParam} from '../../code-studio/utils';
+import style from '../../../style/code-studio/curriculum_catalog_filters.module.scss';
+import {curriculumDataShape} from './curriculumCatalogShapes';
+import CheckboxDropdown from '../CheckboxDropdown';
+import Toggle from '../../componentLibrary/toggle/Toggle.tsx';
+import Button from '@cdo/apps/templates/Button';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import {Heading6, BodyTwoText} from '@cdo/apps/componentLibrary/typography';
+import {
+  translatedCourseOfferingCsTopics,
+  translatedInterdisciplinary,
+  translatedCourseOfferingDeviceTypes,
+  translatedCourseOfferingDurations,
+  translatedGradeLevels,
+  gradeLevelsMap,
+} from '../teacherDashboard/CourseOfferingHelpers';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+
+const filterTypes = {
+  grade: {
+    name: 'grade',
+    label: i18n.grade(),
+    options: translatedGradeLevels,
+  },
+  duration: {
+    name: 'duration',
+    label: i18n.duration(),
+    options: translatedCourseOfferingDurations,
+  },
+  topic: {
+    name: 'topic',
+    label: i18n.topic(),
+    options: {
+      ...translatedInterdisciplinary,
+      ...translatedCourseOfferingCsTopics,
+    },
+  },
+  device: {
+    name: 'device',
+    label: i18n.device(),
+    options: translatedCourseOfferingDeviceTypes,
+  },
+};
+
+const getEmptyFilters = () => {
+  let filters = {translated: false};
+  Object.keys(filterTypes).forEach(filterKey => {
+    filters[filterKey] = [];
+  });
+  return filters;
+};
+
+// Filters out invalid values for the given filter key.
+const getValidParamValues = (filterKey, paramValues) => {
+  if (!Array.isArray(paramValues)) {
+    paramValues = [paramValues];
+  }
+  return paramValues.filter(paramValue => {
+    return Object.keys(filterTypes[filterKey].options).includes(paramValue);
+  });
+};
+
+// Returns initial filter states based on URL parameters (returns empty filters if
+// no relevant parameters in the URL).
+const getInitialFilterStates = () => {
+  const filterTypeKeys = Object.keys(filterTypes);
+  const urlParams = queryParams();
+
+  let filters = getEmptyFilters();
+  Object.keys(urlParams).forEach(paramKey => {
+    if (filterTypeKeys.includes(paramKey)) {
+      filters[paramKey] = getValidParamValues(paramKey, urlParams[paramKey]);
+    } else if (paramKey === 'translated') {
+      filters['translated'] = urlParams[paramKey] === 'true';
+    }
+  });
+  return filters;
+};
+
+// Returns whether the given curriculum matches the checked grade level filters.
+const filterByGradeLevel = (curriculum, gradeFilters) => {
+  if (gradeFilters.length > 0) {
+    if (!curriculum.grade_levels) {
+      return false;
+    } else {
+      const curriculumGradeLevels = curriculum.grade_levels.split(',');
+      const supportsFilteredGradeLevel = gradeFilters.some(grade =>
+        curriculumGradeLevels.includes(gradeLevelsMap[grade])
+      );
+      if (!supportsFilteredGradeLevel) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+// Returns whether the given curriculum matches the checked duration filters.
+const filterByDuration = (curriculum, durationFilters) => {
+  return (
+    durationFilters.length === 0 ||
+    durationFilters.includes(curriculum.duration)
+  );
+};
+
+// Returns whether the given curriculum matches the checked topic filters.
+// (Note: the Interdisciplinary topic will show any course that has been tagged
+// with a school subject (e.g. Math, Science, etc.))
+const filterByTopic = (curriculum, topicFilters) => {
+  if (topicFilters.length > 0) {
+    if (!curriculum.cs_topic) {
+      return false;
+    } else {
+      // Handle main CS topics
+      const curriculumTopics = curriculum.cs_topic.split(',');
+      const supportsFilteredTopics = topicFilters.some(topic =>
+        curriculumTopics.includes(topic)
+      );
+      // Handle case of Interdisciplinary topic
+      const hasAndSupportsInterdisciplinary =
+        topicFilters.includes('interdisciplinary') && curriculum.school_subject;
+      if (!supportsFilteredTopics && !hasAndSupportsInterdisciplinary) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+// Returns whether the given curriculum matches the checked device filters.
+const filterByDevice = (curriculum, deviceFilters) => {
+  if (deviceFilters.length > 0) {
+    if (!curriculum.device_compatibility) {
+      return false;
+    } else {
+      const curriculumDevComp = JSON.parse(curriculum.device_compatibility);
+      const supportsFilteredDevice = deviceFilters.some(
+        device => curriculumDevComp[device] === 'ideal'
+      );
+      if (!supportsFilteredDevice) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+const CurriculumCatalogFilters = ({
+  curriculaData,
+  filteredCurricula,
+  setFilteredCurricula,
+  isEnglish,
+  languageNativeName,
+}) => {
+  const [appliedFilters, setAppliedFilters] = useState(
+    getInitialFilterStates()
+  );
+  const [numFilteredTranslatedCurricula, setNumFilteredTranslatedCurricula] =
+    useState(
+      filteredCurricula.filter(curriculum => curriculum.is_translated).length
+    );
+
+  // Filters out any Curriculum Catalog Cards of courses that do not match the filter criteria.
+  useEffect(() => {
+    const newFilteredCurricula = curriculaData.filter(
+      curriculum =>
+        filterByGradeLevel(curriculum, appliedFilters['grade']) &&
+        filterByDuration(curriculum, appliedFilters['duration']) &&
+        filterByTopic(curriculum, appliedFilters['topic']) &&
+        filterByDevice(curriculum, appliedFilters['device']) &&
+        (!appliedFilters['translated'] || curriculum.is_translated)
+    );
+    const newNumFilteredTranslatedCurricula = newFilteredCurricula.filter(
+      curriculum => curriculum.is_translated
+    ).length;
+
+    setNumFilteredTranslatedCurricula(newNumFilteredTranslatedCurricula);
+    setFilteredCurricula(newFilteredCurricula);
+
+    if (newFilteredCurricula.length === 0) {
+      analyticsReporter.sendEvent(
+        EVENTS.CURRICULUM_CATALOG_NO_AVAILABLE_CURRICULA_EVENT,
+        {
+          filters_selected: JSON.stringify(appliedFilters),
+        }
+      );
+    }
+  }, [curriculaData, appliedFilters, setFilteredCurricula]);
+
+  // Handles updating the given filter and the URL parameters.
+  const handleUpdateFilter = (filterKey, values) => {
+    let newFilters = {...appliedFilters};
+    newFilters[filterKey] = values;
+    setAppliedFilters(newFilters);
+
+    const valuesParam =
+      values.length > 0 || filterKey === 'translated' ? values : undefined;
+    updateQueryParam(filterKey, valuesParam, true);
+  };
+
+  // Selects the given value in the given filter.
+  const handleSelect = (event, filterKey) => {
+    const value = event.target.value;
+    const isChecked = event.target.checked;
+
+    let updatedFilters;
+    if (isChecked) {
+      // Add checked item into applied filters
+      updatedFilters = [...appliedFilters[filterKey], value];
+    } else {
+      // Remove unchecked item from applied filters
+      updatedFilters = appliedFilters[filterKey].filter(item => item !== value);
+    }
+    handleUpdateFilter(filterKey, updatedFilters);
+
+    analyticsReporter.sendEvent(
+      EVENTS.CURRICULUM_CATALOG_DROPDOWN_FILTER_SELECTED_EVENT,
+      {
+        filter_category: filterKey,
+        filter_name: value,
+      }
+    );
+  };
+
+  // Selects all options within the given filter.
+  const handleSelectAllOfFilter = filterKey => {
+    handleUpdateFilter(filterKey, Object.keys(filterTypes[filterKey].options));
+    analyticsReporter.sendEvent(
+      EVENTS.CURRICULUM_CATALOG_DROPDOWN_FILTER_SELECTED_EVENT,
+      {
+        filter_category: filterKey,
+        filter_name: Object.keys(filterTypes[filterKey].options).toString(),
+      }
+    );
+  };
+
+  const handleToggleLanguageFilter = isToggled => {
+    handleUpdateFilter('translated', isToggled);
+    analyticsReporter.sendEvent(
+      EVENTS.CURRICULUM_CATALOG_TOGGLE_LANGUAGE_FILTER_EVENT,
+      {
+        toggle_setting: isToggled,
+      }
+    );
+  };
+
+  // Clears all filter selections.
+  const handleClear = useCallback(() => {
+    setAppliedFilters(getEmptyFilters());
+    Object.keys(filterTypes).forEach(filterKey =>
+      updateQueryParam(filterKey, undefined, false)
+    );
+    if (!isEnglish) {
+      updateQueryParam('translated', undefined, false);
+    }
+  }, [isEnglish]);
+
+  // Clears selections within the given filter.
+  const handleClearAllOfFilter = filterKey => {
+    handleUpdateFilter(filterKey, []);
+  };
+
+  return (
+    <div className={style.catalogFiltersContainer}>
+      <div className={style.catalogDropdownFilters}>
+        <Heading6 className={style.catalogFiltersRowLabel}>
+          {i18n.filterBy()}
+        </Heading6>
+        {Object.keys(filterTypes).map(filterKey => (
+          <CheckboxDropdown
+            key={filterKey}
+            name={filterKey}
+            label={filterTypes[filterKey].label}
+            allOptions={filterTypes[filterKey].options}
+            checkedOptions={appliedFilters[filterKey]}
+            onChange={e => handleSelect(e, filterKey)}
+            handleSelectAll={() => handleSelectAllOfFilter(filterKey)}
+            handleClearAll={() => handleClearAllOfFilter(filterKey)}
+          />
+        ))}
+        <Button
+          id="clear-filters"
+          className={style.catalogClearFiltersButton}
+          type="button"
+          onClick={handleClear}
+          text={i18n.clearFilters()}
+          styleAsText
+          color={Button.ButtonColor.brandSecondaryDefault}
+        />
+      </div>
+      {!isEnglish && (
+        <div className={style.catalogLanguageFilterRow}>
+          <div className={style.catalogLanguageFilterRowNumAvailable}>
+            <BodyTwoText>
+              {i18n.numCurriculaAvailableInLanguage({
+                numCurricula: numFilteredTranslatedCurricula,
+                language: languageNativeName,
+              })}
+            </BodyTwoText>
+            <FontAwesome
+              icon="language"
+              className="fa-solid"
+              title={i18n.courseInYourLanguage()}
+            />
+          </div>
+          <Toggle
+            name="filterTranslatedToggle"
+            label={i18n.onlyShowCurriculaInLanguage({
+              language: languageNativeName,
+            })}
+            size="m"
+            checked={appliedFilters['translated']}
+            onChange={e => handleToggleLanguageFilter(e.target.checked)}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+CurriculumCatalogFilters.propTypes = {
+  curriculaData: PropTypes.arrayOf(curriculumDataShape).isRequired,
+  filteredCurricula: PropTypes.arrayOf(curriculumDataShape),
+  setFilteredCurricula: PropTypes.func.isRequired,
+  isEnglish: PropTypes.bool.isRequired,
+  languageNativeName: PropTypes.string.isRequired,
+};
+
+export default CurriculumCatalogFilters;

--- a/apps/style/code-studio/curriculum_catalog_container.module.scss
+++ b/apps/style/code-studio/curriculum_catalog_container.module.scss
@@ -2,50 +2,6 @@
 
 $container-width: 309px;
 
-.catalogFiltersContainer {
-  display: flex;
-  align-items: baseline;
-  gap: 16px;
-  max-width: 60em;
-  margin: 0 auto;
-  padding: 1em 0;
-
-  button {
-    margin: 0;
-  }
-}
-
-.catalogLanguageFilterRow {
-  display: flex;
-  justify-content: space-between;
-  max-width: 60em;
-  margin: 0 auto;
-  padding: 0 0 1em 0;
-
-  p {
-    margin: 1em 0;
-  }
-
-  i {
-    margin: auto 0.25em;
-    font-size: 1.75em;
-  }
-
-  span {
-    font-size: 16px;
-  }
-}
-
-.catalogLanguageFilterRowNumAvailable {
-  display: flex;
-  flex: start;
-}
-
-button.catalogClearFiltersButton {
-  font-size: 16px;
-  margin-left: auto;
-}
-
 .catalogContentContainer {
   max-width: 60em;
   margin: 0 auto 1em auto;
@@ -108,10 +64,4 @@ button.catalogClearFiltersButton {
 .assignSuccessMessage {
   margin: 16px;
   color: color.$bootstrap_success_text;
-}
-
-.fixedFiltersTop {
-  position: sticky;
-  top: 0;
-  background-color: white;
 }

--- a/apps/style/code-studio/curriculum_catalog_filters.module.scss
+++ b/apps/style/code-studio/curriculum_catalog_filters.module.scss
@@ -1,0 +1,49 @@
+.catalogFiltersContainer {
+  position: sticky;
+  top: 0;
+  background-color: white;
+}
+
+.catalogDropdownFilters {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  max-width: 60em;
+  margin: 0 auto;
+  padding: 1em 0;
+
+  button {
+    margin: 0;
+  }
+}
+
+.catalogLanguageFilterRow {
+  display: flex;
+  justify-content: space-between;
+  max-width: 60em;
+  margin: 0 auto;
+  padding: 0 0 1em 0;
+
+  p {
+    margin: 1em 0;
+  }
+
+  i {
+    margin: auto 0.25em;
+    font-size: 1.75em;
+  }
+
+  span {
+    font-size: 16px;
+  }
+}
+
+.catalogLanguageFilterRowNumAvailable {
+  display: flex;
+  flex: start;
+}
+
+button.catalogClearFiltersButton {
+  font-size: 16px;
+  margin-left: auto;
+}


### PR DESCRIPTION
Refactors filtering components into separate file to help make `CurriculumCatalog.jsx` more readable and concise.

### Demo that behavior through clicking and tab-navigation still works as expected
https://github.com/code-dot-org/code-dot-org/assets/56283563/3e20db4f-cf85-46ab-bd89-9c042f2a3e44

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-640&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and passing drone build.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
