### PR TITLE
Remove setters/getters for value property for text areas

### DIFF
--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -13,6 +13,7 @@ import TextAlignmentPropertyRow, {
   TEXT_ALIGNMENT_LEFT,
 } from './TextAlignmentPropertyRow';
 import BorderProperties from './BorderProperties';
+import * as utils from '../../utils';
 import * as elementUtils from './elementUtils';
 import designMode from '../designMode';
 import themeValues, {CLASSIC_TEXT_AREA_PADDING} from '../themeValues';
@@ -28,6 +29,13 @@ class TextAreaProperties extends React.Component {
   render() {
     const element = this.props.element;
 
+    let escapedText = '';
+    if (element.parentElement.className === 'textArea') {
+      escapedText = utils.unescapeText(element.parentElement.innerHTML);
+    } else {
+      escapedText = utils.unescapeText(element.innerHTML);
+    }
+
     return (
       <div id="propertyRowContainer">
         <PropertyRow
@@ -39,7 +47,7 @@ class TextAreaProperties extends React.Component {
         <PropertyRow
           desc={applabMsg.designElementProperty_text()}
           isMultiLine
-          initialValue={$(element).text()}
+          initialValue={escapedText}
           handleChange={this.props.handleChange.bind(this, 'text')}
         />
         <PropertyRow

--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -38,6 +38,7 @@ class TextAreaProperties extends React.Component {
         />
         <PropertyRow
           desc={applabMsg.designElementProperty_text()}
+          isMultiLine
           initialValue={$(element).text()}
           handleChange={this.props.handleChange.bind(this, 'text')}
         />

--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -13,7 +13,6 @@ import TextAlignmentPropertyRow, {
   TEXT_ALIGNMENT_LEFT,
 } from './TextAlignmentPropertyRow';
 import BorderProperties from './BorderProperties';
-import * as utils from '../../utils';
 import * as elementUtils from './elementUtils';
 import designMode from '../designMode';
 import themeValues, {CLASSIC_TEXT_AREA_PADDING} from '../themeValues';
@@ -29,13 +28,6 @@ class TextAreaProperties extends React.Component {
   render() {
     const element = this.props.element;
 
-    let escapedText = '';
-    if (element.parentElement.className === 'textArea') {
-      escapedText = utils.unescapeText(element.parentElement.innerHTML);
-    } else {
-      escapedText = utils.unescapeText(element.innerHTML);
-    }
-
     return (
       <div id="propertyRowContainer">
         <PropertyRow
@@ -43,12 +35,6 @@ class TextAreaProperties extends React.Component {
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
           isIdRow
-        />
-        <PropertyRow
-          desc={applabMsg.designElementProperty_text()}
-          isMultiLine
-          initialValue={escapedText}
-          handleChange={this.props.handleChange.bind(this, 'text')}
         />
         <PropertyRow
           desc={applabMsg.designElementProperty_widthPx()}
@@ -226,25 +212,5 @@ export default {
         e.preventDefault();
       }
     });
-  },
-
-  onPropertyChange: function (element, name, value) {
-    switch (name) {
-      case 'value':
-        element.innerHTML = value;
-        break;
-      default:
-        return false;
-    }
-    return true;
-  },
-
-  readProperty: function (element, name) {
-    switch (name) {
-      case 'value':
-        return element.innerHTML;
-      default:
-        throw `unknown property name ${name}`;
-    }
   },
 };

--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -37,6 +37,11 @@ class TextAreaProperties extends React.Component {
           isIdRow
         />
         <PropertyRow
+          desc={applabMsg.designElementProperty_text()}
+          initialValue={$(element).text()}
+          handleChange={this.props.handleChange.bind(this, 'text')}
+        />
+        <PropertyRow
           desc={applabMsg.designElementProperty_widthPx()}
           isNumber
           initialValue={parseInt(element.style.width, 10)}

--- a/apps/src/applab/setPropertyDropdown.js
+++ b/apps/src/applab/setPropertyDropdown.js
@@ -393,7 +393,6 @@ PROPERTIES[ElementType.TEXT_AREA] = {
     'textAlign',
     'readonly',
     'hidden',
-    'value',
     'borderWidth',
     'borderColor',
     'borderRadius',

--- a/apps/test/unit/applab/designModeTest.js
+++ b/apps/test/unit/applab/designModeTest.js
@@ -174,11 +174,9 @@ describe('setProperty and read Property', () => {
     });
     it('Sets the expected value for dropdowns, text area, and text input', () => {
       designMode.updateProperty(text_input, 'value', 'Iota Kappa');
-      designMode.updateProperty(text_area, 'value', 'Lambda Mu');
       designMode.updateProperty(dropdown, 'value', 'Eta Theta');
 
       expect(text_input.value).to.equal('Iota Kappa');
-      expect(text_area.innerHTML).to.equal('Lambda Mu');
       expect(dropdown.value).to.equal('Eta Theta');
     });
     it('Uses the asset timestamp in the source path for pictures', () => {
@@ -203,9 +201,6 @@ describe('setProperty and read Property', () => {
     });
     it('Gets the expected value for dropdowns, text area, and text input', () => {
       expect(designMode.readProperty(text_input, 'value')).to.equal('Nu Xi');
-      expect(designMode.readProperty(text_area, 'value')).to.equal(
-        'Omicron Pi'
-      );
       expect(designMode.readProperty(dropdown, 'value')).to.equal(
         'Epsilon Zeta'
       );


### PR DESCRIPTION
Alternative approach to https://github.com/code-dot-org/code-dot-org/pull/53031 -- fully remove the ability to get/set the `value` property on textareas in Applab.

We don't advertise this feature anywhere currently (ie, not in docs or our curriculum), and the case we want to support (getting/setting text in a text area) is handled by the `get/setText` functions as well as `get/setProperty('text-area-id', 'text', 'some text')` available to users.

Shoutout to @fisher-alice for doing most of the work here and pushing us in this direction!

Note that it is possible (likely?) that some student projects will be affected by this change, as the "value" property was listed in the dropdown of properties you can set for a text area. I think we can advise our support team of this change and how users might fix their projects (ie, set the property "text" instead of the property "value").

## Links

- jira ticket: [BC-44](https://codedotorg.atlassian.net/browse/BC-44)
- slack discussion: [here](https://codedotorg.slack.com/archives/C03DBDN67B7/p1690221230623569) and [here](https://codedotorg.slack.com/archives/C03DBDN67B7/p1690404692673569)

## Testing story

Tested manually that:
- get/setProperty('text-area-id', 'value') returns an error
- get/setProperty('text-area-id', 'text') can get/set text
- get/setText('text-area-id', 'some text') gets/sets text
- special characters parsed as text rather
