### PR TITLE
Update Maker micro:bit PDF links - Summer 2023

### DIFF
--- a/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-C-July23.pdf.fetch
+++ b/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-C-July23.pdf.fetch
@@ -1,0 +1,1 @@
+https://cdo-fetch.s3.amazonaws.com/CSF-Booklet-Course-C-July23.pdf

--- a/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-C-v8.pdf.fetch
+++ b/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-C-v8.pdf.fetch
@@ -1,1 +1,0 @@
-https://cdo-fetch.s3.amazonaws.com/CSF-Booklet-Course-C-v8.pdf

--- a/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-D-July23.pdf.fetch
+++ b/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-D-July23.pdf.fetch
@@ -1,0 +1,1 @@
+https://cdo-fetch.s3.amazonaws.com/CSF-Booklet-Course-D-July23.pdf

--- a/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-D-v4.pdf.fetch
+++ b/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-D-v4.pdf.fetch
@@ -1,1 +1,0 @@
-https://cdo-fetch.s3.amazonaws.com/CSF-Booklet-Course-D-v4.pdf

--- a/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-E-July23.pdf.fetch
+++ b/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-E-July23.pdf.fetch
@@ -1,0 +1,1 @@
+https://cdo-fetch.s3.amazonaws.com/CSF-Booklet-Course-E-July23.pdf

--- a/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-E-v5.pdf.fetch
+++ b/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-E-v5.pdf.fetch
@@ -1,1 +1,0 @@
-https://cdo-fetch.s3.amazonaws.com/CSF-Booklet-Course-E-v5.pdf

--- a/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-F-July23.pdf.fetch
+++ b/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-F-July23.pdf.fetch
@@ -1,0 +1,1 @@
+https://cdo-fetch.s3.amazonaws.com/CSF-Booklet-Course-F-July23.pdf

--- a/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-F-v3.pdf.fetch
+++ b/pegasus/sites.v3/code.org/public/maker/assets/CSF-Booklet-Course-F-v3.pdf.fetch
@@ -1,1 +1,0 @@
-https://cdo-fetch.s3.amazonaws.com/CSF-Booklet-Course-F-v3.pdf

--- a/pegasus/sites.v3/code.org/views/csf_microbit_units.haml
+++ b/pegasus/sites.v3/code.org/views/csf_microbit_units.haml
@@ -10,7 +10,7 @@
           .smalltext
             Designed as an extension to Course C this guide offers 4 lessons which cover the events, loops, data and variables using the micro:bit.
         %span{style: "margin-bottom: 2px;"}
-          %a{href: "/maker/assets/CSF-Booklet-Course-C-v8.pdf"}
+          %a{href: "/maker/assets/CSF-Booklet-Course-C-July23.pdf"}
             %button.tutorial-info-start.tutorial-gray
               Get the guide
 
@@ -25,7 +25,7 @@
           .smalltext
             Designed as an extension to Course D this guide offers 4 lessons which cover the events, loops, input/output and variables using the micro:bit.
         %span{style: "margin-bottom: 2px;"}
-          %a{href: "/maker/assets/CSF-Booklet-Course-D-v4.pdf"}
+          %a{href: "/maker/assets/CSF-Booklet-Course-D-July23.pdf"}
             %button.tutorial-info-start.tutorial-gray
               Get the guide
 
@@ -40,7 +40,7 @@
           .smalltext
             Designed as an extension to Course E this guide offers 4 lessons which cover the events, conditionals, functions and impacts of computing using the micro:bit.
         %span{style: "margin-bottom: 2px;"}
-          %a{href: "/maker/assets/CSF-Booklet-Course-E-v5.pdf"}
+          %a{href: "/maker/assets/CSF-Booklet-Course-E-July23.pdf"}
             %button.tutorial-info-start.tutorial-gray
               Get the guide
 
@@ -55,6 +55,6 @@
           .smalltext
             Designed as an extension to Course E this guide offers 4 lessons which cover the variables, simulation, events and conditionals using the micro:bit.
         %span{style: "margin-bottom: 2px;"}
-          %a{href: "/maker/assets/CSF-Booklet-Course-F-v3.pdf"}
+          %a{href: "/maker/assets/CSF-Booklet-Course-F-July23.pdf"}
             %button.tutorial-info-start.tutorial-gray
               Get the guide

--- a/pegasus/sites.v3/code.org/views/csf_microbit_units.haml
+++ b/pegasus/sites.v3/code.org/views/csf_microbit_units.haml
@@ -1,7 +1,7 @@
 .tile-container-responsive{style: "margin-top: 20px;"}
   .col-50
     .tutorial-tile
-      %a{href: "/maker/assets/CSF-Booklet-Course-C-v8.pdf"}
+      %a{href: "/maker/assets/CSF-Booklet-Course-C-July23.pdf"}
         %img.tutorial-tile-img{src: "/images/fill-473x258/maker/microbit-unit-c.png", alt: ""}
       .tutorial-info{style: "height: 330px;"}
         %span
@@ -16,7 +16,7 @@
 
   .col-50
     .tutorial-tile
-      %a{href: "/maker/assets/CSF-Booklet-Course-D-v4.pdf"}
+      %a{href: "/maker/assets/CSF-Booklet-Course-D-July23.pdf"}
         %img.tutorial-tile-img{src: "/images/fill-473x258/maker/microbit-unit-d.png", alt: ""}
       .tutorial-info{style: "height: 330px;"}
         %span
@@ -31,7 +31,7 @@
 
   .col-50
     .tutorial-tile
-      %a{href: "/maker/assets/CSF-Booklet-Course-E-v5.pdf"}
+      %a{href: "/maker/assets/CSF-Booklet-Course-E-July23.pdf"}
         %img.tutorial-tile-img{src: "/images/fill-473x258/maker/microbit-unit-e.png", alt: ""}
       .tutorial-info{style: "height: 330px;"}
         %span
@@ -46,7 +46,7 @@
 
   .col-50
     .tutorial-tile
-      %a{href: "/maker/assets/CSF-Booklet-Course-F-v3.pdf"}
+      %a{href: "/maker/assets/CSF-Booklet-Course-F-July23.pdf"}
         %img.tutorial-tile-img{src: "/images/fill-473x258/maker/microbit-unit-f.png", alt: ""}
       .tutorial-info{style: "height: 330px;"}
         %span


### PR DESCRIPTION
Updating the micro:bit PDF course booklet links on https://code.org/maker/csf-microbit to the 2023 versions 
- These are hosted on AWS

**Jira ticket:** [ACQ-738](https://codedotorg.atlassian.net/browse/ACQ-738)