### PR TITLE
Temporarily Increase Adhoc Creation Timeout

### DIFF
--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -301,7 +301,10 @@ module AWS
       begin
         cfn.wait_until("stack_#{action}_complete".to_sym, stack_name: @stack_id) do |w|
           w.delay = 5 # seconds
-          w.max_attempts = 1.5.hours / w.delay
+          # TODO: lower this back to 1.5 hours once we're no longer building
+          # Node.js from source as part of adhoc creation, which right now is
+          # making this often take longer than that.
+          w.max_attempts = 2.5.hours / w.delay
           w.before_wait do
             yield
             print '.' unless options[:quiet]


### PR DESCRIPTION
We have a hardcoded timeout of 90 minutes that the `rake adhoc:start` command will spend waiting for the adhoc stack to finish provisioning before it gives up. Unfortunately, our stacks do indeed sometimes take longer than that.

Specifically, we recently started compiling Node.js from source as part of the build because the particular versions of Node and Ubuntu that we are using do not allow for a faster option, and doing so takes a significant amount of time. Once we update our servers to a more-recent version of Ubuntu, we can stop compiling node during the build and should be able to drop this limit back down to something reasonable.

## Follow-up work

1. Update to Ubuntu 20+
2. Switch to a faster Node.js installation method
3. Revert this change