### PR TITLE
P20-75: Fix function_defenitions DE translations

### DIFF
--- a/dashboard/config/locales/function_definitions.de-DE.json
+++ b/dashboard/config/locales/function_definitions.de-DE.json
@@ -1317,42 +1317,42 @@
         },
         "MC_HOC_2017_10_RETRY": {
           "fix long path": {
-            "name": "langen Pfad in Ordnung bringen\n"
+            "name": "langen Pfad in Ordnung bringen"
           },
           "fix short path": {
-            "name": "kurzen Pfad in Ordnung bringen\n"
+            "name": "kurzen Pfad in Ordnung bringen"
           }
         },
         "MC_HOC_2017_10_RETRY2022": {
           "fix long path": {
-            "name": "langen Pfad in Ordnung bringen\n"
+            "name": "langen Pfad in Ordnung bringen"
           },
           "fix short path": {
-            "name": "kurzen Pfad in Ordnung bringen\n"
+            "name": "kurzen Pfad in Ordnung bringen"
           }
         },
         "MC_HOC_2017_10_RETRY_2019": {
           "fix long path": {
-            "name": "langen Pfad in Ordnung bringen\n"
+            "name": "langen Pfad in Ordnung bringen"
           },
           "fix short path": {
-            "name": "kurzen Pfad in Ordnung bringen\n"
+            "name": "kurzen Pfad in Ordnung bringen"
           }
         },
         "MC_HOC_2017_10_RETRY_2020": {
           "fix long path": {
-            "name": "langen Pfad in Ordnung bringen\n"
+            "name": "langen Pfad in Ordnung bringen"
           },
           "fix short path": {
-            "name": "kurzen Pfad in Ordnung bringen\n"
+            "name": "kurzen Pfad in Ordnung bringen"
           }
         },
         "MC_HOC_2017_10_RETRY_2021": {
           "fix long path": {
-            "name": "langen Pfad in Ordnung bringen\n"
+            "name": "langen Pfad in Ordnung bringen"
           },
           "fix short path": {
-            "name": "kurzen Pfad in Ordnung bringen\n"
+            "name": "kurzen Pfad in Ordnung bringen"
           }
         },
         "MC_HOC_2017_Ali": {
@@ -3771,7 +3771,7 @@
             "name": "hole alle Kürbisse"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           },
           "pumpkin square": {
             "name": "Kürbis-Quadrat"
@@ -3785,7 +3785,7 @@
             "name": "hole alle Kürbisse"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           },
           "pumpkin square": {
             "name": "Kürbis-Quadrat"
@@ -3799,7 +3799,7 @@
             "name": "hole alle Kürbisse"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           },
           "pumpkin square": {
             "name": "Kürbis-Quadrat"
@@ -3813,7 +3813,7 @@
             "name": "hole alle Kürbisse"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           },
           "pumpkin square": {
             "name": "Kürbis-Quadrat"
@@ -3827,7 +3827,7 @@
             "name": "hole alle Kürbisse"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           },
           "pumpkin square": {
             "name": "Kürbis-Quadrat"
@@ -3840,13 +3840,13 @@
         },
         "courseE_farmer_functions11_predict": {
           "check and pick": {
-            "name": "suchen und pflücken\n"
+            "name": "suchen und pflücken"
           },
           "find pumpkin": {
             "name": "finde Kürbis"
           },
           "wander path": {
-            "name": "Weg entlanggehen\n"
+            "name": "Weg entlanggehen"
           }
         },
         "courseE_farmer_functions11_predict2022": {
@@ -3860,7 +3860,7 @@
             "name": "Landwirtschaftliche Erzeugnisse holen"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           },
           "pumpkin square": {
             "name": "Kürbis-Quadrat"
@@ -3877,7 +3877,7 @@
             "name": "Landwirtschaftliche Erzeugnisse holen"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           },
           "pumpkin square": {
             "name": "Kürbis-Quadrat"
@@ -3894,7 +3894,7 @@
             "name": "Landwirtschaftliche Erzeugnisse holen"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           },
           "pumpkin square": {
             "name": "Kürbis-Quadrat"
@@ -3911,7 +3911,7 @@
             "name": "Landwirtschaftliche Erzeugnisse holen"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           },
           "pumpkin square": {
             "name": "Kürbis-Quadrat"
@@ -3928,7 +3928,7 @@
             "name": "Landwirtschaftliche Erzeugnisse holen"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           },
           "pumpkin square": {
             "name": "Kürbis-Quadrat"
@@ -3936,7 +3936,7 @@
         },
         "courseE_farmer_functions132022": {
           "check for corn": {
-            "name": "Mais suchen\n"
+            "name": "Mais suchen"
           },
           "corn rectangle": {
             "name": "Mais-Rechteck"
@@ -3945,12 +3945,12 @@
             "name": "Salat-Treppe"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           }
         },
         "courseE_farmer_functions13_2018": {
           "check for corn": {
-            "name": "Mais suchen\n"
+            "name": "Mais suchen"
           },
           "corn rectangle": {
             "name": "Mais-Rechteck"
@@ -3959,12 +3959,12 @@
             "name": "Salat-Treppe"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           }
         },
         "courseE_farmer_functions13_2019": {
           "check for corn": {
-            "name": "Mais suchen\n"
+            "name": "Mais suchen"
           },
           "corn rectangle": {
             "name": "Mais-Rechteck"
@@ -3973,12 +3973,12 @@
             "name": "Salat-Treppe"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           }
         },
         "courseE_farmer_functions13_2020": {
           "check for corn": {
-            "name": "Mais suchen\n"
+            "name": "Mais suchen"
           },
           "corn rectangle": {
             "name": "Mais-Rechteck"
@@ -3987,12 +3987,12 @@
             "name": "Salat-Treppe"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           }
         },
         "courseE_farmer_functions13_2021": {
           "check for corn": {
-            "name": "Mais suchen\n"
+            "name": "Mais suchen"
           },
           "corn rectangle": {
             "name": "Mais-Rechteck"
@@ -4001,7 +4001,7 @@
             "name": "Salat-Treppe"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           }
         },
         "courseE_farmer_functions1a2022": {
@@ -4112,7 +4112,7 @@
             "name": "hole alle Kürbisse"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           }
         },
         "courseE_farmer_functions3c1_2018": {
@@ -4123,7 +4123,7 @@
             "name": "hole alle Kürbisse"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           }
         },
         "courseE_farmer_functions3c1_2019": {
@@ -4134,7 +4134,7 @@
             "name": "hole alle Kürbisse"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           }
         },
         "courseE_farmer_functions3c1_2020": {
@@ -4145,7 +4145,7 @@
             "name": "hole alle Kürbisse"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           }
         },
         "courseE_farmer_functions3c1_2021": {
@@ -4156,7 +4156,7 @@
             "name": "hole alle Kürbisse"
           },
           "pick along path": {
-            "name": "am Weg sammeln\n"
+            "name": "am Weg sammeln"
           }
         },
         "courseE_farmer_functions3c2022": {


### PR DESCRIPTION
## Links
- jira ticket: [P20-75](https://codedotorg.atlassian.net/browse/P20-75)

## Issue
The German translation of the function `fix long path` contains the newline escape sequence (`\n`) at the end: `kurzen Pfad in Ordnung bringen\n`

In this case, for some reason, Blockly initializes the function as `function kurzen_Pfad_in_Ordnung_bringen` but the function call reference as `kurzen_Pfad_in_Ordnung_bringen_0A()` (adding `_0A` at the end):

<img width="814" alt="Screenshot 2023-08-02 at 19 14 51" src="https://github.com/code-dot-org/code-dot-org/assets/11708250/38cc4e9d-1bd4-42ee-a18c-cbacacba32f3">

## Solution
Removed the newline escape sequence (`\n`) at the end of each function translation:

<img width="871" alt="Screenshot 2023-08-02 at 19 51 02" src="https://github.com/code-dot-org/code-dot-org/assets/11708250/8b6f8d15-f6d9-4eee-8429-c47e308ce29c">
