### PR TITLE
Fix Violations of and Reenable `Style/Encoding`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -252,11 +252,6 @@ Style/CommentAnnotation:
 Style/DocumentDynamicEvalDefinition:
   Enabled: false
 
-# Offense count: 6
-# This cop supports safe auto-correction (--auto-correct).
-Style/Encoding:
-  Enabled: false
-
 # Offense count: 2
 # This cop supports safe auto-correction (--auto-correct).
 Style/EvalWithLocation:

--- a/bin/oneoff/move_census_data.rb
+++ b/bin/oneoff/move_census_data.rb
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# coding: utf-8
-
 require_relative '../../dashboard/config/environment'
 require 'optparse'
 

--- a/dashboard/legacy/test/middleware/test_assets.rb
+++ b/dashboard/legacy/test/middleware/test_assets.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 require_relative 'files_api_test_base' # Must be required first to establish load paths
 require_relative 'files_api_test_helper'
 require_relative '../../middleware/helpers/asset_bucket'

--- a/lib/country_codes.rb
+++ b/lib/country_codes.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 require 'sort_alphabetical'
 require_relative 'country_regions'
 

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 # Run 'rake' or 'rake -P' to get a list of valid Rake commands.
 
 require 'cdo/chat_client'

--- a/shared/test/test_email_validator.rb
+++ b/shared/test/test_email_validator.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 require_relative 'test_helper'
 
 require 'cdo/email_validator'

--- a/shared/test/test_rake_utils.rb
+++ b/shared/test/test_rake_utils.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 require_relative 'test_helper'
 
 require 'cdo/rake_utils'


### PR DESCRIPTION
> Checks ensures source files have no utf-8 encoding comments.

UTF-8 has been the default source file encoding since Ruby 2, so specifying it is just unnecessary.

Fix applied automatically with `bundle exec rubocop --autocorrect --only Style/Encoding`

## Links

- https://rubystyle.guide/#utf-8
- https://docs.rubocop.org/rubocop/cops_style.html#styleencoding
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Encoding