### PR TITLE
Fix Violations of and Reenable `Style/RedundantBegin`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -400,11 +400,6 @@ Style/OptionalBooleanParameter:
 Style/RedundantAssignment:
   Enabled: false
 
-# Offense count: 6
-# This cop supports safe auto-correction (--auto-correct).
-Style/RedundantBegin:
-  Enabled: false
-
 # Offense count: 29
 # This cop supports safe auto-correction (--auto-correct).
 Style/RedundantCondition:

--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -302,24 +302,22 @@ def pd_applications_status_logs_row(row_hash)
 end
 
 def insert_pd_applications_status_logs_rows(rows)
-  begin
-    ActiveRecord::Base.connection.execute <<~SQL
-      INSERT INTO pd_applications_status_logs (
-        pd_application_id,
-        status,
-        timestamp,
-        position
-      )
-      VALUES
-      #{rows.map {|row| pd_applications_status_logs_row(row)}.join(",\n")}
-    SQL
-  rescue => exception
-    puts exception
-    Honeybadger.notify(
-      exception,
-      error_message: "Error when writing pd_applications_status_logs"
+  ActiveRecord::Base.connection.execute <<~SQL
+    INSERT INTO pd_applications_status_logs (
+      pd_application_id,
+      status,
+      timestamp,
+      position
     )
-  end
+    VALUES
+    #{rows.map {|row| pd_applications_status_logs_row(row)}.join(",\n")}
+  SQL
+rescue => exception
+  puts exception
+  Honeybadger.notify(
+    exception,
+    error_message: "Error when writing pd_applications_status_logs"
+  )
 end
 
 main

--- a/bin/curriculum/backfill-allow-multiple-attempts.rb
+++ b/bin/curriculum/backfill-allow-multiple-attempts.rb
@@ -49,24 +49,22 @@ end
 # Then call assign_attributes to update the level and rewrite the file
 # This method catches exceptions as not all errors are immediately addressable
 def update_dsl_level(level, allow_multiple_attempts)
-  begin
-    allow_multiple_attempts_str = allow_multiple_attempts.to_s
-    path = level.file_path
-    file_contents = File.read(path)
-    text = level.class.decrypt_dsl_text_if_necessary(file_contents)
-    encrypted = file_contents =~ /^encrypted '(.*)'$/m
-    if text.include?('allow_multiple_attempts')
-      return if text.include?("allow_multiple_attempts #{allow_multiple_attempts_str}")
-      text.gsub!(/allow_multiple_attempts.*$/, "allow_multiple_attempts #{allow_multiple_attempts_str}")
-    else
-      text += "\nallow_multiple_attempts #{allow_multiple_attempts_str}"
-    end
-    level.assign_attributes({dsl_text: text, allow_multiple_attempts: allow_multiple_attempts_str, encrypted: encrypted})
-    level.save!
-    raise "allow_multiple_attempts unset for #{level.name}" if level.reload.allow_multiple_attempts.nil?
-  rescue => exception
-    puts "Error updating #{level.name} with error #{exception.inspect}"
+  allow_multiple_attempts_str = allow_multiple_attempts.to_s
+  path = level.file_path
+  file_contents = File.read(path)
+  text = level.class.decrypt_dsl_text_if_necessary(file_contents)
+  encrypted = file_contents =~ /^encrypted '(.*)'$/m
+  if text.include?('allow_multiple_attempts')
+    return if text.include?("allow_multiple_attempts #{allow_multiple_attempts_str}")
+    text.gsub!(/allow_multiple_attempts.*$/, "allow_multiple_attempts #{allow_multiple_attempts_str}")
+  else
+    text += "\nallow_multiple_attempts #{allow_multiple_attempts_str}"
   end
+  level.assign_attributes({dsl_text: text, allow_multiple_attempts: allow_multiple_attempts_str, encrypted: encrypted})
+  level.save!
+  raise "allow_multiple_attempts unset for #{level.name}" if level.reload.allow_multiple_attempts.nil?
+rescue => exception
+  puts "Error updating #{level.name} with error #{exception.inspect}"
 end
 
 def backfill_match_levels

--- a/bin/oneoff/set_2022_ayw_email_settings.rb
+++ b/bin/oneoff/set_2022_ayw_email_settings.rb
@@ -3,12 +3,10 @@
 require_relative '../../dashboard/config/environment'
 
 Pd::Workshop.where("subject LIKE '%Academic Year Workshop%'").select {|w| w.created_at.strftime("%Y") == '2022'}.each do |workshop|
-  begin
-    if workshop.suppress_email?
-      workshop.update!(suppress_email: false)
-      puts "Successfully updated workshop id #{workshop.id}"
-    end
-  rescue => exception
-    puts "Error updating workshop id #{workshop.id}: #{exception}"
+  if workshop.suppress_email?
+    workshop.update!(suppress_email: false)
+    puts "Successfully updated workshop id #{workshop.id}"
   end
+rescue => exception
+  puts "Error updating workshop id #{workshop.id}: #{exception}"
 end

--- a/bin/oneoff/wipe_data/terms_of_service_version
+++ b/bin/oneoff/wipe_data/terms_of_service_version
@@ -4,11 +4,9 @@
 
 require_relative '../../../dashboard/config/environment'
 
-begin
-  User.
-    with_deleted.
-    where.not(terms_of_service_version: nil).
-    find_each do |user|
-      user.update(terms_of_service_version: nil)
-    end
-end
+User.
+  with_deleted.
+  where.not(terms_of_service_version: nil).
+  find_each do |user|
+    user.update(terms_of_service_version: nil)
+  end

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -255,18 +255,16 @@ module Pd::Application
 
     # Include additional text for all the multi-select fields that have the option
     def full_answers
-      @full_answers ||= begin
-        sanitized_form_data_hash.tap do |hash|
-          additional_text_fields.each do |field_name, option, additional_text_field_name|
-            next unless hash.key? field_name
+      @full_answers ||= sanitized_form_data_hash.tap do |hash|
+        additional_text_fields.each do |field_name, option, additional_text_field_name|
+          next unless hash.key? field_name
 
-            option ||= OTHER_WITH_TEXT
-            additional_text_field_name ||= "#{field_name}_other".to_sym
-            hash[field_name] = self.class.answer_with_additional_text hash, field_name, option, additional_text_field_name
-            hash.delete additional_text_field_name
-          end
-        end.slice(*(self.class.filtered_labels(course, status).keys + self.class.additional_labels).uniq)
-      end
+          option ||= OTHER_WITH_TEXT
+          additional_text_field_name ||= "#{field_name}_other".to_sym
+          hash[field_name] = self.class.answer_with_additional_text hash, field_name, option, additional_text_field_name
+          hash.delete additional_text_field_name
+        end
+      end.slice(*(self.class.filtered_labels(course, status).keys + self.class.additional_labels).uniq)
     end
 
     # Camelized (js-standard) format of the full_answers. The keys here will match the raw keys in form_data

--- a/dashboard/lib/email_reminder.rb
+++ b/dashboard/lib/email_reminder.rb
@@ -57,16 +57,14 @@ class EmailReminder
 
   # Send emails for all requests that need reminders.
   def send_all_reminder_emails
-    begin
-      find_requests_needing_reminder.find_each do |request|
-        send_permission_reminder_email request.id
-        @num_reminders_sent += 1
-      end
-    rescue StandardError => exception
-      CDO.log.info exception.message
-    ensure
-      report_results
+    find_requests_needing_reminder.find_each do |request|
+      send_permission_reminder_email request.id
+      @num_reminders_sent += 1
     end
+  rescue StandardError => exception
+    CDO.log.info exception.message
+  ensure
+    report_results
   end
 
   private

--- a/lib/cdo/secrets.rb
+++ b/lib/cdo/secrets.rb
@@ -62,13 +62,11 @@ module Cdo
     # @return [Concurrent::Promises::Future<String>] Resolved value
     def get(key)
       key = key.to_s
-      @values[key] ||= begin
-        client_promise.then do |client|
-          parse_json(get_secret_value(client, key))
-        rescue => exception
-          exception.message << " Key: #{key}"
-          raise
-        end
+      @values[key] ||= client_promise.then do |client|
+        parse_json(get_secret_value(client, key))
+      rescue => exception
+        exception.message << " Key: #{key}"
+        raise
       end
     end
 

--- a/lib/cdo/shared_cache.rb
+++ b/lib/cdo/shared_cache.rb
@@ -34,9 +34,7 @@ module Cdo
     # Generic shared cache.
     # Use memcached if available, with FileStore as fallback.
     def self.cache
-      @@cache ||= begin
-        memcached || ActiveSupport::Cache::FileStore.new(dashboard_dir('tmp', 'cache', 'shared'))
-      end
+      @@cache ||= (memcached || ActiveSupport::Cache::FileStore.new(dashboard_dir('tmp', 'cache', 'shared')))
     end
   end
 end


### PR DESCRIPTION
> This cop checks for redundant `begin` blocks.

I used `bundle exec rubocop --autocorrect --only Style/RedundantBegin` to identify and remove the relevant `begin` and `end` statements, then manually fixed the resulting whitespace issues.

I recommend reviewing [with whitespace changes disabled](https://github.com/code-dot-org/code-dot-org/pull/53141/files?w=1)

## Links

- https://rubystyle.guide/#begin-implicit
- https://docs.rubocop.org/rubocop/cops_style.html#styleredundantbegin
- https://www.rubydoc.info/gems/rubocop/0.27.0/RuboCop/Cop/Style/RedundantBegin