### PR TITLE
Create React UI for editing validations in levelbuilder

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -740,6 +740,8 @@ describe('entry tests', () => {
       './src/sites/studio/pages/levels/editors/fields/_special_level_types.js',
     'levels/editors/fields/_validation_code':
       './src/sites/studio/pages/levels/editors/fields/_validation_code.js',
+    'levels/editors/fields/_validations':
+      './src/sites/studio/pages/levels/editors/fields/_validations.js',
     'levels/editors/fields/_video':
       './src/sites/studio/pages/levels/editors/fields/_video.js',
     'levels/editors/_gamelab':

--- a/apps/src/lab2/levelEditors/validations/EditCondition.tsx
+++ b/apps/src/lab2/levelEditors/validations/EditCondition.tsx
@@ -1,0 +1,86 @@
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import React from 'react';
+import {Condition, ConditionType} from '../../types';
+import moduleStyles from './edit-validations.module.scss';
+
+interface EditConditionProps {
+  condition: Condition;
+  conditionTypes: ConditionType[];
+  index: number;
+  onConditionChange: (condition: Condition, index: number) => void;
+  deleteCondition: (index: number) => void;
+}
+
+/**
+ * Editor for a single validation condition.
+ */
+const EditCondition: React.FunctionComponent<EditConditionProps> = ({
+  condition,
+  conditionTypes,
+  index,
+  onConditionChange,
+  deleteCondition,
+}) => {
+  const currentConditionType = conditionTypes.find(conditionType => {
+    return conditionType.name === condition.name;
+  });
+
+  const isNumeric = currentConditionType?.valueType === 'number';
+
+  return (
+    <div className={moduleStyles.row}>
+      <label htmlFor="conditionName" className={moduleStyles.label}>
+        {'Condition ' + (index + 1) + ':'}
+      </label>
+      <select
+        className={moduleStyles.conditionNameDropdown}
+        name="conditionName"
+        id="conditionName"
+        value={condition.name}
+        onChange={e => {
+          condition.name = e.target.value;
+          if (!currentConditionType?.hasValue) {
+            condition.value = undefined;
+          }
+          onConditionChange(condition, index);
+        }}
+      >
+        {conditionTypes.map((conditionType, index) => {
+          return (
+            <option key={index} value={conditionType.name}>
+              {conditionType.name}
+            </option>
+          );
+        })}
+      </select>
+      {currentConditionType?.hasValue && (
+        <>
+          <label htmlFor="conditionValue" className={moduleStyles.label}>
+            Value:
+          </label>
+          <input
+            type={isNumeric ? 'number' : 'text'}
+            name="conditionValue"
+            id="conditionValue"
+            value={condition.value}
+            onChange={e => {
+              condition.value = isNumeric
+                ? parseInt(e.target.value)
+                : e.target.value;
+              onConditionChange(condition, index);
+            }}
+          />
+        </>
+      )}
+      <button
+        type="button"
+        onClick={() => deleteCondition(index)}
+        className={moduleStyles.deleteConditionButton}
+      >
+        <FontAwesome icon="trash" title={undefined} className="icon" />
+      </button>
+    </div>
+  );
+};
+
+export default EditCondition;

--- a/apps/src/lab2/levelEditors/validations/EditValidation.tsx
+++ b/apps/src/lab2/levelEditors/validations/EditValidation.tsx
@@ -1,0 +1,141 @@
+import Typography from '@cdo/apps/componentLibrary/typography/Typography';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import React from 'react';
+import {ConditionType, Validation, Condition} from '../../types';
+import moduleStyles from './edit-validations.module.scss';
+import EditCondition from './EditCondition';
+
+interface EditValidationProps {
+  validation: Validation;
+  index: number;
+  onValidationChange: (validation: Validation) => void;
+  deleteValidation: (key: string) => void;
+  conditionTypes: ConditionType[];
+  moveValidation: (key: string, direction: 'up' | 'down') => void;
+}
+
+/**
+ * Editor for a single validation set.
+ */
+const EditValidation: React.FunctionComponent<EditValidationProps> = ({
+  validation,
+  index,
+  onValidationChange,
+  deleteValidation,
+  conditionTypes,
+  moveValidation,
+}) => {
+  const onConditionChange = (condition: Condition, index: number) => {
+    validation.conditions[index] = condition;
+    onValidationChange(validation);
+  };
+
+  const addCondition = () => {
+    const defaultCondition = conditionTypes[0];
+    validation.conditions.push({name: defaultCondition.name});
+    onValidationChange(validation);
+  };
+
+  const deleteCondition = (index: number) => {
+    validation.conditions.splice(index, 1);
+    onValidationChange(validation);
+  };
+
+  return (
+    <div className={moduleStyles.validation}>
+      <div className={moduleStyles.row}>
+        <Typography
+          semanticTag="h3"
+          visualAppearance="heading-xs"
+          className={moduleStyles.validationTitle}
+        >
+          {'Validation Set ' + (index + 1)}
+        </Typography>
+        <button
+          type="button"
+          onClick={() => moveValidation(validation.key, 'up')}
+          className={moduleStyles.moveValidationButton}
+        >
+          <FontAwesome icon="arrow-up" title={undefined} className="icon" />
+        </button>
+
+        <button
+          type="button"
+          onClick={() => moveValidation(validation.key, 'down')}
+          className={moduleStyles.moveValidationButton}
+        >
+          <FontAwesome icon="arrow-down" title={undefined} className="icon" />
+        </button>
+        <button
+          type="button"
+          onClick={() => deleteValidation(validation.key)}
+          className={moduleStyles.deleteValidationButton}
+        >
+          <FontAwesome icon="trash" title={undefined} className="icon" />
+        </button>
+      </div>
+      <div className={moduleStyles.row}>
+        <label htmlFor="message" className={moduleStyles.label}>
+          Message:
+        </label>
+        <textarea
+          id="message"
+          name="message"
+          rows={1}
+          className={moduleStyles.message}
+          value={validation.message}
+          onChange={e => {
+            validation.message = e.target.value;
+            onValidationChange(validation);
+          }}
+        />
+      </div>
+      <div className={moduleStyles.row}>
+        <label htmlFor="next" className={moduleStyles.label}>
+          Passes Level?
+        </label>
+        <input
+          type="checkbox"
+          id="next"
+          name="next"
+          checked={validation.next}
+          onChange={e => {
+            validation.next = e.target.checked;
+            onValidationChange(validation);
+          }}
+        />
+      </div>
+      <Typography
+        semanticTag="h4"
+        visualAppearance="body-two"
+        className={moduleStyles.validationTitle}
+      >
+        {'Conditions'}
+      </Typography>
+      {validation.conditions.map((condition, index) => {
+        return (
+          <div className={moduleStyles.row} key={index}>
+            <EditCondition
+              condition={condition}
+              conditionTypes={conditionTypes}
+              index={index}
+              onConditionChange={onConditionChange}
+              deleteCondition={deleteCondition}
+            />
+          </div>
+        );
+      })}
+      <div className={moduleStyles.row}>
+        <button
+          type="button"
+          onClick={addCondition}
+          className={moduleStyles.addConditionButton}
+        >
+          + Add New Condition
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EditValidation;

--- a/apps/src/lab2/levelEditors/validations/EditValidations.tsx
+++ b/apps/src/lab2/levelEditors/validations/EditValidations.tsx
@@ -1,0 +1,164 @@
+import Typography from '@cdo/apps/componentLibrary/typography/Typography';
+import {Validation, ConditionType, AppName} from '../../types';
+import {MusicConditions} from '@cdo/apps/music/progress/MusicValidator';
+import {convertOptionalStringToBoolean} from '@cdo/apps/types/utils';
+import {createUuid} from '@cdo/apps/utils';
+import React, {useState} from 'react';
+import moduleStyles from './edit-validations.module.scss';
+import EditValidation from './EditValidation';
+
+/**
+ * This component is used to edit validations for a level. Currently only used
+ * by Lab2 labs.
+ */
+
+const AppConditions: {[key in AppName]?: ConditionType[]} = {
+  music: Object.values(MusicConditions),
+};
+
+interface EditValidationsProps {
+  initialValidations: Validation[];
+  levelName: string;
+  appName: AppName;
+}
+
+/**
+ * Top-level validations editor component.
+ */
+const EditValidations: React.FunctionComponent<EditValidationsProps> = ({
+  initialValidations,
+  levelName,
+  appName,
+}) => {
+  const [validations, setValidations] = useState<Validation[]>(
+    sanitizeValidations(initialValidations, levelName)
+  );
+
+  const conditionTypes = AppConditions[appName];
+
+  if (conditionTypes === undefined || conditionTypes.length === 0) {
+    return (
+      <div>
+        {`No validation conditions available for app type: ${appName}. Contact the engineering team for further details.`}
+      </div>
+    );
+  }
+
+  const onValidationChange = (validation: Validation) => {
+    setValidations(
+      sanitizeValidations(
+        validations.map(v => {
+          if (v.key === validation.key) {
+            return validation;
+          }
+          return v;
+        }),
+        levelName
+      )
+    );
+  };
+
+  const deleteValidation = (key: string) => {
+    setValidations(
+      sanitizeValidations(
+        validations.filter(validation => {
+          return validation.key !== key;
+        }),
+        levelName
+      )
+    );
+  };
+
+  const moveValidation = (key: string, direction: 'up' | 'down') => {
+    const index = validations.findIndex(validation => {
+      return validation.key === key;
+    });
+
+    if (index === -1) {
+      return;
+    }
+
+    const newIndex = direction === 'up' ? index - 1 : index + 1;
+    if (newIndex < 0 || newIndex >= validations.length) {
+      return;
+    }
+    const newValidations = [...validations];
+    const temp = newValidations[index];
+    newValidations[index] = newValidations[newIndex];
+    newValidations[newIndex] = temp;
+    setValidations(newValidations);
+  };
+
+  const addValidation = () => {
+    const newValidation: Validation = {
+      key: levelName + '_' + createUuid(),
+      message: '',
+      next: false,
+      conditions: [],
+    };
+    setValidations([...validations, newValidation]);
+  };
+
+  return (
+    <div>
+      <input
+        type="hidden"
+        id="level_validations"
+        name="level[validations]"
+        value={JSON.stringify(validations)}
+      />
+      <Typography
+        semanticTag="p"
+        visualAppearance="body-three"
+        className={moduleStyles.title}
+      >
+        Edit validations for this level. Currently only supported by Lab2 labs.
+        <br />
+        NOTE: Validations are checked in the order they are listed. The first
+        validation set that passes is the one that is displayed, so be sure to
+        order your validation sets from most conditions to least.
+      </Typography>
+      {validations.map((validation, index) => {
+        return (
+          <EditValidation
+            key={validation.key}
+            index={index}
+            validation={validation}
+            onValidationChange={onValidationChange}
+            deleteValidation={deleteValidation}
+            conditionTypes={conditionTypes}
+            moveValidation={moveValidation}
+          />
+        );
+      })}
+      <button
+        type="button"
+        className={moduleStyles.addValidationButton}
+        onClick={addValidation}
+      >
+        + Add New Validation
+      </button>
+    </div>
+  );
+};
+
+/**
+ * Ensures that all validations have unique IDs and a conditions array.
+ */
+function sanitizeValidations(
+  validations: Validation[],
+  levelName: string
+): Validation[] {
+  return validations.map(validation => {
+    if (!validation.key) {
+      validation.key = levelName + '_' + createUuid();
+    }
+    validation.next = convertOptionalStringToBoolean(validation.next, false);
+    if (!validation.conditions) {
+      validation.conditions = [];
+    }
+    return validation;
+  });
+}
+
+export default EditValidations;

--- a/apps/src/lab2/levelEditors/validations/EditValidations.tsx
+++ b/apps/src/lab2/levelEditors/validations/EditValidations.tsx
@@ -116,7 +116,7 @@ const EditValidations: React.FunctionComponent<EditValidationsProps> = ({
         <br />
         NOTE: Validations are checked in the order they are listed. The first
         validation set that passes is the one that is displayed, so be sure to
-        order your validation sets from most conditions to least.
+        order your validation sets from most stringent to least.
       </Typography>
       {validations.map((validation, index) => {
         return (

--- a/apps/src/lab2/levelEditors/validations/edit-validations.module.scss
+++ b/apps/src/lab2/levelEditors/validations/edit-validations.module.scss
@@ -62,8 +62,6 @@
 
 .deleteConditionButton {
   @extend %delete-button;
-  // height: 30px;
-  // width: 30px;
   margin: 0 10px;
 }
 

--- a/apps/src/lab2/levelEditors/validations/edit-validations.module.scss
+++ b/apps/src/lab2/levelEditors/validations/edit-validations.module.scss
@@ -1,0 +1,78 @@
+@import 'color.scss';
+@import '../../../mixins.scss';
+
+.row {
+  display: flex;
+  align-items: baseline;
+  padding-bottom: 10px;
+}
+
+.validation {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid black;
+  border-radius: 4px;
+  margin: 20px 0;
+  padding: 20px 10px;
+}
+
+.message {
+  width: 90%;
+}
+
+.validationTitle {
+  padding-bottom: 10px;
+  padding-right: 10px;
+}
+
+.label {
+  padding-right: 10px;
+}
+
+.conditionNameDropdown {
+  margin-right: 10px;
+}
+
+.addConditionButton {
+  font-size: 14px;
+  background-color: $brand_primary_default;
+  color: $neutral_light;
+}
+
+.addValidationButton {
+  font-size: 14px;
+  background-color: $brand_secondary_default;
+  color: $neutral_light;
+}
+
+%icon-button {
+  @include remove-button-styles;
+  font-size: 12px;
+  margin: 0 4px;
+  border-radius: 4px;
+  height: 24px;
+  width: 24px;
+}
+
+%delete-button {
+  @extend %icon-button;
+  background-color: $product_negative_default;
+  color: $neutral_light;
+}
+
+.deleteConditionButton {
+  @extend %delete-button;
+  // height: 30px;
+  // width: 30px;
+  margin: 0 10px;
+}
+
+.deleteValidationButton {
+  @extend %delete-button;
+}
+
+.moveValidationButton {
+  @extend %icon-button;
+  background-color: $neutral-dark60;
+  color: $neutral_light;
+}

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -119,11 +119,18 @@ export interface Condition {
   value?: string | number;
 }
 
+export interface ConditionType {
+  name: string;
+  hasValue: boolean;
+  valueType?: 'string' | 'number';
+}
+
 // Validation in the level.
 export interface Validation {
   conditions: Condition[];
   message: string;
   next: boolean;
+  key: string;
 }
 
 // TODO: these are not all the properties of app options.

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -1,18 +1,22 @@
 // Music Lab specific validations.
 
 import MusicPlayer from '../player/MusicPlayer';
-import {Condition} from '@cdo/apps/lab2/types';
+import {Condition, ConditionType} from '@cdo/apps/lab2/types';
 import ConditionsChecker from '@cdo/apps/lab2/progress/ConditionsChecker';
 import {PlaybackEvent} from '../player/interfaces/PlaybackEvent';
 import {Validator} from '@cdo/apps/lab2/progress/ProgressManager';
 
 export interface ConditionNames {
-  [key: string]: string;
+  [key: string]: ConditionType;
 }
 
-export const ConditionNamesList: ConditionNames = {
-  PLAYED_SOUNDS_TOGETHER: 'played_sounds_together',
-  PLAYED_SOUND_TRIGGERED: 'played_sound_triggered',
+export const MusicConditions: ConditionNames = {
+  PLAYED_SOUNDS_TOGETHER: {
+    name: 'played_sounds_together',
+    hasValue: true,
+    valueType: 'number',
+  },
+  PLAYED_SOUND_TRIGGERED: {name: 'played_sound_triggered', hasValue: false},
 };
 
 export default class MusicValidator extends Validator {
@@ -21,7 +25,7 @@ export default class MusicValidator extends Validator {
     private readonly getPlaybackEvents: () => PlaybackEvent[],
     private readonly player: MusicPlayer,
     private readonly conditionsChecker: ConditionsChecker = new ConditionsChecker(
-      Object.values(ConditionNamesList)
+      Object.values(MusicConditions).map(condition => condition.name)
     )
   ) {
     super();
@@ -45,7 +49,7 @@ export default class MusicValidator extends Validator {
 
         if (eventData.triggered) {
           this.conditionsChecker.addSatisfiedCondition({
-            name: ConditionNamesList.PLAYED_SOUND_TRIGGERED,
+            name: MusicConditions.PLAYED_SOUND_TRIGGERED.name,
           });
         }
       }
@@ -62,7 +66,7 @@ export default class MusicValidator extends Validator {
     ) {
       if (currentNumberSounds >= numberSounds) {
         this.conditionsChecker.addSatisfiedCondition({
-          name: ConditionNamesList.PLAYED_SOUNDS_TOGETHER,
+          name: MusicConditions.PLAYED_SOUNDS_TOGETHER.name,
           value: currentNumberSounds,
         });
       }

--- a/apps/src/sites/studio/pages/levels/editors/fields/_validations.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_validations.js
@@ -1,0 +1,22 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import EditValidations from '@cdo/apps/lab2/levelEditors/validations/EditValidations';
+import getScriptData from '@cdo/apps/util/getScriptData';
+
+$(document).ready(function () {
+  const validations = getScriptData('validations');
+  const levelName = document.querySelector('script[data-levelname]').dataset
+    .levelname;
+  const appName = document.querySelector('script[data-levelname]').dataset
+    .appname;
+
+  ReactDOM.render(
+    <EditValidations
+      initialValidations={validations}
+      levelName={levelName}
+      appName={appName}
+    />,
+    document.getElementById('validations-container')
+  );
+});

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -299,7 +299,7 @@ class LevelsController < ApplicationController
     # first-order member of the properties JSON, rather than simply as a string of
     # JSON belonging to a single property.
     update_level_params[:level_data] = JSON.parse(level_params[:level_data]) if level_params[:level_data]
-    # Update level data with validatons, and remove from level properties.
+    # Update level data with validations, and remove from level properties.
     # We can remove this once validations are read from level properties directly.
     update_level_params[:level_data]["validations"] = JSON.parse(update_level_params[:validations]) if update_level_params[:validations]
     update_level_params[:validations] = nil if level_params[:validations]

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -299,6 +299,10 @@ class LevelsController < ApplicationController
     # first-order member of the properties JSON, rather than simply as a string of
     # JSON belonging to a single property.
     update_level_params[:level_data] = JSON.parse(level_params[:level_data]) if level_params[:level_data]
+    # Update level data with validatons, and remove from level properties.
+    # We can remove this once validations are read from level properties directly.
+    update_level_params[:level_data]["validations"] = JSON.parse(update_level_params[:validations]) if update_level_params[:validations]
+    update_level_params[:validations] = nil if level_params[:validations]
 
     @level.assign_attributes(update_level_params)
     @level.log_changes(current_user)

--- a/dashboard/app/models/levels/music.rb
+++ b/dashboard/app/models/levels/music.rb
@@ -40,6 +40,7 @@ class Music < Blockly
     submittable
     background
     level_data
+    validations
   )
 
   def self.create_from_level_builder(params, level_params)

--- a/dashboard/app/views/levels/editors/_music.html.haml
+++ b/dashboard/app/views/levels/editors/_music.html.haml
@@ -1,3 +1,4 @@
 = render partial: 'levels/editors/fields/music_level_data', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/validations', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_validations.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_validations.html.haml
@@ -1,0 +1,8 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#validations-container"}}
+  Validations
+
+#validations-container.in.collapse
+
+- content_for :body_scripts do
+  %script{src: webpack_asset_path('js/levels/editors/fields/_validations.js'),
+        data: {validations: @level.level_data["validations"].to_json, levelname: @level.name, appname: @level.game&.app}}


### PR DESCRIPTION
This adds a React-based UI for editing validations to levelbuilder pages. This is in an effort to create a nicer UI for authoring validations (rather than hand-crafting code or JSON), and has another big benefit of being able to share front end code with other front end components. This means that we can reference other front-end types, like the list of valid validations, and shared typescript types and interfaces.

Currently, this adds a new field to music levels called "validations", but when saving the level, we merge the validations back into level data. I think we are looking to move towards storing validations on level properties directly, rather than in level data, so when that change is complete, we can tweak some of the code that copies over the validations JSON in levels_controller.

### Testing Notes
I've hand tested this on some Music all the things levels, but i'm sure we'll continue to iterate on this as we start using it more.

https://github.com/code-dot-org/code-dot-org/assets/85528507/790777ef-302d-462b-970a-4428cf94787d


