### PR TITLE
Fix indentation of moving east

### DIFF
--- a/dashboard/config/shared_functions/GamelabJr/moving east.xml
+++ b/dashboard/config/shared_functions/GamelabJr/moving east.xml
@@ -7,22 +7,22 @@
   <field name="NAME" id="moving east">moving east</field>
   <statement name="STACK">
     <block type="gamelab_moveInDirection">
-<field name="DIRECTION">"East"</field>
-<value name="SPRITE">
-<block type="sprite_parameter_get">
-<field name="VAR">this sprite</field>
-</block>
-</value>
-<value name="DISTANCE">
-<block type="gamelab_getProp">
-<field name="PROPERTY">"speed"</field>
-<value name="SPRITE">
-<block type="sprite_parameter_get">
-<field name="VAR">this sprite</field>
-</block>
-</value>
-</block>
-</value>
-</block>
+      <field name="DIRECTION">"East"</field>
+      <value name="SPRITE">
+        <block type="sprite_parameter_get">
+          <field name="VAR">this sprite</field>
+        </block>
+      </value>
+      <value name="DISTANCE">
+        <block type="gamelab_getProp">
+          <field name="PROPERTY">"speed"</field>
+          <value name="SPRITE">
+            <block type="sprite_parameter_get">
+              <field name="VAR">this sprite</field>
+            </block>
+          </value>
+        </block>
+      </value>
+    </block>
   </statement>
 </block>


### PR DESCRIPTION
I think the indentation issue is due to our xml/json changes on the blockly side. This changes the indentation back so we don't get seeding conflicts.


## Follow-up work
I'll look into how we can prevent this from happening on future changes to these functions

