### PR TITLE
[Google Blockly] Fix width of mini toolbox

### DIFF
--- a/apps/src/blockly/addons/cdoBlockFlyout.js
+++ b/apps/src/blockly/addons/cdoBlockFlyout.js
@@ -1,6 +1,9 @@
 import GoogleBlockly from 'blockly/core';
 
 const svgPaths = GoogleBlockly.utils.svgPaths;
+// The width of the border around the root block if it is selected.
+const SELECTED_BORDER_WIDTH = 4;
+
 export default class CdoBlockFlyout extends GoogleBlockly.HorizontalFlyout {
   /**
    * This is a customized flyout class that extends the HorizontalFlyout class.
@@ -92,7 +95,13 @@ export default class CdoBlockFlyout extends GoogleBlockly.HorizontalFlyout {
     const topBlockWidth = this.sourceBlock_.svgGroup_
       .querySelector('path')
       .getBoundingClientRect().width;
-    const blockWidthMinusPadding = topBlockWidth - this.flyoutBlockPadding * 2;
+    let blockWidthMinusPadding = topBlockWidth - this.flyoutBlockPadding * 2;
+
+    // If the block is selected, there is an additional border that we don't want to
+    // count towards the flyout width.
+    if (this.sourceBlock_.svgGroup_.classList.contains('blocklySelected')) {
+      blockWidthMinusPadding -= SELECTED_BORDER_WIDTH * 2;
+    }
     this.width_ = Math.max(this.width_, blockWidthMinusPadding);
     this.setBackgroundPath_(this.width_, this.height_);
     this.position();

--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -45,7 +45,11 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
     if (this.icon) {
       this.icon.style.fill =
         this.colorOverrides?.icon || this.getSourceBlock().style.colourPrimary;
+      console.log(this.icon);
+      console.log(`width before updateSize_ is ${this.size_.width}`);
       this.textElement_.appendChild(this.icon);
+      this.updateSize_();
+      console.log(`width after updateSize_ is ${this.size_.width}`);
     }
   }
 
@@ -97,5 +101,47 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
     if (textElement && textColor) {
       textElement.setAttribute('style', 'fill: ' + textColor);
     }
+  }
+
+  /**
+   * Updates the size of the field based on the text.
+   *
+   * @param margin margin to use when positioning the text element.
+   */
+  updateSize_(margin) {
+    const constants = this.getConstants();
+    const xOffset =
+      margin !== undefined
+        ? margin
+        : this.borderRect_
+        ? this.getConstants()?.FIELD_BORDER_RECT_X_PADDING
+        : 0;
+    let totalWidth = xOffset * 2;
+    console.log({totalWidth});
+    let totalHeight = constants?.FIELD_TEXT_HEIGHT;
+
+    let contentWidth = 0;
+    console.log(
+      `font size: ${constants?.FIELD_TEXT_FONTSIZE}, font weight: ${constants?.FIELD_TEXT_FONTWEIGHT}, font family: ${constants?.FIELD_TEXT_FONTFAMILY}`
+    );
+    if (this.textElement_) {
+      contentWidth = Blockly.utils.dom.getFastTextWidth(
+        this.textElement_,
+        constants?.FIELD_TEXT_FONTSIZE,
+        constants?.FIELD_TEXT_FONTWEIGHT,
+        constants?.FIELD_TEXT_FONTFAMILY
+      );
+      console.log({contentWidth});
+      totalWidth += contentWidth;
+    }
+    if (this.borderRect_) {
+      totalHeight = Math.max(totalHeight, constants?.FIELD_BORDER_RECT_HEIGHT);
+    }
+
+    this.size_.height = totalHeight;
+    this.size_.width = totalWidth;
+
+    this.positionTextElement_(xOffset, contentWidth);
+    this.positionBorderRect_();
   }
 }

--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -45,11 +45,7 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
     if (this.icon) {
       this.icon.style.fill =
         this.colorOverrides?.icon || this.getSourceBlock().style.colourPrimary;
-      console.log(this.icon);
-      console.log(`width before updateSize_ is ${this.size_.width}`);
       this.textElement_.appendChild(this.icon);
-      this.updateSize_();
-      console.log(`width after updateSize_ is ${this.size_.width}`);
     }
   }
 
@@ -101,47 +97,5 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
     if (textElement && textColor) {
       textElement.setAttribute('style', 'fill: ' + textColor);
     }
-  }
-
-  /**
-   * Updates the size of the field based on the text.
-   *
-   * @param margin margin to use when positioning the text element.
-   */
-  updateSize_(margin) {
-    const constants = this.getConstants();
-    const xOffset =
-      margin !== undefined
-        ? margin
-        : this.borderRect_
-        ? this.getConstants()?.FIELD_BORDER_RECT_X_PADDING
-        : 0;
-    let totalWidth = xOffset * 2;
-    console.log({totalWidth});
-    let totalHeight = constants?.FIELD_TEXT_HEIGHT;
-
-    let contentWidth = 0;
-    console.log(
-      `font size: ${constants?.FIELD_TEXT_FONTSIZE}, font weight: ${constants?.FIELD_TEXT_FONTWEIGHT}, font family: ${constants?.FIELD_TEXT_FONTFAMILY}`
-    );
-    if (this.textElement_) {
-      contentWidth = Blockly.utils.dom.getFastTextWidth(
-        this.textElement_,
-        constants?.FIELD_TEXT_FONTSIZE,
-        constants?.FIELD_TEXT_FONTWEIGHT,
-        constants?.FIELD_TEXT_FONTFAMILY
-      );
-      console.log({contentWidth});
-      totalWidth += contentWidth;
-    }
-    if (this.borderRect_) {
-      totalHeight = Math.max(totalHeight, constants?.FIELD_BORDER_RECT_HEIGHT);
-    }
-
-    this.size_.height = totalHeight;
-    this.size_.width = totalWidth;
-
-    this.positionTextElement_(xOffset, contentWidth);
-    this.positionBorderRect_();
   }
 }


### PR DESCRIPTION
We noticed when a mini toolbox block was dragged or expanded/collapsed, the mini toolbox was too wide. The reason this was happening was the border around the block due to it being selected was being counted in the calculation for the flyout width. As a quick fix I am manually subtracting the width of the border, but this could be flaky if blockly ever changes the width of this border.

### Before

https://github.com/code-dot-org/code-dot-org/assets/33666587/ca079b82-5f28-4881-9c0b-3fa3855a6308

### After

https://github.com/code-dot-org/code-dot-org/assets/33666587/eea966f2-f2ee-4288-b264-8e7c1e9290a8


## Links
- jira ticket: [SL-1044](https://codedotorg.atlassian.net/browse/SL-1044)


## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
