### PR TITLE
Expanded card displayed behind a flag

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -66,7 +66,7 @@ const CurriculumCatalogCard = ({
     quickViewButtonDescription={i18n.quickViewDescription({
       course_name: courseDisplayName,
     })}
-    quickViewButtonText={i18n.learnMore()}
+    quickViewButtonText={i18n.quickView()}
     imageAltText={imageAltText}
     translationIconTitle={i18n.courseInYourLanguage()}
     pathToCourse={pathToCourse + '?viewAs=Instructor'}
@@ -225,7 +225,7 @@ const CustomizableCurriculumCatalogCard = ({
                 type="button"
                 onClick={handleQuickView}
                 aria-label={quickViewButtonDescription}
-                text={'Quick View'}
+                text={quickViewButtonText}
               />
             ) : (
               <Button

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -29,6 +29,8 @@ import {
 } from '@cdo/apps/templates/curriculumCatalog/noSectionsToAssignDialogs';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import DCDO from '@cdo/apps/dcdo';
+import ExpandedCurriculumCatalogCard from './ExpandedCurriculumCatalogCard';
 
 const CurriculumCatalogCard = ({
   courseDisplayName,
@@ -122,6 +124,7 @@ const CustomizableCurriculumCatalogCard = ({
   ...props
 }) => {
   const [isAssignDialogOpen, setIsAssignDialogOpen] = useState(false);
+  const [isExpandedCardDisplayed, setIsExpandedCardDisplayed] = useState(false);
 
   const handleClickAssign = () => {
     setIsAssignDialogOpen(true);
@@ -171,6 +174,9 @@ const CustomizableCurriculumCatalogCard = ({
       );
     }
   };
+  const handleQuickView = () => {
+    setIsExpandedCardDisplayed(true);
+  };
 
   return (
     <div>
@@ -213,14 +219,24 @@ const CustomizableCurriculumCatalogCard = ({
                 : style.buttonsContainer_notEnglish
             )}
           >
-            <Button
-              __useDeprecatedTag
-              color={Button.ButtonColor.neutralDark}
-              type="button"
-              href={pathToCourse}
-              aria-label={quickViewButtonDescription}
-              text={quickViewButtonText}
-            />
+            {!!DCDO.get('quick-view', false) ? (
+              <Button
+                __useDeprecatedTag
+                color={Button.ButtonColor.neutralDark}
+                type="button"
+                href={pathToCourse}
+                aria-label={quickViewButtonDescription}
+                text={quickViewButtonText}
+              />
+            ) : (
+              <Button
+                color={Button.ButtonColor.neutralDark}
+                type="button"
+                onClick={handleQuickView}
+                aria-label={quickViewButtonDescription}
+                text={'Quick View'}
+              />
+            )}
             <Button
               color={Button.ButtonColor.brandSecondaryDefault}
               type="button"
@@ -232,6 +248,7 @@ const CustomizableCurriculumCatalogCard = ({
         </div>
       </div>
       {isAssignDialogOpen && renderAssignDialog()}
+      {isExpandedCardDisplayed && <ExpandedCurriculumCatalogCard />}
     </div>
   );
 };

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -221,20 +221,22 @@ const CustomizableCurriculumCatalogCard = ({
           >
             {!!DCDO.get('quick-view', false) ? (
               <Button
-                __useDeprecatedTag
-                color={Button.ButtonColor.neutralDark}
-                type="button"
-                href={pathToCourse}
-                aria-label={quickViewButtonDescription}
-                text={quickViewButtonText}
-              />
-            ) : (
-              <Button
                 color={Button.ButtonColor.neutralDark}
                 type="button"
                 onClick={handleQuickView}
                 aria-label={quickViewButtonDescription}
                 text={'Quick View'}
+              />
+            ) : (
+              <Button
+                __useDeprecatedTag
+                color={Button.ButtonColor.neutralDark}
+                type="button"
+                href={pathToCourse}
+                aria-label={i18n.quickViewDescription({
+                  course_name: courseDisplayName,
+                })}
+                text={i18n.learnMore()}
               />
             )}
             <Button

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -175,7 +175,7 @@ const CustomizableCurriculumCatalogCard = ({
     }
   };
   const handleQuickView = () => {
-    setIsExpandedCardDisplayed(true);
+    setIsExpandedCardDisplayed(!isExpandedCardDisplayed);
   };
 
   return (

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import style from './expanded_curriculum_catalog_card.module.scss';
+
+const ExpandedCurriculumCatalogCard = () => {
+  return <div className={style.expandedCardContainer}>Expanded Card</div>;
+};
+
+export default ExpandedCurriculumCatalogCard;

--- a/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
@@ -1,7 +1,7 @@
 @use 'sass:math';
 
 .expandedCardContainer {
-  position: relative;
+  position: absolute;
   background-color: #f9f9f9;
   color: #333;
   border: 1px solid #ccc;

--- a/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
@@ -1,0 +1,11 @@
+@use 'sass:math';
+
+.expandedCardContainer {
+  position: relative;
+  background-color: #f9f9f9;
+  color: #333;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 10px;
+  z-index: 1;
+}

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -50,6 +50,7 @@ class DCDOBase < DynamicConfigBase
       'curriculum-launch-skinny-banner': DCDO.get('curriculum-launch-skinny-banner', false),
       'ai-pl-launch-banners': DCDO.get('ai-pl-launch-banners', false),
       'family-name-features': DCDO.get('family-name-features', false),
+      'quick-view': DCDO.get('quick-view', false),
     }
   end
 end


### PR DESCRIPTION
Adds the Quick View Button behind a flag. Also created the Expanded Card component and corresponding scss file.

## Flag set to false (default)

<img width="1792" alt="Screenshot 2023-08-03 at 12 01 23 PM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/4251e6bd-7490-4fff-b816-93c13728039d">

## Flag set to true (Expanded Card Quick View)
<img width="1792" alt="Screenshot 2023-08-03 at 12 17 41 PM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/b9d70323-22d0-4319-a108-aefa448d141a">

## Links


- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-657)

## Testing story
Local Testing



## Follow-up work
I will create a PR which will get the basic information of the Expanded Card working.

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
