### PR TITLE
Lab2: access level properties via levelProperties field

### DIFF
--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -13,7 +13,6 @@ import {
 import {
   AppName,
   Channel,
-  LevelData,
   ProjectManagerStorageType,
   ProjectSources,
   LevelProperties,
@@ -58,12 +57,6 @@ export interface LabState {
   validationState: ValidationState;
   // Level properties for the current level.
   levelProperties: LevelProperties | undefined;
-  // Note: the following properties are derived from levelProperties. We should update components that consume
-  // these to access these fields via levelProperties instead.
-  levelData: LevelData | undefined;
-  hideShareAndRemix: boolean;
-  isProjectLevel: boolean;
-  appName: AppName | undefined;
 }
 
 const initialState: LabState = {
@@ -73,11 +66,7 @@ const initialState: LabState = {
   channel: undefined,
   initialSources: undefined,
   validationState: {...initialValidationState},
-  levelData: undefined,
-  hideShareAndRemix: true,
-  isProjectLevel: false,
   levelProperties: undefined,
-  appName: undefined,
 };
 
 // Thunks
@@ -201,6 +190,13 @@ export const hasPageError = (state: {lab: LabState}) => {
   return state.lab.pageError !== undefined;
 };
 
+// If the share and remix buttons should be hidden for the lab. Defaults to true (hidden)
+// if not specified.
+export const shouldHideShareAndRemix = (state: {lab: LabState}): boolean => {
+  const hideShareAndRemix = state.lab.levelProperties?.hideShareAndRemix;
+  return hideShareAndRemix === undefined ? true : hideShareAndRemix;
+};
+
 const labSlice = createSlice({
   name: 'lab',
   initialState,
@@ -227,7 +223,7 @@ const labSlice = createSlice({
     setValidationState(state, action: PayloadAction<ValidationState>) {
       state.validationState = {...action.payload};
     },
-    // Update the level data and initial sources simultaneously when the level changes.
+    // Update the level properties, initial sources, and channel simultaneously when the level changes.
     // These fields are updated together so that labs receive all updates at once.
     onLevelChange(
       state,
@@ -237,22 +233,6 @@ const labSlice = createSlice({
         initialSources?: ProjectSources;
       }>
     ) {
-      // Set individual properties in the redux store based off of level properties.
-      // TODO: Components should access these via levelProperties directly.
-      const {levelData, appName, hideShareAndRemix, isProjectLevel} =
-        action.payload.levelProperties;
-
-      state.appName = appName;
-      state.levelData = levelData;
-      state.hideShareAndRemix =
-        hideShareAndRemix === undefined
-          ? initialState.hideShareAndRemix
-          : hideShareAndRemix;
-      state.isProjectLevel =
-        isProjectLevel === undefined
-          ? initialState.isProjectLevel
-          : isProjectLevel;
-
       state.channel = action.payload.channel;
       state.levelProperties = action.payload.levelProperties;
       state.initialSources = action.payload.initialSources;

--- a/apps/src/lab2/progress/ProgressContainer.tsx
+++ b/apps/src/lab2/progress/ProgressContainer.tsx
@@ -44,7 +44,7 @@ const ProgressContainer: React.FunctionComponent<ProgressContainerProps> = ({
   );
 
   const levelData = useSelector(
-    (state: {lab: LabState}) => state.lab.levelData
+    (state: {lab: LabState}) => state.lab.levelProperties?.levelData
   );
 
   useEffect(() => {

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -7,7 +7,12 @@
 import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 import Lab2Registry from '../Lab2Registry';
-import {LabState, setUpWithLevel, setUpWithoutLevel} from '../lab2Redux';
+import {
+  LabState,
+  setUpWithLevel,
+  setUpWithoutLevel,
+  shouldHideShareAndRemix,
+} from '../lab2Redux';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {getLevelPropertiesPath} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {ProgressState} from '@cdo/apps/code-studio/progressRedux';
@@ -28,11 +33,9 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
   );
 
   const isStandaloneProjectLevel = useSelector(
-    (state: {lab: LabState}) => state.lab.isProjectLevel
+    (state: {lab: LabState}) => state.lab.levelProperties?.isProjectLevel
   );
-  const hideShareAndRemix = useSelector(
-    (state: {lab: LabState}) => state.lab.hideShareAndRemix
-  );
+  const hideShareAndRemix = useSelector(shouldHideShareAndRemix);
   const loadedChannelId = useSelector(
     (state: {lab: LabState}) => state.lab.channel && state.lab.channel.id
   );

--- a/apps/src/lab2/views/Lab2ShareDialog.tsx
+++ b/apps/src/lab2/views/Lab2ShareDialog.tsx
@@ -11,9 +11,10 @@ import popupWindow from '@cdo/apps/code-studio/popup-window';
 const Lab2ShareDialog: React.FunctionComponent<Lab2ShareDialogProps> = ({
   shareUrl,
 }) => {
-  const isProjectLevel = useSelector(
-    (state: {lab: LabState}) => state.lab.isProjectLevel
-  );
+  const isProjectLevel =
+    useSelector(
+      (state: {lab: LabState}) => state.lab.levelProperties?.isProjectLevel
+    ) || false;
   const appType = useSelector(
     (state: {lab: LabState}) => state.lab.channel?.projectType
   );

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -44,7 +44,7 @@ const appsProperties: {[appName in AppName]?: AppProperties} = {
 
 const LabViewsRenderer: React.FunctionComponent = () => {
   const currentAppName = useSelector(
-    (state: {lab: LabState}) => state.lab.appName
+    (state: {lab: LabState}) => state.lab.levelProperties?.appName
   );
 
   const [appsToRender, setAppsToRender] = useState<AppName[]>([]);

--- a/apps/src/lab2/views/MetricsAdapter.tsx
+++ b/apps/src/lab2/views/MetricsAdapter.tsx
@@ -12,7 +12,9 @@ const MetricsAdapter: React.FunctionComponent = () => {
   const channelId = useSelector(
     (state: {lab: LabState}) => state.lab.channel?.id
   );
-  const appName = useSelector((state: {lab: LabState}) => state.lab.appName);
+  const appName = useSelector(
+    (state: {lab: LabState}) => state.lab.levelProperties?.appName
+  );
   const currentLevelId = useSelector(
     (state: {progress: ProgressState}) =>
       state.progress.currentLevelId || undefined

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -752,10 +752,10 @@ const MusicView = connect(
     currentScriptId: state.progress.scriptId,
     currentlyPlayingBlockIds: getCurrentlyPlayingBlockIds(state),
     initialSources: state.lab.initialSources,
-    levelData: state.lab.levelData,
+    levelData: state.lab.levelProperties?.levelData,
     labReadyForReload: state.lab.labReadyForReload,
     isReadOnlyWorkspace: isReadOnlyWorkspace(state),
-    appName: state.lab.appName,
+    appName: state.lab.levelProperties?.appName,
     startingPlayheadPosition: state.music.startingPlayheadPosition,
   }),
   dispatch => ({

--- a/apps/src/standaloneVideo/StandaloneVideo.tsx
+++ b/apps/src/standaloneVideo/StandaloneVideo.tsx
@@ -21,10 +21,10 @@ import styles from './video.module.scss';
 const StandaloneVideo: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
   const levelData = useSelector(
-    (state: {lab: LabState}) => state.lab.levelData
+    (state: {lab: LabState}) => state.lab.levelProperties?.levelData
   );
   const currentAppName = useSelector(
-    (state: {lab: LabState}) => state.lab.appName
+    (state: {lab: LabState}) => state.lab.levelProperties?.appName
   );
 
   const [levelVideo, setLevelVideo] = React.useState<VideoLevelData | null>(


### PR DESCRIPTION
This is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/53127. This updates Lab2 components to access level properties via the levelProperties field in redux, rather than the individual properties on the store, so we're not storing the same information twice.

## Testing story

Tested locally with Music Lab, standalone video, and AI Chat. Confirmed that levels, script levels, project levels, and project beats work correctly, along with sharing/remixing, and AI Chat can access level properties.