### PR TITLE
Change `test` Server's Volume Size

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -520,9 +520,18 @@ Resources:
         # BlockDeviceMappings cannot be modified after instance creation, doing so will DELETE the instance and recreate it.
         # EBS Volume is manually modified via CLI or Console to prevent instance recreation.
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-blockdevicemappings
+        <%
+          # Most of our instances use 64-gigabyte volumes, but we want to use a
+          # slightly larger one for production and a larger one still for test.
+          default_volume_size = 64
+          volume_size_overrides = {
+            production: 128,
+            test: 256
+          }
+        %>
         - DeviceName: /dev/sda1
           Ebs:
-            VolumeSize: <%= rack_env?(:production, :test) ? 128 : 64 %>
+            VolumeSize: <%= volume_size_overrides.fetch(rack_env, default_volume_size) %>
             VolumeType: gp2
       UserData:
         Fn::Base64: !Sub |

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -522,7 +522,7 @@ Resources:
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-blockdevicemappings
         - DeviceName: /dev/sda1
           Ebs:
-            VolumeSize: <%= rack_env?(:production) ? 128 : 64 %>
+            VolumeSize: <%= rack_env?(:production, :test) ? 128 : 64 %>
             VolumeType: gp2
       UserData:
         Fn::Base64: !Sub |


### PR DESCRIPTION
Change from 64 to 256 gigs, mostly just to trigger a replace of the instance to resolve some issues we've been having with this long-standing instance. Note that because the test server has already been manually configured with a volume of this size, we are in effect just resolving some drift with this change rather than actually changing the resources available to the server.

## Testing story

Tested locally with `VERBOSE=1 bundle exec rake stack:validate`

By default:

```
[423]         - DeviceName: /dev/sda1
[424]           Ebs:
[425]             VolumeSize: 64
[426]             VolumeType: gp2
```

With `RAILS_ENV=test`:

```
[434]         - DeviceName: /dev/sda1
[435]           Ebs:
[436]             VolumeSize: 256
[437]             VolumeType: gp2
```

## Deployment strategy & Follow-up work

See https://docs.google.com/document/d/1Mp4Gg4mrnmKuZw9p94OB55jxVMUYVyweBz1tOWyQRBA/edit for more context