### PR TITLE
set up census mapbox CDO variables

### DIFF
--- a/apps/src/sites/code.org/pages/public/yourschool.js
+++ b/apps/src/sites/code.org/pages/public/yourschool.js
@@ -40,6 +40,7 @@ function showYourSchool() {
         teacherApplicationMode={yourschoolElement.data(
           'parameters-teacher-application-mode'
         )}
+        tileset={yourschoolElement.data('parameters-tileset')}
       />
     </Provider>,
     yourschoolElement[0]

--- a/apps/src/templates/census2017/CensusMapReplacement.jsx
+++ b/apps/src/templates/census2017/CensusMapReplacement.jsx
@@ -117,6 +117,7 @@ export default class CensusMapReplacement extends Component {
   static propTypes = {
     onTakeSurveyClick: PropTypes.func.isRequired,
     school: PropTypes.object,
+    tileset: PropTypes.string.isRequired,
   };
 
   map = undefined;
@@ -205,15 +206,15 @@ export default class CensusMapReplacement extends Component {
     var _this = this;
 
     this.map.on('load', function () {
-      _this.map.addSource('censustiles', {
+      _this.map.addSource(_this.props.tileset, {
         type: 'vector',
-        url: 'mapbox://codeorg.censustiles',
+        url: `mapbox://codeorg.${_this.props.tileset}`,
       });
 
       _this.map.addLayer({
         id: 'census-schools',
         type: 'circle',
-        source: 'censustiles',
+        source: _this.props.tileset,
         'source-layer': 'census',
         layout: {
           visibility: 'visible',
@@ -241,7 +242,7 @@ export default class CensusMapReplacement extends Component {
       _this.map.addLayer({
         id: 'census-schools-teaching-cs',
         type: 'symbol',
-        source: 'censustiles',
+        source: _this.props.tileset,
         'source-layer': 'census',
         layout: {
           'icon-image': 'marker-15-green',
@@ -330,7 +331,7 @@ export default class CensusMapReplacement extends Component {
           return;
         }
         flying = false;
-        const features = _this.map.querySourceFeatures('censustiles', {
+        const features = _this.map.querySourceFeatures(_this.props.tileset, {
           sourceLayer: 'census',
           filter: ['all', ['==', 'school_id', school.nces_id]],
         });

--- a/apps/src/templates/census2017/YourSchool.jsx
+++ b/apps/src/templates/census2017/YourSchool.jsx
@@ -23,6 +23,7 @@ class YourSchool extends Component {
     hideMap: PropTypes.bool,
     currentCensusYear: PropTypes.number,
     teacherApplicationMode: PropTypes.string,
+    tileset: PropTypes.string.isRequired,
   };
 
   state = {
@@ -114,6 +115,7 @@ class YourSchool extends Component {
             <CensusMapReplacement
               school={schoolForMap}
               onTakeSurveyClick={this.handleTakeSurveyClick}
+              tileset={this.props.tileset}
             />
           </div>
         )}

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -168,7 +168,9 @@ gdrive_export_secret:     !Secret
 
 # Mapbox
 mapbox_upload_token:
+mapbox_upload_tileset:
 mapbox_access_token:      !Secret
+mapbox_access_tileset:    'censustiles'
 
 # Crowdin
 crowdin_codeorg_api_key:

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -69,3 +69,6 @@ jwks_data:
 jwk_private_key_data:
 
 openai_chat_completion_api_key: ''
+
+# Mapbox
+mapbox_upload_tileset:    'censustiles-dev'

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -38,3 +38,7 @@ imm_reader_subdomain:     'cdo-immersive-reader-prod'
 
 # General CDO Amplitude key
 cdo_amplitude_api_key: !Secret
+
+# Mapbox
+mapbox_upload_tileset:    'censustiles'
+mapbox_access_tileset:    'censustiles'

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -41,4 +41,5 @@ cdo_amplitude_api_key: !Secret
 
 # Mapbox
 mapbox_upload_tileset:    'censustiles'
+mapbox_upload_token:      !Secret
 mapbox_access_tileset:    'censustiles'

--- a/pegasus/sites.v3/code.org/public/yourschool.haml
+++ b/pegasus/sites.v3/code.org/public/yourschool.haml
@@ -29,6 +29,7 @@ social:
 - census_announcement['locale'] = request.locale
 - teacher_application_mode  = DCDO.get("teacher_application_mode", CDO.default_teacher_application_mode)
 - census_announcement['teacher_application_mode'] = teacher_application_mode
+- census_announcement['tileset'] = CDO.mapbox_access_tileset
 
 = inline_css 'trophy_announcement_sparkle.css'
 


### PR DESCRIPTION
Starts https://codedotorg.atlassian.net/browse/ACQ-385. The main reason for this PR was to allow developers to upload non-production datasets to mapbox, so that we can test changes to mapbox data before they go live. however a few other side tasks got pulled in. See commit list for details.

Note that nothing is depending on `CDO.mapbox_upload_tileset` yet, because the code which would use it was removed from [bin/cron/update_census_mapbox](https://github.com/code-dot-org/code-dot-org/blob/80777d646a9351de59404fbd173c67799c43dbda/bin/cron/update_census_mapbox) in [PR 50176](https://github.com/code-dot-org/code-dot-org/pull/50176).

The config param values should now look like this:

variable name | production value | development value | other envs
-- | -- | -- | --
mapbox_upload_token | !Secret | - | -
mapbox_upload_tileset | censustiles | censustiles-dev | -
mapbox_access_token | !Secret | !Secret | !Secret
mapbox_access_tileset | censustiles | censustiles | censustiles

once `bin/cron/update_census_mapbox` is restored, developers will have to do the following steps to upload mapbox data locally:
1. set `CDO.mapbox_upload_token`
2. run `bin/cron/update_census_mapbox` (to be moved out of `cron`)
3. set  `CDO.mapbox_access_tileset` to `censustiles-dev` in order to see the results

## Testing story

Manually verified that the yourschool page still renders the schools on the map correctly, and that the `tileset` prop is correctly set on `CensusMapReplacement`.

## Follow-up work

* restore `bin/cron/update_census_mapbox` and start using `CDO.mapbox_upload_tileset`
* once this PR ships, remove `mapbox_upload_token` secret from chef