### PR TITLE
Enable workshop admins to update scholarship status

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -21,7 +21,7 @@ import {
   UNMATCHED_PARTNER_LABEL,
 } from '../components/regional_partner_dropdown';
 import ConfirmationDialog from '../components/confirmation_dialog';
-import {ScholarshipDropdown} from '../components/scholarshipDropdown';
+import ScholarshipDropdown from '../components/scholarshipDropdown';
 import {
   LabelOverrides as TeacherLabelOverrides,
   PageLabels as TeacherPageLabelsOverrides,

--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -3,29 +3,30 @@ import React from 'react';
 import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import Select from 'react-select';
 
-// update this to lock scholarships so that scholarship status can't be updated via the UI.
-const locked = false;
+const ScholarshipDropdown = ({
+  scholarshipStatus,
+  dropdownOptions,
+  onChange,
+  disabled,
+  isWorkshopAdmin,
+}) => (
+  <FormGroup>
+    <Select
+      clearable={false}
+      value={scholarshipStatus}
+      onChange={onChange}
+      options={dropdownOptions}
+      disabled={!isWorkshopAdmin || disabled}
+    />
+  </FormGroup>
+);
 
-export class ScholarshipDropdown extends React.Component {
-  static propTypes = {
-    scholarshipStatus: PropTypes.string,
-    dropdownOptions: PropTypes.array,
-    onChange: PropTypes.func,
-    disabled: PropTypes.bool,
-    isWorkshopAdmin: PropTypes.bool.isRequired,
-  };
+ScholarshipDropdown.propTypes = {
+  scholarshipStatus: PropTypes.string,
+  dropdownOptions: PropTypes.array,
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool,
+  isWorkshopAdmin: PropTypes.bool.isRequired,
+};
 
-  render() {
-    return (
-      <FormGroup>
-        <Select
-          clearable={false}
-          value={this.props.scholarshipStatus}
-          onChange={this.props.onChange}
-          options={this.props.dropdownOptions}
-          disabled={locked || this.props.disabled}
-        />
-      </FormGroup>
-    );
-  }
-}
+export default ScholarshipDropdown;

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -5,7 +5,7 @@ import {Button, Table} from 'react-bootstrap'; // eslint-disable-line no-restric
 import ConfirmationDialog from '../../components/confirmation_dialog';
 import {enrollmentShape} from '../types';
 import {workshopEnrollmentStyles as styles} from '../workshop_enrollment_styles';
-import {ScholarshipDropdown} from '../../components/scholarshipDropdown';
+import ScholarshipDropdown from '../../components/scholarshipDropdown';
 import Spinner from '../../components/spinner';
 import {WorkshopAdmin, ProgramManager} from '../permission';
 import {CourseSpecificScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfoConstants';


### PR DESCRIPTION
We want workshop admins to be able to update scholarship status: this PR does that. Since it's such a simple component, I went ahead and made it a functional component.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested this manually:
<img width="930" alt="Screenshot 2023-08-09 at 10 15 32 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/967ba1f8-5d3d-4b38-97bb-73f86dab26bf">
<img width="905" alt="Screenshot 2023-08-09 at 10 15 13 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/8d82297a-ee27-42d4-956b-30522af8c56b">

The tests we do have in the DetailView changes the prop directly, even when it should not have been possible to change this value because the scholarship status was locked (a common code smell working with enzyme?):
https://github.com/code-dot-org/code-dot-org/blob/1bf126d02054bbbd642a8f3a970d78ba5bf8ddf2/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js#L432-L433

I tried to fix these, but it wasn't working. That work is tracked here: https://codedotorg.atlassian.net/browse/ACQ-787

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
