### PR TITLE
P20-338: Fix Blockly#failure_message_override translation

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -64,7 +64,7 @@ module I18n
           bubble_choice_description
           short_instructions
           long_instructions
-          failure_message_override
+          failure_message_overrides
           teacher_markdown
           placeholder
           title

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -64,7 +64,7 @@ module I18n
           bubble_choice_description
           short_instructions
           long_instructions
-          failure_message_overrides
+          failure_message_override
           teacher_markdown
           placeholder
           title

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -463,8 +463,12 @@ class Blockly < Level
     end
   end
 
+  # due to some circumstances we refer to the property `failure_message_override` in the plural form,
+  # the plural form alias was added in order not to break the existing i18n business logic and existing translations
+  alias_attribute :failure_message_overrides, :failure_message_override
+
   def localized_failure_message_override
-    get_localized_property('failure_message_override')
+    get_localized_property("failure_message_overrides")
   end
 
   def localized_long_instructions

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -464,7 +464,7 @@ class Blockly < Level
   end
 
   def localized_failure_message_override
-    get_localized_property("failure_message_overrides")
+    get_localized_property('failure_message_override')
   end
 
   def localized_long_instructions

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -463,12 +463,8 @@ class Blockly < Level
     end
   end
 
-  # due to some circumstances we refer to the property `failure_message_override` in the plural form,
-  # the plural form alias was added in order not to break the existing i18n business logic and existing translations
-  alias_attribute :failure_message_overrides, :failure_message_override
-
   def localized_failure_message_override
-    get_localized_property("failure_message_overrides")
+    get_localized_property('failure_message_override')
   end
 
   def localized_long_instructions

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -456,7 +456,7 @@ class Blockly < Level
     if should_localize? && try(property_name)
       I18n.t(
         name,
-        scope: [:data, property_name.pluralize],
+        scope: [:data, property_name],
         default: nil,
         smart: true
       )

--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -1259,7 +1259,7 @@ class BlocklyTest < ActiveSupport::TestCase
 
     I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_overrides'], default: nil, smart: true).once.returns('expected-blockly-level-property-translation')
 
-    assert_equal 'expected-blockly-level-property-translation', level.get_localized_property('failure_message_overrides')
+    assert_equal 'expected-blockly-level-property-translation', level.get_localized_property('failure_message_override')
   end
 
   test 'get_localized_property returns nil when level should not be localized' do
@@ -1269,7 +1269,7 @@ class BlocklyTest < ActiveSupport::TestCase
 
     I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_overrides'], default: nil, smart: true).never
 
-    assert_nil level.get_localized_property('failure_message_overrides')
+    assert_nil level.get_localized_property('failure_message_override')
   end
 
   test 'get_localized_property returns nil when value is nil' do
@@ -1279,13 +1279,13 @@ class BlocklyTest < ActiveSupport::TestCase
 
     I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_overrides'], default: nil, smart: true).never
 
-    assert_nil level.get_localized_property('failure_message_overrides')
+    assert_nil level.get_localized_property('failure_message_override')
   end
 
   test 'localized_failure_message_override returns failure_message_override property translation' do
     level = Blockly.new
 
-    level.expects(:get_localized_property).with('failure_message_overrides').once.returns('expected_failure_message_override_translation')
+    level.expects(:get_localized_property).with('failure_message_override').once.returns('expected_failure_message_override_translation')
 
     assert_equal 'expected_failure_message_override_translation', level.localized_failure_message_override
   end

--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -1259,7 +1259,7 @@ class BlocklyTest < ActiveSupport::TestCase
 
     I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_overrides'], default: nil, smart: true).once.returns('expected-blockly-level-property-translation')
 
-    assert_equal 'expected-blockly-level-property-translation', level.get_localized_property('failure_message_override')
+    assert_equal 'expected-blockly-level-property-translation', level.get_localized_property('failure_message_overrides')
   end
 
   test 'get_localized_property returns nil when level should not be localized' do
@@ -1269,7 +1269,7 @@ class BlocklyTest < ActiveSupport::TestCase
 
     I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_overrides'], default: nil, smart: true).never
 
-    assert_nil level.get_localized_property('failure_message_override')
+    assert_nil level.get_localized_property('failure_message_overrides')
   end
 
   test 'get_localized_property returns nil when value is nil' do
@@ -1279,13 +1279,13 @@ class BlocklyTest < ActiveSupport::TestCase
 
     I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_overrides'], default: nil, smart: true).never
 
-    assert_nil level.get_localized_property('failure_message_override')
+    assert_nil level.get_localized_property('failure_message_overrides')
   end
 
   test 'localized_failure_message_override returns failure_message_override property translation' do
     level = Blockly.new
 
-    level.expects(:get_localized_property).with('failure_message_override').once.returns('expected_failure_message_override_translation')
+    level.expects(:get_localized_property).with('failure_message_overrides').once.returns('expected_failure_message_override_translation')
 
     assert_equal 'expected_failure_message_override_translation', level.localized_failure_message_override
   end

--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -1257,7 +1257,7 @@ class BlocklyTest < ActiveSupport::TestCase
 
     level.stubs(:should_localize?).returns(true)
 
-    I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_overrides'], default: nil, smart: true).once.returns('expected-blockly-level-property-translation')
+    I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_override'], default: nil, smart: true).once.returns('expected-blockly-level-property-translation')
 
     assert_equal 'expected-blockly-level-property-translation', level.get_localized_property('failure_message_override')
   end
@@ -1267,7 +1267,7 @@ class BlocklyTest < ActiveSupport::TestCase
 
     level.stubs(:should_localize?).returns(false)
 
-    I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_overrides'], default: nil, smart: true).never
+    I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_override'], default: nil, smart: true).never
 
     assert_nil level.get_localized_property('failure_message_override')
   end
@@ -1277,7 +1277,7 @@ class BlocklyTest < ActiveSupport::TestCase
 
     level.stubs(:should_localize?).returns(true)
 
-    I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_overrides'], default: nil, smart: true).never
+    I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_override'], default: nil, smart: true).never
 
     assert_nil level.get_localized_property('failure_message_override')
   end

--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -1251,4 +1251,42 @@ class BlocklyTest < ActiveSupport::TestCase
     expected_output = '<div><button id="leftBottomButton"></button><label>Outfit Picker</label></div>'
     assert_equal expected_output, localized_start_html
   end
+
+  test 'get_localized_property returns property translation when level should be localized' do
+    level = Blockly.new(name: 'expected-blockly-level', failure_message_override: 'expected_failure_message_override')
+
+    level.stubs(:should_localize?).returns(true)
+
+    I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_overrides'], default: nil, smart: true).once.returns('expected-blockly-level-property-translation')
+
+    assert_equal 'expected-blockly-level-property-translation', level.get_localized_property('failure_message_override')
+  end
+
+  test 'get_localized_property returns nil when level should not be localized' do
+    level = Blockly.new(name: 'expected-blockly-level', failure_message_override: 'expected_failure_message_override')
+
+    level.stubs(:should_localize?).returns(false)
+
+    I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_overrides'], default: nil, smart: true).never
+
+    assert_nil level.get_localized_property('failure_message_override')
+  end
+
+  test 'get_localized_property returns nil when value is nil' do
+    level = Blockly.new(name: 'expected-blockly-level', failure_message_override: nil)
+
+    level.stubs(:should_localize?).returns(true)
+
+    I18n.expects(:t).with('expected-blockly-level', scope: [:data, 'failure_message_overrides'], default: nil, smart: true).never
+
+    assert_nil level.get_localized_property('failure_message_override')
+  end
+
+  test 'localized_failure_message_override returns failure_message_override property translation' do
+    level = Blockly.new
+
+    level.expects(:get_localized_property).with('failure_message_override').once.returns('expected_failure_message_override_translation')
+
+    assert_equal 'expected_failure_message_override_translation', level.localized_failure_message_override
+  end
 end


### PR DESCRIPTION
We tried to translate the non-existent Blockly property `failure_message_overrides` instead of `failure_message_override`

## Links
- jira ticket: [P20-338](https://codedotorg.atlassian.net/browse/P20-338)

## PR Checklist:
- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
