### PR TITLE
Explicitly Install `ruby-build` Dependencies

### DIFF
--- a/cookbooks/cdo-ruby/recipes/ruby-build.rb
+++ b/cookbooks/cdo-ruby/recipes/ruby-build.rb
@@ -23,6 +23,9 @@ execute 'install ruby-build' do
   not_if "which ruby-build && ruby-build --version | grep --quiet --fixed-strings 'ruby-build #{RUBY_BUILD_VERSION}'"
 end
 
+# Install dependencies require for ruby-build to succeed
+apt_package %w(zlib1g-dev)
+
 execute 'install ruby with ruby build' do
   # Target /usr/local; it might make sense to install ruby itself to /usr as
   # our old apt approach did, but the directory we target here is also the one


### PR DESCRIPTION
`ruby-build` requires `libz` to be installed in order for the "install ruby with ruby build" step to succeed. We install that library in [another cookbook](https://github.com/code-dot-org/code-dot-org/blob/34175761b482c6a4df605c1823389a04e431d79c/cookbooks/cdo-tippecanoe/recipes/default.rb#L1), which presumably is why this has not been an issue on any of our persistent managed servers, but don't install it before building ruby on a new server.

It's not clear why this has not been a problem on adhocs.

## Testing story

Tested manually on the new test server instance that we're trying to start up. Running the chef build failed on a new server with `crypto/comp/c_zlib.c:35:11: fatal error: zlib.h: No such file or directory`; we then manually installed the dependency with `sudo apt-get install libz-dev` and reran the chef build. The chef build then progressed all the way building dashboard assets, at which point we killed it so we could merge this PR before it got too late in the day.

## Follow-up work

After this is merged, we will want to again delete the `test` Client and Node in Chef so they can be recreated by the cloudformation template:

```
knife client delete test
knife node delete test
```

Then before reopening staging, we'll want to verify that the client has been recreated correctly and also recreate the node with `knife node from file` since we expect that one to _not_ get recreated correctly.