### PR TITLE
Refactor music instructions for lab2

### DIFF
--- a/apps/src/code-studio/progressReduxSelectors.js
+++ b/apps/src/code-studio/progressReduxSelectors.js
@@ -251,6 +251,17 @@ export const nextLevelId = state => {
   return nextLevel.id;
 };
 
+export const levelCount = state => {
+  if (getProgressLevelType(state) === ProgressLevelType.LEVEL) {
+    return 1;
+  }
+  if (getProgressLevelType(state) === ProgressLevelType.SCRIPT_LEVEL) {
+    return levelsForLessonId(state.progress, state.progress.currentLessonId)
+      .length;
+  }
+  return 0;
+};
+
 export const lessonExtrasUrl = (state, lessonId) =>
   state.lessonExtrasEnabled
     ? state.lessons.find(lesson => lesson.id === lessonId)

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -36,13 +36,7 @@ import {
   setUndoStatus,
 } from '../redux/musicRedux';
 import KeyHandler from './KeyHandler';
-import {navigateToNextLevel} from '@cdo/apps/code-studio/progressRedux';
-import {
-  levelsForLessonId,
-  ProgressLevelType,
-  getProgressLevelType,
-  currentLevelIndex,
-} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {currentLevelIndex} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {
   isReadOnlyWorkspace,
   setIsLoading,
@@ -69,7 +63,6 @@ import HeaderButtons from './HeaderButtons';
  */
 class UnconnectedMusicView extends React.Component {
   static propTypes = {
-    progressLevelType: PropTypes.string,
     appConfig: PropTypes.object,
 
     /**
@@ -80,7 +73,6 @@ class UnconnectedMusicView extends React.Component {
 
     // populated by Redux
     currentLevelIndex: PropTypes.number,
-    levels: PropTypes.array,
     userId: PropTypes.number,
     userType: PropTypes.string,
     signInState: PropTypes.oneOf(Object.values(SignInState)),
@@ -106,7 +98,6 @@ class UnconnectedMusicView extends React.Component {
     initialSources: PropTypes.object,
     levelData: PropTypes.object,
     startingPlayheadPosition: PropTypes.number,
-    navigateToNextLevel: PropTypes.func,
     isReadOnlyWorkspace: PropTypes.bool,
     updateLoadProgress: PropTypes.func,
     appName: PropTypes.string,
@@ -296,38 +287,6 @@ class UnconnectedMusicView extends React.Component {
     this.props.setIsLoading(false);
   };
 
-  // Returns whether we just have a single level.
-  isSingleLevel = () => {
-    return this.props.progressLevelType === ProgressLevelType.LEVEL;
-  };
-
-  // Returns whether we have multiple levels.
-  isScriptLevel = () => {
-    return this.props.progressLevelType === ProgressLevelType.SCRIPT_LEVEL;
-  };
-
-  getLevelCount = () => {
-    if (!this.hasProgression()) {
-      return 0;
-    }
-
-    // Determine the level count from the external array of levels.
-    if (this.isScriptLevel()) {
-      return this.props.levels.length;
-    }
-
-    // This must be a single level.
-    return 1;
-  };
-
-  // Returns whether we have a progression.
-  // Note that even a single level has a progression in the sense that we
-  // will show instructions and feedback, but we'll only show them for that
-  // single level.
-  hasProgression = () => {
-    return this.isSingleLevel() || this.isScriptLevel();
-  };
-
   getIsPlaying = () => {
     return this.props.isPlaying;
   };
@@ -338,11 +297,6 @@ class UnconnectedMusicView extends React.Component {
 
   getCurrentPlayheadPosition = () => {
     return this.player.getCurrentPlayheadPosition();
-  };
-
-  // When the user initiates going to the next panel in the app.
-  onNextPanel = () => {
-    this.props.navigateToNextLevel();
   };
 
   updateHighlightedBlocks = () => {
@@ -357,7 +311,7 @@ class UnconnectedMusicView extends React.Component {
   };
 
   getStartSources = () => {
-    if (this.hasProgression() && this.props.levelData) {
+    if (!this.props.inIncubator && this.props.levelData?.startSources) {
       return this.props.levelData.startSources;
     } else {
       const startSourcesFilename = 'startSources' + getBlockMode();
@@ -588,10 +542,6 @@ class UnconnectedMusicView extends React.Component {
           hideHeaders={this.props.hideHeaders}
         >
           <Instructions
-            progressionStep={this.props.levelData}
-            currentLevelIndex={this.props.currentLevelIndex}
-            levelCount={this.getLevelCount()}
-            onNextPanel={this.onNextPanel}
             baseUrl={baseAssetUrl}
             vertical={position !== InstructionsPositions.TOP}
             right={position === InstructionsPositions.RIGHT}
@@ -709,17 +659,7 @@ class UnconnectedMusicView extends React.Component {
 
 const MusicView = connect(
   state => ({
-    // The progress redux store tells us whether we are in a script level
-    // or a single level.
-    progressLevelType: getProgressLevelType(state),
-
     currentLevelIndex: currentLevelIndex(state),
-
-    // When we are in a lesson with multiple levels, they are here.
-    levels:
-      getProgressLevelType(state) === ProgressLevelType.SCRIPT_LEVEL
-        ? levelsForLessonId(state.progress, state.progress.currentLessonId)
-        : undefined,
 
     userId: state.currentUser.userId,
     userType: state.currentUser.userType,
@@ -756,7 +696,6 @@ const MusicView = connect(
       dispatch(addOrderedFunctions(orderedFunctions)),
     setIsLoading: isLoading => dispatch(setIsLoading(isLoading)),
     setPageError: pageError => dispatch(setPageError(pageError)),
-    navigateToNextLevel: () => dispatch(navigateToNextLevel()),
     updateLoadProgress: value => dispatch(setSoundLoadingProgress(value)),
     setUndoStatus: value => dispatch(setUndoStatus(value)),
   })

--- a/apps/src/music/views/instructions.module.scss
+++ b/apps/src/music/views/instructions.module.scss
@@ -1,10 +1,11 @@
-@import "color.scss";
-@import "./music-view.module.scss";
+@import 'color.scss';
+@import './music-view.module.scss';
 
 @keyframes slidein {
   from {
     opacity: 0;
-    margin-top: 20px; }
+    margin-top: 20px;
+  }
   to {
     opacity: 1;
     margin-top: 0;
@@ -128,14 +129,14 @@
     .markdownText {
       line-height: 0;
 
-      h1, h2 {
+      h1,
+      h2 {
         margin: 0 0 10px 0;
         line-height: 1.2em;
-        color: $neutral_light;
       }
 
       ol {
-        line-height: 0
+        line-height: 0;
       }
 
       li {

--- a/dashboard/app/views/levels/editors/_music.html.haml
+++ b/dashboard/app/views/levels/editors/_music.html.haml
@@ -1,4 +1,3 @@
-= render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/music_level_data', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_music.html.haml
+++ b/dashboard/app/views/levels/editors/_music.html.haml
@@ -1,3 +1,4 @@
+= render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/music_level_data', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/config/scripts/levels/musiclab_make_a_mix.level
+++ b/dashboard/config/scripts/levels/musiclab_make_a_mix.level
@@ -2,13 +2,14 @@
   <config><![CDATA[{
   "published": true,
   "game_id": 70,
-  "created_at": "2023-06-22T20:17:57.000Z",
+  "created_at": "2023-08-04T05:25:28.000Z",
   "level_num": "custom",
   "user_id": 976,
   "properties": {
     "encrypted": "false",
     "level_data": {
       "library": "happy",
+      "title": "Title Here!",
       "text": "# Let's Make a Mix\nNow it's time to make your first mix! You have the basic ingredients - including a new `lead`(#509919) function that you can use to make a full song.\n##Do This\nIn the toolbox, you'll notice a few new blocks: the \"play random\" block, which plays one of the blocks inside it at random each time it's played, and some `effect`(#7435b2) blocks that let you change the sound of each function.\nWhat can you make with these new tools?",
       "startSources": {
         "variables": [
@@ -266,9 +267,11 @@
       }
     },
     "hide_share_and_remix": "false",
+    "instructions_important": "false",
+    "long_instructions": "# Let's Make a Mix\r\nNow it's time to make your first mix! You have the basic ingredients - including a new `lead`(#509919) function that you can use to make a full song.\r\n## Do This\r\nIn the toolbox, you'll notice a few new blocks: the \\\"play random\\\" block, which plays one of the blocks inside it at random each time it's played, and some `effect`(#7435b2) blocks that let you change the sound of each function.\r\nWhat can you make with these new tools?",
     "preload_asset_list": null
   },
-  "audit_log": "[{\"changed_at\":\"2023-06-22T20:17:57.588+00:00\",\"changed\":[\"cloned from \\\"music_lab_2023_5\\\"\"],\"cloned_from\":\"music_lab_2023_5\"},{\"changed_at\":\"2023-06-22 20:36:28 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-06-22 20:40:32 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-05 21:20:45 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-05 21:24:29 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-05 21:30:49 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-13 22:25:04 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-08-01 20:46:39 +0000\",\"changed\":[\"name\"],\"changed_by_id\":574,\"changed_by_email\":\"brendan+levelbuilder@code.org\"}]"
+  "audit_log": "[{\"changed_at\":\"2023-06-22T20:17:57.588+00:00\",\"changed\":[\"cloned from \\\"music_lab_2023_5\\\"\"],\"cloned_from\":\"music_lab_2023_5\"},{\"changed_at\":\"2023-06-22 20:36:28 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-06-22 20:40:32 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-05 21:20:45 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-05 21:24:29 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-05 21:30:49 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-13 22:25:04 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-08-01 20:46:39 +0000\",\"changed\":[\"name\"],\"changed_by_id\":574,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2023-08-07 15:28:51 -0700\",\"changed\":[\"level_data\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2023-08-07 15:31:07 -0700\",\"changed\":[\"level_data\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2023-08-08 10:56:08 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]"
 }]]></config>
   <blocks/>
 </Music>

--- a/dashboard/config/scripts/levels/musiclab_make_a_mix.level
+++ b/dashboard/config/scripts/levels/musiclab_make_a_mix.level
@@ -2,14 +2,13 @@
   <config><![CDATA[{
   "published": true,
   "game_id": 70,
-  "created_at": "2023-08-04T05:25:28.000Z",
+  "created_at": "2023-06-22T20:17:57.000Z",
   "level_num": "custom",
   "user_id": 976,
   "properties": {
     "encrypted": "false",
     "level_data": {
       "library": "happy",
-      "title": "Title Here!",
       "text": "# Let's Make a Mix\nNow it's time to make your first mix! You have the basic ingredients - including a new `lead`(#509919) function that you can use to make a full song.\n##Do This\nIn the toolbox, you'll notice a few new blocks: the \"play random\" block, which plays one of the blocks inside it at random each time it's played, and some `effect`(#7435b2) blocks that let you change the sound of each function.\nWhat can you make with these new tools?",
       "startSources": {
         "variables": [
@@ -267,11 +266,9 @@
       }
     },
     "hide_share_and_remix": "false",
-    "instructions_important": "false",
-    "long_instructions": "# Let's Make a Mix\r\nNow it's time to make your first mix! You have the basic ingredients - including a new `lead`(#509919) function that you can use to make a full song.\r\n## Do This\r\nIn the toolbox, you'll notice a few new blocks: the \\\"play random\\\" block, which plays one of the blocks inside it at random each time it's played, and some `effect`(#7435b2) blocks that let you change the sound of each function.\r\nWhat can you make with these new tools?",
     "preload_asset_list": null
   },
-  "audit_log": "[{\"changed_at\":\"2023-06-22T20:17:57.588+00:00\",\"changed\":[\"cloned from \\\"music_lab_2023_5\\\"\"],\"cloned_from\":\"music_lab_2023_5\"},{\"changed_at\":\"2023-06-22 20:36:28 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-06-22 20:40:32 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-05 21:20:45 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-05 21:24:29 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-05 21:30:49 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-13 22:25:04 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-08-01 20:46:39 +0000\",\"changed\":[\"name\"],\"changed_by_id\":574,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2023-08-07 15:28:51 -0700\",\"changed\":[\"level_data\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2023-08-07 15:31:07 -0700\",\"changed\":[\"level_data\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2023-08-08 10:56:08 -0700\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]"
+  "audit_log": "[{\"changed_at\":\"2023-06-22T20:17:57.588+00:00\",\"changed\":[\"cloned from \\\"music_lab_2023_5\\\"\"],\"cloned_from\":\"music_lab_2023_5\"},{\"changed_at\":\"2023-06-22 20:36:28 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-06-22 20:40:32 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-05 21:20:45 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-05 21:24:29 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-05 21:30:49 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-07-13 22:25:04 +0000\",\"changed\":[\"level_data\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2023-08-01 20:46:39 +0000\",\"changed\":[\"name\"],\"changed_by_id\":574,\"changed_by_email\":\"brendan+levelbuilder@code.org\"}]"
 }]]></config>
   <blocks/>
 </Music>


### PR DESCRIPTION
This is a refactor for moving the new instructions component out of music lab and into the set of generic components for Lab2. This doesn't change any functionality; I just moved all of the data that the instructions panel needs into the instructions component, rather than having MusicView pass through those fields, since they're nearly all derived from Lab2 state anyway. I also split the instructions component into a wrapper that pulls the correct properties from Lab2, and a view component that just renders the view given the inputs, in case we want to use the instructions panel view outside of the lab2 context for any reason.

As a follow-up, I will move these classes to the Lab2 directory and convert them to typescript.

## Links

https://codedotorg.atlassian.net/browse/SL-1056

## Testing story

Tested locally on music lab levels with progressions.