### PR TITLE
Prevent locked out child from entering their own email as their parent's email

### DIFF
--- a/apps/src/sites/studio/pages/sessions/lockout.js
+++ b/apps/src/sites/studio/pages/sessions/lockout.js
@@ -15,6 +15,7 @@ $(document).ready(function () {
       deleteDate={
         new Date(Date.parse(element.getAttribute('data-delete-date')))
       }
+      studentEmail={element.getAttribute('data-student-email')}
     />,
     element
   );

--- a/apps/src/templates/sessions/LockoutPanel.jsx
+++ b/apps/src/templates/sessions/LockoutPanel.jsx
@@ -8,6 +8,7 @@ import cookies from 'js-cookie';
 import * as color from '../../util/color';
 import headerImage from './images/lockout_penguin.png';
 import headerThanksImage from './images/dancing_penguin.png';
+import {hashString} from '../../utils';
 
 /**
  * This panel represents the page that is displayed to accounts that are being
@@ -16,14 +17,20 @@ import headerThanksImage from './images/dancing_penguin.png';
  * pending request for) parental permission.
  */
 export default function LockoutPanel(props) {
+  const validateEmail = email => {
+    return isEmail(email) && props.studentEmail !== hashString(email);
+  };
+
   // Set the disabled state of the submit button based on the validity of the
   // email in the field.
-  const [disabled, setDisabled] = useState(() => !isEmail(props.pendingEmail));
+  const [disabled, setDisabled] = useState(
+    () => !validateEmail(props.pendingEmail)
+  );
 
   // When the email field is updated, also update the disability state of the
   // submit button.
   const onEmailUpdate = event => {
-    setDisabled(!isEmail(event.target.value));
+    setDisabled(!validateEmail(event.target.value));
   };
 
   // This will set the email to the current pending email and fire off the
@@ -220,6 +227,7 @@ LockoutPanel.propTypes = {
   deleteDate: PropTypes.instanceOf(Date).isRequired,
   pendingEmail: PropTypes.string,
   requestDate: PropTypes.instanceOf(Date),
+  studentEmail: PropTypes.string.isRequired,
 };
 
 const styles = {

--- a/apps/src/templates/sessions/LockoutPanel.story.jsx
+++ b/apps/src/templates/sessions/LockoutPanel.story.jsx
@@ -12,6 +12,7 @@ const Template = args => (
   <LockoutPanel
     apiURL="/permissions"
     deleteDate={new Date(Date.now() + 6 * DAYS)}
+    studentEmail="student@test.com"
     {...args}
   />
 );

--- a/dashboard/app/controllers/policy_compliance_controller.rb
+++ b/dashboard/app/controllers/policy_compliance_controller.rb
@@ -48,8 +48,10 @@ class PolicyComplianceController < ApplicationController
     end
 
     # Validate that the parent email is not the same as the student email
+    # Also remove any subaddressing from the email to prevent abuse
     parent_email = params.require(:'parent-email')
-    if current_user.hashed_email == Digest::MD5.hexdigest(parent_email)
+    sanitized_parent_email = parent_email.sub(/\+[^@]+@/, '@')
+    if current_user.hashed_email == Digest::MD5.hexdigest(sanitized_parent_email)
       redirect_back fallback_location: lockout_path and return
     end
 

--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -65,6 +65,7 @@ class SessionsController < Devise::SessionsController
     # Basic defaults. If the @pending_email is empty, the request was never sent
     @pending_email = ''
     @request_date = DateTime.now
+    @student_email = current_user.hashed_email
 
     # Determine the deletion date as the creation time of the account + 7 days
     @delete_date = current_user.created_at.since(7.days)

--- a/dashboard/app/views/sessions/lockout.html.haml
+++ b/dashboard/app/views/sessions/lockout.html.haml
@@ -7,6 +7,7 @@
       action: :child_account_consent,
       controller: :policy_compliance
     ),
+    student_email: @student_email,
   }
 }
 

--- a/dashboard/test/controllers/policy_compliance_controller_test.rb
+++ b/dashboard/test/controllers/policy_compliance_controller_test.rb
@@ -78,6 +78,19 @@ class PolicyComplianceControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "if a user enters their own email as their parent email, should just redirect back" do
+    user = create(:young_student, :without_parent_permission, email: 'test@studentemail.com')
+    sign_in user
+
+    assert_emails 0 do
+      post '/policy_compliance/child_account_consent', params:
+        {
+          'parent-email': 'test@studentemail.com',
+        }
+      assert_redirected_to lockout_path
+    end
+  end
+
   test "should update user and send an email to the parent upon creating the request" do
     user = create(:young_student, :without_parent_permission
 )

--- a/dashboard/test/controllers/policy_compliance_controller_test.rb
+++ b/dashboard/test/controllers/policy_compliance_controller_test.rb
@@ -91,6 +91,19 @@ class PolicyComplianceControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "if a user enters their own email with a subaddress/plus address, it should redirect back" do
+    user = create(:young_student, :without_parent_permission, email: 'test@studentemail.com')
+    sign_in user
+
+    assert_emails 0 do
+      post '/policy_compliance/child_account_consent', params:
+        {
+          'parent-email': 'test+foo@studentemail.com',
+        }
+      assert_redirected_to lockout_path
+    end
+  end
+
   test "should update user and send an email to the parent upon creating the request" do
     user = create(:young_student, :without_parent_permission
 )

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -84,3 +84,17 @@ Feature: Policy Compliance and Parental Permission
     When I press "lockout-submit"
     Then I wait to see "#lockout-panel-form"
     And element "#parent-email" has value "parent2@example.com"
+
+  Scenario: Student should not be able to enter their own email as their parent's email
+    Given I create a young student in Colorado who has never signed in named "Sally Student" and go home
+
+    # TODO: Can possibly get rid of this when the lockout is redirected on sign in
+    Given I am on "http://studio.code.org/lockout"
+
+    # It should not be a pending request
+    Then I wait to see "#lockout-panel-form"
+    And element "#permission-status" contains text "Not Submitted"
+
+    # Type in the student email as the parent email, which should disable the button
+    And I type the email for "Sally Student" into element "#parent-email"
+    Then element "#lockout-submit" is disabled

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -125,6 +125,12 @@ And(/^I create a (young )?student( in Colorado)?( who has never signed in)? name
   navigate_to replace_hostname('http://studio.code.org') if home
 end
 
+And(/^I type the email for "([^"]*)" into element "([^"]*)"$/) do |name, element|
+  steps <<~GHERKIN
+    And I type "#{@users[name][:email]}" into "#{element}"
+  GHERKIN
+end
+
 And(/^I create a student in the eu named "([^"]*)"$/) do |name|
   create_user(name,
     data_transfer_agreement_required: '1',


### PR DESCRIPTION
A small loophole in the CPA lockout page was that a child could enter their own email as their parent's email, effectively allowing them to bypass the parent permission process.

## Links

[JIRA ticket](https://codedotorg.atlassian.net/browse/P20-300)

## Testing story

Added a UI Sauce Labs test.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
