### PR TITLE
Install `pdftk-java` on Test Server

### DIFF
--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -32,8 +32,7 @@ if %w(staging test adhoc).include?(node.chef_environment)
   pdftk_local_file = "#{Chef::Config[:file_cache_path]}/#{pdftk_file}"
   remote_file pdftk_local_file do
     source "https://mirrors.kernel.org/ubuntu/pool/universe/p/pdftk-java/#{pdftk_file}"
-    # TODO: recalculate
-    # checksum "8a28ba8b100bc0b6e9f3e91c090a9b8a83a5f8a337a91150cbaadad8accb4901"
+    checksum "e14dfd5489e7becb5d825baffc67ce1104e154cd5c8b445e1974ce0397078fdb"
   end
   # Dependencies of pdftk-java.
   apt_package %w(

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -28,11 +28,12 @@ apt_package %w(
 # functionality will work, on test so we can test that functionality, and on
 # adhoc so we can verify that installation continues to work
 if %w(staging test adhoc).include?(node.chef_environment)
-  pdftk_file = 'pdftk-java_3.1.1-1_all.deb'
+  pdftk_file = 'pdftk-java_3.0.9-1_all.deb'
   pdftk_local_file = "#{Chef::Config[:file_cache_path]}/#{pdftk_file}"
   remote_file pdftk_local_file do
     source "https://mirrors.kernel.org/ubuntu/pool/universe/p/pdftk-java/#{pdftk_file}"
-    checksum "8a28ba8b100bc0b6e9f3e91c090a9b8a83a5f8a337a91150cbaadad8accb4901"
+    # TODO: recalculate
+    # checksum "8a28ba8b100bc0b6e9f3e91c090a9b8a83a5f8a337a91150cbaadad8accb4901"
   end
   # Dependencies of pdftk-java.
   apt_package %w(

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -24,8 +24,10 @@ apt_package %w(
   fonts-noto
 )
 
-# Used by lesson plan generator
-if %w(staging test).include?(node.chef_environment)
+# Used by lesson plan generator; we install on staging so the actual
+# functionality will work, on test so we can test that functionality, and on
+# adhoc so we can verify that installation continues to work
+if %w(staging test adhoc).include?(node.chef_environment)
   pdftk_file = 'pdftk-java_3.1.1-1_all.deb'
   pdftk_local_file = "#{Chef::Config[:file_cache_path]}/#{pdftk_file}"
   remote_file pdftk_local_file do

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -25,7 +25,7 @@ apt_package %w(
 )
 
 # Used by lesson plan generator
-if node.chef_environment == 'staging'
+if %w(staging test).include?(node.chef_environment)
   pdftk_file = 'pdftk-java_3.1.1-1_all.deb'
   pdftk_local_file = "#{Chef::Config[:file_cache_path]}/#{pdftk_file}"
   remote_file pdftk_local_file do


### PR DESCRIPTION
Like we do on staging; otherwise, our pegsus tests fail with "Expected 'pdftk' to be installed.", and can't effectively test our PDF generation logic.

Note that the test server previously did have this dependency installed, despite the absense of automatic installation logic. It's not clear exactly how this happened, but we are assuming it was a manual effort.

## Testing story

Going to manually test this on the existing test server by applying the change manually and running `sudo /opt/chef/bin/chef-client`