### PR TITLE
Add AI Rubrics Experiment and Account Setting

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -482,7 +482,7 @@ class RegistrationsController < Devise::RegistrationsController
         :school_id,
         :school_other,
         :school_name,
-        :full_address
+        :full_address,
       ],
       races: [],
     )

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -470,6 +470,7 @@ class RegistrationsController < Devise::RegistrationsController
       :provider,
       :us_state,
       :country_code,
+      :ai_rubrics_disabled,
       school_info_attributes: [
         :country,
         :school_type,
@@ -483,7 +484,7 @@ class RegistrationsController < Devise::RegistrationsController
         :school_name,
         :full_address
       ],
-      races: []
+      races: [],
     )
   end
 

--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -326,4 +326,10 @@ class TestController < ApplicationController
     User.find_by(name: params[:pm_name]).destroy
     head :ok
   end
+
+  def create_pilot
+    name = params.require(:pilot_name)
+    Pilot.create_with(allow_joining_via_url: true, display_name: name).find_or_create_by(name: name)
+    head :ok
+  end
 end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -104,6 +104,7 @@ class User < ApplicationRecord
   #     child account policy.
   #   child_account_compliance_state_last_updated: The date the user became
   #     compliant with our child account policy.
+  #   ai_rubrics_disabled: Turns off AI assessment for a User.
   serialized_attrs %w(
     ops_first_name
     ops_last_name
@@ -140,6 +141,7 @@ class User < ApplicationRecord
     us_state
     country_code
     family_name
+    ai_rubrics_disabled
   )
 
   attr_accessor(

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -137,8 +137,10 @@
       %hr
       %h2= 'AI Settings'
       .field
-        = form.label :ai_rubrics_disabled, 'AI Rubric Assessment Disabled', class: "label-bold"
-        = form.check_box :ai_rubrics_disabled
+        = form.label :ai_rubrics_disabled, class: "label-bold" do
+          = form.check_box :ai_rubrics_disabled
+          %span{style: "position: relative; top: 3px"}
+            = 'Disable AI Rubric Assessment'
       %div= form.submit t('crud.update'), id: 'edit-ai-settings', class: 'btn btn-warning'
 
 - if current_user.migrated?

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -131,7 +131,7 @@
     }
   }
 
-- if experiment_value('ai_rubrics', request)
+- if experiment_value('ai-rubrics', request)
   - if current_user.verified_teacher?
     = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |form|
       %hr

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -131,7 +131,7 @@
     }
   }
 
-- if experiment_value('ai-rubrics', request)
+- if Experiment.enabled?(user: current_user, experiment_name: 'ai-rubrics')
   - if current_user.verified_teacher?
     = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |form|
       %hr

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -135,12 +135,12 @@
   - if current_user.verified_teacher?
     = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |form|
       %hr
-      %h2= 'AI Settings'
+      %h2= t('activerecord.attributes.user.ai_settings_header')
       .field
         = form.label :ai_rubrics_disabled, class: "label-bold" do
           = form.check_box :ai_rubrics_disabled
           %span{style: "position: relative; top: 3px"}
-            = 'Disable AI Rubric Assessment'
+            = t('activerecord.attributes.user.ai_rubrics_disabled')
       %div= form.submit t('crud.update'), id: 'edit-ai-settings', class: 'btn btn-warning'
 
 - if current_user.migrated?

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -131,6 +131,15 @@
     }
   }
 
+- if current_user.teacher?
+  = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |form|
+    %hr
+    %h2= 'AI Settings'
+    .field
+      = form.label :ai_rubrics_disabled, 'AI Rubric Assessment Disabled', class: "label-bold"
+      = form.check_box :ai_rubrics_disabled
+    %div= form.submit t('crud.update'), id: 'edit-ai-settings', class: 'btn btn-warning'
+
 - if current_user.migrated?
   -# Mount point for React ManageLinkedAccounts component.
   %div#manage-linked-accounts

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -131,14 +131,15 @@
     }
   }
 
-- if current_user.teacher?
-  = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |form|
-    %hr
-    %h2= 'AI Settings'
-    .field
-      = form.label :ai_rubrics_disabled, 'AI Rubric Assessment Disabled', class: "label-bold"
-      = form.check_box :ai_rubrics_disabled
-    %div= form.submit t('crud.update'), id: 'edit-ai-settings', class: 'btn btn-warning'
+- if experiment_value('ai_rubrics', request)
+  - if current_user.verified_teacher?
+    = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |form|
+      %hr
+      %h2= 'AI Settings'
+      .field
+        = form.label :ai_rubrics_disabled, 'AI Rubric Assessment Disabled', class: "label-bold"
+        = form.check_box :ai_rubrics_disabled
+      %div= form.submit t('crud.update'), id: 'edit-ai-settings', class: 'btn btn-warning'
 
 - if current_user.migrated?
   -# Mount point for React ManageLinkedAccounts component.

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
         age: 'Age'
         gender: 'Gender'
         edit_header: 'Edit Account Details'
+        ai_settings_header: 'AI Settings'
         finish_sign_up_header: 'Finish creating your account'
         finish_sign_up_header_error: 'Please correct the following errors:'
         finish_sign_up_subheader: 'Fill out the following information to finish creating a Code.org account for <strong>%{email}</strong>.'
@@ -76,6 +77,7 @@ en:
           future: can't be in the future
         user_type: 'Account Type'
         us_state: 'State'
+        ai_rubrics_disabled: 'Disable AI Rubric Assignment'
 
   beta: "beta"
   hello: "Hello world"

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -77,7 +77,7 @@ en:
           future: can't be in the future
         user_type: 'Account Type'
         us_state: 'State'
-        ai_rubrics_disabled: 'Disable AI Rubric Assignment'
+        ai_rubrics_disabled: 'Disable AI Rubric Feature'
 
   beta: "beta"
   hello: "Hello world"

--- a/dashboard/test/ui/features/platform/user_settings.feature
+++ b/dashboard/test/ui/features/platform/user_settings.feature
@@ -1,0 +1,22 @@
+@single_session
+Feature: Updating account settings
+
+# Ensure that the checkbox persists when saved
+# We can, in the future, also peek at the level and see if the AI
+# components are there.
+# We can, in the future, remove the experiment tag guarding the
+# feature.
+Scenario: Teacher wants to disable AI rubrics
+  Given I create a teacher named "Haplo"
+  And I give user "Haplo" authorized teacher permission
+  Given I am on "http://studio.code.org/users/edit?ai-rubrics=1"
+  Then I wait to see "#user_ai_rubrics_disabled"
+  And element "#user_ai_rubrics_disabled" is not checked
+  And I press "#user_ai_rubrics_disabled" using jQuery
+  And element "#user_ai_rubrics_disabled" is checked
+  And I take note of the current loaded page
+  And I press "#edit-ai-settings" using jQuery
+  Then I wait until I am on a different page than I noted before
+  Given I am on "http://studio.code.org/users/edit?ai-rubrics=1"
+  Then I wait to see "#user_ai_rubrics_disabled"
+  And element "#user_ai_rubrics_disabled" is checked

--- a/dashboard/test/ui/features/platform/user_settings.feature
+++ b/dashboard/test/ui/features/platform/user_settings.feature
@@ -7,10 +7,10 @@ Feature: Updating account settings
   # We can, in the future, remove the pilot steps guarding the
   # feature.
   Scenario: Teacher wants to disable AI rubrics
-    Given An administrator logs in and creates the pilot "ai-rubrics"
     Given I create a teacher named "Haplo"
     And I give user "Haplo" authorized teacher permission
-    Given I add the current user to the "ai-rubrics" pilot
+    Given there is a pilot called "ai-rubrics"
+    And I add the current user to the "ai-rubrics" pilot
     Given I am on "http://studio.code.org/users/edit"
     Then I wait to see "#user_ai_rubrics_disabled"
     And element "#user_ai_rubrics_disabled" is not checked

--- a/dashboard/test/ui/features/platform/user_settings.feature
+++ b/dashboard/test/ui/features/platform/user_settings.feature
@@ -1,22 +1,24 @@
 @single_session
 Feature: Updating account settings
 
-# Ensure that the checkbox persists when saved
-# We can, in the future, also peek at the level and see if the AI
-# components are there.
-# We can, in the future, remove the experiment tag guarding the
-# feature.
-Scenario: Teacher wants to disable AI rubrics
-  Given I create a teacher named "Haplo"
-  And I give user "Haplo" authorized teacher permission
-  Given I am on "http://studio.code.org/users/edit?ai-rubrics=1"
-  Then I wait to see "#user_ai_rubrics_disabled"
-  And element "#user_ai_rubrics_disabled" is not checked
-  And I press "#user_ai_rubrics_disabled" using jQuery
-  And element "#user_ai_rubrics_disabled" is checked
-  And I take note of the current loaded page
-  And I press "#edit-ai-settings" using jQuery
-  Then I wait until I am on a different page than I noted before
-  Given I am on "http://studio.code.org/users/edit?ai-rubrics=1"
-  Then I wait to see "#user_ai_rubrics_disabled"
-  And element "#user_ai_rubrics_disabled" is checked
+  # Ensure that the checkbox persists when saved
+  # We can, in the future, also peek at the level and see if the AI
+  # components are there.
+  # We can, in the future, remove the pilot steps guarding the
+  # feature.
+  Scenario: Teacher wants to disable AI rubrics
+    Given An administrator logs in and creates the pilot "ai-rubrics"
+    Given I create a teacher named "Haplo"
+    And I give user "Haplo" authorized teacher permission
+    Given I add the current user to the "ai-rubrics" pilot
+    Given I am on "http://studio.code.org/users/edit"
+    Then I wait to see "#user_ai_rubrics_disabled"
+    And element "#user_ai_rubrics_disabled" is not checked
+    And I press "#user_ai_rubrics_disabled" using jQuery
+    And element "#user_ai_rubrics_disabled" is checked
+    And I take note of the current loaded page
+    And I press "#edit-ai-settings" using jQuery
+    Then I wait until I am on a different page than I noted before
+    Given I am on "http://studio.code.org/users/edit"
+    Then I wait to see "#user_ai_rubrics_disabled"
+    And element "#user_ai_rubrics_disabled" is checked

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -47,8 +47,8 @@ Given(/^I am a (student|teacher)( and go home)?$/) do |user_type, home|
   steps "And I create a #{user_type} named \"#{random_name}\"#{home}"
 end
 
-def generate_user(name, email = nil)
-  email ||= "user#{Time.now.to_i}_#{rand(1_000_000)}@test.xx"
+def generate_user(name)
+  email = "user#{Time.now.to_i}_#{rand(1_000_000)}@test.xx"
   password = name + "password" # hack
   @users ||= {}
   @users[name] = {
@@ -87,7 +87,7 @@ def create_user(name, url: '/users.json', code: 201, **user_opts)
   navigate_to replace_hostname('http://studio.code.org/reset_session')
   Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, tries: 3) do
     # Generate the user
-    email, password = generate_user(name, user_opts[:email])
+    email, password = generate_user(name)
 
     # Set the parent email to the user email, if we see it
     # in the user options (we generate the email, here)
@@ -114,25 +114,6 @@ def create_user(name, url: '/users.json', code: 201, **user_opts)
       code: code
     )
   end
-end
-
-def admin_user
-  require_rails_env
-
-  u = User.find_by(email: 'admin-test@example.com')
-  if u
-    generate_user('admin-test', 'admin-test@example.com')
-  else
-    create_user('admin-test', email: 'admin-test@example.com', user_type: 'teacher', email_preference_opt_in: 'off')
-    u = User.find_by(email: 'admin-test@example.com')
-  end
-
-  unless u.admin
-    u.admin = true
-    u.save!
-  end
-
-  'admin-test'
 end
 
 And(/^I create( as a parent)? a (young )?student( in Colorado)?( who has never signed in)? named "([^"]*)"( and go home)?$/) do |parent_created, young, locked, new_account, name, home|

--- a/dashboard/test/ui/features/step_definitions/experiment_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/experiment_steps.rb
@@ -1,9 +1,3 @@
-def create_pilot(name)
-  require_rails_env
-
-  Pilot.create_with(allow_joining_via_url: true, display_name: name).find_or_create_by(name: name)
-end
-
 When /^I enable the "([^"]*)" course experiment$/ do |experiment_name|
   steps <<-STEPS
     Given I am on "http://studio.code.org/experiments/set_course_experiment/#{experiment_name}"
@@ -16,7 +10,11 @@ end
 
 Given /^there is a pilot called "([^"]*)"$/ do |pilot_name|
   # Create a pilot
-  create_pilot(pilot_name)
+  browser_request(
+    url: '/api/test/create_pilot',
+    method: 'POST',
+    body: {pilot_name: pilot_name}
+  )
 end
 
 And /^I add the current user to the "([^"]*)" pilot$/ do |pilot_name|

--- a/dashboard/test/ui/features/step_definitions/experiment_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/experiment_steps.rb
@@ -1,3 +1,9 @@
+def create_pilot(name)
+  require_rails_env
+
+  Pilot.create_with(allow_joining_via_url: true, display_name: name).find_or_create_by(name: name)
+end
+
 When /^I enable the "([^"]*)" course experiment$/ do |experiment_name|
   steps <<-STEPS
     Given I am on "http://studio.code.org/experiments/set_course_experiment/#{experiment_name}"
@@ -8,24 +14,12 @@ When /^I enable the "([^"]*)" course experiment$/ do |experiment_name|
   STEPS
 end
 
-Given /^An administrator logs in and creates the pilot "([^"]*)"$/ do |pilot_name|
-  # Ensure an admin exists
-  admin = admin_user
-
-  # Log in as the admin and set up the pilot
-  steps <<-STEPS
-    Given I sign in as "#{admin}"
-    Given I am on "http://studio.code.org/admin/pilots"
-    And I take note of the current loaded page
-    When I type "#{pilot_name}" into "#pilot_name"
-    When I type "#{pilot_name}" into "#pilot_display_name"
-    And I press "#pilot_allow_joining_via_url" using jQuery
-    And I press "input[name=commit]" using jQuery
-    Then I wait until I am on a different page than I noted before
-  STEPS
+Given /^there is a pilot called "([^"]*)"$/ do |pilot_name|
+  # Create a pilot
+  create_pilot(pilot_name)
 end
 
-Given /^I add the current user to the "([^"]*)" pilot$/ do |pilot_name|
+And /^I add the current user to the "([^"]*)" pilot$/ do |pilot_name|
   # Use the pilot URL as the logged in user to add themselves
   # to the pilot
   steps <<-STEPS

--- a/dashboard/test/ui/features/step_definitions/experiment_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/experiment_steps.rb
@@ -7,3 +7,28 @@ When /^I enable the "([^"]*)" course experiment$/ do |experiment_name|
     Then element ".alert-success" contains text "You have successfully joined the experiment"
   STEPS
 end
+
+Given /^An administrator logs in and creates the pilot "([^"]*)"$/ do |pilot_name|
+  # Ensure an admin exists
+  admin = admin_user
+
+  # Log in as the admin and set up the pilot
+  steps <<-STEPS
+    Given I sign in as "#{admin}"
+    Given I am on "http://studio.code.org/admin/pilots"
+    And I take note of the current loaded page
+    When I type "#{pilot_name}" into "#pilot_name"
+    When I type "#{pilot_name}" into "#pilot_display_name"
+    And I press "#pilot_allow_joining_via_url" using jQuery
+    And I press "input[name=commit]" using jQuery
+    Then I wait until I am on a different page than I noted before
+  STEPS
+end
+
+Given /^I add the current user to the "([^"]*)" pilot$/ do |pilot_name|
+  # Use the pilot URL as the logged in user to add themselves
+  # to the pilot
+  steps <<-STEPS
+    Given I am on "http://studio.code.org/experiments/set_single_user_experiment/#{pilot_name}"
+  STEPS
+end

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -58,6 +58,8 @@ class HttpCache
     'onetrust_cookie_scripts',
     # Feature flag for the Colorado Privacy Act (CPA)
     'cpa_experience',
+    # Feature flag for enabling AI rubric assessments
+    'ai_rubrics',
     # Page mode, for A/B experiments and feature-flag rollouts.
     'pm'
   ].freeze

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -58,8 +58,6 @@ class HttpCache
     'onetrust_cookie_scripts',
     # Feature flag for the Colorado Privacy Act (CPA)
     'cpa_experience',
-    # Feature flag for enabling AI rubric assessments
-    'ai_rubrics',
     # Page mode, for A/B experiments and feature-flag rollouts.
     'pm'
   ].freeze


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This adds the AI Settings section and a boolean value to turn off the AI rubrics assessment. It is a "disable" setting since the value will be assumed at first to be on. (opt-out)

This is only available to verified teachers.

Uses the `ai-rubrics` experiment value that can be used to obscure the rubrics work unless a verified teacher exists within the pilot of that name.

You can block out such work via an experiment tag (here in some HAML):

```
- if Experiment.enabled?(user: current_user, experiment_name: 'ai-rubrics')
  %p
    This is only seen when the current user is in the ai-rubrics pilot
```

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
- jira ticket: [AITT-82](https://codedotorg.atlassian.net/browse/AITT-82)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Visually:

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/f7c691b3-9354-499a-9f07-0f3ab664debc)

## Deployment strategy

An experiment tag that can be fully turned on via the `DCDO` set experiment functionality. For the pilot, adding verified teachers to the `ai-rubrics` pilot.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
