### PR TITLE
Explicitly Disable `Performance/Detect`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,22 +98,28 @@ Metrics/AbcSize:
 Metrics/BlockNesting:
   Enabled: false
 
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+
+Layout/ExtraSpacing:
+  Enabled: false
+
 Layout/LineLength:
   Enabled: false
 
 Metrics/ModuleLength:
   Enabled: false
 
+# ActiveRecord does not implement a `detect` method and `find` has its own
+# meaning. Correcting ActiveRecord methods with this cop should be considered
+# unsafe, so out of an abundance of caution disable this everywhere.
+Performance/Detect:
+  Enabled: false
+
 Style/AsciiComments:
   Enabled: false
 
 Style/BarePercentLiterals:
-  Enabled: false
-
-Layout/ClosingParenthesisIndentation:
-  Enabled: false
-
-Layout/ExtraSpacing:
   Enabled: false
 
 Style/IdenticalConditionalBranches:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -143,11 +143,6 @@ Naming/MethodParameterName:
 Naming/VariableNumber:
   Enabled: false
 
-# Offense count: 61
-# This cop supports safe auto-correction (--auto-correct).
-Performance/Detect:
-  Enabled: false
-
 # Offense count: 20
 Performance/MethodObjectAsBlock:
   Enabled: false


### PR DESCRIPTION
> This cop is used to identify usages of `select.first`, `select.last`, `find_all.first`, and `find_all.last` and change them to use `detect` instead.
>
> `ActiveRecord` compatibility: `ActiveRecord` does not implement a `detect` method and `find` has its own meaning. Correcting ActiveRecord methods with this cop should be considered unsafe.

Because this cop is unsafe to apply to ActiveRecord methods and because those methods represent the majority of our existing violations of this cop, I think it's safest for us to disable this cop across the whole project. We could alternatively enable it just for directories other than `dashboard`, which for a `Performance/` cop might be justified, but I chose to go with the simpler option.

I also alphabetized our various override entries, since it didn't look like they were ordered intentionally.

What do y'all think?

## Links

- https://www.rubydoc.info/gems/rubocop/0.43.0/RuboCop/Cop/Performance/Detect
- https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancedetect