### PR TITLE
Restricting /lockout to only locked out users

### DIFF
--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -66,7 +66,7 @@ class SessionsController < Devise::SessionsController
 
     # If the user is compliant with the Child Account Policy, redirect them to
     # /home
-    redirect_to '/home' if Policies::ChildAccount.compliant? current_user
+    redirect_to home_path if Policies::ChildAccount.compliant? current_user
 
     # Basic defaults. If the @pending_email is empty, the request was never sent
     @pending_email = ''

--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -1,3 +1,5 @@
+require 'policies/child_account'
+
 class SessionsController < Devise::SessionsController
   include UsersHelper
 
@@ -61,6 +63,10 @@ class SessionsController < Devise::SessionsController
   def lockout
     # If the student isn't signed in, go to the login page
     return redirect_to new_user_session_path unless current_user
+
+    # If the user is compliant with the Child Account Policy, redirect them to
+    # /home
+    redirect_to '/home' if Policies::ChildAccount.compliant? current_user
 
     # Basic defaults. If the @pending_email is empty, the request was never sent
     @pending_email = ''

--- a/dashboard/test/controllers/sessions_controller_test.rb
+++ b/dashboard/test/controllers/sessions_controller_test.rb
@@ -294,4 +294,35 @@ class SessionsControllerTest < ActionController::TestCase
 
     assert @response.cookies["remember_user_token"]
   end
+
+  class Lockout < ActionDispatch::IntegrationTest
+    test 'a compliant user should not be able to visit /lockout' do
+      [
+        [:student],
+        [:teacher],
+        [:locked_out_child, :with_parent_permission],
+      ].each do |traits|
+        user = create(*traits)
+        sign_in user
+
+        get '/lockout'
+
+        assert_redirected_to '/home', "user#{traits} should be redirected to /home"
+      end
+    end
+
+    test 'a non-compliant user should be able to visit /lockout' do
+      [
+        [:locked_out_child],
+        [:locked_out_child, :with_pending_parent_permission],
+      ].each do |traits|
+        user = create(*traits)
+        sign_in user
+
+        get '/lockout'
+
+        assert_response :ok, "user#{traits} can visit /lockout"
+      end
+    end
+  end
 end


### PR DESCRIPTION
During bug bash testing, testers got confused because they would refresh the /lockout page after they got parent permission and the /lockout page reported they were still waiting for parent permission. This happens because the /lockout page is meant to shown to users who do NOT have parent permission. This PR redirects the user away from /lockout if they are not locked out of their account.

## Links
* [JIRA P20-294](https://codedotorg.atlassian.net/browse/P20-294)

## Testing story
* Unit tests
* Manual tests
  * Visit /lockout as a non-locked out student and was redirected
  * Visit /lockout as a locked out student and was NOT redirected.