### PR TITLE
Add a meta description to the maker setup page for use in the Help & Tips tab

### DIFF
--- a/dashboard/app/views/maker/setup.html.haml
+++ b/dashboard/app/views/maker/setup.html.haml
@@ -3,6 +3,10 @@
 %script{src: webpack_asset_path("js/#{js_locale}/applab_locale.js")}
 %script{src: webpack_asset_path('js/maker/setup.js')}
 
+
+- content_for :head do
+  %meta{:name => "description", :content => I18n.t('maker.setup_page_title')}
+
 :css
   .main {
     width: 80%;

--- a/dashboard/app/views/maker/setup.html.haml
+++ b/dashboard/app/views/maker/setup.html.haml
@@ -3,7 +3,7 @@
 %script{src: webpack_asset_path("js/#{js_locale}/applab_locale.js")}
 %script{src: webpack_asset_path('js/maker/setup.js')}
 
-
+- @page_title = I18n.t('maker.setup_page_title')
 - content_for :head do
   %meta{:name => "description", :content => I18n.t('maker.setup_page_title')}
 

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1339,6 +1339,7 @@ en:
       error_invalid_user: 'Invalid user id. Please try logging in again.'
       error_no_code: 'Please enter your login code.'
       confirm_login: 'Select "Confirm" to log in with your Google account.'
+    setup_page_title: 'Maker Setup'
   parent_email_banner:
     text: "**Are you a parent or guardian?** Link your email to this account to stay updated on your child’s progress and projects!"
     link_your_email: "Link your email"


### PR DESCRIPTION
See [this slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1691614169267929). This adds a meta description tag (requested [here](https://github.com/code-dot-org/code-dot-org/blob/3726380c511c45e5bf3c258ac544844d69869d6d/apps/src/templates/instructions/NetworkResourceLink.js#L19C18-L19C18)) to the maker page, so that it can appear in the Help & Tips tab with a title. 

What it looks like in that tab:
<img width="1066" alt="Screenshot 2023-08-10 at 11 05 21 AM" src="https://github.com/code-dot-org/code-dot-org/assets/46464143/13bddf22-3c8e-43cd-8d8c-f47b0e82fa42">


I also set the title of the page to "Maker Setup" because it was easy to do at the same time.
