### PR TITLE
Move music instructions to lab2, convert to typescript

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -95,6 +95,7 @@ export interface LevelProperties {
   disableProjects?: boolean;
   levelData?: LevelData;
   appName: AppName;
+  longInstructions?: string;
 }
 
 // Level configuration data used by project-backed labs that don't require

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -25,6 +25,10 @@ interface InstructionsProps {
 /**
  * Lab2 instructions component. This can be used by any Lab2 lab, and will retrieve
  * all necessary data from the Lab2 redux store.
+ *
+ * Note that currently, this component solely renders instructions, and does not include any features
+ * present on the legacy instructions panel, such as Help & Tips, Documentation, Code Review,
+ * For Teachers Only, etc.
  */
 const Instructions: React.FunctionComponent<InstructionsProps> = ({
   baseUrl, // Currently unused, but may be needed in the future if we support instructions images.

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -14,8 +14,11 @@ import {ProjectLevelData} from '../../types';
 const commonI18n = require('@cdo/locale');
 
 interface InstructionsProps {
+  /** Base asset URL for images */
   baseUrl: string;
+  /** If the instructions panel should be rendered vertically. Defaults to false */
   vertical?: boolean;
+  /** If the instructions panel should be rendered on the right side of the screen. Defaults to false. */
   right?: boolean;
 }
 
@@ -25,8 +28,8 @@ interface InstructionsProps {
  */
 const Instructions: React.FunctionComponent<InstructionsProps> = ({
   baseUrl, // Currently unused, but may be needed in the future if we support instructions images.
-  vertical,
-  right,
+  vertical = false,
+  right = false,
 }) => {
   // Prefer using long instructions if available, otherwise fall back to level data text.
   const instructionsText = useSelector(
@@ -62,12 +65,19 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
 };
 
 interface InstructionsPanelProps {
+  /** Primary instructions text to display. */
   text: string;
+  /** Optional message to display under the main text. This is typically a validation message. */
   message?: string;
+  /** Optional image URL to display. */
   imageUrl?: string;
+  /** If the next button should be shown. */
   showNextButton?: boolean;
+  /** Callback to call when clicking the next button. */
   onNextPanel?: () => void;
+  /** If the instructions panel should be rendered vertically. Defaults to false */
   vertical?: boolean;
+  /** If the instructions panel should be rendered on the right side of the screen. Defaults to false. */
   right?: boolean;
 }
 

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -1,5 +1,4 @@
 @import 'color.scss';
-@import './music-view.module.scss';
 
 @keyframes slidein {
   from {
@@ -16,7 +15,6 @@
   background-color: $neutral_dark;
   width: 100%;
   height: 100%;
-  border-radius: $default-border-radius;
   background-size: 100% 200%;
   padding: 10px;
   box-sizing: border-box;
@@ -85,7 +83,6 @@
           width: 100%;
           position: absolute;
           border: 10px $dark_black solid;
-          border-radius: $default-border-radius;
           z-index: 80;
           cursor: pointer;
         }

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {connect} from 'react-redux';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
-import Instructions from './Instructions';
+import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import Controls from './Controls';
 import Timeline from './Timeline';
 import MusicPlayer from '../player/MusicPlayer';


### PR DESCRIPTION
Move the music lab instructions component into the shared set of lab2 components, and convert to TypeScript.

## Links

https://codedotorg.atlassian.net/browse/LABS-13

## Testing story

Tested locally on music lab levels.