### PR TITLE
Temporarily removing cronjob to delete expire child accounts

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -138,7 +138,6 @@
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'user_geos')
       cronjob at:'0 9 * * 5', do:deploy_dir('bin', 'cron', 'create_rollup_tables')
       cronjob at:"0 8 * * *", do:deploy_dir('bin', 'cron', 'purge_expired_deleted_accounts')
-      cronjob at:"15 8 * * *", do:deploy_dir('bin', 'cron', 'purge_expired_child_accounts')
       cronjob at:'0 4 * * 0', do:deploy_dir('bin', 'cron', 'update_project_count')
     end
   end


### PR DESCRIPTION
Tried running the cronjob manually and found that it timed out. We need to fix the SQL queries so they run faster, otherwise this cronjob will fail every time.

## Links
* [Error in Slack](https://codedotorg.slack.com/archives/C6B838SB0/p1691705335255809)
* [JIRA](https://codedotorg.atlassian.net/browse/P20-64)

## Testing story
Didn't test this change, but it's deleting something which has never run before.

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
