### PR TITLE
Fix TEACH-566 (make the "Decide later" button not toggle the curriculum dropdown menus)

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -39,6 +39,11 @@ export default function CurriculumQuickAssign({
 
   const showPlOfferings = participantType !== ParticipantAudience.student;
 
+  const updateCourse = useCallback(
+    course => updateSection('course', course),
+    [updateSection]
+  );
+
   // Retrieve course offerings on mount and convert to JSON
   useEffect(() => {
     fetch(
@@ -85,7 +90,7 @@ export default function CurriculumQuickAssign({
           courseDataByHeaderValues.forEach(course => {
             if (sectionCourse?.courseOfferingId === course.id) {
               setSelectedCourseOffering(course);
-              updateSectionCourseForExisitngSections(course);
+              updateSectionCourseForExistingSections(course);
               setMarketingAudience(audience);
             }
           });
@@ -110,10 +115,10 @@ export default function CurriculumQuickAssign({
     sectionCourse,
     selectedCourseOffering,
     updateSection,
-    updateSectionCourseForExisitngSections,
+    updateSectionCourseForExistingSections,
   ]);
 
-  const updateSectionCourseForExisitngSections = useCallback(
+  const updateSectionCourseForExistingSections = useCallback(
     course => {
       const courseVersions = {};
       // The structure of cv is an array with the first item an id and the second
@@ -143,43 +148,37 @@ export default function CurriculumQuickAssign({
         hasTextToSpeech: targetUnit?.text_to_speech_enabled,
       };
 
-      updateSection('course', updateSectionData);
+      updateCourse(updateSectionData);
     },
-    [updateSection, sectionCourse]
+    [updateCourse, sectionCourse]
   );
 
   /*
-  When toggling 'decide later', clear out marketing audience or assign one to make
-  the table appear again automatically.
-  Additionally, erase any previously selected course assignment.
+    When toggling 'decide later', erase any selected course assignment.
+    Leave the marketing audience alone to prevent toggling of the table that
+    might be jarring to the user.
   */
   const toggleDecideLater = () => {
-    setDecideLater(!decideLater);
-    updateSection('course', {});
-    if (marketingAudience !== '') {
-      setMarketingAudience('');
-      setSelectedCourseOffering(null);
-    } else {
-      setMarketingAudience(MARKETING_AUDIENCE.ELEMENTARY);
-    }
-  };
-
-  // When selecting a marketing audience, ensure 'decide later' is unchecked
-  const updateMarketingAudience = useCallback(
-    marketingAudience => {
-      setMarketingAudience(marketingAudience);
+    // User clicked "Clear assigned curriculum"
+    if (selectedCourseOffering) {
       setDecideLater(false);
-    },
-    [setDecideLater, setMarketingAudience]
-  );
+    }
+
+    // User clicked "Decide later"
+    else {
+      setDecideLater(!decideLater);
+    }
+
+    updateCourse({});
+    setSelectedCourseOffering(null);
+  };
 
   // To distinguish between types of tables: HOC & PL vs Grade Bands
-  const isPlOrHoc = () => {
-    return (
-      marketingAudience === MARKETING_AUDIENCE.HOC ||
-      marketingAudience === MARKETING_AUDIENCE.PL
-    );
-  };
+  const SelectedQuickAssignTable =
+    marketingAudience === MARKETING_AUDIENCE.HOC ||
+    marketingAudience === MARKETING_AUDIENCE.PL
+      ? QuickAssignTableHocPl
+      : QuickAssignTable;
 
   return (
     <div className={moduleStyles.containerWithMarginTop}>
@@ -211,35 +210,25 @@ export default function CurriculumQuickAssign({
       <CurriculumQuickAssignTopRow
         showPlOfferings={showPlOfferings}
         marketingAudience={marketingAudience}
-        updateMarketingAudience={updateMarketingAudience}
+        updateMarketingAudience={setMarketingAudience}
       />
-      {marketingAudience && !isPlOrHoc() && courseOfferings && (
-        <QuickAssignTable
+      {marketingAudience && courseOfferings && (
+        <SelectedQuickAssignTable
           marketingAudience={marketingAudience}
           courseOfferings={courseOfferings}
-          setSelectedCourseOffering={offering =>
-            setSelectedCourseOffering(offering)
-          }
-          updateCourse={course => updateSection('course', course)}
+          setSelectedCourseOffering={offering => {
+            setDecideLater(false);
+            setSelectedCourseOffering(offering);
+          }}
+          updateCourse={updateCourse}
           sectionCourse={sectionCourse}
           isNewSection={isNewSection}
-        />
-      )}
-      {marketingAudience && isPlOrHoc() && courseOfferings && (
-        <QuickAssignTableHocPl
-          marketingAudience={marketingAudience}
-          courseOfferings={courseOfferings}
-          setSelectedCourseOffering={offering =>
-            setSelectedCourseOffering(offering)
-          }
-          updateCourse={course => updateSection('course', course)}
-          sectionCourse={sectionCourse}
         />
       )}
       {marketingAudience && (
         <VersionUnitDropdowns
           courseOffering={selectedCourseOffering}
-          updateCourse={course => updateSection('course', course)}
+          updateCourse={updateCourse}
           sectionCourse={sectionCourse}
           isNewSection={isNewSection}
         />

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -53,17 +53,40 @@ describe('CurriculumQuickAssign', () => {
     expect(wrapper.find('VersionUnitDropdowns')).to.have.lengthOf(0);
   });
 
-  it('clears decide later when marketing audience selected', () => {
+  it('leaves dropdowns alone when decide later clicked', () => {
     const wrapper = mount(
       <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
     );
 
+    // No dropdowns active at beginning
+    expect(wrapper.find('VersionUnitDropdowns')).to.have.lengthOf(0);
+
+    // Toggle decide later, verify its state changes.
     expect(wrapper.find('input').props().checked).to.equal(false);
     wrapper.find('input').simulate('change');
     expect(wrapper.find('input').props().checked).to.equal(true);
 
-    // Now, click on elementary school button and verify checkbox is deselected
-    wrapper.find('Button').at(0).simulate('click');
+    // Still no dropdowns active
+    expect(wrapper.find('VersionUnitDropdowns')).to.have.lengthOf(0);
+
+    // Uncheck decide later, still no dropdowns active
+    wrapper.find('input').simulate('change');
     expect(wrapper.find('input').props().checked).to.equal(false);
+    expect(wrapper.find('VersionUnitDropdowns')).to.have.lengthOf(0);
+
+    // Open elementary dropdown
+    wrapper
+      .find('Button')
+      .at(0)
+      .simulate('click', {preventDefault: () => {}});
+    expect(wrapper.find('VersionUnitDropdowns')).to.have.lengthOf(1);
+
+    // Toggle decide later on and off, dropdown remains active
+    wrapper.find('input').simulate('change');
+    expect(wrapper.find('input').props().checked).to.equal(true);
+    expect(wrapper.find('VersionUnitDropdowns')).to.have.lengthOf(1);
+    wrapper.find('input').simulate('change');
+    expect(wrapper.find('input').props().checked).to.equal(false);
+    expect(wrapper.find('VersionUnitDropdowns')).to.have.lengthOf(1);
   });
 });


### PR DESCRIPTION
Change the behavior of the "Decide later" button on the section settings page to not toggle the elementary/middle/etc. dropdown menus when it is clicked. Selecting "Decide later" will deselect any selected curriculum, selecting a curriculum item will deselect "Decide later", and in any case the dropdowns will stay as they were.

Video of new behavior:

https://github.com/code-dot-org/code-dot-org/assets/4108328/a39a5053-00d3-4540-a490-e4ad6aafa130


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- jira ticket: [TEACH-566](https://codedotorg.atlassian.net/browse/TEACH-566)

## Testing story

Updated a unit test to reflect the new behavior.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
