### PR TITLE
Fixed assign button issue on course landing page

### DIFF
--- a/apps/src/templates/MultipleAssignButton.jsx
+++ b/apps/src/templates/MultipleAssignButton.jsx
@@ -21,7 +21,7 @@ class MultipleAssignButton extends React.Component {
     scriptId: PropTypes.number,
     assignmentName: PropTypes.string,
     reassignConfirm: PropTypes.func,
-    isOnCoursePage: PropTypes.bool,
+    isAssigningCourse: PropTypes.bool,
     isStandAloneUnit: PropTypes.bool,
     participantAudience: PropTypes.string,
     // Redux
@@ -58,7 +58,7 @@ class MultipleAssignButton extends React.Component {
       isRtl,
       sectionsForDropdown,
       participantAudience,
-      isOnCoursePage,
+      isAssigningCourse,
       reassignConfirm,
     } = this.props;
 
@@ -88,7 +88,7 @@ class MultipleAssignButton extends React.Component {
             scriptId={scriptId}
             courseVersionId={courseVersionId}
             reassignConfirm={reassignConfirm}
-            isOnCoursePage={isOnCoursePage}
+            isAssigningCourse={isAssigningCourse}
             isStandAloneUnit={isStandAloneUnit}
             participantAudience={participantAudience}
           />

--- a/apps/src/templates/courseOverview/CourseOverviewTopRow.js
+++ b/apps/src/templates/courseOverview/CourseOverviewTopRow.js
@@ -43,7 +43,7 @@ export default class CourseOverviewTopRow extends Component {
             sections={sectionsForDropdown}
             showAssignButton={showAssignButton}
             courseId={id}
-            isOnCoursePage={true}
+            isAssigningCourse={true}
             courseOfferingId={courseOfferingId}
             courseVersionId={courseVersionId}
             assignmentName={courseName}

--- a/apps/test/unit/templates/MultipleAssignButtonTest.js
+++ b/apps/test/unit/templates/MultipleAssignButtonTest.js
@@ -20,17 +20,34 @@ describe('MultipleAssignButtonTest', () => {
     updateHiddenScript: updateHiddenScript,
     testingFunction: testingFunction,
     sectionsForDropdown: fakeTeacherSectionsForDropdown,
+    isAssigningCourse: false,
   };
   const setUp = (overrideProps = {}) => {
     const props = {...defaultProps, ...overrideProps};
     return shallow(<MultipleAssignButton {...props} />);
   };
 
-  it('renders a MultipleSectionsAssigner when clicked', () => {
+  it('renders a MultipleSectionsAssigner when clicked on unit page', () => {
     const wrapper = setUp();
     expect(wrapper.find('.uitest-assign-button')).to.exist;
-    expect(wrapper.exists('MultipleSectionsAssigner')).to.be.false;
+    expect(wrapper.exists('Connect(MultipleSectionsAssigner)')).to.be.false;
     wrapper.find('Button').simulate('click');
+    expect(
+      wrapper.find('Connect(MultipleSectionsAssigner)').first().props()
+        .isAssigningCourse
+    ).to.be.false;
+    expect(wrapper.exists('Connect(MultipleSectionsAssigner)')).to.be.true;
+  });
+
+  it('renders a MultipleSectionsAssigner when clicked on course page', () => {
+    const wrapper = setUp({isAssigningCourse: true});
+    expect(wrapper.find('.uitest-assign-button')).to.exist;
+    expect(wrapper.exists('Connect(MultipleSectionsAssigner)')).to.be.false;
+    wrapper.find('Button').simulate('click');
+    expect(
+      wrapper.find('Connect(MultipleSectionsAssigner)').first().props()
+        .isAssigningCourse
+    ).to.be.true;
     expect(wrapper.exists('Connect(MultipleSectionsAssigner)')).to.be.true;
   });
 });


### PR DESCRIPTION
This finishes passing through a parameter from the course landing page to the MultipleSectionAssign component from [TEACH-632](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-632)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

- We already had a unit test that checked to see that the right methods were called but didn't check the results of those methods.  
- I did add to the unit tests of the parent component to ensure that the data was being passed down accurately.
- I believe the best solution to catch this in the future is to create UI test for this component (captured in [TEACH-276](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65/backlog?selectedIssue=TEACH-276))

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
