### PR TITLE
Attempting to fix flaky CPA unit tests

### DIFF
--- a/dashboard/test/lib/email_reminder_test.rb
+++ b/dashboard/test/lib/email_reminder_test.rb
@@ -3,7 +3,7 @@ require 'email_reminder'
 require 'mocha/mini_test'
 
 class EmailReminderTest < ActiveSupport::TestCase
-  setup_all do
+  setup do
     @student = create(:student, child_account_compliance_state: 'not_g')
     @request = create(:parental_permission_request, user_id: @student.id, parent_email: 'foo-parent@code.org')
 

--- a/dashboard/test/lib/services/child_account_test.rb
+++ b/dashboard/test/lib/services/child_account_test.rb
@@ -1,11 +1,11 @@
 require 'test_helper'
 
 class Services::ChildAccountTest < ActiveSupport::TestCase
-  teardown do
-    Timecop.return
-  end
-
   class LockOut < ActiveSupport::TestCase
+    teardown do
+      Timecop.return
+    end
+
     test 'given no user should not throw an error' do
       Services::ChildAccount.lock_out(nil)
     end
@@ -58,6 +58,10 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
   end
 
   class UpdateCompliance < ActiveSupport::TestCase
+    teardown do
+      Timecop.return
+    end
+
     test 'given no user should not throw an error' do
       new_state = Policies::ChildAccount::ComplianceState::LOCKED_OUT
 
@@ -93,6 +97,10 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
   end
 
   class GrantPermissionRequest < ActionDispatch::IntegrationTest
+    teardown do
+      Timecop.return
+    end
+
     test 'given nil request it should do nothing' do
       Services::ChildAccount.grant_permission_request! nil
     end

--- a/dashboard/test/lib/services/child_account_test.rb
+++ b/dashboard/test/lib/services/child_account_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class Services::ChildAccountTest < ActiveSupport::TestCase
+  teardown do
+    Timecop.return
+  end
+
   class LockOut < ActiveSupport::TestCase
     test 'given no user should not throw an error' do
       Services::ChildAccount.lock_out(nil)
@@ -20,6 +24,7 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
       user = create :locked_out_child
       compliance_state = user.child_account_compliance_state
       last_updated = user.child_account_compliance_state_last_updated
+      Timecop.travel 5.minutes
 
       Services::ChildAccount.lock_out(user)
 
@@ -31,6 +36,7 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
       user = create :locked_out_child, :with_pending_parent_permission
       compliance_state = user.child_account_compliance_state
       last_updated = user.child_account_compliance_state_last_updated
+      Timecop.travel 5.minutes
 
       Services::ChildAccount.lock_out(user)
 
@@ -42,6 +48,7 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
       user = create :locked_out_child, :with_parent_permission
       compliance_state = user.child_account_compliance_state
       last_updated = user.child_account_compliance_state_last_updated
+      Timecop.travel 5.minutes
 
       Services::ChildAccount.lock_out(user)
 
@@ -68,6 +75,7 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
       assert_not_nil user.child_account_compliance_state_last_updated
 
       last_updated = user.child_account_compliance_state_last_updated
+      Timecop.travel 5.minutes
       new_state = Policies::ChildAccount::ComplianceState::REQUEST_SENT
       Services::ChildAccount.update_compliance(user, new_state)
 
@@ -75,6 +83,7 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
       assert_not_equal last_updated, user.child_account_compliance_state_last_updated
 
       last_updated = user.child_account_compliance_state_last_updated
+      Timecop.travel 5.minutes
       new_state = Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED
       Services::ChildAccount.update_compliance(user, new_state)
 
@@ -108,6 +117,7 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
       user.reload
       assert_equal Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED, user.child_account_compliance_state
       last_updated = user.child_account_compliance_state_last_updated
+      Timecop.travel 5.minutes
       assert_not_empty last_updated
 
       # No emails should be sent


### PR DESCRIPTION
The DOTD report that two unit tests related to the Colorado Privacy Act project were being flaky.

*EmailReminderTest*
I suspect this test was flaky because the test data was being shared between test runs. That means if the tests run in a different order, then the test data could be in an unexpected state.

*ChildAccountTest*
I suspect this test was flaky because it is measuring timestamp differences but not enough time had passed for there to actually be differences.

## Links
* [JIRA P20-340](https://codedotorg.atlassian.net/browse/P20-340)

## Testing story
* Unit tests still pass.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
