### PR TITLE
Add before_create hook to generate a key for learning goals

### DIFF
--- a/dashboard/app/models/learning_goal.rb
+++ b/dashboard/app/models/learning_goal.rb
@@ -20,6 +20,8 @@ class LearningGoal < ApplicationRecord
   belongs_to :rubric
   has_many :learning_goal_evidence_levels, dependent: :destroy
 
+  before_create :generate_key
+
   def seeding_key(seed_context)
     my_rubric = seed_context.rubrics.find {|r| r.id == rubric_id}
     my_key = {
@@ -27,5 +29,10 @@ class LearningGoal < ApplicationRecord
     }
     rubric_seeding_key = my_rubric.seeding_key(seed_context)
     my_key.merge!(rubric_seeding_key) {|key, _, _| raise "Duplicate key when generating seeding_key: #{key}"}
+  end
+
+  def generate_key
+    return if key.present?
+    self.key = SecureRandom.uuid
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1787,7 +1787,6 @@ FactoryBot.define do
 
   factory :learning_goal do
     association :rubric
-    sequence(:key) {|n| "lg_#{n}"}
     position {0}
     learning_goal {"Test Learning Goal"}
     ai_enabled {false}

--- a/dashboard/test/models/learning_goal_test.rb
+++ b/dashboard/test/models/learning_goal_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class LearningGoalTest < ActiveSupport::TestCase
+  test 'generates key on create if one isnt present' do
+    learning_goal = create :learning_goal, key: nil
+    learning_goal.reload
+    assert learning_goal.key.present?
+  end
+
+  test 'does not generate key on create if one is present' do
+    learning_goal = create :learning_goal, key: 'intentionally-present-key'
+    learning_goal.reload
+    assert_equal 'intentionally-present-key', learning_goal.key
+  end
+end


### PR DESCRIPTION
Learning goals need a key to uniquely identify them through the seed and serialize process (ie getting the content from levelbuilder to production). However, there is no particular need for a user facing key; in current designs, not even curriculum writers need to see the key. Therefore, a before create hook that generates a truly random key makes sense to me -- it'll be a unique alphanumeric code that can easily uniquely identify the learning goal within a rubric.

I considered trying to create a human readable key like we do [for resources](https://github.com/code-dot-org/code-dot-org/blob/082df5a8584ab4a7468eb40e79719e3aedbdfac0/dashboard/app/models/resource.rb#L149), but decided the complexity wasn't worth it given we're not surfacing it to any users. Definitely open to pushback there!