### PR TITLE
URL param used for quick view flag

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -48,12 +48,9 @@ const CurriculumCatalog = ({
 
   const getQuickViewState = () => {
     const urlParams = queryParams();
-    return 'quick_view' in urlParams && urlParams['quick_view'] === 'true'
-      ? true
-      : false;
+    console.log(urlParams['quick_view'] === 'true');
+    return urlParams['quick_view'] === 'true';
   };
-
-  const isQuickViewDisplayed = getQuickViewState();
 
   // Renders search results based on the applied filters (or shows the No matching curriculums
   // message if no results).
@@ -104,7 +101,7 @@ const CurriculumCatalog = ({
                   scriptId={script_id}
                   isStandAloneUnit={is_standalone_unit}
                   onAssignSuccess={response => handleAssignSuccess(response)}
-                  quickViewDisplayed={isQuickViewDisplayed}
+                  quickViewDisplayed={getQuickViewState()}
                   {...props}
                 />
               )

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -48,7 +48,9 @@ const CurriculumCatalog = ({
 
   const getQuickViewState = () => {
     const urlParams = queryParams();
-    return 'quick_view' in urlParams ? true : false;
+    return 'quick_view' in urlParams && urlParams['quick_view'] === 'true'
+      ? true
+      : false;
   };
 
   const isQuickViewDisplayed = getQuickViewState();

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -25,6 +25,8 @@ const CurriculumCatalog = ({
   const [showAssignSuccessMessage, setShowAssignSuccessMessage] =
     useState(false);
 
+  const isQuickViewDisplayed = queryParams()['quick_view'] === 'true';
+
   const handleAssignSuccess = assignmentData => {
     setAssignSuccessMessage(
       i18n.successAssigningCurriculum({
@@ -44,12 +46,6 @@ const CurriculumCatalog = ({
   const handleCloseAssignSuccessMessage = () => {
     setShowAssignSuccessMessage(false);
     setAssignSuccessMessage('');
-  };
-
-  const getQuickViewState = () => {
-    const urlParams = queryParams();
-    console.log(urlParams['quick_view'] === 'true');
-    return urlParams['quick_view'] === 'true';
   };
 
   // Renders search results based on the applied filters (or shows the No matching curriculums
@@ -101,7 +97,7 @@ const CurriculumCatalog = ({
                   scriptId={script_id}
                   isStandAloneUnit={is_standalone_unit}
                   onAssignSuccess={response => handleAssignSuccess(response)}
-                  quickViewDisplayed={getQuickViewState()}
+                  quickViewDisplayed={isQuickViewDisplayed}
                   {...props}
                 />
               )

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -12,6 +12,7 @@ import CurriculumCatalogFilters from './CurriculumCatalogFilters';
 import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {queryParams} from '../../code-studio/utils';
 
 const CurriculumCatalog = ({
   curriculaData,
@@ -44,6 +45,13 @@ const CurriculumCatalog = ({
     setShowAssignSuccessMessage(false);
     setAssignSuccessMessage('');
   };
+
+  const getQuickViewState = () => {
+    const urlParams = queryParams();
+    return 'quick_view' in urlParams ? true : false;
+  };
+
+  const isQuickViewDisplayed = getQuickViewState();
 
   // Renders search results based on the applied filters (or shows the No matching curriculums
   // message if no results).
@@ -94,6 +102,7 @@ const CurriculumCatalog = ({
                   scriptId={script_id}
                   isStandAloneUnit={is_standalone_unit}
                   onAssignSuccess={response => handleAssignSuccess(response)}
+                  quickViewDisplayed={isQuickViewDisplayed}
                   {...props}
                 />
               )

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -29,7 +29,6 @@ import {
 } from '@cdo/apps/templates/curriculumCatalog/noSectionsToAssignDialogs';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
-import DCDO from '@cdo/apps/dcdo';
 import ExpandedCurriculumCatalogCard from './ExpandedCurriculumCatalogCard';
 
 const CurriculumCatalogCard = ({
@@ -42,6 +41,7 @@ const CurriculumCatalogCard = ({
   topics = [],
   pathToCourse,
   onAssignSuccess,
+  quickViewDisplayed,
   ...props
 }) => (
   <CustomizableCurriculumCatalogCard
@@ -71,6 +71,7 @@ const CurriculumCatalogCard = ({
     translationIconTitle={i18n.courseInYourLanguage()}
     pathToCourse={pathToCourse + '?viewAs=Instructor'}
     onAssignSuccess={onAssignSuccess}
+    quickViewDisplayed={quickViewDisplayed}
     {...props}
   />
 );
@@ -98,6 +99,7 @@ CurriculumCatalogCard.propTypes = {
   scriptId: PropTypes.number,
   isStandAloneUnit: PropTypes.bool,
   onAssignSuccess: PropTypes.func,
+  quickViewDisplayed: PropTypes.bool,
 };
 
 const CustomizableCurriculumCatalogCard = ({
@@ -121,6 +123,7 @@ const CustomizableCurriculumCatalogCard = ({
   isSignedOut,
   onAssignSuccess,
   courseId,
+  quickViewDisplayed,
   ...props
 }) => {
   const [isAssignDialogOpen, setIsAssignDialogOpen] = useState(false);
@@ -219,7 +222,7 @@ const CustomizableCurriculumCatalogCard = ({
                 : style.buttonsContainer_notEnglish
             )}
           >
-            {!!DCDO.get('quick-view', false) ? (
+            {quickViewDisplayed ? (
               <Button
                 color={Button.ButtonColor.neutralDark}
                 type="button"
@@ -281,6 +284,7 @@ CustomizableCurriculumCatalogCard.propTypes = {
   imageAltText: PropTypes.string,
   quickViewButtonDescription: PropTypes.string.isRequired,
   assignButtonDescription: PropTypes.string.isRequired,
+  quickViewDisplayed: PropTypes.bool,
 };
 
 export default connect(

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -50,7 +50,6 @@ class DCDOBase < DynamicConfigBase
       'curriculum-launch-skinny-banner': DCDO.get('curriculum-launch-skinny-banner', false),
       'ai-pl-launch-banners': DCDO.get('ai-pl-launch-banners', false),
       'family-name-features': DCDO.get('family-name-features', false),
-      'quick-view': DCDO.get('quick-view', false),
     }
   end
 end


### PR DESCRIPTION
Changes the quick view flag from a DCDO flag to a URL param flag. The flag can be used by appending `quick_view=true` to the URL. 

<img width="1792" alt="Screenshot 2023-08-11 at 10 33 12 AM 1" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/a3f4eca3-af64-45e2-a59d-36848474e7d5">

### No URL Params
<img width="1792" alt="Screenshot 2023-08-11 at 10 38 06 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/c64b5535-673c-4ba9-9ad8-99c08511f2e6">

### Works with Filter Params
<img width="1792" alt="Screenshot 2023-08-11 at 10 38 44 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/a660fffb-3dc7-418f-9c41-42b2e964ffdc">


## Links



- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-657)


## Testing story

Local


## Follow-up work
I will merge this PR with all subsequent PRs and fix merge conflicts.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
