### PR TITLE
Call `FileUtils.rm` More Explicitly in Error Handler

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -160,7 +160,7 @@ namespace :seed do
         raise exception, "Error parsing script file #{filepath}: #{exception}"
       end
     rescue
-      rm SEEDED # if we failed somewhere in the process, we may have seeded some Scripts, but not all that we were supposed to.
+      FileUtils.rm(SEEDED) # if we failed somewhere in the process, we may have seeded some Scripts, but not all that we were supposed to.
       raise
     end
   end


### PR DESCRIPTION
Currently, this fails with:

```
ArgumentError: wrong number of arguments (given 2, expected 1)
/drone/src/dashboard/lib/tasks/seed.rake:163:in `rescue in update_scripts'
/drone/src/dashboard/lib/tasks/seed.rake:155:in `update_scripts'
/drone/src/dashboard/lib/tasks/seed.rake:205:in `block (2 levels) in <top (required)>'
/drone/src/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `block in execute'
/drone/src/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `execute'
/home/circleci/.rbenv/versions/3.0.5/bin/bundle:23:in `load'
/home/circleci/.rbenv/versions/3.0.5/bin/bundle:23:in `<main>'
```

I think this is a result of the update to Ruby 3.0; I can't find the details right now, but I think I remember seeing this same problem manifest somewhere else.

## Links

[Slack discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1692057682838989?thread_ts=1692057677.359369&cid=C0T0PNTM3)

## Testing story

Tested by manually adding a `raise` statement to the relevant code block.