### PR TITLE
Loosen `level_file_glob` Restrictions

### DIFF
--- a/dashboard/lib/policies/level_files.rb
+++ b/dashboard/lib/policies/level_files.rb
@@ -40,7 +40,7 @@ module Policies
     # TODO: once all old level files have been moved out of the config/scripts
     # directory, update this to just inspect config/levels/**
     def self.level_file_glob(level_name)
-      level_name ? "config/**/levels/**/#{level_name}.level" : 'config/**/levels/**/*.level'
+      level_name ? "config/**/#{level_name}.level" : 'config/**/*.level'
     end
   end
 end

--- a/dashboard/lib/policies/level_files.rb
+++ b/dashboard/lib/policies/level_files.rb
@@ -34,8 +34,8 @@ module Policies
     # by name if provided, or all level files if not.
     #
     # Supports both our old level file location at
-    # "config/scripts/levels/{name}.level" and our new level file location at
-    # "config/levels/custom/{game}/{name}.level"
+    # "config/scripts/**/{name}.level" and our new level file location at
+    # "config/levels/(custom|dsl_defined)/{game}/{name}.level"
     #
     # TODO: once all old level files have been moved out of the config/scripts
     # directory, update this to just inspect config/levels/**


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/53066, which inadvertently introduced an invalid restriction that custom level files were specifically in the `dashboard/config/scripts/levels` directory, excluding those level files that sit at the root of the `scripts` directory.

Loosening the glob to search the entire `config` directory should catch all custom level files for now.

## Testing story

I verified with that there are no unexpected `*.level` files that this might begin picking up with `find dashboard/config -name "*.level" -not -path "dashboard/config/scripts/*"`

## Follow-up work

With this change, the restrictions are definitely a little bit looser than we'd like; we don't want to support `.level` files in other subdirectories of `config/` in the long term. 

Fortunately, this is temporary; once all old level files have been moved out of `scripts/` and into `levels/`, we can update the glob to again target a specific subdirectory.