### PR TITLE
Commit files in the dashboard/config/levels directory on levelbuilder

### DIFF
--- a/tools/hooks/restrict_levelbuilder_changes.rb
+++ b/tools/hooks/restrict_levelbuilder_changes.rb
@@ -4,7 +4,9 @@ REPO_DIR = File.expand_path('../../../', __FILE__).freeze
 BLOCKS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/blocks', __FILE__).freeze
 SHARED_FUNCTIONS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/shared_functions', __FILE__).freeze
 LIBRARIES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/libraries', __FILE__).freeze
-LEVELS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/scripts', __FILE__).freeze
+# As written, SCRIPTS_DIR also covers dashboard/config/scripts_json
+SCRIPTS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/scripts', __FILE__).freeze
+LEVELS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/levels', __FILE__).freeze
 COURSES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/courses', __FILE__).freeze
 COURSE_OFFERINGS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/course_offerings', __FILE__).freeze
 DATA_DOCS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/data_docs', __FILE__).freeze
@@ -32,6 +34,6 @@ staged_files = HooksUtils.get_staged_files
 
 staged_files.each do |filename|
   raise "#{ERROR_MESSAGE}\nFile blocked: #{filename}" unless filename.start_with?(
-    BLOCKS_DIR, SHARED_FUNCTIONS_DIR, LIBRARIES_DIR, LEVELS_DIR, COURSES_DIR, COURSE_OFFERINGS_DIR, DATA_DOCS_DIR, REFERENCE_GUIDES_DIR, PROGRAMMING_CLASSES_DIR, PROGRAMMING_ENVIRONMENTS_DIR, PROGRAMMING_EXPRESSIONS_DIR, VIDEO_THUMBNAILS_DIR, FOORM_DIR
+    BLOCKS_DIR, SHARED_FUNCTIONS_DIR, LIBRARIES_DIR, SCRIPTS_DIR, LEVELS_DIR, COURSES_DIR, COURSE_OFFERINGS_DIR, DATA_DOCS_DIR, REFERENCE_GUIDES_DIR, PROGRAMMING_CLASSES_DIR, PROGRAMMING_ENVIRONMENTS_DIR, PROGRAMMING_EXPRESSIONS_DIR, VIDEO_THUMBNAILS_DIR, FOORM_DIR
   ) || ALLOWED_FILES.include?(filename)
 end


### PR DESCRIPTION
We have an allow list of what directories levelbuilder is allowed to commit changes in. #53066 started writing level files to the dashboard/config/levels directory, so we need to update this script to unblock the scoop.

Tested by using a local branch called levelbuilder and trying to commit a file in dashboard/config/levels. It failed before this change and passed after.