### PR TITLE
Ensure non-Admins can edit scholarship details on an application when scholarships are unlocked

### DIFF
--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -16,7 +16,7 @@ const ScholarshipDropdown = ({
       value={scholarshipStatus}
       onChange={onChange}
       options={dropdownOptions}
-      disabled={!isWorkshopAdmin || disabled}
+      disabled={!isWorkshopAdmin && disabled}
     />
   </FormGroup>
 );

--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -3,6 +3,9 @@ import React from 'react';
 import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import Select from 'react-select';
 
+// update this to lock scholarships so that scholarship status can't be updated via the UI.
+const locked = false;
+
 const ScholarshipDropdown = ({
   scholarshipStatus,
   dropdownOptions,
@@ -16,7 +19,7 @@ const ScholarshipDropdown = ({
       value={scholarshipStatus}
       onChange={onChange}
       options={dropdownOptions}
-      disabled={!isWorkshopAdmin && disabled}
+      disabled={disabled || (locked && !isWorkshopAdmin)}
     />
   </FormGroup>
 );


### PR DESCRIPTION
[This PR](https://github.com/code-dot-org/code-dot-org/pull/53196) allowed Workshop Admins to be able to update scholarship status regardless of whether it was locked. That PR removed the `locked` constant (which was necessary) and made it so Workshop Admins could edit that field even when the form wasn't in it's edit state.

Before [the PR mentioned above](https://github.com/code-dot-org/code-dot-org/pull/53196), the logic followed:
- Is the ScholarshipDropdown disabled?
   - Yes --> **Status dropdown is disabled**
   - No --> Is it locked?
      - Yes --> **Status dropdown is disabled**
      - No --> **Status dropdown is enabled**

With this PR, the new logic allows Workshop Admins to override the `locked` value as follows:
- Is the ScholarshipDropdown disabled?
   - Yes --> **Status dropdown is disabled**
   - No --> Is the user a Workshop Admin?
      - Yes --> **Status dropdown is enabled**
      - No --> Is it locked?
         - Yes --> **Status dropdown is disabled**
         - No --> **Status dropdown is enabled**

## Links
PR this builds on: [here](https://github.com/code-dot-org/code-dot-org/pull/53196)

## Testing story
Local testing and drone build.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
