### PR TITLE
Install MySQL 5.7 Even on Ubuntu 20

### DIFF
--- a/cookbooks/cdo-mysql/recipes/client.rb
+++ b/cookbooks/cdo-mysql/recipes/client.rb
@@ -1,9 +1,10 @@
 include_recipe 'cdo-mysql::repo'
 
-apt_package 'libmysqlclient-dev' do
-  version '5.7*'
-end
+# We don't need to install a MySQL 5.7-specific libmysqlclient library,
+# since the 8.0 version distributed by default is backwards-compatible
+# all the way back to MySQL 5.5
+apt_package 'libmysqlclient-dev'
 
 apt_package 'mysql-client' do
-  version '5.7*'
+  version '5.7.42-1ubuntu18.04'
 end

--- a/cookbooks/cdo-mysql/recipes/client.rb
+++ b/cookbooks/cdo-mysql/recipes/client.rb
@@ -1,4 +1,9 @@
 include_recipe 'cdo-mysql::repo'
 
-apt_package 'libmysqlclient-dev'
-apt_package 'mysql-client'
+apt_package 'libmysqlclient-dev' do
+  version '5.7*'
+end
+
+apt_package 'mysql-client' do
+  version '5.7*'
+end

--- a/cookbooks/cdo-mysql/recipes/client.rb
+++ b/cookbooks/cdo-mysql/recipes/client.rb
@@ -5,6 +5,18 @@ include_recipe 'cdo-mysql::repo'
 # all the way back to MySQL 5.5
 apt_package 'libmysqlclient-dev'
 
+# This package get installed by default with the upgrade from Ubuntu 18 to 20,
+# but with it installed, we get an error when attempting to install
+# mysql-community-client, which is a dependency of mysql-client:
+#
+# dpkg: error processing archive /var/cache/apt/archives/mysql-community-client_5.7.42-1ubuntu18.04_amd64.deb (--unpack):
+#  trying to overwrite '/usr/share/mysql/charsets/Index.xml', which is also in package mysql-server-core-8.0 8.0.34-0ubuntu0.20.04.1
+#  Errors were encountered while processing:
+#   /var/cache/apt/archives/mysql-community-client_5.7.42-1ubuntu18.04_amd64.deb
+apt_package 'mysql-server-core-8.0' do
+  action :remove
+end
+
 apt_package 'mysql-client' do
   version '5.7.42-1ubuntu18.04'
 end

--- a/cookbooks/cdo-mysql/recipes/client.rb
+++ b/cookbooks/cdo-mysql/recipes/client.rb
@@ -5,18 +5,7 @@ include_recipe 'cdo-mysql::repo'
 # all the way back to MySQL 5.5
 apt_package 'libmysqlclient-dev'
 
-# This package get installed by default with the upgrade from Ubuntu 18 to 20,
-# but with it installed, we get an error when attempting to install
-# mysql-community-client, which is a dependency of mysql-client:
-#
-# dpkg: error processing archive /var/cache/apt/archives/mysql-community-client_5.7.42-1ubuntu18.04_amd64.deb (--unpack):
-#  trying to overwrite '/usr/share/mysql/charsets/Index.xml', which is also in package mysql-server-core-8.0 8.0.34-0ubuntu0.20.04.1
-#  Errors were encountered while processing:
-#   /var/cache/apt/archives/mysql-community-client_5.7.42-1ubuntu18.04_amd64.deb
-apt_package 'mysql-server-core-8.0' do
-  action :remove
-end
-
+# Pin to MySQL 5.7 until we're ready to update to MySQL 8
 apt_package 'mysql-client' do
   version '5.7.42-1ubuntu18.04'
 end

--- a/cookbooks/cdo-mysql/recipes/repo.rb
+++ b/cookbooks/cdo-mysql/recipes/repo.rb
@@ -1,7 +1,14 @@
 apt_repository 'mysql' do
   uri 'http://repo.mysql.com/apt/ubuntu'
-  distribution node['lsb']['codename']
+
+  # hardcode the distribution we target to Ubuntu 18 rather than whatever our
+  # current is, since that's the last LTS for which a MySQL 5.7 package was
+  # distributed. Once we update to MySQL 8+, this can be restored.
+  distribution 'bionic'
+  #distribution node['lsb']['codename']
+
   components ['mysql-5.7']
+
   # https://dev.mysql.com/doc/refman/5.7/en/checking-gpg-signature.html
   key '3A79BD29'
   keyserver 'keyserver.ubuntu.com'

--- a/cookbooks/cdo-mysql/recipes/repo.rb
+++ b/cookbooks/cdo-mysql/recipes/repo.rb
@@ -4,9 +4,10 @@ apt_repository 'mysql' do
   # hardcode the distribution we target to Ubuntu 18 rather than whatever our
   # current is, since that's the last LTS for which a MySQL 5.7 package was
   # distributed. Once we update to MySQL 8+, this can be restored.
-  distribution 'bionic'
   #distribution node['lsb']['codename']
+  distribution 'bionic'
 
+  # Pin to MySQL 5.7 until we're ready to update to MySQL 8
   components ['mysql-5.7']
 
   # https://dev.mysql.com/doc/refman/5.7/en/checking-gpg-signature.html

--- a/cookbooks/cdo-mysql/recipes/server.rb
+++ b/cookbooks/cdo-mysql/recipes/server.rb
@@ -2,6 +2,7 @@ include_recipe 'cdo-mysql::repo'
 
 apt_package 'mysql-server' do
   action :upgrade
+  version '5.7*'
   notifies :create, 'template[cdo.cnf]', :immediately
   notifies :start, 'service[mysql]', :immediately
   notifies :run, 'execute[mysql-upgrade]', :immediately

--- a/cookbooks/cdo-mysql/recipes/server.rb
+++ b/cookbooks/cdo-mysql/recipes/server.rb
@@ -2,6 +2,7 @@ include_recipe 'cdo-mysql::repo'
 
 apt_package 'mysql-server' do
   action :upgrade
+  # Pin to MySQL 5.7 until we're ready to update to MySQL 8
   version '5.7.42-1ubuntu18.04'
   notifies :create, 'template[cdo.cnf]', :immediately
   notifies :start, 'service[mysql]', :immediately

--- a/cookbooks/cdo-mysql/recipes/server.rb
+++ b/cookbooks/cdo-mysql/recipes/server.rb
@@ -2,7 +2,7 @@ include_recipe 'cdo-mysql::repo'
 
 apt_package 'mysql-server' do
   action :upgrade
-  version '5.7*'
+  version '5.7.42-1ubuntu18.04'
   notifies :create, 'template[cdo.cnf]', :immediately
   notifies :start, 'service[mysql]', :immediately
   notifies :run, 'execute[mysql-upgrade]', :immediately

--- a/docker/dockerfiles/Dockerfile
+++ b/docker/dockerfiles/Dockerfile
@@ -135,7 +135,7 @@ RUN locale-gen en_US.UTF-8
 # install mysql
 RUN curl -sSLOJ https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb && \
     echo "mysql-apt-config mysql-apt-config/select-server select mysql-5.7" | /usr/bin/debconf-set-selections && \
-    dpkg -i mysql-apt-config_0.8.22-1_all.deb || apt-get -fy install && \
+    dpkg -i mysql-apt-config_0.8.22-1_all.deb || apt-get --fix-broken --yes install && \
     rm -rf mysql-apt-config_0.8.22-1_all.deb && \
     apt-get update && \
     # warning: mysql-server debconf hangs forever if wget is already installed (!)


### PR DESCRIPTION
We have some assumptions in our current logic that installs MySQL that will become invalid once we update the version of Ubuntu we target from 18 to 20. In particular, we assume that the version of MySQL that we want to install (currently 5.7) is both distributed by default for the version of Ubuntu we are currently on and is the default version of MySQL that gets installed with that distribution.

In both cases, the fix is simple: explicitly specify the versions we know we want, rather than just grabbing whatever's current. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested in [another branch](https://github.com/code-dot-org/code-dot-org/pull/53304) that we can successfully provision an adhoc instance with Ubuntu 20 with these changes.

Also tested that with these changes in place (and [a little extra manual configuration](https://github.com/code-dot-org/code-dot-org/pull/53400)), we can successfully upgrade an Ubuntu 18 instance to Ubuntu 20

## Deployment strategy

This PR shouldn't result in any change to any of our current servers; it's just ensuring that some of the things that we're doing now we will continue to do after the upgrade.

## Follow-up work

After this, we should be ready to attempt upgrading to Ubuntu 20.