### PR TITLE
Add basic theming support for Lab2 and use with instructions

### DIFF
--- a/apps/src/lab2/views/Lab2.tsx
+++ b/apps/src/lab2/views/Lab2.tsx
@@ -12,18 +12,21 @@ import ProjectContainer from '../projects/ProjectContainer';
 import MetricsAdapter from './MetricsAdapter';
 import LabViewsRenderer from './LabViewsRenderer';
 import DialogManager from './dialogs/DialogManager';
+import ThemeWrapper from './ThemeWrapper';
 
 const Lab2: React.FunctionComponent = () => {
   return (
     <Provider store={getStore()}>
-      <Lab2Wrapper>
-        <DialogManager>
-          <MetricsAdapter />
-          <ProjectContainer channelId={getStandaloneProjectId()}>
-            <LabViewsRenderer />
-          </ProjectContainer>
-        </DialogManager>
-      </Lab2Wrapper>
+      <ThemeWrapper>
+        <Lab2Wrapper>
+          <DialogManager>
+            <MetricsAdapter />
+            <ProjectContainer channelId={getStandaloneProjectId()}>
+              <LabViewsRenderer />
+            </ProjectContainer>
+          </DialogManager>
+        </Lab2Wrapper>
+      </ThemeWrapper>
     </Provider>
   );
 };

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -7,12 +7,13 @@ import AichatView from '@cdo/apps/aichat/views/AichatView';
 import MusicView from '@cdo/apps/music/views/MusicView';
 import StandaloneVideo from '@cdo/apps/standaloneVideo/StandaloneVideo';
 import classNames from 'classnames';
-import React, {useEffect, useState} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 import {LabState} from '../lab2Redux';
 import ProgressContainer from '../progress/ProgressContainer';
 import {AppName} from '../types';
 import moduleStyles from './lab-views-renderer.module.scss';
+import {DEFAULT_THEME, Theme, ThemeContext} from './ThemeWrapper';
 
 // Configuration for how a Lab should be rendered
 interface AppProperties {
@@ -25,12 +26,19 @@ interface AppProperties {
   backgroundMode: boolean;
   /** React View for the Lab */
   node: React.ReactNode;
+  /**
+   * Display theme for this lab. This will likely be configured by user
+   * preferences eventually, but for now this is fixed for each lab. Defaults
+   * to the default theme if not specified.
+   */
+  theme?: Theme;
 }
 
 const appsProperties: {[appName in AppName]?: AppProperties} = {
   music: {
     backgroundMode: true,
     node: <MusicView />,
+    theme: Theme.DARK,
   },
   standalone_video: {
     backgroundMode: false,
@@ -39,6 +47,7 @@ const appsProperties: {[appName in AppName]?: AppProperties} = {
   aichat: {
     backgroundMode: false,
     node: <AichatView />,
+    theme: Theme.LIGHT,
   },
 };
 
@@ -55,6 +64,15 @@ const LabViewsRenderer: React.FunctionComponent = () => {
       setAppsToRender([...appsToRender, currentAppName]);
     }
   }, [currentAppName, appsToRender]);
+
+  // Set the theme for the current app.
+  const {setTheme} = useContext(ThemeContext);
+  useEffect(() => {
+    if (currentAppName) {
+      const theme = appsProperties[currentAppName]?.theme || DEFAULT_THEME;
+      setTheme(theme);
+    }
+  }, [currentAppName, setTheme]);
 
   // Iterate through appsToRender and render Lab views for each. If
   // backgroundMode is true, the Lab view will always be rendered, but

--- a/apps/src/lab2/views/ThemeWrapper.tsx
+++ b/apps/src/lab2/views/ThemeWrapper.tsx
@@ -1,0 +1,37 @@
+import React, {useState} from 'react';
+
+/**
+ * Provides the current theme for all components in a lab.
+ */
+export enum Theme {
+  LIGHT = 'light',
+  DARK = 'dark',
+}
+
+export const DEFAULT_THEME: Theme = Theme.DARK;
+
+interface ThemeWrapperProps {
+  children: React.ReactNode;
+}
+
+const ThemeWrapper: React.FunctionComponent<ThemeWrapperProps> = ({
+  children,
+}) => {
+  const [theme, setTheme] = useState<Theme>(DEFAULT_THEME);
+
+  return (
+    <ThemeContext.Provider value={{theme, setTheme}}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const ThemeContext = React.createContext<{
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}>({
+  theme: DEFAULT_THEME,
+  setTheme: () => undefined,
+});
+
+export default ThemeWrapper;

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -11,8 +11,7 @@
   }
 }
 
-.instructions {
-  background-color: $neutral_dark;
+%instructions {
   width: 100%;
   height: 100%;
   background-size: 100% 200%;
@@ -27,126 +26,158 @@
   &.vertical {
     flex-direction: column;
   }
+}
 
-  .item {
-    display: flex;
-    pointer-events: auto;
-    flex: 1;
-    opacity: 1;
+.instructions-dark {
+  @extend %instructions;
+  background-color: $neutral_dark;
+}
 
-    &.itemVertical {
-      flex-direction: column;
-      overflow: auto;
+.instructions-light {
+  @extend %instructions;
+  background-color: $neutral_dark10;
+}
+
+.item {
+  display: flex;
+  pointer-events: auto;
+  flex: 1;
+  opacity: 1;
+
+  &.itemVertical {
+    flex-direction: column;
+    overflow: auto;
+  }
+}
+
+.itemTitle {
+  font-size: 18px;
+  text-align: left;
+  overflow-wrap: break-word;
+  padding: 5px;
+
+  &Horizontal {
+    max-width: 140px;
+  }
+}
+
+.imageContainer {
+  text-align: center;
+
+  &.horizontal {
+    text-align: left;
+    width: 140px;
+  }
+
+  .image {
+    cursor: pointer;
+    max-height: 120px;
+
+    &.fixedHeight {
+      height: 70px;
+    }
+  }
+
+  .bigImage {
+    position: absolute;
+    width: 440px;
+    text-align: left;
+    top: 0;
+    left: 0;
+
+    &Left {
+      left: auto;
+      right: 0;
     }
 
-    .itemTitle {
-      font-size: 18px;
-      text-align: left;
-      overflow-wrap: break-word;
-      padding: 5px;
-
-      &Horizontal {
-        max-width: 140px;
-      }
+    img {
+      width: 100%;
+      position: absolute;
+      border: 10px $dark_black solid;
+      z-index: 80;
+      cursor: pointer;
     }
+  }
+}
 
-    .imageContainer {
-      text-align: center;
+%text {
+  overflow-y: auto;
+  white-space: pre-wrap;
 
-      &.horizontal {
-        text-align: left;
-        width: 140px;
-      }
+  padding: 15px 20px 5px 20px;
+  border-radius: 4px;
 
-      .image {
-        cursor: pointer;
-        max-height: 120px;
+  margin-bottom: 10px;
+  animation: slidein 0.5s;
+}
 
-        &.fixedHeight {
-          height: 70px;
-        }
-      }
+.text-dark {
+  @extend %text;
+  background-color: $neutral_light;
+  color: $neutral_dark;
+}
 
-      .bigImage {
-        position: absolute;
-        width: 440px;
-        text-align: left;
-        top: 0;
-        left: 0;
+.text-light {
+  @extend %text;
+  background-color: $neutral_white;
+  color: $neutral_dark;
+}
 
-        &.bigImageRight {
-          left: auto;
-          right: 0;
-        }
+%message {
+  padding: 15px 20px 5px 20px;
+  border-radius: 4px;
+  border: dashed $neutral_dark 2px;
+  animation: slidein 0.5s;
+}
 
-        img {
-          width: 100%;
-          position: absolute;
-          border: 10px $dark_black solid;
-          z-index: 80;
-          cursor: pointer;
-        }
-      }
-    }
+.message-dark {
+  @extend %message;
+  background-color: $neutral_light;
+  color: $neutral_dark;
+  border: dashed $neutral_light 2px;
+}
 
-    .text {
-      overflow-y: auto;
-      white-space: pre-wrap;
-      background-color: $neutral_light;
-      padding: 15px 20px 5px 20px;
-      border-radius: 10px;
-      color: $neutral_dark;
-      margin-bottom: 10px;
-      animation: slidein 0.5s;
-    }
+.message-light {
+  @extend %message;
+  background-color: $neutral_dark;
+  color: $neutral_light;
+  border: dashed $neutral_dark 2px;
+}
 
-    .feedback {
-      .message {
-        background-color: $neutral_light;
-        padding: 15px 20px 5px 20px;
-        border-radius: 10px;
-        color: $neutral_dark;
-        border: dashed $neutral_dark 2px;
-        animation: slidein 0.5s;
-      }
+.buttonNext {
+  font-size: 14px;
+  background-color: $brand_secondary_default;
+  border-color: $brand_secondary_default;
+  color: $neutral_light;
+  width: 100%;
+  padding: 5px 10px;
+  border-radius: 4px;
+  height: 38px;
+  margin: 0 0 10px 0;
+}
 
-      .buttonNext {
-        font-size: 14px;
-        background-color: $brand_secondary_default;
-        border-color: $brand_secondary_default;
-        color: $neutral_light;
-        width: 100%;
-        padding: 5px 10px;
-        border-radius: 8px;
-        height: 38px;
-        margin: 0 0 10px 0;
-      }
-    }
+.markdownText {
+  line-height: 0;
 
-    .markdownText {
-      line-height: 0;
+  h1,
+  h2 {
+    margin: 0 0 10px 0;
+    line-height: 1.2em;
+  }
 
-      h1,
-      h2 {
-        margin: 0 0 10px 0;
-        line-height: 1.2em;
-      }
+  ol {
+    line-height: 0;
+  }
 
-      ol {
-        line-height: 0;
-      }
+  li {
+    margin-bottom: 10px;
+  }
 
-      li {
-        margin-bottom: 10px;
-      }
+  code {
+    color: $neutral_light;
+  }
 
-      code {
-        color: $neutral_light;
-      }
-
-      p {
-        font-size: 14px;
-      }
-    }
+  p {
+    font-size: 14px;
   }
 }


### PR DESCRIPTION
This adds a basic top-level theme wrapper to Lab2, which keeps track of the current lab theme, and allows components to update it when necessary. This is implemented via React context. 

The motivation for this change is that we want to reuse the Instructions component in AI Chat, but currently AI Chat is presented in light mode, while Music Lab is in dark mode. This allows us to configure a separate theme per lab, and components can apply the correct styles based on the current lab theme.

I think longer term we want to head towards more global, site-wide theming using design tokens. This is hopefully an intermediate step in that direction that labs can benefit from, but is still fairly isolated as we iterate on a longer term solution.

Also applied some minor style updates from Mark.

Instructions dark theme (Music Lab):

<img width="1512" alt="Screenshot 2023-08-15 at 4 24 55 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/51c2b06b-b353-4217-82e4-f50cc726e1e6">

Instructions light theme (AI Chat):

<img width="1512" alt="Screenshot 2023-08-15 at 4 25 25 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/f79f7b66-ea3d-4ce8-8bc1-846e4ec0314f">

## Testing story

Tested locally on music and aichat levels.