### PR TITLE
Fix student bulk add to save family names

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_students_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_students_controller.rb
@@ -88,6 +88,7 @@ class Api::V1::SectionsStudentsController < Api::V1::JSONApiController
           user_type: User::TYPE_STUDENT,
           provider: User::PROVIDER_SPONSORED,
           name: student["name"],
+          family_name: student["family_name"],
           age: student["age"],
           gender: student["gender"],
           gender_teacher_input: student["gender_teacher_input"],

--- a/dashboard/test/controllers/api/v1/sections_students_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_students_controller_test.rb
@@ -223,7 +223,7 @@ class Api::V1::SectionsStudentsControllerTest < ActionController::TestCase
 
   test 'teacher can add one student to a word section' do
     sign_in @teacher
-    post :bulk_add, params: {section_id: @section.id, students: [{gender_teacher_input: 'f', age: 9, name: 'name'}]}
+    post :bulk_add, params: {section_id: @section.id, students: [{gender_teacher_input: 'f', age: 9, name: 'name', family_name: 'famname'}]}
     assert_response :success
 
     parsed_response = JSON.parse(@response.body)
@@ -234,6 +234,7 @@ class Api::V1::SectionsStudentsControllerTest < ActionController::TestCase
     new_student = User.find_by_id(parsed_response[0]['id'])
 
     assert_equal 'name', new_student.name
+    assert_equal 'famname', new_student.family_name
     assert_equal 9, new_student.age
     assert_equal 'f', new_student.gender
   end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Fix the `bulk_add` students endpoint to save family names, so adding students from the "manage students" table saves family names as expected.

![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/7bbd6e90-353e-4f34-8575-32546f1dcd9b)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [TEACH-639](https://codedotorg.atlassian.net/browse/TEACH-639)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
