### PR TITLE
Add How AI Works link to the video section on code.org/ai

### DIFF
--- a/pegasus/sites.v3/code.org/public/ai/index.haml
+++ b/pegasus/sites.v3/code.org/public/ai/index.haml
@@ -189,7 +189,7 @@ theme: responsive_full_width
 %section#ai-videos
   .wrapper
     %h2=hoc_s(:ai_video_series_title)
-    %p=hoc_s(:ai_video_series_desc)
+    %p=hoc_s(:ai_video_series_desc, markdown: :inline, locals: {how_ai_works_url: "/ai/how-ai-works"})
     .video-series
       = view :ai_vid_chatbots
       = view :ai_vid_creativity

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -528,7 +528,7 @@
   ai_pl_title: "Teaching AI and Machine Learning"
   ai_pl_desc: "Introduction to artificial intelligence and machine learning. Train a machine learning model using AI Lab. and engage with machine learning apps. Consider real-world implications of AI and machine learning."
   ai_video_series_title: "How AI Works"
-  ai_video_series_desc: "This series of short videos will introduce you to how artificial intelligence works and why it matters. Then delve into issues like algorithmic bias and the ethics of AI decision-making."
+  ai_video_series_desc: "This series of short videos will introduce you to how artificial intelligence works and why it matters. Then delve into issues like algorithmic bias and the ethics of AI decision-making. Watch the video series below, or [check out our How AI Works lessons](%{how_ai_works_url})!"
   ai_resources_heading: "Additional resources"
   ai_resources_desc: "Interested in learning more about AI? Here are some additional resources that can help extend your students' learning."
   ai_resources_title_01: "Ethics of AI Panel"


### PR DESCRIPTION
Adds a link to the How AI Works page in the video series section on https://code.org/ai

## Before
<img width="1019" alt="Screenshot 2023-08-16 at 11 57 12 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/0d4bc573-0819-4c76-a5e4-69b60b38a1d8">

## After
<img width="1026" alt="Screenshot 2023-08-16 at 11 57 00 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/1f7d1640-63e3-41f2-9217-0d5f8025b826">
