### PR TITLE
Fix Teacher Enrollment Reminder emails in test mailers preview

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -99,7 +99,7 @@ class Pd::WorkshopMailer < ActionMailer::Base
       to: email_address(@workshop.organizer.name, @workshop.organizer.email)
   end
 
-  def teacher_enrollment_reminder(enrollment, days_before = nil)
+  def teacher_enrollment_reminder(enrollment, options = nil)
     @enrollment = enrollment
     @workshop = enrollment.workshop
     @organizer = @workshop.organizer
@@ -107,7 +107,7 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @cancel_url = url_for controller: 'pd/workshop_enrollment', action: :cancel, code: enrollment.code
     @is_reminder = true
     @pre_workshop_survey_url = enrollment.pre_workshop_survey_url
-    @is_first_pre_survey_email = days_before == INITIAL_PRE_SURVEY_DAYS_BEFORE
+    @is_first_pre_survey_email = options.nil? ? true : options[:days_before] == INITIAL_PRE_SURVEY_DAYS_BEFORE
 
     # Facilitator training workshops use a different email address
     if @enrollment.workshop.course == Pd::Workshop::COURSE_FACILITATOR

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -99,7 +99,7 @@ class Pd::WorkshopMailer < ActionMailer::Base
       to: email_address(@workshop.organizer.name, @workshop.organizer.email)
   end
 
-  def teacher_enrollment_reminder(enrollment, days_before: nil)
+  def teacher_enrollment_reminder(enrollment, days_before = nil)
     @enrollment = enrollment
     @workshop = enrollment.workshop
     @organizer = @workshop.organizer

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -452,7 +452,7 @@ class Pd::Workshop < ApplicationRecord
     errors = []
     scheduled_start_in_days(days).each do |workshop|
       workshop.enrollments.each do |enrollment|
-        email = Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, days_before: days)
+        email = Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, options: {days_before: days})
         email.deliver_now
       rescue => exception
         errors << "teacher enrollment #{enrollment.id} - #{exception.message}"

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -28,7 +28,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
     Pd::Workshop.any_instance.expects(:suppress_reminders?).returns(false).times(3)
 
     assert_emails 3 do
-      Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment).deliver_now
+      Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, options: {days_before: 10}).deliver_now
       Pd::WorkshopMailer.facilitator_enrollment_reminder(facilitator, workshop).deliver_now
       Pd::WorkshopMailer.organizer_enrollment_reminder(workshop).deliver_now
     end
@@ -41,7 +41,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
     Pd::Workshop.any_instance.expects(:suppress_reminders?).returns(true).times(3)
 
     assert_emails 0 do
-      Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment).deliver_now
+      Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, options: {days_before: 10}).deliver_now
       Pd::WorkshopMailer.facilitator_enrollment_reminder(facilitator, workshop).deliver_now
       Pd::WorkshopMailer.organizer_enrollment_reminder(workshop).deliver_now
     end
@@ -63,7 +63,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
     enrollment = create :pd_enrollment, workshop: workshop
 
     assert_no_emails do
-      Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment).deliver_now
+      Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, options: {days_before: 10}).deliver_now
       Pd::WorkshopMailer.facilitator_enrollment_reminder(facilitator, workshop).deliver_now
       Pd::WorkshopMailer.organizer_enrollment_reminder(workshop).deliver_now
     end
@@ -221,7 +221,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
                  end
 
       enrollment = create :pd_enrollment, workshop: workshop
-      mail = Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, days_before: test_case[:days_before])
+      mail = Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, options: {days_before: test_case[:days_before]})
 
       assert links_are_complete_urls?(mail)
     end


### PR DESCRIPTION
Fixes Teacher Enrollment Reminder emails in test mailers previews. Currently, they all show the sad bee (e.g. https://test-studio.code.org/rails/mailers/pd_workshop_mailer/teacher_enrollment_reminder__csa_capstone_10_day).

Now, they render correctly:
![111](https://github.com/code-dot-org/code-dot-org/assets/56283563/23652072-70ee-42e2-8f86-1a4ec6ac4d32)

The issue was that the test/preview files and the regular files were passing in the `days_before` variable differently. In the preview files, it's being passed in inside an object (`options`) while the others pass it in as just a number paramter. This PR makes all of them call it in the same way with an `options` object with a `days_before` entry.

I realize this solution is a bit more verbose but I feel like it leaves it more open in case we want to add future options, rather than a more hard-code-y solution to check if it's a reminder email. I'm super open to pushback for another solution though!

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-716&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and drone build.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
