### PR TITLE
Fix .link-button CSS class

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/common.css
+++ b/pegasus/sites.v3/code.org/public/css/common.css
@@ -406,7 +406,7 @@ button {
 a.link-button {
   display: inline-block;
   color: var(--neutral_white);
-  background-color: #var(--brand_secondary_default);
+  background-color: var(--brand_secondary_default);
   border-radius: 4px;
   padding: 6px 12px;
   font-size: 14px;
@@ -416,7 +416,7 @@ a.link-button {
 
 #map .mapboxgl-popup-close-button {
   margin-top: 0px;
-  background-color: #var(--brand_secondary_default);
+  background-color: var(--brand_secondary_default);
 }
 
 /* Promote page */


### PR DESCRIPTION
Fixes the CSS that was causing buttons with a `.link-button` class to disappear

## Before
<img width="1016" alt="Screenshot 2023-08-16 at 12 15 52 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/d6888135-1820-457e-93a5-527cf4387c18">

## After
<img width="1016" alt="Screenshot 2023-08-16 at 12 15 40 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/a20f8d8b-6bbe-433e-aee5-90e555189ea1">
