### PR TITLE
Update `level_file_path` to Consistently Return a Pathname

### DIFF
--- a/dashboard/lib/policies/level_files.rb
+++ b/dashboard/lib/policies/level_files.rb
@@ -13,7 +13,7 @@ module Policies
       # If we already have a .level file that matches the given level name, use that.
       level_paths = Dir.glob(Rails.root.join(Policies::LevelFiles.level_file_glob(level.name)))
       raise("Multiple .level files for '#{level.name}' found: #{level_paths}") if level_paths.many?
-      return level_paths.first unless level_paths.empty?
+      return Pathname.new(level_paths.first) unless level_paths.empty?
 
       # If we don't yet have a .level file, create a new one at the default path.
       return Policies::LevelFiles.default_level_file_path(level)

--- a/dashboard/test/lib/policies/level_files_test.rb
+++ b/dashboard/test/lib/policies/level_files_test.rb
@@ -32,7 +32,7 @@ module Policies
         'config/scripts/levels/foo/bar/baz',
         'config/levels/custom/foo',
         'config/levels/custom/foo/bar/baz',
-      ].map {|dir| Rails.root.join(dir, "#{level.name}.level").to_s}
+      ].map {|dir| Rails.root.join(dir, "#{level.name}.level")}
 
       level_files.each do |level_file|
         FileUtils.mkdir_p(File.dirname(level_file))


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/53066

Right now, `level_file_path` will return the path as a Pathname when it does not already exist, and as a String if it does. This is because we invoke `default_level_file_path` when it doesn't, which returns a Pathname, and when it does we return the result of `Dir.glob(...).first`, which is a String. This can result in an unexpected inequality when [trying to compare the results of these methods](https://github.com/code-dot-org/code-dot-org/blob/02cce6c47d84efef325c4ff6f699997037ed5a2b/dashboard/lib/services/level_files.rb#L14), and so this fix is required for us to begin using `reorganize_level_file_into_subdirectory`.

To make this method both more consistent internally and with the results of `default_level_file_path`, update the 'file already exists' case to also return a Pathname.

## Testing story

Updated the relevant unit test