### PR TITLE
Require Enrollment for Workshop Attendance

### DIFF
--- a/dashboard/app/controllers/pd/session_attendance_controller.rb
+++ b/dashboard/app/controllers/pd/session_attendance_controller.rb
@@ -24,7 +24,6 @@ class Pd::SessionAttendanceController < ApplicationController
       # If signed out, user must sign in then is redirected back. If signed in to an account not associated
       # with an enrollment in this workshop, user must switch to an account enrolled in this workshop.
       if current_user
-        @safe_names = @session.workshop.unattended_enrollments.get_safe_names
         render :no_enrollment_match
         return
       else
@@ -50,7 +49,6 @@ class Pd::SessionAttendanceController < ApplicationController
     end
 
     enrollment.update!(user: current_user)
-
     attendance = Pd::Attendance.find_restore_or_create_by! session: @session, teacher: current_user
     attendance.update! marked_by_user: nil, enrollment: enrollment
 

--- a/dashboard/app/controllers/pd/session_attendance_controller.rb
+++ b/dashboard/app/controllers/pd/session_attendance_controller.rb
@@ -25,7 +25,7 @@ class Pd::SessionAttendanceController < ApplicationController
       # with an enrollment in this workshop, user must switch to an account enrolled in this workshop.
       if current_user
         @safe_names = @session.workshop.unattended_enrollments.get_safe_names
-        render :match_registration
+        render :no_enrollment_match
         return
       else
         redirect_to "/users/sign_in?user_return_to=/pd/attend/#{@session.code}"

--- a/dashboard/app/views/pd/session_attendance/match_registration.html.haml
+++ b/dashboard/app/views/pd/session_attendance/match_registration.html.haml
@@ -1,5 +1,0 @@
-- content_for(:head) do
-  = stylesheet_link_tag 'css/pd', media: 'all'
-
-%h2 Please Verify Your Workshop Registration
-%h3 We don't recognize your email address in our roster. Please choose your name.

--- a/dashboard/app/views/pd/session_attendance/match_registration.html.haml
+++ b/dashboard/app/views/pd/session_attendance/match_registration.html.haml
@@ -3,22 +3,3 @@
 
 %h2 Please Verify Your Workshop Registration
 %h3 We don't recognize your email address in our roster. Please choose your name.
-
-#application-container.container
-
-  - if flash[:error]
-    .alert.alert-danger{role: 'alert'}
-      = flash[:error]
-
-  .row
-    .col-lg-12
-      - @safe_names.each do |safe_name|
-        - route_options = {action: :select_enrollment, method: :post, params: {safe_name: safe_name[0], enrollment_code: safe_name[1].code}}
-        = button_to safe_name[0], route_options, form_class: 'form-inline', class: 'btn btn-gray'
-
-  .row
-    .col-lg-12
-      - join_route_options = {controller: 'pd/workshop_enrollment', action: 'join_session', session_code: @session.code}
-      = link_to join_route_options do
-        %button{class: "btn btn-primary", style: "font-size: 18px"}
-          My name is not on this list

--- a/dashboard/app/views/pd/session_attendance/no_enrollment_match.haml
+++ b/dashboard/app/views/pd/session_attendance/no_enrollment_match.haml
@@ -1,0 +1,2 @@
+%h2 Workshop Attendance Error
+%p We don't recognize your email address in our roster. Please login with the account associated with your workshop application and enrollment.

--- a/dashboard/app/views/pd/session_attendance/no_enrollment_match.haml
+++ b/dashboard/app/views/pd/session_attendance/no_enrollment_match.haml
@@ -1,2 +1,2 @@
 %h2 Workshop Attendance Error
-%p We don't recognize your email address in our roster. Please login with the account associated with your workshop application and enrollment.
+%p We don't recognize your email address in our roster. Please log in with the account associated with your workshop application and enrollment.

--- a/dashboard/test/controllers/pd/session_attendance_controller_test.rb
+++ b/dashboard/test/controllers/pd/session_attendance_controller_test.rb
@@ -54,11 +54,17 @@ class Pd::SessionAttendanceControllerTest < ActionController::TestCase
     assert_template :too_late
   end
 
-  test 'attend no matching enrollment renders match_registration view' do
+  test 'attend signed out redirects to sign_in page' do
+    get :attend, params: {session_code: @session.code}
+    assert_response :success
+    assert_redirected_to "/users/sign_in?user_return_to=/pd/attend/#{@session.code}"
+  end
+
+  test 'attend no matching enrollment renders no_enrollment_match view' do
     sign_in @teacher
     get :attend, params: {session_code: @session.code}
     assert_response :success
-    assert_template :match_registration
+    assert_template :no_enrollment_match
   end
 
   test 'attend with a matching enrollment creates attendance and redirects to home' do

--- a/dashboard/test/controllers/pd/session_attendance_controller_test.rb
+++ b/dashboard/test/controllers/pd/session_attendance_controller_test.rb
@@ -56,7 +56,6 @@ class Pd::SessionAttendanceControllerTest < ActionController::TestCase
 
   test 'attend signed out redirects to sign_in page' do
     get :attend, params: {session_code: @session.code}
-    assert_response :success
     assert_redirected_to "/users/sign_in?user_return_to=/pd/attend/#{@session.code}"
   end
 

--- a/dashboard/test/controllers/pd/session_attendance_controller_test.rb
+++ b/dashboard/test/controllers/pd/session_attendance_controller_test.rb
@@ -56,7 +56,7 @@ class Pd::SessionAttendanceControllerTest < ActionController::TestCase
 
   test 'attend signed out redirects to sign_in page' do
     get :attend, params: {session_code: @session.code}
-    assert_redirected_to "/users/sign_in?user_return_to=/pd/attend/#{@session.code}"
+    assert_redirected_to_sign_in
   end
 
   test 'attend no matching enrollment renders no_enrollment_match view' do


### PR DESCRIPTION
Currently, when you go to the attendance link for a workshop and you are not signed in as one of the users who is enrolled, you are given the choice to mark attendance as any other user who is enrolled in the workshop:
<img width="1186" alt="Screenshot 2023-04-04 at 8 59 59 PM" src="https://github.com/code-dot-org/code-dot-org/assets/56283563/c15917db-8c89-46a1-9da8-8eece2841718">

Whichever you select, that enrollment becomes permanently associated with the account you are currently signed in as which can lead to problems we see frequently in Zendesk like a workshop attendee clicking on the wrong name and enrollments get mixed up.

This PR eliminates the “choose your name” flow and:
- If the person is signed out, they are sent to the sign in flow (with a url param to redirect them back to the attendance page once they're done)
- If the person is signed in to an account not associated with an enrollment in the workshop, they are shown a message telling them to switch accounts

### Demo
Signed out user tries to go to attendance page and is redirected to the sign in page and then back to the attendance page:

https://github.com/code-dot-org/code-dot-org/assets/56283563/d23b55b5-e229-4e7e-a222-2d711dec94da

Signed in user using an account not associated with the workshop is shown message that they need to switch accounts:

![WorkshopAttendanceError](https://github.com/code-dot-org/code-dot-org/assets/56283563/356e8600-464f-4c3b-a9b0-ef542c4576ed)

Signed in user using an account associated with the workshop still has the same behavior:

https://github.com/code-dot-org/code-dot-org/assets/56283563/46c3cb5c-4c01-48b0-a87a-3b1e5b0129cb

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-505&assignee=60d62161f65054006980bd71)

## Testing story
Update unit tests and passing drone.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
