### PR TITLE
Fix sorting with missing family names

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
@@ -52,20 +52,10 @@ class StudentTable extends React.Component {
     } = this.props;
 
     // Sort students, in-place.
+    const collator = new Intl.Collator();
     isSortedByFamilyName
-      ? students.sort((a, b) => {
-          if (a.familyName && b.familyName) {
-            return a.familyName.localeCompare(b.familyName);
-          } else if (a.familyName) {
-            // Sort empty family names last.
-            return -1;
-          } else if (b.familyName) {
-            return 1;
-          } else {
-            return 0;
-          }
-        })
-      : students.sort((a, b) => a.name.localeCompare(b.name));
+      ? students.sort((a, b) => collator.compare(a.familyName, b.familyName))
+      : students.sort((a, b) => collator.compare(a.name, b.name));
 
     return (
       <table style={styles.table} className="student-table">

--- a/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
@@ -53,7 +53,18 @@ class StudentTable extends React.Component {
 
     // Sort students, in-place.
     isSortedByFamilyName
-      ? students.sort((a, b) => a.familyName.localeCompare(b.familyName))
+      ? students.sort((a, b) => {
+          if (a.familyName && b.familyName) {
+            return a.familyName.localeCompare(b.familyName);
+          } else if (a.familyName) {
+            // Sort empty family names last.
+            return -1;
+          } else if (b.familyName) {
+            return 1;
+          } else {
+            return 0;
+          }
+        })
       : students.sort((a, b) => a.name.localeCompare(b.name));
 
     return (

--- a/apps/test/unit/code-studio/components/progress/teacherPanel/StudentTableTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/teacherPanel/StudentTableTest.jsx
@@ -94,4 +94,18 @@ describe('StudentTable', () => {
     const firstStudentRow = wrapper.find('tr').at(1);
     expect(firstStudentRow.text()).to.match(/^Student 2/);
   });
+
+  it('sorts null family names last', () => {
+    const wrapper = setUp({
+      students: [
+        {id: 1, name: 'Student 1', familyName: 'FamNameB'},
+        {id: 2, name: 'Student 2'},
+        {id: 3, name: 'Student 3', familyName: 'FamNameA'},
+      ],
+      isSortedByFamilyName: true,
+    });
+
+    const lastStudentRow = wrapper.find('tr').at(3);
+    expect(lastStudentRow.text()).to.match(/^Student 2/);
+  });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Fix the teacher panel crashing when attempting to sort by family name in a section with some students without family names.

![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/c2b7e1cd-1ddd-4d87-b486-c6e8dcf3b26c)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [TEACH-643](https://codedotorg.atlassian.net/browse/TEACH-643)

