### PR TITLE
Update privacy links, move urls to shared_constants

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -91,6 +91,7 @@ def main
     ERROR_SEVERITY_LEVELS
     RESTRICTED_PUBLISH_PROJECT_TYPES
     RUBRIC_UNDERSTANDING_LEVELS
+    EMAIL_LINKS
   )
 
   generate_shared_js_file(shared_content, "#{REPO_DIR}/apps/src/util/sharedConstants.js")

--- a/apps/src/lib/ui/ParentLetter.jsx
+++ b/apps/src/lib/ui/ParentLetter.jsx
@@ -7,16 +7,12 @@ import {queryParams} from '../../code-studio/utils';
 import color from '../../util/color';
 import i18n from '@cdo/locale';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import {EmailLinks} from '@cdo/apps/util/sharedConstants';
 
-const PRIVACY_PLEDGE_URL = 'https://studentprivacypledge.org/signatories/';
-const COMMON_SENSE_ARTICLE_URL =
-  'https://privacy.commonsense.org/evaluation/code.org';
 const RESEARCH_ARTICLE_URL =
   'https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536';
 const ENGAGEMENT_URL =
   'https://support.code.org/hc/en-us/articles/360041539831-How-can-I-keep-track-of-what-my-child-is-working-on-on-Code-org-';
-const STUDENT_PRIVACY_POLICY_URL =
-  'https://code.org/privacy-nov2021#protecting-childrens-privacy';
 
 const LOGIN_TYPE_NAMES = {
   [SectionLoginType.clever]: 'Clever accounts',
@@ -134,9 +130,9 @@ class ParentLetter extends React.Component {
           <h1>{i18n.parentLetterStudentPrivacy()}</h1>
           <SafeMarkdown
             markdown={i18n.parentLetterStudentPrivacyDetails({
-              pledgeLink: PRIVACY_PLEDGE_URL,
-              commonSenseLink: COMMON_SENSE_ARTICLE_URL,
-              privacyPolicyLink: STUDENT_PRIVACY_POLICY_URL,
+              pledgeLink: EmailLinks.STUDENT_PRIVACY_PLEDGE_URL,
+              commonSenseLink: EmailLinks.COMMON_SENSE_MEDIA_URL,
+              privacyPolicyLink: EmailLinks.PRIVACY_POLICY_URL,
             })}
           />
           <p>{i18n.parentLetterClosing()}</p>

--- a/dashboard/app/views/parent_mailer/parent_permission_confirmation.html.haml
+++ b/dashboard/app/views/parent_mailer/parent_permission_confirmation.html.haml
@@ -1,15 +1,17 @@
+- require 'cdo/shared_constants'
+
 %p
   Dear Parent/Guardian,
 
 %p
   Thank you for approving your child's use of a Code.org® account (or adding a personal login to an existing Code.org account used in school).  By approving your child's account, you agree to the Code.org
-  %a{href:"https://code.org/tos"}Terms of Service
+  %a{href:SharedConstants::EMAIL_LINKS.TOS_URL}Terms of Service
   and
-  %a{href:"https://code.org/privacy-nov2021#protecting-childrens-privacy"}Privacy Policy.
+  %a{href:SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL}Privacy Policy.
 
 %p
   You can revoke your consent at any time by emailing us at
-  %a{href:"mailto:support@code.org"}support@code.org
+  %a{href:SharedConstants::EMAIL_LINKS.CDO_SUPPORT_MAILTO}support@code.org
   from this email address.  You can also self-delete your child's account by signing in and clicking the user name in the top right corner of the screen, and then selecting "account settings." Simply scroll down to the bottom of that page and follow the instructions there to delete the  account. If you don't see the option for deletion, your child is still enrolled in one or more teachers' sections, and you'll need to ask the teachers to remove them first from that section before you can delete the account.
 
 %p
@@ -17,11 +19,11 @@
 
 %p
   Code.org assigns utmost importance to student data privacy and security. As a not-for-profit organization, they are transparent about the limited data they collect and how they use it.  They do not sell data or exploit it for financial gain. They do not sell ads. Code.org has signed the
-  %a{href:"https://studentprivacypledge.org/signatories/"}Student Privacy Pledge
+  %a{href:SharedConstants::EMAIL_LINKS.STUDENT_PRIVACY_PLEDGE_URL}Student Privacy Pledge
   and their privacy practices are highly rated by
-  %a{href:"https://privacy.commonsense.org/evaluation/code.org"}Common Sense Media.
+  %a{href:SharedConstants::EMAIL_LINKS.COMMON_SENSE_MEDIA_URL}Common Sense Media.
   You can find further details by viewing Code.org's
-  %a{href:"https://code.org/privacy-nov2021#protecting-childrens-privacy"}Privacy Policy.
+  %a{href:SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL}Privacy Policy.
 
 %p
   Thank you for allowing your child to learn with us.

--- a/dashboard/app/views/parent_mailer/parent_permission_reminder.html.haml
+++ b/dashboard/app/views/parent_mailer/parent_permission_reminder.html.haml
@@ -1,3 +1,5 @@
+- require 'cdo/shared_constants'
+
 %p
   Dear Parent/Guardian,
 
@@ -15,19 +17,19 @@
 
 %p
   Code.org assigns utmost importance to student data privacy and security. As a not-for-profit organization, they are transparent about the limited data they collect and how they use it.  They do not sell data or exploit it for financial gain. They do not sell ads. Code.org has signed the
-  %a{href:"https://studentprivacypledge.org/signatories/"}Student Privacy Pledge
+  %a{href:SharedConstants::EMAIL_LINKS.STUDENT_PRIVACY_PLEDGE_URL}Student Privacy Pledge
   and their privacy practices are highly rated by
-  %a{href:"https://privacy.commonsense.org/evaluation/code.org"}Common Sense Media.
+  %a{href:SharedConstants::EMAIL_LINKS.COMMON_SENSE_MEDIA_URL}Common Sense Media.
   You can find further details by viewing Code.org's
-  %a{href:"https://code.org/privacy-nov2021#protecting-childrens-privacy"}Privacy Policy.
+  %a{href:SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL}Privacy Policy.
 
 %p
   By approving your child's account, you agree to the Code.org
-  %a{href:"https://code.org/tos"}Terms of Service
+  %a{href:SharedConstants::EMAIL_LINKS.TOS_URL}Terms of Service
   and
-  %a{href:"https://code.org/privacy-nov2021#protecting-childrens-privacy"}Privacy Policy.
+  %a{href:SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL}Privacy Policy.
   You may withdraw your consent and delete the child's account at any time by contacting us at
-  %a{href:"mailto:support@code.org"}support@code.org
+  %a{href:SharedConstants::EMAIL_LINKS.CDO_SUPPORT_MAILTO}support@code.org
   from your email address receiving this notice.  Your email address will not be used or disclosed by Code.org for any other purpose unless you provide a separate consent.
 
 %p

--- a/dashboard/app/views/parent_mailer/parent_permission_request.html.haml
+++ b/dashboard/app/views/parent_mailer/parent_permission_request.html.haml
@@ -1,3 +1,5 @@
+- require 'cdo/shared_constants'
+
 %p
   Dear Parent/Guardian,
 
@@ -12,19 +14,19 @@
 
 %p
   Code.org assigns utmost importance to student data privacy and security. As a not-for-profit organization, they are transparent about the limited data they collect and how they use it.  They do not sell data or exploit it for financial gain. They do not sell ads. Code.org has signed the
-  %a{href:"https://studentprivacypledge.org/signatories/"}Student Privacy Pledge
+  %a{href:SharedConstants::EMAIL_LINKS.STUDENT_PRIVACY_PLEDGE_URL}Student Privacy Pledge
   and their privacy practices are highly rated by
-  %a{href:"https://privacy.commonsense.org/evaluation/code.org"}Common Sense Media.
+  %a{href:SharedConstants::EMAIL_LINKS.COMMON_SENSE_MEDIA_URL}Common Sense Media.
   You can find further details by viewing Code.org's
-  %a{href:"https://code.org/privacy-nov2021#protecting-childrens-privacy"}Privacy Policy.
+  %a{href:SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL}Privacy Policy.
 
 %p
   By approving your child's account, you agree to the Code.org
-  %a{href:"https://code.org/tos"}Terms of Service
+  %a{href:SharedConstants::EMAIL_LINKS.TOS_URL}Terms of Service
   and
-  %a{href:"https://code.org/privacy-nov2021#protecting-childrens-privacy"}Privacy Policy.
+  %a{href:SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL}Privacy Policy.
   You may withdraw your consent and delete the child's account at any time by contacting us at
-  %a{href:"mailto:support@code.org"}support@code.org
+  %a{href:SharedConstants::EMAIL_LINKS.CDO_SUPPORT_MAILTO}support@code.org
   from your email address receiving this notice.  Your email address will not be used or disclosed by Code.org for any other purpose unless you provide a separate consent.
 
 %p

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -606,4 +606,14 @@ module SharedConstants
       NONE: 0
     }
   ).freeze
+
+  EMAIL_LINKS = OpenStruct.new(
+    {
+      PRIVACY_POLICY_URL: "https://code.org/privacy",
+      TOS_URL: "https://code.org/tos",
+      STUDENT_PRIVACY_PLEDGE_URL: "https://studentprivacypledge.org/signatories/",
+      COMMON_SENSE_MEDIA_URL: "https://privacy.commonsense.org/evaluation/code.org",
+      CDO_SUPPORT_MAILTO: "mailto:support@code.org"
+    }
+  ).freeze
 end


### PR DESCRIPTION
Due to some miscommunication, the incorrect privacy links were added in a [previous update](https://github.com/code-dot-org/code-dot-org/pull/53194) to the CPA parent emails. This updates the privacy policy links to the latest version, and also moves all the reused links from these emails into SharedConstants, where they can be referenced across emails and also in the front-end-generated parent letter. This dries up the code and makes it easier to change these in the future, since it seems like the links and text in these emails changes frequently.

## Links

[JIRA ticket](https://codedotorg.atlassian.net/browse/P20-297)


## Testing story

- Tested locally using the ActionMailer previews for the CPA emails at http://localhost-studio.code.org:3000/rails/mailers.
- Tested the parent letter changes in the storybook for `ParentLetter`

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
