### PR TITLE
[AI Chat] Update AI Chat workspace

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -6,20 +6,26 @@ import ChatWorkspace from './ChatWorkspace';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 const commonI18n = require('@cdo/locale');
+const aichatI18n = require('../locale');
 
 const AichatView: React.FunctionComponent = () => {
   return (
     <div id="aichat-lab" className={moduleStyles.aichatLab}>
       <div className={moduleStyles.instructionsArea}>
         <PanelContainer
-          id="aichat-instructions"
+          id="aichat-instructions-panel"
           headerText={commonI18n.instructions()}
         >
           <Instructions />
         </PanelContainer>
       </div>
       <div className={moduleStyles.chatWorkspaceArea}>
-        <ChatWorkspace />
+        <PanelContainer
+          id={aichatI18n.aichatWorkspaceHeader()}
+          headerText="AI Chat Lab"
+        >
+          <ChatWorkspace />
+        </PanelContainer>
       </div>
     </div>
   );

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -6,7 +6,7 @@ import ChatWorkspace from './ChatWorkspace';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 const commonI18n = require('@cdo/locale');
-const aichatI18n = require('../locale');
+const aichatI18n = require('@cdo/aichat/locale');
 
 const AichatView: React.FunctionComponent = () => {
   return (
@@ -21,8 +21,8 @@ const AichatView: React.FunctionComponent = () => {
       </div>
       <div className={moduleStyles.chatWorkspaceArea}>
         <PanelContainer
-          id={aichatI18n.aichatWorkspaceHeader()}
-          headerText="AI Chat Lab"
+          id="aichat-workspace-panel"
+          headerText={aichatI18n.aichatWorkspaceHeader()}
         >
           <ChatWorkspace />
         </PanelContainer>

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -1,10 +1,8 @@
 import React, {useState, useCallback} from 'react';
-import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import ChatWarningModal from '@cdo/apps/aichat/views/ChatWarningModal';
 import ChatMessage from './ChatMessage';
 import UserChatMessageEditor from './UserChatMessageEditor';
 import moduleStyles from './chatWorkspace.module.scss';
-import aichatI18n from '../locale';
 import {ChatCompletionMessage, Status, Role} from '../types';
 import {demoChatMessages} from './demoMessages'; // demo chat messages - remove when connected to backend
 import {getChatCompletionMessage} from '../chatApi';
@@ -73,25 +71,20 @@ const ChatWorkspace: React.FunctionComponent = () => {
     <ChatWorkspaceContext.Provider value={{onSubmit: onSubmit}}>
       <div id="chat-workspace-area" className={moduleStyles.chatWorkspace}>
         {showWarningModal && <ChatWarningModal onClose={onCloseWarningModal} />}
-        <PanelContainer
-          id="chat-workspace-panel"
-          headerText={aichatI18n.aichatWorkspaceHeader()}
+        <div
+          id="chat-workspace-conversation"
+          className={moduleStyles.conversationArea}
         >
-          <div
-            id="chat-workspace-conversation"
-            className={moduleStyles.conversationArea}
-          >
-            {storedMessages.map(message => (
-              <ChatMessage message={message} key={message.id} />
-            ))}
-          </div>
-          <div
-            id="chat-workspace-editor"
-            className={moduleStyles.userChatMessageEditor}
-          >
-            <UserChatMessageEditor />
-          </div>
-        </PanelContainer>
+          {storedMessages.map(message => (
+            <ChatMessage message={message} key={message.id} />
+          ))}
+        </div>
+        <div
+          id="chat-workspace-editor"
+          className={moduleStyles.userChatMessageEditor}
+        >
+          <UserChatMessageEditor />
+        </div>
       </div>
     </ChatWorkspaceContext.Provider>
   );


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This small PR pulls the `PanelContainer` out of `ChatWorkspace` so that there is more consistency among AI Chat components.
It's a follow-up to #53335 .

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally and saw there were no visible UI changes.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
