### PR TITLE
P20-329: Fix curriculum content i18n sync-in

### DIFF
--- a/bin/i18n/resources/dashboard/curriculum_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/curriculum_content/sync_in.rb
@@ -45,8 +45,6 @@ module I18n
               # write data to path
               name = "#{script.name}.json"
               path = File.join(I18N_SOURCE_FILE_PATH, get_script_subdirectory(script), name)
-              next if I18nScriptUtils.unit_directory_change?(name, path)
-
               FileUtils.mkdir_p(File.dirname(path))
               File.write(path, JSON.pretty_generate(data))
             end

--- a/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_in.rb
@@ -24,7 +24,6 @@ class I18n::Resources::Dashboard::CurriculumContent::SyncInTest < Minitest::Test
 
     ::Services::I18n::CurriculumSyncUtils::Serializers::ScriptCrowdinSerializer.expects(:new).with(script, scope: {only_numbered_lessons: true}).in_sequence(exec_seq).returns(script_serializer_mock)
     I18n::Resources::Dashboard::CurriculumContent::SyncIn.expects(:get_script_subdirectory).with(script).in_sequence(exec_seq).returns('expected_script_subdirectory')
-    I18nScriptUtils.expects(:unit_directory_change?).with('expected_script_name.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
 
     FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/curriculum_content/expected_script_subdirectory')).in_sequence(exec_seq)
     File.expects(:write).with(expected_i18n_source_file_path, %Q[{\n  "expected_data": "expected_data"\n}]).in_sequence(exec_seq)
@@ -47,7 +46,6 @@ class I18n::Resources::Dashboard::CurriculumContent::SyncInTest < Minitest::Test
 
     ::Unit.expects(:find_each).once.yields(script)
     ::ScriptConstants.expects(:i18n?).with(script.name).once.returns(false)
-    ::Services::I18n::CurriculumSyncUtils::Serializers::ScriptCrowdinSerializer.expects(:new).with(script, scope: {only_numbered_lessons: true}).never
 
     I18n::Resources::Dashboard::CurriculumContent::SyncIn.serialize
   end
@@ -65,28 +63,6 @@ class I18n::Resources::Dashboard::CurriculumContent::SyncInTest < Minitest::Test
     ::Services::I18n::CurriculumSyncUtils::Serializers::ScriptCrowdinSerializer.expects(:new).with(script, scope: {only_numbered_lessons: true}).in_sequence(exec_seq).returns(script_serializer_mock)
 
     I18n::Resources::Dashboard::CurriculumContent::SyncIn.expects(:get_script_subdirectory).with(script).never.returns('expected_script_subdirectory')
-    I18nScriptUtils.expects(:unit_directory_change?).with('expected_script_name.json', expected_i18n_source_file_path).never.returns(false)
-    FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/curriculum_content/expected_script_subdirectory')).never
-    File.expects(:write).with(expected_i18n_source_file_path, %Q[{\n  "expected_data": "expected_data"\n}]).never
-
-    I18n::Resources::Dashboard::CurriculumContent::SyncIn.serialize
-  end
-
-  def test_serialization_of_script_with_unit_directory_changed_file
-    exec_seq = sequence('execution')
-    expected_serialized_data = {expected: {expected_data: 'expected_data', unexpected_blank: {}}, unexpeted: 'unexpeted_data'}
-    script_serializer_mock = mock(as_json: mock(compact: expected_serialized_data))
-    expected_i18n_source_file_path = CDO.dir('i18n/locales/source/curriculum_content/expected_script_subdirectory/expected_script_name.json')
-
-    script = FactoryBot.build_stubbed(:script, is_migrated: true, name: 'expected_script_name')
-
-    ::Unit.expects(:find_each).in_sequence(exec_seq).yields(script)
-    ::ScriptConstants.expects(:i18n?).with(script.name).in_sequence(exec_seq).returns(true)
-
-    ::Services::I18n::CurriculumSyncUtils::Serializers::ScriptCrowdinSerializer.expects(:new).with(script, scope: {only_numbered_lessons: true}).in_sequence(exec_seq).returns(script_serializer_mock)
-    I18n::Resources::Dashboard::CurriculumContent::SyncIn.expects(:get_script_subdirectory).with(script).in_sequence(exec_seq).returns('expected_script_subdirectory')
-    I18nScriptUtils.expects(:unit_directory_change?).with('expected_script_name.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(true)
-
     FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/curriculum_content/expected_script_subdirectory')).never
     File.expects(:write).with(expected_i18n_source_file_path, %Q[{\n  "expected_data": "expected_data"\n}]).never
 


### PR DESCRIPTION
## Issues
Before the `I18nScriptUtils.unit_directory_change?` [fix](https://github.com/code-dot-org/code-dot-org/pull/53119/files#diff-2c889d87d9094d585b34681b3136cc4c2cbb8e99a1ecc20cdff673fadaf9ef3cL271-R271), [the method](https://github.com/code-dot-org/code-dot-org/pull/53387/files#diff-93d0f46416cd651f831003761c3b0d6cd9786b5593ea22515928a21601d758a0L48) always returned `false` because of [the invalid level content directory path](https://github.com/code-dot-org/code-dot-org/pull/53119/files#diff-2c889d87d9094d585b34681b3136cc4c2cbb8e99a1ecc20cdff673fadaf9ef3cL271).
So [we always rewrote the existing and already redacted `i18n/locales/source/curriculum_content/*` files data with the latest DB data](https://github.com/code-dot-org/code-dot-org/pull/53119/files#diff-93d0f46416cd651f831003761c3b0d6cd9786b5593ea22515928a21601d758a0R50-R51).

After the `I18nScriptUtils.unit_directory_change?` [fix](https://github.com/code-dot-org/code-dot-org/pull/53119/files#diff-2c889d87d9094d585b34681b3136cc4c2cbb8e99a1ecc20cdff673fadaf9ef3cL271-R271), [the method](https://github.com/code-dot-org/code-dot-org/pull/53387/files#diff-93d0f46416cd651f831003761c3b0d6cd9786b5593ea22515928a21601d758a0L48) starts working as expected and now returns `true` when files already exist.
And because of that, we start redacting again already redacted files:
- The first redaction: `https://example.org/unit1` => `<https://example.org/unit1>`
- The second redaction: `<https://example.org/unit1>` => `[https://example.org/unit1][0]`
  
## Links
- jira ticket: [P20-329](https://codedotorg.atlassian.net/browse/P20-329)