### PR TITLE
Adding a11y labels to both dropdowns in teacher panel

### DIFF
--- a/apps/src/code-studio/components/progress/SectionSelector.jsx
+++ b/apps/src/code-studio/components/progress/SectionSelector.jsx
@@ -50,6 +50,7 @@ function SectionSelector({
     <select
       className="uitest-sectionselect"
       name="sections"
+      aria-label={i18n.selectSection()}
       style={{
         ...styles.select,
         ...style,

--- a/apps/src/templates/SortByNameDropdown.jsx
+++ b/apps/src/templates/SortByNameDropdown.jsx
@@ -17,6 +17,7 @@ function SortByNameDropdown({
       <div style={sortByStyles}>{i18n.sortBy()}</div>
       <select
         name="familyNameSort"
+        aria-label={i18n.sortBy()}
         style={selectStyles}
         defaultValue={i18n.displayName}
         onChange={e => {


### PR DESCRIPTION
Adds aria labels so that a screen reader announces what the dropdown is for. There are two different SectionSelector dropdown files- I verified that the one in the teacher panel is the one in the 'progress' folder, and tested locally via a screenreader.

## Links

- spec: []()
- jira ticket:https://codedotorg.atlassian.net/browse/TEACH-644


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
