### PR TITLE
Use API for authorized teacher permission in UI tests

### DIFF
--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -17,6 +17,13 @@ class TestController < ApplicationController
     head :ok
   end
 
+  def authorized_teacher_access
+    return unless (user = current_user)
+    user.permission = UserPermission::AUTHORIZED_TEACHER
+    user.save!
+    head :ok
+  end
+
   def plc_reviewer_access
     return unless (user = current_user)
     user.permission = UserPermission::PLC_REVIEWER

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -206,11 +206,9 @@ def pass_time_for_user(name, amount_of_time)
   end
 end
 
-And(/^I give user "([^"]*)" authorized teacher permission$/) do |name|
-  require_rails_env
-  user = User.find_by_email_or_hashed_email(@users[name][:email])
-  user.permission = UserPermission::AUTHORIZED_TEACHER
-  user.save!
+And(/^I give user "([^"]*)" authorized teacher permission$/) do |_|
+  # this currently just givgites permissions to whoever is signed in?
+  browser_request(url: '/api/test/authorized_teacher_access', method: 'POST')
 end
 
 And(/^I get universal instructor access$/) do

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -207,7 +207,6 @@ def pass_time_for_user(name, amount_of_time)
 end
 
 And(/^I give user "([^"]*)" authorized teacher permission$/) do |_|
-  # this currently just givgites permissions to whoever is signed in?
   browser_request(url: '/api/test/authorized_teacher_access', method: 'POST')
 end
 


### PR DESCRIPTION
Use our existing test controller for setting the "authorized teacher" permission in UI tests, rather than fully loading Rails to do so. Should help with some test flakiness we've seen in a couple of tests that use this permission, where the loading Rails step was timing out.

Here's a [link](https://codedotorg.slack.com/archives/C03CM903Y/p1692663478023899) with some of the tests that should be affected by this change.

## Testing story

Relying on passing UI tests in Drone that this works as expected.