### PR TITLE
Strip display and family names before save

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -562,6 +562,12 @@ class User < ApplicationRecord
 
   before_save :remove_cleartext_emails, if: -> {student? && migrated? && user_type_changed?}
 
+  before_save :strip_display_family_names
+  def strip_display_family_names
+    self.name = name.strip if name
+    self.family_name = family_name.strip if family_name
+  end
+
   validate :no_family_name_for_teachers
   def no_family_name_for_teachers
     if family_name && (teacher? || sections_as_pl_participant.any?)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -564,8 +564,8 @@ class User < ApplicationRecord
 
   before_save :strip_display_family_names
   def strip_display_family_names
-    self.name = name.strip if name
-    self.family_name = family_name.strip if family_name
+    self.name = name.strip if name && will_save_change_to_name?
+    self.family_name = family_name.strip if family_name && will_save_change_to_properties?
   end
 
   validate :no_family_name_for_teachers

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -572,6 +572,14 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test "saving user strips display name and family name" do
+    user = create :student, name: '  test name  ', family_name: '  test fam name  '
+    user.save
+    user.reload
+    assert_equal user.name, 'test name'
+    assert_equal user.family_name, 'test fam name'
+  end
+
   test "can create a user with age" do
     Timecop.travel Time.local(2013, 9, 1, 12, 0, 0) do
       assert_creates(User) do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -578,6 +578,16 @@ class UserTest < ActiveSupport::TestCase
     user.reload
     assert_equal user.name, 'test name'
     assert_equal user.family_name, 'test fam name'
+
+    user.name = '  test name 2  '
+    user.save
+    user.reload
+    assert_equal user.name, 'test name 2'
+
+    user.family_name = '  test fam name 2  '
+    user.save
+    user.reload
+    assert_equal user.family_name, 'test fam name 2'
   end
 
   test "can create a user with age" do


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Strip starting and trailing whitespace from `user.name` (display names) and `user.properties['family_name']` in a `before_save` callback. Fixes some strange display/sorting behavior in the UI.

Turns out we can do this on the serialized `properties` without any extra effort, so I went with Eric's suggestion of doing it in the model rather than making sure to catch every place in the controller(s).

Tagging platform/infra for optional review because this is a model change, just in case you know of something this could break.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [TEACH-648](https://codedotorg.atlassian.net/browse/TEACH-648)

