### PR TITLE
Updated Rubric AI checkbox styles and tested for accessibility

### DIFF
--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -30,7 +30,7 @@ export default function LearningGoalItem({deleteItem}) {
                 />
               </label>
             </div>
-            <label>
+            <label style={styles.labelAndInput}>
               Use AI to assess
               <input
                 type="checkbox"
@@ -86,6 +86,7 @@ const styles = {
   },
   checkbox: {
     marginLeft: 7,
+    
   },
   label: {
     fontSize: 18,

--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -46,7 +46,7 @@ export default function LearningGoalItem({deleteItem}) {
                 }
                 aria-hidden="true"
               >
-                &#10003; {/* Checkmark HTML code */}
+                ✔
               </span>
             </label>
           </div>
@@ -103,7 +103,6 @@ const styles = {
     color: color.white,
     fontSize: 18,
     textAlign: 'center',
-    fontStyle: 'bold',
     borderColor: color.white,
     borderStyle: 'solid',
     borderWidth: 1,
@@ -117,7 +116,6 @@ const styles = {
     color: color.white,
     fontSize: 18,
     textAlign: 'center',
-    fontStyle: 'bold',
     borderColor: color.black,
     borderStyle: 'solid',
     borderWidth: 1,

--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -86,7 +86,6 @@ const styles = {
   },
   checkbox: {
     marginLeft: 7,
-    
   },
   label: {
     fontSize: 18,

--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import PropTypes, { nominalTypeHack } from 'prop-types';
+import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import {borderRadius} from '@cdo/apps/lib/levelbuilder/constants';
 import EvidenceDescriptions from './EvidenceDescriptions';
@@ -30,8 +30,7 @@ export default function LearningGoalItem({deleteItem}) {
                 />
               </label>
             </div>
-            <label 
-              style={styles.labelAndInput}>
+            <label style={styles.labelAndInput}>
               Use AI to assess
               <input
                 type="checkbox"
@@ -40,7 +39,9 @@ export default function LearningGoalItem({deleteItem}) {
                 style={styles.checkbox}
               />
               <span
-                style={aiEnabled ? (styles.checkboxChecked) : (styles.checkboxBlank)}
+                style={
+                  aiEnabled ? styles.checkboxChecked : styles.checkboxBlank
+                }
                 aria-hidden="true"
               >
                 &#10003;
@@ -105,7 +106,6 @@ const styles = {
     borderStyle: 'solid',
     borderWidth: 1,
     borderRadius: 2,
-    color: color.white,
     margin: 5,
     width: 20,
     height: 20,

--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -38,13 +38,15 @@ export default function LearningGoalItem({deleteItem}) {
                 onChange={handleCheckboxChange}
                 style={styles.checkbox}
               />
+              {/* This span is used for checkbox styling;
+              It is hidden from AT devices */}
               <span
                 style={
                   aiEnabled ? styles.checkboxChecked : styles.checkboxBlank
                 }
-                aria-hidden="true"
-              >
-                &#10003;
+                aria-hidden="true" 
+              > 
+                &#10003; {/* Checkmark HTML code */}
               </span>
             </label>
           </div>

--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -44,8 +44,8 @@ export default function LearningGoalItem({deleteItem}) {
                 style={
                   aiEnabled ? styles.checkboxChecked : styles.checkboxBlank
                 }
-                aria-hidden="true" 
-              > 
+                aria-hidden="true"
+              >
                 &#10003; {/* Checkmark HTML code */}
               </span>
             </label>

--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, { nominalTypeHack } from 'prop-types';
 import color from '@cdo/apps/util/color';
 import {borderRadius} from '@cdo/apps/lib/levelbuilder/constants';
 import EvidenceDescriptions from './EvidenceDescriptions';
@@ -30,7 +30,8 @@ export default function LearningGoalItem({deleteItem}) {
                 />
               </label>
             </div>
-            <label style={styles.labelAndInput}>
+            <label 
+              style={styles.labelAndInput}>
               Use AI to assess
               <input
                 type="checkbox"
@@ -38,6 +39,12 @@ export default function LearningGoalItem({deleteItem}) {
                 onChange={handleCheckboxChange}
                 style={styles.checkbox}
               />
+              <span
+                style={aiEnabled ? (styles.checkboxChecked) : (styles.checkboxBlank)}
+                aria-hidden="true"
+              >
+                &#10003;
+              </span>
             </label>
           </div>
         </div>
@@ -85,7 +92,37 @@ const styles = {
     marginBottom: 20,
   },
   checkbox: {
-    marginLeft: 7,
+    opacity: 0,
+    position: 'absolute',
+  },
+  checkboxChecked: {
+    background: color.cyan,
+    color: color.white,
+    fontSize: 18,
+    textAlign: 'center',
+    fontStyle: 'bold',
+    borderColor: color.white,
+    borderStyle: 'solid',
+    borderWidth: 1,
+    borderRadius: 2,
+    color: color.white,
+    margin: 5,
+    width: 20,
+    height: 20,
+  },
+  checkboxBlank: {
+    background: color.white,
+    color: color.white,
+    fontSize: 18,
+    textAlign: 'center',
+    fontStyle: 'bold',
+    borderColor: color.black,
+    borderStyle: 'solid',
+    borderWidth: 1,
+    borderRadius: 2,
+    margin: 5,
+    width: 20,
+    height: 20,
   },
   label: {
     fontSize: 18,


### PR DESCRIPTION
Story: AITT-124

Changed alignment and styling of "Use AI to assess" checkbox on rubric creation page. Tested with keyboard commands and NVDA screen reader for accessibility.

### Before
<img width="961" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/5552007/8904d2de-7501-4028-a983-8920b9805318">

### After

<img width="757" alt="After-1" src="https://github.com/code-dot-org/code-dot-org/assets/5552007/6be784ba-e54e-413c-91a5-caea88ed3940">

<img width="764" alt="After-2" src="https://github.com/code-dot-org/code-dot-org/assets/5552007/824fb98f-dba8-4617-ae71-94609e77db5c">
