### PR TITLE
Change sort to ignore non-letter characters, null at end, etc.

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
@@ -59,13 +59,16 @@ class StudentTable extends React.Component {
     // Example: comparator(['familyName', 'name']) will sort by familyName
     // first, looking at name if necessary to break ties.
     const comparator = keys => (a, b) =>
-      keys.reduce((result, key) => result || letterCompare(a[key], b[key]), 0);
+      keys.reduce(
+        (result, key) => result || letterCompare(a[key] || '', b[key] || ''),
+        0
+      );
 
     const letterCompare = (a, b) => {
       // Strip out any non-alphabetic characters from the strings before sorting
       // (https://unicode.org/reports/tr44/#Alphabetic)
-      const aLetters = (a || '').replace(/[^\p{Alphabetic}]/gu, '');
-      const bLetters = (b || '').replace(/[^\p{Alphabetic}]/gu, '');
+      const aLetters = a.replace(/[^\p{Alphabetic}]/gu, '');
+      const bLetters = b.replace(/[^\p{Alphabetic}]/gu, '');
 
       const initialCompare = collator.compare(aLetters, bLetters);
 
@@ -77,7 +80,9 @@ class StudentTable extends React.Component {
         return 1;
       }
 
-      return initialCompare;
+      // Use original strings as a fallback if the special-character-stripped
+      // version compares as equal.
+      return initialCompare || collator.compare(a, b);
     };
 
     // Sort students, in-place.

--- a/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
@@ -51,11 +51,39 @@ class StudentTable extends React.Component {
       isSortedByFamilyName,
     } = this.props;
 
-    // Sort students, in-place.
+    // Sort using system default locale.
     const collator = new Intl.Collator();
+
+    // Returns a comparator function that sorts objects a and b by the given
+    // keys, in order of priority.
+    // Example: comparator(['familyName', 'name']) will sort by familyName
+    // first, looking at name if necessary to break ties.
+    const comparator = keys => (a, b) =>
+      keys.reduce((result, key) => result || letterCompare(a[key], b[key]), 0);
+
+    const letterCompare = (a, b) => {
+      // Strip out any non-alphabetic characters from the strings before sorting
+      // (https://unicode.org/reports/tr44/#Alphabetic)
+      const aLetters = (a || '').replace(/[^\p{Alphabetic}]/gu, '');
+      const bLetters = (b || '').replace(/[^\p{Alphabetic}]/gu, '');
+
+      const initialCompare = collator.compare(aLetters, bLetters);
+
+      // Sort strings with letters before strings without
+      if (initialCompare > 0 && !!aLetters && !bLetters) {
+        return -1;
+      }
+      if (initialCompare < 0 && !aLetters && !!bLetters) {
+        return 1;
+      }
+
+      return initialCompare;
+    };
+
+    // Sort students, in-place.
     isSortedByFamilyName
-      ? students.sort((a, b) => collator.compare(a.familyName, b.familyName))
-      : students.sort((a, b) => collator.compare(a.name, b.name));
+      ? students.sort(comparator(['familyName', 'name']))
+      : students.sort(comparator(['name', 'familyName']));
 
     return (
       <table style={styles.table} className="student-table">

--- a/apps/test/unit/code-studio/components/progress/teacherPanel/StudentTableTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/teacherPanel/StudentTableTest.jsx
@@ -109,7 +109,7 @@ describe('StudentTable', () => {
       students: [
         {id: 1, name: 'Student 1', familyName: 'FamNameB'},
         {id: 2, name: 'Student 2'},
-        {id: 3, name: 'Student 3', familyName: 'FamNameA'},
+        {id: 3, name: 'Student 3', familyName: 'ZFamNameA'},
       ],
       isSortedByFamilyName: true,
     });
@@ -119,6 +119,46 @@ describe('StudentTable', () => {
     expect(lastStudentRow.text()).to.not.match(/null/);
     expect(lastStudentRow.text()).to.not.match(/undefined/);
 
+    DCDO.reset();
+  });
+
+  it('ignores non-alphabetic characters in sorting', () => {
+    DCDO.reset();
+    DCDO.set('family-name-features', true);
+
+    const wrapper = setUp({
+      students: [
+        {id: 1, name: 'Student 1', familyName: '1Brown'},
+        {id: 2, name: 'Student 2', familyName: '!Charles'},
+        {id: 3, name: 'Student 3', familyName: 'Adams'},
+      ],
+      isSortedByFamilyName: true,
+    });
+
+    const studentRows = wrapper.find('tr');
+    expect(studentRows.at(1).text()).to.match(/^Student 3/);
+    expect(studentRows.at(2).text()).to.match(/^Student 1/);
+    expect(studentRows.at(3).text()).to.match(/^Student 2/);
+    DCDO.reset();
+  });
+
+  it('sorts by name when family names are equivalent', () => {
+    DCDO.reset();
+    DCDO.set('family-name-features', true);
+
+    const wrapper = setUp({
+      students: [
+        {id: 1, name: 'Eve', familyName: 'Carlson'},
+        {id: 2, name: 'Alice', familyName: 'Carlson'},
+        {id: 3, name: 'Bob', familyName: 'Carlson'},
+      ],
+      isSortedByFamilyName: true,
+    });
+
+    const studentRows = wrapper.find('tr');
+    expect(studentRows.at(1).text()).to.match(/^Alice/);
+    expect(studentRows.at(2).text()).to.match(/^Bob/);
+    expect(studentRows.at(3).text()).to.match(/^Eve/);
     DCDO.reset();
   });
 });


### PR DESCRIPTION
Updates to family name sorting in the student table in the teacher panel view:
1) Students with no family name will be sorted at the end of the list, instead of using an assumed family name of "null".
2) Students with the same family name will be ordered by their given name to break the tie.
3) Non-alphabetical characters will be ignored in the sorting.

Before: (note that "!DropTables" and "1Betterson" come at the beginning of the list, and "Eric" (no family name) is sorted between "Nulio" and "Nulson")
![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/f5f67daa-8d10-4cd9-861b-16098227ba66)

After: ("1Betterson" and "!DropTables" are sorted as "B" and "D" names, respectively; "Eric" (no last name) appears at the end of the list)
![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/b20b8f68-28da-4a7e-9c08-f42dec07811a)


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

JIRA ticket: [TEACH-649](https://codedotorg.atlassian.net/browse/TEACH-649)

## Testing story

Three unit tests:
1) Make sure null sorts between "FamNameB" and "ZFamNameA"
2) Make sure "Adams", "1Brown", and "!Charles" sort in that order
3) Make sure "Alice Carlson", "Bob Carlson", and "Eve Carlson" sort in that order.

I verified all three of these failed in the previous logic.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
