### PR TITLE
skip script preload in rails console

### DIFF
--- a/dashboard/config/initializers/script_preload.rb
+++ b/dashboard/config/initializers/script_preload.rb
@@ -1,6 +1,5 @@
 # Preload script cache before application fork.
-# This speeds up load time of new Unicorn child worker processes
-# and Spring application preloader (Rails console, unit tests).
+# This speeds up load time of new Unicorn child worker processes.
 
 # Skip if this is running a Rake task (e.g. rake db:setup), when running rails console,
 # or when caching is disabled.

--- a/dashboard/config/initializers/script_preload.rb
+++ b/dashboard/config/initializers/script_preload.rb
@@ -2,8 +2,10 @@
 # This speeds up load time of new Unicorn child worker processes
 # and Spring application preloader (Rails console, unit tests).
 
-# Skip if this is running a Rake task (e.g. rake db:setup) or when caching is disabled
+# Skip if this is running a Rake task (e.g. rake db:setup), when running rails console,
+# or when caching is disabled.
 if File.basename($0) != 'rake' &&
+    !defined?(Rails::Console) &&
     Unit.should_cache? &&
     !Rails.application.config.skip_script_preload
   # Populate the shared in-memory cache from the database.


### PR DESCRIPTION
this substantially improves performance of `bin/dashboard-console` on production-console, reducing startup time from 2m50s to 1m10s and reducing memory usage from 3.7GB to 2.1GB.

this change makes sense because the script cache preload is really only meant to be done on production frontends.

cheat sheet for when the script preloader runs: https://docs.google.com/spreadsheets/d/1jtzDt85ipTWAbL7OvRS__JrtMSOwge8fPAldd7X464g/edit#gid=0

## Testing story

- verified on my local machine that `defined?(Rails::Console)` returns `nil` when executed within dashboard-server, and non-nil when executed in dashboard-console.
- I patched this change into production-console and verified that the startup time for rails console is reduced.
