### PR TITLE
P20-329: Fix curriculum content i18n sync-in

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -270,7 +270,7 @@ class I18nScriptUtils
   #
   # Example:
   #   If `course_version` of the script (unit) `csd1` was changed from `2017` to `2023`,
-  #   the new script file `i18n/locales/source/curriculum_content/2023/csd/csd1.json` will not be created
+  #   the new script file `i18n/locales/source/curriculum_content/2023/csd/csd1.json` should not be created
   #   until the previous scrip file `i18n/locales/source/curriculum_content/2017/csd/csd1.json` is synced-out
   #
   # Note we could try here to remove the old version of the file both from the

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -255,30 +255,30 @@ class I18nScriptUtils
   end
 
   # For resources like `course_content` and `curriculum_content`,
-  # sync-in creates the script (unit) course_version/course_offering folders structure
+  # sync-in creates the unit course_version/course_offering folders structure
   # (e.g. `i18n/locales/source/curriculum_content/2017/csd/csd1.json`).
   #
-  # If a script (unit) is updated such that its destination directory changes after
+  # If a unit is updated such that its destination directory changes after
   # creation, we can end up in a situation in which we have multiple copies of
-  # the script file in the repo, which makes it difficult for the sync out to
+  # the unit file in the repo, which makes it difficult for the sync out to
   # know which is the canonical version.
   #
   # To prevent that, here we proactively check for existing files in the
-  # filesystem with the same filename as our target script file, but a
-  # different directory. If found, we refuse to create the second such script
+  # filesystem with the same filename as our target unit file, but a
+  # different directory. If found, we refuse to create the second such unit
   # file and notify of the attempt, so the issue can be manually resolved.
   #
   # Example:
-  #   If `course_version` of the script (unit) `csd1` was changed from `2017` to `2023`,
-  #   the new script file `i18n/locales/source/curriculum_content/2023/csd/csd1.json` should not be created
-  #   until the previous scrip file `i18n/locales/source/curriculum_content/2017/csd/csd1.json` is synced-out
+  #   If `course_version` of the unit `csd1` was changed from `2017` to `2023`,
+  #   the new unit file `i18n/locales/source/curriculum_content/2023/csd/csd1.json` should not be created
+  #   until the previous unit file `i18n/locales/source/curriculum_content/2017/csd/csd1.json` is synced-out
   #
   # Note we could try here to remove the old version of the file both from the
   # filesystem and from github, but it would be significantly harder to also
   # remove it from Crowdin.
-  def self.unit_directory_change?(content_dir, script_i18n_name, script_i18n_filename)
-    matching_files = Dir.glob(File.join(content_dir, "**", script_i18n_name)).reject do |other_filename|
-      other_filename == script_i18n_filename
+  def self.unit_directory_change?(content_dir, unit_i18n_filename, unit_i18n_filepath)
+    matching_files = Dir.glob(File.join(content_dir, "**", unit_i18n_filename)).reject do |other_filename|
+      other_filename == unit_i18n_filepath
     end
 
     return false if matching_files.empty?
@@ -286,12 +286,13 @@ class I18nScriptUtils
     # Clean up the file paths, just to make our output a little nicer
     base = Pathname.new(content_dir)
     relative_matching = matching_files.map {|filename| Pathname.new(filename).relative_path_from(base)}
-    relative_new = Pathname.new(script_i18n_filename).relative_path_from(base)
-    script_name = File.basename(script_i18n_name, '.*')
-    error_class = 'Destination directory for script is attempting to change'
-    error_message = "Script #{script_name} wants to output strings to #{relative_new}, but #{relative_matching.join(' and ')} already exists"
+    relative_new = Pathname.new(unit_i18n_filepath).relative_path_from(base)
+    unit_name = File.basename(unit_i18n_filename, '.*')
+    error_class = 'Destination directory for unit is attempting to change'
+    error_message = "Unit #{unit_name} wants to output strings to #{relative_new}, but #{relative_matching.join(' and ')} already exists"
     log_error(error_class, error_message)
-    return true
+
+    true
   end
 
   def self.log_error(error_class, error_message)

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -267,9 +267,7 @@ class I18nScriptUtils
   # Note we could try here to remove the old version of the file both from the
   # filesystem and from github, but it would be significantly harder to also
   # remove it from Crowdin.
-  def self.unit_directory_change?(script_i18n_name, script_i18n_filename)
-    level_content_directory = CDO.dir(File.join(I18N_SOURCE_DIR, 'course_content'))
-
+  def self.unit_directory_change?(level_content_directory, script_i18n_name, script_i18n_filename)
     matching_files = Dir.glob(File.join(level_content_directory, "**", script_i18n_name)).reject do |other_filename|
       other_filename == script_i18n_filename
     end

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -255,7 +255,7 @@ class I18nScriptUtils
   end
 
   # For resources like `course_content` and `curriculum_content`,
-  # sync-in creates the unit course_version/course_offering folders structure
+  # sync-in creates the unit course_version/course_offering directory structure
   # (e.g. `i18n/locales/source/curriculum_content/2017/csd/csd1.json`).
   #
   # If a unit is updated such that its destination directory changes after

--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -334,7 +334,7 @@ module I18n
 
               script_i18n_name = "#{script.name}.json"
               script_i18n_filename = File.join(script_i18n_directory, script_i18n_name)
-              next if I18nScriptUtils.unit_directory_change?(script_i18n_name, script_i18n_filename)
+              next if I18nScriptUtils.unit_directory_change?(I18N_SOURCE_DIR_PATH, script_i18n_name, script_i18n_filename)
 
               File.write(script_i18n_filename, JSON.pretty_generate(script_strings))
             end

--- a/bin/i18n/resources/dashboard/curriculum_content.rb
+++ b/bin/i18n/resources/dashboard/curriculum_content.rb
@@ -4,7 +4,7 @@ module I18n
   module Resources
     module Dashboard
       module CurriculumContent
-        I18N_SOURCE_FILE_PATH = CDO.dir(File.join(I18N_SOURCE_DIR, 'curriculum_content')).freeze
+        I18N_SOURCE_DIR_PATH = CDO.dir(File.join(I18N_SOURCE_DIR, 'curriculum_content')).freeze
         REDACT_RESTORE_PLUGINS = %w[resourceLink vocabularyDefinition].freeze
 
         def self.sync_in

--- a/bin/i18n/resources/dashboard/curriculum_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/curriculum_content/sync_in.rb
@@ -44,8 +44,8 @@ module I18n
 
               # write data to path
               name = "#{script.name}.json"
-              path = File.join(I18N_SOURCE_FILE_PATH, get_script_subdirectory(script), name)
-              next if I18nScriptUtils.unit_directory_change?(name, path)
+              path = File.join(I18N_SOURCE_DIR_PATH, get_script_subdirectory(script), name)
+              next if I18nScriptUtils.unit_directory_change?(I18N_SOURCE_DIR_PATH, name, path)
 
               FileUtils.mkdir_p(File.dirname(path))
               File.write(path, JSON.pretty_generate(data))
@@ -55,7 +55,7 @@ module I18n
           def self.redact
             originals_dir = I18N_SOURCE_DIR.sub('source', 'original')
 
-            Dir[File.join(I18N_SOURCE_FILE_PATH, '**/*.json')].each do |file|
+            Dir[File.join(I18N_SOURCE_DIR_PATH, '**/*.json')].each do |file|
               original_file = file.sub(I18N_SOURCE_DIR, originals_dir)
               FileUtils.mkdir_p(File.dirname(original_file))
               FileUtils.cp(file, original_file)

--- a/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
@@ -62,7 +62,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     sync_in_instance.expects(:get_i18n_strings).with(level).in_sequence(exec_seq).returns(expected_level_i18n_strings)
     Unit.expects(:unit_in_category?).with('hoc', script.name).in_sequence(exec_seq).returns(true)
     FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/course_content/Hour of Code')).in_sequence(exec_seq)
-    I18nScriptUtils.expects(:unit_directory_change?).with('hoc-script.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
+    I18nScriptUtils.expects(:unit_directory_change?).with(CDO.dir('i18n/locales/source/course_content'), 'hoc-script.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
     File.expects(:write).with(expected_i18n_source_file_path, %Q[{\n  "expected_level_url": {\n    "expected_script_string_key": "expected_script_string_value"\n  }\n}]).in_sequence(exec_seq)
 
     sync_in_instance.expects(:write_to_yml).with('block_categories', expected_block_categories).in_sequence(exec_seq)
@@ -104,7 +104,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     Unit.expects(:unit_in_category?).with('hoc', script.name).in_sequence(exec_seq).returns(false)
     script.expects(:unversioned?).in_sequence(exec_seq).returns(true)
     FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/course_content/other')).in_sequence(exec_seq)
-    I18nScriptUtils.expects(:unit_directory_change?).with('unversioned-script.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
+    I18nScriptUtils.expects(:unit_directory_change?).with(CDO.dir('i18n/locales/source/course_content'), 'unversioned-script.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
     File.expects(:write).with(expected_i18n_source_file_path, %Q[{\n  "expected_level_url": {\n    "expected_script_string_key": "expected_script_string_value"\n  }\n}]).in_sequence(exec_seq)
 
     sync_in_instance.expects(:write_to_yml).with('block_categories', expected_block_categories).in_sequence(exec_seq)
@@ -146,7 +146,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     Unit.expects(:unit_in_category?).with('hoc', script.name).in_sequence(exec_seq).returns(false)
     script.expects(:unversioned?).in_sequence(exec_seq).returns(false)
     FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/course_content/expected_version_year')).in_sequence(exec_seq)
-    I18nScriptUtils.expects(:unit_directory_change?).with('versioned-script.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
+    I18nScriptUtils.expects(:unit_directory_change?).with(CDO.dir('i18n/locales/source/course_content'), 'versioned-script.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
     File.expects(:write).with(expected_i18n_source_file_path, %Q[{\n  "expected_level_url": {\n    "expected_script_string_key": "expected_script_string_value"\n  }\n}]).in_sequence(exec_seq)
 
     sync_in_instance.expects(:write_to_yml).with('block_categories', expected_block_categories).in_sequence(exec_seq)
@@ -188,7 +188,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     Unit.expects(:unit_in_category?).with('hoc', script.name).in_sequence(exec_seq).returns(false)
     script.expects(:unversioned?).in_sequence(exec_seq).returns(false)
     FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/course_content/expected_version_year')).in_sequence(exec_seq)
-    I18nScriptUtils.expects(:unit_directory_change?).with('versioned-script.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(true)
+    I18nScriptUtils.expects(:unit_directory_change?).with(CDO.dir('i18n/locales/source/course_content'), 'versioned-script.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(true)
     File.expects(:write).with(expected_i18n_source_file_path, %Q[{\n  "expected_level_url": {\n    "expected_script_string_key": "expected_script_string_value"\n  }\n}]).never
 
     sync_in_instance.expects(:write_to_yml).with('block_categories', expected_block_categories).in_sequence(exec_seq)
@@ -230,7 +230,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     Unit.expects(:unit_in_category?).with('hoc', script.name).never.returns(false)
     script.expects(:unversioned?).never.returns(false)
     FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/course_content/expected_version_year')).never
-    I18nScriptUtils.expects(:unit_directory_change?).with('versioned-script.json', expected_i18n_source_file_path).never.returns(false)
+    I18nScriptUtils.expects(:unit_directory_change?).with(CDO.dir('i18n/locales/source/course_content'), 'versioned-script.json', expected_i18n_source_file_path).never.returns(false)
     File.expects(:write).with(expected_i18n_source_file_path, %Q[{\n  "expected_level_url": {\n    "expected_script_string_key": "expected_script_string_value"\n  }\n}]).never
 
     sync_in_instance.expects(:write_to_yml).with('block_categories', {}).in_sequence(exec_seq)

--- a/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_in.rb
@@ -24,7 +24,7 @@ class I18n::Resources::Dashboard::CurriculumContent::SyncInTest < Minitest::Test
 
     ::Services::I18n::CurriculumSyncUtils::Serializers::ScriptCrowdinSerializer.expects(:new).with(script, scope: {only_numbered_lessons: true}).in_sequence(exec_seq).returns(script_serializer_mock)
     I18n::Resources::Dashboard::CurriculumContent::SyncIn.expects(:get_script_subdirectory).with(script).in_sequence(exec_seq).returns('expected_script_subdirectory')
-    I18nScriptUtils.expects(:unit_directory_change?).with('expected_script_name.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
+    I18nScriptUtils.expects(:unit_directory_change?).with(CDO.dir('i18n/locales/source/curriculum_content'), 'expected_script_name.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
 
     FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/curriculum_content/expected_script_subdirectory')).in_sequence(exec_seq)
     File.expects(:write).with(expected_i18n_source_file_path, %Q[{\n  "expected_data": "expected_data"\n}]).in_sequence(exec_seq)
@@ -65,7 +65,7 @@ class I18n::Resources::Dashboard::CurriculumContent::SyncInTest < Minitest::Test
     ::Services::I18n::CurriculumSyncUtils::Serializers::ScriptCrowdinSerializer.expects(:new).with(script, scope: {only_numbered_lessons: true}).in_sequence(exec_seq).returns(script_serializer_mock)
 
     I18n::Resources::Dashboard::CurriculumContent::SyncIn.expects(:get_script_subdirectory).with(script).never.returns('expected_script_subdirectory')
-    I18nScriptUtils.expects(:unit_directory_change?).with('expected_script_name.json', expected_i18n_source_file_path).never.returns(false)
+    I18nScriptUtils.expects(:unit_directory_change?).with(CDO.dir('i18n/locales/source/curriculum_content'), 'expected_script_name.json', expected_i18n_source_file_path).never.returns(false)
     FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/curriculum_content/expected_script_subdirectory')).never
     File.expects(:write).with(expected_i18n_source_file_path, %Q[{\n  "expected_data": "expected_data"\n}]).never
 
@@ -85,7 +85,7 @@ class I18n::Resources::Dashboard::CurriculumContent::SyncInTest < Minitest::Test
 
     ::Services::I18n::CurriculumSyncUtils::Serializers::ScriptCrowdinSerializer.expects(:new).with(script, scope: {only_numbered_lessons: true}).in_sequence(exec_seq).returns(script_serializer_mock)
     I18n::Resources::Dashboard::CurriculumContent::SyncIn.expects(:get_script_subdirectory).with(script).in_sequence(exec_seq).returns('expected_script_subdirectory')
-    I18nScriptUtils.expects(:unit_directory_change?).with('expected_script_name.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(true)
+    I18nScriptUtils.expects(:unit_directory_change?).with(CDO.dir('i18n/locales/source/curriculum_content'), 'expected_script_name.json', expected_i18n_source_file_path).in_sequence(exec_seq).returns(true)
 
     FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/curriculum_content/expected_script_subdirectory')).never
     File.expects(:write).with(expected_i18n_source_file_path, %Q[{\n  "expected_data": "expected_data"\n}]).never

--- a/bin/test/i18n/test_i18n_script_utils.rb
+++ b/bin/test/i18n/test_i18n_script_utils.rb
@@ -63,28 +63,28 @@ class I18nScriptUtilsTest < Minitest::Test
   def test_unit_directory_changing
     exec_seq = sequence('execution')
 
-    expected_i18n_dir   = CDO.dir('i18n/locales/source/expected_i18n_dir')
-    expected_file_name  = 'expected.json'
-    expected_file1_path = CDO.dir('i18n/locales/source/expected_i18n_dir/1/expected.json')
-    expected_file2_path = CDO.dir('i18n/locales/source/expected_i18n_dir/2/expected.json')
+    expected_content_dir         = CDO.dir('i18n/locales/source/expected_content_dir')
+    expected_unit_i18n_filename  = 'expected_unit_i18n.json'
+    expected_unit_i18n_filepath1 = CDO.dir('i18n/locales/source/expected_content_dir/1/expected_unit_i18n.json')
+    expected_unit_i18n_filepath2 = CDO.dir('i18n/locales/source/expected_content_dir/2/expected_unit_i18n.json')
 
-    Dir.expects(:glob).with(File.join(expected_i18n_dir, '**', expected_file_name)).in_sequence(exec_seq).returns([expected_file2_path])
+    Dir.expects(:glob).with(File.join(expected_content_dir, '**', expected_unit_i18n_filename)).in_sequence(exec_seq).returns([expected_unit_i18n_filepath2])
     I18nScriptUtils.expects(:log_error).with(
-      'Destination directory for script is attempting to change',
-      'Script expected wants to output strings to 1/expected.json, but 2/expected.json already exists'
+      'Destination directory for unit is attempting to change',
+      'Unit expected wants to output strings to 1/expected_unit_i18n.json, but 2/expected_unit_i18n.json already exists'
     ).in_sequence(exec_seq)
 
-    assert I18nScriptUtils.unit_directory_change?(expected_i18n_dir, expected_file_name, expected_file1_path)
+    assert I18nScriptUtils.unit_directory_change?(expected_content_dir, expected_unit_i18n_filename, expected_unit_i18n_filepath1)
   end
 
   def test_unit_directory_changing_when_no_matching_files
-    expected_i18n_dir  = CDO.dir('i18n/locales/source/expected_i18n_dir')
-    expected_file_name = 'expected.json'
-    expected_file_path = CDO.dir('i18n/locales/source/expected_i18n_dir/expected.json')
+    expected_content_dir        = CDO.dir('i18n/locales/source/expected_content_dir')
+    expected_unit_i18n_filename = 'expected_unit_i18n.json'
+    expected_unit_i18n_filepath = CDO.dir('i18n/locales/source/expected_content_dir/expected_unit_i18n.json')
 
-    Dir.expects(:glob).with(File.join(expected_i18n_dir, '**', expected_file_name)).once.returns([expected_file_path])
+    Dir.expects(:glob).with(File.join(expected_content_dir, '**', expected_unit_i18n_filename)).once.returns([expected_unit_i18n_filepath])
 
-    refute I18nScriptUtils.unit_directory_change?(expected_i18n_dir, expected_file_name, expected_file_path)
+    refute I18nScriptUtils.unit_directory_change?(expected_content_dir, expected_unit_i18n_filename, expected_unit_i18n_filepath)
   end
 
   def test_yml_file_fixing

--- a/bin/test/i18n/test_i18n_script_utils.rb
+++ b/bin/test/i18n/test_i18n_script_utils.rb
@@ -71,7 +71,7 @@ class I18nScriptUtilsTest < Minitest::Test
     Dir.expects(:glob).with(File.join(expected_content_dir, '**', expected_unit_i18n_filename)).in_sequence(exec_seq).returns([expected_unit_i18n_filepath2])
     I18nScriptUtils.expects(:log_error).with(
       'Destination directory for unit is attempting to change',
-      'Unit expected wants to output strings to 1/expected_unit_i18n.json, but 2/expected_unit_i18n.json already exists'
+      'Unit expected_unit_i18n wants to output strings to 1/expected_unit_i18n.json, but 2/expected_unit_i18n.json already exists'
     ).in_sequence(exec_seq)
 
     assert I18nScriptUtils.unit_directory_change?(expected_content_dir, expected_unit_i18n_filename, expected_unit_i18n_filepath1)

--- a/bin/test/i18n/test_i18n_script_utils.rb
+++ b/bin/test/i18n/test_i18n_script_utils.rb
@@ -63,26 +63,28 @@ class I18nScriptUtilsTest < Minitest::Test
   def test_unit_directory_changing
     exec_seq = sequence('execution')
 
-    expected_file_name = 'expected.json'
-    expected_file1_path = CDO.dir('i18n/locales/source/course_content/1/expected.json')
-    expected_file2_path = CDO.dir('i18n/locales/source/course_content/2/expected.json')
+    expected_i18n_dir   = CDO.dir('i18n/locales/source/expected_i18n_dir')
+    expected_file_name  = 'expected.json'
+    expected_file1_path = CDO.dir('i18n/locales/source/expected_i18n_dir/1/expected.json')
+    expected_file2_path = CDO.dir('i18n/locales/source/expected_i18n_dir/2/expected.json')
 
-    Dir.expects(:glob).with(CDO.dir('i18n/locales/source/course_content/**/expected.json')).in_sequence(exec_seq).returns([expected_file2_path])
+    Dir.expects(:glob).with(File.join(expected_i18n_dir, '**', expected_file_name)).in_sequence(exec_seq).returns([expected_file2_path])
     I18nScriptUtils.expects(:log_error).with(
       'Destination directory for script is attempting to change',
       'Script expected wants to output strings to 1/expected.json, but 2/expected.json already exists'
     ).in_sequence(exec_seq)
 
-    assert I18nScriptUtils.unit_directory_change?(expected_file_name, expected_file1_path)
+    assert I18nScriptUtils.unit_directory_change?(expected_i18n_dir, expected_file_name, expected_file1_path)
   end
 
   def test_unit_directory_changing_when_no_matching_files
+    expected_i18n_dir  = CDO.dir('i18n/locales/source/expected_i18n_dir')
     expected_file_name = 'expected.json'
-    expected_file_path = 'i18n/locales/source/course_content/expected.json'
+    expected_file_path = CDO.dir('i18n/locales/source/expected_i18n_dir/expected.json')
 
-    Dir.expects(:glob).with(CDO.dir('i18n/locales/source/course_content/**/expected.json')).once.returns([expected_file_path])
+    Dir.expects(:glob).with(File.join(expected_i18n_dir, '**', expected_file_name)).once.returns([expected_file_path])
 
-    refute I18nScriptUtils.unit_directory_change?(expected_file_name, expected_file_path)
+    refute I18nScriptUtils.unit_directory_change?(expected_i18n_dir, expected_file_name, expected_file_path)
   end
 
   def test_yml_file_fixing


### PR DESCRIPTION
Because [`I18nScriptUtils.unit_directory_change?`](https://github.com/code-dot-org/code-dot-org/pull/53403/files#diff-33254942a96145eebf4363cd53e6e6d501933be5dc1590515e287557138085e5R337) checking wasn't working correctly for `curriculum_content`, we didn't rewrite already existing files, instead, we keep redacting the same already redacted file every `sync-in` run:
- Link to markdown: `https://example.org/unit1` => `<https://example.org/unit1>`
- The first redaction: `<https://example.org/unit1>` => `[https://example.org/unit1][0]`
- The next redactions: `[https://example.org/unit1][0]` => `[https://example.org/unit1][0]`

## Links
- jira ticket: [P20-329](https://codedotorg.atlassian.net/browse/P20-329)
