### PR TITLE
Allows locked out accounts to set their age when it is blank.

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -346,6 +346,8 @@ class ApplicationController < ActionController::Base
       lockout_path,
       # The locked out student needs access to the policy consent API's
       policy_compliance_child_account_consent_path,
+      # The age interstitial when the age isn't known will block the lockout page
+      users_set_age_path,
     ].include?(request.path)
 
     redirect_to lockout_path unless Policies::ChildAccount.compliant?(current_user)

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -7,7 +7,6 @@ class RegistrationsController < Devise::RegistrationsController
     :edit, :update, :destroy, :upgrade, :set_email, :set_user_type,
     :migrate_to_multi_auth, :demigrate_from_multi_auth
   ]
-  skip_before_action :assert_child_account_policy, only: [:set_age]
   skip_before_action :verify_authenticity_token, only: [:set_age]
   skip_before_action :clear_sign_up_session_vars, only: [:new, :begin_sign_up, :cancel, :create]
 

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -7,6 +7,7 @@ class RegistrationsController < Devise::RegistrationsController
     :edit, :update, :destroy, :upgrade, :set_email, :set_user_type,
     :migrate_to_multi_auth, :demigrate_from_multi_auth
   ]
+  skip_before_action :assert_child_account_policy, only: [:set_age]
   skip_before_action :verify_authenticity_token, only: [:set_age]
   skip_before_action :clear_sign_up_session_vars, only: [:new, :begin_sign_up, :cancel, :create]
 
@@ -208,7 +209,8 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   # Set age for the current user if empty - skips CSRF verification because this can be called
-  # from cached pages which will not populate the CSRF token
+  # from cached pages which will not populate the CSRF token. This also skips lockout policy
+  # checks since those depend on the age being set.
   def set_age
     return head(:forbidden) unless current_user
     current_user.update(age: params[:user][:age]) if current_user.age.blank?


### PR DESCRIPTION
When a student somehow creates an account (or has an existing account) that does not contain an age (via a `birthday` or explicitly a set `age` attribute), they will be presented with a modal interrupting their use of the site prompting them to enter an age. This is to patch such users so that all users will have an age when interacting with the site.

However, this modal interrupts students from interacting with the lockout page so they can't get parental permission... which in turn blocks them from setting an age since the route setting the age is blocked due to the lockout. A Catch-22 that essentially permanently locks them out.

This patch allows the `/set_age` route, which is a special route that sets an age if and only if the age is blank, during the lockout. This route is the one used by the aforementioned age interstitial.

The question of how a student can have a state (`CO`) set and not an age is an open one. The accounts seem to be google authenticated accounts, which seemingly get to have their age validations skipped. No effort to prevent that deferral is done, here, just letting the age setting work as expected is fixed here.

No follow up work or patching of user accounts is needed. The affected accounts can just log in again and use the age popup as expected. After the fix, such user support tickets should respond as such.

Here is an image from a customer showing the issue; this modal is blocking the lockout flow and won't go away because the PATCH route the modal hits is locked out:

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/8e5dced0-82ae-4768-8e42-c061dc20db72)

Big collaborative effort with Carl on this one. Big thanks to Carl for getting this fixed.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
- jira ticket: [P20-350](https://codedotorg.atlassian.net/browse/P20-350)
- several zendesk support tickets referred to [in slack](https://codedotorg.slack.com/archives/CFTFD6BPV/p1692732262221739)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Some manual testing. To reproduce the behavior:

* Create a student account by any means. It forces the age to be set on create.
* In the dashboard console, erase the birthday: `u = User.last; u.update(birthday: nil)`
* Erase the age: `u.update(age: nil)`
* Now the account has no age. The age popup would appear.
* Set the state to `CO`: `u.us_state = "CO"; u.save`
* Now this account will be locked AND the age pop up will appear.

Before this fix, the modal will be presented, but it cannot succeed. Since the `/set_age` route does not return success, the modal does not close. This leaves the student in a locked state with no ability to get to the permission form.

After the fix, the age popup will succeed. If they report they are 13, they are not redirected home but would be if they refreshed the lockout page. Otherwise, they can interact with the lockout flow normally.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
