### PR TITLE
Extract partitionBlocksByType into dedicated util function

### DIFF
--- a/apps/src/blockly/addons/cdoBlockSerializer.js
+++ b/apps/src/blockly/addons/cdoBlockSerializer.js
@@ -1,21 +1,8 @@
 import GoogleBlockly from 'blockly/core';
 import {PROCEDURE_DEFINITION_TYPES} from '../constants';
+import {partitionBlocksByType} from './cdoUtils';
 
 const unknownBlockState = {type: 'unknown', enabled: false};
-
-// Move blocks of the specified types to the front of the list. Used by load()
-function partitionBlocksByType(blockStates, prioritizedBlockTypes) {
-  const prioritizedBlocks = [];
-  const remainingBlocks = [];
-
-  blockStates.forEach(block => {
-    prioritizedBlockTypes.includes(block.type)
-      ? prioritizedBlocks.push(block)
-      : remainingBlocks.push(block);
-  });
-
-  return [...prioritizedBlocks, ...remainingBlocks];
-}
 
 export default class CdoBlockSerializer extends GoogleBlockly.serialization
   .blocks.BlockSerializer {

--- a/apps/src/blockly/addons/cdoBlockSerializer.js
+++ b/apps/src/blockly/addons/cdoBlockSerializer.js
@@ -15,7 +15,6 @@ export default class CdoBlockSerializer extends GoogleBlockly.serialization
    * @param {Blockly.Workspace} workspace - The workspace to deserialize into.
    */
   load(stateToLoad, workspace) {
-    console.log('stateToLoad: ', stateToLoad['blocks']);
     // Procedure definitions should be loaded ahead of call blocks, so that the
     // procedures map is updated correctly.
     const blockStates = partitionBlocksByType(stateToLoad['blocks'], {

--- a/apps/src/blockly/addons/cdoBlockSerializer.js
+++ b/apps/src/blockly/addons/cdoBlockSerializer.js
@@ -17,10 +17,11 @@ export default class CdoBlockSerializer extends GoogleBlockly.serialization
   load(stateToLoad, workspace) {
     // Procedure definitions should be loaded ahead of call blocks, so that the
     // procedures map is updated correctly.
-    const blockStates = partitionBlocksByType(stateToLoad['blocks'], {
-      prioritizedBlockTypes: PROCEDURE_DEFINITION_TYPES,
-      isJson: true,
-    });
+    const blockStates = partitionBlocksByType(
+      stateToLoad['blocks'],
+      PROCEDURE_DEFINITION_TYPES,
+      false
+    );
 
     for (const blockState of blockStates) {
       try {

--- a/apps/src/blockly/addons/cdoBlockSerializer.js
+++ b/apps/src/blockly/addons/cdoBlockSerializer.js
@@ -15,12 +15,13 @@ export default class CdoBlockSerializer extends GoogleBlockly.serialization
    * @param {Blockly.Workspace} workspace - The workspace to deserialize into.
    */
   load(stateToLoad, workspace) {
+    console.log('stateToLoad: ', stateToLoad['blocks']);
     // Procedure definitions should be loaded ahead of call blocks, so that the
     // procedures map is updated correctly.
-    const blockStates = partitionBlocksByType(
-      stateToLoad['blocks'],
-      PROCEDURE_DEFINITION_TYPES
-    );
+    const blockStates = partitionBlocksByType(stateToLoad['blocks'], {
+      prioritizedBlockTypes: PROCEDURE_DEFINITION_TYPES,
+      isJson: true,
+    });
 
     for (const blockState of blockStates) {
       try {

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -214,17 +214,19 @@ export function registerCustomProcedureBlocks() {
 /**
  * Partitions blocks of the specified types to the front of the list.
  *
- * @param {Element[]} blockElements - An array of block elements to be partitioned.
- * @param {string[]} prioritizedBlockTypes - An array of strings representing block types.
- *    These types are moved to the front of the list while otherwise maintaining order.
- * @returns {Element[]} A new array of block elements partitioned based on their types.
+ * @param {Element[]|Object[]} blocks - An array of block elements or JSON blocks to be partitioned.
+ * @param {Object} [options] - An object containing partitioning options.
+ * @param {string[]} [options.prioritizedBlockTypes] - An array of strings representing block types to move to the front.
+ * @param {boolean} [options.isJson] - A flag indicating whether the blocks are JSON blocks (vs. block elements).
+ * @returns {Element[]|Object[]} A new array of block elements or JSON blocks partitioned based on their types.
  */
-export function partitionBlocksByType(blockElements, prioritizedBlockTypes) {
+export function partitionBlocksByType(blocks, options = {}) {
+  const {prioritizedBlockTypes, isJson} = options;
   const prioritizedBlocks = [];
   const remainingBlocks = [];
 
-  blockElements.forEach(block => {
-    const blockType = block.getAttribute('type');
+  blocks.forEach(block => {
+    const blockType = isJson ? block.type : block.getAttribute('type');
     prioritizedBlockTypes.includes(blockType)
       ? prioritizedBlocks.push(block)
       : remainingBlocks.push(block);

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -220,13 +220,16 @@ export function registerCustomProcedureBlocks() {
  * @param {boolean} [options.isJson] - A flag indicating whether the blocks are JSON blocks (vs. block elements).
  * @returns {Element[]|Object[]} A new array of block elements or JSON blocks partitioned based on their types.
  */
-export function partitionBlocksByType(blocks = [], options = {}) {
-  const {prioritizedBlockTypes = [], isJson = false} = options;
+export function partitionBlocksByType(
+  blocks = [],
+  prioritizedBlockTypes = [],
+  isBlockElements = true
+) {
   const prioritizedBlocks = [];
   const remainingBlocks = [];
 
   blocks.forEach(block => {
-    const blockType = isJson ? block.type : block.getAttribute('type');
+    const blockType = isBlockElements ? block.getAttribute('type') : block.type;
     prioritizedBlockTypes.includes(blockType)
       ? prioritizedBlocks.push(block)
       : remainingBlocks.push(block);

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -210,3 +210,25 @@ export function registerCustomProcedureBlocks() {
   unregisterProcedureBlocks();
   Blockly.common.defineBlocks(procedureBlocks);
 }
+
+/**
+ * Partitions blocks of the specified types to the front of the list.
+ *
+ * @param {Element[]} blockElements - An array of block elements to be partitioned.
+ * @param {string[]} prioritizedBlockTypes - An array of strings representing block types.
+ *    These types are moved to the front of the list while otherwise maintaining order.
+ * @returns {Element[]} A new array of block elements partitioned based on their types.
+ */
+export function partitionBlocksByType(blockElements, prioritizedBlockTypes) {
+  const prioritizedBlocks = [];
+  const remainingBlocks = [];
+
+  blockElements.forEach(block => {
+    const blockType = block.getAttribute('type');
+    prioritizedBlockTypes.includes(blockType)
+      ? prioritizedBlocks.push(block)
+      : remainingBlocks.push(block);
+  });
+
+  return [...prioritizedBlocks, ...remainingBlocks];
+}

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -220,8 +220,8 @@ export function registerCustomProcedureBlocks() {
  * @param {boolean} [options.isJson] - A flag indicating whether the blocks are JSON blocks (vs. block elements).
  * @returns {Element[]|Object[]} A new array of block elements or JSON blocks partitioned based on their types.
  */
-export function partitionBlocksByType(blocks, options = {}) {
-  const {prioritizedBlockTypes, isJson} = options;
+export function partitionBlocksByType(blocks = [], options = {}) {
+  const {prioritizedBlockTypes = [], isJson = false} = options;
   const prioritizedBlocks = [];
   const remainingBlocks = [];
 

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -122,9 +122,9 @@ export function getPartitionedBlockElements(xml, prioritizedBlockTypes) {
 
   // Procedure definitions should be loaded ahead of call
   // blocks, so that the procedures map is updated correctly.
-  const partitionedBlockElements = partitionBlocksByType(
-    blockElements,
-    prioritizedBlockTypes
-  );
+  const partitionedBlockElements = partitionBlocksByType(blockElements, {
+    prioritizedBlockTypes,
+    isJson: false,
+  });
   return partitionedBlockElements;
 }

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -1,4 +1,5 @@
 import {PROCEDURE_DEFINITION_TYPES} from '../constants';
+import {partitionBlocksByType} from './cdoUtils';
 
 export default function initializeBlocklyXml(blocklyWrapper) {
   // Clear xml namespace
@@ -126,26 +127,4 @@ export function getPartitionedBlockElements(xml, prioritizedBlockTypes) {
     prioritizedBlockTypes
   );
   return partitionedBlockElements;
-}
-
-/**
- * Partitions blocks of the specified types to the front of the list.
- *
- * @param {Element[]} blockElements - An array of block elements to be partitioned.
- * @param {string[]} prioritizedBlockTypes - An array of strings representing block types.
- *    These types are moved to the front of the list while otherwise maintaining order.
- * @returns {Element[]} A new array of block elements partitioned based on their types.
- */
-export function partitionBlocksByType(blockElements, prioritizedBlockTypes) {
-  const prioritizedBlocks = [];
-  const remainingBlocks = [];
-
-  blockElements.forEach(block => {
-    const blockType = block.getAttribute('type');
-    prioritizedBlockTypes.includes(blockType)
-      ? prioritizedBlocks.push(block)
-      : remainingBlocks.push(block);
-  });
-
-  return [...prioritizedBlocks, ...remainingBlocks];
 }

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -122,9 +122,10 @@ export function getPartitionedBlockElements(xml, prioritizedBlockTypes) {
 
   // Procedure definitions should be loaded ahead of call
   // blocks, so that the procedures map is updated correctly.
-  const partitionedBlockElements = partitionBlocksByType(blockElements, {
+  const partitionedBlockElements = partitionBlocksByType(
+    blockElements,
     prioritizedBlockTypes,
-    isJson: false,
-  });
+    true
+  );
   return partitionedBlockElements;
 }

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -331,7 +331,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
       // Google Blockly only. Registers custom blocks for modal function editor.
     },
     partitionBlocksByType() {
-      // TODO: Add comment
+      // Google Blockly only. Used to load/render certain block types before others.
     },
   };
   blocklyWrapper.customBlocks = customBlocks;

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -330,6 +330,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
     registerCustomProcedureBlocks() {
       // Google Blockly only. Registers custom blocks for modal function editor.
     },
+    partitionBlocksByType() {
+      // TODO: Add comment
+    },
   };
   blocklyWrapper.customBlocks = customBlocks;
 

--- a/apps/test/unit/blockly/addons/cdoUtilsTest.js
+++ b/apps/test/unit/blockly/addons/cdoUtilsTest.js
@@ -1,0 +1,42 @@
+import {expect} from '../../../util/reconfiguredChai';
+import {partitionBlocksByType} from '@cdo/apps/blockly/addons/cdoUtils';
+import {PROCEDURE_DEFINITION_TYPES} from '@cdo/apps/blockly/constants';
+
+const parser = new DOMParser();
+
+describe('CdoUtils', function () {
+  describe('partitionBlocksByType', function () {
+    it('should partition block elements based on their types', function () {
+      // Sample block elements
+      const blockData = [
+        '<block type="blockType1"></block>',
+        '<block type="procedures_defnoreturn"></block>',
+        '<block type="blockType2"></block>',
+      ];
+      const blockElements = blockData.map(block => {
+        return parser.parseFromString(block, 'text/xml').querySelector('block');
+      });
+
+      // Create a copy of the blockElements array
+      const blockElementsCopy = [...blockElements];
+
+      // Call the function
+      const partitionedBlockElements = partitionBlocksByType(
+        blockElementsCopy,
+        PROCEDURE_DEFINITION_TYPES
+      );
+
+      // Expected partitioned block elements
+      const expectedPartitionedElements = [
+        blockElements[1],
+        blockElements[0],
+        blockElements[2],
+      ];
+
+      // Compare the result with the expected partitioned elements
+      expect(partitionedBlockElements).to.deep.equal(
+        expectedPartitionedElements
+      );
+    });
+  });
+});

--- a/apps/test/unit/blockly/addons/cdoUtilsTest.js
+++ b/apps/test/unit/blockly/addons/cdoUtilsTest.js
@@ -15,12 +15,12 @@ describe('CdoUtils', () => {
         {type: 'blockType2'},
         {type: 'Dancelab_whenSetup'},
       ];
-      const options = {
-        prioritizedBlockTypes: ['when_run', 'Dancelab_whenSetup'],
-        isJson: true,
-      };
 
-      const result = partitionBlocksByType(blocks, options);
+      const result = partitionBlocksByType(
+        blocks,
+        ['when_run', 'Dancelab_whenSetup'],
+        false
+      );
       expect(result).to.deep.equal([
         {type: 'when_run'},
         {type: 'Dancelab_whenSetup'},
@@ -35,43 +35,39 @@ describe('CdoUtils', () => {
         '<block type="procedures_defnoreturn"></block>'
       );
       const block3 = createBlockElement('<block type="blockType2"></block>');
-
       const blockElements = [block1, block2, block3];
-      const options = {
-        prioritizedBlockTypes: PROCEDURE_DEFINITION_TYPES,
-        isJson: false,
-      };
 
-      const result = partitionBlocksByType(blockElements, options);
+      const result = partitionBlocksByType(
+        blockElements,
+        PROCEDURE_DEFINITION_TYPES,
+        true
+      );
       expect(result).to.deep.equal([block2, block1, block3]);
     });
 
     it('should handle an empty block array', () => {
-      const options = {
-        prioritizedBlockTypes: PROCEDURE_DEFINITION_TYPES,
-        isJson: false,
-      };
-      const result = partitionBlocksByType([], options);
+      const result = partitionBlocksByType(
+        [],
+        PROCEDURE_DEFINITION_TYPES,
+        true
+      );
       expect(result).to.deep.equal([]);
     });
 
     it('should return the original array if no prioritized types are provided', () => {
       const blocks = [{type: 'A'}, {type: 'B'}, {type: 'C'}];
-      const options = {isJson: true};
 
-      const result = partitionBlocksByType(blocks, options);
+      const result = partitionBlocksByType(blocks, undefined, false);
       expect(result).to.deep.equal(blocks);
     });
 
-    it('should not thrown an error and default to using blockElements if isJson is not provided', () => {
+    it('should not thrown an error and default to using blockElements if isBlockElement is not provided', () => {
       const block1 = createBlockElement('<block type="C"></block>');
       const block2 = createBlockElement('<block type="B"></block>');
       const block3 = createBlockElement('<block type="A"></block>');
-
       const blockElements = [block1, block2, block3];
-      const options = {prioritizedBlockTypes: ['A']};
 
-      const result = partitionBlocksByType(blockElements, options);
+      const result = partitionBlocksByType(blockElements, ['A']);
       expect(result).to.deep.equal([block3, block1, block2]);
     });
 

--- a/apps/test/unit/blockly/addons/cdoUtilsTest.js
+++ b/apps/test/unit/blockly/addons/cdoUtilsTest.js
@@ -3,40 +3,87 @@ import {partitionBlocksByType} from '@cdo/apps/blockly/addons/cdoUtils';
 import {PROCEDURE_DEFINITION_TYPES} from '@cdo/apps/blockly/constants';
 
 const parser = new DOMParser();
+const createBlockElement = data =>
+  parser.parseFromString(data, 'text/xml').querySelector('block');
 
-describe('CdoUtils', function () {
-  describe('partitionBlocksByType', function () {
-    it('should partition block elements based on their types', function () {
-      // Sample block elements
-      const blockData = [
-        '<block type="blockType1"></block>',
-        '<block type="procedures_defnoreturn"></block>',
-        '<block type="blockType2"></block>',
+describe('CdoUtils', () => {
+  describe('partitionBlocksByType', () => {
+    it('should work with JSON blocks and prioritized types', () => {
+      const blocks = [
+        {type: 'blockType1'},
+        {type: 'when_run'},
+        {type: 'blockType2'},
+        {type: 'Dancelab_whenSetup'},
       ];
-      const blockElements = blockData.map(block => {
-        return parser.parseFromString(block, 'text/xml').querySelector('block');
-      });
+      const options = {
+        prioritizedBlockTypes: ['when_run', 'Dancelab_whenSetup'],
+        isJson: true,
+      };
 
-      // Create a copy of the blockElements array
-      const blockElementsCopy = [...blockElements];
+      const result = partitionBlocksByType(blocks, options);
+      expect(result).to.deep.equal([
+        {type: 'when_run'},
+        {type: 'Dancelab_whenSetup'},
+        {type: 'blockType1'},
+        {type: 'blockType2'},
+      ]);
+    });
 
-      // Call the function
-      const partitionedBlockElements = partitionBlocksByType(
-        blockElementsCopy,
-        PROCEDURE_DEFINITION_TYPES
+    it('should work with block elements and prioritized types', () => {
+      const block1 = createBlockElement('<block type="blockType1"></block>');
+      const block2 = createBlockElement(
+        '<block type="procedures_defnoreturn"></block>'
       );
+      const block3 = createBlockElement('<block type="blockType2"></block>');
 
-      // Expected partitioned block elements
-      const expectedPartitionedElements = [
-        blockElements[1],
-        blockElements[0],
-        blockElements[2],
-      ];
+      const blockElements = [block1, block2, block3];
+      const options = {
+        prioritizedBlockTypes: PROCEDURE_DEFINITION_TYPES,
+        isJson: false,
+      };
 
-      // Compare the result with the expected partitioned elements
-      expect(partitionedBlockElements).to.deep.equal(
-        expectedPartitionedElements
-      );
+      const result = partitionBlocksByType(blockElements, options);
+      expect(result).to.deep.equal([block2, block1, block3]);
+    });
+
+    it('should handle an empty block array', () => {
+      const options = {
+        prioritizedBlockTypes: PROCEDURE_DEFINITION_TYPES,
+        isJson: false,
+      };
+      const result = partitionBlocksByType([], options);
+      expect(result).to.deep.equal([]);
+    });
+
+    it('should return the original array if no prioritized types are provided', () => {
+      const blocks = [{type: 'A'}, {type: 'B'}, {type: 'C'}];
+      const options = {isJson: true};
+
+      const result = partitionBlocksByType(blocks, options);
+      expect(result).to.deep.equal(blocks);
+    });
+
+    it('should not thrown an error and default to using blockElements if isJson is not provided', () => {
+      const block1 = createBlockElement('<block type="C"></block>');
+      const block2 = createBlockElement('<block type="B"></block>');
+      const block3 = createBlockElement('<block type="A"></block>');
+
+      const blockElements = [block1, block2, block3];
+      const options = {prioritizedBlockTypes: ['A']};
+
+      const result = partitionBlocksByType(blockElements, options);
+      expect(result).to.deep.equal([block3, block1, block2]);
+    });
+
+    it('should handle undefined options', () => {
+      const block1 = createBlockElement('<block type="C"></block>');
+      const block2 = createBlockElement('<block type="B"></block>');
+      const block3 = createBlockElement('<block type="A"></block>');
+
+      const blockElements = [block1, block2, block3];
+
+      const result = partitionBlocksByType(blockElements);
+      expect(result).to.deep.equal(blockElements);
     });
   });
 });

--- a/apps/test/unit/blockly/addons/cdoXmlTest.js
+++ b/apps/test/unit/blockly/addons/cdoXmlTest.js
@@ -1,45 +1,11 @@
 import {expect} from '../../../util/reconfiguredChai';
 import {
-  partitionBlocksByType,
   getPartitionedBlockElements,
   createBlockOrderMap,
 } from '@cdo/apps/blockly/addons/cdoXml';
 import {PROCEDURE_DEFINITION_TYPES} from '@cdo/apps/blockly/constants';
 
 const parser = new DOMParser();
-
-describe('partitionBlocksByType', function () {
-  it('should partition block elements based on their types', function () {
-    // Sample block elements
-    const blockData = [
-      '<block type="blockType1"></block>',
-      '<block type="procedures_defnoreturn"></block>',
-      '<block type="blockType2"></block>',
-    ];
-    const blockElements = blockData.map(block => {
-      return parser.parseFromString(block, 'text/xml').querySelector('block');
-    });
-
-    // Create a copy of the blockElements array
-    const blockElementsCopy = [...blockElements];
-
-    // Call the function
-    const partitionedBlockElements = partitionBlocksByType(
-      blockElementsCopy,
-      PROCEDURE_DEFINITION_TYPES
-    );
-
-    // Expected partitioned block elements
-    const expectedPartitionedElements = [
-      blockElements[1],
-      blockElements[0],
-      blockElements[2],
-    ];
-
-    // Compare the result with the expected partitioned elements
-    expect(partitionedBlockElements).to.deep.equal(expectedPartitionedElements);
-  });
-});
 
 describe('getPartitionedBlockElements', function () {
   it('should return partitioned block elements based on their types', function () {

--- a/apps/test/unit/blockly/addons/cdoXmlTest.js
+++ b/apps/test/unit/blockly/addons/cdoXmlTest.js
@@ -7,61 +7,65 @@ import {PROCEDURE_DEFINITION_TYPES} from '@cdo/apps/blockly/constants';
 
 const parser = new DOMParser();
 
-describe('getPartitionedBlockElements', function () {
-  it('should return partitioned block elements based on their types', function () {
-    // Sample XML data
-    const xmlData = `
+describe('CdoXml', function () {
+  describe('getPartitionedBlockElements', function () {
+    it('should return partitioned block elements based on their types', function () {
+      // Sample XML data
+      const xmlData = `
         <xml>
           <block type="blockType1"></block>
           <block type="procedures_defnoreturn"></block>
           <block type="blockType2"></block>
         </xml>
       `;
-    const xmlDoc = parser.parseFromString(xmlData, 'text/xml');
+      const xmlDoc = parser.parseFromString(xmlData, 'text/xml');
 
-    // Call the function
-    const partitionedBlockElements = getPartitionedBlockElements(
-      xmlDoc.documentElement,
-      PROCEDURE_DEFINITION_TYPES
-    );
+      // Call the function
+      const partitionedBlockElements = getPartitionedBlockElements(
+        xmlDoc.documentElement,
+        PROCEDURE_DEFINITION_TYPES
+      );
 
-    // Expected partitioned block elements
-    const expectedPartitionedElements = [
-      xmlDoc.querySelector('block[type="procedures_defnoreturn"]'),
-      xmlDoc.querySelector('block[type="blockType1"]'),
-      xmlDoc.querySelector('block[type="blockType2"]'),
-    ];
+      // Expected partitioned block elements
+      const expectedPartitionedElements = [
+        xmlDoc.querySelector('block[type="procedures_defnoreturn"]'),
+        xmlDoc.querySelector('block[type="blockType1"]'),
+        xmlDoc.querySelector('block[type="blockType2"]'),
+      ];
 
-    // Compare the result with the expected partitioned elements
-    expect(partitionedBlockElements).to.deep.equal(expectedPartitionedElements);
+      // Compare the result with the expected partitioned elements
+      expect(partitionedBlockElements).to.deep.equal(
+        expectedPartitionedElements
+      );
+    });
   });
-});
 
-describe('createBlockOrderMap', function () {
-  it('should create a block order map for the given XML', function () {
-    // Sample XML data
-    const xmlData = `
+  describe('createBlockOrderMap', function () {
+    it('should create a block order map for the given XML', function () {
+      // Sample XML data
+      const xmlData = `
             <xml>
               <block type="blockType1"></block>
               <block type="procedures_defnoreturn"></block>
               <block type="blockType2"></block>
             </xml>
           `;
-    const xmlDoc = parser.parseFromString(xmlData, 'text/xml');
+      const xmlDoc = parser.parseFromString(xmlData, 'text/xml');
 
-    // Call the function
-    const blockOrderMap = createBlockOrderMap(xmlDoc.documentElement);
+      // Call the function
+      const blockOrderMap = createBlockOrderMap(xmlDoc.documentElement);
 
-    // Expected block order map
-    const expectedMap = new Map();
-    expectedMap.set(1, 0);
-    expectedMap.set(0, 1);
-    expectedMap.set(2, 2);
-    // Convert maps to arrays and compare
-    const blockOrderMapArray = Array.from(blockOrderMap);
-    const expectedMapArray = Array.from(expectedMap);
+      // Expected block order map
+      const expectedMap = new Map();
+      expectedMap.set(1, 0);
+      expectedMap.set(0, 1);
+      expectedMap.set(2, 2);
+      // Convert maps to arrays and compare
+      const blockOrderMapArray = Array.from(blockOrderMap);
+      const expectedMapArray = Array.from(expectedMap);
 
-    // Compare the result with the expected map
-    expect(blockOrderMapArray).to.deep.equal(expectedMapArray);
+      // Compare the result with the expected map
+      expect(blockOrderMapArray).to.deep.equal(expectedMapArray);
+    });
   });
 });

--- a/apps/test/unit/blockly/addons/cdoXmlTest.js
+++ b/apps/test/unit/blockly/addons/cdoXmlTest.js
@@ -7,65 +7,61 @@ import {PROCEDURE_DEFINITION_TYPES} from '@cdo/apps/blockly/constants';
 
 const parser = new DOMParser();
 
-describe('CdoXml', function () {
-  describe('getPartitionedBlockElements', function () {
-    it('should return partitioned block elements based on their types', function () {
-      // Sample XML data
-      const xmlData = `
+describe('getPartitionedBlockElements', function () {
+  it('should return partitioned block elements based on their types', function () {
+    // Sample XML data
+    const xmlData = `
         <xml>
           <block type="blockType1"></block>
           <block type="procedures_defnoreturn"></block>
           <block type="blockType2"></block>
         </xml>
       `;
-      const xmlDoc = parser.parseFromString(xmlData, 'text/xml');
+    const xmlDoc = parser.parseFromString(xmlData, 'text/xml');
 
-      // Call the function
-      const partitionedBlockElements = getPartitionedBlockElements(
-        xmlDoc.documentElement,
-        PROCEDURE_DEFINITION_TYPES
-      );
+    // Call the function
+    const partitionedBlockElements = getPartitionedBlockElements(
+      xmlDoc.documentElement,
+      PROCEDURE_DEFINITION_TYPES
+    );
 
-      // Expected partitioned block elements
-      const expectedPartitionedElements = [
-        xmlDoc.querySelector('block[type="procedures_defnoreturn"]'),
-        xmlDoc.querySelector('block[type="blockType1"]'),
-        xmlDoc.querySelector('block[type="blockType2"]'),
-      ];
+    // Expected partitioned block elements
+    const expectedPartitionedElements = [
+      xmlDoc.querySelector('block[type="procedures_defnoreturn"]'),
+      xmlDoc.querySelector('block[type="blockType1"]'),
+      xmlDoc.querySelector('block[type="blockType2"]'),
+    ];
 
-      // Compare the result with the expected partitioned elements
-      expect(partitionedBlockElements).to.deep.equal(
-        expectedPartitionedElements
-      );
-    });
+    // Compare the result with the expected partitioned elements
+    expect(partitionedBlockElements).to.deep.equal(expectedPartitionedElements);
   });
+});
 
-  describe('createBlockOrderMap', function () {
-    it('should create a block order map for the given XML', function () {
-      // Sample XML data
-      const xmlData = `
+describe('createBlockOrderMap', function () {
+  it('should create a block order map for the given XML', function () {
+    // Sample XML data
+    const xmlData = `
             <xml>
               <block type="blockType1"></block>
               <block type="procedures_defnoreturn"></block>
               <block type="blockType2"></block>
             </xml>
           `;
-      const xmlDoc = parser.parseFromString(xmlData, 'text/xml');
+    const xmlDoc = parser.parseFromString(xmlData, 'text/xml');
 
-      // Call the function
-      const blockOrderMap = createBlockOrderMap(xmlDoc.documentElement);
+    // Call the function
+    const blockOrderMap = createBlockOrderMap(xmlDoc.documentElement);
 
-      // Expected block order map
-      const expectedMap = new Map();
-      expectedMap.set(1, 0);
-      expectedMap.set(0, 1);
-      expectedMap.set(2, 2);
-      // Convert maps to arrays and compare
-      const blockOrderMapArray = Array.from(blockOrderMap);
-      const expectedMapArray = Array.from(expectedMap);
+    // Expected block order map
+    const expectedMap = new Map();
+    expectedMap.set(1, 0);
+    expectedMap.set(0, 1);
+    expectedMap.set(2, 2);
+    // Convert maps to arrays and compare
+    const blockOrderMapArray = Array.from(blockOrderMap);
+    const expectedMapArray = Array.from(expectedMap);
 
-      // Compare the result with the expected map
-      expect(blockOrderMapArray).to.deep.equal(expectedMapArray);
-    });
+    // Compare the result with the expected map
+    expect(blockOrderMapArray).to.deep.equal(expectedMapArray);
   });
 });


### PR DESCRIPTION
Before this PR, we had two versions of the `partitionBlocksByType` function, one in `cdoBlockSerializer.js` that operated on JSON blocks using `block.type` and one in `cdoXml.js` that operated on block elements using `block.getAttribute('type')`. This PR creates a single version in `cdoUtils.js` that can operate on either block elements or JSON blocks. Use of `block.type` or `block.getAttribute('type')` is controlled by the boolean argument `isBlockElements`. I also added some additional tests. 

## Links

https://codedotorg.atlassian.net/browse/SL-1088

## Testing story

Added tests and included the test cases from the original implementation to confirm that they still pass. 

## Follow-up work

Rebase https://github.com/code-dot-org/code-dot-org/pull/53154.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
