### PR TITLE
Lab2/Music: don't save when viewing other users' projects

### DIFF
--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -259,7 +259,12 @@ export default class ProjectManager {
     // We can't save without a last channel or last source.
     // We also know we don't need to save if we don't have sources to save
     // or a channel to save.
-    if (!this.lastChannel || !(this.sourcesToSave || this.channelToSave)) {
+    // We also cannot save if the user is not the owner of this project.
+    if (
+      !this.lastChannel ||
+      !this.lastChannel.isOwner ||
+      !(this.sourcesToSave || this.channelToSave)
+    ) {
       this.executeSaveNoopListeners(this.lastChannel);
       return;
     }

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -440,6 +440,10 @@ class UnconnectedMusicView extends React.Component {
   };
 
   saveCode = (forceSave = false) => {
+    // Can't save if this is a read-only workspace.
+    if (this.props.isReadOnlyWorkspace) {
+      return;
+    }
     const workspaceCode = this.musicBlocklyWorkspace.getCode();
     const sourcesToSave = {
       source: JSON.stringify(workspaceCode),

--- a/apps/test/unit/lab2/projects/ProjectManagerTest.ts
+++ b/apps/test/unit/lab2/projects/ProjectManagerTest.ts
@@ -235,6 +235,22 @@ describe('ProjectManager', () => {
       assert.deepEqual(e, error);
     }
   });
+
+  it('does not trigger a save if the user is not the owner', async () => {
+    const readonlyChannel = {...FAKE_CHANNEL, isOwner: false};
+    channelsStore.load.returns(Promise.resolve(readonlyChannel));
+    stubSuccessfulSourceLoad(sourcesStore);
+    const projectManager = new ProjectManager(
+      sourcesStore,
+      channelsStore,
+      FAKE_CHANNEL_ID,
+      false
+    );
+    await projectManager.load();
+    await projectManager.save(UPDATED_SOURCE);
+    assert.isTrue(sourcesStore.save.notCalled);
+    assert.isTrue(channelsStore.save.notCalled);
+  });
 });
 
 // Helper functions


### PR DESCRIPTION
We noticed in our logs that we were getting a handful of 401 unauthorized errors, and were able to repro when viewing another user's project, since we try to save regardless of whether the user is the owner or not. This updates both Music Lab and Lab2 to prevent saving if the user is not the project owner.

## Links

https://codedotorg.atlassian.net/browse/SL-1085

## Testing story

Tested locally + unit.