### PR TITLE
Call `reorganize_level_file_into_subdirectory` on Save

### DIFF
--- a/dashboard/lib/services/level_files.rb
+++ b/dashboard/lib/services/level_files.rb
@@ -26,10 +26,9 @@ module Services
       # this level and are ready for that file to be updated.
       return unless Policies::LevelFiles.write_to_file?(level) && level.published
 
-      # TODO: Once we've verified we can successfully invoke this method on old
-      # stable levels, uncomment this line so we can begin applying it to levels
-      # under active development.
-      #Services::LevelFiles.reorganize_level_file_into_subdirectory(level)
+      # TODO: Once we've moved all existing level files into the new directory
+      # structure, remove this invocation
+      Services::LevelFiles.reorganize_level_file_into_subdirectory(level)
 
       file_path = Policies::LevelFiles.level_file_path(level)
       FileUtils.mkdir_p(File.dirname(file_path))


### PR DESCRIPTION
Now that we've been successfully writing files for newly-created levels into the new directory structure and have successfully tested moving over existing levels in bulk, we want to start moving over levels that are under active development, too.

Next steps are to run bulk updates for all existing stale levels.

## Links

- [slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1690914736685239)
- https://github.com/code-dot-org/code-dot-org/pull/53066

## Testing story

Tested locally with `levelbuilder_mode: true`