### PR TITLE
Add instructions editor to music lab levels

### DIFF
--- a/dashboard/app/views/levels/editors/_music.html.haml
+++ b/dashboard/app/views/levels/editors/_music.html.haml
@@ -1,3 +1,4 @@
+= render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/music_level_data', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}


### PR DESCRIPTION
Adds the instructions editor the music lab level edit pages since our Instructions component can consume them now.

![Screenshot 2023-08-22 at 1 37 38 PM](https://github.com/code-dot-org/code-dot-org/assets/85528507/d50b2cc9-0ad6-4583-acac-177f4903bdd9)
![Screenshot 2023-08-22 at 1 38 01 PM](https://github.com/code-dot-org/code-dot-org/assets/85528507/373c8342-14b3-4484-a43e-6eba77db5c9d)

## Links

https://codedotorg.atlassian.net/browse/SL-1071