### PR TITLE
Comment out static directories to test storybook deploy

### DIFF
--- a/apps/.storybook/main.js
+++ b/apps/.storybook/main.js
@@ -3,9 +3,11 @@ const storybookWebpackConfig = require('../webpack').storybookConfig;
 module.exports = {
   stories: ['../src/**/*.story.@(js|jsx|ts|tsx)'],
   staticDirs: [
-    '../build/package/',
-    '../../dashboard/public',
-    '../../pegasus/sites.v3/code.org/public'
+    // Temporarily commented out to test whether we can deploy storybook to our public repo (see storybook-deploy.sh for details)
+    // In the meantime, feel free to uncomment these if you need them for serving storybook locally
+    // '../build/package/',
+    // '../../dashboard/public',
+    // '../../pegasus/sites.v3/code.org/public'
   ],
   addons: [
     '@storybook/addon-a11y',


### PR DESCRIPTION
[My last attempt](https://codedotorg.slack.com/archives/C03DBDN67B7/p1691017050913929) to get our public storybook site working failed because the commit containing the new build was too big.

Investigation showed that there are huge (hopefully unnecessary?) directories being copied into the Storybook deploy directory, which looks like it is a result of a refactor to get us onto a newer version of Storybook last summer. The refactor I think took some configuration that used to only apply to when you are serving storybook locally, and made it apply to building storybook as well. More detail in the Jira ticket linked below.

I'd like to try and build the site without these static directories, and see if we can get the site deployed.

## Links

- Jira ticket: [SL-1079](https://codedotorg.atlassian.net/browse/SL-1079)

## Testing story

I built Storybook locally with these changes, and the site appeared to mostly(?) work, although I only skimmed some components. If I can get a built version of the site out publicly, us/design can take a closer look and see if anything is broken.

## Follow-up work

If this works, I'll still need to do some follow-up work to see if we can separate the static directories needed for running storybook locally (what are these used for locally?) and the ones needed for the build (currently they're both configured via the `staticDirs` property).