### PR TITLE
skip firebase upload if rules file is not found

### DIFF
--- a/lib/rake/firebase.rake
+++ b/lib/rake/firebase.rake
@@ -25,12 +25,13 @@ namespace :firebase do
             "set `use_my_apps: true` in locals.yml and then run `rake package:apps:symlink`.\n\n"
         end
         if !File.exist?('public/blockly')
-          raise 'Could not upload firebase security rules because an apps package was not found at dashboard/public/blockly.'
+          ChatClient.log 'Could not upload firebase security rules because an apps package was not found at dashboard/public/blockly. Skipping upload.', color: 'yellow'
         elsif !File.exist?('public/blockly/firebase/rules.json')
-          raise 'Could not upload firebase security rules because the apps package does not contain firebase/rules.json.'
+          ChatClient.log 'Could not upload firebase security rules because the apps package does not contain firebase/rules.json. Skipping upload.', color: 'yellow'
+        else
+          url = "https://#{CDO.firebase_name}.firebaseio.com/.settings/rules.json?auth=#{CDO.firebase_secret}"
+          RakeUtils.system("curl -X PUT -T ./public/blockly/firebase/rules.json '#{url}'")
         end
-        url = "https://#{CDO.firebase_name}.firebaseio.com/.settings/rules.json?auth=#{CDO.firebase_secret}"
-        RakeUtils.system("curl -X PUT -T ./public/blockly/firebase/rules.json '#{url}'")
       end
     end
   end


### PR DESCRIPTION
## Background

When the apps build fails, we can get stuck in a loop where the firebase rules upload fails before apps gets a chance to build again: https://github.com/code-dot-org/code-dot-org/blob/489a15c4a0f7cd4a266b255a73eece192d5589e6/lib/rake/ci.rake#L95-L96

For a recent example with details, see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1692747906609169?thread_ts=1692745200.550689&cid=C0T0PNTM3).

We have also had many instances in the past where the firebase rules upload fails, the dev of the day spends time investigating, and eventually just does a simple rerun.

For more context, the last time we updated the rules was [4 years ago](https://github.com/code-dot-org/code-dot-org/commits/1252155cdb8866fcf53440cb4cfade0e8600562e/apps/firebase/rules.bolt), and we are planning to [get rid of firebase this year](https://docs.google.com/document/d/1_FEda6c67k-IGWd1wBAGBInCResvS2_73Axn62CU15U/edit#bookmark=id.83ffoaw09c0b).

## Description

Based on all this, the solution I'm proposing is to warn without failing the build when the firebase upload fails. in most cases, the build will pass (and upload will succeed) on the very next build, and there is very little consequence to firebase failing to upload on a given build even if it does include rules changes.

## Testing story

manually verified that the common case still executes by patching the new code onto staging: https://github.com/code-dot-org/code-dot-org/blob/445ce3ab030d2b7cf1bf0f01fc0ff63b58f559d9/lib/rake/firebase.rake#L31-L33
