### PR TITLE
Fix Barlow font on Pegasus

### DIFF
--- a/pegasus/sites.v3/code.org/styles_min/050-theme.css
+++ b/pegasus/sites.v3/code.org/styles_min/050-theme.css
@@ -3,6 +3,22 @@
   and shared/css/font.scss
 */
 
+/* Import Barlow fonts */
+@font-face {
+  font-family: 'Barlow Semi Condensed Semibold';
+  font-style: normal;
+  font-weight: 600;
+  src: url('/fonts/barlowSemiCondensed/BarlowSemiCondensed-SemiBold.ttf') format('truetype'),
+local('?');
+}
+
+@font-face {
+  font-family: 'Barlow Semi Condensed Medium';
+  font-style: normal;
+  font-weight: 500;
+  src: url('/fonts/barlowSemiCondensed/BarlowSemiCondensed-Medium.ttf') format('truetype'), local('?');
+}
+
 :root {
   /* Colors */
   --brand_primary_light: #ABDFE5;


### PR DESCRIPTION
Import the Barlow font in the CSS so it works correctly on Pegasus. 

**Context:** Barlow wasn't showing correctly on machines that don't have the font installed.

**Related PR:**
- https://github.com/code-dot-org/code-dot-org/pull/53386

**Jira ticket:** [ACQ-869](https://codedotorg.atlassian.net/browse/ACQ-869)