### PR TITLE
Add email validation to policy compliance controller

### DIFF
--- a/dashboard/app/controllers/policy_compliance_controller.rb
+++ b/dashboard/app/controllers/policy_compliance_controller.rb
@@ -47,9 +47,12 @@ class PolicyComplianceController < ApplicationController
       redirect_back fallback_location: lockout_path and return
     end
 
+    parent_email = params.require(:'parent-email')
+    unless Cdo::EmailValidator.email_address?(parent_email)
+      return head :bad_request
+    end
     # Validate that the parent email is not the same as the student email
     # Also remove any subaddressing from the email to prevent abuse
-    parent_email = params.require(:'parent-email')
     sanitized_parent_email = parent_email.sub(/\+[^@]+@/, '@')
     if current_user.hashed_email == Digest::MD5.hexdigest(sanitized_parent_email)
       redirect_back fallback_location: lockout_path and return
@@ -89,13 +92,6 @@ class PolicyComplianceController < ApplicationController
     # Save (will reassign the updated_at date)
     permission_request.save!
 
-    # Update the User
-    Services::ChildAccount.update_compliance(
-      current_user,
-      Policies::ChildAccount::ComplianceState::REQUEST_SENT
-    )
-    current_user.save!
-
     # Send the request email
     ParentMailer.parent_permission_request(
       permission_request.parent_email,
@@ -106,6 +102,13 @@ class PolicyComplianceController < ApplicationController
         only_path: false,
       )
     ).deliver_now
+
+    # Update the User
+    Services::ChildAccount.update_compliance(
+      current_user,
+      Policies::ChildAccount::ComplianceState::REQUEST_SENT
+    )
+    current_user.save!
 
     # Redirect back to the page spawning the request
     redirect_back fallback_location: lockout_path

--- a/dashboard/test/controllers/policy_compliance_controller_test.rb
+++ b/dashboard/test/controllers/policy_compliance_controller_test.rb
@@ -104,6 +104,17 @@ class PolicyComplianceControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "if a user enters an invalid email, it should return a 400" do
+    user = create(:young_student, :without_parent_permission)
+    sign_in user
+
+    post '/policy_compliance/child_account_consent', params:
+      {
+        'parent-email': 'bademail',
+      }
+    assert_response :bad_request
+  end
+
   test "should update user and send an email to the parent upon creating the request" do
     user = create(:young_student, :without_parent_permission
 )


### PR DESCRIPTION
The lockout page has validation to ensure the parent email is a valid email address, but we encountered an error where a user was able to bypass (possibly unintentionally via an odd browser setup) the validation and submit a permission request to a malformed email address. Since the code that updates the user's permission status happens before the code that sends the email, the user's status was erroneously updated to REQUEST_SENT even though no request was actually sent.

This adds validation to the policy_compliance_controller to ensure that the value for the parent-email parameter is actually an email address. It also moves the block of code that updates the user's permission status to REQUEST_SENT to after the code that sends the email. Since the email code is synchronous, it seems safe - and it will fix cases like this where an error occurred causing no email to be sent.

## Links

[JIRA ticket](https://codedotorg.atlassian.net/browse/P20-367)
[Honeybadger Error](https://app.honeybadger.io/projects/3240/faults/99658045)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
