### PR TITLE
Show image if no video expanded card

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -308,6 +308,8 @@ const CustomizableCurriculumCatalogCard = ({
           assignButtonDescription={assignButtonDescription}
           onClose={onQuickViewClick}
           isInUS={isInUS}
+          imageSrc={imageSrc}
+          imageAltText={imageAltText}
         />
       )}
     </div>

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -29,6 +29,8 @@ const ExpandedCurriculumCatalogCard = ({
   assignButtonDescription,
   onClose,
   isInUS,
+  imageSrc,
+  imageAltText,
 }) => {
   const iconData = {
     ideal: {
@@ -83,16 +85,24 @@ const ExpandedCurriculumCatalogCard = ({
                       {description}
                     </BodyTwoText>
                   </div>
-                  <div className={style.videoContainer}>
-                    <iframe
-                      width="100%"
-                      height="100%"
-                      style={{border: 'none'}}
-                      src={video}
-                      title=""
-                      allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                      allowFullScreen
-                    />
+                  <div className={style.mediaContainer}>
+                    {video ? (
+                      <div className={style.videoContainer}>
+                        <iframe
+                          width="100%"
+                          height="100%"
+                          style={{border: 'none'}}
+                          src={video}
+                          title=""
+                          allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                          allowFullScreen
+                        />
+                      </div>
+                    ) : (
+                      <div className={style.videoContainer}>
+                        <img src={imageSrc} alt={imageAltText} />
+                      </div>
+                    )}
                   </div>
                 </div>
                 <div className={style.linksContainer}>
@@ -230,5 +240,7 @@ ExpandedCurriculumCatalogCard.propTypes = {
   assignButtonDescription: PropTypes.string,
   onClose: PropTypes.func,
   isInUS: PropTypes.bool,
+  imageSrc: PropTypes.string,
+  imageAltText: PropTypes.string,
 };
 export default ExpandedCurriculumCatalogCard;

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -99,8 +99,12 @@ const ExpandedCurriculumCatalogCard = ({
                         />
                       </div>
                     ) : (
-                      <div className={style.videoContainer}>
-                        <img src={imageSrc} alt={imageAltText} />
+                      <div className={style.imageContainer}>
+                        <img
+                          src={imageSrc}
+                          alt={imageAltText}
+                          style={{height: '100%'}}
+                        />
                       </div>
                     )}
                   </div>

--- a/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
@@ -204,6 +204,7 @@ $container-width: 960px;
 
 .videoContainer {
   height: 246.5px;
+  width: 100%;
 }
 
 .arrowContainer {
@@ -229,4 +230,13 @@ $container-width: 960px;
   margin-top: -9px;
   background: $neutral_white;
   z-index: 1;
+}
+
+.mediaContainer {
+  display: flex;
+  justify-content: center;
+}
+
+.imageContainer {
+  height: 140px;
 }

--- a/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
@@ -238,5 +238,5 @@ $container-width: 960px;
 }
 
 .imageContainer {
-  height: 140px;
+  height: 166px;
 }


### PR DESCRIPTION
Uses the curriculum catalog card image if the video prop is null.

### Image shown if the video is null
<img width="1104" alt="Screenshot 2023-08-23 at 2 58 21 PM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/7979a102-7fc2-41c0-a5b8-c4edf14c64c0">



## Links




- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-834)


## Testing story
Local



