### PR TITLE
Split first/last name on Google Classroom import (TEACH-557)

### DIFF
--- a/dashboard/app/models/sections/google_classroom_section.rb
+++ b/dashboard/app/models/sections/google_classroom_section.rb
@@ -35,13 +35,15 @@ class GoogleClassroomSection < OmniAuthSection
   def self.from_service(course_id, owner_id, student_list, section_name)
     code = "G-#{course_id}"
 
+    set_family_name = DCDO.get('google_classroom_family_name', false)
+
     students = student_list.map do |student|
       OmniAuth::AuthHash.new(
         uid: student.user_id,
         provider: 'google_oauth2',
         info: {
-          name: student.profile.name.given_name,
-          family_name: student.profile.name.family_name,
+          name: set_family_name ? student.profile.name.given_name : student.profile.name.full_name,
+          family_name: set_family_name ? student.profile.name.family_name : nil,
         },
       )
     end

--- a/dashboard/app/models/sections/google_classroom_section.rb
+++ b/dashboard/app/models/sections/google_classroom_section.rb
@@ -40,7 +40,8 @@ class GoogleClassroomSection < OmniAuthSection
         uid: student.user_id,
         provider: 'google_oauth2',
         info: {
-          name: student.profile.name.full_name,
+          name: student.profile.name.given_name,
+          family_name: student.profile.name.family_name,
         },
       )
     end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -808,7 +808,7 @@ class User < ApplicationRecord
     user.provider = auth.provider
     user.uid = auth.uid
     user.name = name_from_omniauth auth.info.name
-    user.family_name = auth.info.family_name
+    user.family_name = auth.info.family_name if auth.info.family_name.present?
     user.user_type = params['user_type'] || auth.info.user_type
     user.user_type = 'teacher' if user.user_type == 'staff' # Powerschool sends through 'staff' instead of 'teacher'
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -808,6 +808,7 @@ class User < ApplicationRecord
     user.provider = auth.provider
     user.uid = auth.uid
     user.name = name_from_omniauth auth.info.name
+    user.family_name = auth.info.family_name
     user.user_type = params['user_type'] || auth.info.user_type
     user.user_type = 'teacher' if user.user_type == 'staff' # Powerschool sends through 'staff' instead of 'teacher'
 

--- a/dashboard/test/models/sections/google_classroom_section_test.rb
+++ b/dashboard/test/models/sections/google_classroom_section_test.rb
@@ -1,7 +1,8 @@
 require 'test_helper'
 
 class GoogleClassroomSectionTest < ActiveSupport::TestCase
-  test 'from google classroom service' do
+  test 'from google classroom service without family name import' do
+    DCDO.stubs(:get).with('google_classroom_family_name', false).returns(false)
     owner = create :teacher
     student_list = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(
       {
@@ -24,7 +25,10 @@ class GoogleClassroomSectionTest < ActiveSupport::TestCase
     assert section.provider_managed?
     assert_equal 'G-101', section.code
     assert_equal 'Test Section A', section.name
-    assert_equal 50, section.students.count
+    section.students.reload
+    assert_equal 50, section.students.length
+    assert_equal 'Sample User 1', section.students.first.name
+    assert_nil section.students.first.family_name
 
     assert_no_difference 'User.count' do
       # Should find the existing Google Classroom section.
@@ -34,6 +38,47 @@ class GoogleClassroomSectionTest < ActiveSupport::TestCase
       # Should update the name to match the imported name.
       assert_equal 'Test Section B', section_2.name
     end
+    DCDO.unstub(:get)
+  end
+
+  test 'from google classroom service with family name import' do
+    DCDO.stubs(:get).with('google_classroom_family_name', false).returns(true)
+    owner = create :teacher
+    student_list = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(
+      {
+        students: (1..50).map do |i|
+          {
+            userId: i,
+            profile: {
+              name: {
+                fullName: "Sample User #{i}",
+                givenName: "Sample",
+                familyName: "User #{i}"
+              }
+            }
+          }
+        end
+      }.to_json
+    ).students
+
+    section = GoogleClassroomSection.from_service('101', owner.id, student_list, 'Test Section A')
+    assert section.provider_managed?
+    assert_equal 'G-101', section.code
+    assert_equal 'Test Section A', section.name
+    section.students.reload
+    assert_equal 50, section.students.length
+    assert_equal 'Sample', section.students.first.name
+    assert_equal 'User 1', section.students.first.family_name
+
+    assert_no_difference 'User.count' do
+      # Should find the existing Google Classroom section.
+      section_2 = GoogleClassroomSection.from_service('101', owner.id, student_list, 'Test Section B')
+      assert_equal section.id, section_2.id
+
+      # Should update the name to match the imported name.
+      assert_equal 'Test Section B', section_2.name
+    end
+    DCDO.unstub(:get)
   end
 
   test 'strips emoji from section name' do

--- a/dashboard/test/models/sections/google_classroom_section_test.rb
+++ b/dashboard/test/models/sections/google_classroom_section_test.rb
@@ -8,7 +8,7 @@ class GoogleClassroomSectionTest < ActiveSupport::TestCase
     owner = create :teacher
     student_list = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(
       {
-        students: (1..50).map do |i|
+        students: (1..5).map do |i|
           {
             userId: i,
             profile: {
@@ -28,7 +28,7 @@ class GoogleClassroomSectionTest < ActiveSupport::TestCase
     assert_equal 'G-101', section.code
     assert_equal 'Test Section A', section.name
     section.students.reload
-    assert_equal 50, section.students.length
+    assert_equal 5, section.students.length
     assert_equal 'Sample User 1', section.students.first.name
     assert_nil section.students.first.family_name
 
@@ -50,7 +50,7 @@ class GoogleClassroomSectionTest < ActiveSupport::TestCase
     owner = create :teacher
     student_list = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(
       {
-        students: (1..50).map do |i|
+        students: (1..5).map do |i|
           {
             userId: i,
             profile: {
@@ -70,7 +70,7 @@ class GoogleClassroomSectionTest < ActiveSupport::TestCase
     assert_equal 'G-101', section.code
     assert_equal 'Test Section A', section.name
     section.students.reload
-    assert_equal 50, section.students.length
+    assert_equal 5, section.students.length
     assert_equal 'Sample', section.students.first.name
     assert_equal 'User 1', section.students.first.family_name
 

--- a/dashboard/test/models/sections/google_classroom_section_test.rb
+++ b/dashboard/test/models/sections/google_classroom_section_test.rb
@@ -3,7 +3,9 @@ require 'test_helper'
 class GoogleClassroomSectionTest < ActiveSupport::TestCase
   test 'from google classroom service without family name import' do
     DCDO.stubs(:get).with('google_classroom_family_name', false).returns(false)
-    DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)    owner = create :teacher
+    DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
+
+    owner = create :teacher
     student_list = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(
       {
         students: (1..50).map do |i|
@@ -43,7 +45,9 @@ class GoogleClassroomSectionTest < ActiveSupport::TestCase
 
   test 'from google classroom service with family name import' do
     DCDO.stubs(:get).with('google_classroom_family_name', false).returns(true)
-    DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)    owner = create :teacher
+    DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
+
+    owner = create :teacher
     student_list = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(
       {
         students: (1..50).map do |i|

--- a/dashboard/test/models/sections/google_classroom_section_test.rb
+++ b/dashboard/test/models/sections/google_classroom_section_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class GoogleClassroomSectionTest < ActiveSupport::TestCase
   test 'from google classroom service without family name import' do
     DCDO.stubs(:get).with('google_classroom_family_name', false).returns(false)
-    owner = create :teacher
+    DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)    owner = create :teacher
     student_list = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(
       {
         students: (1..50).map do |i|
@@ -43,7 +43,7 @@ class GoogleClassroomSectionTest < ActiveSupport::TestCase
 
   test 'from google classroom service with family name import' do
     DCDO.stubs(:get).with('google_classroom_family_name', false).returns(true)
-    owner = create :teacher
+    DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)    owner = create :teacher
     student_list = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(
       {
         students: (1..50).map do |i|

--- a/dashboard/test/models/sections/google_classroom_section_test.rb
+++ b/dashboard/test/models/sections/google_classroom_section_test.rb
@@ -6,7 +6,16 @@ class GoogleClassroomSectionTest < ActiveSupport::TestCase
     student_list = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(
       {
         students: (1..50).map do |i|
-          {userId: i, profile: {name: {fullName: "Sample User #{i}"}}}
+          {
+            userId: i,
+            profile: {
+              name: {
+                fullName: "Sample User #{i}",
+                givenName: "Sample",
+                familyName: "User #{i}"
+              }
+            }
+          }
         end
       }.to_json
     ).students


### PR DESCRIPTION
This change updates the Google Classroom student import logic to populate the `name` field with the student's given name and the `family_name` field with the student's family name, instead of the prior behavior of putting the full name into the `name` field and leaving the `family_name` field blank.

There's a DCDO flag `google_classroom_family_name` that controls this behavior.

![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/a0c0ce41-dbb8-42ec-a144-f79a09e51488)

## Links

jira ticket: [TEACH-557](https://codedotorg.atlassian.net/browse/TEACH-557)

## Testing story

Ruby tests for both with/without the DCDO flag.

## Deployment strategy

## Follow-up work

[TEACH-654](https://codedotorg.atlassian.net/browse/TEACH-654) tracks cleanup of family name DCDO flags.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
