### PR TITLE
[Google Blockly] Add modal function editor experiment

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -2,6 +2,7 @@ import * as GoogleBlockly from 'blockly/core';
 import BlockSvgFrame from '../../addons/blockSvgFrame';
 import msg from '@cdo/locale';
 import {procedureDefMutator} from './mutators/procedureDefMutator';
+import experiments from '@cdo/apps/util/experiments';
 
 // In Lab2, the level properties are in Redux, not appOptions. To make this work in Lab2,
 // we would need to send that property from the backend and save it in lab2Redux.
@@ -94,21 +95,22 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
 
 // Respond to the click of a call block's edit button
 export const editButtonHandler = function () {
-  // Eventually, this will be where we create a modal function editor.
-  // For now, just find the function definition block and select it.
-  const workspace = this.getSourceBlock().workspace;
-  const name = this.getSourceBlock().getFieldValue('NAME');
-  const definition = GoogleBlockly.Procedures.getDefinition(name, workspace);
-  if (definition) {
-    workspace.centerOnBlock(definition.id);
-    definition.select();
+  if (experiments.isEnabled(experiments.MODAL_FUNCTION_EDITOR)) {
+    const procedure = this.getSourceBlock().getProcedureModel();
+    if (procedure) {
+      Blockly.functionEditor.showForFunction(procedure);
+    }
+  } else {
+    // If we aren't using the new modal function editor yet, just center the block that
+    // was clicked.
+    const workspace = this.getSourceBlock().workspace;
+    const name = this.getSourceBlock().getFieldValue('NAME');
+    const definition = GoogleBlockly.Procedures.getDefinition(name, workspace);
+    if (definition) {
+      workspace.centerOnBlock(definition.id);
+      definition.select();
+    }
   }
-
-  // TODO: When we are ready, this is how we can open the modal function editor.
-  // const procedure = this.getSourceBlock().getProcedureModel();
-  // if (procedure) {
-  //   Blockly.functionEditor.showForFunction(procedure);
-  // }
 };
 
 // This extension adds an edit button to the end of a procedure call block.

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -59,6 +59,7 @@ import {
   ObservableProcedureModel,
   ObservableParameterModel,
 } from '@blockly/block-shareable-procedures';
+import experiments from '@cdo/apps/util/experiments';
 
 const options = {
   contextMenu: true,
@@ -673,13 +674,14 @@ function initializeBlocklyWrapper(blocklyInstance) {
     const hiddenDefinitionWorkspace = new Blockly.Workspace();
     blocklyWrapper.setHiddenDefinitionWorkspace(hiddenDefinitionWorkspace);
 
-    if (options.useModalFunctionEditor) {
-      // The modal function editor is currently a work in progress so we are leaving
-      // it commented out.
-      // TODO: To use the modal function editor, uncomment these lines and update
-      // editButtonHandler in procedureBlocks.js.
-      // blocklyWrapper.functionEditor = new FunctionEditor();
-      // blocklyWrapper.functionEditor.init(opt_options);
+    if (
+      options.useModalFunctionEditor &&
+      experiments.isEnabled(experiments.MODAL_FUNCTION_EDITOR)
+    ) {
+      // If the modal function editor is enabled for this level and
+      // the dcdo flag is on, initialize the modal function editor.
+      blocklyWrapper.functionEditor = new FunctionEditor();
+      blocklyWrapper.functionEditor.init(opt_options);
     }
 
     return workspace;

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -45,6 +45,8 @@ experiments.GENDER_FEATURE_ENABLED = 'gender';
 // Experiment for enabling the CPA lockout
 experiments.CPA_EXPERIENCE = 'cpa_experience';
 experiments.AI_RUBRICS = 'ai-rubrics';
+// Experiment for enabling the Google Blockly modal function editor
+experiments.MODAL_FUNCTION_EDITOR = 'modalFunctionEditor';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
In order to make testing easier, this PR adds an experiment flag to enable the Google Blockly modal function editor. It is still a work in progress so we don't want it fully enabled for users yet. The experiment flag is `modalFunctionEditor`.


## Testing story
Tested locally that with the flag the modal function editor is enabled, and without the flag it is disabled.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
