### PR TITLE
Restricting family name amplitude events

### DIFF
--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -459,7 +459,12 @@ class ManageStudentsTable extends Component {
         selectedColumn,
       }),
     });
-    if (selectedColumn === COLUMNS.FAMILY_NAME) {
+    if (
+      !!DCDO.get('family-name-features', false) &&
+      this.props.participantType === 'student' &&
+      selectedColumn === COLUMNS.FAMILY_NAME
+    ) {
+      // Only in non-PL sections, only when DCDO flag is on.
       this.props.setSortByFamilyName(
         true,
         this.props.sectionId,


### PR DESCRIPTION
Checks for a DCDO flag and participant type before logging family name sorting events.

Context: It appears that the manage student table keeps track of an enum of column names, but it is not kept accurate now that we *sometimes* have a family name column. I was using this column name/id enum for amplitude logging, and without family name, it meant that the age column was sending amplitude events for 'sorting by family name'. This pr checks first that the DCDO flag is on and the class is non-PL so we *know* that there is a family name column to sort by before sending an event. 

## Links



- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-653

## Testing story

I tested the family name amplitude events locally in the console:

Flag on, PL section -> No event
Flag off, PL section -> No event
Flag on, student section -> Event!
Flag off, student section -> No event

I also verified that display name sorting is still logged in all cases.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
