### PR TITLE
Bump activesupport from 7.0.4.3 to 7.0.7.2 in /cookbooks

### DIFF
--- a/cookbooks/Gemfile.lock
+++ b/cookbooks/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.3)
+    activesupport (7.0.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -404,7 +404,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     inifile (3.0.0)
     iniparse (1.5.0)
@@ -477,7 +477,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitar (0.9)
-    minitest (5.18.0)
+    minitest (5.19.0)
     mixlib-archive (1.1.7)
       mixlib-log
     mixlib-authentication (3.0.10)


### PR DESCRIPTION
placeholder PR with a short branch name just for testing https://github.com/code-dot-org/code-dot-org/pull/53443 on an adhoc; the original branch name is too long