### PR TITLE
Add basic eyes test for manage students table

### DIFF
--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -268,6 +268,13 @@ Then /^I navigate to teacher dashboard for the section I saved with experiment "
   }
 end
 
+Then /^I navigate to manage students for the section I saved$/ do
+  expect(@section_id).to be > 0
+  steps %{
+    Then I am on "http://studio.code.org/teacher_dashboard/sections/#{@section_id}/manage_students"
+  }
+end
+
 Then /^I navigate to the script "([^"]*)" lesson (\d+) lesson extras page for the section I saved$/ do |script_name, lesson_num|
   expect(@section_id).to be > 0
   steps %{

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -1,0 +1,17 @@
+@no_mobile
+@eyes
+Feature: Using the manage students tab of the teacher dashboard
+
+  Scenario: Viewing the manage students tab in normal and edit mode
+    When I open my eyes to test "manage students tab"
+    Given I create an authorized teacher-associated student named "Sally"
+
+    # Navigate to Manage Students tab as Teacher
+    When I sign in as "Teacher_Sally" and go home
+    And I wait until element "a:contains('Untitled Section')" is visible
+    And I save the section id from row 0 of the section table
+    Then I navigate to manage students for the section I saved
+    And I wait until element "#uitest-manage-students-table" is visible
+    And I see no difference for "manage students tab"
+
+    And I close my eyes


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds a basic eyes tests on the manage students tab, just to get us some visual regression coverage here. I tried adding some more tests, but I couldn't get it to click on the "edit all" button no matter how many variations of selectors and waits I tried. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [TEACH-626](https://codedotorg.atlassian.net/browse/TEACH-626)


