### PR TITLE
Fix Violations of and Reenable  `Lint/AmbiguousBlockAssociation`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,11 +55,6 @@ Layout/MultilineOperationIndentation:
 Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: false
 
-# Offense count: 105
-# Configuration parameters: IgnoredMethods.
-Lint/AmbiguousBlockAssociation:
-  Enabled: false
-
 # Offense count: 858
 # This cop supports safe auto-correction (--auto-correct).
 Lint/AmbiguousRegexpLiteral:

--- a/aws/cloudformation/test/test_fast_snapshot_restore.rb
+++ b/aws/cloudformation/test/test_fast_snapshot_restore.rb
@@ -37,8 +37,10 @@ class TestFastSnapshotRestore < Minitest::Test
   end
 
   def expect_api(*requests)
-    assert_equal(requests.map(&:first).map {|(op, params)| {operation_name: op, params: params}},
-      EC2.api_requests.map {|req| req.slice(:operation_name, :params)})
+    assert_equal(
+      requests.map(&:first).map {|(op, params)| {operation_name: op, params: params}},
+      EC2.api_requests.map {|req| req.slice(:operation_name, :params)}
+    )
   end
 
   def test_create

--- a/aws/cloudformation/test/test_fast_snapshot_restore.rb
+++ b/aws/cloudformation/test/test_fast_snapshot_restore.rb
@@ -37,8 +37,8 @@ class TestFastSnapshotRestore < Minitest::Test
   end
 
   def expect_api(*requests)
-    assert_equal requests.map(&:first).map {|(op, params)| {operation_name: op, params: params}},
-      EC2.api_requests.map {|req| req.slice(:operation_name, :params)}
+    assert_equal(requests.map(&:first).map {|(op, params)| {operation_name: op, params: params}},
+      EC2.api_requests.map {|req| req.slice(:operation_name, :params)})
   end
 
   def test_create

--- a/bin/k5-professional-development-survey-results
+++ b/bin/k5-professional-development-survey-results
@@ -47,7 +47,7 @@ def main
       keys = data.keys
       puts CSV.generate_line keys
     end
-    puts CSV.generate_line keys.map {|i| data[i]}
+    puts CSV.generate_line(keys.map {|i| data[i]})
   end
 end
 

--- a/cookbooks/cdo-apps/libraries/cdo_apps.rb
+++ b/cookbooks/cdo-apps/libraries/cdo_apps.rb
@@ -93,7 +93,7 @@ module CdoApps
     # as its contents and invoke the restart whenever those contents change.
     file "#{app_name}_listeners" do
       path "#{Chef::Config[:file_cache_path]}/#{app_name}_listeners"
-      content lazy {"#{node['cdo-secrets']["#{app_name}_sock"]}:#{node['cdo-secrets']["#{app_name}_port"]}"}
+      content(lazy {"#{node['cdo-secrets']["#{app_name}_sock"]}:#{node['cdo-secrets']["#{app_name}_port"]}"})
       notifies :run, "execute[restart #{app_name} service]", :immediately
     end
 

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -48,7 +48,7 @@ class LevelLoader
       # level_concept_difficulty) when we bulk-load the level properties.
       new_level_names = level_file_names.
         reject {|name| existing_level_names.include? name}
-      Level.import! new_level_names.map {|name| {name: name}}
+      Level.import!(new_level_names.map {|name| {name: name}})
 
       # Load level properties from disk and build a collection of levels that
       # have changed.

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -131,34 +131,34 @@ module Api::V1::Pd
       sign_in @workshop_admin
       get :quick_view, params: {role: 'csd_teachers', regional_partner_value: @regional_partner.id}
       assert_response :success
-      assert_equal [@csd_teacher_application_with_partner.id, @csd_incomplete_application_with_partner.id],
-        JSON.parse(@response.body).map {|r| r['id']}
+      assert_equal([@csd_teacher_application_with_partner.id, @csd_incomplete_application_with_partner.id],
+        JSON.parse(@response.body).map {|r| r['id']})
     end
 
     test 'quick view if not admin returns applications without incomplete apps and with filter' do
       sign_in @program_manager
       get :quick_view, params: {role: 'csd_teachers', regional_partner_value: @regional_partner.id}
       assert_response :success
-      assert_equal [@csd_teacher_application_with_partner.id], JSON.parse(@response.body).map {|r| r['id']}
+      assert_equal([@csd_teacher_application_with_partner.id], JSON.parse(@response.body).map {|r| r['id']})
     end
 
     test "quick view returns applications with regional partner filter unset" do
       sign_in @workshop_admin
       get :quick_view, params: {role: 'csd_teachers'}
       assert_response :success
-      assert_equal [
+      assert_equal([
         @csd_teacher_application.id,
         @csd_teacher_application_with_partner.id,
         @csd_incomplete_application_with_partner.id
       ],
-        JSON.parse(@response.body).map {|r| r['id']}
+        JSON.parse(@response.body).map {|r| r['id']})
     end
 
     test "quick view returns applications with regional partner filter set to no partner" do
       sign_in @workshop_admin
       get :quick_view, params: {role: 'csd_teachers', regional_partner_value: 'none'}
       assert_response :success
-      assert_equal [@csd_teacher_application.id], JSON.parse(@response.body).map {|r| r['id']}
+      assert_equal([@csd_teacher_application.id], JSON.parse(@response.body).map {|r| r['id']})
     end
 
     # TODO: remove this test when workshop_organizer is deprecated

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -131,8 +131,10 @@ module Api::V1::Pd
       sign_in @workshop_admin
       get :quick_view, params: {role: 'csd_teachers', regional_partner_value: @regional_partner.id}
       assert_response :success
-      assert_equal([@csd_teacher_application_with_partner.id, @csd_incomplete_application_with_partner.id],
-        JSON.parse(@response.body).map {|r| r['id']})
+      assert_equal(
+        [@csd_teacher_application_with_partner.id, @csd_incomplete_application_with_partner.id],
+        JSON.parse(@response.body).map {|r| r['id']}
+      )
     end
 
     test 'quick view if not admin returns applications without incomplete apps and with filter' do
@@ -146,12 +148,14 @@ module Api::V1::Pd
       sign_in @workshop_admin
       get :quick_view, params: {role: 'csd_teachers'}
       assert_response :success
-      assert_equal([
-        @csd_teacher_application.id,
-        @csd_teacher_application_with_partner.id,
-        @csd_incomplete_application_with_partner.id
-      ],
-        JSON.parse(@response.body).map {|r| r['id']})
+      assert_equal(
+        [
+          @csd_teacher_application.id,
+          @csd_teacher_application_with_partner.id,
+          @csd_incomplete_application_with_partner.id
+        ],
+        JSON.parse(@response.body).map {|r| r['id']}
+      )
     end
 
     test "quick view returns applications with regional partner filter set to no partner" do

--- a/dashboard/test/controllers/api/v1/pd/course_facilitators_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/course_facilitators_controller_test.rb
@@ -28,6 +28,6 @@ class Api::V1::Pd::CourseFacilitatorsControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     response_body = JSON.parse(response.body)
-    assert_equal [facilitator2, facilitator1].map(&:email), response_body.map {|f| f['email']}
+    assert_equal([facilitator2, facilitator1].map(&:email), response_body.map {|f| f['email']})
   end
 end

--- a/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
@@ -264,9 +264,9 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ActionController::Tes
 
     # Check expected row counts for our test workshops
     # (We don't count all rows to insulate this test against existing state)
-    assert_equal 10, response.count {|row| row[11] == @pm_workshop.id.to_s}
-    assert_equal 10, response.count {|row| row[11] == @workshop.id.to_s}
-    assert_equal 1, response.count {|row| row[11] == @other_workshop.id.to_s}
+    assert_equal(10, response.count {|row| row[11] == @pm_workshop.id.to_s})
+    assert_equal(10, response.count {|row| row[11] == @workshop.id.to_s})
+    assert_equal(1, response.count {|row| row[11] == @other_workshop.id.to_s})
   end
 
   private

--- a/dashboard/test/controllers/api/v1/pd/workshop_organizers_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_organizers_controller_test.rb
@@ -25,12 +25,12 @@ class Api::V1::Pd::WorkshopOrganizersControllerTest < ActionController::TestCase
         name: organizer.name,
         email: organizer.email
       }.stringify_keys
-      assert_equal expected, response.find {|o| o['id'] == organizer.id}
+      assert_equal(expected, response.find {|o| o['id'] == organizer.id})
     end
 
     # No non-organizers returned
     non_organizers.each do |non_organizer|
-      refute response.any? {|o| o['id'] == non_organizer.id}
+      refute(response.any? {|o| o['id'] == non_organizer.id})
     end
   end
 end

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
@@ -270,7 +270,7 @@ module Api::V1::Pd
         'surveys/pd/workshop_csf_intro_post_test',
         'surveys/pd/csd_csp_facilitator_post_survey'
       ]
-      assert_equal form_names, response.map {|h| h['name']}
+      assert_equal(form_names, response.map {|h| h['name']})
 
       sign_in @workshop_admin
 

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -323,7 +323,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
     response = JSON.parse(@response.body)
 
     assert_equal 2, response['workshops'].count
-    assert_equal [later_workshop.id, earlier_workshop.id], response['workshops'].map {|w| w['id']}
+    assert_equal([later_workshop.id, earlier_workshop.id], response['workshops'].map {|w| w['id']})
     assert_equal filters.stringify_keys, response['filters']
   end
 

--- a/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
@@ -54,12 +54,15 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
     get :index, params: {user_q: other_submitter.email}
     assert_response :success
     response = JSON.parse(@response.body)
-    assert_equal([
+    assert_equal(
       [
-        [submissions.first.id, nil, submissions.first.updated_at],
-        [submissions.second.id, 'escalated', submissions.second.updated_at]
-      ]
-    ], response['submissions'].map {|submission| submission['review_ids']})
+        [
+          [submissions.first.id, nil, submissions.first.updated_at],
+          [submissions.second.id, 'escalated', submissions.second.updated_at]
+        ]
+      ],
+      response['submissions'].map {|submission| submission['review_ids']}
+    )
 
     # Verify expected pagination metadata
     assert_equal(
@@ -82,12 +85,15 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
     get :index, params: {user_q: unmigrated_submitter.email}
     assert_response :success
     response = JSON.parse(@response.body)
-    assert_equal([
+    assert_equal(
       [
-        [submissions.first.id, nil, submissions.first.updated_at],
-        [submissions.second.id, 'escalated', submissions.second.updated_at]
-      ]
-    ], response['submissions'].map {|submission| submission['review_ids']})
+        [
+          [submissions.first.id, nil, submissions.first.updated_at],
+          [submissions.second.id, 'escalated', submissions.second.updated_at]
+        ]
+      ],
+      response['submissions'].map {|submission| submission['review_ids']}
+    )
 
     # Verify expected pagination metadata
     assert_equal(
@@ -171,20 +177,23 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     response = JSON.parse(@response.body)
-    assert_equal([
+    assert_equal(
       [
-        [@level_3_reviews.first.id, nil, @level_3_reviews.first.updated_at],
-        [@level_3_reviews.second.id, 'escalated', @level_3_reviews.second.updated_at]
+        [
+          [@level_3_reviews.first.id, nil, @level_3_reviews.first.updated_at],
+          [@level_3_reviews.second.id, 'escalated', @level_3_reviews.second.updated_at]
+        ],
+        [
+          [@level_2_reviews.first.id, nil, @level_2_reviews.first.updated_at],
+          [@level_2_reviews.second.id, 'accepted', @level_2_reviews.second.updated_at]
+        ],
+        [
+          [@level_1_reviews.first.id, nil, @level_1_reviews.first.updated_at],
+          [@level_1_reviews.second.id, 'escalated', @level_1_reviews.second.updated_at]
+        ]
       ],
-      [
-        [@level_2_reviews.first.id, nil, @level_2_reviews.first.updated_at],
-        [@level_2_reviews.second.id, 'accepted', @level_2_reviews.second.updated_at]
-      ],
-      [
-        [@level_1_reviews.first.id, nil, @level_1_reviews.first.updated_at],
-        [@level_1_reviews.second.id, 'escalated', @level_1_reviews.second.updated_at]
-      ]
-    ], response['submissions'].map {|submission| submission['review_ids']})
+      response['submissions'].map {|submission| submission['review_ids']}
+    )
 
     # Verify expected pagination metadata
     assert_equal(

--- a/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
@@ -54,12 +54,12 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
     get :index, params: {user_q: other_submitter.email}
     assert_response :success
     response = JSON.parse(@response.body)
-    assert_equal [
+    assert_equal([
       [
         [submissions.first.id, nil, submissions.first.updated_at],
         [submissions.second.id, 'escalated', submissions.second.updated_at]
       ]
-    ], response['submissions'].map {|submission| submission['review_ids']}
+    ], response['submissions'].map {|submission| submission['review_ids']})
 
     # Verify expected pagination metadata
     assert_equal(
@@ -82,12 +82,12 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
     get :index, params: {user_q: unmigrated_submitter.email}
     assert_response :success
     response = JSON.parse(@response.body)
-    assert_equal [
+    assert_equal([
       [
         [submissions.first.id, nil, submissions.first.updated_at],
         [submissions.second.id, 'escalated', submissions.second.updated_at]
       ]
-    ], response['submissions'].map {|submission| submission['review_ids']}
+    ], response['submissions'].map {|submission| submission['review_ids']})
 
     # Verify expected pagination metadata
     assert_equal(
@@ -115,17 +115,17 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
 
     # R. Daneel's submissions are found
     PeerReview.where(submitter: daneel).each do |pr|
-      assert response['submissions'].any? {|submission| submission['review_ids'].any? {|r| r[0] == pr.id}}
+      assert(response['submissions'].any? {|submission| submission['review_ids'].any? {|r| r[0] == pr.id}})
     end
 
     # Danielle's submissions are found
     PeerReview.where(submitter: danielle).each do |pr|
-      assert response['submissions'].any? {|submission| submission['review_ids'].any? {|r| r[0] == pr.id}}
+      assert(response['submissions'].any? {|submission| submission['review_ids'].any? {|r| r[0] == pr.id}})
     end
 
     # Toothy the Gerbil's submissions are not found
     PeerReview.where(submitter: gerbil).each do |pr|
-      refute response['submissions'].any? {|submission| submission['review_ids'].any? {|r| r[0] == pr.id}}
+      refute(response['submissions'].any? {|submission| submission['review_ids'].any? {|r| r[0] == pr.id}})
     end
   end
 
@@ -171,7 +171,7 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     response = JSON.parse(@response.body)
-    assert_equal [
+    assert_equal([
       [
         [@level_3_reviews.first.id, nil, @level_3_reviews.first.updated_at],
         [@level_3_reviews.second.id, 'escalated', @level_3_reviews.second.updated_at]
@@ -184,7 +184,7 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
         [@level_1_reviews.first.id, nil, @level_1_reviews.first.updated_at],
         [@level_1_reviews.second.id, 'escalated', @level_1_reviews.second.updated_at]
       ]
-    ], response['submissions'].map {|submission| submission['review_ids']}
+    ], response['submissions'].map {|submission| submission['review_ids']})
 
     # Verify expected pagination metadata
     assert_equal(

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -770,7 +770,7 @@ class CoursesControllerTest < ActionController::TestCase
     assert_response :success
     response_body = JSON.parse(@response.body)
     assert_equal 4, response_body.length
-    assert_equal ['All Code', 'All Resources', 'All Standards', 'All Vocabulary'], response_body.map {|r| r['name']}
+    assert_equal(['All Code', 'All Resources', 'All Standards', 'All Vocabulary'], response_body.map {|r| r['name']})
   end
 
   test "get_rollup_resources doesn't return rollups if no lesson in a unit has the associated object" do
@@ -789,6 +789,6 @@ class CoursesControllerTest < ActionController::TestCase
     assert_response :success
     response_body = JSON.parse(@response.body)
     assert_equal 2, response_body.length
-    assert_equal ['All Resources', 'All Standards'], response_body.map {|r| r['name']}
+    assert_equal(['All Resources', 'All Standards'], response_body.map {|r| r['name']})
   end
 end

--- a/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
@@ -196,7 +196,7 @@ class Pd::ProfessionalLearningLandingControllerTest < ActionController::TestCase
     load_pl_landing @teacher
 
     response = assigns(:landing_page_data)
-    assert_equal ['CSP Support', 'ECS Support', 'Bills Fandom 101'], response[:summarized_plc_enrollments].map {|enrollment| enrollment[:courseName]}
+    assert_equal(['CSP Support', 'ECS Support', 'Bills Fandom 101'], response[:summarized_plc_enrollments].map {|enrollment| enrollment[:courseName]})
   end
 
   def go_to_workshop(workshop, teacher)

--- a/dashboard/test/controllers/project_commits_controller_test.rb
+++ b/dashboard/test/controllers/project_commits_controller_test.rb
@@ -33,7 +33,7 @@ class ProjectCommitsControllerTest < ActionController::TestCase
 
     returned_commits = JSON.parse(@response.body)
     assert_equal 3, returned_commits.length
-    assert_equal ['First comment', 'Second comment', 'Third comment'], returned_commits.map {|c| c['comment']}
+    assert_equal(['First comment', 'Second comment', 'Third comment'], returned_commits.map {|c| c['comment']})
   end
 
   test "can fetch project commits and blank comments are filtered out" do
@@ -55,7 +55,7 @@ class ProjectCommitsControllerTest < ActionController::TestCase
 
     returned_commits = JSON.parse(@response.body)
     assert_equal 2, returned_commits.length
-    assert_equal ['First comment', 'Third comment'], returned_commits.map {|c| c['comment']}
+    assert_equal(['First comment', 'Third comment'], returned_commits.map {|c| c['comment']})
   end
 
   test "can fetch project commits of students project if their teacher" do

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -860,7 +860,7 @@ class ScriptsControllerTest < ActionController::TestCase
       is_migrated: true,
       last_updated_at: unit.updated_at.to_s,
     }
-    assert_equal teacher_resources.map(&:key), Unit.find_by_name(unit.name).resources.map {|r| r[:key]}
+    assert_equal(teacher_resources.map(&:key), Unit.find_by_name(unit.name).resources.map {|r| r[:key]})
   end
 
   test 'updates migrated student resources' do
@@ -885,7 +885,7 @@ class ScriptsControllerTest < ActionController::TestCase
       is_migrated: true,
       last_updated_at: unit.updated_at.to_s,
     }
-    assert_equal student_resources.map(&:key), Unit.find_by_name(unit.name).student_resources.map {|r| r[:key]}
+    assert_equal(student_resources.map(&:key), Unit.find_by_name(unit.name).student_resources.map {|r| r[:key]})
   end
 
   test 'updates pilot_experiment' do
@@ -1753,7 +1753,7 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_response :success
     response_body = JSON.parse(@response.body)
     assert_equal 4, response_body.length
-    assert_equal ['All Code', 'All Resources', 'All Standards', 'All Vocabulary'], response_body.map {|r| r['name']}
+    assert_equal(['All Code', 'All Resources', 'All Standards', 'All Vocabulary'], response_body.map {|r| r['name']})
   end
 
   test "get_rollup_resources doesn't return rollups if no lesson in a unit has the associated object" do
@@ -1771,7 +1771,7 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_response :success
     response_body = JSON.parse(@response.body)
     assert_equal 2, response_body.length
-    assert_equal ['All Resources', 'All Standards'], response_body.map {|r| r['name']}
+    assert_equal(['All Resources', 'All Standards'], response_body.map {|r| r['name']})
   end
 
   test "get_unit bypasses cache for edit route" do

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1557,11 +1557,11 @@ class DeleteAccountsHelperTest < ActionView::TestCase
       form_ids = PEGASUS_DB[:forms].where(email: email).map {|f| f[:id]}
 
       refute_empty PEGASUS_DB[:forms].where(id: form_ids)
-      assert PEGASUS_DB[:forms].where(id: form_ids).any? {|f| f[:email].present?}
+      assert(PEGASUS_DB[:forms].where(id: form_ids).any? {|f| f[:email].present?})
 
       purge_all_accounts_with_email email
 
-      refute PEGASUS_DB[:forms].where(id: form_ids).any? {|f| f[:email].present?}
+      refute(PEGASUS_DB[:forms].where(id: form_ids).any? {|f| f[:email].present?})
     end
   end
 
@@ -1571,11 +1571,11 @@ class DeleteAccountsHelperTest < ActionView::TestCase
       form_ids = PEGASUS_DB[:forms].where(user_id: user.id).map {|f| f[:id]}
 
       refute_empty PEGASUS_DB[:forms].where(id: form_ids)
-      assert PEGASUS_DB[:forms].where(id: form_ids).any? {|f| f[:email].present?}
+      assert(PEGASUS_DB[:forms].where(id: form_ids).any? {|f| f[:email].present?})
 
       purge_user user
 
-      refute PEGASUS_DB[:forms].where(id: form_ids).any? {|f| f[:email].present?}
+      refute(PEGASUS_DB[:forms].where(id: form_ids).any? {|f| f[:email].present?})
     end
   end
 

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -234,9 +234,9 @@ class LevelsHelperTest < ActionView::TestCase
 
     callouts = select_and_remember_callouts
 
-    assert callouts.any? {|callout| callout['id'] == callout1.id}
-    assert callouts.any? {|callout| callout['id'] == callout2.id}
-    assert callouts.none? {|callout| callout['id'] == irrelevant_callout.id}
+    assert(callouts.any? {|callout| callout['id'] == callout1.id})
+    assert(callouts.any? {|callout| callout['id'] == callout2.id})
+    assert(callouts.none? {|callout| callout['id'] == irrelevant_callout.id})
   end
 
   test "should localize callouts" do
@@ -249,7 +249,7 @@ class LevelsHelperTest < ActionView::TestCase
 
     callouts = select_and_remember_callouts
 
-    assert callouts.any? {|c| c['localized_text'] == 'Hit "Run" to try your program'}
+    assert(callouts.any? {|c| c['localized_text'] == 'Hit "Run" to try your program'})
   end
 
   test 'app_options returns camelCased view option on Blockly level' do

--- a/dashboard/test/integration/omniauth/utils.rb
+++ b/dashboard/test/integration/omniauth/utils.rb
@@ -151,7 +151,7 @@ module OmniauthCallbacksControllerTests
       study_groups = study_records.map {|e| e[:study_group]}.uniq.compact
       study_events = study_records.map {|e| e[:event]}
 
-      assert study_records.all? {|record| record[:data_string].present?}
+      assert(study_records.all? {|record| record[:data_string].present?})
       assert_equal 1, study_records.map {|r| r[:data_string]}.uniq.count
       assert_equal [expected_study_group], study_groups
       assert_equal expected_events, study_events

--- a/dashboard/test/lib/api/v1/school_autocomplete_test.rb
+++ b/dashboard/test/lib/api/v1/school_autocomplete_test.rb
@@ -26,13 +26,13 @@ class Api::V1::SchoolAutocompleteTest < ActiveSupport::TestCase
   test 'search by unique name matches only 1 school' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('Chalkville', MAXIMUM_RESULTS, false)
     assert_equal 1, search_results.count
-    assert search_results.detect {|school| school[:nces_id] == '10000200277'}
+    assert(search_results.detect {|school| school[:nces_id] == '10000200277'})
   end
 
   test 'search by zip returns match' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('98936', MAXIMUM_RESULTS, false)
     # CHILDREN'S VILLAGE is in 98936
-    assert search_results.detect {|school| school[:nces_id] == '530537003179'}
+    assert(search_results.detect {|school| school[:nces_id] == '530537003179'})
   end
 
   test 'search by zip with no schools in it returns no match' do
@@ -43,35 +43,35 @@ class Api::V1::SchoolAutocompleteTest < ActiveSupport::TestCase
   test 'search by school name also matches city' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('Albertville', MAXIMUM_RESULTS, false)
     # ALBERTVILLE HIGH SCH
-    assert search_results.detect {|school| school[:nces_id] == '10000500871'}
+    assert(search_results.detect {|school| school[:nces_id] == '10000500871'})
     # ALA AVENUE MIDDLE is in	ALBERTVILLE	AL
-    assert search_results.detect {|school| school[:nces_id] == '10000500870'}
+    assert(search_results.detect {|school| school[:nces_id] == '10000500870'})
   end
 
   test 'search by partial name matches school' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('Albert', MAXIMUM_RESULTS, false)
     # ALBERT EINSTEIN ACADEMY ELEMENTARY
-    assert search_results.detect {|school| school[:nces_id] == '60000113717'}
+    assert(search_results.detect {|school| school[:nces_id] == '60000113717'})
   end
 
   test 'search by partial word matches school' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('Alb', MAXIMUM_RESULTS, false)
     # ALBERT EINSTEIN ACADEMY ELEMENTARY
-    assert search_results.detect {|school| school[:nces_id] == '60000113717'}
+    assert(search_results.detect {|school| school[:nces_id] == '60000113717'})
   end
 
   test 'search by common abbreviation returns multiple matches' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('Sch', MAXIMUM_RESULTS, false)
     assert_equal 8, search_results.count
     # Alakanuk School
-    assert search_results.detect {|school| school[:nces_id] == '20000300216'}
+    assert(search_results.detect {|school| school[:nces_id] == '20000300216'})
     # Sequoyah Sch   Chalkville Campus
-    assert search_results.detect {|school| school[:nces_id] == '10000200277'}
+    assert(search_results.detect {|school| school[:nces_id] == '10000200277'})
   end
 
   test 'punctuation in search is ignored' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('Pathways-College', MAXIMUM_RESULTS, false)
-    assert search_results.detect {|school| school[:nces_id] == '60001411746'}
+    assert(search_results.detect {|school| school[:nces_id] == '60001411746'})
   end
 
   test 'search by non-existent school name has no matches' do
@@ -82,34 +82,34 @@ class Api::V1::SchoolAutocompleteTest < ActiveSupport::TestCase
   test 'new search by unique name matches only 1 school' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('Chalkville', MAXIMUM_RESULTS, true)
     assert_equal 1, search_results.count
-    assert search_results.detect {|school| school[:nces_id] == '10000200277'}
+    assert(search_results.detect {|school| school[:nces_id] == '10000200277'})
   end
 
   # New search drops support for search by zip.
   test 'new search by zip does not return match' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('98936', MAXIMUM_RESULTS, true)
-    refute search_results.detect {|school| school[:nces_id] == '530537003179'}
+    refute(search_results.detect {|school| school[:nces_id] == '530537003179'})
   end
 
   test 'new search by school name also matches city' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('Albertville', MAXIMUM_RESULTS, true)
     # ALBERTVILLE HIGH SCH
-    assert search_results.detect {|school| school[:nces_id] == '10000500871'}
+    assert(search_results.detect {|school| school[:nces_id] == '10000500871'})
     # ALA AVENUE MIDDLE is in	ALBERTVILLE	AL
-    assert search_results.detect {|school| school[:nces_id] == '10000500870'}
+    assert(search_results.detect {|school| school[:nces_id] == '10000500870'})
   end
 
   test 'new search by partial name matches school' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('Albert', MAXIMUM_RESULTS, true)
     # ALBERT EINSTEIN ACADEMY ELEMENTARY
-    assert search_results.detect {|school| school[:nces_id] == '60000113717'}
+    assert(search_results.detect {|school| school[:nces_id] == '60000113717'})
   end
 
   # New search does not support search by a single partial word.
   test 'new search by partial word does not match school' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('Alb', MAXIMUM_RESULTS, true)
     # ALBERT EINSTEIN ACADEMY ELEMENTARY
-    refute search_results.detect {|school| school[:nces_id] == '60000113717'}
+    refute(search_results.detect {|school| school[:nces_id] == '60000113717'})
   end
 
   # New search intentionally has fewer low relevance matches with common abbreviations.
@@ -117,14 +117,14 @@ class Api::V1::SchoolAutocompleteTest < ActiveSupport::TestCase
     search_results = Api::V1::SchoolAutocomplete.get_matches('Sch', MAXIMUM_RESULTS, true)
     assert_equal 4, search_results.count
     # Ala Avenue Middle Sch
-    assert search_results.detect {|school| school[:nces_id] == '10000500870'}
+    assert(search_results.detect {|school| school[:nces_id] == '10000500870'})
     # Albertville High Sch
-    assert search_results.detect {|school| school[:nces_id] == '10000500871'}
+    assert(search_results.detect {|school| school[:nces_id] == '10000500871'})
   end
 
   test 'punctuation in new search is ignored' do
     search_results = Api::V1::SchoolAutocomplete.get_matches('Pathways-College', MAXIMUM_RESULTS, true)
-    assert search_results.detect {|school| school[:nces_id] == '60001411746'}
+    assert(search_results.detect {|school| school[:nces_id] == '60001411746'})
   end
 
   test 'new search by non-existent school name has no matches' do

--- a/dashboard/test/lib/api/v1/school_district_autocomplete_test.rb
+++ b/dashboard/test/lib/api/v1/school_district_autocomplete_test.rb
@@ -6,13 +6,13 @@ class Api::V1::SchoolDistrictAutocompleteTest < ActiveSupport::TestCase
   test 'search by unique name matches only 1 school district' do
     search_results = Api::V1::SchoolDistrictAutocomplete.get_matches('LOWER KUSKOKWIM SCHOOL DISTRICT', MAXIMUM_RESULTS)
     assert_equal 1, search_results.count
-    assert search_results.detect {|school_district| school_district[:nces_id] == '200001'}
+    assert(search_results.detect {|school_district| school_district[:nces_id] == '200001'})
   end
 
   test 'search by city returns match' do
     search_results = Api::V1::SchoolDistrictAutocomplete.get_matches('Baxley', MAXIMUM_RESULTS)
     # APPLING COUNTY district is headquartered in Baxley
-    assert search_results.detect {|school_district| school_district[:nces_id] == '1300060'}
+    assert(search_results.detect {|school_district| school_district[:nces_id] == '1300060'})
   end
 
   test 'search by city with no matching districts returns no match' do
@@ -23,18 +23,18 @@ class Api::V1::SchoolDistrictAutocompleteTest < ActiveSupport::TestCase
   test 'search by partial name matches school district' do
     search_results = Api::V1::SchoolDistrictAutocomplete.get_matches('Appling', MAXIMUM_RESULTS)
     # Appling County
-    assert search_results.detect {|school_district| school_district[:nces_id] == '1300060'}
+    assert(search_results.detect {|school_district| school_district[:nces_id] == '1300060'})
   end
 
   test 'search by partial word matches school district' do
     search_results = Api::V1::SchoolDistrictAutocomplete.get_matches('App', MAXIMUM_RESULTS)
     # Appling County
-    assert search_results.detect {|school_district| school_district[:nces_id] == '1300060'}
+    assert(search_results.detect {|school_district| school_district[:nces_id] == '1300060'})
   end
 
   test 'search with punctuation matches school district with punctuation in name' do
     search_results = Api::V1::SchoolDistrictAutocomplete.get_matches('Acton-Agua Dulce Unified', MAXIMUM_RESULTS)
-    assert search_results.detect {|school_district| school_district[:nces_id] == '600001'}
+    assert(search_results.detect {|school_district| school_district[:nces_id] == '600001'})
   end
 
   test 'search by non-existent school district name has no matches' do

--- a/dashboard/test/lib/vocabulary_autocomplete_test.rb
+++ b/dashboard/test/lib/vocabulary_autocomplete_test.rb
@@ -26,7 +26,7 @@ class VocabularyAutocompleteTest < ActiveSupport::TestCase
   test "finds multiple matches" do
     matches = VocabularyAutocomplete.get_search_matches('pro', 5, @course_version_2018)
     assert_equal 2, matches.length
-    assert_equal ['Debugging', 'Programming'], matches.map {|m| m[:word]}
+    assert_equal(['Debugging', 'Programming'], matches.map {|m| m[:word]})
   end
 
   test "restricts matches by limit" do

--- a/dashboard/test/models/block_test.rb
+++ b/dashboard/test/models/block_test.rb
@@ -74,7 +74,7 @@ class BlockTest < ActiveSupport::TestCase
     block.name = block.name + '_the_great'
     block.save
 
-    assert Block.for(block.pool).any? {|b| b[:name] == block.name}
+    assert(Block.for(block.pool).any? {|b| b[:name] == block.name})
     refute File.exist? old_file_path
     refute File.exist? old_js_path
   end
@@ -94,7 +94,7 @@ class BlockTest < ActiveSupport::TestCase
   end
 
   test 'always includes blocks from the default pool' do
-    assert Block.for.any? {|b| b[:pool] == Block::DEFAULT_POOL}
+    assert(Block.for.any? {|b| b[:pool] == Block::DEFAULT_POOL})
   end
 
   test 'file_path works for unmodified and modified blocks' do

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -950,7 +950,7 @@ class LessonTest < ActiveSupport::TestCase
       assert_equal 2, copied_lesson.script_levels.length
       assert_equal [level1, level2], copied_lesson.script_levels.map(&:level)
       assert_equal 2, copied_lesson.resources.length
-      assert_equal @original_lesson.resources.map {|r| r.attributes.slice('name', 'url', 'properties').to_a}, copied_lesson.resources.map {|r| r.attributes.slice('name', 'url', 'properties').to_a}
+      assert_equal(@original_lesson.resources.map {|r| r.attributes.slice('name', 'url', 'properties').to_a}, copied_lesson.resources.map {|r| r.attributes.slice('name', 'url', 'properties').to_a})
       assert_equal 2, copied_lesson.vocabularies.length
       assert_equal @original_lesson.vocabularies.map(&:word), copied_lesson.vocabularies.map(&:word)
       assert_equal 2, copied_lesson.objectives.length
@@ -1006,7 +1006,7 @@ class LessonTest < ActiveSupport::TestCase
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
       assert_equal @destination_script, copied_lesson.script
       assert_equal 1, copied_lesson.resources.length
-      assert_equal @original_lesson.resources.map {|r| r.attributes.slice('name', 'url', 'properties').to_a}, copied_lesson.resources.map {|r| r.attributes.slice('name', 'url', 'properties').to_a}
+      assert_equal(@original_lesson.resources.map {|r| r.attributes.slice('name', 'url', 'properties').to_a}, copied_lesson.resources.map {|r| r.attributes.slice('name', 'url', 'properties').to_a})
 
       copied_resource1 = @destination_course_version.resources.find_by_name('resource1')
       refute_nil copied_resource1
@@ -1014,7 +1014,7 @@ class LessonTest < ActiveSupport::TestCase
       refute_nil copied_resource2
       assert_equal @destination_script.lessons.last.lesson_activities.last.activity_sections.first.description, "Resource 1: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(copied_resource1)}]. Resource 2: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(copied_resource2)}]."
       assert_equal 2, @destination_script.lessons.last.lesson_activities.last.activity_sections.last.tips.length
-      assert_equal ["Resource 1: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(copied_resource1)}]", "description without resource"], @destination_script.lessons.last.lesson_activities.last.activity_sections.last.tips.map {|t| t['markdown']}
+      assert_equal(["Resource 1: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(copied_resource1)}]", "description without resource"], @destination_script.lessons.last.lesson_activities.last.activity_sections.last.tips.map {|t| t['markdown']})
     end
 
     test "preparation resource markdown is updated when cloning lesson" do
@@ -1028,7 +1028,7 @@ class LessonTest < ActiveSupport::TestCase
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
       assert_equal @destination_script, copied_lesson.script
       assert_equal 1, copied_lesson.resources.length
-      assert_equal @original_lesson.resources.map {|r| r.attributes.slice('name', 'url', 'properties').to_a}, copied_lesson.resources.map {|r| r.attributes.slice('name', 'url', 'properties').to_a}
+      assert_equal(@original_lesson.resources.map {|r| r.attributes.slice('name', 'url', 'properties').to_a}, copied_lesson.resources.map {|r| r.attributes.slice('name', 'url', 'properties').to_a})
 
       copied_resource1 = @destination_course_version.resources.find_by_name('resource1')
       refute_nil copied_resource1

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -58,7 +58,7 @@ class Pd::SessionTest < ActiveSupport::TestCase
     end
 
     codes = sessions.pluck(:code)
-    assert codes.all? {|code| code.present? && code.length == 4}
+    assert(codes.all? {|code| code.present? && code.length == 4})
     assert_equal 10, codes.uniq.size
   end
 

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -625,9 +625,9 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     # save out of order
     workshops.shuffle.each(&:save!)
 
-    assert_equal [0, 0, 1, 2], Pd::Workshop.order_by_enrollment_count.map {|w| w.enrollments.count}
-    assert_equal [0, 0, 1, 2], Pd::Workshop.order_by_enrollment_count(desc: false).map {|w| w.enrollments.count}
-    assert_equal [2, 1, 0, 0], Pd::Workshop.order_by_enrollment_count(desc: true).map {|w| w.enrollments.count}
+    assert_equal([0, 0, 1, 2], Pd::Workshop.order_by_enrollment_count.map {|w| w.enrollments.count})
+    assert_equal([0, 0, 1, 2], Pd::Workshop.order_by_enrollment_count(desc: false).map {|w| w.enrollments.count})
+    assert_equal([2, 1, 0, 0], Pd::Workshop.order_by_enrollment_count(desc: true).map {|w| w.enrollments.count})
   end
 
   test 'order_by_enrollment_count with duplicates' do
@@ -640,8 +640,8 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     # save out of order
     workshops.shuffle.each(&:save!)
 
-    assert_equal [0, 0, 0, 1], Pd::Workshop.order_by_enrollment_count(desc: false).map {|w| w.enrollments.count}
-    assert_equal [1, 0, 0, 0], Pd::Workshop.order_by_enrollment_count(desc: true).map {|w| w.enrollments.count}
+    assert_equal([0, 0, 0, 1], Pd::Workshop.order_by_enrollment_count(desc: false).map {|w| w.enrollments.count})
+    assert_equal([1, 0, 0, 0], Pd::Workshop.order_by_enrollment_count(desc: true).map {|w| w.enrollments.count})
   end
 
   test 'order_by_state' do

--- a/dashboard/test/models/programming_class_test.rb
+++ b/dashboard/test/models/programming_class_test.rb
@@ -78,7 +78,7 @@ class ProgrammingClassTest < ActiveSupport::TestCase
     method_summary = programming_class.summarize_programming_methods
 
     assert_equal 3, method_summary.length
-    assert_equal [programming_method1.key, programming_method2.key, programming_method3.key], method_summary.map {|m| m[:key]}
+    assert_equal([programming_method1.key, programming_method2.key, programming_method3.key], method_summary.map {|m| m[:key]})
     assert_equal 2, method_summary[0][:overloads].length
     assert_equal 1, method_summary[1][:overloads].length
     assert_equal 0, method_summary[2][:overloads].length

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -718,9 +718,9 @@ class UnitGroupTest < ActiveSupport::TestCase
 
     [csp_2017, csp_2018, csp_2019, csp_2020].each do |c|
       summary = c.summarize_course_versions(create(:teacher))
-      assert_equal ["Computer Science Principles ('17-'18)", "Computer Science Principles ('18-'19)", "Computer Science Principles ('19-'20)"], summary.values.map {|h| h[:name]}
-      assert_equal [true, true, false], summary.values.map {|h| h[:is_stable]}
-      assert_equal [false, true, false], summary.values.map {|h| h[:is_recommended]}
+      assert_equal(["Computer Science Principles ('17-'18)", "Computer Science Principles ('18-'19)", "Computer Science Principles ('19-'20)"], summary.values.map {|h| h[:name]})
+      assert_equal([true, true, false], summary.values.map {|h| h[:is_stable]})
+      assert_equal([false, true, false], summary.values.map {|h| h[:is_recommended]})
     end
   end
 
@@ -736,9 +736,9 @@ class UnitGroupTest < ActiveSupport::TestCase
 
     [csp_2017, csp_2018, csp_2019, csp_2020].each do |c|
       summary = c.summarize_course_versions(create(:student))
-      assert_equal ["Computer Science Principles ('18-'19)"], summary.values.map {|h| h[:name]}
-      assert_equal [true], summary.values.map {|h| h[:is_stable]}
-      assert_equal [true], summary.values.map {|h| h[:is_recommended]}
+      assert_equal(["Computer Science Principles ('18-'19)"], summary.values.map {|h| h[:name]})
+      assert_equal([true], summary.values.map {|h| h[:is_stable]})
+      assert_equal([true], summary.values.map {|h| h[:is_recommended]})
     end
   end
 

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -1085,9 +1085,9 @@ class UnitTest < ActiveSupport::TestCase
 
     [foo16, foo17, foo18, foo19].each do |s|
       summary = s.summarize_course_versions(create(:teacher))
-      assert_equal ["foo-2016", "foo-2017", "foo-2018"], summary.values.map {|h| h[:name]}
-      assert_equal [true, true, false], summary.values.map {|h| h[:is_stable]}
-      assert_equal [false, true, false], summary.values.map {|h| h[:is_recommended]}
+      assert_equal(["foo-2016", "foo-2017", "foo-2018"], summary.values.map {|h| h[:name]})
+      assert_equal([true, true, false], summary.values.map {|h| h[:is_stable]})
+      assert_equal([false, true, false], summary.values.map {|h| h[:is_recommended]})
     end
   end
 
@@ -1115,9 +1115,9 @@ class UnitTest < ActiveSupport::TestCase
 
     [foo17, foo18, foo19].each do |s|
       summary = s.summarize_course_versions(create(:student))
-      assert_equal ["foo-2017"], summary.values.map {|h| h[:name]}
-      assert_equal [true], summary.values.map {|h| h[:is_stable]}
-      assert_equal [true], summary.values.map {|h| h[:is_recommended]}
+      assert_equal(["foo-2017"], summary.values.map {|h| h[:name]})
+      assert_equal([true], summary.values.map {|h| h[:is_stable]})
+      assert_equal([true], summary.values.map {|h| h[:is_recommended]})
     end
   end
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3495,7 +3495,7 @@ class UserTest < ActiveSupport::TestCase
       courses_and_scripts = @student.recent_student_courses_and_units(false)
       assert_equal 2, courses_and_scripts.length
 
-      assert_equal ['Computer Science Discoveries', 'Unit Other'], courses_and_scripts.map {|cs| cs[:title]}
+      assert_equal(['Computer Science Discoveries', 'Unit Other'], courses_and_scripts.map {|cs| cs[:title]})
     end
 
     test "it does not return pl scripts that are in returned pl courses" do
@@ -3505,7 +3505,7 @@ class UserTest < ActiveSupport::TestCase
       courses_and_scripts = @teacher.recent_pl_courses_and_units(false)
       assert_equal 2, courses_and_scripts.length
 
-      assert_equal ['Computer Science Discoveries PL Course', 'PL Unit Other'], courses_and_scripts.map {|cs| cs[:title]}
+      assert_equal(['Computer Science Discoveries PL Course', 'PL Unit Other'], courses_and_scripts.map {|cs| cs[:title]})
     end
 
     test "it optionally does not return primary course in returned student courses" do
@@ -3527,7 +3527,7 @@ class UserTest < ActiveSupport::TestCase
 
       assert_equal 1, courses_and_scripts.length
 
-      assert_equal ['testcourse'], courses_and_scripts.map {|cs| cs[:name]}
+      assert_equal(['testcourse'], courses_and_scripts.map {|cs| cs[:name]})
     end
   end
 

--- a/lib/cdo/hamburger.rb
+++ b/lib/cdo/hamburger.rb
@@ -192,18 +192,18 @@ class Hamburger
 
     case options[:user_type]
     when 'teacher'
-      entries = entries.concat teacher_entries.each {|e| e[:class] = visibility[:show_teacher_options]}
+      entries = entries.concat(teacher_entries.each {|e| e[:class] = visibility[:show_teacher_options]})
       entries << {type: "divider", class: get_divider_visibility(visibility[:show_teacher_options], visibility[:show_help_options]), id: "after-teacher"}
     when 'student'
-      entries = entries.concat student_entries.each {|e| e[:class] = visibility[:show_student_options]}
+      entries = entries.concat(student_entries.each {|e| e[:class] = visibility[:show_student_options]})
       entries << {type: "divider", class: get_divider_visibility(visibility[:show_student_options], visibility[:show_help_options]), id: "after-student"}
     else
-      entries = entries.concat signed_out_entries.each {|e| e[:class] = visibility[:show_signed_out_options]}
+      entries = entries.concat(signed_out_entries.each {|e| e[:class] = visibility[:show_signed_out_options]})
       entries << {type: "divider", class: get_divider_visibility(visibility[:show_signed_out_options], visibility[:show_help_options]), id: "after-signed-out"}
     end
 
     help_contents = HelpHeader.get_help_contents(options)
-    entries.concat help_contents.each {|e| e[:class] = visibility[:show_help_options]}
+    entries.concat(help_contents.each {|e| e[:class] = visibility[:show_help_options]})
     entries << {type: "divider", class: get_divider_visibility(visibility[:show_help_options], visibility[:show_pegasus_options]), id: "after-help"}
 
     # Pegasus options.

--- a/lib/pdf/collate.rb
+++ b/lib/pdf/collate.rb
@@ -22,7 +22,7 @@ module PDF
   end
 
   def self.get_local_markdown_paths(collate_file)
-    existing_files get_local_pdf_paths(collate_file).map {|f| f.sub('.pdf', '.md')}
+    existing_files(get_local_pdf_paths(collate_file).map {|f| f.sub('.pdf', '.md')})
   end
 
   def self.string_is_url(filename)

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -305,7 +305,7 @@ class TestI18nStringUrlTracker < Minitest::Test
     I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source] + '2', test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
-    assert_equal %w(test test2), @firehose_records&.map {|x| x[:source]}
+    assert_equal(%w(test test2), @firehose_records&.map {|x| x[:source]})
   end
 
   def test_log_given_unknown_string_key_should_not_be_logged

--- a/lib/test/test_hamburger.rb
+++ b/lib/test/test_hamburger.rb
@@ -4,7 +4,7 @@ require 'active_support/i18n'
 
 class HamburgerTest < Minitest::Test
   def assert_includes_id(items, id)
-    assert items.find {|e| e[:id] == id}
+    assert(items.find {|e| e[:id] == id})
   end
 
   # Visibility CSS class tests.
@@ -161,13 +161,13 @@ class HamburgerTest < Minitest::Test
 
   def test_hamburger_content_expandable_en
     contents = Hamburger.get_hamburger_contents({level: nil, script_level: nil, user_type: nil, language: "en"})
-    assert contents[:entries].find {|e| e[:type] == "expander"}
+    assert(contents[:entries].find {|e| e[:type] == "expander"})
   end
 
   def test_hamburger_content_noexpandable_nonen
     contents = Hamburger.get_hamburger_contents({level: nil, script_level: nil, user_type: nil, language: "fr"})
     # 'legal_entries' is an allowable section in non-english.
-    refute contents[:entries].find {|e| e[:type] == "expander" && e[:id] != "legal_entries"}
+    refute(contents[:entries].find {|e| e[:type] == "expander" && e[:id] != "legal_entries"})
   end
 
   # Header content tests.

--- a/lib/test/test_help_header.rb
+++ b/lib/test/test_help_header.rb
@@ -4,11 +4,11 @@ require 'active_support/i18n'
 
 class HelpHeaderTest < Minitest::Test
   def assert_includes_id(items, id)
-    assert items.find {|e| e[:id] == id}
+    assert(items.find {|e| e[:id] == id})
   end
 
   def refute_includes_id(items, id)
-    assert_nil items.find {|e| e[:id] == id}
+    assert_nil(items.find {|e| e[:id] == id})
   end
 
   def test_help_header_non_level

--- a/pegasus/data/static_models.rb
+++ b/pegasus/data/static_models.rb
@@ -122,7 +122,7 @@ module StaticModels
     end
 
     def order(key)
-      self.class.new sort {|a, b| a[key].to_s <=> b[key].to_s}
+      self.class.new(sort {|a, b| a[key].to_s <=> b[key].to_s})
     end
   end
 end

--- a/pegasus/test/test_form_routes.rb
+++ b/pegasus/test/test_form_routes.rb
@@ -52,7 +52,7 @@ class FormRoutesTest < SequelTestCase
       create_volunteer name: 'Middle', location: here
       create_volunteer name: 'Newest', location: here
       results = search location: here
-      assert_equal %w(Newest Middle Oldest), results.map {|r| r['name_s']}
+      assert_equal(%w(Newest Middle Oldest), results.map {|r| r['name_s']})
     end
 
     def create_volunteer(name:, location:)


### PR DESCRIPTION
> Checks for ambiguous block association with method when param passed without parentheses.

Ruby allows you to invoke blocks with methods like `foo bar { ... }`, and will attempt to figure out for you whether you meant `foo(bar { ... })` or `foo(bar) { ... }`. I'm definitely in favor of this change, as I'm generally in favor of using explicit parentheses in Ruby even when the language allows you to be ambiguous.

Fix applied automatically with `bundle exec rubocop --autocorrect-all --only Lint/AmbiguousBlockAssociation`; I then manually fixed up some resulting indentation errors.

## Links

- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/AmbiguousBlockAssociation
- https://docs.rubocop.org/rubocop/cops_lint.html#lintambiguousblockassociation