### PR TITLE
P20-372: Fix Blockly Core i18n sync-out

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -495,7 +495,8 @@ module I18n
           end
           translations_with_fallback = sort_and_sanitize(translations_with_fallback)
 
-          # Original script `apps/node_modules/@code-dot-org/blockly/i18n/codeorg-messages.sh`
+          # Replaced the original script `apps/node_modules/@code-dot-org/blockly/i18n/codeorg-messages.sh`
+          # to generate js translation files right away only for the "changed files"
           js_translations = translations_with_fallback.each_with_object('') do |(i18n_key, i18n_val), js_string|
             js_string << %Q[Blockly.Msg.#{i18n_key} = "#{i18n_val}";\n]
           end

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -29,7 +29,6 @@ module I18n
       restore_redacted_files
       distribute_translations(upload_manifests)
       copy_untranslated_apps
-      rebuild_blockly_js_files
       restore_markdown_headers
       Services::I18n::CurriculumSyncUtils.sync_out
       HocSyncUtils.sync_out
@@ -494,9 +493,15 @@ module I18n
           translations_with_fallback = blockly_english.merge(translations) do |_key, english, translation|
             translation.empty? ? english : translation
           end
-          relname = File.basename(loc_file)
-          destination = "apps/node_modules/@code-dot-org/blockly/#{locale_dir}/#{relname}"
-          sanitize_data_and_write(translations_with_fallback, destination)
+          translations_with_fallback = sort_and_sanitize(translations_with_fallback)
+
+          # Original script `apps/node_modules/@code-dot-org/blockly/i18n/codeorg-messages.sh`
+          js_translations = translations_with_fallback.each_with_object('') do |(i18n_key, i18n_val), js_string|
+            js_string << %Q[Blockly.Msg.#{i18n_key} = "#{i18n_val}";\n]
+          end
+          destination = CDO.dir(File.join('apps/lib/blockly', "#{js_locale}.js"))
+          FileUtils.mkdir_p(File.dirname(destination))
+          File.write(destination, js_translations)
         end
 
         ### Pegasus markdown
@@ -605,17 +610,6 @@ module I18n
         untranslated_apps.each do |app|
           app_locale = prop[:locale_s].tr('-', '_').downcase!
           FileUtils.cp_r "apps/i18n/#{app}/en_us.json", "apps/i18n/#{app}/#{app_locale}.json"
-        end
-      end
-    end
-
-    def self.rebuild_blockly_js_files
-      I18nScriptUtils.run_bash_script "apps/node_modules/@code-dot-org/blockly/i18n/codeorg-messages.sh"
-      Dir.chdir('apps') do
-        _stdout, stderr, status = Open3.capture3('yarn build')
-        unless status == 0
-          puts "Error building apps:"
-          puts stderr
         end
       end
     end

--- a/bin/test/i18n/test_sync-out.rb
+++ b/bin/test/i18n/test_sync-out.rb
@@ -9,7 +9,6 @@ class I18n::SyncOutTest < Minitest::Test
     I18n::SyncOut.expects(:restore_redacted_files).in_sequence(exec_seq)
     I18n::SyncOut.expects(:distribute_translations).with(false).in_sequence(exec_seq)
     I18n::SyncOut.expects(:copy_untranslated_apps).in_sequence(exec_seq)
-    I18n::SyncOut.expects(:rebuild_blockly_js_files).in_sequence(exec_seq)
     I18n::SyncOut.expects(:restore_markdown_headers).in_sequence(exec_seq)
     Services::I18n::CurriculumSyncUtils.expects(:sync_out).in_sequence(exec_seq)
     HocSyncUtils.expects(:sync_out).in_sequence(exec_seq)
@@ -29,7 +28,6 @@ class I18n::SyncOutTest < Minitest::Test
     I18n::SyncOut.expects(:restore_redacted_files)
     I18n::SyncOut.expects(:distribute_translations).with(expected_upload_manifests_arg).once
     I18n::SyncOut.expects(:copy_untranslated_apps)
-    I18n::SyncOut.expects(:rebuild_blockly_js_files)
     I18n::SyncOut.expects(:restore_markdown_headers)
     Services::I18n::CurriculumSyncUtils.expects(:sync_out)
     HocSyncUtils.expects(:sync_out)
@@ -48,7 +46,6 @@ class I18n::SyncOutTest < Minitest::Test
     I18n::SyncOut.stubs(:restore_redacted_files).raises(expected_error)
     I18n::SyncOut.stubs(:distribute_translations).raises(expected_error)
     I18n::SyncOut.stubs(:copy_untranslated_apps).raises(expected_error)
-    I18n::SyncOut.stubs(:rebuild_blockly_js_files).raises(expected_error)
     I18n::SyncOut.stubs(:restore_markdown_headers).raises(expected_error)
     Services::I18n::CurriculumSyncUtils.stubs(:sync_out).raises(expected_error)
     HocSyncUtils.stubs(:sync_out).raises(expected_error)


### PR DESCRIPTION
## Issue

Blocky Core `sync-out` process steps:
1. Move `i18n/locales/Italian/blockly-core/core.json` =>`i18n/locales/it-IT/blockly-core/core.json` => `apps/node_modules/@code-dot-org/blockly/i18n/locales/it-IT/core.json`
3. Transform all the i18n JSON files from [`apps/node_modules/@code-dot-org/blockly/i18n/locales/{locale}/core.json`](https://github.com/code-dot-org/blockly/tree/main/i18n/locales) to JS strings and move them to to JS files [`apps/lib/blockly/{locale}.js`](https://github.com/code-dot-org/code-dot-org/tree/staging/apps/lib/blockly)

It's working only until we download the new version of the  `apps/node_modules/@code-dot-org/blockly` lib on the `i18n-server` and all the `sync-out` updates in `apps/node_modules/@code-dot-org/blockly/i18n/locales` files disappear.

Because of that, all the `apps/lib/blockly/*.js` files are reset back to the original CDO-Blockly lib file states without any Crowdin updates. Example: [The Crowdin translation "Farbe mit"](https://github.com/code-dot-org/code-dot-org/pull/53490/files#diff-74a17eedc0ffb00db4d69908c3e5c91cc942e013f4374632e34ba7f493c166a9L25) reset back to [the original (initial) translation "Farbe festlegen auf"](https://github.com/code-dot-org/blockly/blame/main/i18n/locales/de-DE/core.json#L26)

## Solution
Skiped the [`apps/node_modules/@code-dot-org/blockly/i18n/codeorg-messages.sh`](https://github.com/code-dot-org/blockly/blob/main/i18n/codeorg-messages.sh) script process to generate js translation files right away only for the "changed files".

## Links
- jira ticket: [P20-372](https://codedotorg.atlassian.net/browse/P20-372)

## Sync-out result
| Before `sync-out` | After `sync-out` |
| ------------------ | ----------------- |
| ![Screenshot 2023-08-28 at 22 26 40](https://github.com/code-dot-org/code-dot-org/assets/11708250/6ed62e2b-3c5a-4dfd-88ea-28d0181119d0) | ![Screenshot 2023-08-28 at 22 47 20](https://github.com/code-dot-org/code-dot-org/assets/11708250/0eecbce0-3d72-49fd-9ef7-bfbb4a962d5d) |
