### PR TITLE
Rubrics: a couple of small bug fixes

### DIFF
--- a/apps/src/templates/rubrics/LearningGoal.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.jsx
@@ -39,8 +39,8 @@ export default function LearningGoal({
   };
 
   return (
-    <details className={style.learningGoalRow} onClick={handleClick}>
-      <summary className={style.learningGoalHeader}>
+    <details className={style.learningGoalRow}>
+      <summary className={style.learningGoalHeader} onClick={handleClick}>
         <div className={style.learningGoalHeaderLeftSide}>
           {isOpen && (
             <FontAwesome

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -11,8 +11,8 @@ export default function RubricFloatingActionButton({rubric, reportingData}) {
 
   const handleClick = () => {
     const eventName = isOpen
-      ? EVENTS.RUBRIC_CLOSED_FROM_FAB
-      : EVENTS.RUBRIC_OPENED_FROM_FAB;
+      ? EVENTS.RUBRIC_CLOSED_FROM_FAB_EVENT
+      : EVENTS.RUBRIC_OPENED_FROM_FAB_EVENT;
     analyticsReporter.sendEvent(eventName, reportingData);
     setIsOpen(!isOpen);
   };

--- a/apps/test/unit/templates/rubrics/LearningGoalTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalTest.jsx
@@ -94,7 +94,7 @@ describe('LearningGoal', () => {
       />
     );
     expect(wrapper.find('FontAwesome').props().icon).to.equal('angle-down');
-    wrapper.find('details').simulate('click');
+    wrapper.find('summary').simulate('click');
     expect(wrapper.find('FontAwesome').props().icon).to.equal('angle-up');
   });
 
@@ -107,7 +107,7 @@ describe('LearningGoal', () => {
         reportingData={{unitName: 'test-2023', levelName: 'test-level'}}
       />
     );
-    wrapper.find('details').simulate('click');
+    wrapper.find('summary').simulate('click');
     expect(sendEventSpy).to.have.been.calledWith(
       EVENTS.RUBRIC_LEARNING_GOAL_EXPANDED_EVENT,
       {
@@ -117,7 +117,7 @@ describe('LearningGoal', () => {
         learningGoal: 'Testing',
       }
     );
-    wrapper.find('details').simulate('click');
+    wrapper.find('summary').simulate('click');
     expect(sendEventSpy).to.have.been.calledWith(
       EVENTS.RUBRIC_LEARNING_GOAL_COLLAPSED_EVENT,
       {

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -27,12 +27,12 @@ describe('RubricFloatingActionButton', () => {
     );
     wrapper.find('button').simulate('click');
     expect(sendEventSpy).to.have.been.calledWith(
-      EVENTS.RUBRIC_OPENED_FROM_FAB,
+      EVENTS.RUBRIC_OPENED_FROM_FAB_EVENT,
       reportingData
     );
     wrapper.find('button').simulate('click');
     expect(sendEventSpy).to.have.been.calledWith(
-      EVENTS.RUBRIC_CLOSED_FROM_FAB,
+      EVENTS.RUBRIC_CLOSED_FROM_FAB_EVENT,
       reportingData
     );
     sendEventSpy.restore();


### PR DESCRIPTION
Fixes two small bugs:

1. The arrow on the learning goals was changing when clicking anywhere in the component, even if it didn't open or close the component.

Before:

https://github.com/code-dot-org/code-dot-org/assets/46464143/39b47659-b83b-4f86-8511-29d0fcdb66c1


After:


https://github.com/code-dot-org/code-dot-org/assets/46464143/a10bfbd6-5a10-4737-99db-ea22dae17d37




2. The Amplitude event for opening the FAB was showing undefined.

Before:
```
[AMPLITUDE ANALYTICS EVENT]: undefined. Payload: {"payload":{"unitName":"allthethings","courseName":"allthethingscourse","levelName":"CSD U3 Sprites scene challenge_allthethings"}}
```

After:
```
[AMPLITUDE ANALYTICS EVENT]: Rubric Opened From FAB. Payload: {"payload":{"unitName":"allthethings","courseName":"allthethingscourse","levelName":"CSD U3 Sprites scene challenge_allthethings"}}
```