### PR TITLE
Remove feedback survey on progress view

### DIFF
--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -286,6 +286,5 @@ export const fakeProgressTableReduxInitialState = (
     },
     unitSelection: {scriptId: scriptData.id},
     locales: {localeCode: 'en-US'},
-    isRtl: false,
   };
 };

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
@@ -29,7 +29,6 @@ import {
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import classnames from 'classnames';
 import {studentShape} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
 
 /**
  * Since our progress tables are built out of standard HTML table elements,
@@ -356,18 +355,6 @@ class ProgressTableView extends React.Component {
             />
           </div>
         </div>
-        <div style={styles.midpageBanner}>
-          <Notification
-            type={NotificationType.feedback}
-            notice={i18n.feedbackShareBannerTitle()}
-            details={i18n.feedbackShareBannerDesc()}
-            buttonText={i18n.feedbackShareBannerButton()}
-            buttonLink={
-              'https://studio.code.org/form/share_feedback_progress_table'
-            }
-            dismissible={true}
-          />
-        </div>
         {this.props.currentView === ViewType.DETAIL ? (
           <ProgressLegend
             includeCsfColumn={this.props.scriptData.csf}
@@ -393,9 +380,6 @@ const styles = {
   contentView: {
     display: 'inline-block',
     width: parseInt(progressTableStyleConstants.CONTENT_VIEW_WIDTH),
-  },
-  midpageBanner: {
-    marginTop: '60px',
   },
 };
 

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableViewTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableViewTest.jsx
@@ -23,7 +23,6 @@ import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import {unitTestExports} from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableLessonNumber';
 import * as Sticky from 'reactabular-sticky';
 import locales from '@cdo/apps/redux/localesRedux';
-import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import {
   fakeLessonWithLevels,
   fakeStudents,
@@ -52,7 +51,6 @@ const setUp = (currentView = ViewType.SUMMARY, overrideState = {}) => {
       sectionProgress,
       unitSelection,
       locales,
-      isRtl,
     }),
     _.merge({}, initialState, overrideState)
   );


### PR DESCRIPTION
We have enough (~197) responses on our feedback survey for the progress view, so we're taking it down. Git auto-revert of original PR (#51340) did not work, so doing the removal manually.

## Testing story
Tested locally

_Before_
![image](https://github.com/code-dot-org/code-dot-org/assets/2933346/4db59da6-fc74-42ca-ad0b-dfcb00cff049)

_After_
![image](https://github.com/code-dot-org/code-dot-org/assets/2933346/49e072e8-8691-4dda-ba1b-65beff4bf150)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
