### PR TITLE
P20-372: Fix Blockly Core sync-out translation data

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -498,7 +498,7 @@ module I18n
           # Replaced the original script `apps/node_modules/@code-dot-org/blockly/i18n/codeorg-messages.sh`
           # to generate js translation files right away only for the "changed files"
           js_translations = translations_with_fallback.each_with_object('') do |(i18n_key, i18n_val), js_string|
-            js_string << %Q[Blockly.Msg.#{i18n_key} = "#{i18n_val}";\n]
+            js_string << "Blockly.Msg.#{i18n_key} = #{JSON.dump(i18n_val)};\n"
           end
           destination = CDO.dir(File.join('apps/lib/blockly', "#{js_locale}.js"))
           FileUtils.mkdir_p(File.dirname(destination))


### PR DESCRIPTION
Fixing broken strings like: https://github.com/code-dot-org/code-dot-org/blob/674aaef6f21ca8162dae8872b9c63e7dccd34640/apps/lib/blockly/km_kh.js#L46-L47

## Links
- jira ticket: [P20-372](https://codedotorg.atlassian.net/browse/P20-372)