### PR TITLE
Revert "disable flaky application dashboard tests (#52452)"

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application_dashboard.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application_dashboard.feature
@@ -14,9 +14,7 @@ Feature: Teacher Application Dashboard
     And I press the first ".Select-option" element
     Then I wait until element "span:contains('Withdrawn')" is visible
     And I wait until element "td:contains('Unreviewed')" is not visible
-    # Eyes snapshot temporarily disabled due to flakiness.
-    # Fix tracked here: https://codedotorg.atlassian.net/browse/ACQ-620
-    # And I see no difference for "Admin Course View"
+    And I see no difference for "Admin Course View"
 
     # Access the Detail View by navigating to the first row's "view application" button href
     # rather than clicking so it does not open in a new tab.
@@ -35,7 +33,5 @@ Feature: Teacher Application Dashboard
     Then I wait until element "table#summary-csp-teachers" is visible
     Then I click selector "table#summary-csp-teachers ~ .btn:contains(View accepted cohort)"
     Then I wait until element "table#cohort-view" is visible
-    # Eyes snapshot temporarily disabled due to flakiness.
-    # Fix tracked here: https://codedotorg.atlassian.net/browse/ACQ-620
-    # And I see no difference for "Admin Cohort View"
+    And I see no difference for "Admin Cohort View"
     And I close my eyes


### PR DESCRIPTION
This reverts commit 4489e17da4ccac2af5cafe998449f589cc5cecd9. Re-eneables eyes test for teacher application dashboard as the underlying flakiness with RP drop down has been fixed with commit #d0d1e3a

## Links

JIRA: https://codedotorg.atlassian.net/browse/ACQ-789

## Testing story

Validating the new changes as part of drone run.

## Deployment strategy

As part of regular DTT. 

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
