### PR TITLE
Change secondary button border width to 1px

### DIFF
--- a/apps/src/templates/button.module.scss
+++ b/apps/src/templates/button.module.scss
@@ -1,5 +1,5 @@
-@import "color.scss";
-@import "font.scss";
+@import 'color.scss';
+@import 'font.scss';
 
 // Note: Keep these constants in sync with Button.jsx.
 $button-height-default: 34px;
@@ -25,7 +25,7 @@ a:visited,
   &.main {
     display: inline-block;
     font-size: 12px;
-    font-family: "Gotham 4r", sans-serif;
+    font-family: 'Gotham 4r', sans-serif;
     border: 1px solid $border_gray;
     border-radius: 3px;
     text-decoration: none;
@@ -214,7 +214,7 @@ a:visited,
     background-color: $brand_secondary_default;
     border-color: $brand_secondary_default;
     border-radius: 4px;
-    border-width: 2px;
+    border-width: 1px;
     line-height: 30px;
 
     &:hover {
@@ -238,7 +238,7 @@ a:visited,
   &.neutralDark {
     color: $neutral_dark;
     background-color: $neutral_white;
-    border: 2px solid $neutral_dark;
+    border: 1px solid $neutral_dark;
     border-radius: 4px;
     line-height: 30px;
 
@@ -264,6 +264,10 @@ a:visited,
       padding-left: 16px;
       padding-right: 16px;
       font-family: $gotham-bold;
+    }
+
+    &:active {
+      border-width: 2px;
     }
   }
 
@@ -311,7 +315,7 @@ a:visited,
     color: $teal;
     border-width: 0;
     background-color: unset;
-    font-family: "Gotham 5r", sans-serif;
+    font-family: 'Gotham 5r', sans-serif;
     box-shadow: none;
     padding: 0;
     margin: 0;


### PR DESCRIPTION
Changes the secondary button border width to 1 px except for when the button is pressed, the border-width is 2px.

<img width="1792" alt="Screenshot 2023-08-29 at 2 55 47 PM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/d82229d2-ea75-4948-b7f9-dfcc8432af70">

## Testing story
Local

