### PR TITLE
Finish up teacher views of rubrics and add stories

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1055,6 +1055,7 @@
   "featureUnpublishedWarning": "This project is currently unpublished. It can still be marked as featured, but it will not show in the gallery until the owner publishes it.",
   "feedback": "Feedback",
   "feedbackAll": "All Teacher Feedback",
+  "feedbackAvailableOnLevel": "Feedback will be available on Level {levelPosition}",
   "feedbackCommentAreaHeader": "Teacher Feedback",
   "feedbackDownloadFileName": "Feedback for {sectionName} in {scriptName} on {date}.csv",
   "feedbackDownloadOverview": "This CSV file contains all feedback you’ve completed for your section {sectionName} in levels within **{scriptName}**. You can leave feedback for your students by going to a level in this unit, viewing a student's work, and clicking the \"Feedback\" tab.",

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -57,7 +57,7 @@ function initPage() {
   const rubricFabMountPoint = document.getElementById('rubric-fab-mount-point');
   if (rubricFabMountPoint && experiments.isEnabled('ai-rubrics')) {
     const rubricData = getScriptData('rubricdata');
-    const {rubric, studentLevelInfo, onLevelForEvaluation} = rubricData;
+    const {rubric, studentLevelInfo} = rubricData;
     const reportingData = {
       unitName: config.script_name,
       courseName: config.course_name,
@@ -68,7 +68,7 @@ function initPage() {
         rubric={rubric}
         studentLevelInfo={studentLevelInfo}
         reportingData={reportingData}
-        onLevelForEvaluation={onLevelForEvaluation}
+        currentLevelName={config.level_name}
       />,
       rubricFabMountPoint
     );

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -57,7 +57,7 @@ function initPage() {
   const rubricFabMountPoint = document.getElementById('rubric-fab-mount-point');
   if (rubricFabMountPoint && experiments.isEnabled('ai-rubrics')) {
     const rubricData = getScriptData('rubricdata');
-    const {rubric, studentLevelInfo} = rubricData;
+    const {rubric, studentLevelInfo, onLevelForEvaluation} = rubricData;
     const reportingData = {
       unitName: config.script_name,
       courseName: config.course_name,
@@ -68,6 +68,7 @@ function initPage() {
         rubric={rubric}
         studentLevelInfo={studentLevelInfo}
         reportingData={reportingData}
+        onLevelForEvaluation={onLevelForEvaluation}
       />,
       rubricFabMountPoint
     );

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -34,11 +34,13 @@ export default function RubricContainer({
   rubric,
   studentLevelInfo,
   teacherHasEnabledAi,
-  onLevelForEvaluation,
+  currentLevelName,
   reportingData,
 }) {
+  const onLevelForEvaluation = currentLevelName === rubric.level.name;
   const canProvideFeedback = !!studentLevelInfo && onLevelForEvaluation;
   const {lesson} = rubric;
+  const rubricLevel = rubric.level;
   return (
     <div className={style.rubricContainer}>
       <div className={style.rubricHeader}>
@@ -55,28 +57,37 @@ export default function RubricContainer({
                   lessonName: lesson.name,
                 })}
               </Heading5>
-              <div className={style.studentMetadata}>
-                {studentLevelInfo.timeSpent && (
+              {onLevelForEvaluation && (
+                <div className={style.studentMetadata}>
+                  {studentLevelInfo.timeSpent && (
+                    <BodyThreeText className={style.singleMetadatum}>
+                      <FontAwesome icon="clock" />
+                      <span>{formatTimeSpent(studentLevelInfo.timeSpent)}</span>
+                    </BodyThreeText>
+                  )}
                   <BodyThreeText className={style.singleMetadatum}>
-                    <FontAwesome icon="clock" />
-                    <span>{formatTimeSpent(studentLevelInfo.timeSpent)}</span>
+                    <FontAwesome icon="rocket" />
+                    {i18n.numAttempts({
+                      numAttempts: studentLevelInfo.attempts || 0,
+                    })}
                   </BodyThreeText>
-                )}
-                <BodyThreeText className={style.singleMetadatum}>
-                  <FontAwesome icon="rocket" />
-                  {i18n.numAttempts({
-                    numAttempts: studentLevelInfo.attempts || 0,
+                  {studentLevelInfo.lastAttempt && (
+                    <BodyThreeText className={style.singleMetadatum}>
+                      <FontAwesome icon="calendar" />
+                      <span>
+                        {formatLastAttempt(studentLevelInfo.lastAttempt)}
+                      </span>
+                    </BodyThreeText>
+                  )}
+                </div>
+              )}
+              {!onLevelForEvaluation && rubricLevel?.position && (
+                <BodyThreeText>
+                  {i18n.feedbackAvailableOnLevel({
+                    levelPosition: rubricLevel.position,
                   })}
                 </BodyThreeText>
-                {studentLevelInfo.lastAttempt && (
-                  <BodyThreeText className={style.singleMetadatum}>
-                    <FontAwesome icon="calendar" />
-                    <span>
-                      {formatLastAttempt(studentLevelInfo.lastAttempt)}
-                    </span>
-                  </BodyThreeText>
-                )}
-              </div>
+              )}
             </div>
           </div>
         )}
@@ -101,5 +112,5 @@ RubricContainer.propTypes = {
   reportingData: reportingDataShape,
   studentLevelInfo: studentLevelInfoShape,
   teacherHasEnabledAi: PropTypes.bool,
-  onLevelForEvaluation: PropTypes.bool,
+  currentLevelName: PropTypes.string,
 };

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -34,10 +34,10 @@ export default function RubricContainer({
   rubric,
   studentLevelInfo,
   teacherHasEnabledAi,
+  onLevelForEvaluation,
   reportingData,
 }) {
-  // TODO: [AITT-113] Also check if viewing the right level to give feedback
-  const canProvideFeedback = !!studentLevelInfo;
+  const canProvideFeedback = !!studentLevelInfo && onLevelForEvaluation;
   const {lesson} = rubric;
   return (
     <div className={style.rubricContainer}>
@@ -101,4 +101,5 @@ RubricContainer.propTypes = {
   reportingData: reportingDataShape,
   studentLevelInfo: studentLevelInfoShape,
   teacherHasEnabledAi: PropTypes.bool,
+  onLevelForEvaluation: PropTypes.bool,
 };

--- a/apps/src/templates/rubrics/RubricContainer.story.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.story.jsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import {RubricUnderstandingLevels} from '@cdo/apps/util/sharedConstants';
+import RubricContainer from './RubricContainer';
+
+export default {
+  title: 'RubricContainer',
+  component: RubricContainer,
+};
+
+const defaultRubric = {
+  lesson: {
+    position: 3,
+    name: 'Testing',
+  },
+  learningGoals: [
+    {
+      key: 'story-learning-goal-1',
+      learningGoal: 'Coding Proficiency',
+      aiEnabled: false,
+      evidenceLevels: [
+        {
+          id: 1,
+          understanding: RubricUnderstandingLevels.EXTENSIVE,
+          teacherDescription: 'Student is able to write fully correct code',
+        },
+        {
+          id: 2,
+          understanding: 2,
+          teacherDescription: 'Student is able to write some correct code',
+        },
+        {
+          id: 3,
+          understanding: RubricUnderstandingLevels.LIMITED,
+          teacherDescription: 'Student is able to write partially correct code',
+        },
+        {
+          id: 4,
+          understanding: RubricUnderstandingLevels.NONE,
+          teacherDescription: 'Student is unable to write correct code',
+        },
+      ],
+    },
+    {
+      key: 'story-learning-goal-2',
+      learningGoal: 'Testing',
+      aiEnabled: true,
+      evidenceLevels: [
+        {
+          id: 1,
+          understanding: RubricUnderstandingLevels.EXTENSIVE,
+          teacherDescription: 'Student has written tests with high coverage',
+        },
+        {
+          id: 2,
+          understanding: 2,
+          teacherDescription:
+            'Student has written tests with significant coverage but missed a couple of cases',
+        },
+        {
+          id: 3,
+          understanding: RubricUnderstandingLevels.LIMITED,
+          teacherDescription:
+            'Student has written a test but misses several cases',
+        },
+        {
+          id: 4,
+          understanding: RubricUnderstandingLevels.NONE,
+          teacherDescription: 'Student has not written any tests',
+        },
+      ],
+    },
+  ],
+};
+
+const defaultStudentLevelInfo = {
+  name: 'Ada Lovelace',
+  attempts: 2,
+  timeSpent: '7m 35s',
+  lastAttempt: '5/26/23',
+};
+
+const Template = args => (
+  <RubricContainer
+    rubric={defaultRubric}
+    teacherHasEnabledAi={false}
+    studentLevelInfo={null}
+    {...args}
+  />
+);
+
+export const ViewingOwnWorkAiEnabled = Template.bind({});
+ViewingOwnWorkAiEnabled.args = {
+  studentLevelInfo: null,
+  teacherHasEnabledAi: true,
+};
+
+export const ViewingOwnWorkAiDisabled = Template.bind({});
+ViewingOwnWorkAiDisabled.args = {
+  studentLevelInfo: null,
+  teacherHasEnabledAi: false,
+};
+
+export const ViewingStudentWorkAiEnabled = Template.bind({});
+ViewingStudentWorkAiEnabled.args = {
+  studentLevelInfo: {...defaultStudentLevelInfo, submitted: true},
+  teacherHasEnabledAi: true,
+};
+
+export const ViewingStudentWorkAiDisabled = Template.bind({});
+ViewingStudentWorkAiDisabled.args = {
+  studentLevelInfo: {...defaultStudentLevelInfo, submitted: true},
+  teacherHasEnabledAi: false,
+};

--- a/apps/src/templates/rubrics/RubricContainer.story.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.story.jsx
@@ -75,7 +75,7 @@ const defaultRubric = {
 const defaultStudentLevelInfo = {
   name: 'Ada Lovelace',
   attempts: 2,
-  timeSpent: '7m 35s',
+  timeSpent: 404,
   lastAttempt: '5/26/23',
 };
 
@@ -83,7 +83,7 @@ const Template = args => (
   <RubricContainer
     rubric={defaultRubric}
     teacherHasEnabledAi={false}
-    studentLevelInfo={null}
+    studentLevelInfo={defaultStudentLevelInfo}
     {...args}
   />
 );
@@ -100,14 +100,32 @@ ViewingOwnWorkAiDisabled.args = {
   teacherHasEnabledAi: false,
 };
 
-export const ViewingStudentWorkAiEnabled = Template.bind({});
-ViewingStudentWorkAiEnabled.args = {
+export const ViewingStudentWorkOnNonAssessmentLevelAiEnabled = Template.bind(
+  {}
+);
+ViewingStudentWorkOnNonAssessmentLevelAiEnabled.args = {
   studentLevelInfo: {...defaultStudentLevelInfo, submitted: true},
   teacherHasEnabledAi: true,
 };
 
-export const ViewingStudentWorkAiDisabled = Template.bind({});
-ViewingStudentWorkAiDisabled.args = {
+export const ViewingStudentWorkOnNonAssessmentLevelAiDisabled = Template.bind(
+  {}
+);
+ViewingStudentWorkOnNonAssessmentLevelAiDisabled.args = {
   studentLevelInfo: {...defaultStudentLevelInfo, submitted: true},
   teacherHasEnabledAi: false,
+};
+
+export const ViewingStudentWorkOnAssessmentLevelAiEnabled = Template.bind({});
+ViewingStudentWorkOnAssessmentLevelAiEnabled.args = {
+  studentLevelInfo: {...defaultStudentLevelInfo, submitted: true},
+  teacherHasEnabledAi: true,
+  onLevelForEvaluation: true,
+};
+
+export const ViewingStudentWorkOnAssessmentLevelAiDisabled = Template.bind({});
+ViewingStudentWorkOnAssessmentLevelAiDisabled.args = {
+  studentLevelInfo: {...defaultStudentLevelInfo, submitted: true},
+  teacherHasEnabledAi: false,
+  onLevelForEvaluation: true,
 };

--- a/apps/src/templates/rubrics/RubricContainer.story.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.story.jsx
@@ -7,10 +7,16 @@ export default {
   component: RubricContainer,
 };
 
+const rubricLevelName = 'free_play_level';
+
 const defaultRubric = {
   lesson: {
     position: 3,
     name: 'Testing',
+  },
+  level: {
+    name: rubricLevelName,
+    position: 5,
   },
   learningGoals: [
     {
@@ -84,6 +90,7 @@ const Template = args => (
     rubric={defaultRubric}
     teacherHasEnabledAi={false}
     studentLevelInfo={defaultStudentLevelInfo}
+    currentLevelName={rubricLevelName}
     {...args}
   />
 );
@@ -106,6 +113,7 @@ export const ViewingStudentWorkOnNonAssessmentLevelAiEnabled = Template.bind(
 ViewingStudentWorkOnNonAssessmentLevelAiEnabled.args = {
   studentLevelInfo: {...defaultStudentLevelInfo, submitted: true},
   teacherHasEnabledAi: true,
+  currentLevelName: 'not_free_play_level',
 };
 
 export const ViewingStudentWorkOnNonAssessmentLevelAiDisabled = Template.bind(
@@ -114,18 +122,17 @@ export const ViewingStudentWorkOnNonAssessmentLevelAiDisabled = Template.bind(
 ViewingStudentWorkOnNonAssessmentLevelAiDisabled.args = {
   studentLevelInfo: {...defaultStudentLevelInfo, submitted: true},
   teacherHasEnabledAi: false,
+  currentLevelName: 'not_free_play_level',
 };
 
 export const ViewingStudentWorkOnAssessmentLevelAiEnabled = Template.bind({});
 ViewingStudentWorkOnAssessmentLevelAiEnabled.args = {
   studentLevelInfo: {...defaultStudentLevelInfo, submitted: true},
   teacherHasEnabledAi: true,
-  onLevelForEvaluation: true,
 };
 
 export const ViewingStudentWorkOnAssessmentLevelAiDisabled = Template.bind({});
 ViewingStudentWorkOnAssessmentLevelAiDisabled.args = {
   studentLevelInfo: {...defaultStudentLevelInfo, submitted: true},
   teacherHasEnabledAi: false,
-  onLevelForEvaluation: true,
 };

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import PropTypes from 'prop-types';
 import style from './rubrics.module.scss';
 const icon = require('@cdo/static/AI-FAB.png');
 import RubricContainer from './RubricContainer';
@@ -13,6 +14,7 @@ import {
 export default function RubricFloatingActionButton({
   rubric,
   studentLevelInfo,
+  onLevelForEvaluation,
   reportingData,
 }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -40,6 +42,7 @@ export default function RubricFloatingActionButton({
           rubric={rubric}
           studentLevelInfo={studentLevelInfo}
           reportingData={reportingData}
+          onLevelForEvaluation={onLevelForEvaluation}
           teacherHasEnabledAi
         />
       )}
@@ -50,5 +53,6 @@ export default function RubricFloatingActionButton({
 RubricFloatingActionButton.propTypes = {
   rubric: rubricShape,
   studentLevelInfo: studentLevelInfoShape,
+  onLevelForEvaluation: PropTypes.bool,
   reportingData: reportingDataShape,
 };

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -14,7 +14,7 @@ import {
 export default function RubricFloatingActionButton({
   rubric,
   studentLevelInfo,
-  onLevelForEvaluation,
+  currentLevelName,
   reportingData,
 }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -42,7 +42,7 @@ export default function RubricFloatingActionButton({
           rubric={rubric}
           studentLevelInfo={studentLevelInfo}
           reportingData={reportingData}
-          onLevelForEvaluation={onLevelForEvaluation}
+          currentLevelName={currentLevelName}
           teacherHasEnabledAi
         />
       )}
@@ -53,6 +53,6 @@ export default function RubricFloatingActionButton({
 RubricFloatingActionButton.propTypes = {
   rubric: rubricShape,
   studentLevelInfo: studentLevelInfoShape,
-  onLevelForEvaluation: PropTypes.bool,
+  currentLevelName: PropTypes.string,
   reportingData: reportingDataShape,
 };

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -66,7 +66,7 @@
   gap: 0.5rem;
   align-self: stretch;
 
-  h5 {
+  h5, p {
     margin-bottom: 0;
   }
 }
@@ -75,9 +75,6 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-}
-p.singleMetadatum {
-  margin-bottom: 0;
 }
 
 .learningGoalContainer {

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -23,28 +23,91 @@ describe('RubricContainer', () => {
       position: 3,
       name: 'Data Structures',
     },
+    level: {
+      name: 'test_level',
+      position: 7,
+    },
   };
 
-  it('shows learning goals', () => {
+  const defaultProps = {
+    rubric: defaultRubric,
+    teacherHasEnabledAi: true,
+    studentLevelInfo: {},
+    currentLevelName: 'test_level',
+  };
+
+  it('shows learning goals with correct props when viewing student work on assessment level', () => {
     const wrapper = shallow(
-      <RubricContainer rubric={defaultRubric} teacherHasEnabledAi />
+      <RubricContainer
+        {...defaultProps}
+        studentLevelInfo={{name: 'Grace Hopper', timeSpent: 706}}
+      />
     );
     const renderedLearningGoals = wrapper.find('LearningGoal');
     expect(renderedLearningGoals).to.have.lengthOf(2);
     expect(
       renderedLearningGoals.at(0).props().learningGoal.learningGoal
     ).to.equal('goal 1');
+    expect(renderedLearningGoals.at(0).props().canProvideFeedback).to.equal(
+      true
+    );
     expect(
       renderedLearningGoals.at(1).props().learningGoal.learningGoal
     ).to.equal('goal 2');
+    expect(renderedLearningGoals.at(1).props().canProvideFeedback).to.equal(
+      true
+    );
+  });
+
+  it('shows learning goals with correct props when viewing student work on non assessment level', () => {
+    const wrapper = shallow(
+      <RubricContainer
+        {...defaultProps}
+        studentLevelInfo={{name: 'Grace Hopper', timeSpent: 706}}
+        currentLevelName="non_assessment_level"
+      />
+    );
+    const renderedLearningGoals = wrapper.find('LearningGoal');
+    expect(renderedLearningGoals).to.have.lengthOf(2);
+    expect(
+      renderedLearningGoals.at(0).props().learningGoal.learningGoal
+    ).to.equal('goal 1');
+    expect(renderedLearningGoals.at(0).props().canProvideFeedback).to.equal(
+      false
+    );
+    expect(
+      renderedLearningGoals.at(1).props().learningGoal.learningGoal
+    ).to.equal('goal 2');
+    expect(renderedLearningGoals.at(1).props().canProvideFeedback).to.equal(
+      false
+    );
+  });
+
+  it('shows learning goals with correct props when not viewing student work', () => {
+    const wrapper = shallow(
+      <RubricContainer {...defaultProps} studentLevelInfo={null} />
+    );
+    const renderedLearningGoals = wrapper.find('LearningGoal');
+    expect(renderedLearningGoals).to.have.lengthOf(2);
+    expect(
+      renderedLearningGoals.at(0).props().learningGoal.learningGoal
+    ).to.equal('goal 1');
+    expect(renderedLearningGoals.at(0).props().canProvideFeedback).to.equal(
+      false
+    );
+    expect(
+      renderedLearningGoals.at(1).props().learningGoal.learningGoal
+    ).to.equal('goal 2');
+    expect(renderedLearningGoals.at(1).props().canProvideFeedback).to.equal(
+      false
+    );
   });
 
   it('shows level title', () => {
     // mount is needed in order for text() to work
     const wrapper = mount(
       <RubricContainer
-        rubric={defaultRubric}
-        teacherHasEnabledAi
+        {...defaultProps}
         studentLevelInfo={{
           name: 'Grace Hopper',
         }}
@@ -57,8 +120,7 @@ describe('RubricContainer', () => {
     // mount is needed in order for text() to work
     const wrapper = mount(
       <RubricContainer
-        rubric={defaultRubric}
-        teacherHasEnabledAi
+        {...defaultProps}
         studentLevelInfo={{
           name: 'Grace Hopper',
           timeSpent: 305,
@@ -77,8 +139,7 @@ describe('RubricContainer', () => {
     // mount is needed in order for text() to work
     const wrapper = mount(
       <RubricContainer
-        rubric={defaultRubric}
-        teacherHasEnabledAi
+        {...defaultProps}
         studentLevelInfo={{
           name: 'Grace Hopper',
         }}
@@ -88,5 +149,22 @@ describe('RubricContainer', () => {
     expect(wrapper.text()).to.not.include('time spent');
     expect(wrapper.text()).to.include('0 attempts');
     expect(wrapper.text()).to.not.include('last updated');
+  });
+
+  it('doesnt show student level data if not on level for evaluation', () => {
+    // mount is needed in order for text() to work
+    const wrapper = mount(
+      <RubricContainer
+        {...defaultProps}
+        studentLevelInfo={{
+          name: 'Grace Hopper',
+          attempts: 6,
+        }}
+        currentLevelName="not_test_level"
+      />
+    );
+    expect(wrapper.text()).to.include('Grace Hopper');
+    expect(wrapper.text()).to.not.include('6 attempts');
+    expect(wrapper.text()).to.include('Feedback will be available on Level 7');
   });
 });

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -166,10 +166,7 @@ class ScriptLevelsController < ApplicationController
 
     @rubric = @script_level.lesson.rubric
     if @rubric
-      @rubric_data = {
-        rubric: @rubric.summarize,
-        onLevelForEvaluation: @level.id == @rubric.level_id
-      }
+      @rubric_data = {rubric: @rubric.summarize}
       if @script_level.lesson.rubric && view_as_other
         viewing_user_level = @view_as_user.user_levels.find_by(script: @script_level.script, level: @level)
         @rubric_data[:studentLevelInfo] = {

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -166,7 +166,10 @@ class ScriptLevelsController < ApplicationController
 
     @rubric = @script_level.lesson.rubric
     if @rubric
-      @rubric_data = {rubric: @rubric.summarize}
+      @rubric_data = {
+        rubric: @rubric.summarize,
+        onLevelForEvaluation: @level.id == @rubric.level_id
+      }
       if @script_level.lesson.rubric && view_as_other
         viewing_user_level = @view_as_user.user_levels.find_by(script: @script_level.script, level: @level)
         @rubric_data[:studentLevelInfo] = {

--- a/dashboard/app/models/rubric.rb
+++ b/dashboard/app/models/rubric.rb
@@ -18,7 +18,7 @@ class Rubric < ApplicationRecord
   belongs_to :lesson
 
   def summarize
-    level_position = lesson.script_levels.filter {|sl| sl.levels.include?(level)}.first&.position
+    script_level = lesson.script_levels.find {|sl| sl.levels.include?(level)}
     {
       learningGoals: learning_goals.map(&:summarize),
       lesson: {
@@ -27,7 +27,7 @@ class Rubric < ApplicationRecord
       },
       level: {
         name: level.name,
-        position: level_position,
+        position: script_level&.position,
       }
     }
   end

--- a/dashboard/app/models/rubric.rb
+++ b/dashboard/app/models/rubric.rb
@@ -18,11 +18,16 @@ class Rubric < ApplicationRecord
   belongs_to :lesson
 
   def summarize
+    level_position = lesson.script_levels.filter {|sl| sl.levels.include?(level)}.first&.position
     {
       learningGoals: learning_goals.map(&:summarize),
       lesson: {
         name: lesson.name,
         position: lesson.relative_position,
+      },
+      level: {
+        name: level.name,
+        position: level_position,
       }
     }
   end


### PR DESCRIPTION
The only significant change in this PR is making the rubric view aware of which level it is on. In particular, the rubric is shown on every level in the lesson but feedback is only available on one level (generally the assessment level).

The rubric looks the same on the assessment level:

![Screenshot 2023-08-31 at 10 12 02 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/a08e7e73-25b0-426e-aabf-bb61c3345a6e)


But on another level, it looks a bit different:

![Screenshot 2023-08-31 at 10 11 37 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/d95f286a-cc68-43df-93d2-fe4923b0211b)

In this PR, I also added some storybook entries for `RubricContainer` covering a combination of:
- AI enabled/disabled
- Viewing own work vs student work
- Viewing student work on assessment level vs not
I found this helpful for checking all of these cases when making small styling changes. This component won't be used elsewhere, so I'm open to pushback if folks don't think it should live in our codebase.

