### PR TITLE
Update default_hoc_mode to pre-hoc

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -417,7 +417,7 @@ levelbuilder_mode:
 # make it easier to tell the difference
 use_local_header_color:
 
-default_hoc_mode: post-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_mode: pre-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''      # overridden by 'hoc_launch' DCDO param, except in :test
 
 # teacher_application_mode values: 'open', 'closing-soon', 'closed'


### PR DESCRIPTION
Updates `default_hoc_mode` to `pre_hoc` in preparation for Hour of Code this year. This only affects the `test` environment since the other environments use the DCDO `hoc_mode` param. This follows the change made last year for Hour of Code: https://github.com/code-dot-org/code-dot-org/pull/47987/files.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-856&assignee=60d62161f65054006980bd71)
Spec: [last item under the 'Manual Updates Required' section](https://docs.google.com/document/d/1npRdcuOhOPGghHXkBZain_7ZvRrqvizAbwT1gwlAaK8/edit)

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
