### PR TITLE
Import family names for new users created from Clever section imports (TEACH-558)

### DIFF
--- a/dashboard/app/models/sections/clever_section.rb
+++ b/dashboard/app/models/sections/clever_section.rb
@@ -35,13 +35,16 @@ class CleverSection < OmniAuthSection
   def self.from_service(course_id, owner_id, student_list, section_name)
     code = "C-#{course_id}"
 
+    set_family_name = DCDO.get('clever_family_name', false)
+
     students = student_list.map do |student|
       data = student['data']
       OmniAuth::AuthHash.new(
         uid: data['id'],
         provider: 'clever',
         info: {
-          name: data['name'],
+          name: set_family_name ? data['name']['first'] : data['name'],
+          family_name: set_family_name ? data['name']['last'] : nil,
           dob: data['dob'],
         },
       )

--- a/dashboard/test/models/sections/clever_section_test.rb
+++ b/dashboard/test/models/sections/clever_section_test.rb
@@ -18,7 +18,7 @@ class CleverSectionTest < ActiveSupport::TestCase
     assert_nil section.students.first.family_name
 
     assert_no_difference 'User.count' do
-      # Should find the existing Google Classroom section.
+      # Should find the existing Clever section.
       section_2 = CleverSection.from_service('101', owner.id, student_list, 'Clever Section B')
       assert_equal section.id, section_2.id
 
@@ -46,7 +46,7 @@ class CleverSectionTest < ActiveSupport::TestCase
     assert_equal 'Smith', section.students.first.family_name
 
     assert_no_difference 'User.count' do
-      # Should find the existing Google Classroom section.
+      # Should find the existing Clever section.
       section_2 = CleverSection.from_service('101', owner.id, student_list, 'Clever Section B')
       assert_equal section.id, section_2.id
 

--- a/dashboard/test/models/sections/clever_section_test.rb
+++ b/dashboard/test/models/sections/clever_section_test.rb
@@ -29,6 +29,7 @@ class CleverSectionTest < ActiveSupport::TestCase
 
   test 'from clever service with family name import' do
     DCDO.stubs(:get).with('clever_family_name', false).returns(true)
+    DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
 
     owner = create :teacher
     student_list = [

--- a/dashboard/test/models/sections/clever_section_test.rb
+++ b/dashboard/test/models/sections/clever_section_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class CleverSectionTest < ActiveSupport::TestCase
-  test 'from clever service' do
+  test 'from clever service without family name import' do
     owner = create :teacher
     student_list = [
       {'data' => {'dob' => '2002-09-04T00:00:00.000Z', 'name' => {'first' => 'Ethan', 'last' => 'Doe'}, 'id' => '5966ed736b21538e3c000004'}},
@@ -10,9 +10,12 @@ class CleverSectionTest < ActiveSupport::TestCase
     ]
 
     section = CleverSection.from_service('101', owner.id, student_list, 'Clever Section A')
+    section.reload
     assert section.provider_managed?
     assert_equal 'C-101', section.code
     assert_equal 'Clever Section A', section.name
+    assert_equal 'Elizabeth Smith', section.students.first.name
+    assert_nil section.students.first.family_name
 
     assert_no_difference 'User.count' do
       # Should find the existing Google Classroom section.
@@ -22,5 +25,35 @@ class CleverSectionTest < ActiveSupport::TestCase
       # Should update the name to match the imported name.
       assert_equal 'Clever Section B', section_2.name
     end
+  end
+
+  test 'from clever service with family name import' do
+    DCDO.stubs(:get).with('clever_family_name', false).returns(true)
+
+    owner = create :teacher
+    student_list = [
+      {'data' => {'dob' => '2002-09-04T00:00:00.000Z', 'name' => {'first' => 'Ethan', 'last' => 'Doe'}, 'id' => '5966ed736b21538e3c000004'}},
+      {'data' => {'dob' => '2000-02-11T00:00:00.000Z', 'name' => {'first' => 'Lily', 'last' => 'Fake'}, 'id' => '5966ed736b21538e3c000005'}},
+      {'data' => {'dob' => '2002-05-21T00:00:00.000Z', 'name' => {'first' => 'Elizabeth', 'last' => 'Smith'}, 'id' => '5966ed736b21538e3c000006'}},
+    ]
+
+    section = CleverSection.from_service('101', owner.id, student_list, 'Clever Section A')
+    section.reload
+    assert section.provider_managed?
+    assert_equal 'C-101', section.code
+    assert_equal 'Clever Section A', section.name
+    assert_equal 'Elizabeth', section.students.first.name
+    assert_equal 'Smith', section.students.first.family_name
+
+    assert_no_difference 'User.count' do
+      # Should find the existing Google Classroom section.
+      section_2 = CleverSection.from_service('101', owner.id, student_list, 'Clever Section B')
+      assert_equal section.id, section_2.id
+
+      # Should update the name to match the imported name.
+      assert_equal 'Clever Section B', section_2.name
+    end
+
+    DCDO.unstub(:get)
   end
 end


### PR DESCRIPTION
This change affects users created at the time a section is imported from Clever. While before the `name` field was set to the student's full first and last name, now (when the applicable DCDO flag is enabled) the `name` field will be set to the first name and the `family_name` field will be set to the last name.

Screenshot below. Note that the "Lily Fake" user does not have their family name set because they first logged into Code.org prior to the teacher's action to import the section, and updating the name is out of scope for this task.
![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/36d5972a-3305-401b-84c3-7100f6845e36)

## Links
JIRA ticket: [TEACH-558](https://codedotorg.atlassian.net/browse/TEACH-558)

## Testing story

Unit tests for with/without the DCDO flag enabled.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
