### PR TITLE
Filtering warden info from Honeybadger reports

### DIFF
--- a/dashboard/config/honeybadger.yml
+++ b/dashboard/config/honeybadger.yml
@@ -5,3 +5,6 @@ exceptions:
   notify_at_exit: false
 breadcrumbs:
   enabled: true
+request:
+  filter_keys:
+    - "warden.user.user.key"

--- a/dashboard/test/integration/honeybadger_test.rb
+++ b/dashboard/test/integration/honeybadger_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class HoneybadgerErrorController < ApplicationController
+  def raise_error
+    Honeybadger.notify("Test Error!")
+    raise "Test Error!"
+  end
+end
+
+class HoneybadgerTest < ActionDispatch::IntegrationTest
+  setup do
+    Rails.application.routes.draw do
+      get 'raise_error' => 'honeybadger_error#raise_error'
+    end
+
+    Honeybadger.configure do |config|
+      @original_backend = config.backend
+      config.backend = 'test'
+      @original_api_key = config.api_key
+      config.api_key = 'test_key'
+    end
+  end
+
+  teardown do
+    Rails.application.reload_routes!
+
+    Honeybadger.configure do |config|
+      config.backend = @original_backend
+      config.api_key = @original_api_key
+    end
+  end
+
+  # The value Honeybadger will set a filtered value to.
+  FILTERED = "[FILTERED]"
+
+  test "does NOT log encrypted data" do
+    student = create :student
+    sign_in student
+
+    get raise_error_path
+
+    notice = Honeybadger::Backend::Test.notifications[:notices].first&.as_json
+    assert_not_nil notice
+    assert_equal FILTERED, notice[:request][:session]["warden.user.user.key"]
+  end
+end


### PR DESCRIPTION
We are logging some encrypted data related to the User in our Honeybadger logs, so this PR adds a filter the data before it is sent to Honeybadger

## Links
* [JIRA P20-118](https://codedotorg.atlassian.net/browse/P20-118)
* [Docs for filtering Honeybadger data](https://docs.honeybadger.io/lib/ruby/getting-started/filtering-sensitive-data/)

## Testing story
* Unit test
