### PR TITLE
hide feedback tab when Teacher Assistent Rubric exists

### DIFF
--- a/apps/src/redux/instructions.js
+++ b/apps/src/redux/instructions.js
@@ -32,6 +32,7 @@ const SET_TTS_AUTOPLAY_ENABLED_FOR_LEVEL =
   'instructions/SET_TTS_AUTOPLAY_ENABLED_FOR_LEVEL';
 const SET_CODE_REVIEW_ENABLED_FOR_LEVEL =
   'instructions/SET_CODE_REVIEW_ENABLED_FOR_LEVEL';
+const SET_TA_RUBRIC = 'instructions/SET_TA_RUBRIC';
 
 /**
  * Some scenarios:
@@ -77,6 +78,7 @@ const instructionsInitialState = {
   muteBackgroundMusic: () => {},
   unmuteBackgroundMusic: () => {},
   programmingEnvironment: null,
+  taRubric: null,
 };
 
 export default function reducer(state = {...instructionsInitialState}, action) {
@@ -216,6 +218,12 @@ export default function reducer(state = {...instructionsInitialState}, action) {
     });
   }
 
+  if (action.type === SET_TA_RUBRIC) {
+    return Object.assign({}, state, {
+      taRubric: action.taRubric,
+    });
+  }
+
   return state;
 }
 
@@ -328,6 +336,11 @@ export const setDynamicInstructionsOverlayDismissCallback =
     type: SET_DYNAMIC_INSTRUCTIONS_DISMISS_CALLBACK,
     dynamicInstructionsDismissCallback,
   });
+
+export const setTaRubric = taRubric => ({
+  type: SET_TA_RUBRIC,
+  taRubric,
+});
 
 // HELPERS
 

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -9,6 +9,7 @@ import {setIsMiniView} from '@cdo/apps/code-studio/progressRedux';
 import instructions, {
   setTtsAutoplayEnabledForLevel,
   setCodeReviewEnabledForLevel,
+  setTaRubric,
 } from '@cdo/apps/redux/instructions';
 import experiments from '@cdo/apps/util/experiments';
 import RubricFloatingActionButton from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
@@ -63,6 +64,7 @@ function initPage() {
       courseName: config.course_name,
       levelName: config.level_name,
     };
+    getStore().dispatch(setTaRubric(rubric));
     ReactDOM.render(
       <RubricFloatingActionButton
         rubric={rubric}

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -154,7 +154,7 @@ class TopInstructions extends Component {
           ? TabType.COMMENTS
           : TabType.INSTRUCTIONS),
       latestFeedback: null,
-      rubric: null,
+      miniRubric: null,
       studentId: studentId,
       teacherViewingStudentWork: teacherViewingStudentWork,
       fetchingData: true,
@@ -222,7 +222,7 @@ class TopInstructions extends Component {
     if (serverLevelId && !taRubric) {
       promises.push(
         topInstructionsDataApi.getRubric(serverLevelId).done(data => {
-          this.setState({rubric: data});
+          this.setState({miniRubric: data});
         })
       );
     }
@@ -605,7 +605,7 @@ class TopInstructions extends Component {
     const {
       latestFeedback,
       teacherViewingStudentWork,
-      rubric,
+      miniRubric,
       tabSelected,
       fetchingData,
       token,
@@ -647,7 +647,7 @@ class TopInstructions extends Component {
 
     const displayFeedbackTab =
       !taRubric &&
-      (!!rubric ||
+      (!!miniRubric ||
         teacherViewingStudentWork ||
         (this.isViewingAsStudent && !!latestFeedback));
 
@@ -695,7 +695,7 @@ class TopInstructions extends Component {
           isCSDorCSP={isCSDorCSP}
           displayHelpTab={displayHelpTab}
           displayFeedback={displayFeedbackTab}
-          levelHasRubric={!!rubric}
+          levelHasMiniRubric={!!miniRubric}
           displayDocumentationTab={displayDocumentationTab}
           displayReviewTab={displayReviewTab}
           isViewingAsTeacher={this.isViewingAsTeacher}
@@ -734,7 +734,7 @@ class TopInstructions extends Component {
               <TeacherFeedbackTab
                 teacherViewingStudentWork={teacherViewingStudentWork}
                 visible={tabSelected === TabType.COMMENTS}
-                rubric={rubric}
+                rubric={miniRubric}
                 innerRef={ref => (this.commentTab = ref)}
                 latestFeedback={latestFeedback}
                 token={token}

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -38,7 +38,7 @@ import Button from '../Button';
 import i18n from '@cdo/locale';
 import ContainedLevelResetButton from './ContainedLevelResetButton';
 import {queryParams} from '@cdo/apps/code-studio/utils';
-import {rubricShape} from '../rubrics/rubricShapes';
+import {rubricShape} from '@cdo/apps/templates/rubrics/rubricShapes';
 
 const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
 const RESIZER_HEIGHT = styleConstants['resize-bar-width'];

--- a/apps/src/templates/instructions/TopInstructionsHeader.jsx
+++ b/apps/src/templates/instructions/TopInstructionsHeader.jsx
@@ -18,7 +18,7 @@ function TopInstructionsHeader(props) {
     isCSDorCSP,
     displayHelpTab,
     displayFeedback,
-    levelHasRubric,
+    levelHasMiniRubric,
     displayDocumentationTab,
     displayReviewTab,
     isViewingAsTeacher,
@@ -123,7 +123,7 @@ function TopInstructionsHeader(props) {
               onClick={handleCommentTabClick}
               selected={tabSelected === TabType.COMMENTS}
               isLegacyTextColor={isOldPurpleColor}
-              text={levelHasRubric ? i18n.rubric() : i18n.feedback()}
+              text={levelHasMiniRubric ? i18n.rubric() : i18n.feedback()}
               teacherOnly={teacherOnly}
               isMinecraft={isMinecraft}
               isRtl={isRtl}
@@ -276,7 +276,7 @@ TopInstructionsHeader.propTypes = {
   isCSDorCSP: PropTypes.bool,
   displayHelpTab: PropTypes.bool,
   displayFeedback: PropTypes.bool,
-  levelHasRubric: PropTypes.bool,
+  levelHasMiniRubric: PropTypes.bool,
   displayDocumentationTab: PropTypes.bool,
   displayReviewTab: PropTypes.bool,
   isViewingAsTeacher: PropTypes.bool,

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -15,7 +15,7 @@ export default function RubricFloatingActionButton({
   studentLevelInfo,
   reportingData,
 }) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(!!studentLevelInfo);
 
   const handleClick = () => {
     const eventName = isOpen

--- a/apps/test/unit/templates/instructions/TopInstructionsHeaderTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsHeaderTest.jsx
@@ -14,7 +14,7 @@ const DEFAULT_PROPS = {
   isCSDorCSP: true,
   displayHelpTab: true,
   displayFeedback: true,
-  levelHasRubric: false,
+  levelHasMiniRubric: false,
   isViewingAsTeacher: false,
   isViewingAsInstructorInTraining: false,
   hasBackgroundMusic: false,
@@ -78,9 +78,9 @@ describe('TopInstructionsHeader', () => {
     expect(commentTab.props().selected).to.be.true;
   });
 
-  it('on the comments tab selects when displayFeedback and levelHasRubric text is rubric', () => {
+  it('on the comments tab selects when displayFeedback and levelHasMiniRubric text is rubric', () => {
     const wrapper = setUp({
-      levelHasRubric: true,
+      levelHasMiniRubric: true,
       displayFeedback: true,
       tabSelected: TabType.COMMENTS,
     });
@@ -88,9 +88,9 @@ describe('TopInstructionsHeader', () => {
     expect(commentTab.props().text).to.equal(i18n.rubric());
   });
 
-  it('on the comments tab selects when displayFeedback and levelHasRubric = false text is feedback', () => {
+  it('on the comments tab selects when displayFeedback and levelHasMiniRubric = false text is feedback', () => {
     const wrapper = setUp({
-      levelHasRubric: false,
+      levelHasMiniRubric: false,
       displayFeedback: true,
       tabSelected: TabType.COMMENTS,
     });

--- a/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
@@ -172,14 +172,14 @@ describe('TopInstructions', () => {
   });
 
   describe('viewing the Feedback Tab', () => {
-    describe('as a instructor', () => {
-      it('passes displayFeedback = false to TopInstructionsHeader on a level with no rubric where the instructor is not viewing student work', () => {
+    describe('as an instructor', () => {
+      it('passes displayFeedback = false to TopInstructionsHeader on a level with no miniRubric where the instructor is not viewing student work', () => {
         const wrapper = shallow(<TopInstructions {...DEFAULT_PROPS} />);
 
         wrapper.setState({
           tabSelected: 'instructions',
           feedbacks: [],
-          rubric: null,
+          miniRubric: null,
           teacherViewingStudentWork: false,
           studentId: null,
           fetchingData: false,
@@ -190,13 +190,13 @@ describe('TopInstructions', () => {
           .be.false;
       });
 
-      it('passes displayFeedback = true to TopInstructionsHeader on a level with a rubric where the instructor is not viewing student work', () => {
+      it('passes displayFeedback = true to TopInstructionsHeader on a level with a miniRubric where the instructor is not viewing student work', () => {
         const wrapper = shallow(<TopInstructions {...DEFAULT_PROPS} />);
 
         wrapper.setState({
           tabSelected: 'instructions',
           feedbacks: [],
-          rubric: {
+          miniRubric: {
             keyConcept: 'This is the key concept',
             performanceLevel1: 'Includes more than needed',
             performanceLevel2: 'Includes exactly all needed elements',
@@ -244,7 +244,7 @@ describe('TopInstructions', () => {
               student_id: 1,
             },
           ],
-          rubric: {
+          miniRubric: {
             keyConcept: 'This is the key concept',
             performanceLevel1: 'Includes more than needed',
             performanceLevel2: 'Includes exactly all needed elements',
@@ -261,7 +261,7 @@ describe('TopInstructions', () => {
           .be.true;
       });
 
-      it('passes displayFeedback = false to TopInstructionsHeader on a level where the instructor has not given feedback and there is no rubric', () => {
+      it('passes displayFeedback = false to TopInstructionsHeader on a level where the instructor has not given feedback and there is no miniRubric', () => {
         const wrapper = shallow(
           <TopInstructions {...DEFAULT_PROPS} viewAs={ViewType.Participant} />
         );
@@ -269,7 +269,7 @@ describe('TopInstructions', () => {
         wrapper.setState({
           tabSelected: 'instructions',
           feedbacks: [],
-          rubric: null,
+          miniRubric: null,
           teacherViewingStudentWork: false,
           studentId: 1,
           fetchingData: false,

--- a/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
@@ -213,6 +213,31 @@ describe('TopInstructions', () => {
           .be.true;
       });
 
+      it('passes displayFeedback = false to TopInstructionsHeader on a level with a TA Rubric', () => {
+        const wrapper = shallow(
+          <TopInstructions {...DEFAULT_PROPS} taRubric={{learningGoals: []}} />
+        );
+
+        wrapper.setState({
+          tabSelected: 'instructions',
+          feedbacks: [],
+          miniRubric: {
+            keyConcept: 'This is the key concept',
+            performanceLevel1: 'Includes more than needed',
+            performanceLevel2: 'Includes exactly all needed elements',
+            performanceLevel3: 'Has some of the needed elements',
+            performanceLevel4: 'No work done',
+          },
+          teacherViewingStudentWork: false,
+          studentId: null,
+          fetchingData: false,
+          token: null,
+        });
+
+        expect(wrapper.find(TopInstructionsHeader).props().displayFeedback).to
+          .be.false;
+      });
+
       it('passes displayFeedback = true to TopInstructionsHeader teacher is viewing student work', () => {
         const props = {...DEFAULT_PROPS, displayReviewTab: true};
         const wrapper = shallow(<TopInstructions {...props} />);
@@ -259,6 +284,44 @@ describe('TopInstructions', () => {
 
         expect(wrapper.find(TopInstructionsHeader).props().displayFeedback).to
           .be.true;
+      });
+
+      it('passes displayFeedback = false to TopInstructionsHeader on a level where there is a TA Rubric', () => {
+        const wrapper = shallow(
+          <TopInstructions
+            {...DEFAULT_PROPS}
+            viewAs={ViewType.Participant}
+            taRubric={{learningGoals: []}}
+          />
+        );
+
+        wrapper.setState({
+          tabSelected: 'instructions',
+          feedbacks: [
+            {
+              comment: 'Good work!',
+              created_at: '2019-03-26T19:56:53.000Z',
+              id: 5,
+              level_id: 123,
+              performance: 'performanceLevel2',
+              student_id: 1,
+            },
+          ],
+          miniRubric: {
+            keyConcept: 'This is the key concept',
+            performanceLevel1: 'Includes more than needed',
+            performanceLevel2: 'Includes exactly all needed elements',
+            performanceLevel3: 'Has some of the needed elements',
+            performanceLevel4: 'No work done',
+          },
+          teacherViewingStudentWork: false,
+          studentId: 1,
+          fetchingData: false,
+          token: null,
+        });
+
+        expect(wrapper.find(TopInstructionsHeader).props().displayFeedback).to
+          .be.false;
       });
 
       it('passes displayFeedback = false to TopInstructionsHeader on a level where the instructor has not given feedback and there is no miniRubric', () => {

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -7,9 +7,20 @@ import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import RubricFloatingActionButton from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
 
 describe('RubricFloatingActionButton', () => {
-  it('begins closed', () => {
+  it('begins closed when student level info is null', () => {
     const wrapper = shallow(<RubricFloatingActionButton />);
     expect(wrapper.find('RubricContainer').length).to.equal(0);
+  });
+
+  it('begins open when student level info is provided', () => {
+    const wrapper = shallow(
+      <RubricFloatingActionButton
+        studentLevelInfo={{
+          name: 'Grace Hopper',
+        }}
+      />
+    );
+    expect(wrapper.find('RubricContainer').length).to.equal(1);
   });
 
   it('opens RubricContainer when clicked', () => {


### PR DESCRIPTION
This PR:
- Hides the "Feedback" tab when a TA Rubric exists (I named the new rubrics "TA Rubrics" here and renamed `rubric` in `TopInstructions` to `miniRubric` for clarity). Right now, this only applies to people using the experiment flag / in the pilot as those are the only experiences that will have a rubric in the instructions store
- Opens the rubric by default when viewing student work to be consistent with the experience of defaulting to the feedback tab when viewing student work

### Testing
I'm mostly relying on existing tests for this but I did confirm that disabling the experiment caused the Feedback tab to reappear. I added a couple of tests for the new behavior described above.