### PR TITLE
add faster bin/dashboard-console-skip-preload

### DIFF
--- a/bin/dashboard-console-skip-preload
+++ b/bin/dashboard-console-skip-preload
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+require_relative '../deployment'
+
+# run rails console but skip the script preload step, which can take a long time
+# in production and other environments where script caching is enabled.
+def main
+  Dir.chdir(dashboard_dir) do
+    exec "SKIP_SCRIPT_PRELOAD=1 ./bin/rails console"
+  end
+end
+
+main

--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -66,10 +66,6 @@ Dashboard::Application.configure do
   # skip precompiling of all assets on the first request for any asset.
   config.assets.check_precompiled_asset = false
 
-  # Whether or not to skip script preloading. Setting this to true
-  # significantly speeds up server startup time
-  config.skip_script_preload = true
-
   # Set to :debug to see everything in the log.
   config.log_level = :debug
 

--- a/dashboard/config/environments/production.rb
+++ b/dashboard/config/environments/production.rb
@@ -76,10 +76,6 @@ Dashboard::Application.configure do
   # don't act like a levelbuilder by default
   config.levelbuilder_mode = CDO.with_default(false).levelbuilder_mode
 
-  # Whether or not to skip script preloading. Setting this to true
-  # significantly speeds up server startup time
-  config.skip_script_preload = false
-
   # The activities_old table should not be part of the schema
   # DELETE_ME when the activities old table gets removed
   ActiveRecord::SchemaDumper.ignore_tables = ["activities_old"]

--- a/dashboard/config/environments/staging.rb
+++ b/dashboard/config/environments/staging.rb
@@ -73,8 +73,4 @@ Dashboard::Application.configure do
 
   # don't act like a levelbuilder by default
   config.levelbuilder_mode = CDO.with_default(false).levelbuilder_mode
-
-  # Whether or not to skip script preloading. Setting this to true
-  # significantly speeds up server startup time
-  config.skip_script_preload = false
 end

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -75,9 +75,5 @@ Dashboard::Application.configure do
   # Set to :debug to see everything in the log.
   config.log_level = :info
 
-  # Whether or not to skip script preloading. Setting this to true
-  # significantly speeds up server startup time.
-  config.skip_script_preload = false
-
   config.experiment_cache_time_seconds = 0
 end

--- a/dashboard/config/initializers/script_preload.rb
+++ b/dashboard/config/initializers/script_preload.rb
@@ -1,10 +1,9 @@
 # Preload script cache before application fork.
-# This speeds up load time of new Unicorn child worker processes.
+# This speeds up load time of new Unicorn child worker processes
+# and Spring application preloader (Rails console, unit tests).
 
-# Skip if this is running a Rake task (e.g. rake db:setup), when running rails console,
-# or when caching is disabled.
+# Skip if this is running a Rake task (e.g. rake db:setup) or when caching is disabled
 if File.basename($0) != 'rake' &&
-    !defined?(Rails::Console) &&
     Unit.should_cache? &&
     !Rails.application.config.skip_script_preload
   # Populate the shared in-memory cache from the database.

--- a/dashboard/config/initializers/script_preload.rb
+++ b/dashboard/config/initializers/script_preload.rb
@@ -5,7 +5,7 @@
 # Skip if this is running a Rake task (e.g. rake db:setup) or when caching is disabled
 if File.basename($0) != 'rake' &&
     Unit.should_cache? &&
-    !Rails.application.config.skip_script_preload
+    !ENV['SKIP_SCRIPT_PRELOAD']
   # Populate the shared in-memory cache from the database.
   Unit.unit_cache_to_cache unless Rails.cache.is_a?(ActiveSupport::Cache::MemoryStore)
   Unit.script_cache


### PR DESCRIPTION
This PR reverts https://github.com/code-dot-org/code-dot-org/pull/53398 and proposes a new solution for speeding up startup time for bin/dashboard-console. See [slack](https://codedotorg.slack.com/archives/C03CK49G9/p1693485357383119?thread_ts=1692720701.174539&cid=C03CK49G9) for why the old approach didn't work. 

new solution:
* use presence of an environment variable to disable script cache preloading
* add bin/dashboard-console-skip-preload command to run rails console with the new env var set

collateral damage:
* remove rails config.skip_script_preload because it had no effect. see https://github.com/code-dot-org/code-dot-org/pull/53398 and the linked [gsheet](https://docs.google.com/spreadsheets/d/1jtzDt85ipTWAbL7OvRS__JrtMSOwge8fPAldd7X464g/edit#gid=0) for justification.

## Testing story

verified locally that bin/dashboard-console-skip-preload causes script preloading to be skipped, and bin/dashboard-console does not (this required temporarily modifying should_cache? to return true)