### PR TITLE
Fixed null available resources

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -469,7 +469,9 @@ class CourseOffering < ApplicationRecord
   end
 
   def get_available_resources(locale_code='en-us')
-    lessons = latest_published_version(locale_code).units.first.lessons
+    latest_version = latest_published_version(locale_code)
+    units = latest_version&.units
+    lessons = units&.first&.lessons
 
     return nil if lessons.empty?
     lesson_plan = lessons.first.lesson_plan_html_url


### PR DESCRIPTION


Fixes: undefined method 'units' for nil:NilClass found in:
`lessons = latest_published_version(locale_code).units.first.lessons`

Breaks up the statement into three parts in order to check if there are any null references when retrieving the available resources for a course offering.