### PR TITLE
Add family name column to stats tab table

### DIFF
--- a/apps/src/templates/teacherDashboard/StatsTable.jsx
+++ b/apps/src/templates/teacherDashboard/StatsTable.jsx
@@ -37,7 +37,7 @@ class StatsTable extends Component {
     if (studentUrl) {
       return (
         <a
-          className="uitest-name-cell"
+          className="uitest-display-name-cell"
           style={tableLayoutStyles.link}
           href={studentUrl}
           target="_blank"
@@ -47,12 +47,12 @@ class StatsTable extends Component {
         </a>
       );
     } else {
-      return <span className="uitest-name-cell">{name}</span>;
+      return <span className="uitest-display-name-cell">{name}</span>;
     }
   };
 
   familyNameFormatter = familyName => {
-    return <span>{familyName}</span>;
+    return <span className="uitest-family-name-cell">{familyName}</span>;
   };
 
   getSortingColumns = () => {
@@ -66,7 +66,7 @@ class StatsTable extends Component {
         header: {
           label: i18n.name(),
           props: {
-            className: 'uitest-name-header',
+            className: 'uitest-display-name-header',
             style: {
               ...tableLayoutStyles.headerCell,
             },
@@ -87,6 +87,7 @@ class StatsTable extends Component {
         header: {
           label: i18n.familyName(),
           props: {
+            className: 'uitest-family-name-header',
             style: {
               ...tableLayoutStyles.headerCell,
             },

--- a/apps/src/templates/teacherDashboard/StatsTable.jsx
+++ b/apps/src/templates/teacherDashboard/StatsTable.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
+import DCDO from '@cdo/apps/dcdo';
 import * as Table from 'reactabular-table';
 import * as sort from 'sortabular';
 import wrappedSortable from '../tables/wrapped_sortable';
@@ -60,72 +61,88 @@ class StatsTable extends Component {
   };
 
   getColumns = sortable => {
-    return [
-      {
-        property: 'name',
-        header: {
-          label: i18n.name(),
-          props: {
-            className: 'uitest-display-name-header',
-            style: {
-              ...tableLayoutStyles.headerCell,
-            },
-          },
-          transforms: [sortable],
-        },
-        cell: {
-          formatters: [this.nameFormatter],
-          props: {
-            style: {
-              ...tableLayoutStyles.cell,
-            },
-          },
-        },
-      },
-      {
-        property: 'familyName',
-        header: {
-          label: i18n.familyName(),
-          props: {
-            className: 'uitest-family-name-header',
-            style: {
-              ...tableLayoutStyles.headerCell,
-            },
-          },
-          transforms: [sortable],
-        },
-        cell: {
-          formatters: [this.familyNameFormatter],
-          props: {
-            style: {
-              ...tableLayoutStyles.cell,
-            },
-          },
-        },
-      },
-      {
-        property: 'completedLevelsCount',
-        header: {
-          label: i18n.completedLevels(),
-          props: {
-            style: {
-              ...tableLayoutStyles.headerCell,
-              ...styles.rightAlignText,
-            },
-          },
-          transforms: [sortable],
-        },
-        cell: {
-          props: {
-            style: {
-              ...tableLayoutStyles.cell,
-              ...styles.rightAlignText,
-            },
-          },
-        },
-      },
-    ];
+    const columns = [this.nameColumn(sortable)];
+
+    if (!!DCDO.get('family-name-features', false)) {
+      columns.push(this.familyNameColumn(sortable));
+    }
+
+    columns.push(this.completedLevelsCountColumn(sortable));
+
+    return columns;
   };
+
+  nameColumn(sortable) {
+    return {
+      property: 'name',
+      header: {
+        label: i18n.name(),
+        props: {
+          className: 'uitest-display-name-header',
+          style: {
+            ...tableLayoutStyles.headerCell,
+          },
+        },
+        transforms: [sortable],
+      },
+      cell: {
+        formatters: [this.nameFormatter],
+        props: {
+          style: {
+            ...tableLayoutStyles.cell,
+          },
+        },
+      },
+    };
+  }
+
+  familyNameColumn(sortable) {
+    return {
+      property: 'familyName',
+      header: {
+        label: i18n.familyName(),
+        props: {
+          className: 'uitest-family-name-header',
+          style: {
+            ...tableLayoutStyles.headerCell,
+          },
+        },
+        transforms: [sortable],
+      },
+      cell: {
+        formatters: [this.familyNameFormatter],
+        props: {
+          style: {
+            ...tableLayoutStyles.cell,
+          },
+        },
+      },
+    };
+  }
+
+  completedLevelsCountColumn(sortable) {
+    return {
+      property: 'completedLevelsCount',
+      header: {
+        label: i18n.completedLevels(),
+        props: {
+          style: {
+            ...tableLayoutStyles.headerCell,
+            ...styles.rightAlignText,
+          },
+        },
+        transforms: [sortable],
+      },
+      cell: {
+        props: {
+          style: {
+            ...tableLayoutStyles.cell,
+            ...styles.rightAlignText,
+          },
+        },
+      },
+    };
+  }
 
   // The user requested a new sorting column. Adjust the state accordingly.
   onSort = selectedColumn => {

--- a/apps/src/templates/teacherDashboard/StatsTable.jsx
+++ b/apps/src/templates/teacherDashboard/StatsTable.jsx
@@ -19,6 +19,7 @@ class StatsTable extends Component {
 
     // Provided by redux.
     scriptName: PropTypes.string,
+    participantType: PropTypes.string,
   };
 
   state = {};
@@ -64,7 +65,10 @@ class StatsTable extends Component {
     const columns = [this.nameColumn(sortable)];
 
     if (!!DCDO.get('family-name-features', false)) {
-      columns.push(this.familyNameColumn(sortable));
+      if (this.props.participantType === 'student') {
+        // Only in non-PL sections.
+        columns.push(this.familyNameColumn(sortable));
+      }
     }
 
     columns.push(this.completedLevelsCountColumn(sortable));
@@ -201,4 +205,7 @@ const styles = {
 export const UnconnectedStatsTable = StatsTable;
 export default connect(state => ({
   scriptName: getSelectedScriptName(state),
+  participantType:
+    state.teacherSections.sections[state.teacherSections.selectedSectionId]
+      .participantType,
 }))(StatsTable);

--- a/apps/src/templates/teacherDashboard/StatsTable.jsx
+++ b/apps/src/templates/teacherDashboard/StatsTable.jsx
@@ -51,6 +51,10 @@ class StatsTable extends Component {
     }
   };
 
+  familyNameFormatter = familyName => {
+    return <span>{familyName}</span>;
+  };
+
   getSortingColumns = () => {
     return this.state.sortingColumns || {};
   };
@@ -71,6 +75,26 @@ class StatsTable extends Component {
         },
         cell: {
           formatters: [this.nameFormatter],
+          props: {
+            style: {
+              ...tableLayoutStyles.cell,
+            },
+          },
+        },
+      },
+      {
+        property: 'familyName',
+        header: {
+          label: i18n.familyName(),
+          props: {
+            style: {
+              ...tableLayoutStyles.headerCell,
+            },
+          },
+          transforms: [sortable],
+        },
+        cell: {
+          formatters: [this.familyNameFormatter],
           props: {
             style: {
               ...tableLayoutStyles.cell,

--- a/apps/test/unit/templates/teacherDashboard/StatsTableTest.js
+++ b/apps/test/unit/templates/teacherDashboard/StatsTableTest.js
@@ -48,6 +48,7 @@ describe('StatsTable', () => {
     const wrapper = mount(
       <StatsTable
         sectionId={1}
+        participantType="student"
         students={students}
         studentsCompletedLevelCount={studentsCompletedLevelCount}
       />
@@ -80,6 +81,25 @@ describe('StatsTable', () => {
     expect(nameCells.at(0).text()).to.equal('Lastname C');
     expect(nameCells.at(1).text()).to.equal('Lastname B');
     expect(nameCells.at(2).text()).to.equal('Lastname A');
+
+    DCDO.reset();
+  });
+
+  it('does not render a family name field in PL sections', async () => {
+    DCDO.reset();
+    DCDO.set('family-name-features', true);
+
+    const wrapper = mount(
+      <StatsTable
+        sectionId={1}
+        participantType="teacher"
+        students={students}
+        studentsCompletedLevelCount={studentsCompletedLevelCount}
+      />
+    );
+
+    expect(wrapper.find('uitest-family-name-header').exists()).to.be.false;
+    expect(wrapper.find('uitest-family-name-cell').exists()).to.be.false;
 
     DCDO.reset();
   });

--- a/apps/test/unit/templates/teacherDashboard/StatsTableTest.js
+++ b/apps/test/unit/templates/teacherDashboard/StatsTableTest.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import DCDO from '@cdo/apps/dcdo';
 import {mount} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import {UnconnectedStatsTable as StatsTable} from '@cdo/apps/templates/teacherDashboard/StatsTable';
@@ -41,6 +42,9 @@ describe('StatsTable', () => {
   });
 
   it('sorts students by the correct name upon clicking the name header cells', () => {
+    DCDO.reset();
+    DCDO.set('family-name-features', true);
+
     const wrapper = mount(
       <StatsTable
         sectionId={1}
@@ -49,32 +53,34 @@ describe('StatsTable', () => {
       />
     );
 
-    // first click should sort students A-Z
+    // first click on display name header should sort students A-Z
     wrapper.find('.uitest-display-name-header').simulate('click');
     let nameCells = wrapper.find('.uitest-display-name-cell');
     expect(nameCells.at(0).text()).to.equal('Student A');
     expect(nameCells.at(1).text()).to.equal('Student B');
     expect(nameCells.at(2).text()).to.equal('Student C');
 
-    // second click should sort students Z-A
+    // second click on display name header should sort students Z-A
     wrapper.find('.uitest-display-name-header').simulate('click');
     nameCells = wrapper.find('.uitest-display-name-cell');
     expect(nameCells.at(0).text()).to.equal('Student C');
     expect(nameCells.at(1).text()).to.equal('Student B');
     expect(nameCells.at(2).text()).to.equal('Student A');
 
-    // first click should sort students by family name A-Z
+    // first click on family name header should sort students by family name A-Z
     wrapper.find('.uitest-family-name-header').simulate('click');
     nameCells = wrapper.find('.uitest-family-name-cell');
     expect(nameCells.at(0).text()).to.equal('Lastname A');
     expect(nameCells.at(1).text()).to.equal('Lastname B');
     expect(nameCells.at(2).text()).to.equal('Lastname C');
 
-    // second click should sort students Z-A
+    // second click on family name header should sort students by family name Z-A
     wrapper.find('.uitest-family-name-header').simulate('click');
     nameCells = wrapper.find('.uitest-family-name-cell');
     expect(nameCells.at(0).text()).to.equal('Lastname C');
     expect(nameCells.at(1).text()).to.equal('Lastname B');
     expect(nameCells.at(2).text()).to.equal('Lastname A');
+
+    DCDO.reset();
   });
 });

--- a/apps/test/unit/templates/teacherDashboard/StatsTableTest.js
+++ b/apps/test/unit/templates/teacherDashboard/StatsTableTest.js
@@ -4,9 +4,9 @@ import {expect} from '../../../util/reconfiguredChai';
 import {UnconnectedStatsTable as StatsTable} from '@cdo/apps/templates/teacherDashboard/StatsTable';
 
 const students = [
-  {id: 3, name: 'Student C'},
-  {id: 2, name: 'Student B'},
-  {id: 1, name: 'Student A'},
+  {id: 3, name: 'Student C', familyName: 'Lastname A'},
+  {id: 2, name: 'Student B', familyName: 'Lastname B'},
+  {id: 1, name: 'Student A', familyName: 'Lastname C'},
 ];
 const studentsCompletedLevelCount = {
   1: 15,
@@ -40,7 +40,7 @@ describe('StatsTable', () => {
     expect(studentRows).to.have.length(3);
   });
 
-  it('sorts students by name upon clicking student name header cell', () => {
+  it('sorts students by the correct name upon clicking the name header cells', () => {
     const wrapper = mount(
       <StatsTable
         sectionId={1}
@@ -50,17 +50,31 @@ describe('StatsTable', () => {
     );
 
     // first click should sort students A-Z
-    wrapper.find('.uitest-name-header').simulate('click');
-    let nameCells = wrapper.find('.uitest-name-cell');
+    wrapper.find('.uitest-display-name-header').simulate('click');
+    let nameCells = wrapper.find('.uitest-display-name-cell');
     expect(nameCells.at(0).text()).to.equal('Student A');
     expect(nameCells.at(1).text()).to.equal('Student B');
     expect(nameCells.at(2).text()).to.equal('Student C');
 
     // second click should sort students Z-A
-    wrapper.find('.uitest-name-header').simulate('click');
-    nameCells = wrapper.find('.uitest-name-cell');
+    wrapper.find('.uitest-display-name-header').simulate('click');
+    nameCells = wrapper.find('.uitest-display-name-cell');
     expect(nameCells.at(0).text()).to.equal('Student C');
     expect(nameCells.at(1).text()).to.equal('Student B');
     expect(nameCells.at(2).text()).to.equal('Student A');
+
+    // first click should sort students by family name A-Z
+    wrapper.find('.uitest-family-name-header').simulate('click');
+    nameCells = wrapper.find('.uitest-family-name-cell');
+    expect(nameCells.at(0).text()).to.equal('Lastname A');
+    expect(nameCells.at(1).text()).to.equal('Lastname B');
+    expect(nameCells.at(2).text()).to.equal('Lastname C');
+
+    // second click should sort students Z-A
+    wrapper.find('.uitest-family-name-header').simulate('click');
+    nameCells = wrapper.find('.uitest-family-name-cell');
+    expect(nameCells.at(0).text()).to.equal('Lastname C');
+    expect(nameCells.at(1).text()).to.equal('Lastname B');
+    expect(nameCells.at(2).text()).to.equal('Lastname A');
   });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

<!-- ## Links -->

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally

Sorted by family name, ascending
![image](https://github.com/code-dot-org/code-dot-org/assets/2933346/cd47a3bb-0ad2-4f4b-97fa-13e840a92524)

Sorted by family name, descending
![image](https://github.com/code-dot-org/code-dot-org/assets/2933346/c6fbc29c-aa4e-4146-be22-ba79dd6acf85)

PL section does not show family name column
![image](https://github.com/code-dot-org/code-dot-org/assets/2933346/3e749c9c-50c8-40f5-a22b-4b878bf5b014)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
