### PR TITLE
AI 101 - Add video #2 and LLM slides

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/ai-pl-101-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/ai-pl-101-styles.scss
@@ -128,7 +128,8 @@
   }
 
   &__image,
-  &__video {
+  &__video,
+  &__slides {
 
     @media (min-width: 971px) {
       margin: 20px 0 20px 20px;

--- a/pegasus/sites.v3/code.org/views/ai_101_videos.haml
+++ b/pegasus/sites.v3/code.org/views/ai_101_videos.haml
@@ -8,9 +8,9 @@
 
 - video_id = ["ai_101_01", "ai_101_02", "", "ai_chatbots"]
 
-- video_code = ["ik70A1ge-aY", "tePdN6me9rg", "", "X-AWdfSFCHQ"]
+- video_code = ["ik70A1ge-aY", "SgGVlTTXxMI", "", "X-AWdfSFCHQ"]
 
-- video_download_path = ["//videos.code.org/ai_101_for_teachers/ai_101_fireside_chat_01.mp4", "", "//videos.code.org/ai_series/HowAIWorks_LLM_SM_CoBrand.mp4"]
+- video_download_path = ["//videos.code.org/ai_101_for_teachers/ai_101_fireside_chat_01.mp4", "//videos.code.org/ai_101_for_teachers/ai_101_demystifying_ai_02.mp4", "//videos.code.org/ai_series/HowAIWorks_LLM_SM_CoBrand.mp4"]
 
 - video_101_index.times do |index|
   .action-block.action-block--two-col

--- a/pegasus/sites.v3/code.org/views/ai_101_videos.haml
+++ b/pegasus/sites.v3/code.org/views/ai_101_videos.haml
@@ -1,22 +1,25 @@
-- video_101_index = 6
+- video_101_index = 7
 
-- video_101_tags = [hoc_s(:module_label_new), hoc_s(:module_label_new), hoc_s(:module_label_coming_soon), hoc_s(:module_label_coming_soon), hoc_s(:module_label_coming_soon), hoc_s(:module_label_coming_soon)]
+- video_101_tags = [hoc_s(:module_label_available_now), hoc_s(:module_label_new), hoc_s(:module_label_new), hoc_s(:module_label_available_now), hoc_s(:module_label_coming_soon), hoc_s(:module_label_coming_soon), hoc_s(:module_label_coming_soon)]
 
-- video_101_title = [hoc_s(:ai_pl_101_video_title_1), hoc_s(:how_ai_works_hero_heading), hoc_s(:ai_pl_101_video_title_2), hoc_s(:ai_pl_101_video_title_3), hoc_s(:ai_pl_101_video_title_4), hoc_s(:ai_pl_101_video_title_5)]
+- video_101_title = [hoc_s(:ai_pl_101_video_title_1), hoc_s(:ai_pl_101_video_title_2), hoc_s(:ai_pl_101_llm_slides_title), hoc_s(:how_ai_works_hero_heading), hoc_s(:ai_pl_101_video_title_3), hoc_s(:ai_pl_101_video_title_4), hoc_s(:ai_pl_101_video_title_5)]
 
-- video_101_desc = [hoc_s(:ai_pl_101_video_desc_1), hoc_s(:ai_pl_101_video_desc_6), hoc_s(:ai_pl_101_video_desc_2), hoc_s(:ai_pl_101_video_desc_3), hoc_s(:ai_pl_101_video_desc_4), hoc_s(:ai_pl_101_video_desc_5)]
+- video_101_desc = [hoc_s(:ai_pl_101_video_desc_1), hoc_s(:ai_pl_101_video_desc_6), hoc_s(:ai_pl_101_llm_slides_desc), hoc_s(:ai_pl_101_video_desc_2), hoc_s(:ai_pl_101_video_desc_3), hoc_s(:ai_pl_101_video_desc_4), hoc_s(:ai_pl_101_video_desc_5)]
 
-- video_id = ["ai_101_01", "ai_chatbots"]
+- video_id = ["ai_101_01", "ai_101_02", "", "ai_chatbots"]
 
-- video_code = ["ik70A1ge-aY", "X-AWdfSFCHQ"]
+- video_code = ["ik70A1ge-aY", "tePdN6me9rg", "", "X-AWdfSFCHQ"]
 
-- video_download_path = ["//videos.code.org/ai_101_for_teachers/ai_101_fireside_chat_01.mp4", "//videos.code.org/ai_series/HowAIWorks_LLM_SM_CoBrand.mp4"]
+- video_download_path = ["//videos.code.org/ai_101_for_teachers/ai_101_fireside_chat_01.mp4", "", "//videos.code.org/ai_series/HowAIWorks_LLM_SM_CoBrand.mp4"]
 
 - video_101_index.times do |index|
   .action-block.action-block--two-col
-    - if index === 0 || index === 1
+    - if index === 0 || index === 1 || index === 3
       %figure.video-101__video.col-50
         = view :display_video_thumbnail, id: video_id[index], video_code: video_code[index], play_button: 'center', letterbox: 'false', download_path: video_download_path[index]
+    - elsif index === 2
+      %figure.video-101__slides.col-50
+        %iframe{allowfullscreen: "true", frameborder: "0", height: "258", mozallowfullscreen: "true", src: "https://docs.google.com/presentation/d/e/2PACX-1vRBPHqheht4zNPoFJhPPqT5T9a0b-J6Tm4MYdLRlbZSXBNaGHSFwisQmmdzJqQDs8Rl4cBZcyOLIXKy/embed?start=false&loop=false&delayms=3000", webkitallowfullscreen: "true", width: "459", style: "max-width: 100%;"}
     - else
       .video-101__image
         %img{src: "/images/ai/pl/101/coming-soon.jpg", alt: "", style: "width: 100%"}
@@ -27,9 +30,12 @@
         = video_101_title[index]
       %p.heading-sm
         = video_101_desc[index]
-      - if index === 1
+      - if index === 3
         %a.link-button{href: "/ai#ai-videos"}
           = hoc_s(:call_to_action_watch_now)
-      - if index >= 2
+      - elsif index === 2
+        %a.link-button{href: "https://docs.google.com/presentation/d/e/2PACX-1vRBPHqheht4zNPoFJhPPqT5T9a0b-J6Tm4MYdLRlbZSXBNaGHSFwisQmmdzJqQDs8Rl4cBZcyOLIXKy/pub?start=false&loop=false&delayms=3000", target: "_blank", rel: "noopener noreferrer"}
+          = hoc_s(:call_to_action_get_guide)
+      - if index >= 4
         %a.link-button.secondary{href: "#newsletter-signup"}
           = hoc_s(:call_to_action_notify_available)

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -197,6 +197,7 @@
   call_to_action_notify_available: "Notify me when available"
   call_to_action_register_early_access: "Register for early access"
   call_to_action_open_positions: "View open positions"
+  call_to_action_get_guide: "Get the guide"
 
   aria_label_call_to_action_afe: "Learn more about Amazon Future Engineer"
   aria_label_call_to_action_teaching_csf: "Start the Teaching Computer Science Fundamentals professional learning program"
@@ -330,6 +331,7 @@
   module_label_student_content_resources: "Content & resources"
   module_label_new: "New"
   module_label_coming_soon: "Coming soon"
+  module_label_available_now: "Available Now"
   module_label_video_series: "Video series"
   module_label_self_paced: "Self-paced module"
 
@@ -576,6 +578,8 @@
   ai_pl_101_video_title_5: "Bringing AI to the Classroom"
   ai_pl_101_video_desc_5: "This session focuses on teaching about AI, evaluating and utilizing AI educational tools, and leveraging AI for student assessment. With a rich blend of theory, practical examples, and resources, it aims to empower educators to navigate the AI landscape and enhance student learning experiences."
   ai_pl_101_video_desc_6: "Learn more about the new technology driving the large changes in AI, featuring two new videos on Large Language Models (like ChatGPT) and Generative AI. Hear how these new technologies work directly from the experts: Mira Murati, CTO of OpenAI, and Cristóbal Valenzuela, CEO of RunwayML."
+  ai_pl_101_llm_slides_title: "Large Language Model Prompts for Educators"
+  ai_pl_101_llm_slides_desc: "Tools for getting the best possible output from LLMs like ChatGPT, from beginner to advanced. Includes starter prompts for those just dipping their toes in, as well as advanced tools for those looking to maximize their potential."
 
   how_ai_works_hero_heading: "How AI Works"
   how_ai_works_hero_desc: "Dive into the world of AI with \"How AI Works,\" our video series and accompanying lessons!"


### PR DESCRIPTION
Update the https://code.org/ai/pl/101 page for Phase II of the launch:
- Add _Demystifying AI for Educators_ video
- Add LLM slides section

**Jira ticket:** [ACQ-782](https://codedotorg.atlassian.net/browse/ACQ-782)

----

### Before
<img width="751" alt="Screenshot 2023-08-31 at 1 02 12 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/6a8636b0-53a6-41db-8628-3b510522c5e1">

### After
<img width="751" alt="Screenshot 2023-08-31 at 1 02 29 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/2a978905-58d0-430a-a4a3-a2f74fe0c45b">
