### PR TITLE
Serialize new field

### DIFF
--- a/dashboard/config/course_offerings/20-hour.json
+++ b/dashboard/config/course_offerings/20-hour.json
@@ -15,6 +15,7 @@
   "description": "Let's go! This accelerated course covers core computer science and programming concepts.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2013-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2013-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/2018hoc-ab.json
+++ b/dashboard/config/course_offerings/2018hoc-ab.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/2021-cs-discoveries-deeper-learning-.json
+++ b/dashboard/config/course_offerings/2021-cs-discoveries-deeper-learning-.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/2021-cs-principles-deeper-learning.json
+++ b/dashboard/config/course_offerings/2021-cs-principles-deeper-learning.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/2021drafting-1.json
+++ b/dashboard/config/course_offerings/2021drafting-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/2021drafting.json
+++ b/dashboard/config/course_offerings/2021drafting.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/ai-classroom-test.json
+++ b/dashboard/config/course_offerings/ai-classroom-test.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/ai-ethics.json
+++ b/dashboard/config/course_offerings/ai-ethics.json
@@ -15,6 +15,7 @@
   "description": "Reflect on the ethical implications of AI, then work together to create an \"AI Code of Ethics\" resource for AI creators and legislators everywhere.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/tJQSyzBUAew/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=tJQSyzBUAew&wmode=transparent",
-  "published_date": "2020-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2020-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/ai-lab.json
+++ b/dashboard/config/course_offerings/ai-lab.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/ai-temp.json
+++ b/dashboard/config/course_offerings/ai-temp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/ai-unit-pilot.json
+++ b/dashboard/config/course_offerings/ai-unit-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/aichat.json
+++ b/dashboard/config/course_offerings/aichat.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/aiml.json
+++ b/dashboard/config/course_offerings/aiml.json
@@ -15,6 +15,7 @@
   "description": "Explore how computers learn from data to make decisions, then develop projects around real-world data and design an app to solve a personally relevant problem.",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/bGJ05vdI3xA/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=bGJ05vdI3xA&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 460
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 460,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/algebra.json
+++ b/dashboard/config/course_offerings/algebra.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/algebraa.json
+++ b/dashboard/config/course_offerings/algebraa.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/algebrab.json
+++ b/dashboard/config/course_offerings/algebrab.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/algebrademo.json
+++ b/dashboard/config/course_offerings/algebrademo.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/all-the-plc-things.json
+++ b/dashboard/config/course_offerings/all-the-plc-things.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/alltheblocklythings.json
+++ b/dashboard/config/course_offerings/alltheblocklythings.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/alltheselfpacedplthings.json
+++ b/dashboard/config/course_offerings/alltheselfpacedplthings.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/allthesurveys.json
+++ b/dashboard/config/course_offerings/allthesurveys.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/allthethingscourse.json
+++ b/dashboard/config/course_offerings/allthethingscourse.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/allthettsthings.json
+++ b/dashboard/config/course_offerings/allthettsthings.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/allthevalidation.json
+++ b/dashboard/config/course_offerings/allthevalidation.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/amy-playground.json
+++ b/dashboard/config/course_offerings/amy-playground.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/amys-playground.json
+++ b/dashboard/config/course_offerings/amys-playground.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/andrea-test-dlp.json
+++ b/dashboard/config/course_offerings/andrea-test-dlp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/andrea-test.json
+++ b/dashboard/config/course_offerings/andrea-test.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/angelina-playground.json
+++ b/dashboard/config/course_offerings/angelina-playground.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/applab-1hour.json
+++ b/dashboard/config/course_offerings/applab-1hour.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/applab-2hour.json
+++ b/dashboard/config/course_offerings/applab-2hour.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/applab-intro-staging.json
+++ b/dashboard/config/course_offerings/applab-intro-staging.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/applab-intro.json
+++ b/dashboard/config/course_offerings/applab-intro.json
@@ -15,6 +15,7 @@
   "description": "Welcome to AppLab! Create your own app in JavaScript using either block-based programming or text.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/wAuYr1IntQs/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=wAuYr1IntQs&wmode=transparent",
-  "published_date": "2017-11-27 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2017-11-27 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/apps-for-good.json
+++ b/dashboard/config/course_offerings/apps-for-good.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/aquatic.json
+++ b/dashboard/config/course_offerings/aquatic.json
@@ -15,6 +15,7 @@
   "description": "Build and explore with Minecraft! Use your creativity and problem solving skills to explore and build underwater worlds with code.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/92sMXSm4dIg/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=92sMXSm4dIg&wmode=transparent",
-  "published_date": "2018-11-12 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2018-11-12 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/artist-and-bb8.json
+++ b/dashboard/config/course_offerings/artist-and-bb8.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/artist.json
+++ b/dashboard/config/course_offerings/artist.json
@@ -15,6 +15,7 @@
   "description": "In this activity, students use programming blocks to create images of increasing complexity.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/ws8rmHcqXeM/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=ws8rmHcqXeM&wmode=transparent",
-  "published_date": "2015-01-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2015-01-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/artistexemplar.json
+++ b/dashboard/config/course_offerings/artistexemplar.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/asunplugged.json
+++ b/dashboard/config/course_offerings/asunplugged.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/aws-demo.json
+++ b/dashboard/config/course_offerings/aws-demo.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/basketball.json
+++ b/dashboard/config/course_offerings/basketball.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/ip051U7Rvds/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=ip051U7Rvds&wmode=transparent",
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/bingo.json
+++ b/dashboard/config/course_offerings/bingo.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/blockchain.json
+++ b/dashboard/config/course_offerings/blockchain.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/MjibPL4tGqo/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=MjibPL4tGqo&wmode=transparent",
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/code-break-staging.json
+++ b/dashboard/config/course_offerings/code-break-staging.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/code-break-younger-staging.json
+++ b/dashboard/config/course_offerings/code-break-younger-staging.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/code-break-younger.json
+++ b/dashboard/config/course_offerings/code-break-younger.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/27ln76y27IQ/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=27ln76y27IQ&wmode=transparent",
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/code-break.json
+++ b/dashboard/config/course_offerings/code-break.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/27ln76y27IQ/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=27ln76y27IQ&wmode=transparent",
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/codestudiopuzzlechallenge.json
+++ b/dashboard/config/course_offerings/codestudiopuzzlechallenge.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/colehoc17.json
+++ b/dashboard/config/course_offerings/colehoc17.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/colehoc2017.json
+++ b/dashboard/config/course_offerings/colehoc2017.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/contagion-guided-practice-1.json
+++ b/dashboard/config/course_offerings/contagion-guided-practice-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/contagion-guided-practice.json
+++ b/dashboard/config/course_offerings/contagion-guided-practice.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/contagion-pilot-1.json
+++ b/dashboard/config/course_offerings/contagion-pilot-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/contagion-pilot.json
+++ b/dashboard/config/course_offerings/contagion-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/counting-csc.json
+++ b/dashboard/config/course_offerings/counting-csc.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/course-e-2018.json
+++ b/dashboard/config/course_offerings/course-e-2018.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/course-f-2018.json
+++ b/dashboard/config/course_offerings/course-f-2018.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/course1.json
+++ b/dashboard/config/course_offerings/course1.json
@@ -15,6 +15,7 @@
   "description": "There's no I in Team! In this course, students create programs that help them learn to collaborate with others and persist through difficult tasks.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2014-08-01 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2014-08-01 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/course2.json
+++ b/dashboard/config/course_offerings/course2.json
@@ -15,6 +15,7 @@
   "description": "In this course, students create programs to solve problems, as well as interactive games or stories to share.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2014-08-01 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2014-08-01 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/course3.json
+++ b/dashboard/config/course_offerings/course3.json
@@ -15,6 +15,7 @@
   "description": "Students dive deeper into programming topics introduced in previous courses to create flexible solutions to more complex problems.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2014-08-01 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2014-08-01 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/course4.json
+++ b/dashboard/config/course_offerings/course4.json
@@ -15,6 +15,7 @@
   "description": "In this course, students learn to tackle increasingly complex puzzles and combine several concepts when solving challenges. ",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2016-05-06 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2016-05-06 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/course4pre.json
+++ b/dashboard/config/course_offerings/course4pre.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursea-draft.json
+++ b/dashboard/config/course_offerings/coursea-draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursea.json
+++ b/dashboard/config/course_offerings/coursea.json
@@ -15,6 +15,7 @@
   "description": "In this course, students work with others, investigate problem-solving techniques, and learn to program using commands like loops and events.",
   "professional_learning_program": "https://code.org/professional-development-workshops",
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 93
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 93,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/courseb-draft.json
+++ b/dashboard/config/course_offerings/courseb-draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/courseb.json
+++ b/dashboard/config/course_offerings/courseb.json
@@ -15,6 +15,7 @@
   "description": "Students continue learning programming basics, as well as persistence and critical thinking. At the end of the course, students can create games in Play Lab!",
   "professional_learning_program": "https://code.org/professional-development-workshops",
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 93
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 93,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursec-draft.json
+++ b/dashboard/config/course_offerings/coursec-draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursec.json
+++ b/dashboard/config/course_offerings/coursec.json
@@ -15,6 +15,7 @@
   "description": "In this course, students create programs with sequencing, loops, and events. They also investigate problem-solving techniques and build interactive games.",
   "professional_learning_program": "https://code.org/professional-development-workshops",
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 93
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 93,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursed-draft.json
+++ b/dashboard/config/course_offerings/coursed-draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursed-ramp.json
+++ b/dashboard/config/course_offerings/coursed-ramp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursed.json
+++ b/dashboard/config/course_offerings/coursed.json
@@ -15,6 +15,7 @@
   "description": "This course covers concepts like loops and events from earlier courses, before moving on to algorithms, conditionals, and more.",
   "professional_learning_program": "https://code.org/professional-development-workshops",
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 93
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 93,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursee-draft.json
+++ b/dashboard/config/course_offerings/coursee-draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursee-ramp.json
+++ b/dashboard/config/course_offerings/coursee-ramp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursee.json
+++ b/dashboard/config/course_offerings/coursee.json
@@ -15,6 +15,7 @@
   "description": "Get to know the Sprite Lab programming environment in this course! By the end, students will use code to create a game or drawing.",
   "professional_learning_program": "https://code.org/professional-development-workshops",
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 93
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 93,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursef-2022-pilot.json
+++ b/dashboard/config/course_offerings/coursef-2022-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursef-draft.json
+++ b/dashboard/config/course_offerings/coursef-draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursef-ramp.json
+++ b/dashboard/config/course_offerings/coursef-ramp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/coursef.json
+++ b/dashboard/config/course_offerings/coursef.json
@@ -15,6 +15,7 @@
   "description": "Decisions, decisions! This course teaches students about variables, as they're given greater autonomy and choices while creating an interactive project. ",
   "professional_learning_program": "https://code.org/professional-development-workshops",
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 93
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 93,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/craft17-kiki.json
+++ b/dashboard/config/course_offerings/craft17-kiki.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/craft17.json
+++ b/dashboard/config/course_offerings/craft17.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/craft18.json
+++ b/dashboard/config/course_offerings/craft18.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-discoveries-deeper-learning-2019---2020.json
+++ b/dashboard/config/course_offerings/cs-discoveries-deeper-learning-2019---2020.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-discoveries-deeper-learning-2021.json
+++ b/dashboard/config/course_offerings/cs-discoveries-deeper-learning-2021.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-discoveries-facilitator-in-training-2018-2019.json
+++ b/dashboard/config/course_offerings/cs-discoveries-facilitator-in-training-2018-2019.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-discoveries-facilitator-in-training.json
+++ b/dashboard/config/course_offerings/cs-discoveries-facilitator-in-training.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-discoveries-facilitators-in-training-2018-2019.json
+++ b/dashboard/config/course_offerings/cs-discoveries-facilitators-in-training-2018-2019.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-discoveries-teachercon-novice.json
+++ b/dashboard/config/course_offerings/cs-discoveries-teachercon-novice.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-discoviers-teachercon-novice.json
+++ b/dashboard/config/course_offerings/cs-discoviers-teachercon-novice.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-in-algebra-legacy.json
+++ b/dashboard/config/course_offerings/cs-in-algebra-legacy.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-in-algebra-support.json
+++ b/dashboard/config/course_offerings/cs-in-algebra-support.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-in-science-legacy.json
+++ b/dashboard/config/course_offerings/cs-in-science-legacy.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-in-science-support.json
+++ b/dashboard/config/course_offerings/cs-in-science-support.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-in-science.json
+++ b/dashboard/config/course_offerings/cs-in-science.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-principles-curriculum-training-for-facilitators.json
+++ b/dashboard/config/course_offerings/cs-principles-curriculum-training-for-facilitators.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-principles-deeper-learning-2019---2020.json
+++ b/dashboard/config/course_offerings/cs-principles-deeper-learning-2019---2020.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-principles-deeper-learning-2021.json
+++ b/dashboard/config/course_offerings/cs-principles-deeper-learning-2021.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-principles-facilitator-in-training-2018-2019.json
+++ b/dashboard/config/course_offerings/cs-principles-facilitator-in-training-2018-2019.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-principles-facilitator-in-training.json
+++ b/dashboard/config/course_offerings/cs-principles-facilitator-in-training.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-principles-facilitators-in-training-2018-2019.json
+++ b/dashboard/config/course_offerings/cs-principles-facilitators-in-training-2018-2019.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-principles-support.json
+++ b/dashboard/config/course_offerings/cs-principles-support.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs-principles-teachercon-novice.json
+++ b/dashboard/config/course_offerings/cs-principles-teachercon-novice.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cs4all-invasive-species.json
+++ b/dashboard/config/course_offerings/cs4all-invasive-species.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-async.json
+++ b/dashboard/config/course_offerings/csa-async.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-backpack-2022.json
+++ b/dashboard/config/course_offerings/csa-backpack-2022.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-celebrity-lab.json
+++ b/dashboard/config/course_offerings/csa-celebrity-lab.json
@@ -15,6 +15,7 @@
   "description": "Practice for the big exam with this lab, which focuses on calling methods and building strings in an interesting and engaging way.",
   "professional_learning_program": null,
   "video": null,
-  "published_date": "2022-08-01 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2022-08-01 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-collegeboard-labs.json
+++ b/dashboard/config/course_offerings/csa-collegeboard-labs.json
@@ -15,6 +15,7 @@
   "description": "\"Hey Siri, what's natural language processing?\" The answer may be complicated, but this lab makes it easy to create a program that responds to your sentences.",
   "professional_learning_program": null,
   "video": null,
-  "published_date": "2022-08-01 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2022-08-01 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-data-lab.json
+++ b/dashboard/config/course_offerings/csa-data-lab.json
@@ -15,6 +15,7 @@
   "description": "Is this real life? Yes! Incorporate real-world data sets into hands-on programming assignments with this lab.",
   "professional_learning_program": null,
   "video": null,
-  "published_date": "2022-08-01 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2022-08-01 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-draft-pl.json
+++ b/dashboard/config/course_offerings/csa-draft-pl.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-examples-21.json
+++ b/dashboard/config/course_offerings/csa-examples-21.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-examples-22.json
+++ b/dashboard/config/course_offerings/csa-examples-22.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-frq-practice-2019.json
+++ b/dashboard/config/course_offerings/csa-frq-practice-2019.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-frq-practice-2021.json
+++ b/dashboard/config/course_offerings/csa-frq-practice-2021.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-frq-practice-2022.json
+++ b/dashboard/config/course_offerings/csa-frq-practice-2022.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-frq-practice-2023.json
+++ b/dashboard/config/course_offerings/csa-frq-practice-2023.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-frq-practice-pre2019.json
+++ b/dashboard/config/course_offerings/csa-frq-practice-pre2019.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-frq-practice.json
+++ b/dashboard/config/course_offerings/csa-frq-practice.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-labs.json
+++ b/dashboard/config/course_offerings/csa-labs.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-pilot-extra.json
+++ b/dashboard/config/course_offerings/csa-pilot-extra.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-pilot-facilitator.json
+++ b/dashboard/config/course_offerings/csa-pilot-facilitator.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-pl-standalone-code-2022.json
+++ b/dashboard/config/course_offerings/csa-pl-standalone-code-2022.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-preview.json
+++ b/dashboard/config/course_offerings/csa-preview.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-self-paced-pl.json
+++ b/dashboard/config/course_offerings/csa-self-paced-pl.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-software-engineering.json
+++ b/dashboard/config/course_offerings/csa-software-engineering.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-u6-dev.json
+++ b/dashboard/config/course_offerings/csa-u6-dev.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-u7-dev.json
+++ b/dashboard/config/course_offerings/csa-u7-dev.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-u8-dev.json
+++ b/dashboard/config/course_offerings/csa-u8-dev.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-validation-pilot.json
+++ b/dashboard/config/course_offerings/csa-validation-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa-videos.json
+++ b/dashboard/config/course_offerings/csa-videos.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa.json
+++ b/dashboard/config/course_offerings/csa.json
@@ -15,6 +15,7 @@
   "description": "Introduce students to software engineering and design as they learn the Java programming language in this free curriculum for AP® Computer Science A (AP® CSA).",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/lFkFi2jGs70/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=lFkFi2jGs70&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa1-2022-exemplars.json
+++ b/dashboard/config/course_offerings/csa1-2022-exemplars.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa1-exemplars.json
+++ b/dashboard/config/course_offerings/csa1-exemplars.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa2-2022-exemplars.json
+++ b/dashboard/config/course_offerings/csa2-2022-exemplars.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa2-exemplars.json
+++ b/dashboard/config/course_offerings/csa2-exemplars.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa3-exemplars.json
+++ b/dashboard/config/course_offerings/csa3-exemplars.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa4-exemplars.json
+++ b/dashboard/config/course_offerings/csa4-exemplars.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa5-exemplars.json
+++ b/dashboard/config/course_offerings/csa5-exemplars.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa6-exemplars.json
+++ b/dashboard/config/course_offerings/csa6-exemplars.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa7-exemplars.json
+++ b/dashboard/config/course_offerings/csa7-exemplars.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csa8-exemplars.json
+++ b/dashboard/config/course_offerings/csa8-exemplars.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-adaptations.json
+++ b/dashboard/config/course_offerings/csc-adaptations.json
@@ -15,6 +15,7 @@
   "description": "Use code to model animal adaptations, deepening your understanding of how different species have evolved to survive in their environments.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/LmqbEewwOGc/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=LmqbEewwOGc&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 421
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 421,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-bookcover.json
+++ b/dashboard/config/course_offerings/csc-bookcover.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-bookcovers.json
+++ b/dashboard/config/course_offerings/csc-bookcovers.json
@@ -15,6 +15,7 @@
   "description": "Use code to create an interactive cover of a book, using sprites and text to convey characters, setting, and more.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/CqUNczW1oKs/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=CqUNczW1oKs&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 421
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 421,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-ecosystems-1.json
+++ b/dashboard/config/course_offerings/csc-ecosystems-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-ecosystems.json
+++ b/dashboard/config/course_offerings/csc-ecosystems.json
@@ -15,6 +15,7 @@
   "description": "Code a marine ecosystem simulation to discover the delicate balance of organisms' interdependencies, then explore sustainable solutions to human impact.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/Nrk0kDJr1ks/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=Nrk0kDJr1ks&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 421
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 421,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-fables.json
+++ b/dashboard/config/course_offerings/csc-fables.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-function-machines-pilot.json
+++ b/dashboard/config/course_offerings/csc-function-machines-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-landmarks-pilot.json
+++ b/dashboard/config/course_offerings/csc-landmarks-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-mappinglandmarks.json
+++ b/dashboard/config/course_offerings/csc-mappinglandmarks.json
@@ -15,6 +15,7 @@
   "description": "Use coding to develop a map that tells a story, allowing you to explore geographic information in an engaging and interactive way.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/Aut4zw_U3dg/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=Aut4zw_U3dg&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 421
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 421,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-particles.json
+++ b/dashboard/config/course_offerings/csc-particles.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-2022-ecosystems.json
+++ b/dashboard/config/course_offerings/csc-pilot-2022-ecosystems.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-2022-fables.json
+++ b/dashboard/config/course_offerings/csc-pilot-2022-fables.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-2022-starquilts.json
+++ b/dashboard/config/course_offerings/csc-pilot-2022-starquilts.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-2022-timecapsule.json
+++ b/dashboard/config/course_offerings/csc-pilot-2022-timecapsule.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-fa2022-ecosystem.json
+++ b/dashboard/config/course_offerings/csc-pilot-fa2022-ecosystem.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-fa2022-particles.json
+++ b/dashboard/config/course_offerings/csc-pilot-fa2022-particles.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-fa2022-timecapsule.json
+++ b/dashboard/config/course_offerings/csc-pilot-fa2022-timecapsule.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-starquilts.json
+++ b/dashboard/config/course_offerings/csc-starquilts.json
@@ -15,6 +15,7 @@
   "description": "Learn code to create geometric patterns in stunning star quilts, blending mathematical concepts with creative expression.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/XtbUUMbqeSY/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=XtbUUMbqeSY&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 421
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 421,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csc-timecapsule.json
+++ b/dashboard/config/course_offerings/csc-timecapsule.json
@@ -15,6 +15,7 @@
   "description": "Create a digital time capsule poem to capture a moment in time to share with the future.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/9zkGt7EkbOs/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=9zkGt7EkbOs&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 421
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 421,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd-bugs.json
+++ b/dashboard/config/course_offerings/csd-bugs.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd-playground.json
+++ b/dashboard/config/course_offerings/csd-playground.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd-post-survey.json
+++ b/dashboard/config/course_offerings/csd-post-survey.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd-sample-online.json
+++ b/dashboard/config/course_offerings/csd-sample-online.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd-test-saving-state.json
+++ b/dashboard/config/course_offerings/csd-test-saving-state.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd-tests.json
+++ b/dashboard/config/course_offerings/csd-tests.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd-videos.json
+++ b/dashboard/config/course_offerings/csd-videos.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd.json
+++ b/dashboard/config/course_offerings/csd.json
@@ -15,6 +15,7 @@
   "description": "An introductory course that empowers students to engage with computer science as a medium for creativity, communication, problem solving, and fun.",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/g4qfsH8bc8s/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=g4qfsH8bc8s&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 346
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 346,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd1-old.json
+++ b/dashboard/config/course_offerings/csd1-old.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd1.json
+++ b/dashboard/config/course_offerings/csd1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd2-old.json
+++ b/dashboard/config/course_offerings/csd2-old.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd2-projects-temp.json
+++ b/dashboard/config/course_offerings/csd2-projects-temp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd2-virtual.json
+++ b/dashboard/config/course_offerings/csd2-virtual.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd2.json
+++ b/dashboard/config/course_offerings/csd2.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd3-1819draft.json
+++ b/dashboard/config/course_offerings/csd3-1819draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd3-old.json
+++ b/dashboard/config/course_offerings/csd3-old.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd3-virtual.json
+++ b/dashboard/config/course_offerings/csd3-virtual.json
@@ -15,6 +15,7 @@
   "description": "Move at your own pace in this introduction to our Game Lab environment as you program animations, interactive art, and games.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/PXn9gKiKKFo/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=PXn9gKiKKFo&wmode=transparent",
-  "published_date": "2020-03-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2020-03-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd3.json
+++ b/dashboard/config/course_offerings/csd3.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd4-draft.json
+++ b/dashboard/config/course_offerings/csd4-draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd4-old.json
+++ b/dashboard/config/course_offerings/csd4-old.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd4-preview-2021-1.json
+++ b/dashboard/config/course_offerings/csd4-preview-2021-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd4-preview-2021.json
+++ b/dashboard/config/course_offerings/csd4-preview-2021.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd4.json
+++ b/dashboard/config/course_offerings/csd4.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd5-draft.json
+++ b/dashboard/config/course_offerings/csd5-draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd5-old.json
+++ b/dashboard/config/course_offerings/csd5-old.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd5-preview-2021-1.json
+++ b/dashboard/config/course_offerings/csd5-preview-2021-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd5-preview-2021.json
+++ b/dashboard/config/course_offerings/csd5-preview-2021.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd5.json
+++ b/dashboard/config/course_offerings/csd5.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd6-draft.json
+++ b/dashboard/config/course_offerings/csd6-draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd6-old.json
+++ b/dashboard/config/course_offerings/csd6-old.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd6-pilot.json
+++ b/dashboard/config/course_offerings/csd6-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd6-projects.json
+++ b/dashboard/config/course_offerings/csd6-projects.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd6.json
+++ b/dashboard/config/course_offerings/csd6.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csd7.json
+++ b/dashboard/config/course_offerings/csd7.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csdgraveyard.json
+++ b/dashboard/config/course_offerings/csdgraveyard.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csf-2021-pilot-1.json
+++ b/dashboard/config/course_offerings/csf-2021-pilot-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csf-2021-pilot.json
+++ b/dashboard/config/course_offerings/csf-2021-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csf-pilot.json
+++ b/dashboard/config/course_offerings/csf-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csf-secret-sample-story.json
+++ b/dashboard/config/course_offerings/csf-secret-sample-story.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csf-secret-sample.json
+++ b/dashboard/config/course_offerings/csf-secret-sample.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csf2harvey.json
+++ b/dashboard/config/course_offerings/csf2harvey.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csl-vn.json
+++ b/dashboard/config/course_offerings/csl-vn.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp-ap.json
+++ b/dashboard/config/course_offerings/csp-ap.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp-ca-a.json
+++ b/dashboard/config/course_offerings/csp-ca-a.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp-exam.json
+++ b/dashboard/config/course_offerings/csp-exam.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp-mid-survey.json
+++ b/dashboard/config/course_offerings/csp-mid-survey.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp-online-test.json
+++ b/dashboard/config/course_offerings/csp-online-test.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp-playground.json
+++ b/dashboard/config/course_offerings/csp-playground.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp-pre-survey.json
+++ b/dashboard/config/course_offerings/csp-pre-survey.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp-support.json
+++ b/dashboard/config/course_offerings/csp-support.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp.json
+++ b/dashboard/config/course_offerings/csp.json
@@ -15,6 +15,7 @@
   "description": "Taught as an intro or AP course, this curriculum introduces students to computer science and challenges them to explore how technology can impact the world. ",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/jQm0z894CG0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=jQm0z894CG0&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 347
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 347,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp3-recovery.json
+++ b/dashboard/config/course_offerings/csp3-recovery.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp3-staging.json
+++ b/dashboard/config/course_offerings/csp3-staging.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp3-virtual.json
+++ b/dashboard/config/course_offerings/csp3-virtual.json
@@ -15,6 +15,7 @@
   "description": "Unlock the ability to make rich, interactive apps with JavaScript in the App Lab!",
   "professional_learning_program": null,
   "video": null,
-  "published_date": "2020-03-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2020-03-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp5-virtual-part2.json
+++ b/dashboard/config/course_offerings/csp5-virtual-part2.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp5-virtual.json
+++ b/dashboard/config/course_offerings/csp5-virtual.json
@@ -15,6 +15,7 @@
   "description": "Go at your own pace with this introduction to the App Lab programming environment, in which students use JavaScript to create interactive apps.",
   "professional_learning_program": null,
   "video": null,
-  "published_date": "2020-03-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2020-03-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csp6.json
+++ b/dashboard/config/course_offerings/csp6.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspassessment.json
+++ b/dashboard/config/course_offerings/cspassessment.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspexam1-mwu7ildym9.json
+++ b/dashboard/config/course_offerings/cspexam1-mwu7ildym9.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspexam2-akwgah1ac5.json
+++ b/dashboard/config/course_offerings/cspexam2-akwgah1ac5.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/csplessonsamples.json
+++ b/dashboard/config/course_offerings/csplessonsamples.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspoptional.json
+++ b/dashboard/config/course_offerings/cspoptional.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspunit1-support-test.json
+++ b/dashboard/config/course_offerings/cspunit1-support-test.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspunit1-support.json
+++ b/dashboard/config/course_offerings/cspunit1-support.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspunit1.json
+++ b/dashboard/config/course_offerings/cspunit1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspunit2.json
+++ b/dashboard/config/course_offerings/cspunit2.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspunit3.json
+++ b/dashboard/config/course_offerings/cspunit3.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspunit3temp.json
+++ b/dashboard/config/course_offerings/cspunit3temp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspunit4.json
+++ b/dashboard/config/course_offerings/cspunit4.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspunit4draft.json
+++ b/dashboard/config/course_offerings/cspunit4draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspunit5.json
+++ b/dashboard/config/course_offerings/cspunit5.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspunit6.json
+++ b/dashboard/config/course_offerings/cspunit6.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/cspunit6draft.json
+++ b/dashboard/config/course_offerings/cspunit6draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/curriculum-sandbox-levels.json
+++ b/dashboard/config/course_offerings/curriculum-sandbox-levels.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/dance-2019.json
+++ b/dashboard/config/course_offerings/dance-2019.json
@@ -15,6 +15,7 @@
   "description": "One of our most popular lessons! Get creative when you use code to make animated characters bust a move in this introductory activity. Requires sound, reading.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/tY09z2y8-xQ/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=tY09z2y8-xQ&wmode=transparent",
-  "published_date": "2019-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2019-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/dance-draft.json
+++ b/dashboard/config/course_offerings/dance-draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/dance-extras-2019.json
+++ b/dashboard/config/course_offerings/dance-extras-2019.json
@@ -15,6 +15,7 @@
   "description": "One of our most popular lessons! Get creative when you use code to make animated characters bust a move in this introductory activity. Requires sound, reading.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/pIxdBhJb8lc/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=pIxdBhJb8lc&wmode=transparent",
-  "published_date": "2019-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2019-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/dance-extras-gallery.json
+++ b/dashboard/config/course_offerings/dance-extras-gallery.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/dance-extras.json
+++ b/dashboard/config/course_offerings/dance-extras.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/pIxdBhJb8lc/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=pIxdBhJb8lc&wmode=transparent",
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/dance-low.json
+++ b/dashboard/config/course_offerings/dance-low.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/dance-unplugged.json
+++ b/dashboard/config/course_offerings/dance-unplugged.json
@@ -15,6 +15,7 @@
   "description": "Get your groove on—offline! Learn how to jazz up your program with events. Events can control actions and even make multiple things act in sync.",
   "professional_learning_program": null,
   "video": null,
-  "published_date": "2019-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2019-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/dance.json
+++ b/dashboard/config/course_offerings/dance.json
@@ -15,6 +15,7 @@
   "description": "One of our most popular lessons! Get creative when you use code to make animated characters bust a move in this introductory activity. Requires sound, reading.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/bVHSrWuROrk/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=bVHSrWuROrk&wmode=transparent",
-  "published_date": "2018-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2018-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/dani-june-2020-test.json
+++ b/dashboard/config/course_offerings/dani-june-2020-test.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/data-society.json
+++ b/dashboard/config/course_offerings/data-society.json
@@ -15,6 +15,7 @@
   "description": "In this unit, students learn about the importance of using data to solve problems and understand how computers can help in this process. ",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/15aqFQQVBWU/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=15aqFQQVBWU&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 443
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 443,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/deepdive-debugging.json
+++ b/dashboard/config/course_offerings/deepdive-debugging.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/default.json
+++ b/dashboard/config/course_offerings/default.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/denny-science-8.json
+++ b/dashboard/config/course_offerings/denny-science-8.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/denny-science-copy.json
+++ b/dashboard/config/course_offerings/denny-science-copy.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/denny-science.json
+++ b/dashboard/config/course_offerings/denny-science.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/design-process.json
+++ b/dashboard/config/course_offerings/design-process.json
@@ -15,6 +15,7 @@
   "description": "Through design challenges, a team project, and building an app prototype, this unit prompts students to consider the broader social impacts of computer science.",
   "professional_learning_program": "https://code.org/apply",
   "video": null,
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 443
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 443,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/devices.json
+++ b/dashboard/config/course_offerings/devices.json
@@ -15,6 +15,7 @@
   "description": "In this unit, students use App Lab and Adafruit's Circuit Playground to develop programs that use the same hardware inputs and outputs found in smart devices.",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/3wy9EXKhbtU/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=3wy9EXKhbtU&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 401
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 401,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/dlp-core.json
+++ b/dashboard/config/course_offerings/dlp-core.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/dlp-csd-mod4.json
+++ b/dashboard/config/course_offerings/dlp-csd-mod4.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/dlp-csp-mod4.json
+++ b/dashboard/config/course_offerings/dlp-csp-mod4.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/drafting.json
+++ b/dashboard/config/course_offerings/drafting.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/duino.json
+++ b/dashboard/config/course_offerings/duino.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/e-f-ramp.json
+++ b/dashboard/config/course_offerings/e-f-ramp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/ecs-support-legacy.json
+++ b/dashboard/config/course_offerings/ecs-support-legacy.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/ecs-support.json
+++ b/dashboard/config/course_offerings/ecs-support.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/edit-code-1.json
+++ b/dashboard/config/course_offerings/edit-code-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/edit-code.json
+++ b/dashboard/config/course_offerings/edit-code.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/emma.json
+++ b/dashboard/config/course_offerings/emma.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/emmas-playground.json
+++ b/dashboard/config/course_offerings/emmas-playground.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/equity-support.json
+++ b/dashboard/config/course_offerings/equity-support.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/events.json
+++ b/dashboard/config/course_offerings/events.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/explore-data-1.json
+++ b/dashboard/config/course_offerings/explore-data-1.json
@@ -15,6 +15,7 @@
   "description": "Learn more about how you can explore data in bar charts and histograms. Code, create, and decode data magic using App Lab. Let's visualize and conquer!",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/OjUEFHo3Yw0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=OjUEFHo3Yw0&wmode=transparent",
-  "published_date": "2021-07-14 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2021-07-14 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/express.json
+++ b/dashboard/config/course_offerings/express.json
@@ -15,6 +15,7 @@
   "description": "Let your students learn computer science at their own pace! Learn to create computer programs, develop problem-solving skills, and work through fun challenges.",
   "professional_learning_program": "https://code.org/professional-development-workshops",
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 93
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 93,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/ey-ecosystems.json
+++ b/dashboard/config/course_offerings/ey-ecosystems.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/facilitators-in-training-summer-2019.json
+++ b/dashboard/config/course_offerings/facilitators-in-training-summer-2019.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/facilitators-in-training-summer-reflections-2019.json
+++ b/dashboard/config/course_offerings/facilitators-in-training-summer-reflections-2019.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/fancygeometry-pilot.json
+++ b/dashboard/config/course_offerings/fancygeometry-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/fit-weekend-in-person.json
+++ b/dashboard/config/course_offerings/fit-weekend-in-person.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/fit2019-apprentice-1.json
+++ b/dashboard/config/course_offerings/fit2019-apprentice-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/fit2019-apprentice.json
+++ b/dashboard/config/course_offerings/fit2019-apprentice.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/flappy-impact-study.json
+++ b/dashboard/config/course_offerings/flappy-impact-study.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/flappy.json
+++ b/dashboard/config/course_offerings/flappy.json
@@ -15,6 +15,7 @@
   "description": "Create a game using basic block code in this introductory computer science activity.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/VQ4lo6Huylc/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=VQ4lo6Huylc&wmode=transparent",
-  "published_date": "2014-02-26 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2014-02-26 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/fmscsd3preview.json
+++ b/dashboard/config/course_offerings/fmscsd3preview.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/focus-on-coding.json
+++ b/dashboard/config/course_offerings/focus-on-coding.json
@@ -15,6 +15,7 @@
   "description": "Are you ready to code? This unit empowers students to strengthen their programming skills in web development, app development, and more.",
   "professional_learning_program": "https://code.org/apply",
   "video": null,
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 443
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 443,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/focus-on-creativity.json
+++ b/dashboard/config/course_offerings/focus-on-creativity.json
@@ -15,6 +15,7 @@
   "description": "What will you create? This unit empowers students to be creative as they make websites, animations, games, and apps for devices. ",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/aAS3K93_Nks/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=aAS3K93_Nks&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 443
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 443,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/focus-on-data.json
+++ b/dashboard/config/course_offerings/focus-on-data.json
@@ -15,6 +15,7 @@
   "description": "This unit empowers students to use data to solve problems by engaging with computer science as a medium for creativity, communication, problem-solving, and fun.",
   "professional_learning_program": "https://code.org/apply",
   "video": null,
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 443
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 443,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/focus-on-design-with-purpose.json
+++ b/dashboard/config/course_offerings/focus-on-design-with-purpose.json
@@ -15,6 +15,7 @@
   "description": "In this unit, students are challenged to think about user needs when it comes to designing websites and apps.",
   "professional_learning_program": "https://code.org/apply",
   "video": null,
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 443
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 443,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/focus-on-hardware.json
+++ b/dashboard/config/course_offerings/focus-on-hardware.json
@@ -15,6 +15,7 @@
   "description": "Let's talk hardware! This unit helps students learn how to use physical devices to solve problems.",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/OAx_6-wdslM/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=OAx_6-wdslM&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 443
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 443,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/focus-on-impact-in-society.json
+++ b/dashboard/config/course_offerings/focus-on-impact-in-society.json
@@ -15,6 +15,7 @@
   "description": "How does code impact the world around us? In this unit, students are challenged to consider the broader social impacts of various aspects of computer science.",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/QvyTEx1wyOY/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=QvyTEx1wyOY&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 443
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 443,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/frequency-analysis.json
+++ b/dashboard/config/course_offerings/frequency-analysis.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/frozen-2018-test-b.json
+++ b/dashboard/config/course_offerings/frozen-2018-test-b.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/frozen-2018-test.json
+++ b/dashboard/config/course_offerings/frozen-2018-test.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/frozen-2018.json
+++ b/dashboard/config/course_offerings/frozen-2018.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/frozen.json
+++ b/dashboard/config/course_offerings/frozen.json
@@ -15,6 +15,7 @@
   "description": "Join Anna and Elsa as they explore the magic and beauty of ice with code! Create snowflakes and patterns as you ice-skate and make a winter wonderland.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/H1-paxNG4kw/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=H1-paxNG4kw&wmode=transparent",
-  "published_date": "2014-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2014-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/gamelab-demo.json
+++ b/dashboard/config/course_offerings/gamelab-demo.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/gamelab-hackathon.json
+++ b/dashboard/config/course_offerings/gamelab-hackathon.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/gamelab.json
+++ b/dashboard/config/course_offerings/gamelab.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/gamelabprojects.json
+++ b/dashboard/config/course_offerings/gamelabprojects.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/glj-behavior-test.json
+++ b/dashboard/config/course_offerings/glj-behavior-test.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/grade5.json
+++ b/dashboard/config/course_offerings/grade5.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/gumball.json
+++ b/dashboard/config/course_offerings/gumball.json
@@ -15,6 +15,7 @@
   "description": "Ever wanted to create your own game with characters you design? Use code to make them interact, score points, throw things, or vanish each other—it's up to you!",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/0QQVL8oKEaA/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=0QQVL8oKEaA&wmode=transparent",
-  "published_date": "2015-11-30 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2015-11-30 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/haikubot-pilot.json
+++ b/dashboard/config/course_offerings/haikubot-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/halloween.json
+++ b/dashboard/config/course_offerings/halloween.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hello-world-animals.json
+++ b/dashboard/config/course_offerings/hello-world-animals.json
@@ -15,6 +15,7 @@
   "description": "Lions and tigers and bears, oh my! In this animal-themed intro to Sprite Lab, students learn computer science basics by building fun, interactive projects.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/blePeROA7fA/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=blePeROA7fA&wmode=transparent",
-  "published_date": "2021-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2021-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hello-world-batman.json
+++ b/dashboard/config/course_offerings/hello-world-batman.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hello-world-csc.json
+++ b/dashboard/config/course_offerings/hello-world-csc.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hello-world-emoji.json
+++ b/dashboard/config/course_offerings/hello-world-emoji.json
@@ -15,6 +15,7 @@
   "description": "In this emoji-themed intro to Sprite Lab, students learn computer science basics by building fun, interactive projects.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/blePeROA7fA/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=blePeROA7fA&wmode=transparent",
-  "published_date": "2021-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2021-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hello-world-food.json
+++ b/dashboard/config/course_offerings/hello-world-food.json
@@ -15,6 +15,7 @@
   "description": "Let's see what's on the menu! In this food-themed intro to Sprite Lab, students learn computer science basics by building fun, interactive projects.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/blePeROA7fA/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=blePeROA7fA&wmode=transparent",
-  "published_date": "2021-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2021-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hello-world-retro.json
+++ b/dashboard/config/course_offerings/hello-world-retro.json
@@ -15,6 +15,7 @@
   "description": "Go old school! In this retro-themed intro to Sprite Lab, students learn computer science basics by building fun, interactive projects",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/blePeROA7fA/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=blePeROA7fA&wmode=transparent",
-  "published_date": "2021-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2021-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hello-world-soccer.json
+++ b/dashboard/config/course_offerings/hello-world-soccer.json
@@ -15,6 +15,7 @@
   "description": "Goooooal! In this soccer-themed introduction to our Sprite Lab, students learn the basics of computer science by building fun, interactive projects.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/blePeROA7fA/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=blePeROA7fA&wmode=transparent",
-  "published_date": "2022-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2022-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hello-world-space.json
+++ b/dashboard/config/course_offerings/hello-world-space.json
@@ -15,6 +15,7 @@
   "description": "3, 2, 1... blast off! In this space-themed introduction to our Sprite Lab, students learn the basics of computer science by building fun, interactive projects.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/blePeROA7fA/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=blePeROA7fA&wmode=transparent",
-  "published_date": "2022-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2022-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hero.json
+++ b/dashboard/config/course_offerings/hero.json
@@ -15,6 +15,7 @@
   "description": "Build and explore with Minecraft! Players write code that instructs the Agent to execute their commands and overcome in-game obstacles. ",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/vD0cVvXEKdo/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=vD0cVvXEKdo&wmode=transparent",
-  "published_date": "2017-11-27 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2017-11-27 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hoc-amazon-poc.json
+++ b/dashboard/config/course_offerings/hoc-amazon-poc.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hoc-encryption.json
+++ b/dashboard/config/course_offerings/hoc-encryption.json
@@ -15,6 +15,7 @@
   "description": "Psssst! Got a secret? Learn about the need for encryption and simple techniques for cracking secret messages in this Hour of Code activity.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/ZghMPWGXexs/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=ZghMPWGXexs&wmode=transparent",
-  "published_date": "2015-08-21 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2015-08-21 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hoc-impact-study.json
+++ b/dashboard/config/course_offerings/hoc-impact-study.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hour-of-code.json
+++ b/dashboard/config/course_offerings/hour-of-code.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/hourofcode.json
+++ b/dashboard/config/course_offerings/hourofcode.json
@@ -15,6 +15,7 @@
   "description": "Try the basics of computer science with characters from Angry Birds, Plants vs. Zombies, and Scrat from Ice Age!",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/bQilo5ecSX4/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=bQilo5ecSX4&wmode=transparent",
-  "published_date": "2013-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2013-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/how-ai-works.json
+++ b/dashboard/config/course_offerings/how-ai-works.json
@@ -15,6 +15,7 @@
   "description": "These lessons supplement the video series. Each lesson is paired with a single video from the series, diving-deeper into the concepts introduced in the videos. ",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/YlwVMtNEWKA/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=YlwVMtNEWKA&wmode=transparent",
-  "published_date": "2023-08-15 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2023-08-15 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/iceage.json
+++ b/dashboard/config/course_offerings/iceage.json
@@ -15,6 +15,7 @@
   "description": "Join Sid and Scrat from \"Ice Age\" for a fun introduction to computer science as you use basic block code to create a game.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/ap_5Ft3KocU/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=ap_5Ft3KocU&wmode=transparent",
-  "published_date": "2015-12-03 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2015-12-03 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/infinity.json
+++ b/dashboard/config/course_offerings/infinity.json
@@ -15,6 +15,7 @@
   "description": "Join Disney Infinity characters like Elsa and Baymax for a fun introduction to computer science as you use basic block code to create a game.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/vQGOfhsb76o/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=vQGOfhsb76o&wmode=transparent",
-  "published_date": "2015-08-02 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2015-08-02 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/interactive-games-animations.json
+++ b/dashboard/config/course_offerings/interactive-games-animations.json
@@ -15,6 +15,7 @@
   "description": "Engaging the same design process that computer scientists use, students learn programming concepts and develop images, animations, interactive art, and games.",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/PXn9gKiKKFo/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=PXn9gKiKKFo&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 443
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 443,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/jess-test-script-1.json
+++ b/dashboard/config/course_offerings/jess-test-script-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/jess-test-script.json
+++ b/dashboard/config/course_offerings/jess-test-script.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/jigsaw.json
+++ b/dashboard/config/course_offerings/jigsaw.json
@@ -15,6 +15,7 @@
   "description": "Give students an idea of what to expect — mouse skills, lab manners, completing puzzles, and more — when they head to the computer lab.",
   "professional_learning_program": null,
   "video": null,
-  "published_date": "2015-01-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2015-01-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/jr-test.json
+++ b/dashboard/config/course_offerings/jr-test.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/k1hoc2017.json
+++ b/dashboard/config/course_offerings/k1hoc2017.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/k5-onlinepd.json
+++ b/dashboard/config/course_offerings/k5-onlinepd.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/k5-support.json
+++ b/dashboard/config/course_offerings/k5-support.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/k5concepts.json
+++ b/dashboard/config/course_offerings/k5concepts.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/kaitie-test-script.json
+++ b/dashboard/config/course_offerings/kaitie-test-script.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/katie-practice.json
+++ b/dashboard/config/course_offerings/katie-practice.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/katies-playground.json
+++ b/dashboard/config/course_offerings/katies-playground.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/kindertest.json
+++ b/dashboard/config/course_offerings/kindertest.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/kodea-pd-2021.json
+++ b/dashboard/config/course_offerings/kodea-pd-2021.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/mc.json
+++ b/dashboard/config/course_offerings/mc.json
@@ -15,6 +15,7 @@
   "description": "Learn the basics of computer science by programming Alex or Steve to move through a simulated piece of a Minecraft world.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/Fzwa6Pm03Zk/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=Fzwa6Pm03Zk&wmode=transparent",
-  "published_date": "2016-11-17 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2016-11-17 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/microbit-temp.json
+++ b/dashboard/config/course_offerings/microbit-temp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/microbit.json
+++ b/dashboard/config/course_offerings/microbit.json
@@ -15,6 +15,7 @@
   "description": "In this unit, students use App Lab and the BBC micro:bit to develop programs that use the same hardware inputs and outputs found in smart devices.",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/u2u7UJSRuko/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=u2u7UJSRuko&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 444
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 444,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/mike-test.json
+++ b/dashboard/config/course_offerings/mike-test.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/minecraft.json
+++ b/dashboard/config/course_offerings/minecraft.json
@@ -15,6 +15,7 @@
   "description": "YOU make the rules in this activity, where you can learn basic computer science skills to create your own Minecraft game to share with others! ",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/55jADN4Y7Pg/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=55jADN4Y7Pg&wmode=transparent",
-  "published_date": "2015-11-16 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2015-11-16 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/ml-playground.json
+++ b/dashboard/config/course_offerings/ml-playground.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/moneppo-1.json
+++ b/dashboard/config/course_offerings/moneppo-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/musiclab-pilot.json
+++ b/dashboard/config/course_offerings/musiclab-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/musiclab.json
+++ b/dashboard/config/course_offerings/musiclab.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/netsim.json
+++ b/dashboard/config/course_offerings/netsim.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/nevada-standards-aligned-fifth-grade-2023.json
+++ b/dashboard/config/course_offerings/nevada-standards-aligned-fifth-grade-2023.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/nevada-standards-aligned-fifth-grade.json
+++ b/dashboard/config/course_offerings/nevada-standards-aligned-fifth-grade.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/nevada-standards-aligned-first-grade.json
+++ b/dashboard/config/course_offerings/nevada-standards-aligned-first-grade.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/nevada-standards-aligned-fourth-grade.json
+++ b/dashboard/config/course_offerings/nevada-standards-aligned-fourth-grade.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/nevada-standards-aligned-kindergarten.json
+++ b/dashboard/config/course_offerings/nevada-standards-aligned-kindergarten.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/nevada-standards-aligned-second-grade.json
+++ b/dashboard/config/course_offerings/nevada-standards-aligned-second-grade.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/nevada-standards-aligned-third-grade.json
+++ b/dashboard/config/course_offerings/nevada-standards-aligned-third-grade.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/new-d.json
+++ b/dashboard/config/course_offerings/new-d.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/new-e.json
+++ b/dashboard/config/course_offerings/new-e.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/new-express.json
+++ b/dashboard/config/course_offerings/new-express.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/new-f.json
+++ b/dashboard/config/course_offerings/new-f.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/new-stages-sept-2017.json
+++ b/dashboard/config/course_offerings/new-stages-sept-2017.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/novice-view.json
+++ b/dashboard/config/course_offerings/novice-view.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/oceans.json
+++ b/dashboard/config/course_offerings/oceans.json
@@ -15,6 +15,7 @@
   "description": "In this fun introduction to artificial intelligence, you train a real machine learning model to identify sea creatures and trash in the ocean. ",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/KHbwOetbmbs/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=KHbwOetbmbs&wmode=transparent",
-  "published_date": "2019-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2019-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/odometer.json
+++ b/dashboard/config/course_offerings/odometer.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/other-plc-course.json
+++ b/dashboard/config/course_offerings/other-plc-course.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/outbreak-csc.json
+++ b/dashboard/config/course_offerings/outbreak-csc.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/outbreak-module.json
+++ b/dashboard/config/course_offerings/outbreak-module.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/outbreak.json
+++ b/dashboard/config/course_offerings/outbreak.json
@@ -15,6 +15,7 @@
   "description": "In this engaging introduction to computer science, you create a simulation to understand how quickly a virus can spread and what can be done to slow it down.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/ZHA2_dOktVY/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=ZHA2_dOktVY&wmode=transparent",
-  "published_date": "2021-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2021-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/outbreakmodule.json
+++ b/dashboard/config/course_offerings/outbreakmodule.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/peru.json
+++ b/dashboard/config/course_offerings/peru.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/petgame.json
+++ b/dashboard/config/course_offerings/petgame.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/physcomp-temp.json
+++ b/dashboard/config/course_offerings/physcomp-temp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/pixelation.json
+++ b/dashboard/config/course_offerings/pixelation.json
@@ -15,6 +15,7 @@
   "description": "Encode images with bits and bytes! Type out the binary yourself to create your own pixel masterpiece.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/rJOa5Q5a1WM/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rJOa5Q5a1WM&wmode=transparent",
-  "published_date": "2015-10-02 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2015-10-02 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/pl-csd-bugs.json
+++ b/dashboard/config/course_offerings/pl-csd-bugs.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/pl-csd-summer.json
+++ b/dashboard/config/course_offerings/pl-csd-summer.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/pl-playground.json
+++ b/dashboard/config/course_offerings/pl-playground.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/playground.json
+++ b/dashboard/config/course_offerings/playground.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/playlab.json
+++ b/dashboard/config/course_offerings/playlab.json
@@ -15,6 +15,7 @@
   "description": "Make your own stories and games with basic block code. Add speech bubbles and backgrounds, score points, and more—let's play and learn!",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/nVsZyQIZyPc/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=nVsZyQIZyPc&wmode=transparent",
-  "published_date": "2021-05-27 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2021-05-27 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/plc-bugbash-course.json
+++ b/dashboard/config/course_offerings/plc-bugbash-course.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/pluralsight.json
+++ b/dashboard/config/course_offerings/pluralsight.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/poem-art.json
+++ b/dashboard/config/course_offerings/poem-art.json
@@ -15,6 +15,7 @@
   "description": "Roses are red, violets are blue, animate your poem, and learn computer science too! This lesson integrates ELA and CS by using code to convey a poem's mood.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/uvwUWTTjIXo/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=uvwUWTTjIXo&wmode=transparent",
-  "published_date": "2021-11-18 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2021-11-18 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/poembot-hoc.json
+++ b/dashboard/config/course_offerings/poembot-hoc.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/poembot-springforum21.json
+++ b/dashboard/config/course_offerings/poembot-springforum21.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/poembot.json
+++ b/dashboard/config/course_offerings/poembot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/poemmaker.json
+++ b/dashboard/config/course_offerings/poemmaker.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/poetry-hoc3.json
+++ b/dashboard/config/course_offerings/poetry-hoc3.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/poetry.json
+++ b/dashboard/config/course_offerings/poetry.json
@@ -15,6 +15,7 @@
   "description": "Explore the intersection of coding and language arts by creating interactive poems, illustrating the mood and tone with code.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/vT9imQY8Dsc/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=vT9imQY8Dsc&wmode=transparent",
-  "published_date": "2021-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": 421
+  "published_date": "2021-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": 421,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/poster-1.json
+++ b/dashboard/config/course_offerings/poster-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/poster-draft.json
+++ b/dashboard/config/course_offerings/poster-draft.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/poster-experiment.json
+++ b/dashboard/config/course_offerings/poster-experiment.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/poster.json
+++ b/dashboard/config/course_offerings/poster.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/pre-express.json
+++ b/dashboard/config/course_offerings/pre-express.json
@@ -15,6 +15,7 @@
   "description": "Let your pre-reader students learn computer science at their own pace! Learn to create computer programs, solve problems, and work through fun challenges.",
   "professional_learning_program": "https://code.org/professional-development-workshops",
   "video": "https://www.youtube-nocookie.com/embed/rNIM1fzJ8u0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=rNIM1fzJ8u0&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 93
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 93,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/problem-solving-computing.json
+++ b/dashboard/config/course_offerings/problem-solving-computing.json
@@ -15,6 +15,7 @@
   "description": "Framed within the broader pursuit of problem solving, this unit is an introduction to computer science featuring a series of puzzles, challenges, and more.",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/z7RaFPT3DTE/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=z7RaFPT3DTE&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 346
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 346,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/public-key-cryptography.json
+++ b/dashboard/config/course_offerings/public-key-cryptography.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/pwc.json
+++ b/dashboard/config/course_offerings/pwc.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/rbo-reference.json
+++ b/dashboard/config/course_offerings/rbo-reference.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/removed19.json
+++ b/dashboard/config/course_offerings/removed19.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/sb-pt-cont.json
+++ b/dashboard/config/course_offerings/sb-pt-cont.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/sb-pt-exp.json
+++ b/dashboard/config/course_offerings/sb-pt-exp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/sconyers.json
+++ b/dashboard/config/course_offerings/sconyers.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/seesaw-adaptations.json
+++ b/dashboard/config/course_offerings/seesaw-adaptations.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-aiml.json
+++ b/dashboard/config/course_offerings/self-paced-pl-aiml.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csa.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csa.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csc.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csc.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csd-2021.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd-2021.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csd.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csd5.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd5.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csd6-2021.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd6-2021.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csd7-2021.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd7-2021.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csd8-2021.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd8-2021.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csp-2021.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csp-2021.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csp.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-microbit.json
+++ b/dashboard/config/course_offerings/self-paced-pl-microbit.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-physical-computing.json
+++ b/dashboard/config/course_offerings/self-paced-pl-physical-computing.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/soccer.json
+++ b/dashboard/config/course_offerings/soccer.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/special-fun.json
+++ b/dashboard/config/course_offerings/special-fun.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/specialseries.json
+++ b/dashboard/config/course_offerings/specialseries.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/spelling-bee.json
+++ b/dashboard/config/course_offerings/spelling-bee.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/sports.json
+++ b/dashboard/config/course_offerings/sports.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/ip051U7Rvds/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=ip051U7Rvds&wmode=transparent",
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/spritelab-ee.json
+++ b/dashboard/config/course_offerings/spritelab-ee.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/spritelab-simple.json
+++ b/dashboard/config/course_offerings/spritelab-simple.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/spritelab-validated.json
+++ b/dashboard/config/course_offerings/spritelab-validated.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/spritelab.json
+++ b/dashboard/config/course_offerings/spritelab.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/starwars.json
+++ b/dashboard/config/course_offerings/starwars.json
@@ -15,6 +15,7 @@
   "description": "Use JavaScript to learn to program droids, and create your own Star Wars game in a galaxy far, far away.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/vNjiHkQQl6A/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=vNjiHkQQl6A&wmode=transparent",
-  "published_date": "2015-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2015-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/starwarsblocks.json
+++ b/dashboard/config/course_offerings/starwarsblocks.json
@@ -15,6 +15,7 @@
   "description": "Use block coding to learn to program droids, and create your own Star Wars game in a galaxy far, far away.",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/v7jSy_yE9U0/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=v7jSy_yE9U0&wmode=transparent",
-  "published_date": "2015-12-01 05:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2015-12-01 13:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/step.json
+++ b/dashboard/config/course_offerings/step.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/subgoal-labels-opt-in.json
+++ b/dashboard/config/course_offerings/subgoal-labels-opt-in.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/subgoals-assessment-staging.json
+++ b/dashboard/config/course_offerings/subgoals-assessment-staging.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/teachercon.json
+++ b/dashboard/config/course_offerings/teachercon.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/tess-test-course.json
+++ b/dashboard/config/course_offerings/tess-test-course.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/tess-testing-focus-on-creativity.json
+++ b/dashboard/config/course_offerings/tess-testing-focus-on-creativity.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/tess-testing-problem-solving.json
+++ b/dashboard/config/course_offerings/tess-testing-problem-solving.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/tesspltest23.json
+++ b/dashboard/config/course_offerings/tesspltest23.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/tesstest921.json
+++ b/dashboard/config/course_offerings/tesstest921.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/tesstesting.json
+++ b/dashboard/config/course_offerings/tesstesting.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/test--csp-online-teacher-support.json
+++ b/dashboard/config/course_offerings/test--csp-online-teacher-support.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/test-nv-coursea.json
+++ b/dashboard/config/course_offerings/test-nv-coursea.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/test-teaching-ap-cs-unit-1.json
+++ b/dashboard/config/course_offerings/test-teaching-ap-cs-unit-1.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/test-wednesday.json
+++ b/dashboard/config/course_offerings/test-wednesday.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/testing-digital-information.json
+++ b/dashboard/config/course_offerings/testing-digital-information.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/testing.json
+++ b/dashboard/config/course_offerings/testing.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/teststandard.json
+++ b/dashboard/config/course_offerings/teststandard.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/testtess.json
+++ b/dashboard/config/course_offerings/testtess.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/text-compression.json
+++ b/dashboard/config/course_offerings/text-compression.json
@@ -15,6 +15,7 @@
   "description": "Decode the compression puzzle! Shrink data, swap symbols, and uncover the secrets of lightning-fast info transfer. Let's compress and conquer!",
   "professional_learning_program": null,
   "video": "https://www.youtube-nocookie.com/embed/LCGkcn1f-ms/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=LCGkcn1f-ms&wmode=transparent",
-  "published_date": "2021-08-09 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": null
+  "published_date": "2021-08-09 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/textbook.json
+++ b/dashboard/config/course_offerings/textbook.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/time4cs-control.json
+++ b/dashboard/config/course_offerings/time4cs-control.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/time4cs-experiment.json
+++ b/dashboard/config/course_offerings/time4cs-experiment.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/time4csdemo.json
+++ b/dashboard/config/course_offerings/time4csdemo.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/transferring-over.json
+++ b/dashboard/config/course_offerings/transferring-over.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/tutorial-video---code-studio-puzzle-challenge.json
+++ b/dashboard/config/course_offerings/tutorial-video---code-studio-puzzle-challenge.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/ui-test-versioned-script.json
+++ b/dashboard/config/course_offerings/ui-test-versioned-script.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/usability.json
+++ b/dashboard/config/course_offerings/usability.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/valentine.json
+++ b/dashboard/config/course_offerings/valentine.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/vigenere.json
+++ b/dashboard/config/course_offerings/vigenere.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/virtual-holding-place.json
+++ b/dashboard/config/course_offerings/virtual-holding-place.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/virtual-pl-csd-summer.json
+++ b/dashboard/config/course_offerings/virtual-pl-csd-summer.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/virustest.json
+++ b/dashboard/config/course_offerings/virustest.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/vpl-csa.json
+++ b/dashboard/config/course_offerings/vpl-csa.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/vpl-csd-ayw-pilot.json
+++ b/dashboard/config/course_offerings/vpl-csd-ayw-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/vpl-csd-summer-ci.json
+++ b/dashboard/config/course_offerings/vpl-csd-summer-ci.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/vpl-csd-summer-pilot-ci.json
+++ b/dashboard/config/course_offerings/vpl-csd-summer-pilot-ci.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/vpl-csd-summer-pilot.json
+++ b/dashboard/config/course_offerings/vpl-csd-summer-pilot.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/vpl-csd.json
+++ b/dashboard/config/course_offerings/vpl-csd.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/vpl-csp.json
+++ b/dashboard/config/course_offerings/vpl-csp.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/web-development.json
+++ b/dashboard/config/course_offerings/web-development.json
@@ -15,6 +15,7 @@
   "description": "Students learn problem solving, creative expression, and teamwork as they work to create and share content on their very own web pages.",
   "professional_learning_program": "https://code.org/apply",
   "video": "https://www.youtube-nocookie.com/embed/itx0RYOnoBs/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=itx0RYOnoBs&wmode=transparent",
-  "published_date": "2023-07-10 04:00:00 UTC",
-  "self_paced_pl_course_offering_id": 443
+  "published_date": "2023-07-10 11:00:00 UTC",
+  "self_paced_pl_course_offering_id": 443,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/workshop-gamelab.json
+++ b/dashboard/config/course_offerings/workshop-gamelab.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }

--- a/dashboard/config/course_offerings/workshop-maker.json
+++ b/dashboard/config/course_offerings/workshop-maker.json
@@ -16,5 +16,6 @@
   "professional_learning_program": null,
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_id": null
+  "self_paced_pl_course_offering_id": null,
+  "self_paced_pl_course_offering_key": null
 }


### PR DESCRIPTION
This PR serializes the new `self_paced_pl_course_offering_key` using `CourseOffering.all.each(&:write_serialization)`.
This PR follow [this PR](https://github.com/code-dot-org/code-dot-org/pull/53563) and [this PR](https://github.com/code-dot-org/code-dot-org/pull/53564). 



## Follow-up work
I will make the necessary changes within the course offering editor in order to make sure that the key of the self paced pl is saved rather than the id. 


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
