### PR TITLE
Serve static directories only when serving Storybook locally

### DIFF
--- a/apps/.storybook/main.js
+++ b/apps/.storybook/main.js
@@ -1,14 +1,14 @@
+const envConstants = require('../envConstants');
 const storybookWebpackConfig = require('../webpack').storybookConfig;
+
+const staticDirs = envConstants.STORYBOOK_STATIC_ASSETS ? [
+    '../build/package/',
+    '../../dashboard/public',
+  ] : [];
 
 module.exports = {
   stories: ['../src/**/*.story.@(js|jsx|ts|tsx)'],
-  staticDirs: [
-    // Temporarily commented out to test whether we can deploy storybook to our public repo (see storybook-deploy.sh for details)
-    // In the meantime, feel free to uncomment these if you need them for serving storybook locally
-    // '../build/package/',
-    // '../../dashboard/public',
-    // '../../pegasus/sites.v3/code.org/public'
-  ],
+  staticDirs: staticDirs,
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-essentials',

--- a/apps/.storybook/main.js
+++ b/apps/.storybook/main.js
@@ -8,7 +8,7 @@ const staticDirs = envConstants.STORYBOOK_STATIC_ASSETS ? [
 
 module.exports = {
   stories: ['../src/**/*.story.@(js|jsx|ts|tsx)'],
-  staticDirs: staticDirs,
+  staticDirs,
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-essentials',

--- a/apps/.storybook/preview-head.html
+++ b/apps/.storybook/preview-head.html
@@ -3,7 +3,6 @@
 <link rel="stylesheet" media="all" href="css/levelbuilder.css" />
 <link rel="stylesheet" media="all" href="css/pd.css" />
 <link rel="stylesheet" media="all" href="css/droplet/droplet.min.css" />
-<link rel="stylesheet" media="all" href="/css/brstrap.css" />
 <script src="https://use.fontawesome.com/8c9a5ecdc4.js"></script>
 <script src="js/en_us/common_locale.js"></script>
 <script src="js/en_us/applab_locale.js"></script>

--- a/apps/envConstants.js
+++ b/apps/envConstants.js
@@ -45,5 +45,7 @@ module.exports = {
   BROWSER: process.env.BROWSER,
   // If set, will turn on react hot loader and run the webpack dev server
   HOT: !!process.env.HOT,
-  LEVEL_TYPE: process.env.LEVEL_TYPE
+  LEVEL_TYPE: process.env.LEVEL_TYPE,
+  // Include static assets when serving storybook locally
+  STORYBOOK_STATIC_ASSETS: process.env.STORYBOOK_STATIC_ASSETS,
 };

--- a/apps/package.json
+++ b/apps/package.json
@@ -31,7 +31,7 @@
     "start:craft": "DEV=1 grunt dev --app=craft --watch-notify;",
     "test-audio": "echo \"Open your browser to http://127.0.0.1:8080/test/audio/audio_test.html\" && http-server .",
     "prestorybook": "curl -o build/package/css/application.css http://localhost-studio.code.org:3000/assets/application.css || curl -o build/package/css/application.css https://code-dot-org.github.io/cdo-styleguide/css/application.css; curl -o build/package/css/font-awesome.css http://localhost-studio.code.org:3000/assets/font-awesome.css",
-    "storybook": "start-storybook -p 9001",
+    "storybook": "STORYBOOK_STATIC_ASSETS=1 start-storybook -p 9001",
     "storybook:deploy": "./script/deploy-storybook.sh",
     "storybook:test": "grunt storybookTest"
   },


### PR DESCRIPTION
We temporarily commented out code that includes static assets when running Storybook locally in order to get our public site back up and running. This change reinstates those directories when running Storybook locally, but continues to exclude them when deploying Storybook.

I have a [separate PR here](https://github.com/code-dot-org/code-dot-org/pull/53569) that gives an example of how we could become less dependent on these static directories when running Storybook, but in the meantime didn't want to regress any functionality if people are running storybook locally and want to access assets as they have before.

I also remove one of the static directories (pegasus), which was [added in this PR](https://github.com/code-dot-org/code-dot-org/pull/38367). The functionality in that PR was [removed](https://github.com/code-dot-org/code-dot-org/pull/49650) in January of this year.

## Testing story

Tested manually that when running storybook locally (ie, via `yarn storybook`), I had access to the assets at the two static directories listed. Also tested that building storybook (ie, via `yarn deploy:storybook` with the github push commented out from `deploy-storybook.sh`) excluded these directories (desired behavior).