### PR TITLE
P20-348: Create unit tests for animations i18n sync-out

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,13 +103,15 @@ group :development, :test do
   # For UI testing.
   gem 'cucumber'
   gem 'eyes_selenium', '3.18.4'
+  gem 'fakefs', '~> 2.5.0', require: false
   gem 'minitest', '~> 5.15'
   gem 'minitest-around'
   gem 'minitest-reporters', '~> 1.2.0.beta3'
+  gem 'minitest-spec-context', '~> 0.0.3'
   gem 'minitest-stub-const', '~> 0.6'
   gem 'net-http-persistent'
   gem 'rinku'
-  gem 'rspec'
+  gem 'rspec', require: false
   gem 'selenium-webdriver', '~> 4.0'
   gem 'spring', '~> 3.1.1'
   gem 'spring-commands-testunit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,6 +370,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    fakefs (2.5.0)
     fakeredis (0.6.0)
       redis (~> 3.2)
     faraday (1.10.3)
@@ -533,6 +534,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    minitest-spec-context (0.0.5)
     minitest-stub-const (0.6)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
@@ -966,6 +968,7 @@ DEPENDENCIES
   execjs
   eyes_selenium (= 3.18.4)
   factory_bot_rails (~> 6.2)
+  fakefs (~> 2.5.0)
   fakeredis
   firebase
   firebase_token_generator
@@ -1000,6 +1003,7 @@ DEPENDENCIES
   minitest (~> 5.15)
   minitest-around
   minitest-reporters (~> 1.2.0.beta3)
+  minitest-spec-context (~> 0.0.3)
   minitest-stub-const (~> 0.6)
   mocha
   mysql2 (>= 0.4.1)

--- a/bin/animation_assets/manifest_builder.rb
+++ b/bin/animation_assets/manifest_builder.rb
@@ -40,13 +40,19 @@ class ManifestBuilder
     @warnings = []
   end
 
+  def default_s3_bucket
+    @default_s3_bucket ||= Aws::S3::Bucket.new(DEFAULT_S3_BUCKET)
+  end
+
+  def animation_objects
+    @animation_objects ||= get_animation_objects
+  end
+
   #
   # Main Entry Point
   #
   def rebuild_animation_library_manifest
     # Connect to S3 and get a listing of all objects in the animation library bucket
-    bucket = Aws::S3::Bucket.new(DEFAULT_S3_BUCKET)
-    animation_objects = get_animation_objects(bucket)
     info "Found #{animation_objects.size} animations."
 
     info "Building animation metadata..."
@@ -74,7 +80,7 @@ class ManifestBuilder
         #{dim 'd[ o_0 ]b'}
     EOS
 
-    if @options[:spritelab] && @options[:upload_to_s3]
+    if upload_spritelab_to_s3?
       manifest_filename = generate_spritelab_manifest_filename
       info "Uploading #{manifest_filename} to S3"
       AWS::S3.upload_to_bucket(
@@ -108,8 +114,6 @@ class ManifestBuilder
   #
   def download_entire_animation_library
     # Connect to S3 and get a listing of all objects in the animation library bucket
-    bucket = Aws::S3::Bucket.new(DEFAULT_S3_BUCKET)
-    animation_objects = get_animation_objects(bucket)
     info "Found #{animation_objects.size} animations."
 
     info "Downloading library..."
@@ -180,9 +184,6 @@ class ManifestBuilder
   # Returns a map of names and aliases used in animation metadata
   # for translation
   def get_animation_strings
-    bucket = Aws::S3::Bucket.new(DEFAULT_S3_BUCKET)
-    animation_objects = get_animation_objects(bucket)
-
     animation_metadata = build_animation_metadata(animation_objects, read_old_metadata)
     strings = Hash.new
     animation_metadata.each do |_, metadata|
@@ -194,16 +195,17 @@ class ManifestBuilder
     return strings.sort.to_h
   end
 
+  def initial_animation_metadata
+    @initial_animation_metadata ||= build_animation_metadata(animation_objects, {})
+  end
+
   # Takes in a locale (for the file suffix) and a map of string translations
   # and replaces the aliases of the aliases of the animations with their translation.
   # Then, the localized manifest is uploaded to S3 with the suffix .{locale}.json
   def upload_localized_manifest(locale, strings)
-    return unless @options[:spritelab] && @options[:upload_to_s3]
+    return unless upload_spritelab_to_s3?
 
-    @bucket ||= Aws::S3::Bucket.new(DEFAULT_S3_BUCKET)
-    @animation_objects ||= get_animation_objects(@bucket)
-
-    animation_metadata = build_animation_metadata(@animation_objects, {})
+    animation_metadata = initial_animation_metadata
     animation_metadata.each do |_, metadata|
       metadata['aliases'] = metadata['aliases'].map {|aliaz| strings[aliaz]}
       metadata['aliases'].delete_if(&:blank?)
@@ -229,7 +231,7 @@ class ManifestBuilder
 
   # Given an S3 bucket, return map of animation file objects:
   # ret_val['animation_name'] = {'json': JSON file, 'png': PNG file}
-  def get_animation_objects(bucket)
+  def get_animation_objects(bucket = default_s3_bucket)
     animations_by_name = {}
     prefix = @options[:spritelab] ? 'spritelab' : 'gamelab'
     bucket.objects({prefix: prefix}).each do |object_summary|
@@ -454,5 +456,9 @@ class ManifestBuilder
 
   def warn(s)
     puts(s)
+  end
+
+  def upload_spritelab_to_s3?
+    @options[:spritelab] && @options[:upload_to_s3]
   end
 end

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -5,8 +5,12 @@ require 'cdo/honeybadger'
 require 'cgi'
 require 'fileutils'
 require 'psych'
+require 'ruby-progressbar'
+require 'parallel'
 
-I18N_SOURCE_DIR = "i18n/locales/source"
+I18N_LOCALES_DIR = 'i18n/locales'.freeze
+I18N_SOURCE_DIR = File.join(I18N_LOCALES_DIR, 'source').freeze
+I18N_ORIGINAL_DIR = File.join(I18N_LOCALES_DIR, 'original').freeze
 
 CROWDIN_PROJECTS = {
   codeorg: {
@@ -51,6 +55,9 @@ CROWDIN_TEST_PROJECTS = {
 }
 
 class I18nScriptUtils
+  PROGRESS_BAR_FORMAT = '%t: |%B| %p% %a'.freeze
+  PARALLEL_PROCESSES = Parallel.processor_count / 2
+
   # Because we log many of the i18n operations to slack, we often want to
   # explicitly force stdout to operate synchronously, rather than buffering
   # output and dumping a whole lot of output into slack all at once.
@@ -320,5 +327,58 @@ class I18nScriptUtils
     yml_data.gsub!(/^([a-z]+(?:-[A-Z]+)?):(.*)/, '"\1":\2') # Fixes the "no:" problem.
 
     File.write(filepath, yml_data)
+  end
+
+  # Return true iff the specified file in the specified locale had changes
+  # since the last successful sync-out.
+  #
+  # @param locale [String] the locale code to check. This can be either the
+  #  four-letter code used internally (ie, "es-ES", "es-MX", "it-IT", etc), OR
+  #  the two-letter code used by crowdin, for those languages for which we have
+  #  only a single variation ("it", "de", etc).
+  #
+  # @param file [String] the path to the file to check. Note that this should be
+  #  the relative path of the file as it exists within the locale directory; ie
+  #  "/dashboard/base.yml", "/blockly-mooc/maze.json",
+  #  "/course_content/2018/coursea-2018.json", etc.
+  def self.file_changed?(locale, file)
+    @change_data ||= CROWDIN_PROJECTS.map do |_project_identifier, project_options|
+      # TODO: investigate the condition as a potential cause of sync fails
+      unless File.exist?(project_options[:files_to_sync_out_json])
+        raise <<~ERR
+          File not found #{project_options[:files_to_sync_out_json]}.
+
+          We expect to find a file containing a list of files changed by the most
+          recent sync down; if this file does not exist, it likely means that no
+          sync down has been run on this machine, so there is nothing to sync out
+        ERR
+      end
+      JSON.load_file(project_options[:files_to_sync_out_json])
+    end
+
+    crowdin_code = PegasusLanguages.get_code_by_locale(locale)
+
+    @change_data.any? {|change_data| change_data.dig(locale, file) || change_data.dig(crowdin_code, file)}
+  end
+
+  # Formats strings like 'en-US' to 'en_us'
+  #
+  # @param [String] locale the BCP 47 (IETF language tag) format (e.g., 'en-US')
+  # @return [String] the BCP 47 (IETF language tag) JS format (e.g., 'en_us')
+  def self.to_js_locale(locale)
+    locale.tr('-', '_').downcase
+  end
+
+  def self.create_progress_bar(**args)
+    ProgressBar.create(**args, format: PROGRESS_BAR_FORMAT)
+  end
+
+  def self.process_in_threads(data_array, **args)
+    Parallel.each(data_array, **args, in_threads: PARALLEL_PROCESSES) {|data| yield(data)}
+  end
+
+  def self.delete_empty_crowdin_locale_dir(crowdin_locale)
+    crowdin_locale_dir = CDO.dir(File.join(I18N_LOCALES_DIR, crowdin_locale))
+    FileUtils.rm_r(crowdin_locale_dir) if Dir.empty?(crowdin_locale_dir)
   end
 end

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../dashboard/config/environment', __FILE__)
+require File.expand_path('../../../pegasus/helpers/pegasus_languages', __FILE__)
 
 require 'cdo/google/drive'
 require 'cdo/honeybadger'

--- a/bin/i18n/resources/apps.rb
+++ b/bin/i18n/resources/apps.rb
@@ -8,6 +8,10 @@ module I18n
         ExternalSources.sync_in
         Labs.sync_in
       end
+
+      def self.sync_out
+        Animations.sync_out
+      end
     end
   end
 end

--- a/bin/i18n/resources/apps/animations.rb
+++ b/bin/i18n/resources/apps/animations.rb
@@ -1,21 +1,21 @@
-require 'fileutils'
-require 'json'
-
 require_relative '../../i18n_script_utils'
-require_relative '../../../animation_assets/manifest_builder'
+
+Dir[File.expand_path('../animations/**/*.rb', __FILE__)].sort.each {|file| require file}
 
 module I18n
   module Resources
     module Apps
       module Animations
-        I18N_SOURCE_FILE_PATH = CDO.dir(File.join(I18N_SOURCE_DIR, 'animations/spritelab_animation_library.json')).freeze
+        DIR_NAME = 'animations'.freeze
+        I18N_SOURCE_DIR_PATH = CDO.dir(File.join(I18N_SOURCE_DIR, DIR_NAME)).freeze
+        SPRITELAB_FILE_NAME = 'spritelab_animation_library.json'.freeze
 
         def self.sync_in
-          FileUtils.mkdir_p(File.dirname(I18N_SOURCE_FILE_PATH))
+          SyncIn.perform
+        end
 
-          animation_strings = ManifestBuilder.new({spritelab: true, quiet: true}).get_animation_strings
-
-          File.write(I18N_SOURCE_FILE_PATH, JSON.pretty_generate(animation_strings))
+        def self.sync_out
+          SyncOut.perform
         end
       end
     end

--- a/bin/i18n/resources/apps/animations/sync_in.rb
+++ b/bin/i18n/resources/apps/animations/sync_in.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+
+require 'fileutils'
+require 'json'
+
+require_relative '../../../../animation_assets/manifest_builder'
+require_relative '../../../i18n_script_utils'
+require_relative '../animations'
+
+module I18n
+  module Resources
+    module Apps
+      module Animations
+        class SyncIn
+          def self.perform
+            new.execute
+          end
+
+          def execute
+            progress_bar.start
+
+            FileUtils.mkdir_p(I18N_SOURCE_DIR_PATH)
+            progress_bar.progress = 1
+
+            animation_strings = spritelab_manifest_builder.get_animation_strings
+            progress_bar.progress = 95
+
+            File.write(File.join(I18N_SOURCE_DIR_PATH, SPRITELAB_FILE_NAME), JSON.pretty_generate(animation_strings))
+
+            progress_bar.finish
+          end
+
+          private
+
+          def spritelab_manifest_builder
+            @spritelab_manifest_builder ||= ManifestBuilder.new({spritelab: true, quiet: true})
+          end
+
+          def progress_bar
+            @progress_bar ||= I18nScriptUtils.create_progress_bar(title: 'Apps/animations sync-in')
+          end
+        end
+      end
+    end
+  end
+end
+
+I18n::Resources::Apps::Animations::SyncIn.perform if __FILE__ == $0

--- a/bin/i18n/resources/apps/animations/sync_out.rb
+++ b/bin/i18n/resources/apps/animations/sync_out.rb
@@ -3,6 +3,7 @@
 require 'fileutils'
 require 'json'
 
+require_relative '../../../../../pegasus/helpers/pegasus_languages'
 require_relative '../../../../animation_assets/manifest_builder'
 require_relative '../../../i18n_script_utils'
 require_relative '../animations'

--- a/bin/i18n/resources/apps/animations/sync_out.rb
+++ b/bin/i18n/resources/apps/animations/sync_out.rb
@@ -1,0 +1,92 @@
+#!/usr/bin/env ruby
+
+require 'fileutils'
+require 'json'
+
+require_relative '../../../../animation_assets/manifest_builder'
+require_relative '../../../i18n_script_utils'
+require_relative '../animations'
+
+module I18n
+  module Resources
+    module Apps
+      module Animations
+        class SyncOut
+          def self.perform
+            new.execute
+          end
+
+          def execute
+            progress_bar.start
+
+            progress_bar.finish && return unless crowdin_spritelab_files_exist?
+
+            # Memoizes animation metadata before processing in threads
+            # to prevent them from being downloaded multiple times (in each thread separately)
+            spritelab_manifest_builder.initial_animation_metadata
+            progress_bar.progress = 30
+
+            I18nScriptUtils.process_in_threads(pegasus_languages) do |pegasus_lang|
+              crowdin_locale = pegasus_lang[:crowdin_name_s]
+              crowdin_spritelab_file_path = crowdin_locale_spritelab_file_path(crowdin_locale)
+              next unless File.exist?(crowdin_spritelab_file_path)
+
+              locale = pegasus_lang[:locale_s]
+
+              i18n_spritelab_file_path = CDO.dir(File.join(I18N_LOCALES_DIR, locale, DIR_NAME, SPRITELAB_FILE_NAME))
+              FileUtils.mkdir_p(File.dirname(i18n_spritelab_file_path))
+              FileUtils.mv crowdin_spritelab_file_path, i18n_spritelab_file_path, force: true
+              FileUtils.rm_r File.dirname(crowdin_spritelab_file_path)
+              I18nScriptUtils.delete_empty_crowdin_locale_dir(crowdin_locale)
+
+              next if locale == 'en-US'
+
+              js_locale = I18nScriptUtils.to_js_locale(locale)
+              translations = JSON.load_file(i18n_spritelab_file_path)
+              spritelab_manifest_builder.upload_localized_manifest(js_locale, translations)
+            ensure
+              mutex.synchronize do
+                @lang_progress_incr ||= (progress_bar.total - progress_bar.progress).to_f / pegasus_languages.size
+                progress_bar.progress += @lang_progress_incr
+              rescue ProgressBar::InvalidProgressError
+                progress_bar.finish
+              end
+            end
+
+            progress_bar.finish
+          end
+
+          private
+
+          def mutex
+            @mutex ||= Thread::Mutex.new
+          end
+
+          def pegasus_languages
+            @pegasus_languages ||= PegasusLanguages.get_crowdin_name_and_locale
+          end
+
+          def progress_bar
+            @progress_bar ||= I18nScriptUtils.create_progress_bar(title: 'Apps/animations sync-out')
+          end
+
+          def spritelab_manifest_builder
+            @spritelab_manifest_builder ||= ManifestBuilder.new({spritelab: true, upload_to_s3: true, quiet: true})
+          end
+
+          def crowdin_locale_spritelab_file_path(crowdin_locale)
+            CDO.dir(File.join(I18N_LOCALES_DIR, crowdin_locale, DIR_NAME, SPRITELAB_FILE_NAME))
+          end
+
+          def crowdin_spritelab_files_exist?
+            pegasus_languages.any? do |pegasus_lang|
+              File.exist?(crowdin_locale_spritelab_file_path(pegasus_lang[:crowdin_name_s]))
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+I18n::Resources::Apps::Animations::SyncOut.perform if __FILE__ == $0

--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -43,7 +43,7 @@ class I18nSync
       # download and distribute translations from the previous sync
       return_to_staging_branch
       sync_down if should_i "sync down"
-      sync_out(true) if should_i "sync out"
+      sync_out if should_i "sync out"
       CreateI18nPullRequests.down_and_out if @options[:with_pull_request] && should_i("create the down & out PR")
 
       # force switch to the staging branch to collect and upload the most relevant English content
@@ -67,7 +67,7 @@ class I18nSync
         sync_down
       when 'out'
         puts "Distributing translations from i18n/locales out into codebase"
-        sync_out(true)
+        sync_out
         if @options[:with_pull_request] && should_i("create the down & out PR")
           CreateI18nPullRequests.down_and_out
         end
@@ -83,8 +83,8 @@ class I18nSync
     I18n::SyncIn.perform
   end
 
-  def sync_out(upload_manifests = false)
-    I18n::SyncOut.perform(upload_manifests: upload_manifests)
+  def sync_out
+    I18n::SyncOut.perform
   end
 
   def parse_options(args)

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -21,13 +21,16 @@ require_relative 'i18n_script_utils'
 require_relative 'redact_restore_utils'
 require_relative '../animation_assets/manifest_builder'
 
+Dir[File.expand_path('../resources/**/*.rb', __FILE__)].sort.each {|file| require file}
+
 module I18n
   module SyncOut
-    def self.perform(upload_manifests: false)
+    def self.perform
       puts "Sync out starting"
+      I18n::Resources::Apps.sync_out
       rename_from_crowdin_name_to_locale
       restore_redacted_files
-      distribute_translations(upload_manifests)
+      distribute_translations
       copy_untranslated_apps
       restore_markdown_headers
       Services::I18n::CurriculumSyncUtils.sync_out
@@ -65,38 +68,6 @@ module I18n
           # This will happen if a sync-down hasn't happened since the last successful sync-out.
           puts "No temp file #{files_to_sync_out_path} found to backup."
         end
-      end
-    end
-
-    # Return true iff the specified file in the specified locale had changes
-    # since the last successful sync-out.
-    #
-    # @param locale [String] the locale code to check. This can be either the
-    #  four-letter code used internally (ie, "es-ES", "es-MX", "it-IT", etc), OR
-    #  the two-letter code used by crowdin, for those languages for which we have
-    #  only a single variation ("it", "de", etc).
-    #
-    # @param file [String] the path to the file to check. Note that this should be
-    #  the relative path of the file as it exists within the locale directory; ie
-    #  "/dashboard/base.yml", "/blockly-mooc/maze.json",
-    #  "/course_content/2018/coursea-2018.json", etc.
-    def self.file_changed?(locale, file)
-      @change_datas ||= CROWDIN_PROJECTS.map do |_project_identifier, project_options|
-        unless File.exist?(project_options[:files_to_sync_out_json])
-          raise <<~ERR
-            File not found #{project_options[:files_to_sync_out_json]}.
-
-            We expect to find a file containing a list of files changed by the most
-            recent sync down; if this file does not exist, it likely means that no
-            sync down has been run on this machine, so there is nothing to sync out
-          ERR
-        end
-        JSON.parse File.read(project_options[:files_to_sync_out_json])
-      end
-
-      crowdin_code = PegasusLanguages.get_code_by_locale(locale)
-      return @change_datas.any? do |change_data|
-        change_data.dig(locale, file) || change_data.dig(crowdin_code, file)
       end
     end
 
@@ -338,7 +309,7 @@ module I18n
 
       Dir.glob(File.join(locale_dir, "course_content/**/*.json")) do |course_strings_file|
         relative_path = course_strings_file.delete_prefix(locale_dir)
-        next unless file_changed?(locale, relative_path)
+        next unless I18nScriptUtils.file_changed?(locale, relative_path)
 
         course_strings = JSON.parse(File.read(course_strings_file))
         next unless course_strings
@@ -392,7 +363,7 @@ module I18n
 
     # Distribute downloaded translations from i18n/locales
     # back to blockly, apps, pegasus, and dashboard.
-    def self.distribute_translations(upload_manifests)
+    def self.distribute_translations
       locales = PegasusLanguages.get_locale
       puts "Distributing translations in #{locales.count} locales, parallelized between #{Parallel.processor_count / 2} processes"
 
@@ -406,7 +377,7 @@ module I18n
         Dir.glob("i18n/locales/#{locale}/dashboard/*.{json,yml}") do |loc_file|
           ext = File.extname(loc_file)
           relative_path = loc_file.delete_prefix(locale_dir)
-          next unless file_changed?(locale, relative_path)
+          next unless I18nScriptUtils.file_changed?(locale, relative_path)
 
           basename = File.basename(loc_file, ext)
           postprocess_course_resources(locale, loc_file) if File.basename(loc_file) == 'courses.yml'
@@ -429,10 +400,10 @@ module I18n
         distribute_course_content(locale)
 
         ### Apps
-        js_locale = locale.tr('-', '_').downcase
+        js_locale = I18nScriptUtils.to_js_locale(locale)
         Dir.glob("#{locale_dir}/blockly-mooc/*.json") do |loc_file|
           relative_path = loc_file.delete_prefix(locale_dir)
-          next unless file_changed?(locale, relative_path)
+          next unless I18nScriptUtils.file_changed?(locale, relative_path)
 
           basename = File.basename(loc_file, '.json')
           destination = "apps/i18n/#{basename}/#{js_locale}.json"
@@ -442,7 +413,7 @@ module I18n
         ### ml-playground strings to Apps directory
         Dir.glob("#{locale_dir}/external-sources/ml-playground/mlPlayground.json") do |loc_file|
           relative_path = loc_file.delete_prefix(locale_dir)
-          next unless file_changed?(locale, relative_path)
+          next unless I18nScriptUtils.file_changed?(locale, relative_path)
 
           basename = File.basename(loc_file, '.json')
           destination = "apps/i18n/#{basename}/#{js_locale}.json"
@@ -454,7 +425,7 @@ module I18n
           ml_playground_path = "apps/i18n/mlPlayground/#{js_locale}.json"
           dataset_id = File.basename(loc_file, '.json')
           relative_path = loc_file.delete_prefix(locale_dir)
-          next unless file_changed?(locale, relative_path)
+          next unless I18nScriptUtils.file_changed?(locale, relative_path)
 
           external_translations = parse_file(loc_file)
           next if external_translations.empty?
@@ -466,23 +437,13 @@ module I18n
           sanitize_data_and_write(existing_translations, ml_playground_path)
         end
 
-        ### Animation library
-        spritelab_animation_translation_path = "/animations/spritelab_animation_library.json"
-        if file_changed?(locale, spritelab_animation_translation_path)
-          @manifest_builder ||= ManifestBuilder.new({spritelab: true, upload_to_s3: true, quiet: true})
-          spritelab_animation_translation_file = File.join(locale_dir, spritelab_animation_translation_path)
-          translations = JSON.parse(File.read(spritelab_animation_translation_file))
-          # Use js_locale here as the animation library is used by apps
-          @manifest_builder.upload_localized_manifest(js_locale, translations) if upload_manifests
-        end
-
         ### Blockly Core
         # Blockly doesn't know how to fall back to English, so here we manually and
         # explicitly default all untranslated strings to English.
         blockly_english = JSON.parse(File.read("i18n/locales/source/blockly-core/core.json"))
         Dir.glob("#{locale_dir}/blockly-core/*.json") do |loc_file|
           relative_path = loc_file.delete_prefix(locale_dir)
-          next unless file_changed?(locale, relative_path)
+          next unless I18nScriptUtils.file_changed?(locale, relative_path)
 
           translations = JSON.parse(File.read(loc_file))
           # Create a hash containing all translations, with English strings in
@@ -508,7 +469,7 @@ module I18n
         ### Pegasus markdown
         Dir.glob("#{locale_dir}/codeorg-markdown/**/*.*") do |loc_file|
           relative_path = loc_file.delete_prefix("#{locale_dir}/codeorg-markdown")
-          next unless file_changed?(locale, relative_path)
+          next unless I18nScriptUtils.file_changed?(locale, relative_path)
 
           destination_dir = "pegasus/sites.v3/code.org/i18n/public"
           # The `views` path is actually outside of the `public` path, so when we
@@ -527,7 +488,7 @@ module I18n
         Dir.glob("i18n/locales/#{locale}/docs/*.json") do |loc_file|
           # Each programming environment file gets merged into programming_environments.{locale}.json
           relative_path = loc_file.delete_prefix(locale_dir)
-          next unless file_changed?(locale, relative_path)
+          next unless I18nScriptUtils.file_changed?(locale, relative_path)
 
           loc_data = JSON.parse(File.read(loc_file))
           next if loc_data.empty?
@@ -548,7 +509,7 @@ module I18n
           # For every framework, we place the frameworks and categories in their
           # respective places.
           relative_path = loc_file.delete_prefix(locale_dir)
-          next unless file_changed?(locale, relative_path)
+          next unless I18nScriptUtils.file_changed?(locale, relative_path)
 
           # These JSON files contain the framework name, a set of categories, and a
           # set of standards.

--- a/bin/test/animation_assets/test_manifest_builder.rb
+++ b/bin/test/animation_assets/test_manifest_builder.rb
@@ -7,7 +7,7 @@ class ManifestBuilderTest < Minitest::Test
     Aws::CredentialProviderChain.any_instance.stubs(:static_credentials).returns(aws_credentials_mock)
   end
 
-  def test_get_animation_strings_for_spritelab_quietly
+  def test_getting_animation_strings_for_spritelab_quietly
     animation_strings = nil
 
     VCR.use_cassette('animations/manifest_spritelab_strings', record: :none) do
@@ -15,5 +15,68 @@ class ManifestBuilderTest < Minitest::Test
     end
 
     assert_equal({'test_alias_1' => 'test_alias_1', 'test_alias_2' => 'test_alias_2'}, animation_strings)
+  end
+
+  def test_uploading_localized_manifest_for_spritelab_quietly
+    expected_spritelab_animations_manifest_data = <<-JSON.strip.gsub(/^ {6}/, '')
+      {
+        "//": [
+          "Animation Library Manifest",
+          "GENERATED FILE: DO NOT MODIFY DIRECTLY",
+          "See tools/scripts/rebuildAnimationLibraryManifest.rb for more information."
+        ],
+        "metadata": {
+          "category_test_1/valid_test": {
+            "name": "valid_test",
+            "categories": [
+              "test_category"
+            ],
+            "frameCount": 1,
+            "frameSize": {
+              "x": 100,
+              "y": 200
+            },
+            "looping": true,
+            "frameDelay": 2,
+            "jsonLastModified": "2021-01-19 23:48:52 UTC",
+            "pngLastModified": "2021-01-19 23:48:53 UTC",
+            "version": "QtaHBb9VSb33E0CMEgEECueLtkomMS9t",
+            "sourceUrl": "/api/v1/animation-library/spritelab/QtaHBb9VSb33E0CMEgEECueLtkomMS9t/category_test_1/valid_test.png",
+            "sourceSize": {
+              "x": 400,
+              "y": 400
+            }
+          }
+        },
+        "categories": {
+          "test_category": [
+            "category_test_1/valid_test"
+          ]
+        },
+        "aliases": {
+          "expected_test_alias_1_translation": [
+            "category_test_1/valid_test"
+          ],
+          "valid_test": [
+            "category_test_1/valid_test"
+          ]
+        }
+      }
+    JSON
+
+    AWS::S3.expects(:upload_to_bucket).with(
+      'cdo-animation-library',
+      'animation-manifests/manifests/spritelabCostumeLibrary.en_us.json',
+      expected_spritelab_animations_manifest_data,
+      acl: 'public-read',
+      no_random: true,
+      content_type: 'json',
+    ).once
+
+    VCR.use_cassette('animations/manifest_spritelab_strings', record: :none) do
+      ManifestBuilder.new({spritelab: true, upload_to_s3: true, quite: true}).upload_localized_manifest(
+        'en_us', {'test_alias_1' => 'expected_test_alias_1_translation'}
+      )
+    end
   end
 end

--- a/bin/test/i18n/resources/apps/animation/test_sync_in.rb
+++ b/bin/test/i18n/resources/apps/animation/test_sync_in.rb
@@ -1,0 +1,22 @@
+require_relative '../../../../test_helper'
+require_relative '../../../../../i18n/resources/apps/animations/sync_in'
+
+describe I18n::Resources::Apps::Animations::SyncIn do
+  def around
+    FakeFS.with_fresh {yield}
+  end
+
+  before do
+    STDOUT.stubs(:print)
+  end
+
+  describe '.perform' do
+    it 'sync-in animations' do
+      ManifestBuilder.expects(new: mock(get_animation_strings: {test: 'example'})).with({spritelab: true, quiet: true}).once
+
+      I18n::Resources::Apps::Animations::SyncIn.perform
+
+      assert_equal %Q[{\n  "test": "example"\n}], File.read(CDO.dir('i18n/locales/source/animations/spritelab_animation_library.json'))
+    end
+  end
+end

--- a/bin/test/i18n/resources/apps/animation/test_sync_out.rb
+++ b/bin/test/i18n/resources/apps/animation/test_sync_out.rb
@@ -2,7 +2,7 @@ require_relative '../../../../test_helper'
 require_relative '../../../../../i18n/resources/apps/animations/sync_out'
 
 describe I18n::Resources::Apps::Animations::SyncOut do
-  PegasusLanguages = Class.new
+  I18n::Resources::Apps::Animations::SyncOut::PegasusLanguages = Class.new
 
   def around
     FakeFS.with_fresh {yield}
@@ -37,7 +37,9 @@ describe I18n::Resources::Apps::Animations::SyncOut do
     end
 
     before do
-      PegasusLanguages.stubs(:get_crowdin_name_and_locale).returns([{crowdin_name_s: crowdin_locale, locale_s: i18n_locale}])
+      I18n::Resources::Apps::Animations::SyncOut::PegasusLanguages.stubs(:get_crowdin_name_and_locale).returns(
+        [{crowdin_name_s: crowdin_locale, locale_s: i18n_locale}]
+      )
     end
 
     context 'when Crowdin locale file exists' do

--- a/bin/test/i18n/resources/apps/animation/test_sync_out.rb
+++ b/bin/test/i18n/resources/apps/animation/test_sync_out.rb
@@ -1,0 +1,107 @@
+require_relative '../../../../test_helper'
+require_relative '../../../../../i18n/resources/apps/animations/sync_out'
+
+describe I18n::Resources::Apps::Animations::SyncOut do
+  PegasusLanguages = Class.new
+
+  def around
+    FakeFS.with_fresh {yield}
+  end
+
+  before do
+    STDOUT.stubs(:print)
+  end
+
+  describe '.perform' do
+    it 'call #execute' do
+      I18n::Resources::Apps::Animations::SyncOut.any_instance.expects(:execute).once
+
+      I18n::Resources::Apps::Animations::SyncOut.perform
+    end
+  end
+
+  describe '#execute' do
+    let(:described_instance) {I18n::Resources::Apps::Animations::SyncOut.new}
+
+    let(:crowdin_locale) {'crowdin_locale'}
+    let(:i18n_locale) {'i18n-LOCALE'}
+
+    let(:spritelab_file_content) {'expected_spritelab_file_content'}
+    let(:crowdin_spritelab_file_path) {CDO.dir(File.join('i18n/locales', crowdin_locale, 'animations/spritelab_animation_library.json'))}
+    let(:i18n_spritelab_file_path) {CDO.dir(File.join('i18n/locales', i18n_locale, 'animations/spritelab_animation_library.json'))}
+
+    let(:spritelab_manifest_builder) do
+      manifest_builder_stub = stub
+      ManifestBuilder.stubs(:new).with({spritelab: true, upload_to_s3: true, quiet: true}).returns(manifest_builder_stub)
+      manifest_builder_stub
+    end
+
+    before do
+      PegasusLanguages.stubs(:get_crowdin_name_and_locale).returns([{crowdin_name_s: crowdin_locale, locale_s: i18n_locale}])
+    end
+
+    context 'when Crowdin locale file exists' do
+      before do
+        FileUtils.mkdir_p(File.dirname(crowdin_spritelab_file_path))
+        File.write(crowdin_spritelab_file_path, JSON.dump(spritelab_file_content))
+      end
+
+      context 'if the file is not en-US' do
+        let(:crowdin_locale) {'Not English'}
+        let(:i18n_locale) {'not-EN'}
+
+        it 'sync-out the file' do
+          spritelab_manifest_builder.expects(:initial_animation_metadata).once
+          I18nScriptUtils.expects(:delete_empty_crowdin_locale_dir).with(crowdin_locale).once
+          I18nScriptUtils.expects(:to_js_locale).with(i18n_locale).once.returns('expected_js_locale')
+          spritelab_manifest_builder.expects(:upload_localized_manifest).with('expected_js_locale', spritelab_file_content).once
+
+          assert File.exist?(crowdin_spritelab_file_path)
+          refute File.exist?(i18n_spritelab_file_path)
+
+          described_instance.execute
+
+          refute File.exist?(crowdin_spritelab_file_path)
+          assert File.exist?(i18n_spritelab_file_path)
+        end
+      end
+
+      context 'if the file is en-US' do
+        let(:crowdin_locale) {'English'}
+        let(:i18n_locale) {'en-US'}
+
+        it 'does not sync-out the file' do
+          spritelab_manifest_builder.expects(:initial_animation_metadata).once
+          I18nScriptUtils.expects(:delete_empty_crowdin_locale_dir).with(crowdin_locale).once
+          I18nScriptUtils.expects(:to_js_locale).with(i18n_locale).never.returns('expected_js_locale')
+          spritelab_manifest_builder.expects(:upload_localized_manifest).with('expected_js_locale', spritelab_file_content).never
+
+          assert File.exist?(crowdin_spritelab_file_path)
+          refute File.exist?(i18n_spritelab_file_path)
+
+          described_instance.execute
+
+          refute File.exist?(crowdin_spritelab_file_path)
+          assert File.exist?(i18n_spritelab_file_path)
+        end
+      end
+    end
+
+    context 'when Crowdin locale file does not exist' do
+      it 'skips the locale sync-out' do
+        spritelab_manifest_builder.expects(:initial_animation_metadata).never
+        I18nScriptUtils.expects(:delete_empty_crowdin_locale_dir).with(crowdin_locale).never
+        I18nScriptUtils.expects(:to_js_locale).with(i18n_locale).never.returns('expected_js_locale')
+        spritelab_manifest_builder.expects(:upload_localized_manifest).with('expected_js_locale', spritelab_file_content).never
+
+        refute File.exist?(crowdin_spritelab_file_path)
+        refute File.exist?(i18n_spritelab_file_path)
+
+        described_instance.execute
+
+        refute File.exist?(crowdin_spritelab_file_path)
+        refute File.exist?(i18n_spritelab_file_path)
+      end
+    end
+  end
+end

--- a/bin/test/i18n/resources/apps/animation/test_sync_out.rb
+++ b/bin/test/i18n/resources/apps/animation/test_sync_out.rb
@@ -2,8 +2,6 @@ require_relative '../../../../test_helper'
 require_relative '../../../../../i18n/resources/apps/animations/sync_out'
 
 describe I18n::Resources::Apps::Animations::SyncOut do
-  I18n::Resources::Apps::Animations::SyncOut::PegasusLanguages = Class.new
-
   def around
     FakeFS.with_fresh {yield}
   end
@@ -37,9 +35,7 @@ describe I18n::Resources::Apps::Animations::SyncOut do
     end
 
     before do
-      I18n::Resources::Apps::Animations::SyncOut::PegasusLanguages.stubs(:get_crowdin_name_and_locale).returns(
-        [{crowdin_name_s: crowdin_locale, locale_s: i18n_locale}]
-      )
+      PegasusLanguages.stubs(:get_crowdin_name_and_locale).returns([{crowdin_name_s: crowdin_locale, locale_s: i18n_locale}])
     end
 
     context 'when Crowdin locale file exists' do

--- a/bin/test/i18n/resources/apps/test_animations.rb
+++ b/bin/test/i18n/resources/apps/test_animations.rb
@@ -3,14 +3,14 @@ require_relative '../../../../i18n/resources/apps/animations'
 
 class I18n::Resources::Apps::AnimationsTest < Minitest::Test
   def test_sync_in
-    exec_seq = sequence('execution')
-
-    manifest_builder = mock(get_animation_strings: {test: 'example'})
-    ManifestBuilder.stubs(new: manifest_builder).with({spritelab: true, quiet: true})
-
-    FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/animations')).in_sequence(exec_seq)
-    File.expects(:write).with(CDO.dir('i18n/locales/source/animations/spritelab_animation_library.json'), %Q[{\n  "test": "example"\n}]).in_sequence(exec_seq)
+    I18n::Resources::Apps::Animations::SyncIn.expects(:perform).once
 
     I18n::Resources::Apps::Animations.sync_in
+  end
+
+  def test_sync_out
+    I18n::Resources::Apps::Animations::SyncOut.expects(:perform).once
+
+    I18n::Resources::Apps::Animations.sync_out
   end
 end

--- a/bin/test/i18n/resources/test_apps.rb
+++ b/bin/test/i18n/resources/test_apps.rb
@@ -11,4 +11,12 @@ class I18n::Resources::AppsTest < Minitest::Test
 
     I18n::Resources::Apps.sync_in
   end
+
+  def test_sync_out
+    exec_seq = sequence('execution')
+
+    I18n::Resources::Apps::Animations.expects(:sync_out).in_sequence(exec_seq)
+
+    I18n::Resources::Apps.sync_out
+  end
 end

--- a/bin/test/i18n/test_i18n_script_utils.rb
+++ b/bin/test/i18n/test_i18n_script_utils.rb
@@ -102,8 +102,6 @@ class I18nScriptUtilsTest < Minitest::Test
 end
 
 describe I18nScriptUtils do
-  I18nScriptUtils::PegasusLanguages = Class.new
-
   def around
     FakeFS.with_fresh {yield}
   end
@@ -125,7 +123,7 @@ describe I18nScriptUtils do
 
           File.expects(:exist?).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns(true)
           JSON.expects(:load_file).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns({expected_locale => {expected_file_path => 'true'}})
-          I18nScriptUtils::PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns('unexpected_crowdin_locale')
+          PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns('unexpected_crowdin_locale')
 
           assert I18nScriptUtils.file_changed?(expected_locale, expected_file_path)
         end
@@ -145,7 +143,7 @@ describe I18nScriptUtils do
 
           File.expects(:exist?).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns(true)
           JSON.expects(:load_file).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns({expected_crowdin_locale => {expected_file_path => 'true'}})
-          I18nScriptUtils::PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns(expected_crowdin_locale)
+          PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns(expected_crowdin_locale)
 
           assert I18nScriptUtils.file_changed?(expected_locale, expected_file_path)
         end
@@ -164,7 +162,7 @@ describe I18nScriptUtils do
 
           File.expects(:exist?).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns(true)
           JSON.expects(:load_file).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns({expected_locale => {'unexpected_file_path' => 'true'}})
-          I18nScriptUtils::PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns('unexpected_crowdin_locale')
+          PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns('unexpected_crowdin_locale')
 
           refute I18nScriptUtils.file_changed?(expected_locale, expected_file_path)
         end
@@ -181,7 +179,7 @@ describe I18nScriptUtils do
 
           File.expects(:exist?).with(expected_files_to_sync_out_json).once.returns(false)
           JSON.expects(:load_file).with(expected_files_to_sync_out_json).never
-          I18nScriptUtils::PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).never
+          PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).never
 
           actual_error = assert_raises(RuntimeError) {I18nScriptUtils.file_changed?(expected_locale, expected_file_path)}
           assert_match /File not found #{expected_files_to_sync_out_json}/, actual_error.message

--- a/bin/test/i18n/test_i18n_script_utils.rb
+++ b/bin/test/i18n/test_i18n_script_utils.rb
@@ -95,4 +95,129 @@ class I18nScriptUtilsTest < Minitest::Test
 
     I18nScriptUtils.fix_yml_file(provided_yaml_file_path)
   end
+
+  def test_to_js_locale_returns_formated_js_locale
+    assert_equal 'en_us', I18nScriptUtils.to_js_locale('en-US')
+  end
+end
+
+describe I18nScriptUtils do
+  PegasusLanguages = Class.new
+
+  def around
+    FakeFS.with_fresh {yield}
+  end
+
+  describe '.file_changed?' do
+    before do
+      I18nScriptUtils.remove_instance_variable(:@change_data) if I18nScriptUtils.instance_variable_get(:@change_data)
+    end
+
+    context 'when expected file is found by i18_locale' do
+      it 'returns true' do
+        expected_files_to_sync_out_json = 'expected/files_to_sync_out.json'
+
+        I18nScriptUtils.stub_const(:CROWDIN_PROJECTS, {expected_project: {files_to_sync_out_json: expected_files_to_sync_out_json}}) do
+          exec_seq = sequence('execution')
+
+          expected_locale = 'expected_i18_locale'
+          expected_file_path = '/expected/file.json'
+
+          File.expects(:exist?).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns(true)
+          JSON.expects(:load_file).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns({expected_locale => {expected_file_path => 'true'}})
+          PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns('unexpected_crowdin_locale')
+
+          assert I18nScriptUtils.file_changed?(expected_locale, expected_file_path)
+        end
+      end
+    end
+
+    context 'when expected file is found by crowdin_locale' do
+      it 'returns true' do
+        expected_files_to_sync_out_json = 'expected/files_to_sync_out.json'
+
+        I18nScriptUtils.stub_const(:CROWDIN_PROJECTS, {expected_project: {files_to_sync_out_json: expected_files_to_sync_out_json}}) do
+          exec_seq = sequence('execution')
+
+          expected_locale = 'expected_i18_locale'
+          expected_crowdin_locale = 'expected_crowdin_locale'
+          expected_file_path = '/expected/file.json'
+
+          File.expects(:exist?).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns(true)
+          JSON.expects(:load_file).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns({expected_crowdin_locale => {expected_file_path => 'true'}})
+          PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns(expected_crowdin_locale)
+
+          assert I18nScriptUtils.file_changed?(expected_locale, expected_file_path)
+        end
+      end
+    end
+
+    context 'when expected file is not found' do
+      it 'returns false' do
+        expected_files_to_sync_out_json = 'expected/files_to_sync_out.json'
+
+        I18nScriptUtils.stub_const(:CROWDIN_PROJECTS, {expected_project: {files_to_sync_out_json: expected_files_to_sync_out_json}}) do
+          exec_seq = sequence('execution')
+
+          expected_locale = 'expected_i18_locale'
+          expected_file_path = '/expected/file.json'
+
+          File.expects(:exist?).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns(true)
+          JSON.expects(:load_file).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns({expected_locale => {'unexpected_file_path' => 'true'}})
+          PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns('unexpected_crowdin_locale')
+
+          refute I18nScriptUtils.file_changed?(expected_locale, expected_file_path)
+        end
+      end
+    end
+
+    context 'when project :files_to_sync_out_json_file does not exist' do
+      it 'raises error' do
+        expected_files_to_sync_out_json = 'expected/files_to_sync_out.json'
+
+        I18nScriptUtils.stub_const(:CROWDIN_PROJECTS, {expected_project: {files_to_sync_out_json: expected_files_to_sync_out_json}}) do
+          expected_locale = 'expected_i18_locale'
+          expected_file_path = '/expected/file.json'
+
+          File.expects(:exist?).with(expected_files_to_sync_out_json).once.returns(false)
+          JSON.expects(:load_file).with(expected_files_to_sync_out_json).never
+          PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).never
+
+          actual_error = assert_raises(RuntimeError) {I18nScriptUtils.file_changed?(expected_locale, expected_file_path)}
+          assert_match /File not found #{expected_files_to_sync_out_json}/, actual_error.message
+        end
+      end
+    end
+  end
+
+  describe '.delete_empty_crowdin_locale_dir' do
+    let(:crowdin_locale) {'expected_crowdin_locale'}
+    let(:crowdin_locale_dir_path) {CDO.dir(File.join('i18n/locales', crowdin_locale))}
+
+    before do
+      FileUtils.mkdir_p(crowdin_locale_dir_path)
+    end
+
+    context 'when Crowdin locale dir is empty' do
+      it 'deletes the Crowdin locale dir' do
+        assert File.directory?(crowdin_locale_dir_path)
+
+        I18nScriptUtils.delete_empty_crowdin_locale_dir(crowdin_locale)
+
+        refute File.directory?(crowdin_locale_dir_path)
+      end
+    end
+
+    context 'when Crowdin locale dir is not empty' do
+      before do
+        FileUtils.touch(File.join(crowdin_locale_dir_path, 'test.txt'))
+      end
+
+      it 'does not delete the Crowdin locale dir' do
+        I18nScriptUtils.delete_empty_crowdin_locale_dir(crowdin_locale)
+
+        assert File.directory?(crowdin_locale_dir_path)
+      end
+    end
+  end
 end

--- a/bin/test/i18n/test_i18n_script_utils.rb
+++ b/bin/test/i18n/test_i18n_script_utils.rb
@@ -102,7 +102,7 @@ class I18nScriptUtilsTest < Minitest::Test
 end
 
 describe I18nScriptUtils do
-  PegasusLanguages = Class.new
+  I18nScriptUtils::PegasusLanguages = Class.new
 
   def around
     FakeFS.with_fresh {yield}
@@ -125,7 +125,7 @@ describe I18nScriptUtils do
 
           File.expects(:exist?).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns(true)
           JSON.expects(:load_file).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns({expected_locale => {expected_file_path => 'true'}})
-          PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns('unexpected_crowdin_locale')
+          I18nScriptUtils::PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns('unexpected_crowdin_locale')
 
           assert I18nScriptUtils.file_changed?(expected_locale, expected_file_path)
         end
@@ -145,7 +145,7 @@ describe I18nScriptUtils do
 
           File.expects(:exist?).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns(true)
           JSON.expects(:load_file).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns({expected_crowdin_locale => {expected_file_path => 'true'}})
-          PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns(expected_crowdin_locale)
+          I18nScriptUtils::PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns(expected_crowdin_locale)
 
           assert I18nScriptUtils.file_changed?(expected_locale, expected_file_path)
         end
@@ -164,7 +164,7 @@ describe I18nScriptUtils do
 
           File.expects(:exist?).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns(true)
           JSON.expects(:load_file).with(expected_files_to_sync_out_json).in_sequence(exec_seq).returns({expected_locale => {'unexpected_file_path' => 'true'}})
-          PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns('unexpected_crowdin_locale')
+          I18nScriptUtils::PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).in_sequence(exec_seq).returns('unexpected_crowdin_locale')
 
           refute I18nScriptUtils.file_changed?(expected_locale, expected_file_path)
         end
@@ -181,7 +181,7 @@ describe I18nScriptUtils do
 
           File.expects(:exist?).with(expected_files_to_sync_out_json).once.returns(false)
           JSON.expects(:load_file).with(expected_files_to_sync_out_json).never
-          PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).never
+          I18nScriptUtils::PegasusLanguages.expects(:get_code_by_locale).with(expected_locale).never
 
           actual_error = assert_raises(RuntimeError) {I18nScriptUtils.file_changed?(expected_locale, expected_file_path)}
           assert_match /File not found #{expected_files_to_sync_out_json}/, actual_error.message

--- a/bin/test/i18n/test_sync-out.rb
+++ b/bin/test/i18n/test_sync-out.rb
@@ -5,9 +5,10 @@ class I18n::SyncOutTest < Minitest::Test
   def test_performing
     exec_seq = sequence('execution')
 
+    I18n::Resources::Apps.expects(:sync_out).in_sequence(exec_seq)
     I18n::SyncOut.expects(:rename_from_crowdin_name_to_locale).in_sequence(exec_seq)
     I18n::SyncOut.expects(:restore_redacted_files).in_sequence(exec_seq)
-    I18n::SyncOut.expects(:distribute_translations).with(false).in_sequence(exec_seq)
+    I18n::SyncOut.expects(:distribute_translations).in_sequence(exec_seq)
     I18n::SyncOut.expects(:copy_untranslated_apps).in_sequence(exec_seq)
     I18n::SyncOut.expects(:restore_markdown_headers).in_sequence(exec_seq)
     Services::I18n::CurriculumSyncUtils.expects(:sync_out).in_sequence(exec_seq)
@@ -21,26 +22,10 @@ class I18n::SyncOutTest < Minitest::Test
     end
   end
 
-  def test_performing_with_manifests_upload
-    expected_upload_manifests_arg = 'expected_upload_manifests_arg'
-
-    I18n::SyncOut.expects(:rename_from_crowdin_name_to_locale)
-    I18n::SyncOut.expects(:restore_redacted_files)
-    I18n::SyncOut.expects(:distribute_translations).with(expected_upload_manifests_arg).once
-    I18n::SyncOut.expects(:copy_untranslated_apps)
-    I18n::SyncOut.expects(:restore_markdown_headers)
-    Services::I18n::CurriculumSyncUtils.expects(:sync_out)
-    HocSyncUtils.expects(:sync_out)
-    I18nScriptUtils.expects(:run_standalone_script)
-    I18nScriptUtils.expects(:run_standalone_script)
-    I18n::SyncOut.expects(:clean_up_sync_out)
-
-    I18n::SyncOut.perform(upload_manifests: expected_upload_manifests_arg)
-  end
-
   def test_exception_handling
     expected_error = 'expected_error'
 
+    I18n::Resources::Apps.stubs(:sync_out).raises(expected_error)
     I18n::SyncOut.stubs(:rename_from_crowdin_name_to_locale).raises(expected_error)
     I18n::SyncOut.stubs(:rename_from_crowdin_name_to_locale).raises(expected_error)
     I18n::SyncOut.stubs(:restore_redacted_files).raises(expected_error)

--- a/bin/test/test_helper.rb
+++ b/bin/test/test_helper.rb
@@ -1,7 +1,5 @@
 require_relative '../../shared/test/test_helper'
 
-ENV['RACK_ENV'] ||= 'test'
-
 # Set up JUnit output for Circle
 reporters = [Minitest::Reporters::SpecReporter.new]
 if ENV['CIRCLECI']

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -1,4 +1,5 @@
 require 'test_reporter'
+require 'rspec'
 
 if defined? ActiveRecord
   ActiveRecord::Migration&.check_pending!

--- a/pegasus/helpers/pegasus_languages.rb
+++ b/pegasus/helpers/pegasus_languages.rb
@@ -1,3 +1,5 @@
+require_relative '../src/env'
+
 require 'cdo/db'
 require 'cdo/languages'
 

--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -2,10 +2,12 @@
 ENV['RACK_ENV'] = 'test'
 ENV['UNIT_TEST'] = '1'
 
+require 'fakefs/safe'
 require 'minitest/autorun'
 require 'rack/test'
 require 'minitest/reporters'
 require 'minitest/around/unit'
+require 'minitest-spec-context'
 require 'minitest/stub_const'
 require 'mocha/mini_test'
 require 'vcr'


### PR DESCRIPTION
1. Modularized the Apps `animations` resource `sync-out` business logic
2. Created unit tests for the Apps `animations` resource `sync-out` business logic
3. Created unit tests for `I18nScriptUtils.file_changed?`
4. Created unit tests for `I18nScriptUtils.to_js_locale`
5. Created unit tests for `ManifestBuilder#upload_localized_manifest`
6. Created executable script `bundle exec bin/i18n/resources/apps/animations/sync_in.rb`
7. Created executable script `bundle exec bin/i18n/resources/apps/animations/sync_out.rb`

## Links
- jira ticket: [P20-348](https://codedotorg.atlassian.net/browse/P20-348)
- reverted PR: [53436](https://github.com/code-dot-org/code-dot-org/pull/53436)