### PR TITLE
Revert "Use Production-Compatible Caching for `CurriculumPdfs`"

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
+++ b/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
@@ -39,8 +39,8 @@ module Services
 
         # Check S3 to see if we've already generated a PDF for the given lesson.
         def lesson_plan_pdf_exists_for?(lesson, student_facing=false)
-          pathname = get_lesson_plan_pathname(lesson, student_facing).to_s
-          return pdf_exists_at?(pathname)
+          pathname = get_lesson_plan_pathname(lesson, student_facing)
+          AWS::S3.cached_exists_in_bucket?(S3_BUCKET, pathname.to_s)
         end
 
         # Generate the PDF for the given lesson into the given directory. Can

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -104,8 +104,10 @@ module Services
         # Check s3 to see if we've already generated a resource rollup PDF for
         # the given script
         def script_resources_pdf_exists_for?(script)
-          pathname = get_script_resources_pathname(script).to_s
-          return pdf_exists_at?(pathname)
+          AWS::S3.cached_exists_in_bucket?(
+            S3_BUCKET,
+            get_script_resources_pathname(script).to_s
+          )
         end
 
         # Generates a title page for the given lesson; this is used in the

--- a/dashboard/lib/services/curriculum_pdfs/script_overview.rb
+++ b/dashboard/lib/services/curriculum_pdfs/script_overview.rb
@@ -37,8 +37,10 @@ module Services
         # Check S3 to see if we've already generated an overview PDF for the
         # given script
         def script_overview_pdf_exists_for?(script)
-          pathname = get_script_overview_pathname(script).to_s
-          return pdf_exists_at?(pathname)
+          AWS::S3.cached_exists_in_bucket?(
+            S3_BUCKET,
+            get_script_overview_pathname(script).to_s
+          )
         end
 
         # Generate a PDF containing not only the Unit page itself but also

--- a/dashboard/lib/services/curriculum_pdfs/utils.rb
+++ b/dashboard/lib/services/curriculum_pdfs/utils.rb
@@ -25,17 +25,6 @@ module Services
           # the direct S3 link.
           DEBUG ? "https://#{S3_BUCKET}.s3.amazonaws.com" : "https://lesson-plans.code.org"
         end
-
-        def pdf_exists_at?(pathname)
-          return false if pathname.blank?
-
-          cache_key = "CurriculumPdfs/pdf_exists/#{pathname}"
-          return CDO.shared_cache.read(cache_key) if CDO.shared_cache.exist?(cache_key)
-
-          result = AWS::S3.exists_in_bucket(S3_BUCKET, pathname)
-          CDO.shared_cache.write(cache_key, result)
-          return result
-        end
       end
     end
   end

--- a/dashboard/test/lib/services/curriculum_pdfs_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs_test.rb
@@ -7,16 +7,17 @@ module Services
 
     setup do
       PDF.stubs(:generate_from_url)
+      AWS::S3.unstub(:cached_exists_in_bucket?)
     end
 
     test 'get_pdfless_lessons will only include lessons not present in S3' do
       unit_with_lesson_pdfs = create :script, :with_lessons, seeded_from: Time.now
-      AWS::S3.stubs(:exists_in_bucket).with do |_bucket, key|
+      AWS::S3.stubs(:cached_exists_in_bucket?).with do |_bucket, key|
         key.include?(unit_with_lesson_pdfs.name)
       end.returns(true)
 
       unit_without_lesson_pdfs = create :script, :with_lessons, seeded_from: Time.now
-      AWS::S3.stubs(:exists_in_bucket).with do |_bucket, key|
+      AWS::S3.stubs(:cached_exists_in_bucket?).with do |_bucket, key|
         key.include?(unit_without_lesson_pdfs.name)
       end.returns(false)
 
@@ -25,7 +26,6 @@ module Services
     end
 
     test 'get_pdfless_lessons excludes lessons without lesson plans' do
-      AWS::S3.stubs(:exists_in_bucket).returns(false)
       unit_with_lesson_plans = create :script, :with_lessons
       unit_without_lesson_plans = create :script, :with_lessons
       unit_without_lesson_plans.lessons.each do |lesson|

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -89,9 +89,7 @@ class ActiveSupport::TestCase
     CDO.stubs(:optimize_webpack_assets).returns(false)
     CDO.stubs(:use_my_apps).returns(true)
 
-    # Don't attempt to make actual AWS API calls, either, for the same reason
     AWS::S3.stubs(:cached_exists_in_bucket?).returns(true)
-    AWS::S3.stubs(:exists_in_bucket).returns(true)
   end
 
   teardown do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#53480

This change _might_ have caused staging to start recreating all PDF's, or at least an outsized set of them. Reverting to confirm and to get a clean build.

Slack: https://codedotorg.slack.com/archives/C0T0PNTM3/p1693578683345019