### PR TITLE
Revert "Revert "Use Production-Compatible Caching for `CurriculumPdfs`""

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
+++ b/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
@@ -39,8 +39,8 @@ module Services
 
         # Check S3 to see if we've already generated a PDF for the given lesson.
         def lesson_plan_pdf_exists_for?(lesson, student_facing=false)
-          pathname = get_lesson_plan_pathname(lesson, student_facing)
-          AWS::S3.cached_exists_in_bucket?(S3_BUCKET, pathname.to_s)
+          pathname = get_lesson_plan_pathname(lesson, student_facing).to_s
+          return pdf_exists_at?(pathname)
         end
 
         # Generate the PDF for the given lesson into the given directory. Can

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -104,10 +104,8 @@ module Services
         # Check s3 to see if we've already generated a resource rollup PDF for
         # the given script
         def script_resources_pdf_exists_for?(script)
-          AWS::S3.cached_exists_in_bucket?(
-            S3_BUCKET,
-            get_script_resources_pathname(script).to_s
-          )
+          pathname = get_script_resources_pathname(script).to_s
+          return pdf_exists_at?(pathname)
         end
 
         # Generates a title page for the given lesson; this is used in the

--- a/dashboard/lib/services/curriculum_pdfs/script_overview.rb
+++ b/dashboard/lib/services/curriculum_pdfs/script_overview.rb
@@ -37,10 +37,8 @@ module Services
         # Check S3 to see if we've already generated an overview PDF for the
         # given script
         def script_overview_pdf_exists_for?(script)
-          AWS::S3.cached_exists_in_bucket?(
-            S3_BUCKET,
-            get_script_overview_pathname(script).to_s
-          )
+          pathname = get_script_overview_pathname(script).to_s
+          return pdf_exists_at?(pathname)
         end
 
         # Generate a PDF containing not only the Unit page itself but also

--- a/dashboard/lib/services/curriculum_pdfs/utils.rb
+++ b/dashboard/lib/services/curriculum_pdfs/utils.rb
@@ -25,6 +25,17 @@ module Services
           # the direct S3 link.
           DEBUG ? "https://#{S3_BUCKET}.s3.amazonaws.com" : "https://lesson-plans.code.org"
         end
+
+        def pdf_exists_at?(pathname)
+          return false if pathname.blank?
+
+          cache_key = "CurriculumPdfs/pdf_exists/#{pathname}"
+          return CDO.shared_cache.read(cache_key) if CDO.shared_cache.exist?(cache_key)
+
+          result = AWS::S3.exists_in_bucket(S3_BUCKET, pathname)
+          CDO.shared_cache.write(cache_key, result)
+          return result
+        end
       end
     end
   end

--- a/dashboard/test/lib/services/curriculum_pdfs/utils_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs/utils_test.rb
@@ -22,4 +22,38 @@ class Services::CurriculumPdfs::UtilsTest < ActiveSupport::TestCase
       Time.parse("2007-01-29 12:34:56")
     )
   end
+
+  test 'pdf_exists_at will cache if possible' do
+    test_pathname = "foo.pdf"
+    expected_cache_key = "CurriculumPdfs/pdf_exists/\"foo.pdf\""
+
+    # The test environment by default will not even attempt to cache.
+    CDO.shared_cache.expects(:exist?).never
+    CDO.shared_cache.expects(:read).never
+    CDO.shared_cache.expects(:write).never
+    AWS::S3.expects(:exists_in_bucket).once.returns(true)
+    assert Services::CurriculumPdfs.pdf_exists_at?(test_pathname)
+
+    # But if we're using MemCache (as we do in production), we will attempt to
+    # read from and write to the cache.
+    mock_memcache = mock
+    mock_memcache.stubs(:is_a?).with(ActiveSupport::Cache::MemCacheStore).returns(true)
+    CDO.stubs(:shared_cache).returns(mock_memcache)
+
+    # Write to the cache if it isn't already populated.
+    CDO.shared_cache.expects(:exist?).with(expected_cache_key).returns(false)
+    CDO.shared_cache.expects(:read).never
+    CDO.shared_cache.expects(:write).with(expected_cache_key, true)
+    AWS::S3.expects(:exists_in_bucket).once.returns(true)
+    assert Services::CurriculumPdfs.pdf_exists_at?(test_pathname)
+
+    # Read from the cache if it is.
+    CDO.shared_cache.expects(:exist?).with(expected_cache_key).returns(true)
+    CDO.shared_cache.expects(:read).with(expected_cache_key).returns(true)
+    CDO.shared_cache.expects(:write).never
+    AWS::S3.expects(:exists_in_bucket).never
+    assert Services::CurriculumPdfs.pdf_exists_at?(test_pathname)
+
+    CDO.unstub(:shared_cache)
+  end
 end

--- a/dashboard/test/lib/services/curriculum_pdfs_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs_test.rb
@@ -7,17 +7,16 @@ module Services
 
     setup do
       PDF.stubs(:generate_from_url)
-      AWS::S3.unstub(:cached_exists_in_bucket?)
     end
 
     test 'get_pdfless_lessons will only include lessons not present in S3' do
       unit_with_lesson_pdfs = create :script, :with_lessons, seeded_from: Time.now
-      AWS::S3.stubs(:cached_exists_in_bucket?).with do |_bucket, key|
+      AWS::S3.stubs(:exists_in_bucket).with do |_bucket, key|
         key.include?(unit_with_lesson_pdfs.name)
       end.returns(true)
 
       unit_without_lesson_pdfs = create :script, :with_lessons, seeded_from: Time.now
-      AWS::S3.stubs(:cached_exists_in_bucket?).with do |_bucket, key|
+      AWS::S3.stubs(:exists_in_bucket).with do |_bucket, key|
         key.include?(unit_without_lesson_pdfs.name)
       end.returns(false)
 
@@ -26,6 +25,7 @@ module Services
     end
 
     test 'get_pdfless_lessons excludes lessons without lesson plans' do
+      AWS::S3.stubs(:exists_in_bucket).returns(false)
       unit_with_lesson_plans = create :script, :with_lessons
       unit_without_lesson_plans = create :script, :with_lessons
       unit_without_lesson_plans.lessons.each do |lesson|

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -89,7 +89,9 @@ class ActiveSupport::TestCase
     CDO.stubs(:optimize_webpack_assets).returns(false)
     CDO.stubs(:use_my_apps).returns(true)
 
+    # Don't attempt to make actual AWS API calls, either, for the same reason
     AWS::S3.stubs(:cached_exists_in_bucket?).returns(true)
+    AWS::S3.stubs(:exists_in_bucket).returns(true)
   end
 
   teardown do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#53582, restoring https://github.com/code-dot-org/code-dot-org/pull/53480

The first attempt at this change caused the staging build to keep regenerating PDFs that it had already generated, because the first time we checked for the existence of any given PDFs we cached the `false` result; then, because the filesystem-backed cache used in non-production environments never automatically expires anything, we would never updated that value.

The fix is only attempt to cache the existence or nonexistence of a PDF in production. Note that we still don't define an explicit timeline for expiration in production; we assume that from the perspective of servers other than staging, the truth value of this will be consistent for a given version of a given PDF.