### PR TITLE
[Merge after Sept 8th] Lock scholarships dropdown

### DIFF
--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -4,7 +4,7 @@ import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-
 import Select from 'react-select';
 
 // update this to lock scholarships so that scholarship status can't be updated via the UI.
-const locked = false;
+const locked = true;
 
 const ScholarshipDropdown = ({
   scholarshipStatus,


### PR DESCRIPTION
Repeats the work done in [this PR](https://github.com/code-dot-org/code-dot-org/pull/47883/files) to lock the scholarship dropdown in the teacher application details view. I don't believe any updates to the test file will be necessary due to how the logic updated to account for workshop admins between [this PR](https://github.com/code-dot-org/code-dot-org/pull/53196/files) and [this PR](https://github.com/code-dot-org/code-dot-org/pull/53301/files).
![scholarship_locked](https://github.com/code-dot-org/code-dot-org/assets/56283563/cd05b753-bf3c-4029-ba51-a77141205763)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-768&assignee=60d62161f65054006980bd71)
Last year's PR: [here](https://github.com/code-dot-org/code-dot-org/pull/47883)

## Testing story
Local testing and drone build.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
