### PR TITLE
Quick fix to Email metrics missing some data

### DIFF
--- a/dashboard/app/mailers/concerns/ActionMailerMetrics.rb
+++ b/dashboard/app/mailers/concerns/ActionMailerMetrics.rb
@@ -13,6 +13,9 @@ module ActionMailerMetrics
   # ActionMailer that created the message.
   CLASS_HEADER = "X-ActionMailer-Class"
 
+  UNKNOWN_ACTION = 'unknown_action'.freeze
+  UNKNOWN_CLASS = 'unknown_class'.freeze
+
   # Set custom headers on the message so we know where it originated from.
   def set_metrics_headers
     headers[ACTION_HEADER] = action_name
@@ -21,11 +24,13 @@ module ActionMailerMetrics
 
   # Returns the ActionMailer action name which created the given message.
   def self.get_message_action(message)
-    message.header[ACTION_HEADER].to_s
+    message_action = message.header[ACTION_HEADER]
+    message_action ? message_action.to_s : UNKNOWN_ACTION
   end
 
   # Returns the ActionMailer class name which created the given message.
   def self.get_message_class(message)
-    message.header[CLASS_HEADER].to_s
+    message_class = message.header[CLASS_HEADER]
+    message_class ? message_class.to_s : UNKNOWN_CLASS
   end
 end

--- a/dashboard/app/mailers/email_delivery_interceptor.rb
+++ b/dashboard/app/mailers/email_delivery_interceptor.rb
@@ -6,8 +6,8 @@ require 'cdo/aws/metrics'
 #
 class EmailDeliveryInterceptor
   def self.delivering_email(message)
-    action = ActionMailerMetrics.get_message_action(message)
-    mailer_class = ActionMailerMetrics.get_message_class(message)
+    action = ActionMailerMetrics.get_message_action(message) || 'unknown_action'
+    mailer_class = ActionMailerMetrics.get_message_class(message) || 'unknown_class'
     metrics = [
       {
         metric_name: :EmailToSend,

--- a/dashboard/app/mailers/email_delivery_interceptor.rb
+++ b/dashboard/app/mailers/email_delivery_interceptor.rb
@@ -6,8 +6,8 @@ require 'cdo/aws/metrics'
 #
 class EmailDeliveryInterceptor
   def self.delivering_email(message)
-    action = ActionMailerMetrics.get_message_action(message) || 'unknown_action'
-    mailer_class = ActionMailerMetrics.get_message_class(message) || 'unknown_class'
+    action = ActionMailerMetrics.get_message_action(message)
+    mailer_class = ActionMailerMetrics.get_message_class(message)
     metrics = [
       {
         metric_name: :EmailToSend,

--- a/dashboard/app/mailers/email_delivery_observer.rb
+++ b/dashboard/app/mailers/email_delivery_observer.rb
@@ -6,8 +6,8 @@ require 'cdo/aws/metrics'
 #
 class EmailDeliveryObserver
   def self.delivered_email(message)
-    action = ActionMailerMetrics.get_message_action(message) || 'unknown_action'
-    mailer_class = ActionMailerMetrics.get_message_class(message) || 'unknown_class'
+    action = ActionMailerMetrics.get_message_action(message)
+    mailer_class = ActionMailerMetrics.get_message_class(message)
     metrics = [
       {
         metric_name: :EmailSent,

--- a/dashboard/app/mailers/email_delivery_observer.rb
+++ b/dashboard/app/mailers/email_delivery_observer.rb
@@ -6,8 +6,8 @@ require 'cdo/aws/metrics'
 #
 class EmailDeliveryObserver
   def self.delivered_email(message)
-    action = ActionMailerMetrics.get_message_action(message)
-    mailer_class = ActionMailerMetrics.get_message_class(message)
+    action = ActionMailerMetrics.get_message_action(message) || 'unknown_action'
+    mailer_class = ActionMailerMetrics.get_message_class(message) || 'unknown_class'
     metrics = [
       {
         metric_name: :EmailSent,


### PR DESCRIPTION
We recently updated our EmailMetrics to try to include more information about what specific emails are being sent. Some of the new data we are trying to log is the Class name and the method (action) name used to generate the email.
After shipping this change we started getting [Honeybader errors saying a metric value is empty](https://app.honeybadger.io/projects/3240/faults/99575911/oldest#notice-summary). Since this suspiciously happened soon after these new metrics were added, I have added a quick patch to provide default values if some of the data is missing.

## Links
* [JIRA P20-382](https://codedotorg.atlassian.net/browse/P20-382)
* [Honeybadger errors](https://app.honeybadger.io/projects/3240/faults/99575911/oldest#notice-summary)

## Testing story
None

