### PR TITLE
P20-348: Fix ManifestBuilder#upload_localized_manifest on multiple calls

### DIFF
--- a/bin/animation_assets/manifest_builder.rb
+++ b/bin/animation_assets/manifest_builder.rb
@@ -205,7 +205,7 @@ class ManifestBuilder
   def upload_localized_manifest(locale, strings)
     return unless upload_spritelab_to_s3?
 
-    animation_metadata = initial_animation_metadata
+    animation_metadata = initial_animation_metadata.deep_dup
     animation_metadata.each do |_, metadata|
       metadata['aliases'] = metadata['aliases'].map {|aliaz| strings[aliaz]}
       metadata['aliases'].delete_if(&:blank?)

--- a/bin/test/animation_assets/test_manifest_builder.rb
+++ b/bin/test/animation_assets/test_manifest_builder.rb
@@ -1,82 +1,97 @@
 require_relative '../test_helper'
 require_relative '../../animation_assets/manifest_builder'
 
-class ManifestBuilderTest < Minitest::Test
-  def setup
-    aws_credentials_mock = Aws::Credentials.new('test_aws_key', 'test_aws_secret')
-    Aws::CredentialProviderChain.any_instance.stubs(:static_credentials).returns(aws_credentials_mock)
+describe ManifestBuilder do
+  let(:aws_credentials) {Aws::Credentials.new('test_aws_key', 'test_aws_secret')}
+
+  before do
+    STDOUT.stubs(:print)
+    Aws::CredentialProviderChain.any_instance.stubs(:static_credentials).returns(aws_credentials)
   end
 
-  def test_getting_animation_strings_for_spritelab_quietly
-    animation_strings = nil
+  describe '#get_animation_strings' do
+    context 'for spritelab quietly' do
+      let(:manifest_builder) {ManifestBuilder.new({spritelab: true, quite: true})}
 
-    VCR.use_cassette('animations/manifest_spritelab_strings', record: :none) do
-      animation_strings = ManifestBuilder.new({spritelab: true, quite: true}).get_animation_strings
+      it 'returns spritelab animation strings' do
+        animation_strings = nil
+
+        VCR.use_cassette('animations/manifest_spritelab_strings', record: :none) do
+          animation_strings = manifest_builder.get_animation_strings
+        end
+
+        assert_equal({'test_alias_1' => 'test_alias_1', 'test_alias_2' => 'test_alias_2'}, animation_strings)
+      end
     end
-
-    assert_equal({'test_alias_1' => 'test_alias_1', 'test_alias_2' => 'test_alias_2'}, animation_strings)
   end
 
-  def test_uploading_localized_manifest_for_spritelab_quietly
-    expected_spritelab_animations_manifest_data = <<-JSON.strip.gsub(/^ {6}/, '')
-      {
-        "//": [
-          "Animation Library Manifest",
-          "GENERATED FILE: DO NOT MODIFY DIRECTLY",
-          "See tools/scripts/rebuildAnimationLibraryManifest.rb for more information."
-        ],
-        "metadata": {
-          "category_test_1/valid_test": {
-            "name": "valid_test",
-            "categories": [
-              "test_category"
+  describe '#upload_localized_manifest' do
+    context 'for spritelab quitly' do
+      let(:manifest_builder) {ManifestBuilder.new({spritelab: true, upload_to_s3: true, quite: true})}
+
+      it 'uploads spritelab animations manifest to the S3 bucket' do
+        expected_uploads = 2
+        expected_manifest_data = <<-JSON.strip.gsub(/^ {10}/, '')
+          {
+            "//": [
+              "Animation Library Manifest",
+              "GENERATED FILE: DO NOT MODIFY DIRECTLY",
+              "See tools/scripts/rebuildAnimationLibraryManifest.rb for more information."
             ],
-            "frameCount": 1,
-            "frameSize": {
-              "x": 100,
-              "y": 200
+            "metadata": {
+              "category_test_1/valid_test": {
+                "name": "valid_test",
+                "categories": [
+                  "test_category"
+                ],
+                "frameCount": 1,
+                "frameSize": {
+                  "x": 100,
+                  "y": 200
+                },
+                "looping": true,
+                "frameDelay": 2,
+                "jsonLastModified": "2021-01-19 23:48:52 UTC",
+                "pngLastModified": "2021-01-19 23:48:53 UTC",
+                "version": "QtaHBb9VSb33E0CMEgEECueLtkomMS9t",
+                "sourceUrl": "/api/v1/animation-library/spritelab/QtaHBb9VSb33E0CMEgEECueLtkomMS9t/category_test_1/valid_test.png",
+                "sourceSize": {
+                  "x": 400,
+                  "y": 400
+                }
+              }
             },
-            "looping": true,
-            "frameDelay": 2,
-            "jsonLastModified": "2021-01-19 23:48:52 UTC",
-            "pngLastModified": "2021-01-19 23:48:53 UTC",
-            "version": "QtaHBb9VSb33E0CMEgEECueLtkomMS9t",
-            "sourceUrl": "/api/v1/animation-library/spritelab/QtaHBb9VSb33E0CMEgEECueLtkomMS9t/category_test_1/valid_test.png",
-            "sourceSize": {
-              "x": 400,
-              "y": 400
+            "categories": {
+              "test_category": [
+                "category_test_1/valid_test"
+              ]
+            },
+            "aliases": {
+              "expected_test_alias_1_translation": [
+                "category_test_1/valid_test"
+              ],
+              "valid_test": [
+                "category_test_1/valid_test"
+              ]
             }
           }
-        },
-        "categories": {
-          "test_category": [
-            "category_test_1/valid_test"
-          ]
-        },
-        "aliases": {
-          "expected_test_alias_1_translation": [
-            "category_test_1/valid_test"
-          ],
-          "valid_test": [
-            "category_test_1/valid_test"
-          ]
-        }
-      }
-    JSON
+        JSON
 
-    AWS::S3.expects(:upload_to_bucket).with(
-      'cdo-animation-library',
-      'animation-manifests/manifests/spritelabCostumeLibrary.en_us.json',
-      expected_spritelab_animations_manifest_data,
-      acl: 'public-read',
-      no_random: true,
-      content_type: 'json',
-    ).once
+        AWS::S3.expects(:upload_to_bucket).with(
+          'cdo-animation-library',
+          'animation-manifests/manifests/spritelabCostumeLibrary.en_us.json',
+          expected_manifest_data,
+          acl: 'public-read',
+          no_random: true,
+          content_type: 'json',
+        ).times(expected_uploads)
 
-    VCR.use_cassette('animations/manifest_spritelab_strings', record: :none) do
-      ManifestBuilder.new({spritelab: true, upload_to_s3: true, quite: true}).upload_localized_manifest(
-        'en_us', {'test_alias_1' => 'expected_test_alias_1_translation'}
-      )
+        VCR.use_cassette('animations/manifest_spritelab_strings', record: :none) do
+          expected_uploads.times do
+            manifest_builder.upload_localized_manifest('en_us', {'test_alias_1' => 'expected_test_alias_1_translation'})
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Issue
`aliases` are deleted on the first call of `#upload_localized_manifest` in `#generate_json`, so they are not present in memoized `#initial_animation_metadata` on the next calls:
https://github.com/code-dot-org/code-dot-org/blob/2e11a5dbdb000a5d1e73777f59757da56f3af93e/bin/animation_assets/manifest_builder.rb#L430-L433

1. `bundler: failed to load command: ./bin/i18n/sync-all.rb (./bin/i18n/sync-all.rb)`
2. `Apps/animations sync-out: Sync out failed from the error: undefined method 'map' for nil:NilClass`
3. `/home/ubuntu/code-dot-org/bin/animation_assets/manifest_builder.rb:210:in block in upload_localized_manifest': undefined method map' for nil:NilClass (NoMethodError)`
4. `from /home/ubuntu/code-dot-org/bin/animation_assets/manifest_builder.rb:209:in 'each'`

## Links
- jira ticket: [P20-348](https://codedotorg.atlassian.net/browse/P20-348)