### PR TITLE
[App Lab] Fix image file path for remixed App Lab projects

### DIFF
--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -415,6 +415,9 @@ designMode.updateProperty = function (
       } else if (DATA_PREFIX_REGEX.test(value)) {
         element.src = value;
       } else {
+        if (!getStore().getState().pageConstants.isCurriculumLevel) {
+          value = value.replace('image://', '');
+        }
         element.src =
           value === ''
             ? '/blockly/media/1x1.gif'

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -415,9 +415,6 @@ designMode.updateProperty = function (
       } else if (DATA_PREFIX_REGEX.test(value)) {
         element.src = value;
       } else {
-        if (!getStore().getState().pageConstants.isCurriculumLevel) {
-          value = value.replace('image://', '');
-        }
         element.src =
           value === ''
             ? '/blockly/media/1x1.gif'

--- a/apps/src/assetManagement/assetPrefix.js
+++ b/apps/src/assetManagement/assetPrefix.js
@@ -82,7 +82,13 @@ export function fixPath(filename) {
   if (SOUND_PREFIX_REGEX.test(filename)) {
     return filename.replace(SOUND_PREFIX, soundPathPrefix);
   }
+
   const state = getStore().getState();
+
+  // If a curriculum level is remixed, any images that were copied from a starter asset
+  // image contains 'image://' in its filenmae.
+  // We want to strip this starter asset prefix from the filename so that the correct
+  // image file path is returned.
   if (!state.pageConstants.isCurriculumLevel) {
     filename = filename.replace(STARTER_ASSET_PREFIX, '');
   }

--- a/apps/src/assetManagement/assetPrefix.js
+++ b/apps/src/assetManagement/assetPrefix.js
@@ -82,9 +82,11 @@ export function fixPath(filename) {
   if (SOUND_PREFIX_REGEX.test(filename)) {
     return filename.replace(SOUND_PREFIX, soundPathPrefix);
   }
-
+  const state = getStore().getState();
+  if (!state.pageConstants.isCurriculumLevel) {
+    filename = filename.replace(STARTER_ASSET_PREFIX, '');
+  }
   if (STARTER_ASSET_PREFIX_REGEX.test(filename)) {
-    const state = getStore().getState();
     return filename.replace(
       STARTER_ASSET_PREFIX,
       starterAssetPathPrefix(state.level.name)

--- a/apps/test/unit/applab/ExporterTest.js
+++ b/apps/test/unit/applab/ExporterTest.js
@@ -1,5 +1,14 @@
 import {assert, expect} from '../../util/reconfiguredChai';
 import sinon from 'sinon';
+import pageConstantsReducer, {
+  setPageConstants,
+} from '@cdo/apps/redux/pageConstants';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux,
+} from '@cdo/apps/redux';
 
 var testUtils = require('../../util/testUtils');
 import * as assetPrefix from '@cdo/apps/assetManagement/assetPrefix';
@@ -239,6 +248,13 @@ describe('Applab Exporter,', function () {
 
     stashedCookieKey = window.userNameCookieKey;
     window.userNameCookieKey = 'CoolUser';
+    stubRedux();
+    registerReducers({pageConstants: pageConstantsReducer});
+    getStore().dispatch(
+      setPageConstants({
+        isCurriculumLevel: true,
+      })
+    );
   });
 
   afterEach(function () {
@@ -246,6 +262,7 @@ describe('Applab Exporter,', function () {
     window.fetch.restore();
     assetPrefix.init({});
     window.userNameCookieKey = stashedCookieKey;
+    restoreRedux();
   });
 
   describe("when assets can't be fetched,", function () {

--- a/apps/test/unit/applab/designModeTest.js
+++ b/apps/test/unit/applab/designModeTest.js
@@ -1,15 +1,6 @@
 import {expect} from '../../util/reconfiguredChai';
 import designMode from '@cdo/apps/applab/designMode';
 import elementLibrary from '@cdo/apps/applab/designElements/library';
-import pageConstantsReducer, {
-  setPageConstants,
-} from '@cdo/apps/redux/pageConstants';
-import {
-  getStore,
-  registerReducers,
-  stubRedux,
-  restoreRedux,
-} from '@cdo/apps/redux';
 
 describe('appendPx', () => {
   it('returns a valid css positive integer', function () {
@@ -189,16 +180,8 @@ describe('setProperty and read Property', () => {
       expect(dropdown.value).to.equal('Eta Theta');
     });
     it('Uses the asset timestamp in the source path for pictures', () => {
-      stubRedux();
-      registerReducers({pageConstants: pageConstantsReducer});
-      getStore().dispatch(
-        setPageConstants({
-          isCurriculumLevel: true,
-        })
-      );
       designMode.updateProperty(picture, 'picture', 'picture.jpg', 123456);
       expect(picture.src).to.contain('picture.jpg?t=123456');
-      restoreRedux();
     });
   });
 

--- a/apps/test/unit/applab/designModeTest.js
+++ b/apps/test/unit/applab/designModeTest.js
@@ -1,6 +1,15 @@
 import {expect} from '../../util/reconfiguredChai';
 import designMode from '@cdo/apps/applab/designMode';
 import elementLibrary from '@cdo/apps/applab/designElements/library';
+import pageConstantsReducer, {
+  setPageConstants,
+} from '@cdo/apps/redux/pageConstants';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux,
+} from '@cdo/apps/redux';
 
 describe('appendPx', () => {
   it('returns a valid css positive integer', function () {
@@ -114,10 +123,18 @@ describe('onDuplicate screen', () => {
 
     originalScreen = elementLibrary.createElement('SCREEN', 0, 0);
     designModeElement.appendChild(originalScreen);
+    stubRedux();
+    registerReducers({pageConstants: pageConstantsReducer});
+    getStore().dispatch(
+      setPageConstants({
+        isCurriculumLevel: true,
+      })
+    );
   });
 
   afterEach(() => {
     document.body.removeChild(designModeElement);
+    restoreRedux();
   });
 
   it('duplicates the background color of the screen', () => {
@@ -180,8 +197,16 @@ describe('setProperty and read Property', () => {
       expect(dropdown.value).to.equal('Eta Theta');
     });
     it('Uses the asset timestamp in the source path for pictures', () => {
+      stubRedux();
+      registerReducers({pageConstants: pageConstantsReducer});
+      getStore().dispatch(
+        setPageConstants({
+          isCurriculumLevel: true,
+        })
+      );
       designMode.updateProperty(picture, 'picture', 'picture.jpg', 123456);
       expect(picture.src).to.contain('picture.jpg?t=123456');
+      restoreRedux();
     });
   });
 

--- a/apps/test/unit/applab/designModeTest.js
+++ b/apps/test/unit/applab/designModeTest.js
@@ -1,6 +1,15 @@
 import {expect} from '../../util/reconfiguredChai';
 import designMode from '@cdo/apps/applab/designMode';
 import elementLibrary from '@cdo/apps/applab/designElements/library';
+import pageConstantsReducer, {
+  setPageConstants,
+} from '@cdo/apps/redux/pageConstants';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux,
+} from '@cdo/apps/redux';
 
 describe('appendPx', () => {
   it('returns a valid css positive integer', function () {
@@ -180,8 +189,16 @@ describe('setProperty and read Property', () => {
       expect(dropdown.value).to.equal('Eta Theta');
     });
     it('Uses the asset timestamp in the source path for pictures', () => {
+      stubRedux();
+      registerReducers({pageConstants: pageConstantsReducer});
+      getStore().dispatch(
+        setPageConstants({
+          isCurriculumLevel: true,
+        })
+      );
       designMode.updateProperty(picture, 'picture', 'picture.jpg', 123456);
       expect(picture.src).to.contain('picture.jpg?t=123456');
+      restoreRedux();
     });
   });
 

--- a/apps/test/unit/applab/importTest.js
+++ b/apps/test/unit/applab/importTest.js
@@ -10,6 +10,15 @@ import {
   getImportableProject,
   importScreensAndAssets,
 } from '@cdo/apps/applab/import';
+import pageConstantsReducer, {
+  setPageConstants,
+} from '@cdo/apps/redux/pageConstants';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux,
+} from '@cdo/apps/redux';
 
 describe('The applab/import module', () => {
   allowConsoleErrors();
@@ -369,6 +378,17 @@ describe('The applab/import module', () => {
           [project.screens[0], project.screens[1]],
           [{filename: 'asset3.png'}, {filename: 'asset4.png'}]
         ).then(onResolve, onReject);
+        stubRedux();
+        registerReducers({pageConstants: pageConstantsReducer});
+        getStore().dispatch(
+          setPageConstants({
+            isCurriculumLevel: true,
+          })
+        );
+      });
+
+      afterEach(() => {
+        restoreRedux();
       });
 
       it('will import the specified screens', () => {

--- a/apps/test/unit/assetManagement/assetPrefixTest.js
+++ b/apps/test/unit/assetManagement/assetPrefixTest.js
@@ -13,6 +13,9 @@ describe('apps/src/assetManagement/assetPrefix.js', () => {
           level: {
             name: 'test-level',
           },
+          pageConstants: {
+            isCurriculumLevel: true,
+          },
         }),
       });
     });

--- a/apps/test/unit/gamelab/ExporterTest.js
+++ b/apps/test/unit/gamelab/ExporterTest.js
@@ -4,6 +4,15 @@ import sinon from 'sinon';
 var testUtils = require('../../util/testUtils');
 import * as assetPrefix from '@cdo/apps/assetManagement/assetPrefix';
 import Exporter from '@cdo/apps/p5lab/gamelab/Exporter';
+import pageConstantsReducer, {
+  setPageConstants,
+} from '@cdo/apps/redux/pageConstants';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux,
+} from '@cdo/apps/redux';
 
 const emptyAnimationOpts = {
   animationList: {
@@ -95,12 +104,20 @@ describe('The Gamelab Exporter,', function () {
 
     stashedCookieKey = window.userNameCookieKey;
     window.userNameCookieKey = 'CoolUser';
+    stubRedux();
+    registerReducers({pageConstants: pageConstantsReducer});
+    getStore().dispatch(
+      setPageConstants({
+        isCurriculumLevel: true,
+      })
+    );
   });
 
   afterEach(function () {
     server.restore();
     assetPrefix.init({});
     window.userNameCookieKey = stashedCookieKey;
+    restoreRedux();
   });
 
   describe("when assets can't be fetched,", function () {

--- a/apps/test/unit/p5lab/redux/animationListTest.js
+++ b/apps/test/unit/p5lab/redux/animationListTest.js
@@ -21,13 +21,33 @@ import {createStore} from '../../../util/redux';
 import {expect} from '../../../util/reconfiguredChai';
 import {setExternalGlobals} from '../../../util/testUtils';
 import commonReducers from '@cdo/apps/redux/commonReducers';
-import {setPageConstants} from '@cdo/apps/redux/pageConstants';
+import pageConstantsReducer, {
+  setPageConstants,
+} from '@cdo/apps/redux/pageConstants';
 const project = require('@cdo/apps/code-studio/initApp/project');
 import * as assetPrefix from '@cdo/apps/assetManagement/assetPrefix';
 import _ from 'lodash';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux,
+} from '@cdo/apps/redux';
 
 describe('animationList', function () {
   setExternalGlobals(beforeEach, afterEach);
+  beforeEach(() => {
+    stubRedux();
+    registerReducers({pageConstants: pageConstantsReducer});
+    getStore().dispatch(
+      setPageConstants({
+        isCurriculumLevel: true,
+      })
+    );
+  });
+  afterEach(() => {
+    restoreRedux();
+  });
   describe('animationSourceUrl', function () {
     const key = 'foo';
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR fixes the paths of image files for App Lab projects that are remixed from levels that have image starter assets so they are no longer broken and displayed as expected.

Screencast video BEFORE UPDATE: When level is remixed, starter asset images are broken.

https://github.com/code-dot-org/code-dot-org/assets/107423305/c37ce270-5b3b-4c94-ba44-0a842112a2ad



Screencast video AFTER UPDATE:



https://github.com/code-dot-org/code-dot-org/assets/107423305/e59ea01c-07d4-45b2-9999-f12fb17ff75c




Image files that are stored in starter assets are prepended with 'image://', e.g., 'image://Bat.png'. In `assetPrefix.js` the image starter asset file path is set to 'level_starter_assets/level_name/file_name', e.g., 'level_starter_assets/example_level_name/Bat.png. However, for remixed projects, the images are copied and stored in v3 so the file path should be set to 'v3/assets/channel_id>/file_name', e.g., 'v3/assets/abcd123examplechannelid/Bat.png'.

Thus, in `designMode.js`, I add a check to see if this is a curriculum level and if not, then remove the `STARTER_ASSET_PREFIX`, i.e., 'image://` from the file name.

This PR is in response to [this ZenDesk ticket](https://codeorg.zendesk.com/agent/tickets/456145) - the teacher wanted to be able to share solutions to a particular level. 
Note that the level must be **remixed** in order for the images to work. If the level is shared, the image remain broken in the share URL - this is the current behavior on production as well.

Here's a screencast video AFTER the update of a user logged in on a curriculum level and then retrieving the 'Share' URL. As a standalone project, the images are broken. Note that this is the current behavior on production as well.


https://github.com/code-dot-org/code-dot-org/assets/107423305/69acc36c-1c2e-420a-ad03-49d51967e285



Here's a screencast video AFTER the update - copying and pasting the 'Share' URL link but in an incognito window. Thus a 'different' user logs in and then after clicking on 'Remix' the images are displayed correctly:


https://github.com/code-dot-org/code-dot-org/assets/107423305/10ccddf4-710f-4420-9537-1c6028b4bfdf



This bug fix was known for a while by curriculum and the fix will make creating exemplar (solution) projects easier to share - [Slack discussion](https://codedotorg.slack.com/archives/C1B3PNDL7/p1648831623069409).




## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-38)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally and updated unit tests to stub redux (`isCurriculumLevel`) in 5 test files.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
