### PR TITLE
Revert CPA emails to original privacy text

### DIFF
--- a/dashboard/app/views/parent_mailer/parent_permission_confirmation.html.haml
+++ b/dashboard/app/views/parent_mailer/parent_permission_confirmation.html.haml
@@ -18,11 +18,9 @@
   Code.org is a US-based nonprofit that provides free computer science courses and activities.  We collect limited personal data solely for the purpose of providing the services, including:  Display Name (we recommend using only first name - used to provide welcome); Username (not actual name); Passwords; Hashed Email Address (not stored in retrievable format - can't be used to contact student); Age (not birthday); and Gender (optional) (used for aggregate measurements).
 
 %p
-  Code.org assigns utmost importance to student data privacy and security. As a not-for-profit organization, they are transparent about the limited data they collect and how they use it.  They do not sell data or exploit it for financial gain. They do not sell ads. Code.org has signed the
-  %a{href:SharedConstants::EMAIL_LINKS.STUDENT_PRIVACY_PLEDGE_URL}Student Privacy Pledge
-  and their privacy practices are highly rated by
-  %a{href:SharedConstants::EMAIL_LINKS.COMMON_SENSE_MEDIA_URL}Common Sense Media.
-  You can find further details by viewing Code.org's
+  We do not sell data or exploit it for financial gain. We do not sell ads.  We do not store student email addresses in a retrievable format.  For more information on Code.org accounts for children under 13 years old, please see our
+  %u Children's Privacy Notice,
+  which is part of our full
   %a{href:SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL}Privacy Policy.
 
 %p

--- a/dashboard/app/views/parent_mailer/parent_permission_reminder.html.haml
+++ b/dashboard/app/views/parent_mailer/parent_permission_reminder.html.haml
@@ -16,11 +16,9 @@
   Code.org is a US-based nonprofit that provides free computer science courses and activities.  We collect limited personal data solely for the purpose of providing the services, including:  Display Name (we recommend using only first name - used to provide welcome); Username (not actual name); Passwords; Hashed Email Address (not stored in retrievable format - can't be used to contact student); Age (not birthday); and Gender (optional) (used for aggregate measurements).
 
 %p
-  Code.org assigns utmost importance to student data privacy and security. As a not-for-profit organization, they are transparent about the limited data they collect and how they use it.  They do not sell data or exploit it for financial gain. They do not sell ads. Code.org has signed the
-  %a{href:SharedConstants::EMAIL_LINKS.STUDENT_PRIVACY_PLEDGE_URL}Student Privacy Pledge
-  and their privacy practices are highly rated by
-  %a{href:SharedConstants::EMAIL_LINKS.COMMON_SENSE_MEDIA_URL}Common Sense Media.
-  You can find further details by viewing Code.org's
+  We do not sell data or exploit it for financial gain. We do not sell ads.  We do not store student email addresses in a retrievable format.  For more information on Code.org accounts for children under 13 years old, please see our
+  %u Children's Privacy Notice,
+  which is part of our full
   %a{href:SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL}Privacy Policy.
 
 %p

--- a/dashboard/app/views/parent_mailer/parent_permission_request.html.haml
+++ b/dashboard/app/views/parent_mailer/parent_permission_request.html.haml
@@ -13,11 +13,9 @@
   Code.org is a US-based nonprofit that provides free computer science courses and activities.  We collect limited personal data solely for the purpose of providing the services, including:  Display Name (we recommend using only first name - used to provide welcome); Username (not actual name); Passwords; Hashed Email Address (not stored in retrievable format - can't be used to contact student); Age (not birthday); and Gender (optional) (used for aggregate measurements).
 
 %p
-  Code.org assigns utmost importance to student data privacy and security. As a not-for-profit organization, they are transparent about the limited data they collect and how they use it.  They do not sell data or exploit it for financial gain. They do not sell ads. Code.org has signed the
-  %a{href:SharedConstants::EMAIL_LINKS.STUDENT_PRIVACY_PLEDGE_URL}Student Privacy Pledge
-  and their privacy practices are highly rated by
-  %a{href:SharedConstants::EMAIL_LINKS.COMMON_SENSE_MEDIA_URL}Common Sense Media.
-  You can find further details by viewing Code.org's
+  We do not sell data or exploit it for financial gain. We do not sell ads.  We do not store student email addresses in a retrievable format.  For more information on Code.org accounts for children under 13 years old, please see our
+  %u Children's Privacy Notice,
+  which is part of our full
   %a{href:SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL}Privacy Policy.
 
 %p


### PR DESCRIPTION
Change back to the first iteration of privacy text for CPA emails

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
