### PR TITLE
[Merge after Sept 8] Move to 2024-2025 application setting

### DIFF
--- a/lib/cdo/shared_constants/pd/shared_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_application_constants.rb
@@ -15,10 +15,11 @@ module Pd
       YEAR_21_22 = '2021-2022'.freeze,
       YEAR_22_23 = '2022-2023'.freeze,
       YEAR_23_24 = '2023-2024'.freeze,
-      YEAR_24_25 = '2024-2025'.freeze
+      YEAR_24_25 = '2024-2025'.freeze,
+      YEAR_25_26 = '2025-2026'.freeze
     ].freeze
 
-    APPLICATION_CURRENT_YEAR = YEAR_23_24
+    APPLICATION_CURRENT_YEAR = YEAR_24_25
 
     COHORT_CALCULATOR_STATUSES = %w(
       accepted


### PR DESCRIPTION
Following [this PR](https://github.com/code-dot-org/code-dot-org/pull/48052) from last year, this archives all of the applications from the 2023-2024 school year and sets the new application year to 2024-2025. In addition, I added the following school year since there are some calls to a `next_year`.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-770&assignee=60d62161f65054006980bd71)

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
