### PR TITLE
Add submitted_at timestamp to learning_goal_evidence_levels

### DIFF
--- a/dashboard/app/models/learning_goal_evaluation.rb
+++ b/dashboard/app/models/learning_goal_evaluation.rb
@@ -15,6 +15,7 @@
 #  context          :text(65535)
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  submitted_at     :datetime
 #
 class LearningGoalEvaluation < ApplicationRecord
   belongs_to :learning_goal

--- a/dashboard/db/migrate/20230831145020_add_submitted_at_to_learning_goal_evaluations.rb
+++ b/dashboard/db/migrate/20230831145020_add_submitted_at_to_learning_goal_evaluations.rb
@@ -1,0 +1,5 @@
+class AddSubmittedAtToLearningGoalEvaluations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :learning_goal_evaluations, :submitted_at, :datetime
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_20_231439) do
+ActiveRecord::Schema.define(version: 2023_08_31_145020) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -635,6 +635,7 @@ ActiveRecord::Schema.define(version: 2023_07_20_231439) do
     t.text "context"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "submitted_at"
   end
 
   create_table "learning_goal_evidence_levels", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
For the new TA Rubrics, teachers will submit feedback to students and students should not be able to see the feedback until it is submitted. This means we need to keep track of whether or not feedback is submitted in the `learning_goal_evaluations` table. I decided to make this column a timestamp as, eventually, we'll want a version history for feedback (afaict, not dissimilar from the way TeacherFeedback works now), with timestamps.