### PR TITLE
Take down AFE banner temporarily

### DIFF
--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -61,6 +61,11 @@ export const UnconnectedTeacherHomepage = ({
   const teacherReminders = useRef(null);
   const flashes = useRef(null);
 
+  /* We are hiding the AFE banner to free up space on the Teacher Homepage (September 2023) when
+   * we want to show the AFE banner again remove the next line and uses of 'shouldShowAFEBanner'.
+   */
+  const shouldShowAFEBanner = false;
+
   /* We are hiding the PL application banner to free up space on the Teacher Homepage (May 2023)
    * when we want to show the Census banner again set this to true
    */
@@ -154,7 +159,7 @@ export const UnconnectedTeacherHomepage = ({
   // Verify background image works for both LTR and RTL languages.
   const backgroundUrl = '/shared/images/banners/teacher-homepage-hero.jpg';
 
-  const showAFEBanner = isEnglish && afeEligible;
+  const showAFEBanner = shouldShowAFEBanner && isEnglish && afeEligible;
 
   // Send one analytics event when a teacher logs in. Use session storage to determine
   // whether they've just logged in.

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -61,8 +61,8 @@ export const UnconnectedTeacherHomepage = ({
   const teacherReminders = useRef(null);
   const flashes = useRef(null);
 
-  /* We are hiding the AFE banner to free up space on the Teacher Homepage (September 2023) when
-   * we want to show the AFE banner again remove the next line and uses of 'shouldShowAFEBanner'.
+  /* We are hiding the AFE banner to free up space on the Teacher Homepage as of September 2023).
+   * When we want to show the AFE banner again remove the next line and uses of 'shouldShowAFEBanner'.
    */
   const shouldShowAFEBanner = false;
 

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -150,9 +150,14 @@ describe('TeacherHomepage', () => {
     assert.equal(wrapper.find('CensusTeacherBanner').length, 0);
   });
 
-  it('renders a DonorTeacherBanner if isEnglish and afeEligible is true', () => {
+  /*
+    We have disabled the AFE Banner on the Teacher Homepage (September 2023) to conserve
+    space. If we decide to show the banner again this test will need to be updated. See
+    TeacherHomepage.jsx to make the banner show.
+   */
+  it('does not render a DonorTeacherBanner even if isEnglish and afeEligible are true', () => {
     const wrapper = setUp({isEnglish: true, afeEligible: true});
-    assert(wrapper.find('DonorTeacherBanner').exists());
+    assert(!wrapper.find('DonorTeacherBanner').exists());
   });
 
   it('renders a TeacherSections component', () => {


### PR DESCRIPTION
We don’t want to have too many banners on the Teacher Homepage so we will hide the AFE promotion banner from the teacher homepage while the Access Report Banner is up. I followed [how another banner has been temporarily hidden](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/templates/studioHomepages/TeacherHomepage.jsx#L64-L67) to make room on the Teacher Homepage.

### Previous view when user was AFE eligible and viewing in English
![Show_AFE](https://github.com/code-dot-org/code-dot-org/assets/56283563/f248a9f3-42d9-4602-9566-0698f8398fe7)

### Now with disabling it for all users
![No_AFE](https://github.com/code-dot-org/code-dot-org/assets/56283563/343e6093-e794-4a42-b442-8ddf070750ba)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-825&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and drone build.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
