### PR TITLE
Set up container for Dance on Lab2

### DIFF
--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -1,0 +1,44 @@
+import Instructions from '@cdo/apps/lab2/views/components/Instructions';
+import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import React from 'react';
+import moduleStyles from './dance-view.module.scss';
+
+const DANCE_VISUALIZATION_ID = 'dance-visualization';
+const BLOCKLY_DIV_ID = 'dance-blockly-div';
+
+/**
+ * Renders the Lab2 version of Dance Lab. This separate container
+ * allows us to support both Lab2 and legacy Dance.
+ */
+const DanceView: React.FunctionComponent = () => {
+  return (
+    <div id="dance-lab" className={moduleStyles.danceLab}>
+      <div className={moduleStyles.visualizationArea}>
+        <div className={moduleStyles.visualizationColumn}>
+          <div
+            id={DANCE_VISUALIZATION_ID}
+            className={moduleStyles.visualization}
+          />
+        </div>
+      </div>
+      <div className={moduleStyles.workArea}>
+        <PanelContainer
+          id="dance-instructions-panel"
+          headerText="Instructions"
+          className={moduleStyles.instructionsArea}
+        >
+          <Instructions layout="horizontal" />
+        </PanelContainer>
+        <PanelContainer
+          id="dance-workspace-panel"
+          headerText="Workspace"
+          className={moduleStyles.workspaceArea}
+        >
+          <div id={BLOCKLY_DIV_ID} />
+        </PanelContainer>
+      </div>
+    </div>
+  );
+};
+
+export default DanceView;

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -2,6 +2,7 @@ import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import React from 'react';
 import moduleStyles from './dance-view.module.scss';
+const commonI18n = require('@cdo/locale');
 
 const DANCE_VISUALIZATION_ID = 'dance-visualization';
 const BLOCKLY_DIV_ID = 'dance-blockly-div';
@@ -24,14 +25,14 @@ const DanceView: React.FunctionComponent = () => {
       <div className={moduleStyles.workArea}>
         <PanelContainer
           id="dance-instructions-panel"
-          headerText="Instructions"
+          headerText={commonI18n.instructions()}
           className={moduleStyles.instructionsArea}
         >
           <Instructions layout="horizontal" />
         </PanelContainer>
         <PanelContainer
           id="dance-workspace-panel"
-          headerText="Workspace"
+          headerText={commonI18n.workspaceHeaderShort()}
           className={moduleStyles.workspaceArea}
         >
           <div id={BLOCKLY_DIV_ID} />

--- a/apps/src/dance/lab2/views/constants.scss
+++ b/apps/src/dance/lab2/views/constants.scss
@@ -1,0 +1,3 @@
+// TODO: Should this move up to Lab2 components?
+
+$visualization-size: 400px;

--- a/apps/src/dance/lab2/views/dance-view.module.scss
+++ b/apps/src/dance/lab2/views/dance-view.module.scss
@@ -1,0 +1,40 @@
+@import 'color.scss';
+@import './constants.scss';
+
+.danceLab {
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 2px;
+}
+
+.visualizationArea {
+  flex: 0;
+  height: 100%;
+  background-color: $neutral_dark10;
+}
+
+.visualizationColumn {
+  margin: 2px 5px;
+}
+
+.visualization {
+  // TODO: support resizing
+  width: $visualization-size;
+  height: $visualization-size;
+  background-color: $neutral_white;
+}
+
+.workArea {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.instructionsArea {
+  flex: 0;
+}
+
+.workspaceArea {
+  flex: 1;
+}

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -4,6 +4,7 @@
  * helps facilitate level-switching between labs without page reloads.
  */
 import AichatView from '@cdo/apps/aichat/views/AichatView';
+import DanceView from '@cdo/apps/dance/lab2/views/DanceView';
 import MusicView from '@cdo/apps/music/views/MusicView';
 import StandaloneVideo from '@cdo/apps/standaloneVideo/StandaloneVideo';
 import classNames from 'classnames';
@@ -47,6 +48,11 @@ const appsProperties: {[appName in AppName]?: AppProperties} = {
   aichat: {
     backgroundMode: false,
     node: <AichatView />,
+    theme: Theme.LIGHT,
+  },
+  dance: {
+    backgroundMode: false,
+    node: <DanceView />,
     theme: Theme.LIGHT,
   },
 };

--- a/apps/src/lab2/views/components/PanelContainer.tsx
+++ b/apps/src/lab2/views/components/PanelContainer.tsx
@@ -10,6 +10,7 @@ interface PanelContainerProps {
   rightHeaderContent?: React.ReactNode;
   leftHeaderContent?: React.ReactNode;
   hideHeaders?: boolean;
+  className?: string;
 }
 
 /**
@@ -26,12 +27,17 @@ const PanelContainer: React.FunctionComponent<PanelContainerProps> = ({
   leftHeaderContent,
   children,
   hideHeaders,
+  className,
 }) => {
   const {theme} = useContext(ThemeContext);
 
   return (
     <div
-      className={classNames('panelContainer', moduleStyles.panelContainer)}
+      className={classNames(
+        'panelContainer',
+        moduleStyles.panelContainer,
+        className
+      )}
       id={id}
     >
       {!hideHeaders && (

--- a/dashboard/app/models/levels/dancelab.rb
+++ b/dashboard/app/models/levels/dancelab.rb
@@ -59,10 +59,6 @@ class Dancelab < GamelabJr
     true
   end
 
-  def uses_lab2?
-    uses_lab2
-  end
-
   def common_blocks(type)
   end
 

--- a/dashboard/app/models/levels/dancelab.rb
+++ b/dashboard/app/models/levels/dancelab.rb
@@ -27,6 +27,7 @@
 class Dancelab < GamelabJr
   serialized_attrs %w(
     default_song
+    uses_lab2
   )
 
   def self.skins
@@ -56,6 +57,10 @@ class Dancelab < GamelabJr
 
   def uses_google_blockly?
     true
+  end
+
+  def uses_lab2?
+    uses_lab2
   end
 
   def common_blocks(type)

--- a/dashboard/config/levels/custom/dance/Dance Lab2 Level 1.level
+++ b/dashboard/config/levels/custom/dance/Dance Lab2 Level 1.level
@@ -1,0 +1,85 @@
+<Dancelab>
+  <config><![CDATA[{
+  "game_id": 63,
+  "created_at": "2023-09-05T19:46:08.000Z",
+  "level_num": "custom",
+  "user_id": 182,
+  "properties": {
+    "skin": "gamelab",
+    "helper_libraries": [
+      "DanceLab"
+    ],
+    "hide_animation_mode": "true",
+    "show_type_hints": "true",
+    "use_modal_function_editor": "true",
+    "embed": "false",
+    "instructions_important": "false",
+    "submittable": "false",
+    "is_k1": "false",
+    "never_autoplay_video": "false",
+    "disable_param_editing": "true",
+    "disable_variable_editing": "false",
+    "disable_procedure_autopopulate": "false",
+    "top_level_procedure_autopopulate": "false",
+    "hide_share_and_remix": "false",
+    "disable_if_else_editing": "false",
+    "include_shared_functions": "false",
+    "free_play": "false",
+    "hide_view_data_button": "false",
+    "show_debug_watch": "false",
+    "expand_debugger": "false",
+    "debugger_disabled": "false",
+    "start_in_animation_tab": "false",
+    "all_animations_single_frame": "false",
+    "pause_animations_by_default": "false",
+    "hide_custom_blocks": "true",
+    "use_default_sprites": "false",
+    "validation_code": "//after 1 measure, make sure there is a sprite. if not, fail immediately\r\nif (nativeAPI.getTime(\"measures\") > 1) {\r\n  if (sprites.length === 0) {\r\n    nativeAPI.fail(\"danceFeedbackNeedNewDancer\");\r\n  }\r\n}\r\n\r\nif (nativeAPI.getTime(\"measures\") > 2) {\r\n  nativeAPI.pass();\r\n}",
+    "default_song": "hammer",
+    "long_instructions": "Let's get this moose dancing! Click the `\"dancer1\" do \"Floss\" forever` block onto the \"at 4 measures\" block to make him start flossing at the second measure.",
+    "uses_lab2": true,
+    "preload_asset_list": null
+  },
+  "published": true,
+  "notes": "",
+  "audit_log": "[{\"changed_at\":\"2023-09-05T12:46:08.190-07:00\",\"changed\":[\"cloned from \\\"allthethings HOC Dance 1\\\"\"],\"cloned_from\":\"allthethings HOC Dance 1\"}]"
+}]]></config>
+  <blocks>
+    <start_blocks>
+      <xml>
+        <block type="Dancelab_whenSetupSong" movable="false">
+          <title name="SONG">"hammer"</title>
+          <statement name="DO">
+            <block type="Dancelab_makeNewDanceSprite">
+              <title name="COSTUME" config="&quot;CAT&quot;, &quot;MOOSE&quot;">"MOOSE"</title>
+              <title name="NAME">new_dancer</title>
+              <title name="LOCATION">{x: 200, y: 200}</title>
+            </block>
+          </statement>
+        </block>
+      </xml>
+    </start_blocks>
+    <toolbox_blocks>
+      <xml>
+        <block type="Dancelab_makeNewDanceSprite">
+          <title name="COSTUME">"moose"</title>
+          <title name="NAME">dancer1</title>
+          <value name="LOCATION">
+            <block type="Dancelab_location_picker">
+              <title name="LOCATION">undefined</title>
+            </block>
+          </value>
+        </block>
+        <block type="Dancelab_changeMoveLR">
+          <title name="SPRITE">dancer1</title>
+          <title name="MOVE">6</title>
+          <title name="DIR">-1</title>
+        </block>
+        <block type="Dancelab_atTimestamp">
+          <title name="TIMESTAMP">4</title>
+          <title name="UNIT">"measures"</title>
+        </block>
+      </xml>
+    </toolbox_blocks>
+  </blocks>
+</Dancelab>

--- a/dashboard/config/levels/custom/dance/Dance Lab2 Level 2.level
+++ b/dashboard/config/levels/custom/dance/Dance Lab2 Level 2.level
@@ -1,0 +1,85 @@
+<Dancelab>
+  <config><![CDATA[{
+  "game_id": 63,
+  "created_at": "2023-09-05T19:46:23.000Z",
+  "level_num": "custom",
+  "user_id": 182,
+  "properties": {
+    "skin": "gamelab",
+    "helper_libraries": [
+      "DanceLab"
+    ],
+    "hide_animation_mode": "true",
+    "show_type_hints": "true",
+    "use_modal_function_editor": "true",
+    "embed": "false",
+    "instructions_important": "false",
+    "submittable": "false",
+    "is_k1": "false",
+    "never_autoplay_video": "false",
+    "disable_param_editing": "true",
+    "disable_variable_editing": "false",
+    "disable_procedure_autopopulate": "false",
+    "top_level_procedure_autopopulate": "false",
+    "hide_share_and_remix": "false",
+    "disable_if_else_editing": "false",
+    "include_shared_functions": "false",
+    "free_play": "false",
+    "hide_view_data_button": "false",
+    "show_debug_watch": "false",
+    "expand_debugger": "false",
+    "debugger_disabled": "false",
+    "start_in_animation_tab": "false",
+    "all_animations_single_frame": "false",
+    "pause_animations_by_default": "false",
+    "hide_custom_blocks": "true",
+    "use_default_sprites": "false",
+    "validation_code": "//after 1 measure, make sure there is a sprite. if not, fail immediately\r\nif (nativeAPI.getTime(\"measures\") > 1) {\r\n  if (sprites.length === 0) {\r\n    nativeAPI.fail(\"danceFeedbackNeedNewDancer\");\r\n  }\r\n}\r\n\r\nif (nativeAPI.getTime(\"measures\") > 2) {\r\n  nativeAPI.pass();\r\n}",
+    "default_song": "hammer",
+    "long_instructions": "Let's get this moose dancing! Click the `\"dancer1\" do \"Floss\" forever` block onto the \"at 4 measures\" block to make him start flossing at the second measure.",
+    "uses_lab2": true,
+    "preload_asset_list": null
+  },
+  "published": true,
+  "notes": "",
+  "audit_log": "[{\"changed_at\":\"2023-09-05T12:46:23.392-07:00\",\"changed\":[\"cloned from \\\"allthethings HOC Dance 1\\\"\"],\"cloned_from\":\"allthethings HOC Dance 1\"}]"
+}]]></config>
+  <blocks>
+    <start_blocks>
+      <xml>
+        <block type="Dancelab_whenSetupSong" movable="false">
+          <title name="SONG">"hammer"</title>
+          <statement name="DO">
+            <block type="Dancelab_makeNewDanceSprite">
+              <title name="COSTUME" config="&quot;CAT&quot;, &quot;MOOSE&quot;">"MOOSE"</title>
+              <title name="NAME">new_dancer</title>
+              <title name="LOCATION">{x: 200, y: 200}</title>
+            </block>
+          </statement>
+        </block>
+      </xml>
+    </start_blocks>
+    <toolbox_blocks>
+      <xml>
+        <block type="Dancelab_makeNewDanceSprite">
+          <title name="COSTUME">"moose"</title>
+          <title name="NAME">dancer1</title>
+          <value name="LOCATION">
+            <block type="Dancelab_location_picker">
+              <title name="LOCATION">undefined</title>
+            </block>
+          </value>
+        </block>
+        <block type="Dancelab_changeMoveLR">
+          <title name="SPRITE">dancer1</title>
+          <title name="MOVE">6</title>
+          <title name="DIR">-1</title>
+        </block>
+        <block type="Dancelab_atTimestamp">
+          <title name="TIMESTAMP">4</title>
+          <title name="UNIT">"measures"</title>
+        </block>
+      </xml>
+    </toolbox_blocks>
+  </blocks>
+</Dancelab>

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -386,6 +386,8 @@ en:
               name: AI Chat
             lesson-51:
               name: AI Rubrics
+            lesson-52:
+              name: Dance Lab2
         algebraPD2b:
           title: Computer Science in Algebra PD
           description: 'Phase 2 Online: Blended Summer Study'

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2023-08-18 17:05:56 UTC",
+    "serialized_at": "2023-09-05 19:46:49 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -799,6 +799,21 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
+    },
+    {
+      "key": "lesson-52",
+      "name": "Dance Lab2",
+      "absolute_position": 52,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 49,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-52",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
     }
   ],
   "lesson_activities": [
@@ -1459,6 +1474,18 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
+    },
+    {
+      "key": "fdc0f83f-442b-47e4-8f5a-8ca827acf9e2",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "fdc0f83f-442b-47e4-8f5a-8ca827acf9e2",
+        "lesson.key": "lesson-52",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
     }
   ],
   "activity_sections": [
@@ -1970,6 +1997,16 @@
       "seeding_key": {
         "activity_section.key": "b3608bf0-72c8-4abc-8ed2-f66fbde0eb82",
         "lesson_activity.key": "6b12d6f3-6c14-4c9d-aaab-4052da94fe1a"
+      }
+    },
+    {
+      "key": "c34e51d8-607b-4436-854d-f77eb3240711",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "c34e51d8-607b-4436-854d-f77eb3240711",
+        "lesson_activity.key": "fdc0f83f-442b-47e4-8f5a-8ca827acf9e2"
       }
     }
   ],
@@ -6291,6 +6328,48 @@
       "level_keys": [
         "CSD U3 Sprites scene challenge_allthethings"
       ]
+    },
+    {
+      "chapter": 178,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Lab2 Level 1"
+        ],
+        "lesson.key": "lesson-52",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "c34e51d8-607b-4436-854d-f77eb3240711"
+      },
+      "level_keys": [
+        "Dance Lab2 Level 1"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 2,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Lab2 Level 2"
+        ],
+        "lesson.key": "lesson-52",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "c34e51d8-607b-4436-854d-f77eb3240711"
+      },
+      "level_keys": [
+        "Dance Lab2 Level 2"
+      ]
     }
   ],
   "levels_script_levels": [
@@ -8542,6 +8621,30 @@
         "lesson_group.key": "",
         "script.name": "allthethings",
         "activity_section.key": "b3608bf0-72c8-4abc-8ed2-f66fbde0eb82"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Lab2 Level 1",
+        "script_level.level_keys": [
+          "Dance Lab2 Level 1"
+        ],
+        "lesson.key": "lesson-52",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "c34e51d8-607b-4436-854d-f77eb3240711"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Lab2 Level 2",
+        "script_level.level_keys": [
+          "Dance Lab2 Level 2"
+        ],
+        "lesson.key": "lesson-52",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "c34e51d8-607b-4436-854d-f77eb3240711"
       }
     }
   ],


### PR DESCRIPTION
Initial setup for porting Dance Party onto Lab2. This creates a separate container (`DanceView`) which serves as the entrypoint for Lab2 dance - having the separate entrypoint means we should be able to switch between legacy Dance and Lab2 dance simply with the `uses_lab2` flag, and we should be able to port over Lab2 functionality ideally without disrupting legacy Dance.

This also adds a new lesson to allthethings with two Dance Party levels with `uses_lab2` set to true (otherwise copied from the existing allthethings dance lesson).

<img width="1510" alt="Screenshot 2023-09-05 at 12 58 16 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/81a6f01f-2468-4526-9bd3-d31cb5c9ef6f">

## Links

https://codedotorg.atlassian.net/browse/LABS-55

## Testing story

Tested locally.