### PR TITLE
Turn back on the Access Report Survey Banner on Teacher Homepage

### DIFF
--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -66,10 +66,6 @@ export const UnconnectedTeacherHomepage = ({
    */
   const showPLBanner = false;
 
-  /* We are hiding the Census banner to free up space on the Teacher Homepage (May 2023)
-   * when we want to show the Census banner again remove the next line
-   */
-  showCensusBanner = false;
   const [displayCensusBanner, setDisplayCensusBanner] =
     useState(showCensusBanner);
   const [censusSubmittedSuccessfully, setCensusSubmittedSuccessfully] =

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -140,14 +140,9 @@ describe('TeacherHomepage', () => {
     assert(!wrapper.find('Notification').exists());
   });
 
-  /*
-    We have disabled the Census Banner on the Teacher Homepage (March 2023) to conserve
-    space. If we decide to show the banner again this test will need to be updated. See
-    TeacherHomepage.jsx to make the banner show.
-   */
-  it('does not render a CensusTeacherBanner even if showCensusBanner is true', () => {
+  it('renders CensusTeacherBanner if showCensusBanner is true', () => {
     const wrapper = setUp({showCensusBanner: true});
-    assert.equal(wrapper.find('CensusTeacherBanner').length, 0);
+    assert(wrapper.find('CensusTeacherBanner').exists());
   });
 
   it('renders a DonorTeacherBanner if isEnglish and afeEligible is true', () => {


### PR DESCRIPTION
We hid the Access Report Teacher Homepage banner back in the spring in order to save space. As teachers start the year we want to bring it back. This flips some of the changes in [this PR](https://github.com/code-dot-org/code-dot-org/pull/51654) to bring the banner back.

### Previously hid banner for all users
![Prev_no_banner](https://github.com/code-dot-org/code-dot-org/assets/56283563/6db8e705-c5c5-4a9d-a4e9-e11a644b3778)

### Now shows the Access Report for teachers at schools with an NCES id
![yes_banner](https://github.com/code-dot-org/code-dot-org/assets/56283563/ca3a13ef-2dee-44ba-896f-33d7107f52e3)

## Links
Jira task: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-806&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and updating unit test.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
