### PR TITLE
Add sorting by family name to progress table (TEACH-564)

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
@@ -8,6 +8,7 @@ import DCDO from '@cdo/apps/dcdo';
 import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {levelWithProgress, studentShape} from './types';
+import letterCompare from '@cdo/apps/util/letterCompare';
 
 class StudentTable extends React.Component {
   static propTypes = {
@@ -51,9 +52,6 @@ class StudentTable extends React.Component {
       isSortedByFamilyName,
     } = this.props;
 
-    // Sort using system default locale.
-    const collator = new Intl.Collator();
-
     // Returns a comparator function that sorts objects a and b by the given
     // keys, in order of priority.
     // Example: comparator(['familyName', 'name']) will sort by familyName
@@ -63,27 +61,6 @@ class StudentTable extends React.Component {
         (result, key) => result || letterCompare(a[key] || '', b[key] || ''),
         0
       );
-
-    const letterCompare = (a, b) => {
-      // Strip out any non-alphabetic characters from the strings before sorting
-      // (https://unicode.org/reports/tr44/#Alphabetic)
-      const aLetters = a.replace(/[^\p{Alphabetic}]/gu, '');
-      const bLetters = b.replace(/[^\p{Alphabetic}]/gu, '');
-
-      const initialCompare = collator.compare(aLetters, bLetters);
-
-      // Sort strings with letters before strings without
-      if (initialCompare > 0 && !!aLetters && !bLetters) {
-        return -1;
-      }
-      if (initialCompare < 0 && !aLetters && !!bLetters) {
-        return 1;
-      }
-
-      // Use original strings as a fallback if the special-character-stripped
-      // version compares as equal.
-      return initialCompare || collator.compare(a, b);
-    };
 
     // Sort students, in-place.
     isSortedByFamilyName

--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -188,6 +188,7 @@ export const fakeStudents = studentCount => {
     .map((_, i) => ({
       id: i,
       name: `student-${i}`,
+      familyName: `student-${studentCount - i}`,
     }));
 };
 
@@ -256,6 +257,9 @@ export const fakeProgressTableReduxInitialState = (
   const sectionId = randomNumberUpTo100();
 
   return {
+    currentUser: {
+      isSortedByFamilyName: false,
+    },
     progress: {
       lessonGroups: [],
       lessons: lessons,

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -143,7 +143,7 @@ class SectionProgress extends Component {
     const lessons = scriptData ? scriptData.lessons : [];
     const scriptWithStandardsSelected =
       levelDataInitialized && scriptData.hasStandards;
-    const progressTableViewEnabled =
+    const showProgressTable =
       levelDataInitialized &&
       (currentView === ViewType.SUMMARY || currentView === ViewType.DETAIL);
     const standardsStyle =
@@ -174,15 +174,14 @@ class SectionProgress extends Component {
           )}
         </div>
         <div style={styles.topRowContainer}>
-          {progressTableViewEnabled &&
-            !!DCDO.get('family-name-features', false) && (
-              <SortByNameDropdown
-                selectStyles={styles.sortOrderSelect}
-                sectionId={sectionId}
-                unitName={scriptData?.title}
-                source={SECTION_PROGRESS}
-              />
-            )}
+          {showProgressTable && !!DCDO.get('family-name-features', false) && (
+            <SortByNameDropdown
+              selectStyles={styles.sortOrderSelect}
+              sectionId={sectionId}
+              unitName={scriptData?.title}
+              source={SECTION_PROGRESS}
+            />
+          )}
           {levelDataInitialized && <ProgressViewHeader />}
         </div>
 
@@ -194,9 +193,7 @@ class SectionProgress extends Component {
               className="fa-pulse fa-3x"
             />
           )}
-          {progressTableViewEnabled && (
-            <ProgressTableView currentView={currentView} />
-          )}
+          {showProgressTable && <ProgressTableView currentView={currentView} />}
           {levelDataInitialized && currentView === ViewType.STANDARDS && (
             <div id="uitest-standards-view" style={standardsStyle}>
               <StandardsView
@@ -209,6 +206,8 @@ class SectionProgress extends Component {
     );
   }
 }
+
+const sortOrderMargin = 10;
 
 const styles = {
   heading: {
@@ -241,8 +240,8 @@ const styles = {
     textAlign: 'center',
   },
   sortOrderSelect: {
-    marginRight: 10,
-    width: parseInt(styleConstants.STUDENT_LIST_WIDTH) - 10,
+    marginRight: sortOrderMargin,
+    width: parseInt(styleConstants.STUDENT_LIST_WIDTH) - sortOrderMargin,
   },
 };
 

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -22,6 +22,11 @@ import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import ProgressViewHeader from './ProgressViewHeader';
 import logToCloud from '@cdo/apps/logToCloud';
+import SortByNameDropdown from '@cdo/apps/templates/SortByNameDropdown';
+import DCDO from '@cdo/apps/dcdo';
+import styleConstants from './progressTables/progress-table-constants.module.scss';
+
+const SECTION_PROGRESS = 'SectionProgress';
 
 /**
  * Given a particular section, this component owns figuring out which script to
@@ -131,12 +136,16 @@ class SectionProgress extends Component {
       currentView,
       scriptId,
       scriptData,
+      sectionId,
       showStandardsIntroDialog,
     } = this.props;
     const levelDataInitialized = this.levelDataInitialized();
     const lessons = scriptData ? scriptData.lessons : [];
     const scriptWithStandardsSelected =
       levelDataInitialized && scriptData.hasStandards;
+    const progressTableViewEnabled =
+      levelDataInitialized &&
+      (currentView === ViewType.SUMMARY || currentView === ViewType.DETAIL);
     const standardsStyle =
       currentView === ViewType.STANDARDS ? styles.show : styles.hide;
     return (
@@ -164,8 +173,18 @@ class SectionProgress extends Component {
             <LessonSelector lessons={lessons} onChange={this.onChangeLevel} />
           )}
         </div>
-
-        {levelDataInitialized && <ProgressViewHeader />}
+        <div style={styles.topRowContainer}>
+          {progressTableViewEnabled &&
+            !!DCDO.get('family-name-features', false) && (
+              <SortByNameDropdown
+                selectStyles={styles.sortOrderSelect}
+                sectionId={sectionId}
+                unitName={scriptData?.title}
+                source={SECTION_PROGRESS}
+              />
+            )}
+          {levelDataInitialized && <ProgressViewHeader />}
+        </div>
 
         <div style={{clear: 'both'}}>
           {!levelDataInitialized && (
@@ -175,11 +194,9 @@ class SectionProgress extends Component {
               className="fa-pulse fa-3x"
             />
           )}
-          {levelDataInitialized &&
-            (currentView === ViewType.SUMMARY ||
-              currentView === ViewType.DETAIL) && (
-              <ProgressTableView currentView={currentView} />
-            )}
+          {progressTableViewEnabled && (
+            <ProgressTableView currentView={currentView} />
+          )}
           {levelDataInitialized && currentView === ViewType.STANDARDS && (
             <div id="uitest-standards-view" style={standardsStyle}>
               <StandardsView
@@ -222,6 +239,10 @@ const styles = {
   studentTooltip: {
     display: 'flex',
     textAlign: 'center',
+  },
+  sortOrderSelect: {
+    marginRight: 10,
+    width: parseInt(styleConstants.STUDENT_LIST_WIDTH) - 10,
   },
 };
 

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
@@ -27,6 +27,7 @@ import {
   getLevelIconHeaderFormatter,
 } from './progressTableHelpers';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import letterCompare from '@cdo/apps/util/letterCompare';
 import classnames from 'classnames';
 import {studentShape} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
@@ -84,6 +85,7 @@ class ProgressTableView extends React.Component {
     lessonOfInterest: PropTypes.number.isRequired,
     studentTimestamps: PropTypes.object.isRequired,
     localeCode: PropTypes.string,
+    isSortedByFamilyName: PropTypes.bool,
   };
 
   constructor(props) {
@@ -107,8 +109,24 @@ class ProgressTableView extends React.Component {
     // `studentTableRowType` object to track their expanded state. these
     // objects also include an `expansionIndex` to determine which lesson
     // formatter to use to render the row.
+
+    // Returns a comparator function that sorts objects a and b by the given
+    // keys, in order of priority.
+    // Example: comparator(['familyName', 'name']) will sort by familyName
+    // first, looking at name if necessary to break ties.
+    const comparator = keys => (a, b) =>
+      keys.reduce(
+        (result, key) => result || letterCompare(a[key] || '', b[key] || ''),
+        0
+      );
+
+    // Sort students, in-place.
+    const sortedStudents = props.isSortedByFamilyName
+      ? props.students.sort(comparator(['familyName', 'name']))
+      : props.students.sort(comparator(['name', 'familyName']));
+
     this.state = {
-      rows: props.students.map((student, index) => {
+      rows: sortedStudents.map((student, index) => {
         return {
           id: idForExpansionIndex(student.id, 0),
           student: student,
@@ -137,6 +155,33 @@ class ProgressTableView extends React.Component {
     if (prevProps.currentView !== this.props.currentView) {
       this.setRowsToRender();
     }
+    if (prevProps.isSortedByFamilyName !== this.props.isSortedByFamilyName) {
+      this.sortTableRows();
+    }
+  }
+
+  sortTableRows() {
+    const comparator = keys => (a, b) =>
+      keys.reduce(
+        (result, key) =>
+          result || letterCompare(a.student[key] || '', b.student[key] || ''),
+        0
+      );
+
+    const sortedRows = this.props.isSortedByFamilyName
+      ? this.state.rows.sort(comparator(['familyName', 'name']))
+      : this.state.rows.sort(comparator(['name', 'familyName']));
+
+    // Alternate dark/light background (child rows use same color as parent)
+    let darkBackground = true;
+    this.setState({
+      rows: sortedRows.map(row => {
+        if (row.expansionIndex === 0) {
+          darkBackground = !darkBackground;
+        }
+        return {...row, useDarkBackground: darkBackground};
+      }),
+    });
   }
 
   /**
@@ -387,6 +432,7 @@ export const UnconnectedProgressTableView = ProgressTableView;
 
 export default connect(
   state => ({
+    isSortedByFamilyName: state.currentUser.isSortedByFamilyName,
     sectionId: state.teacherSections.selectedSectionId,
     students: state.teacherSections.selectedStudents,
     scriptData: getCurrentUnitData(state),

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.story.jsx
@@ -15,6 +15,7 @@ import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgress
 import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import locales from '@cdo/apps/redux/localesRedux';
+import currentUser from '@cdo/apps/templates/currentUserRedux';
 
 /**
  * The variety of stories here can be useful during development, but add
@@ -77,6 +78,9 @@ function createStore(numStudents, numLessons) {
   }
 
   const initialState = {
+    currentUser: {
+      isSortedByFamilyName: true,
+    },
     sectionProgress: {
       ...buildSectionProgress(section.students, scriptData),
       lessonOfInterest: 0,
@@ -95,6 +99,7 @@ function createStore(numStudents, numLessons) {
 
   return reduxStore(
     {
+      currentUser,
       sectionProgress,
       unitSelection,
       teacherSections,

--- a/apps/src/util/letterCompare.js
+++ b/apps/src/util/letterCompare.js
@@ -1,0 +1,28 @@
+const collator = new Intl.Collator();
+
+/**
+ * This comparator function is used to sort strings without respect to any
+ * non-alphabetic characters, putting strings composed solely of non-alphabetic
+ * characters at the end of the list. Ties are broken by using non-alphabetic
+ * characters.
+ **/
+export default function letterCompare(a, b) {
+  // Strip out any non-alphabetic characters from the strings before sorting
+  // (https://unicode.org/reports/tr44/#Alphabetic)
+  const aLetters = a.replace(/[^\p{Alphabetic}]/gu, '');
+  const bLetters = b.replace(/[^\p{Alphabetic}]/gu, '');
+
+  const initialCompare = collator.compare(aLetters, bLetters);
+
+  // Sort strings with letters before strings without
+  if (initialCompare > 0 && !!aLetters && !bLetters) {
+    return -1;
+  }
+  if (initialCompare < 0 && !aLetters && !!bLetters) {
+    return 1;
+  }
+
+  // Use original strings as a fallback if the special-character-stripped
+  // version compares as equal.
+  return initialCompare || collator.compare(a, b);
+}

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableViewTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableViewTest.jsx
@@ -264,4 +264,26 @@ describe('ProgressTableView', () => {
     wrapper.onToggleRow(rowData.student.id);
     expect(wrapper.state.rows).to.have.lengthOf(STUDENTS.length);
   });
+
+  it('sorts by family name', () => {
+    // The default test helper sorts by given name
+    const givenNameWrapper = setUp()
+      .find(UnconnectedProgressTableView)
+      .instance();
+
+    const overrideState = {currentUser: {isSortedByFamilyName: true}};
+    const familyNameWrapper = setUp(ViewType.SUMMARY, overrideState)
+      .find(UnconnectedProgressTableView)
+      .instance();
+
+    expect(givenNameWrapper.state.rows).to.have.lengthOf(STUDENTS.length);
+    expect(familyNameWrapper.state.rows).to.have.lengthOf(STUDENTS.length);
+
+    // The student generator makes the first student have the first given name
+    // alphabetically. The last student has the first family name alphabetically
+    expect(givenNameWrapper.state.rows[0].student.id).to.equal(0);
+    expect(familyNameWrapper.state.rows[0].student.id).to.equal(
+      STUDENTS.length - 1
+    );
+  });
 });

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableViewTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableViewTest.jsx
@@ -16,6 +16,7 @@ import ProgressTableDetailCell from '@cdo/apps/templates/sectionProgress/progres
 import ProgressTableLevelIconSet from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableLevelIconSet';
 import {ViewType} from '@cdo/apps/templates/sectionProgress/sectionProgressConstants';
 import {createStore, combineReducers} from 'redux';
+import currentUser from '@cdo/apps/templates/currentUserRedux';
 import progress from '@cdo/apps/code-studio/progressRedux';
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
@@ -46,6 +47,7 @@ const initialState = fakeProgressTableReduxInitialState(
 const setUp = (currentView = ViewType.SUMMARY, overrideState = {}) => {
   const store = createStore(
     combineReducers({
+      currentUser,
       progress,
       teacherSections,
       sectionProgress,


### PR DESCRIPTION
This change adds a "Sort by:" dropdown to the progress table. It uses the same sorting logic as on the teacher panel student table.

Screenshot (sorted by family name)
<img width="805" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/4108328/88832338-a3e9-45df-b444-868b6399c6b5">

Screenshot (sorted by display name)
<img width="803" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/4108328/aa976a86-d637-493c-80e4-6151304201a6">

## Links
- jira ticket: [TEACH-564](https://codedotorg.atlassian.net/browse/TEACH-564)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
