### PR TITLE
Add a Simple Test Page for DCDO on Pegasus

### DIFF
--- a/pegasus/sites.v3/code.org/public/test_dcdo.haml
+++ b/pegasus/sites.v3/code.org/public/test_dcdo.haml
@@ -1,0 +1,1 @@
+= DCDO.get("test_dcdo_on_pegasus", nil).inspect


### PR DESCRIPTION
We've been having some issues getting changes to DCDO settings to become visible on Pegasus pages recently, and we'd like to have a simple way to validate that the basic functionality of this feature is still working.

## Links

See thread at https://codedotorg.slack.com/archives/C03CK49G9/p1693520167252039?thread_ts=1693504098.114849&cid=C03CK49G9 for more context.

## Testing story

| Description | Screenshot |
| ---- | ----|
| Simple test input: `DCDO.set("test_dcdo_on_pegasus", "Simple test string")` | ![Screenshot 2023-09-05 at 16-38-47 Anybody can learn Code org](https://github.com/code-dot-org/code-dot-org/assets/244100/f2833090-faab-40c2-af64-c572f858ae21)
| Default if no value set | ![Screenshot 2023-09-05 at 16-37-40 Anybody can learn Code org](https://github.com/code-dot-org/code-dot-org/assets/244100/05218658-1f50-44a4-bef1-5b7dd1cc0a05)
| Will display even falsy values: `DCDO.set("test_dcdo_on_pegasus", false)` | ![Screenshot 2023-09-05 at 16-47-37 Anybody can learn Code org](https://github.com/code-dot-org/code-dot-org/assets/244100/d3c8821d-f4c8-4ab3-8d0b-a0bc8dcfabaf)