### PR TITLE
[Blockly] Run blocklayout tests on chrome only

### DIFF
--- a/dashboard/test/ui/features/star_labs/blocklayout.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayout.feature
@@ -1,3 +1,4 @@
+@chrome
 Feature: Block auto-layout
 
 Background:

--- a/dashboard/test/ui/features/star_labs/blocklayoutjson.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayoutjson.feature
@@ -1,3 +1,4 @@
+@chrome
 Feature: Block auto-layout after JSON conversion
 
 Background:


### PR DESCRIPTION
Temporarily disables block layout tests for iPhone/iPad to unblock test build. As of https://github.com/code-dot-org/code-dot-org/pull/53154, `when run` blocks now always appear at the top (vs. the random order that they appear in in our UI tests after we auto-place blocks). This is a definite improvement/desired behavior, but iPad/iPhone tests might not be updated before DTP time tomorrow. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
