### PR TITLE
P20-368: Fix I18nScriptUtils.delete_empty_crowdin_locale_dir when the dir does not exist

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -439,6 +439,10 @@ class I18nScriptUtils
 
   def self.delete_empty_crowdin_locale_dir(crowdin_locale)
     crowdin_locale_dir = CDO.dir(File.join(I18N_LOCALES_DIR, crowdin_locale))
-    FileUtils.rm_r(crowdin_locale_dir) if Dir.empty?(crowdin_locale_dir)
+
+    return unless File.exist?(crowdin_locale_dir)
+    return unless Dir.empty?(crowdin_locale_dir)
+
+    FileUtils.rm_r(crowdin_locale_dir)
   end
 end

--- a/bin/test/i18n/test_i18n_script_utils.rb
+++ b/bin/test/i18n/test_i18n_script_utils.rb
@@ -353,6 +353,12 @@ describe I18nScriptUtils do
       FileUtils.mkdir_p(crowdin_locale_dir_path)
     end
 
+    context 'when Crowdin locale dir does not exist' do
+      it 'does not raise the error "No such file or directory"' do
+        I18nScriptUtils.delete_empty_crowdin_locale_dir('unexpected_crowdin_locale')
+      end
+    end
+
     context 'when Crowdin locale dir is empty' do
       it 'deletes the Crowdin locale dir' do
         assert File.directory?(crowdin_locale_dir_path)


### PR DESCRIPTION
## Issue
1. `bundler: failed to load command: ./bin/i18n/sync-all.rb (./bin/i18n/sync-all.rb)`
2. `/home/ubuntu/code-dot-org/bin/i18n/i18n_script_utils.rb:442:in 'empty?': No such file or directory @ rb_dir_s_empty_p - /home/ubuntu/code-dot-org/i18n/locales/English (Errno::ENOENT)`

## Links
- jira ticket: [P20-368](https://codedotorg.atlassian.net/browse/P20-368)