### PR TITLE
Add CSF pre and post workshop emails

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -474,7 +474,7 @@ class Pd::Workshop < ApplicationRecord
       end
 
       # send pre-workshop email for CSA, CSD, CSP facilitators 10 days before the workshop only
-      next unless days == 10 && (workshop.course == COURSE_CSD || workshop.course == COURSE_CSP || workshop.course == COURSE_CSA)
+      next unless days == 10 && (workshop.course == COURSE_CSD || workshop.course == COURSE_CSP || workshop.course == COURSE_CSA || workshop.course == COURSE_CSF)
       workshop.facilitators.each do |facilitator|
         next unless facilitator.email
         begin
@@ -578,7 +578,7 @@ class Pd::Workshop < ApplicationRecord
 
   # Send Post-surveys to facilitators of CSD and CSP workshops
   def send_facilitator_post_surveys
-    if course == COURSE_CSD || course == COURSE_CSP || course == COURSE_CSA
+    if course == COURSE_CSD || course == COURSE_CSP || course == COURSE_CSA || course == COURSE_CSF
       facilitators.each do |facilitator|
         next unless facilitator.email
 

--- a/dashboard/app/views/pd/workshop_mailer/facilitator_post_workshop.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/facilitator_post_workshop.html.haml
@@ -34,7 +34,10 @@ As a reminder, there are a number of ways for you to get support between worksho
   %li
     Engage with other facilitators in the
     = link_to('Facilitator Forum', 'https://forum.code.org/c/facilitators') + ' and'
-    = link_to('Facilitator Slack channel', 'https://codefacilitators6-12.slack.com/messages')
+    - if @workshop.course == 'CS Fundamentals'
+      = link_to('Facilitator Slack channel', 'https://csffacilitators.slack.com/messages')
+    - else
+      = link_to('Facilitator Slack channel', 'https://codefacilitators6-12.slack.com/messages')
   %li
     Email
     = mail_to('facilitators@code.org')

--- a/dashboard/app/views/pd/workshop_mailer/facilitator_pre_workshop.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/facilitator_pre_workshop.html.haml
@@ -18,9 +18,14 @@
       =link_to('facilitator landing page', 'https://code.org/educate/facilitator-landing/CSD') + '.'
     - elsif @workshop.course == 'Computer Science A'
       =link_to('facilitator landing page', 'https://code.org/educate/facilitator-landing/CSA') + '.'
+    - elsif @workshop.course == 'CS Fundamentals'
+      =link_to('facilitator landing page', 'https://code.org/educate/facilitator-landing/CSF') + '.'
   %li
     Have quick questions about resources, agendas, or participant requests? Post them in the facilitator
-    =link_to('Slack', 'https://codefacilitators6-12.slack.com/messages')
+    - if @workshop.course == 'CS Fundamentals'
+      =link_to('Slack', 'https://csffacilitators.slack.com/messages')
+    - else
+      =link_to('Slack', 'https://codefacilitators6-12.slack.com/messages')
     channel!
   %li
     Want to share useful resources or engage in longer discussions with the facilitator community? Use the

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -207,7 +207,7 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
       }
   end
 
-  def facilitator_post_workshop_no_rp_csf_intro
+  def facilitator_post_workshop_csf_intro
     # TODO: figure out correct params?
     # the way we set up workshops for mailers means they won't have an id.
     # We want to test that this mailer can extract the workshop id correctly--find
@@ -223,7 +223,7 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
       }
   end
 
-  def facilitator_post_workshop_no_rp_csf_deepdive
+  def facilitator_post_workshop_csf_deepdive
     # TODO: figure out correct params?
     # the way we set up workshops for mailers means they won't have an id.
     # We want to test that this mailer can extract the workshop id correctly--find

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -208,7 +208,6 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
   end
 
   def facilitator_post_workshop_csf_intro
-    # TODO: figure out correct params?
     # the way we set up workshops for mailers means they won't have an id.
     # We want to test that this mailer can extract the workshop id correctly--find
     # an unused id and assign it to this workshop.
@@ -224,7 +223,6 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
   end
 
   def facilitator_post_workshop_csf_deepdive
-    # TODO: figure out correct params?
     # the way we set up workshops for mailers means they won't have an id.
     # We want to test that this mailer can extract the workshop id correctly--find
     # an unused id and assign it to this workshop.

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -165,6 +165,20 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
       target: :facilitator
   end
 
+  def facilitator_pre_workshop_csf_intro
+    mail :facilitator_pre_workshop,
+      Pd::Workshop::COURSE_CSF,
+      Pd::Workshop::SUBJECT_CSF_101,
+      target: :facilitator
+  end
+
+  def facilitator_pre_workshop_csf_deppdive
+    mail :facilitator_pre_workshop,
+      Pd::Workshop::COURSE_CSF,
+      Pd::Workshop::SUBJECT_CSF_201,
+      target: :facilitator
+  end
+
   def facilitator_post_workshop_csp_summer
     regional_partner = build :regional_partner, name: 'We Teach Code'
 
@@ -186,6 +200,38 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
     mail :facilitator_post_workshop,
       Pd::Workshop::COURSE_CSD,
       Pd::Workshop::SUBJECT_CSD_WORKSHOP_1,
+      target: :facilitator,
+      workshop_params: {
+        num_sessions: 1,
+        id: highest_workshop_id + 5
+      }
+  end
+
+  def facilitator_post_workshop_no_rp_csf_intro
+    # TODO: figure out correct params?
+    # the way we set up workshops for mailers means they won't have an id.
+    # We want to test that this mailer can extract the workshop id correctly--find
+    # an unused id and assign it to this workshop.
+    highest_workshop_id = Pd::Workshop.last&.id || 0
+    mail :facilitator_post_workshop,
+      Pd::Workshop::COURSE_CSF,
+      Pd::Workshop::SUBJECT_CSF_101,
+      target: :facilitator,
+      workshop_params: {
+        num_sessions: 1,
+        id: highest_workshop_id + 5
+      }
+  end
+
+  def facilitator_post_workshop_no_rp_csf_deepdive
+    # TODO: figure out correct params?
+    # the way we set up workshops for mailers means they won't have an id.
+    # We want to test that this mailer can extract the workshop id correctly--find
+    # an unused id and assign it to this workshop.
+    highest_workshop_id = Pd::Workshop.last&.id || 0
+    mail :facilitator_post_workshop,
+      Pd::Workshop::COURSE_CSF,
+      Pd::Workshop::SUBJECT_CSF_201,
       target: :facilitator,
       workshop_params: {
         num_sessions: 1,

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -172,7 +172,7 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
       target: :facilitator
   end
 
-  def facilitator_pre_workshop_csf_deppdive
+  def facilitator_pre_workshop_csf_deepdive
     mail :facilitator_pre_workshop,
       Pd::Workshop::COURSE_CSF,
       Pd::Workshop::SUBJECT_CSF_201,

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -838,7 +838,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     Pd::Workshop.send_reminder_for_upcoming_in_days(10)
   end
 
-  test '10 day reminder for csf workshop does not send pre email to facilitators' do
+  test '10 day reminder for csf workshop sends pre email to facilitators' do
     mock_mail = stub
     mock_mail.stubs(:deliver_now).returns(nil)
 
@@ -846,7 +846,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     create_list :pd_enrollment, 3, workshop: workshop
     Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
 
-    Pd::WorkshopMailer.expects(:facilitator_pre_workshop).returns(mock_mail).never
+    Pd::WorkshopMailer.expects(:facilitator_pre_workshop).returns(mock_mail).times(2)
     Pd::Workshop.send_reminder_for_upcoming_in_days(10)
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Add new emails for CSF facilitators, that work in the same way as the matching emails for CSD facilitators.

Adds 4 new mailers:
* facilitator_pre_workshop_csf_intro
* facilitator_pre_workshop_csf_deepdive
* facilitator_post_workshop_csf_intro
* facilitator_post_workshop_csf_deepdive

It's hard to get a lot of confidence in these without having a way to test manually with real workshop data, so please do point out if there's any extra testing I can do here.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->
- jira ticket: [ACQ-750](https://codedotorg.atlassian.net/browse/ACQ-750)

