### PR TITLE
[Blockly] Reenable blocklayout UI tests

### DIFF
--- a/dashboard/test/ui/features/star_labs/blocklayout.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayout.feature
@@ -1,4 +1,3 @@
-@chrome
 Feature: Block auto-layout
 Background:
   Given I am on "http://studio.code.org/flappy/10?noautoplay=true"

--- a/dashboard/test/ui/features/star_labs/blocklayout.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayout.feature
@@ -1,6 +1,5 @@
 @chrome
 Feature: Block auto-layout
-
 Background:
   Given I am on "http://studio.code.org/flappy/10?noautoplay=true"
   And I wait for the page to fully load
@@ -8,12 +7,12 @@ Background:
 Scenario: Auto-placing malformed start blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle with extra newlines
   Then block "whenClick" is near offset "16, 86"
-  And block "whenCollideGround" is near offset "16, 184"
+  And block "whenCollideGround" is near offset "16, 186"
 
 Scenario: Auto-placing blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle
   Then block "whenClick" is near offset "16, 86"
-  And block "whenCollideGround" is near offset "16, 184"
+  And block "whenCollideGround" is near offset "16, 186"
 
 Scenario: Auto-placing blocks with XML positioning
   Given I am on "http://studio.code.org/s/allthethings/lessons/5/levels/4?noautoplay=true"

--- a/dashboard/test/ui/features/star_labs/blocklayoutjson.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayoutjson.feature
@@ -1,4 +1,3 @@
-@chrome
 Feature: Block auto-layout after JSON conversion
 
 Background:

--- a/dashboard/test/ui/features/star_labs/blocklayoutjson.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayoutjson.feature
@@ -9,9 +9,9 @@ Background:
 Scenario: Auto-placing malformed start blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle with extra newlines
   Then block "whenClick" is near offset "16, 86"
-  And block "whenCollideGround" is near offset "16, 184"
+  And block "whenCollideGround" is near offset "16, 186"
 
 Scenario: Auto-placing blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle
   Then block "whenClick" is near offset "16, 86"
-  And block "whenCollideGround" is near offset "16, 184"
+  And block "whenCollideGround" is near offset "16, 186"


### PR DESCRIPTION
When we merged https://github.com/code-dot-org/code-dot-org/pull/53154, some iPad and iPhone UI tests failed, so we turned them off temporarily by running the tests in Chrome only (see https://github.com/code-dot-org/code-dot-org/pull/53627). This PR updates the assertions and reenables the tests for all browsers. I confirmed the tests should pass by running them via a SauceLabs tunnel locally. 

## Links

See: https://codedotorg.atlassian.net/browse/CT-19

## Testing story
 
Confirmed UI tests pass locally in all browsers.

![Screenshot 2023-09-06 at 1 53 20 PM](https://github.com/code-dot-org/code-dot-org/assets/26844240/7f444c14-31b2-40c8-9da8-bb64d9711876)

![Screenshot 2023-09-06 at 2 26 26 PM](https://github.com/code-dot-org/code-dot-org/assets/26844240/e6cc9ed6-ed32-4234-b0e8-0b0788f749bc)

![Screenshot 2023-09-06 at 2 26 42 PM](https://github.com/code-dot-org/code-dot-org/assets/26844240/65ae86e4-a8d4-43ec-872c-e7cafd7c1619)


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
