### PR TITLE
set up first Active Job and unit test

### DIFF
--- a/dashboard/app/jobs/application_job.rb
+++ b/dashboard/app/jobs/application_job.rb
@@ -1,0 +1,7 @@
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
+end

--- a/dashboard/app/jobs/send_placeholder_email_job.rb
+++ b/dashboard/app/jobs/send_placeholder_email_job.rb
@@ -1,0 +1,7 @@
+class SendPlaceholderEmailJob < ApplicationJob
+  queue_as :default
+
+  def perform(user)
+    PlaceholderMailer.placeholder_email(user).deliver_now
+  end
+end

--- a/dashboard/app/mailers/placeholder_mailer.rb
+++ b/dashboard/app/mailers/placeholder_mailer.rb
@@ -1,0 +1,8 @@
+# This is a placeholder mailer initially used to test out active job.
+# Once we are using active job for real features we can delete this file.
+
+class PlaceholderMailer < ApplicationMailer
+  def placeholder_email(user)
+    mail to: user.email, from: 'noreply@code.org', subject: 'Placeholder Email'
+  end
+end

--- a/dashboard/app/views/placeholder_mailer/placeholder_email.haml
+++ b/dashboard/app/views/placeholder_mailer/placeholder_email.haml
@@ -1,0 +1,4 @@
+%p
+  This is a placeholder email sent in the
+  = Rails.env
+  environment.

--- a/dashboard/test/jobs/send_placeholder_email_job_test.rb
+++ b/dashboard/test/jobs/send_placeholder_email_job_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class SendPlaceholderEmailJobTest < ActiveJob::TestCase
+  test "job sends placeholder email" do
+    user = create :user
+    PlaceholderMailer.expects(:placeholder_email).with(user).returns(
+      mock {|mail| mail.stubs(:deliver_now)}
+    )
+    perform_enqueued_jobs do
+      SendPlaceholderEmailJob.perform_later(user)
+    end
+  end
+end


### PR DESCRIPTION
Finishes 
* https://codedotorg.atlassian.net/browse/AITT-135
* https://codedotorg.atlassian.net/browse/AITT-131

This PR just sets up a first active job and corresponding unit test. No config changes were needed because by default we already use the `:async` adapter in development and the `:test` adapter in unit tests, which is what we want. In a future step, when we want to run these jobs in production using something other than the `:async` adapter (which we'll need to do before launching any user-facing feature which uses Active Jobs), we'll have to configure a different queue adapter at that time.

For more background, see:
* https://edgeguides.rubyonrails.org/configuring.html#config-active-job-queue-adapter
* https://edgeguides.rubyonrails.org/testing.html#testing-jobs

## Testing story

* manually verified in dev environment that `SendPlaceholderEmailJob.perform_later(User.first)` causes an email to be sent. to verify this on your own local dev environment, take a look at what gets logged to `dashboard/log/development.log`. 
* new unit test

## Future work

For next steps, see [productionize Rubric AI proposal](https://docs.google.com/document/d/1uttsY8qFzq_untRpSnvGYTvi7HLhMTNSKA7j39f0v-8/edit#heading=h.iw2iu9wvmnvd) --> alternative: pycall

