### PR TITLE
Kaitie/evidence levels save

### DIFF
--- a/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptions.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptions.jsx
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import EvidenceDescriptionsRow from './EvidenceDescriptionsRow';
 
-export default function EvidenceDescriptions({isAiEnabled}) {
+export default function EvidenceDescriptions({
+  isAiEnabled,
+  learningGoalData,
+  updateLearningGoal,
+}) {
   return (
     <div>
       <div style={styles.grid}>
@@ -18,18 +22,30 @@ export default function EvidenceDescriptions({isAiEnabled}) {
       <EvidenceDescriptionsRow
         isAiEnabled={isAiEnabled}
         evidenceLabel={'Extensive Evidence'}
+        evidenceLevelData={learningGoalData.evidenceLevels[3]}
+        understanding={3}
+        updateLearningGoal={updateLearningGoal}
       />
       <EvidenceDescriptionsRow
         isAiEnabled={isAiEnabled}
         evidenceLabel={'Convincing Evidence'}
+        evidenceLevelData={learningGoalData.evidenceLevels[2]}
+        understanding={2}
+        updateLearningGoal={updateLearningGoal}
       />
       <EvidenceDescriptionsRow
         isAiEnabled={isAiEnabled}
         evidenceLabel={'Limited Evidence'}
+        evidenceLevelData={learningGoalData.evidenceLevels[1]}
+        understanding={1}
+        updateLearningGoal={updateLearningGoal}
       />
       <EvidenceDescriptionsRow
         isAiEnabled={isAiEnabled}
         evidenceLabel={'No Evidence'}
+        evidenceLevelData={learningGoalData.evidenceLevels[0]}
+        understanding={0}
+        updateLearningGoal={updateLearningGoal}
       />
     </div>
   );
@@ -37,6 +53,8 @@ export default function EvidenceDescriptions({isAiEnabled}) {
 
 EvidenceDescriptions.propTypes = {
   isAiEnabled: PropTypes.bool,
+  learningGoalData: PropTypes.object,
+  updateLearningGoal: PropTypes.func,
 };
 
 const styles = {

--- a/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptions.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptions.jsx
@@ -22,28 +22,36 @@ export default function EvidenceDescriptions({
       <EvidenceDescriptionsRow
         isAiEnabled={isAiEnabled}
         evidenceLabel={'Extensive Evidence'}
-        evidenceLevelData={learningGoalData.evidenceLevels[3]}
+        evidenceLevelData={
+          learningGoalData.learningGoalEvidenceLevelsAttributes[3]
+        }
         understanding={3}
         updateLearningGoal={updateLearningGoal}
       />
       <EvidenceDescriptionsRow
         isAiEnabled={isAiEnabled}
         evidenceLabel={'Convincing Evidence'}
-        evidenceLevelData={learningGoalData.evidenceLevels[2]}
+        evidenceLevelData={
+          learningGoalData.learningGoalEvidenceLevelsAttributes[2]
+        }
         understanding={2}
         updateLearningGoal={updateLearningGoal}
       />
       <EvidenceDescriptionsRow
         isAiEnabled={isAiEnabled}
         evidenceLabel={'Limited Evidence'}
-        evidenceLevelData={learningGoalData.evidenceLevels[1]}
+        evidenceLevelData={
+          learningGoalData.learningGoalEvidenceLevelsAttributes[1]
+        }
         understanding={1}
         updateLearningGoal={updateLearningGoal}
       />
       <EvidenceDescriptionsRow
         isAiEnabled={isAiEnabled}
         evidenceLabel={'No Evidence'}
-        evidenceLevelData={learningGoalData.evidenceLevels[0]}
+        evidenceLevelData={
+          learningGoalData.learningGoalEvidenceLevelsAttributes[0]
+        }
         understanding={0}
         updateLearningGoal={updateLearningGoal}
       />

--- a/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptions.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptions.jsx
@@ -24,7 +24,6 @@ export default function EvidenceDescriptions({
         evidenceLevelData={
           learningGoalData.learningGoalEvidenceLevelsAttributes[3]
         }
-        understanding={3}
         updateLearningGoal={updateLearningGoal}
       />
       <EvidenceDescriptionsRow
@@ -33,7 +32,6 @@ export default function EvidenceDescriptions({
         evidenceLevelData={
           learningGoalData.learningGoalEvidenceLevelsAttributes[2]
         }
-        understanding={2}
         updateLearningGoal={updateLearningGoal}
       />
       <EvidenceDescriptionsRow
@@ -42,7 +40,6 @@ export default function EvidenceDescriptions({
         evidenceLevelData={
           learningGoalData.learningGoalEvidenceLevelsAttributes[1]
         }
-        understanding={1}
         updateLearningGoal={updateLearningGoal}
       />
       <EvidenceDescriptionsRow
@@ -51,7 +48,6 @@ export default function EvidenceDescriptions({
         evidenceLevelData={
           learningGoalData.learningGoalEvidenceLevelsAttributes[0]
         }
-        understanding={0}
         updateLearningGoal={updateLearningGoal}
       />
     </div>

--- a/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptions.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptions.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import EvidenceDescriptionsRow from './EvidenceDescriptionsRow';
+import {UNDERSTANDING_LEVEL_STRINGS} from '@cdo/apps/templates/rubrics/rubricHelpers';
 
 export default function EvidenceDescriptions({
   learningGoalData,
@@ -20,35 +21,39 @@ export default function EvidenceDescriptions({
       </div>
       <EvidenceDescriptionsRow
         isAiEnabled={learningGoalData.aiEnabled}
-        evidenceLabel={'Extensive Evidence'}
+        evidenceLabel={UNDERSTANDING_LEVEL_STRINGS[3]}
         evidenceLevelData={
           learningGoalData.learningGoalEvidenceLevelsAttributes[3]
         }
         updateLearningGoal={updateLearningGoal}
+        learningGoalId={learningGoalData.id}
       />
       <EvidenceDescriptionsRow
         isAiEnabled={learningGoalData.aiEnabled}
-        evidenceLabel={'Convincing Evidence'}
+        evidenceLabel={UNDERSTANDING_LEVEL_STRINGS[2]}
         evidenceLevelData={
           learningGoalData.learningGoalEvidenceLevelsAttributes[2]
         }
         updateLearningGoal={updateLearningGoal}
+        learningGoalId={learningGoalData.id}
       />
       <EvidenceDescriptionsRow
         isAiEnabled={learningGoalData.aiEnabled}
-        evidenceLabel={'Limited Evidence'}
+        evidenceLabel={UNDERSTANDING_LEVEL_STRINGS[1]}
         evidenceLevelData={
           learningGoalData.learningGoalEvidenceLevelsAttributes[1]
         }
         updateLearningGoal={updateLearningGoal}
+        learningGoalId={learningGoalData.id}
       />
       <EvidenceDescriptionsRow
         isAiEnabled={learningGoalData.aiEnabled}
-        evidenceLabel={'No Evidence'}
+        evidenceLabel={UNDERSTANDING_LEVEL_STRINGS[0]}
         evidenceLevelData={
           learningGoalData.learningGoalEvidenceLevelsAttributes[0]
         }
         updateLearningGoal={updateLearningGoal}
+        learningGoalId={learningGoalData.id}
       />
     </div>
   );

--- a/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptions.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptions.jsx
@@ -4,7 +4,6 @@ import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import EvidenceDescriptionsRow from './EvidenceDescriptionsRow';
 
 export default function EvidenceDescriptions({
-  isAiEnabled,
   learningGoalData,
   updateLearningGoal,
 }) {
@@ -20,7 +19,7 @@ export default function EvidenceDescriptions({
         </Heading6>
       </div>
       <EvidenceDescriptionsRow
-        isAiEnabled={isAiEnabled}
+        isAiEnabled={learningGoalData.aiEnabled}
         evidenceLabel={'Extensive Evidence'}
         evidenceLevelData={
           learningGoalData.learningGoalEvidenceLevelsAttributes[3]
@@ -29,7 +28,7 @@ export default function EvidenceDescriptions({
         updateLearningGoal={updateLearningGoal}
       />
       <EvidenceDescriptionsRow
-        isAiEnabled={isAiEnabled}
+        isAiEnabled={learningGoalData.aiEnabled}
         evidenceLabel={'Convincing Evidence'}
         evidenceLevelData={
           learningGoalData.learningGoalEvidenceLevelsAttributes[2]
@@ -38,7 +37,7 @@ export default function EvidenceDescriptions({
         updateLearningGoal={updateLearningGoal}
       />
       <EvidenceDescriptionsRow
-        isAiEnabled={isAiEnabled}
+        isAiEnabled={learningGoalData.aiEnabled}
         evidenceLabel={'Limited Evidence'}
         evidenceLevelData={
           learningGoalData.learningGoalEvidenceLevelsAttributes[1]
@@ -47,7 +46,7 @@ export default function EvidenceDescriptions({
         updateLearningGoal={updateLearningGoal}
       />
       <EvidenceDescriptionsRow
-        isAiEnabled={isAiEnabled}
+        isAiEnabled={learningGoalData.aiEnabled}
         evidenceLabel={'No Evidence'}
         evidenceLevelData={
           learningGoalData.learningGoalEvidenceLevelsAttributes[0]
@@ -60,7 +59,6 @@ export default function EvidenceDescriptions({
 }
 
 EvidenceDescriptions.propTypes = {
-  isAiEnabled: PropTypes.bool,
   learningGoalData: PropTypes.object,
   updateLearningGoal: PropTypes.func,
 };

--- a/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptionsRow.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptionsRow.jsx
@@ -5,7 +5,6 @@ export default function EvidenceDescriptionsRow({
   isAiEnabled,
   evidenceLabel,
   evidenceLevelData,
-  understanding,
   updateLearningGoal,
 }) {
   const handleTeacherDescriptionChange = event => {
@@ -13,7 +12,7 @@ export default function EvidenceDescriptionsRow({
       evidenceLevelData.learningGoalId,
       'learningGoalEvidenceLevelsAttributes',
       event.target.value,
-      understanding,
+      evidenceLevelData.understanding,
       'teacherDescription'
     );
   };
@@ -23,7 +22,7 @@ export default function EvidenceDescriptionsRow({
       evidenceLevelData.learningGoalId,
       'learningGoalEvidenceLevelsAttributes',
       event.target.value,
-      understanding,
+      evidenceLevelData.understanding,
       'aiPrompt'
     );
   };
@@ -52,7 +51,6 @@ EvidenceDescriptionsRow.propTypes = {
   isAiEnabled: PropTypes.bool,
   evidenceLabel: PropTypes.string,
   evidenceLevelData: PropTypes.object,
-  understanding: PropTypes.number,
   updateLearningGoal: PropTypes.func,
 };
 

--- a/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptionsRow.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptionsRow.jsx
@@ -11,7 +11,7 @@ export default function EvidenceDescriptionsRow({
   const handleTeacherDescriptionChange = event => {
     updateLearningGoal(
       evidenceLevelData.learningGoalId,
-      'evidenceLevels',
+      'learningGoalEvidenceLevelsAttributes',
       event.target.value,
       understanding,
       'teacherDescription'
@@ -21,7 +21,7 @@ export default function EvidenceDescriptionsRow({
   const handleAiPromptChange = event => {
     updateLearningGoal(
       evidenceLevelData.learningGoalId,
-      'evidenceLevels',
+      'learningGoalEvidenceLevelsAttributes',
       event.target.value,
       understanding,
       'aiPrompt'

--- a/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptionsRow.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptionsRow.jsx
@@ -1,16 +1,48 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function EvidenceDescriptionsRow({isAiEnabled, evidenceLabel}) {
+export default function EvidenceDescriptionsRow({
+  isAiEnabled,
+  evidenceLabel,
+  evidenceLevelData,
+  understanding,
+  updateLearningGoal,
+}) {
+  const handleTeacherDescriptionChange = event => {
+    updateLearningGoal(
+      evidenceLevelData.learningGoalId,
+      'evidenceLevels',
+      event.target.value,
+      understanding,
+      'teacherDescription'
+    );
+  };
+
+  const handleAiPromptChange = event => {
+    updateLearningGoal(
+      evidenceLevelData.learningGoalId,
+      'evidenceLevels',
+      event.target.value,
+      understanding,
+      'aiPrompt'
+    );
+  };
+
   return (
     <div style={styles.grid}>
       <label style={styles.gridLabels}>{evidenceLabel}</label>
-      <textarea style={styles.textareaBoxes} />
+      <textarea
+        style={styles.textareaBoxes}
+        value={evidenceLevelData.teacherDescription}
+        onChange={handleTeacherDescriptionChange}
+      />
       <textarea
         className={'ui-test-ai-prompt-textbox'}
         style={styles.textareaBoxes}
         disabled={!isAiEnabled}
         required={isAiEnabled}
+        value={evidenceLevelData.aiPrompt}
+        onChange={handleAiPromptChange}
       />
     </div>
   );
@@ -19,6 +51,9 @@ export default function EvidenceDescriptionsRow({isAiEnabled, evidenceLabel}) {
 EvidenceDescriptionsRow.propTypes = {
   isAiEnabled: PropTypes.bool,
   evidenceLabel: PropTypes.string,
+  evidenceLevelData: PropTypes.object,
+  understanding: PropTypes.number,
+  updateLearningGoal: PropTypes.func,
 };
 
 const styles = {

--- a/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptionsRow.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptionsRow.jsx
@@ -6,10 +6,11 @@ export default function EvidenceDescriptionsRow({
   evidenceLabel,
   evidenceLevelData,
   updateLearningGoal,
+  learningGoalId,
 }) {
   const handleTeacherDescriptionChange = event => {
     updateLearningGoal(
-      evidenceLevelData.learningGoalId,
+      learningGoalId,
       'learningGoalEvidenceLevelsAttributes',
       event.target.value,
       evidenceLevelData.understanding,
@@ -19,7 +20,7 @@ export default function EvidenceDescriptionsRow({
 
   const handleAiPromptChange = event => {
     updateLearningGoal(
-      evidenceLevelData.learningGoalId,
+      learningGoalId,
       'learningGoalEvidenceLevelsAttributes',
       event.target.value,
       evidenceLevelData.understanding,
@@ -52,6 +53,7 @@ EvidenceDescriptionsRow.propTypes = {
   evidenceLabel: PropTypes.string,
   evidenceLevelData: PropTypes.object,
   updateLearningGoal: PropTypes.func,
+  learningGoalId: PropTypes.any, // TODO: decide if this is an int
 };
 
 const styles = {

--- a/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptionsRow.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/EvidenceDescriptionsRow.jsx
@@ -53,7 +53,7 @@ EvidenceDescriptionsRow.propTypes = {
   evidenceLabel: PropTypes.string,
   evidenceLevelData: PropTypes.object,
   updateLearningGoal: PropTypes.func,
-  learningGoalId: PropTypes.any, // TODO: decide if this is an int
+  learningGoalId: PropTypes.any, // This will be number for exisiting LearningGoals but a string for new LearningGoals
 };
 
 const styles = {

--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -73,8 +73,6 @@ export default function LearningGoalItem({
       </div>
       <div style={styles.activityBody}>
         <EvidenceDescriptions
-          // TODO: Refactor so you just pass in existing LEarningGoalData
-          isAiEnabled={exisitingLearningGoalData.aiEnabled}
           learningGoalData={exisitingLearningGoalData}
           updateLearningGoal={updateLearningGoal}
         />

--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -73,7 +73,10 @@ export default function LearningGoalItem({
       </div>
       <div style={styles.activityBody}>
         <EvidenceDescriptions
+          // TODO: Refactor so you just pass in existing LEarningGoalData
           isAiEnabled={exisitingLearningGoalData.aiEnabled}
+          learningGoalData={exisitingLearningGoalData}
+          updateLearningGoal={updateLearningGoal}
         />
         <Button
           text="Delete key concept"

--- a/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
@@ -25,6 +25,32 @@ export default function RubricsContainer({
             learningGoal: '',
             aiEnabled: false,
             position: 1,
+            evidenceLevels: [
+              {
+                learningGoalId: 'learningGoal-1',
+                teacherDescription: '',
+                understanding: 0,
+                aiPrompt: '',
+              },
+              {
+                learningGoalId: 'learningGoal-1',
+                teacherDescription: '',
+                understanding: 1,
+                aiPrompt: '',
+              },
+              {
+                learningGoalId: 'learningGoal-1',
+                teacherDescription: '',
+                understanding: 2,
+                aiPrompt: '',
+              },
+              {
+                learningGoalId: 'learningGoal-1',
+                teacherDescription: '',
+                understanding: 3,
+                aiPrompt: '',
+              },
+            ],
           },
         ]
   );
@@ -55,6 +81,32 @@ export default function RubricsContainer({
       learningGoal: '',
       aiEnabled: false,
       position: nextPosition,
+      evidenceLevels: [
+        {
+          learningGoalId: newId,
+          teacherDescription: '',
+          understanding: 0,
+          aiPrompt: '',
+        },
+        {
+          learningGoalId: newId,
+          teacherDescription: '',
+          understanding: 1,
+          aiPrompt: '',
+        },
+        {
+          learningGoalId: newId,
+          teacherDescription: '',
+          understanding: 2,
+          aiPrompt: '',
+        },
+        {
+          learningGoalId: newId,
+          teacherDescription: '',
+          understanding: 3,
+          aiPrompt: '',
+        },
+      ],
     };
   };
 
@@ -76,13 +128,42 @@ export default function RubricsContainer({
     setLearningGoalList(updatedLearningGoalList);
   };
 
-  const updateLearningGoal = (idToUpdate, keyToUpdate, newValue) => {
+  const updateLearningGoal = (
+    idToUpdate,
+    keyToUpdate,
+    newValue,
+    evidenceLevel,
+    descriptionType
+  ) => {
     const newLearningGoalData = learningGoalList.map(learningGoal => {
       if (idToUpdate === learningGoal.id) {
-        return {
-          ...learningGoal,
-          [keyToUpdate]: newValue,
-        };
+        if (keyToUpdate === 'evidenceLevels') {
+          if (descriptionType === 'teacherDescription') {
+            const newEvidenceLevels = learningGoal.evidenceLevels;
+            newEvidenceLevels.find(
+              level => level.understanding === evidenceLevel
+            ).teacherDescription = newValue;
+            return {
+              ...learningGoal,
+              [keyToUpdate]: newEvidenceLevels,
+            };
+          }
+          if (descriptionType === 'aiPrompt') {
+            const newEvidenceLevels = learningGoal.evidenceLevels;
+            newEvidenceLevels.find(
+              level => level.understanding === evidenceLevel
+            ).aiPrompt = newValue;
+            return {
+              ...learningGoal,
+              [keyToUpdate]: newEvidenceLevels,
+            };
+          }
+        } else {
+          return {
+            ...learningGoal,
+            [keyToUpdate]: newValue,
+          };
+        }
       } else {
         return learningGoal;
       }
@@ -125,7 +206,9 @@ export default function RubricsContainer({
     })
       .then(response => response.json())
       .then(data => {
-        navigateToHref(data.redirectUrl);
+        if (!rubric) {
+          navigateToHref(data.redirectUrl);
+        }
       })
       .catch(err => {
         console.error('Error saving rubric:' + err);

--- a/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
@@ -217,6 +217,8 @@ export default function RubricsContainer({
 
   /**
    * Transforms the keys of an object from camelCase to snake_case.
+   * Intended to transform the keys of objects in an array of an object.
+   * In this case, it is only intended into the first nested layer.
    * @param {object} obj - The object with keys in camelCase format.
    * @returns {object} - The object with keys in snake_case format.
    */

--- a/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
@@ -27,25 +27,21 @@ export default function RubricsContainer({
             position: 1,
             learningGoalEvidenceLevelsAttributes: [
               {
-                // learningGoalId: 'learningGoal-1',
                 teacherDescription: '',
                 understanding: 0,
                 aiPrompt: '',
               },
               {
-                // learningGoalId: 'learningGoal-1',
                 teacherDescription: '',
                 understanding: 1,
                 aiPrompt: '',
               },
               {
-                // learningGoalId: 'learningGoal-1',
                 teacherDescription: '',
                 understanding: 2,
                 aiPrompt: '',
               },
               {
-                // learningGoalId: 'learningGoal-1',
                 teacherDescription: '',
                 understanding: 3,
                 aiPrompt: '',
@@ -83,25 +79,21 @@ export default function RubricsContainer({
       position: nextPosition,
       learningGoalEvidenceLevelsAttributes: [
         {
-          // learningGoalId: newId,
           teacherDescription: '',
           understanding: 0,
           aiPrompt: '',
         },
         {
-          // learningGoalId: newId,
           teacherDescription: '',
           understanding: 1,
           aiPrompt: '',
         },
         {
-          // learningGoalId: newId,
           teacherDescription: '',
           understanding: 2,
           aiPrompt: '',
         },
         {
-          // learningGoalId: newId,
           teacherDescription: '',
           understanding: 3,
           aiPrompt: '',
@@ -133,7 +125,7 @@ export default function RubricsContainer({
     keyToUpdate,
     newValue,
     evidenceLevel,
-    evidenceLevelDescriptionField
+    evidenceLevelKeyToUpdate
   ) => {
     const newLearningGoalData = learningGoalList.map(learningGoal => {
       if (idToUpdate === learningGoal.id) {
@@ -142,7 +134,7 @@ export default function RubricsContainer({
             learningGoal.learningGoalEvidenceLevelsAttributes;
           newEvidenceLevels.find(
             level => level.understanding === evidenceLevel
-          )[evidenceLevelDescriptionField] = newValue;
+          )[evidenceLevelKeyToUpdate] = newValue;
           return {
             ...learningGoal,
             [keyToUpdate]: newEvidenceLevels,
@@ -160,12 +152,14 @@ export default function RubricsContainer({
     setLearningGoalList(newLearningGoalData);
   };
 
-  // TODO: Check that there is at least one programming level here
+  // TODO-AITT-168: Check that there is at least one submittable programming level here
   const initialLevelForAssessment = !!rubric ? rubric.levelId : levels[0].id;
   const [selectedLevelForAssessment, setSelectedLevelForAssessment] = useState(
     initialLevelForAssessment
   );
 
+  // TODO-AITT-169: Create notification for when a rubric has been saved
+  // TODO-AITT-171: Enable deleting LearningGoals when saveRubric is called
   const saveRubric = event => {
     event.preventDefault();
     const dataUrl = !!rubric ? `/rubrics/${rubric.id}` : RUBRIC_PATH;
@@ -176,8 +170,9 @@ export default function RubricsContainer({
       ? document.querySelector('meta[name="csrf-token"]').attributes['content']
           .value
       : null;
-    let learningGoalListAsData = transformKeys(learningGoalList);
-    learningGoalListAsData = removeNewIds(learningGoalListAsData);
+    const learningGoalListAsData = removeNewIds(
+      transformKeys(learningGoalList)
+    );
 
     const rubric_data = {
       levelId: selectedLevelForAssessment,
@@ -204,14 +199,20 @@ export default function RubricsContainer({
       });
   };
 
-  function removeNewIds(keyConceptArr) {
-    console.log(keyConceptArr);
-    keyConceptArr.forEach(keyConceptArr => {
-      if (!isNumber(keyConceptArr.id)) {
-        delete keyConceptArr.id;
+  /**
+   * Removes the Ids from the newly added LearningGoals.
+   * Context: We use ids of LearningGoals in the front end to connect data.
+   * However, when a new LearningGoal is added in the front end, we want to
+   * have an id to modify the components, but then delete that id before saving
+   * the new LearningGoals to the back end so that new ids can be assigned by Rails.
+   */
+  function removeNewIds(keyConceptList) {
+    keyConceptList.forEach(keyConceptList => {
+      if (!isNumber(keyConceptList.id)) {
+        delete keyConceptList.id;
       }
     });
-    return keyConceptArr;
+    return keyConceptList;
   }
 
   /**
@@ -247,8 +248,6 @@ export default function RubricsContainer({
     setSelectedLevelForAssessment(event.target.value);
   };
 
-  // TODO: In the future we might want to filter the levels in the dropdown for "submittable" levels
-  //  "submittable" is in the properties of each level in the list.
   return (
     <div>
       <Heading1>Create or modify your rubric</Heading1>

--- a/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
@@ -25,7 +25,7 @@ export default function RubricsContainer({
             learningGoal: '',
             aiEnabled: false,
             position: 1,
-            evidenceLevels: [
+            learningGoalEvidenceLevelsAttributes: [
               {
                 learningGoalId: 'learningGoal-1',
                 teacherDescription: '',
@@ -81,7 +81,7 @@ export default function RubricsContainer({
       learningGoal: '',
       aiEnabled: false,
       position: nextPosition,
-      evidenceLevels: [
+      learningGoalEvidenceLevelsAttributes: [
         {
           learningGoalId: newId,
           teacherDescription: '',
@@ -137,27 +137,16 @@ export default function RubricsContainer({
   ) => {
     const newLearningGoalData = learningGoalList.map(learningGoal => {
       if (idToUpdate === learningGoal.id) {
-        if (keyToUpdate === 'evidenceLevels') {
-          if (descriptionType === 'teacherDescription') {
-            const newEvidenceLevels = learningGoal.evidenceLevels;
-            newEvidenceLevels.find(
-              level => level.understanding === evidenceLevel
-            ).teacherDescription = newValue;
-            return {
-              ...learningGoal,
-              [keyToUpdate]: newEvidenceLevels,
-            };
-          }
-          if (descriptionType === 'aiPrompt') {
-            const newEvidenceLevels = learningGoal.evidenceLevels;
-            newEvidenceLevels.find(
-              level => level.understanding === evidenceLevel
-            ).aiPrompt = newValue;
-            return {
-              ...learningGoal,
-              [keyToUpdate]: newEvidenceLevels,
-            };
-          }
+        if (keyToUpdate === 'learningGoalEvidenceLevelsAttributes') {
+          const newEvidenceLevels =
+            learningGoal.learningGoalEvidenceLevelsAttributes;
+          newEvidenceLevels.find(
+            level => level.understanding === evidenceLevel
+          )[descriptionType] = newValue;
+          return {
+            ...learningGoal,
+            [keyToUpdate]: newEvidenceLevels,
+          };
         } else {
           return {
             ...learningGoal,
@@ -215,21 +204,33 @@ export default function RubricsContainer({
       });
   };
 
-  // transforms keys from camelCase to snake_case for rails
-  // specifically created to do this for an array of objects
-  // with keys in camelCase
-  function transformKeys(startingList) {
-    const newList = [];
+  /**
+   * Transforms the keys of an object from camelCase to snake_case.
+   * @param {object} obj - The object with keys in camelCase format.
+   * @returns {object} - The object with keys in snake_case format.
+   */
+  function transformObjectKeys(obj) {
+    const newObj = {};
 
-    startingList.forEach(item => {
-      const newItem = {};
-      for (const [key, value] of Object.entries(item)) {
-        newItem[snakeCase(key)] = value;
+    for (const [key, value] of Object.entries(obj)) {
+      if (Array.isArray(value)) {
+        newObj[snakeCase(key)] = value.map(item => transformObjectKeys(item));
+      } else {
+        newObj[snakeCase(key)] = value;
       }
-      newList.push(newItem);
-    });
+    }
 
-    return newList;
+    return newObj;
+  }
+
+  /**
+   * Transforms the keys of objects inside an array from camelCase to snake_case.
+   * Designed specifically for an array of objects with keys in camelCase.
+   * @param {array} startingList - The list containing objects with camelCase keys.
+   * @returns {array} - The list containing objects with snake_case keys.
+   */
+  function transformKeys(startingList) {
+    return startingList.map(item => transformObjectKeys(item));
   }
 
   const handleDropdownChange = event => {

--- a/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
@@ -4,7 +4,7 @@ import {BodyTwoText, Heading1} from '@cdo/apps/componentLibrary/typography';
 import Button from '@cdo/apps/templates/Button';
 import {navigateToHref} from '@cdo/apps/utils';
 import RubricEditor from './RubricEditor';
-import {snakeCase} from 'lodash';
+import {snakeCase, isNumber} from 'lodash';
 
 const RUBRIC_PATH = '/rubrics';
 
@@ -20,32 +20,32 @@ export default function RubricsContainer({
       ? rubric.learningGoals
       : [
           {
-            key: 'learningGoal-1',
-            id: 'learningGoal-1',
+            key: 'ui-1',
+            id: 'ui-1',
             learningGoal: '',
             aiEnabled: false,
             position: 1,
             learningGoalEvidenceLevelsAttributes: [
               {
-                learningGoalId: 'learningGoal-1',
+                // learningGoalId: 'learningGoal-1',
                 teacherDescription: '',
                 understanding: 0,
                 aiPrompt: '',
               },
               {
-                learningGoalId: 'learningGoal-1',
+                // learningGoalId: 'learningGoal-1',
                 teacherDescription: '',
                 understanding: 1,
                 aiPrompt: '',
               },
               {
-                learningGoalId: 'learningGoal-1',
+                // learningGoalId: 'learningGoal-1',
                 teacherDescription: '',
                 understanding: 2,
                 aiPrompt: '',
               },
               {
-                learningGoalId: 'learningGoal-1',
+                // learningGoalId: 'learningGoal-1',
                 teacherDescription: '',
                 understanding: 3,
                 aiPrompt: '',
@@ -66,7 +66,7 @@ export default function RubricsContainer({
       learningGoalNumber++;
     }
 
-    return `learningGoal-${learningGoalNumber}`;
+    return `ui-${learningGoalNumber}`;
   };
 
   const emptyKeyConcept = () => {
@@ -83,25 +83,25 @@ export default function RubricsContainer({
       position: nextPosition,
       learningGoalEvidenceLevelsAttributes: [
         {
-          learningGoalId: newId,
+          // learningGoalId: newId,
           teacherDescription: '',
           understanding: 0,
           aiPrompt: '',
         },
         {
-          learningGoalId: newId,
+          // learningGoalId: newId,
           teacherDescription: '',
           understanding: 1,
           aiPrompt: '',
         },
         {
-          learningGoalId: newId,
+          // learningGoalId: newId,
           teacherDescription: '',
           understanding: 2,
           aiPrompt: '',
         },
         {
-          learningGoalId: newId,
+          // learningGoalId: newId,
           teacherDescription: '',
           understanding: 3,
           aiPrompt: '',
@@ -133,7 +133,7 @@ export default function RubricsContainer({
     keyToUpdate,
     newValue,
     evidenceLevel,
-    descriptionType
+    evidenceLevelDescriptionField
   ) => {
     const newLearningGoalData = learningGoalList.map(learningGoal => {
       if (idToUpdate === learningGoal.id) {
@@ -142,7 +142,7 @@ export default function RubricsContainer({
             learningGoal.learningGoalEvidenceLevelsAttributes;
           newEvidenceLevels.find(
             level => level.understanding === evidenceLevel
-          )[descriptionType] = newValue;
+          )[evidenceLevelDescriptionField] = newValue;
           return {
             ...learningGoal,
             [keyToUpdate]: newEvidenceLevels,
@@ -176,8 +176,8 @@ export default function RubricsContainer({
       ? document.querySelector('meta[name="csrf-token"]').attributes['content']
           .value
       : null;
-
-    const learningGoalListAsData = transformKeys(learningGoalList);
+    let learningGoalListAsData = transformKeys(learningGoalList);
+    learningGoalListAsData = removeNewIds(learningGoalListAsData);
 
     const rubric_data = {
       levelId: selectedLevelForAssessment,
@@ -203,6 +203,16 @@ export default function RubricsContainer({
         console.error('Error saving rubric:' + err);
       });
   };
+
+  function removeNewIds(keyConceptArr) {
+    console.log(keyConceptArr);
+    keyConceptArr.forEach(keyConceptArr => {
+      if (!isNumber(keyConceptArr.id)) {
+        delete keyConceptArr.id;
+      }
+    });
+    return keyConceptArr;
+  }
 
   /**
    * Transforms the keys of an object from camelCase to snake_case.

--- a/apps/test/unit/lib/levelbuilder/rubrics/EvidenceDescriptionRowTest.js
+++ b/apps/test/unit/lib/levelbuilder/rubrics/EvidenceDescriptionRowTest.js
@@ -4,9 +4,19 @@ import {expect} from '../../../../util/reconfiguredChai';
 import EvidenceDescriptionsRow from '@cdo/apps/lib/levelbuilder/rubrics/EvidenceDescriptionsRow.jsx';
 
 describe('EvidenceDescriptionsRow', () => {
+  const evidenceLevelData = {
+    learningGoalId: 'learningGoal-1',
+    teacherDescription: 'description',
+    understanding: 0,
+    aiPrompt: '',
+  };
   it('renders correctly', () => {
     const wrapper = shallow(
-      <EvidenceDescriptionsRow isAiEnabled={true} evidenceLabel="Test" />
+      <EvidenceDescriptionsRow
+        isAiEnabled={true}
+        evidenceLabel="Test"
+        evidenceLevelData={evidenceLevelData}
+      />
     );
     expect(wrapper.find('div').length).to.equal(1);
     expect(wrapper.find('label').length).to.equal(1);
@@ -15,7 +25,11 @@ describe('EvidenceDescriptionsRow', () => {
 
   it('enables the AI prompt textbox when isAiEnabled is true', () => {
     const wrapper = shallow(
-      <EvidenceDescriptionsRow isAiEnabled={true} evidenceLabel="Test" />
+      <EvidenceDescriptionsRow
+        isAiEnabled={true}
+        evidenceLabel="Test"
+        evidenceLevelData={evidenceLevelData}
+      />
     );
     const aiPromptTextbox = wrapper.find('.ui-test-ai-prompt-textbox');
     expect(aiPromptTextbox.prop('disabled')).to.be.false;
@@ -24,7 +38,11 @@ describe('EvidenceDescriptionsRow', () => {
 
   it('disables the AI prompt textbox when isAiEnabled is false', () => {
     const wrapper = shallow(
-      <EvidenceDescriptionsRow isAiEnabled={false} evidenceLabel="Test" />
+      <EvidenceDescriptionsRow
+        isAiEnabled={false}
+        evidenceLabel="Test"
+        evidenceLevelData={evidenceLevelData}
+      />
     );
     const aiPromptTextbox = wrapper.find('.ui-test-ai-prompt-textbox');
     expect(aiPromptTextbox.prop('disabled')).to.be.true;

--- a/apps/test/unit/lib/levelbuilder/rubrics/LearningGoalItemTest.js
+++ b/apps/test/unit/lib/levelbuilder/rubrics/LearningGoalItemTest.js
@@ -36,8 +36,10 @@ describe('LearningGoalItem', () => {
   it('disables editing of AI textboxes when unchecked', () => {
     const wrapper = shallow(<LearningGoalItem {...defaultProps} />);
     expect(wrapper.find('input[type="checkbox"]').prop('checked')).to.be.false;
-    expect(wrapper.find('EvidenceDescriptions').at(0).props().isAiEnabled).to.be
-      .false;
+    expect(
+      wrapper.find('EvidenceDescriptions').at(0).props().learningGoalData
+        .aiEnabled
+    ).to.be.false;
   });
 
   it('enables editing of AI textboxes when checked', () => {
@@ -54,8 +56,10 @@ describe('LearningGoalItem', () => {
       />
     );
     expect(wrapper.find('input[type="checkbox"]').prop('checked')).to.be.true;
-    expect(wrapper.find('EvidenceDescriptions').at(0).props().isAiEnabled).to.be
-      .true;
+    expect(
+      wrapper.find('EvidenceDescriptions').at(0).props().learningGoalData
+        .aiEnabled
+    ).to.be.true;
   });
 
   it('calls deleteItem when delete button is clicked', () => {

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -35,9 +35,10 @@ class RubricsController < ApplicationController
     @lesson = @rubric.lesson
 
     if @rubric.update(rubric_params)
-      redirect_to edit_rubric_path(@rubric.id), notice: 'Rubric was successfully updated.'
+      render json: @rubric
+      # tried redirect, couldn't get it to work.  Need to add notice. redirect_to edit_rubric_path(@rubric.id), notice: 'Rubric was successfully updated.'
     else
-      render :edit
+      render action: 'edit'
     end
   end
 

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -36,7 +36,7 @@ class RubricsController < ApplicationController
 
     if @rubric.update(rubric_params)
       render json: @rubric
-      # tried redirect, couldn't get it to work.  Need to add notice. redirect_to edit_rubric_path(@rubric.id), notice: 'Rubric was successfully updated.'
+      # KT NOTE FOR FUTURE WORK: tried redirect, couldn't get it to work.  Need to add notice. redirect_to edit_rubric_path(@rubric.id), notice: 'Rubric was successfully updated.'
     else
       render action: 'edit'
     end
@@ -45,6 +45,21 @@ class RubricsController < ApplicationController
   private
 
   def rubric_params
-    params.transform_keys(&:underscore).permit(:level_id, :lesson_id, learning_goals_attributes: [:learning_goal, :ai_enabled, :position])
+    params.transform_keys(&:underscore).permit(
+      :level_id,
+      :lesson_id,
+      learning_goals_attributes: [
+        :learning_goal,
+        :ai_enabled,
+        :position,
+        {
+          learning_goal_evidence_levels_attributes: [
+            :understanding,
+            :teacher_description,
+            :ai_prompt
+          ]
+        }
+      ],
+    )
   end
 end

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -29,14 +29,13 @@ class RubricsController < ApplicationController
   end
 
   # TODO (Kaitie): Update the update action
+  # TODO(KT) [AITT-163]: add notice that rubric was successfully updated
   # PATCH /rubrics/:rubric_id
   def update
     @rubric = Rubric.find(params[:id])
     @lesson = @rubric.lesson
-
     if @rubric.update(rubric_params)
       render json: @rubric
-      # KT NOTE FOR FUTURE WORK: tried redirect, couldn't get it to work.  Need to add notice. redirect_to edit_rubric_path(@rubric.id), notice: 'Rubric was successfully updated.'
     else
       render action: 'edit'
     end
@@ -49,11 +48,14 @@ class RubricsController < ApplicationController
       :level_id,
       :lesson_id,
       learning_goals_attributes: [
+        :id,
         :learning_goal,
         :ai_enabled,
         :position,
         {
           learning_goal_evidence_levels_attributes: [
+            :id,
+            :learning_goal_id,
             :understanding,
             :teacher_description,
             :ai_prompt

--- a/dashboard/app/models/learning_goal.rb
+++ b/dashboard/app/models/learning_goal.rb
@@ -22,6 +22,8 @@ class LearningGoal < ApplicationRecord
 
   before_create :generate_key
 
+  accepts_nested_attributes_for :learning_goal_evidence_levels
+
   def summarize
     {
       key: key,
@@ -53,7 +55,7 @@ class LearningGoal < ApplicationRecord
       position: position,
       learningGoal: learning_goal,
       aiEnabled: ai_enabled,
-      learning_goal_evidence_levels: learning_goal_evidence_levels.map(&:summarize_for_rubric_edit)
+      learningGoalEvidenceLevelsAttributes: learning_goal_evidence_levels.map(&:summarize_for_rubric_edit)
     }
   end
 end

--- a/dashboard/app/models/rubric.rb
+++ b/dashboard/app/models/rubric.rb
@@ -32,7 +32,7 @@ class Rubric < ApplicationRecord
     }
   end
 
-  accepts_nested_attributes_for :learning_goals
+  accepts_nested_attributes_for :learning_goals, allow_destroy: true
 
   def seeding_key(seed_context)
     my_lesson = seed_context.lessons.find {|l| l.id == lesson_id}


### PR DESCRIPTION
This finishes up the front and back end for creating new rubrics
- Saves the "Evidence Levels" in tables.  
- Redirects to the edit page after the new rubric is created
- Correctly shows the new rubric information on the edit page.

The image below shows the information that is now saved and displayed after creating a new rubric.

<img width="935" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/925db237-a4b7-46e0-9f52-1749765eddc6">


## Links



## Testing story



## Deployment strategy

## Follow-up work

- UI tests would be helpful for this feature.  I plan to do that along with the edit rubric work.  

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
