### PR TITLE
Add CSF 2023, CSC 2023, and How AI Works to translation pipeline

### DIFF
--- a/bin/i18n/resources/dashboard/curriculum_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/curriculum_content/sync_in.rb
@@ -74,9 +74,10 @@ module I18n
             # catchall for scripts without courses
             return 'other' if script.get_course_version.blank?
 
-            # special-case CSF; we want to group all CSF courses together, even though
-            # they all have different course offerings.
+            # special-case CSF and CSC; we want to group all CSF courses together and all CSC courses together,
+            # even though they all have different course offerings.
             return File.join(script.get_course_version.key, 'csf') if script.csf?
+            return File.join(script.get_course_version.key, 'csc') if script.csc?
 
             # base case
             return File.join(script.get_course_version.key, script.get_course_version.course_offering.key)

--- a/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_in.rb
@@ -146,7 +146,7 @@ class I18n::Resources::Dashboard::CurriculumContent::SyncInTest < Minitest::Test
     script.expects(:csf?).in_sequence(exec_seq).returns(false)
     script.expects(:csc?).in_sequence(exec_seq).returns(true)
 
-    assert_equal 'expected_course_version_key/csf', I18n::Resources::Dashboard::CurriculumContent::SyncIn.get_script_subdirectory(script)
+    assert_equal 'expected_course_version_key/csc', I18n::Resources::Dashboard::CurriculumContent::SyncIn.get_script_subdirectory(script)
   end
 
   def test_getting_subdirectory_of_not_csf_script

--- a/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_in.rb
@@ -137,6 +137,18 @@ class I18n::Resources::Dashboard::CurriculumContent::SyncInTest < Minitest::Test
     assert_equal 'expected_course_version_key/csf', I18n::Resources::Dashboard::CurriculumContent::SyncIn.get_script_subdirectory(script)
   end
 
+  def test_getting_subdirectory_of_csc_script
+    exec_seq = sequence('execution')
+    script = FactoryBot.build_stubbed(:script, name: 'expected_script_name')
+
+    Unit.expects(:unit_in_category?).with('hoc', 'expected_script_name').in_sequence(exec_seq).returns(false)
+    script.stubs(:get_course_version).returns(stub(key: 'expected_course_version_key'))
+    script.expects(:csf?).in_sequence(exec_seq).returns(false)
+    script.expects(:csc?).in_sequence(exec_seq).returns(true)
+
+    assert_equal 'expected_course_version_key/csf', I18n::Resources::Dashboard::CurriculumContent::SyncIn.get_script_subdirectory(script)
+  end
+
   def test_getting_subdirectory_of_not_csf_script
     exec_seq = sequence('execution')
     script = FactoryBot.build_stubbed(:script, name: 'expected_script_name')
@@ -144,6 +156,7 @@ class I18n::Resources::Dashboard::CurriculumContent::SyncInTest < Minitest::Test
     Unit.expects(:unit_in_category?).with('hoc', 'expected_script_name').in_sequence(exec_seq).returns(false)
     script.stubs(:get_course_version).returns(stub(key: 'expected_course_version_key', course_offering: stub(key: 'expected_course_offering_key')))
     script.expects(:csf?).in_sequence(exec_seq).returns(false)
+    script.expects(:csc?).in_sequence(exec_seq).returns(false)
 
     assert_equal 'expected_course_version_key/expected_course_offering_key', I18n::Resources::Dashboard::CurriculumContent::SyncIn.get_script_subdirectory(script)
   end

--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -92,6 +92,16 @@ module ScriptConstants
       EXPRESS_2022_NAME = 'express-2022'.freeze,
       PRE_READER_EXPRESS_2022_NAME = 'pre-express-2022'.freeze,
     ],
+    csf_2023: [
+      COURSEA_2023_NAME = 'coursea-2023'.freeze,
+      COURSEB_2023_NAME = 'courseb-2023'.freeze,
+      COURSEC_2023_NAME = 'coursec-2023'.freeze,
+      COURSED_2023_NAME = 'coursed-2023'.freeze,
+      COURSEE_2023_NAME = 'coursee-2023'.freeze,
+      COURSEF_2023_NAME = 'coursef-2023'.freeze,
+      EXPRESS_2023_NAME = 'express-2023'.freeze,
+      PRE_READER_EXPRESS_2023_NAME = 'pre-express-2023'.freeze,
+    ],
     csc_2021: [
       POETRY_2021_NAME = 'poetry-2021'.freeze,
       AI_ETHICS_2021_NAME = 'ai-ethics-2021'.freeze,
@@ -139,6 +149,7 @@ module ScriptConstants
       HOC_NAME = 'hourofcode'.freeze, # 2014 hour of code
       DANCE_PARTY_NAME = 'dance'.freeze, # 2018 hour of code
       DANCE_PARTY_EXTRAS_NAME = 'dance-extras'.freeze, # 2018 hour of code
+      HOW_AI_WORKS_2023_NAME = 'how-ai-works-2023'.freeze,
     ],
     csf_international: [
       COURSE1_NAME = 'course1'.freeze,
@@ -208,6 +219,16 @@ module ScriptConstants
       MINECRAFT_AQUATIC_NAME
     ],
   }.freeze
+
+  TRANSLATEABLE_CSC_UNITS = [
+    POETRY_2023_NAME = 'poetry-2023'.freeze,
+    CSC_BOOKCOVERS_2023_NAME = 'csc-bookcovers-2023'.freeze,
+    CSC_STARQUILTS_2023_NAME = 'csc-starquilts-2023'.freeze,
+    CSC_ECOSYSTEMS_2023_NAME = 'csc-ecosystems-2023'.freeze,
+    CSC_ADAPTATIONS_2023_NAME = 'csc-adaptations-2023'.freeze,
+    CSC_TIMECAPSULE_2023_NAME = 'csc-timecapsule-2023'.freeze,
+    CSC_MAPPINGLANDMARKS_2023_NAME = 'csc-mappinglandmarks-2023'.freeze,
+  ].freeze
 
   ADDITIONAL_I18N_UNITS = [
     APPLAB_1HOUR = 'applab-1hour'.freeze,
@@ -318,6 +339,7 @@ module ScriptConstants
       ScriptConstants.unit_in_category?(:csf_2020, script) ||
       ScriptConstants.unit_in_category?(:csf_2021, script) ||
       ScriptConstants.unit_in_category?(:csf_2022, script) ||
+      ScriptConstants.unit_in_category?(:csf_2023, script) ||
       ScriptConstants.unit_in_category?(:csd, script) ||
       ScriptConstants.unit_in_category?(:csd_2018, script) ||
       ScriptConstants.unit_in_category?(:csd_2019, script) ||
@@ -326,6 +348,7 @@ module ScriptConstants
       ScriptConstants.unit_in_category?(:twenty_hour, script) ||
       ScriptConstants.unit_in_category?(:hoc, script) ||
       script == JIGSAW_NAME ||
+      TRANSLATEABLE_CSC_UNITS.include?(script) ||
       ADDITIONAL_I18N_UNITS.include?(script)
   end
 end


### PR DESCRIPTION
Adds 16 units to the translation pipeline:
- CSF 2023 (8 units)
- How AI Works
- 7 CSC Units (the modules listed at https://code.org/educate/csc)
  - Coding Book Covers
  - Coding Interactive Maps
  - Coding Geometric Star Quilt
  - Coding a Time Capsule
  - Coding with Poetry
  - Modeling Animal Adaptations
  - Simulating a Marine Ecosystem
 
**Question for a platform team engineer**: I noticed in one of the sync in modules, there's a `get_script_subdirectory` [method](https://github.com/code-dot-org/code-dot-org/blob/8752cb283ff182be56885b350289f94e3748f291/bin/i18n/resources/dashboard/curriculum_content/sync_in.rb#L70). Should I add a case for CSC?

See [this Slack thread](https://codedotorg.slack.com/archives/CFTFD6BPV/p1694107826135039) and the resulting [Jira ticket](https://codedotorg.atlassian.net/browse/TEACH-665) for more details.