### PR TITLE
P20-368: Fix ml-playground i18n sync-out

### DIFF
--- a/bin/test/i18n/resources/apps/external_sources/test_sync_out.rb
+++ b/bin/test/i18n/resources/apps/external_sources/test_sync_out.rb
@@ -2,8 +2,6 @@ require_relative '../../../../test_helper'
 require_relative '../../../../../i18n/resources/apps/external_sources/sync_out'
 
 describe I18n::Resources::Apps::ExternalSources::SyncOut do
-  let(:sync_out) {I18n::Resources::Apps::Labs::SyncIn.new}
-
   def around
     FakeFS.with_fresh {yield}
   end
@@ -23,260 +21,294 @@ describe I18n::Resources::Apps::ExternalSources::SyncOut do
   describe '#execute' do
     let(:sync_out) {I18n::Resources::Apps::ExternalSources::SyncOut.new}
 
-    let(:crowdin_locale) {'crowdin_locale'}
-    let(:i18n_locale) {'i18n-LOCALE'}
-    let(:i18n_js_locale) {'js_locale'}
-
-    let(:crowdin_locale_ml_playground_file_path) {CDO.dir(File.join('i18n/locales', crowdin_locale, 'external-sources/ml-playground/mlPlayground.json'))}
-    let(:ml_playground_file_content) {{'ml_playground' => 'expected_translation'}}
-    let(:i18n_locale_ml_playground_file_path) {CDO.dir(File.join('i18n/locales', i18n_locale, 'external-sources/ml-playground/mlPlayground.json'))}
-
-    let(:crowdin_locale_ml_playground_dataset_file_path) {CDO.dir(File.join('i18n/locales', crowdin_locale, 'external-sources/ml-playground/datasets/expected_dataset.json'))}
-    let(:ml_playground_dataset_file_content) {{'ml_playground_dataset' => 'expected_translation'}}
-    let(:i18n_locale_ml_playground_dataset_file_path) {CDO.dir(File.join('i18n/locales', i18n_locale, 'external-sources/ml-playground/datasets/expected_dataset.json'))}
-
-    let(:crowdin_locale_blockly_core_file_path) {CDO.dir(File.join('i18n/locales', crowdin_locale, 'blockly-core/core.json'))}
-    let(:blockly_core_file_content) {{'BLOCKLY_CORE' => 'Crowdin "translation"'}}
-    let(:i18n_locale_blockly_core_file_path) {CDO.dir(File.join('i18n/locales', i18n_locale, 'blockly-core/core.json'))}
-
-    let(:apps_i18n_ml_playground_file_path) {CDO.dir(File.join("apps/i18n/mlPlayground/#{i18n_js_locale}.json"))}
-    let(:apps_lib_blockly_i18n_js_file_path) {CDO.dir(File.join("apps/lib/blockly/#{i18n_js_locale}.js"))}
+    let(:crowdin_locale) {'Not English'}
+    let(:i18n_locale) {'not-EN'}
+    let(:i18n_js_locale) {'not_en'}
 
     before do
       PegasusLanguages.stubs(:get_crowdin_name_and_locale).returns([{crowdin_name_s: crowdin_locale, locale_s: i18n_locale}])
       I18nScriptUtils.stubs(:to_js_locale).with(i18n_locale).returns(i18n_js_locale)
     end
 
-    context 'when the file is not en-US' do
-      let(:crowdin_locale) {'Not English'}
-      let(:i18n_locale) {'not-EN'}
+    it 'deletes empty Crowdin locale dir' do
+      I18nScriptUtils.expects(:remove_empty_dir).with(CDO.dir('i18n/locales', crowdin_locale)).once
 
-      it 'deletes empty Crowdin locale dir' do
-        I18nScriptUtils.expects(:remove_empty_dir).with(CDO.dir('i18n/locales', crowdin_locale)).once
+      sync_out.execute
+    end
 
-        sync_out.execute
-      end
+    describe 'ml-playground translations distribution' do
+      let(:target_i18n_file_path) {CDO.dir("apps/i18n/mlPlayground/#{i18n_js_locale}.json")}
 
-      context 'if Crowdin locale `external-sources/ml-playground/ml_playground.json` file exists' do
+      context 'when Crowdin locale `external-sources/ml-playground/ml_playground.json` file exists' do
+        let(:crowdin_ml_playground_file_path) {CDO.dir('i18n/locales', crowdin_locale, 'external-sources/ml-playground/mlPlayground.json')}
+        let(:crowdin_ml_playground_translations) {{'ml_playground' => 'expected_crowdin_translations'}}
+        let(:i18n_ml_playground_file_path) {CDO.dir('i18n/locales', i18n_locale, 'external-sources/ml-playground/mlPlayground.json')}
+
+        let(:expected_new_ml_playground_translations) {crowdin_ml_playground_translations}
+        let(:expected_new_target_i18n_file_data) {'sorted_and_sanitized_ml_playground_translations'}
+
         before do
-          FileUtils.mkdir_p(File.dirname(crowdin_locale_ml_playground_file_path))
-          File.write(crowdin_locale_ml_playground_file_path, JSON.dump(ml_playground_file_content))
+          FileUtils.mkdir_p(File.dirname(crowdin_ml_playground_file_path))
+          File.write(crowdin_ml_playground_file_path, JSON.dump(crowdin_ml_playground_translations))
+
+          I18nScriptUtils.stubs(:sort_and_sanitize).with(expected_new_ml_playground_translations).returns(expected_new_target_i18n_file_data)
         end
 
-        it 'distributes the file' do
-          expected_apps_i18n_ml_playground_file_content = 'expected_apps_i18n_ml_playground_file_content'
-
-          I18nScriptUtils.expects(:sort_and_sanitize).with(ml_playground_file_content).once.returns(
-            expected_apps_i18n_ml_playground_file_content
-          )
-
+        it 'distributes the translations' do
           sync_out.execute
 
-          assert File.exist?(apps_i18n_ml_playground_file_path)
-          assert_equal JSON.dump(expected_apps_i18n_ml_playground_file_content), File.read(apps_i18n_ml_playground_file_path)
+          assert File.exist?(target_i18n_file_path)
+          assert_equal expected_new_target_i18n_file_data, JSON.load_file(target_i18n_file_path)
         end
 
         it 'moves the file from Crowdin locale dir to I18n locale dir' do
-          assert File.exist?(crowdin_locale_ml_playground_file_path)
-          refute File.exist?(i18n_locale_ml_playground_file_path)
+          assert File.exist?(crowdin_ml_playground_file_path)
+          refute File.exist?(i18n_ml_playground_file_path)
 
           sync_out.execute
 
-          refute File.exist?(crowdin_locale_ml_playground_file_path)
-          assert File.exist?(i18n_locale_ml_playground_file_path)
+          refute File.exist?(crowdin_ml_playground_file_path)
+          assert File.exist?(i18n_ml_playground_file_path)
+          assert_equal crowdin_ml_playground_translations, JSON.load_file(i18n_ml_playground_file_path)
         end
 
-        context 'and Crowdin locale ml_playground dataset file exists' do
-          before do
-            # Should be replaced with the crowdin_locale_ml_playground_file_path
-            FileUtils.mkdir_p(File.dirname(i18n_locale_ml_playground_file_path))
-            FileUtils.touch(i18n_locale_ml_playground_file_path)
-
-            FileUtils.mkdir_p(File.dirname(crowdin_locale_ml_playground_dataset_file_path))
-            File.write(crowdin_locale_ml_playground_dataset_file_path, JSON.dump(ml_playground_dataset_file_content))
-          end
-
-          it 'distributes Crowdin files' do
-            exec_seq = sequence('execution')
-            expected_apps_i18n_ml_playground_file_content = 'expected_apps_i18n_ml_playground_file_content'
-
-            I18nScriptUtils.expects(:sort_and_sanitize).with(ml_playground_file_content).in_sequence(exec_seq).returns(ml_playground_file_content)
-            I18nScriptUtils.expects(:sort_and_sanitize).with(
-              ml_playground_file_content.merge('datasets' => {'expected_dataset' => ml_playground_dataset_file_content})
-            ).in_sequence(exec_seq).returns(
-              expected_apps_i18n_ml_playground_file_content
-            )
-
-            sync_out.execute
-
-            assert File.exist?(apps_i18n_ml_playground_file_path)
-            assert_equal JSON.dump(expected_apps_i18n_ml_playground_file_content), File.read(apps_i18n_ml_playground_file_path)
-          end
-
-          it 'replaces I18n locale dir files with Crowdin locale dir files' do
-            assert File.exist?(crowdin_locale_ml_playground_file_path)
-            assert File.exist?(crowdin_locale_ml_playground_dataset_file_path)
-
-            assert File.exist?(i18n_locale_ml_playground_file_path)
-            refute File.exist?(i18n_locale_ml_playground_dataset_file_path)
-
-            sync_out.execute
-
-            refute File.exist?(crowdin_locale_ml_playground_file_path)
-            refute File.exist?(crowdin_locale_ml_playground_dataset_file_path)
-
-            assert File.exist?(i18n_locale_ml_playground_file_path)
-            assert File.exist?(i18n_locale_ml_playground_dataset_file_path)
-          end
-        end
-      end
-
-      context 'if Crowdin locale ml_playground dataset file exists' do
-        before do
-          FileUtils.mkdir_p(File.dirname(crowdin_locale_ml_playground_dataset_file_path))
-          File.write(crowdin_locale_ml_playground_dataset_file_path, JSON.dump(ml_playground_dataset_file_content))
-        end
-
-        it 'distributes the file' do
-          expected_apps_i18n_ml_playground_file_content = 'expected_apps_i18n_ml_playground_file_content'
-
-          I18nScriptUtils.expects(:sort_and_sanitize).with(
-            {'datasets' => {'expected_dataset' => ml_playground_dataset_file_content}}
-          ).once.returns(
-            expected_apps_i18n_ml_playground_file_content
-          )
-
-          sync_out.execute
-
-          assert File.exist?(apps_i18n_ml_playground_file_path)
-          assert_equal JSON.dump(expected_apps_i18n_ml_playground_file_content), File.read(apps_i18n_ml_playground_file_path)
-        end
-
-        it 'moves the file from Crowdin locale dir to I18n locale dir' do
-          assert File.exist?(crowdin_locale_ml_playground_dataset_file_path)
-          refute File.exist?(i18n_locale_ml_playground_dataset_file_path)
-
-          sync_out.execute
-
-          refute File.exist?(crowdin_locale_ml_playground_dataset_file_path)
-          assert File.exist?(i18n_locale_ml_playground_dataset_file_path)
-        end
-      end
-
-      context 'if Crowdin locale blockly-core/core.json file exists' do
-        before do
-          FileUtils.mkdir_p(File.dirname(crowdin_locale_blockly_core_file_path))
-          File.write(crowdin_locale_blockly_core_file_path, JSON.dump(blockly_core_file_content))
-        end
-
-        it 'distributes the file' do
-          I18nScriptUtils.expects(:sort_and_sanitize).with(blockly_core_file_content).once.returns(blockly_core_file_content)
-
-          sync_out.execute
-
-          assert File.exist?(apps_lib_blockly_i18n_js_file_path)
-          assert_equal %Q[Blockly.Msg.BLOCKLY_CORE = "Crowdin \\"translation\\"";\n], File.read(apps_lib_blockly_i18n_js_file_path)
-        end
-
-        it 'moves the file from Crowdin locale dir to I18n locale dir' do
-          assert File.exist?(crowdin_locale_blockly_core_file_path)
-          refute File.exist?(i18n_locale_blockly_core_file_path)
-
-          sync_out.execute
-
-          refute File.exist?(crowdin_locale_blockly_core_file_path)
-          assert File.exist?(i18n_locale_blockly_core_file_path)
-        end
-
-        context 'and I18n source blockly-core/core.json files exists' do
-          let(:i18n_source_blockly_core_file_path) {CDO.dir(File.join('i18n/locales/source/blockly-core/core.json'))}
-          let(:en_blockly_core_file_content) do
+        context 'when the target i18n file with `datasets` translations is already exist' do
+          let(:initial_target_i18n_file_data) do
             {
-              'BLOCKLY_CORE' => 'Source "translation"',
-              'BLOCKLY_CORE_2' => 'Source 2 "translation"',
+              'ml_playground' => 'apps_i18n_translation',
+              'datasets' => {
+                'dataset1' => 'expected_apps_i18n_dataset1_translation',
+              }
+            }
+          end
+          let(:expected_new_ml_playground_translations) do
+            {
+              **crowdin_ml_playground_translations,
+              'datasets' => initial_target_i18n_file_data['datasets'],
             }
           end
 
           before do
-            # Should be replaced with the crowdin_locale_blockly_core_file_path
-            FileUtils.mkdir_p(File.dirname(i18n_locale_blockly_core_file_path))
-            FileUtils.touch(i18n_locale_blockly_core_file_path)
-
-            FileUtils.mkdir_p(File.dirname(i18n_source_blockly_core_file_path))
-            File.write(i18n_source_blockly_core_file_path, JSON.dump(en_blockly_core_file_content))
+            FileUtils.mkdir_p(File.dirname(target_i18n_file_path))
+            File.write(target_i18n_file_path, JSON.dump(initial_target_i18n_file_data))
           end
 
-          it 'distributes the Crowdin file with merged I18n source file content' do
-            expected_apps_lib_blockly_i18n_js_file_content = <<-JS.gsub(/^ {14}/, '')
-              Blockly.Msg.BLOCKLY_CORE = "Crowdin \\"translation\\"";
-              Blockly.Msg.BLOCKLY_CORE_2 = "Source 2 \\"translation\\"";
-            JS
+          it 'the updated target i18n file data contains the `datasets` translations' do
+            sync_out.execute
+
+            assert File.exist?(target_i18n_file_path)
+            assert_equal expected_new_target_i18n_file_data, JSON.load_file(target_i18n_file_path)
+          end
+        end
+
+        context 'when the files are en-US' do
+          let(:crowdin_locale) {'English'}
+          let(:i18n_locale) {'en-US'}
+          let(:i18n_js_locale) {'en_us'}
+
+          it 'does not distribute the translations' do
+            sync_out.execute
+
+            refute File.exist?(target_i18n_file_path)
+          end
+
+          it 'moves the file from Crowdin locale dir to I18n locale dir' do
+            assert File.exist?(crowdin_ml_playground_file_path)
+            refute File.exist?(i18n_ml_playground_file_path)
 
             sync_out.execute
 
-            assert File.exist?(apps_lib_blockly_i18n_js_file_path)
-            assert_equal expected_apps_lib_blockly_i18n_js_file_content, File.read(apps_lib_blockly_i18n_js_file_path)
+            refute File.exist?(crowdin_ml_playground_file_path)
+            assert File.exist?(i18n_ml_playground_file_path)
+            assert_equal crowdin_ml_playground_translations, JSON.load_file(i18n_ml_playground_file_path)
+          end
+        end
+      end
+
+      context 'when Crowdin locale ml_playground dataset file exists' do
+        let(:dataset_id) {'expected_dataset_id'}
+        let(:crowdin_ml_playground_dataset_file_path) {CDO.dir('i18n/locales', crowdin_locale, "external-sources/ml-playground/datasets/#{dataset_id}.json")}
+        let(:crowdin_ml_playground_dataset_translations) {{'ml_playground_dataset' => 'expected_translation'}}
+        let(:i18n_ml_playground_dataset_file_path) {CDO.dir('i18n/locales', i18n_locale, "external-sources/ml-playground/datasets/#{dataset_id}.json")}
+
+        let(:expected_new_ml_playground_datasets_translations) do
+          {
+            'datasets' => {
+              dataset_id => crowdin_ml_playground_dataset_translations
+            }
+          }
+        end
+        let(:expected_new_target_i18n_file_data) {'sorted_and_sanitized_ml_playground_dataset_translations'}
+
+        before do
+          FileUtils.mkdir_p(File.dirname(crowdin_ml_playground_dataset_file_path))
+          File.write(crowdin_ml_playground_dataset_file_path, JSON.dump(crowdin_ml_playground_dataset_translations))
+
+          I18nScriptUtils.stubs(:sort_and_sanitize).with(expected_new_ml_playground_datasets_translations).returns(expected_new_target_i18n_file_data)
+        end
+
+        it 'distributes the translations' do
+          sync_out.execute
+
+          assert File.exist?(target_i18n_file_path)
+          assert_equal expected_new_target_i18n_file_data, JSON.load_file(target_i18n_file_path)
+        end
+
+        it 'moves the file from Crowdin locale dir to I18n locale dir' do
+          assert File.exist?(crowdin_ml_playground_dataset_file_path)
+          refute File.exist?(i18n_ml_playground_dataset_file_path)
+
+          sync_out.execute
+
+          refute File.exist?(crowdin_ml_playground_dataset_file_path)
+          assert File.exist?(i18n_ml_playground_dataset_file_path)
+          assert_equal crowdin_ml_playground_dataset_translations, JSON.load_file(i18n_ml_playground_dataset_file_path)
+        end
+
+        context 'when the target i18n file with `datasets` translations is already exist' do
+          let(:initial_target_i18n_file_data) do
+            {
+              'ml_playground' => 'expected_apps_i18n_translation',
+              'datasets' => {
+                dataset_id => 'apps_i18n_dataset_translation',
+              }
+            }
+          end
+          let(:expected_new_ml_playground_datasets_translations) do
+            {
+              'ml_playground' => initial_target_i18n_file_data['ml_playground'],
+              'datasets' => {
+                dataset_id => crowdin_ml_playground_dataset_translations
+              },
+            }
           end
 
-          it 'replaces I18n locale dir files with Crowdin locale dir files' do
-            assert File.exist?(crowdin_locale_blockly_core_file_path)
-            assert File.exist?(i18n_locale_blockly_core_file_path)
+          before do
+            FileUtils.mkdir_p(File.dirname(target_i18n_file_path))
+            File.write(target_i18n_file_path, JSON.dump(initial_target_i18n_file_data))
+          end
+
+          it 'replaces the existing target i18n file `datasets` translations with the new ones' do
+            sync_out.execute
+
+            assert File.exist?(target_i18n_file_path)
+            assert_equal expected_new_target_i18n_file_data, JSON.load_file(target_i18n_file_path)
+          end
+        end
+
+        context 'when the files are en-US' do
+          let(:crowdin_locale) {'English'}
+          let(:i18n_locale) {'en-US'}
+          let(:i18n_js_locale) {'en_us'}
+
+          it 'does not distribute the translations' do
+            sync_out.execute
+
+            refute File.exist?(target_i18n_file_path)
+          end
+
+          it 'moves the file from Crowdin locale dir to I18n locale dir' do
+            assert File.exist?(crowdin_ml_playground_dataset_file_path)
+            refute File.exist?(i18n_ml_playground_dataset_file_path)
 
             sync_out.execute
 
-            refute File.exist?(crowdin_locale_blockly_core_file_path)
-            assert File.exist?(i18n_locale_blockly_core_file_path)
+            refute File.exist?(crowdin_ml_playground_dataset_file_path)
+            assert File.exist?(i18n_ml_playground_dataset_file_path)
+            assert_equal crowdin_ml_playground_dataset_translations, JSON.load_file(i18n_ml_playground_dataset_file_path)
           end
         end
       end
     end
 
-    context 'when the files are en-US' do
-      let(:crowdin_locale) {'English'}
-      let(:i18n_locale) {'en-US'}
+    describe 'Blockly Core translations distribution' do
+      let(:target_i18n_file_path) {CDO.dir("apps/lib/blockly/#{i18n_js_locale}.js")}
+
+      let(:crowdin_blockly_core_file_path) {CDO.dir('i18n/locales', crowdin_locale, 'blockly-core/core.json')}
+      let(:crowdin_blockly_core_file_data) {{'BLOCKLY_CORE' => 'Crowdin "translation"'}}
+      let(:i18n_blockly_core_file_path) {CDO.dir('i18n/locales', i18n_locale, 'blockly-core/core.json')}
+
+      let(:expected_new_blockly_core_translations) {crowdin_blockly_core_file_data}
+      let(:expected_new_target_i18n_file_data) {expected_new_blockly_core_translations}
 
       before do
-        FileUtils.mkdir_p(File.dirname(crowdin_locale_ml_playground_file_path))
-        File.write(crowdin_locale_ml_playground_file_path, JSON.dump(ml_playground_file_content))
+        FileUtils.mkdir_p(File.dirname(crowdin_blockly_core_file_path))
+        File.write(crowdin_blockly_core_file_path, JSON.dump(crowdin_blockly_core_file_data))
 
-        FileUtils.mkdir_p(File.dirname(crowdin_locale_ml_playground_dataset_file_path))
-        File.write(crowdin_locale_ml_playground_dataset_file_path, JSON.dump(ml_playground_dataset_file_content))
-
-        FileUtils.mkdir_p(File.dirname(crowdin_locale_blockly_core_file_path))
-        File.write(crowdin_locale_blockly_core_file_path, JSON.dump(blockly_core_file_content))
+        I18nScriptUtils.stubs(:sort_and_sanitize).with(expected_new_blockly_core_translations).returns(expected_new_target_i18n_file_data)
       end
 
-      it 'does not distribute the files' do
+      it 'distributes the translations' do
         sync_out.execute
 
-        refute File.exist?(apps_i18n_ml_playground_file_path)
-        refute File.exist?(apps_lib_blockly_i18n_js_file_path)
+        assert File.exist?(target_i18n_file_path)
+        assert_equal %Q[Blockly.Msg.BLOCKLY_CORE = "Crowdin \\"translation\\"";\n], File.read(target_i18n_file_path)
       end
 
-      it 'moves the files from Crowdin locale dir to I18n locale dir' do
-        assert File.exist?(crowdin_locale_ml_playground_file_path)
-        assert File.exist?(crowdin_locale_ml_playground_dataset_file_path)
-        assert File.exist?(crowdin_locale_blockly_core_file_path)
-
-        refute File.exist?(i18n_locale_ml_playground_file_path)
-        refute File.exist?(i18n_locale_ml_playground_dataset_file_path)
-        refute File.exist?(i18n_locale_blockly_core_file_path)
+      it 'moves the file from Crowdin locale dir to I18n locale dir' do
+        assert File.exist?(crowdin_blockly_core_file_path)
+        refute File.exist?(i18n_blockly_core_file_path)
 
         sync_out.execute
 
-        refute File.exist?(crowdin_locale_ml_playground_file_path)
-        refute File.exist?(crowdin_locale_ml_playground_dataset_file_path)
-        refute File.exist?(crowdin_locale_blockly_core_file_path)
-
-        assert File.exist?(i18n_locale_ml_playground_file_path)
-        assert File.exist?(i18n_locale_ml_playground_dataset_file_path)
-        assert File.exist?(i18n_locale_blockly_core_file_path)
+        refute File.exist?(crowdin_blockly_core_file_path)
+        assert File.exist?(i18n_blockly_core_file_path)
+        assert_equal crowdin_blockly_core_file_data, JSON.load_file(i18n_blockly_core_file_path)
       end
 
-      it 'deletes empty Crowdin locale dir' do
-        I18nScriptUtils.expects(:remove_empty_dir).with(CDO.dir('i18n/locales', crowdin_locale)).once
+      context 'when the I18n source `blockly-core/core.json` files exists' do
+        let(:i18n_source_blockly_core_file_path) {CDO.dir('i18n/locales/source/blockly-core/core.json')}
+        let(:i18n_source_blockly_core_file_data) do
+          {
+            'BLOCKLY_CORE' => 'Source "translation"',
+            'BLOCKLY_CORE_2' => 'Source 2 "translation"',
+          }
+        end
 
-        sync_out.execute
+        let(:expected_new_blockly_core_translations) do
+          {
+            'BLOCKLY_CORE' => 'Crowdin "translation"',
+            'BLOCKLY_CORE_2' => i18n_source_blockly_core_file_data['BLOCKLY_CORE_2'],
+          }
+        end
+
+        before do
+          FileUtils.mkdir_p(File.dirname(i18n_source_blockly_core_file_path))
+          File.write(i18n_source_blockly_core_file_path, JSON.dump(i18n_source_blockly_core_file_data))
+        end
+
+        it 'distributes the Crowdin file with merged I18n source file content' do
+          expected_target_i18n_file_content = <<-JS.gsub(/^ {12}/, '')
+            Blockly.Msg.BLOCKLY_CORE = "Crowdin \\"translation\\"";
+            Blockly.Msg.BLOCKLY_CORE_2 = "Source 2 \\"translation\\"";
+          JS
+
+          sync_out.execute
+          assert_equal expected_target_i18n_file_content, File.read(target_i18n_file_path)
+        end
+      end
+
+      context 'when the files are en-US' do
+        let(:crowdin_locale) {'English'}
+        let(:i18n_locale) {'en-US'}
+        let(:i18n_js_locale) {'en_us'}
+
+        it 'does not distribute the translations' do
+          sync_out.execute
+
+          refute File.exist?(target_i18n_file_path)
+        end
+
+        it 'moves the file from Crowdin locale dir to I18n locale dir' do
+          assert File.exist?(crowdin_blockly_core_file_path)
+          refute File.exist?(i18n_blockly_core_file_path)
+
+          sync_out.execute
+
+          refute File.exist?(crowdin_blockly_core_file_path)
+          assert File.exist?(i18n_blockly_core_file_path)
+          assert_equal crowdin_blockly_core_file_data, JSON.load_file(i18n_blockly_core_file_path)
+        end
       end
     end
   end


### PR DESCRIPTION
Since `ml-playground/mlPlayground.json` doesn't contain `datasets` translations,
the existing `datasets` translations need to be put back into the apps i18n file.
https://github.com/code-dot-org/code-dot-org/pull/53696/files#diff-e3673b0235644288591279de1920539d2860e3c3de96a1b5d53cb28ca02c318eL6

## Links
- jira ticket: [P20-368](https://codedotorg.atlassian.net/browse/P20-368)