### PR TITLE
Top align topics in expanded card when multiple lines

### DIFF
--- a/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
@@ -121,7 +121,6 @@ $container-width: 960px;
 
 .iconWithDescription {
   display: flex;
-  align-items: center;
   column-gap: 8px;
   white-space: nowrap;
 
@@ -134,12 +133,13 @@ $container-width: 960px;
   i {
     font-size: 0.875em;
     color: $neutral_dark80;
+    align-self: flex-start;
+    padding-top: 4px;
   }
 }
 
 .infoContainer {
   display: flex;
-  align-items: center;
   column-gap: 20px;
 }
 
@@ -258,4 +258,9 @@ $container-width: 960px;
 
 .imageContainer {
   height: 166px;
+}
+
+.topicsContainer {
+  display: flex;
+  align-items: top;
 }

--- a/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
@@ -259,8 +259,3 @@ $container-width: 960px;
 .imageContainer {
   height: 166px;
 }
-
-.topicsContainer {
-  display: flex;
-  align-items: top;
-}


### PR DESCRIPTION
Topics in Expanded card are top aligned when the topics span multiple lines.

### Topics are top aligned when spanning multiple lines
<img width="1073" alt="Screenshot 2023-09-11 at 11 24 21 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/63e88579-c6d9-4014-a951-cae43fe61610">


### Topics appear the same as before when spanning only one line
<img width="1066" alt="Screenshot 2023-09-11 at 11 18 14 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/2795e68c-8d73-4796-a837-1aeee0521942">
