### PR TITLE
Add direct-access dcdo flag check

### DIFF
--- a/pegasus/sites.v3/code.org/public/test_dcdo.haml
+++ b/pegasus/sites.v3/code.org/public/test_dcdo.haml
@@ -1,1 +1,3 @@
 = DCDO.get("test_dcdo_on_pegasus", nil).inspect
+<br>
+= DCDO.instance_variable_get('@datastore_cache')&.instance_variable_get('@datastore')&.get('test_dcdo_on_pegasus')&.inspect


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Add another check to the DCDO test page that tries to bypass the `DCDO` object caching, in order to rule that out as a potential source of the issue here. When I tested this locally, it took a few seconds longer for the cached version to update than the direct-access version, which is what I would expect in development. If the direct-access version doesn't update sooner in production, that's another clue that our caching issue is at a higher level, like HAML rendering.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->
- jira ticket: [ACQ-882](https://codedotorg.atlassian.net/browse/ACQ-882)

