### PR TITLE
Delete Learning Goal Button deletes from front and back end

### DIFF
--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -6,7 +6,7 @@ import EvidenceDescriptions from './EvidenceDescriptions';
 import Button from '../../../templates/Button';
 
 export default function LearningGoalItem({
-  deleteItem,
+  deleteLearningGoal,
   exisitingLearningGoalData,
   updateLearningGoal,
 }) {
@@ -25,6 +25,10 @@ export default function LearningGoalItem({
       'learningGoal',
       event.target.value
     );
+  };
+
+  const handleDelete = event => {
+    deleteLearningGoal(exisitingLearningGoalData.id);
   };
 
   return (
@@ -79,7 +83,7 @@ export default function LearningGoalItem({
         <Button
           text="Delete key concept"
           color={Button.ButtonColor.red}
-          onClick={() => deleteItem()}
+          onClick={handleDelete}
           icon="trash"
           iconClassName="fa-trash"
           className="ui-test-delete-concept-button"
@@ -90,7 +94,7 @@ export default function LearningGoalItem({
 }
 
 LearningGoalItem.propTypes = {
-  deleteItem: PropTypes.func,
+  deleteLearningGoal: PropTypes.func,
   exisitingLearningGoalData: PropTypes.object,
   updateLearningGoal: PropTypes.func,
 };

--- a/apps/src/lib/levelbuilder/rubrics/RubricEditor.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/RubricEditor.jsx
@@ -5,19 +5,21 @@ import Button from '@cdo/apps/templates/Button';
 
 export default function RubricEditor({
   addNewConcept,
-  deleteItem,
+  deleteLearningGoal,
   learningGoalList,
   updateLearningGoal,
 }) {
   const renderLearningGoalItems = learningGoalList.map(goal => {
-    return (
-      <LearningGoalItem
-        deleteItem={() => deleteItem(goal.id)}
-        key={goal.id}
-        exisitingLearningGoalData={goal}
-        updateLearningGoal={updateLearningGoal}
-      />
-    );
+    if (!goal._destroy) {
+      return (
+        <LearningGoalItem
+          deleteLearningGoal={deleteLearningGoal}
+          key={goal.id}
+          exisitingLearningGoalData={goal}
+          updateLearningGoal={updateLearningGoal}
+        />
+      );
+    }
   });
 
   return (
@@ -38,7 +40,7 @@ export default function RubricEditor({
 
 RubricEditor.propTypes = {
   learningGoalList: PropTypes.array,
-  deleteItem: PropTypes.func,
+  deleteLearningGoal: PropTypes.func,
   addNewConcept: PropTypes.func,
   updateLearningGoal: PropTypes.func,
 };

--- a/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
@@ -112,14 +112,6 @@ export default function RubricsContainer({
     setLearningGoalList([...oldLearningGoalList, startingData]);
   };
 
-  const deleteKeyConcept = id => {
-    event.preventDefault();
-    var updatedLearningGoalList = learningGoalList.filter(
-      item => item.id !== id
-    );
-    setLearningGoalList(updatedLearningGoalList);
-  };
-
   const updateLearningGoal = (
     idToUpdate,
     keyToUpdate,
@@ -145,6 +137,20 @@ export default function RubricsContainer({
             [keyToUpdate]: newValue,
           };
         }
+      } else {
+        return learningGoal;
+      }
+    });
+    setLearningGoalList(newLearningGoalData);
+  };
+
+  const deleteLearningGoal = idToDelete => {
+    const newLearningGoalData = learningGoalList.map(learningGoal => {
+      if (idToDelete === learningGoal.id) {
+        return {
+          ...learningGoal,
+          _destroy: true,
+        };
       } else {
         return learningGoal;
       }
@@ -229,7 +235,11 @@ export default function RubricsContainer({
       if (Array.isArray(value)) {
         newObj[snakeCase(key)] = value.map(item => transformObjectKeys(item));
       } else {
-        newObj[snakeCase(key)] = value;
+        if (key === '_destroy') {
+          newObj[key] = value;
+        } else {
+          newObj[snakeCase(key)] = value;
+        }
       }
     }
 
@@ -276,7 +286,7 @@ export default function RubricsContainer({
       <RubricEditor
         learningGoalList={learningGoalList}
         addNewConcept={addNewConceptHandler}
-        deleteItem={id => deleteKeyConcept(id)}
+        deleteLearningGoal={deleteLearningGoal}
         updateLearningGoal={updateLearningGoal}
       />
       <div style={styles.bottomRow}>

--- a/apps/test/unit/lib/levelbuilder/rubrics/LearningGoalItemTest.js
+++ b/apps/test/unit/lib/levelbuilder/rubrics/LearningGoalItemTest.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 
 describe('LearningGoalItem', () => {
   let defaultProps;
-  const deleteItemSpy = sinon.spy();
+  const deleteLearningGoalSpy = sinon.spy();
   const exisitingLearningGoalData = {
     key: 'learningGoal-1',
     id: 'learningGoal-1',
@@ -16,7 +16,7 @@ describe('LearningGoalItem', () => {
 
   beforeEach(() => {
     defaultProps = {
-      deleteItem: deleteItemSpy,
+      deleteLearningGoal: deleteLearningGoalSpy,
       exisitingLearningGoalData: exisitingLearningGoalData,
     };
   });
@@ -62,9 +62,9 @@ describe('LearningGoalItem', () => {
     ).to.be.true;
   });
 
-  it('calls deleteItem when delete button is clicked', () => {
+  it('calls deleteLearningGoal when delete button is clicked', () => {
     const wrapper = shallow(<LearningGoalItem {...defaultProps} />);
     wrapper.find('Button').simulate('click');
-    expect(deleteItemSpy.calledOnce).to.be.true;
+    expect(deleteLearningGoalSpy.calledOnce).to.be.true;
   });
 });

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -66,6 +66,7 @@ class RubricsController < ApplicationController
         :learning_goal,
         :ai_enabled,
         :position,
+        :_destroy,
         {
           learning_goal_evidence_levels_attributes: [
             :id,


### PR DESCRIPTION


Currently, the "Delete key concept" button deletes a learning goal from the UI, but when saving the rubric, the key concept was not deleted from the back end.  This PR fixes that. 

The video shows deleting an existing learning goal, adding a new one, and then pressing save.  I reloaded the page to show that indeed on re-load one learning goal has been removed and a new one has been put in place. 


https://github.com/code-dot-org/code-dot-org/assets/24883357/1cb12f8e-a7c8-4c0d-99fb-b3437f573a53



## Links

[AITT - 171](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?selectedIssue=AITT-171)


## Testing story

I modified the existing test for this component.
