### PR TITLE
Restore "do not require teacher application on AYW workshops (#50988)"

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -131,7 +131,7 @@ class Pd::Workshop < ApplicationRecord
   # Whether enrollment in this workshop requires an application
   def require_application?
     courses = [COURSE_CSP, COURSE_CSD, COURSE_CSA]
-    subjects = ACADEMIC_YEAR_SUBJECTS.push(SUBJECT_SUMMER_WORKSHOP)
+    subjects = [SUBJECT_SUMMER_WORKSHOP]
     courses.include?(course) && subjects.include?(subject) &&
       regional_partner && regional_partner.link_to_partner_application.blank?
   end

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1520,9 +1520,9 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert workshop.require_application?
   end
 
-  test 'CSD academic year workshop must require teacher application' do
+  test 'CSD academic year workshop must not require teacher application' do
     workshop = create :csd_academic_year_workshop, regional_partner: @regional_partner
-    assert workshop.require_application?
+    refute workshop.require_application?
   end
 
   test 'CSA summer workshop must require teacher application' do


### PR DESCRIPTION
This reverts commit 020e4693637b2147d7ba343fd828acec461442cf.

Reverting because there are too many (175) teachers enrolled in summer workshops where applications will be required for AYWs, but no application id is present. See [slack](https://codedotorg.slack.com/archives/C04540KNGDQ/p1694117153643569) for details.

## Testing story

unit test updates as part of this change