### PR TITLE
Corrects self paced pl ids when seeding

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -387,6 +387,13 @@ class CourseOffering < ApplicationRecord
   # seed_all
   def self.seed_record(file_path)
     properties = properties_from_file(File.read(file_path))
+    key = properties[:self_paced_pl_course_offering_key]
+    new_self_paced_pl_course_offering = CourseOffering.find_by_key(key)
+    if new_self_paced_pl_course_offering.nil? && !key.nil?
+      warn "self_paced_pl_course_offering_key: #{key} not found. Please seed again to fix."
+    else
+      properties[:self_paced_pl_course_offering_id] = new_self_paced_pl_course_offering&.id
+    end
     properties.delete(:self_paced_pl_course_offering_key)
     course_offering = CourseOffering.find_or_initialize_by(key: properties[:key])
     course_offering.update! properties

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -746,7 +746,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
   end
 
   test "can serialize and seed course offerings" do
-    course_offering = create :course_offering, key: 'course-offering-1', grade_levels: 'K,1,2', curriculum_type: 'Course', marketing_initiative: 'HOC', header: 'Popular Media', image: 'https://images.code.org/spritelab.JPG', cs_topic: 'Artificial Intelligence,Cybersecurity', school_subject: 'Math,Science', device_compatibility: "{'computer':'ideal','chromebook':'not_recommended','tablet':'incompatible','mobile':'incompatible','no_device':'incompatible'}", description: "An introductory course that empowers students to engage with computer science as a medium for creativity, communication, an problem solving.", professional_learning_program: "https://code.org/apply", video: "https://youtu.be/T45kEEBzrT8", published_date: DateTime.new(2023, 7, 5, 4, 30), self_paced_pl_course_offering_id: 165
+    course_offering = create :course_offering, key: 'course-offering-1', grade_levels: 'K,1,2', curriculum_type: 'Course', marketing_initiative: 'HOC', header: 'Popular Media', image: 'https://images.code.org/spritelab.JPG', cs_topic: 'Artificial Intelligence,Cybersecurity', school_subject: 'Math,Science', device_compatibility: "{'computer':'ideal','chromebook':'not_recommended','tablet':'incompatible','mobile':'incompatible','no_device':'incompatible'}", description: "An introductory course that empowers students to engage with computer science as a medium for creativity, communication, an problem solving.", professional_learning_program: "https://code.org/apply", video: "https://youtu.be/T45kEEBzrT8", published_date: DateTime.new(2023, 7, 5, 4, 30), self_paced_pl_course_offering_id: nil
     serialization = course_offering.serialize
     previous_course_offering = course_offering.freeze
     course_offering.destroy!
@@ -757,6 +757,20 @@ class CourseOfferingTest < ActiveSupport::TestCase
     new_course_offering = CourseOffering.find_by(key: new_course_offering_key)
     assert_equal previous_course_offering.attributes.except('id', 'created_at', 'updated_at'),
       new_course_offering.attributes.except('id', 'created_at', 'updated_at')
+  end
+
+  test "can seed correct self paced pl id based on self paced pl key" do
+    course_offering = create :course_offering, key: 'course-offering-1'
+    self_paced_pl_course = create :course_offering, key: 'self-paced-test-course'
+    serialization = course_offering.serialize
+    serialization[:self_paced_pl_course_offering_key] = "self-paced-test-course"
+
+    File.stubs(:read).returns(serialization.to_json)
+
+    CourseOffering.seed_record("config/course_offerings/course-offering-1.json")
+    new_course_offering = CourseOffering.find_by(key: course_offering.key)
+    assert_equal new_course_offering.self_paced_pl_course_offering_id,
+      self_paced_pl_course.id
   end
 
   test "validates grade_levels" do


### PR DESCRIPTION
This PR follows work done in [this PR](https://github.com/code-dot-org/code-dot-org/pull/53739). Corrects the `self_paced_pl_course_offering_id` within the course offering using the `self_paced_pl_course_offering_key` in the serialization files. The Self Paced Professional Learning now appears in the expanded card once re-seeded.
<img width="1091" alt="Screenshot 2023-09-13 at 12 55 02 PM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/7931bb14-2163-4af8-8469-8040a2ed53e3">
## Links





- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-931)


## Testing story
Ran tests within dashboard/test/models/course_offering_test.rb

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->





## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
