### PR TITLE
Hide expanded card if not in filtered changes

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {curriculumDataShape} from './curriculumCatalogShapes';
 import i18n from '@cdo/locale';
@@ -28,6 +28,16 @@ const CurriculumCatalog = ({
   const [expandedCardKey, setExpandedCardKey] = useState(null);
 
   const isQuickViewDisplayed = queryParams()['quick_view'] === 'true';
+
+  useEffect(() => {
+    const expandedCardFound = filteredCurricula.some(
+      co => expandedCardKey in co
+    );
+
+    if (!expandedCardFound) {
+      setExpandedCardKey(null);
+    }
+  }, [expandedCardKey, filteredCurricula]);
 
   const handleAssignSuccess = assignmentData => {
     setAssignSuccessMessage(

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -13,6 +13,7 @@ import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/Curricu
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {queryParams} from '../../code-studio/utils';
+import {filter} from 'lodash';
 
 const CurriculumCatalog = ({
   curriculaData,
@@ -31,7 +32,7 @@ const CurriculumCatalog = ({
 
   useEffect(() => {
     const expandedCardFound = filteredCurricula.some(
-      co => expandedCardKey in co
+      co => expandedCardKey === co['key']
     );
 
     if (!expandedCardFound) {
@@ -68,6 +69,7 @@ const CurriculumCatalog = ({
   // message if no results).
   const renderSearchResults = () => {
     if (filteredCurricula.length > 0) {
+      console.log();
       return (
         <div className={style.catalogContentCards}>
           {filteredCurricula

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -13,7 +13,6 @@ import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/Curricu
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {queryParams} from '../../code-studio/utils';
-import {filter} from 'lodash';
 
 const CurriculumCatalog = ({
   curriculaData,
@@ -69,7 +68,6 @@ const CurriculumCatalog = ({
   // message if no results).
   const renderSearchResults = () => {
     if (filteredCurricula.length > 0) {
-      console.log();
       return (
         <div className={style.catalogContentCards}>
           {filteredCurricula


### PR DESCRIPTION
Closes an open expanded card if the new filters applied does not include this Course Offering. It will keep an expanded card open if the course offering is included in the new filtered curricula and the Youtube video will also keep playing.

https://github.com/code-dot-org/code-dot-org/assets/137838584/6d1d126f-994e-4d83-add3-5dfb8c306441


## Links

- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-905)

## Testing story
Local


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
