### PR TITLE
add csd-2023 and AI-ethics to translation pipeline

### DIFF
--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -150,12 +150,23 @@ module ScriptConstants
       DANCE_PARTY_NAME = 'dance'.freeze, # 2018 hour of code
       DANCE_PARTY_EXTRAS_NAME = 'dance-extras'.freeze, # 2018 hour of code
       HOW_AI_WORKS_2023_NAME = 'how-ai-works-2023'.freeze,
+      AI_ETHICS_2023_NAME = 'ai-ethics-2023'.freeze,
     ],
     csf_international: [
       COURSE1_NAME = 'course1'.freeze,
       COURSE2_NAME = 'course2'.freeze,
       COURSE3_NAME = 'course3'.freeze,
       COURSE4_NAME = 'course4'.freeze,
+    ],
+    csd_2023: [
+      CSD1_2023_NAME = 'csd1-2022'.freeze,
+      CSD2_2023_NAME = 'csd2-2022'.freeze,
+      CSD3_2023_NAME = 'csd3-2022'.freeze,
+      CSD4_2023_NAME = 'csd4-2022'.freeze,
+      CSD5_2023_NAME = 'csd5-2022'.freeze,
+      CSD6A_2023_NAME = 'csd6a-2022'.freeze,
+      CSD6B_2023_NAME = 'csd6b-2022'.freeze,
+      CSD7_2023_NAME = 'csd7-2022'.freeze,
     ],
     csd_2022: [
       CSD1_2022_NAME = 'csd1-2022'.freeze,
@@ -345,6 +356,7 @@ module ScriptConstants
       ScriptConstants.unit_in_category?(:csd_2019, script) ||
       ScriptConstants.unit_in_category?(:csd_2021, script) ||
       ScriptConstants.unit_in_category?(:csd_2022, script) ||
+      ScriptConstants.unit_in_category?(:csd_2023, script) ||
       ScriptConstants.unit_in_category?(:twenty_hour, script) ||
       ScriptConstants.unit_in_category?(:hoc, script) ||
       script == JIGSAW_NAME ||


### PR DESCRIPTION
Adds 9 units to the translation pipeline:
- CSD 2023 (8 units)
- AI-Ethics-2023 (note: I added this to the HOC group)

See [this Slack thread](https://codedotorg.slack.com/archives/CFTFD6BPV/p1694553661581409) and the resulting [Jira ticket](https://codedotorg.atlassian.net/browse/TEACH-666) for more details.

Also, note [Bethany's PR](https://github.com/code-dot-org/code-dot-org/pull/53676) for similar work.

**Question for reviewer:**  As I was following Bethany's work, it looked like she added a test for the csc_script.  However it looks like this is not necessary for this PR because the CSD tests would already be covered in [test_getting_subdirectory_of_not_csf_script](https://github.com/code-dot-org/code-dot-org/blob/811a13523835b00b0b692932d4a67b41554d22b2/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_in.rb#L152).  And the AI-Ethics-2023 script is already part of HOC.  I am newer to reading/writing ruby tests so let me know if I am off here.