### PR TITLE
Fix I18n::Utils::MalformedI18nReporter

### DIFF
--- a/bin/i18n/utils/malformed_i18n_reporter.rb
+++ b/bin/i18n/utils/malformed_i18n_reporter.rb
@@ -69,7 +69,7 @@ module I18n
       end
 
       def collect_malformed_translations(key, file_name, translation)
-        return if translation.empty?
+        return if translation.nil? || translation.empty?
 
         case translation
         when Hash

--- a/bin/test/i18n/utils/test_malformed_i18n_reporter.rb
+++ b/bin/test/i18n/utils/test_malformed_i18n_reporter.rb
@@ -63,6 +63,21 @@ describe I18n::Utils::MalformedI18nReporter do
         assert_empty malformed_i18n_reporter.worksheet_data
       end
     end
+
+    context 'when a translation is nil' do
+      let(:i18n_file_data) do
+        {
+          invalid_i18n_hash: {
+            null: nil,
+          },
+        }
+      end
+
+      it 'does nothing' do
+        malformed_i18n_reporter.process_file(i18n_file_path)
+        assert_empty malformed_i18n_reporter.worksheet_data
+      end
+    end
   end
 
   describe '#report' do


### PR DESCRIPTION
# Issue
1. Sync out failed from the error: NoMethodError: undefined method 'empty?' for nil:NilClass
2. bundler: failed to load command: ./bin/i18n/sync-all.rb (./bin/i18n/sync-all.rb)
3. `/home/ubuntu/code-dot-org/bin/i18n/utils/malformed_i18n_reporter.rb:72`:in collect_malformed_translations: NoMethodError: undefined method empty?' for nil:NilClass (Parallel::UndumpableException)