### PR TITLE
Pegasus - Set set_dir: true sitewide for RTL languages

### DIFF
--- a/pegasus/sites.v3/code.org/themes/responsive.haml
+++ b/pegasus/sites.v3/code.org/themes/responsive.haml
@@ -1,6 +1,6 @@
 !!! 5
 
-- if @header['set_dir']
+- if ! @header['set_dir']
   - dir = language_dir_class
 
 %html{dir: dir}

--- a/pegasus/sites.v3/code.org/themes/responsive_full_width.haml
+++ b/pegasus/sites.v3/code.org/themes/responsive_full_width.haml
@@ -1,6 +1,6 @@
 !!! 5
 
-- if @header['set_dir']
+- if ! @header['set_dir']
   - dir = language_dir_class
 
 %html{dir: dir}


### PR DESCRIPTION
Allow for all pages on Pegasus to display correctly for RTL languages (see example: https://code.org/csd)

**Jira ticket:** [ACQ-792](https://codedotorg.atlassian.net/browse/ACQ-792)

----

### Before
<img width="968" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/b1e81a21-00d2-4ef0-84bc-b3831b8bcc06">

### After
<img width="969" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/6121dc61-c660-46de-999a-a1ed48b1d8a5">
