### PR TITLE
Update some Hardcoded Level File Paths

### DIFF
--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -280,7 +280,7 @@ class LevelTest < ActiveSupport::TestCase
   end
 
   test 'update custom level from file' do
-    LevelLoader.import_levels 'config/scripts/levels/K-1 Bee 2.level'
+    LevelLoader.import_levels 'config/levels/custom/maze/K-1 Bee 2.level'
     level = Level.find_by_name('K-1 Bee 2')
     assert_equal 'bee', level.skin
     assert_equal '[[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,1,0,-1,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0]]',
@@ -290,7 +290,7 @@ class LevelTest < ActiveSupport::TestCase
   test 'creating custom level from file sets level_concept_difficulty' do
     Level.find_by_name('K-1 Bee 2')&.destroy
     assert_nil Level.find_by_name('K-1 Bee 2')
-    LevelLoader.import_levels 'config/scripts/levels/K-1 Bee 2.level'
+    LevelLoader.import_levels 'config/levels/custom/maze/K-1 Bee 2.level'
     level = Level.find_by_name('K-1 Bee 2')
     refute_nil level
 


### PR DESCRIPTION
As part of our ongoing work to reorganize the level files into smaller subdirectories. The specific existing level files referred to by these tests got reorganized on levelbuilder last night, and the DTT started failing this morning because the files are no longer located at those paths.

In the long term, we should probably update this test to not be using actual site data like it is, but in the short term simply updating the hardcoded paths to point to the new location should work to get everything passing again.

I also grepped our test directory for other instances of `config/scripts`, and confirmed that all instances are testing content that still belongs in that directory.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

See thread at https://codedotorg.slack.com/archives/C03CM903Y/p1694795389182249

## Testing story

Tested locally with `RAILS_ENV=test RACK_ENV=test TZ=UTC bundle exec ruby -Itest test/models/level_test.rb -n test_update_custom_level_from_file` and `RAILS_ENV=test RACK_ENV=test TZ=UTC bundle exec ruby -Itest test/models/level_test.rb -n test_creating_custom_level_from_file_sets_level_concept_difficulty`