### PR TITLE
Integrate song loading with Lab2 Dance

### DIFF
--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -11,7 +11,7 @@ import i18n from '@cdo/locale';
 import AgeDialog from '../templates/AgeDialog';
 import {getFilteredSongKeys, getFilterStatus} from '@cdo/apps/dance/songs';
 
-const SongSelector = Radium(
+export const SongSelector = Radium(
   class extends React.Component {
     static propTypes = {
       enableSongSelection: PropTypes.bool,

--- a/apps/src/dance/danceRedux.ts
+++ b/apps/src/dance/danceRedux.ts
@@ -14,12 +14,15 @@ export interface DanceState {
   selectedSong: string;
   songData: SongData;
   runIsStarting: boolean;
+  // Fields below are used only by Lab2 Dance
+  isRunning: boolean;
 }
 
 const initialState: DanceState = {
   selectedSong: 'macklemore90',
   songData: {},
   runIsStarting: false,
+  isRunning: false,
 };
 
 // THUNKS
@@ -36,7 +39,7 @@ export const initSongs = createAsyncThunk(
         isProjectLevel: boolean;
         freePlay: boolean;
       };
-      onAuthError: () => void;
+      onAuthError: (songId: string) => void;
       onSongSelected?: (songId: string) => void;
     },
     {dispatch}
@@ -60,7 +63,7 @@ export const initSongs = createAsyncThunk(
     loadSong(selectedSong, songData, (status: number) => {
       if (status === 403) {
         // Something is wrong, because we just fetched cloudfront credentials.
-        onAuthError();
+        onAuthError(selectedSong);
       }
     });
 
@@ -76,7 +79,7 @@ export const setSong = createAsyncThunk(
   async (
     payload: {
       songId: string;
-      onAuthError: () => void;
+      onAuthError: (songId: string) => void;
       onSongSelected?: (songId: string) => void;
     },
     {dispatch, getState}
@@ -99,7 +102,7 @@ export const setSong = createAsyncThunk(
         loadSong(songId, songData, (status: number) => {
           if (status === 403) {
             // Something is wrong, because we just re-fetched cloudfront credentials.
-            onAuthError();
+            onAuthError(songId);
           }
         });
       }

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {TypedUseSelectorHook, useSelector} from 'react-redux';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
@@ -6,6 +6,13 @@ import AgeDialog from '@cdo/apps/templates/AgeDialog';
 import {CurrentUserState} from '@cdo/apps/templates/CurrentUserState';
 import {getFilterStatus} from '../../songs';
 import moduleStyles from './dance-view.module.scss';
+import {SongSelector} from '../../DanceVisualizationColumn';
+import {DanceState, initSongs, reducers, setSong} from '../../danceRedux';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import Lab2MetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
+import {LabState} from '@cdo/apps/lab2/lab2Redux';
+import {DanceLevelProperties, DanceProjectSources} from '../../types';
+import {registerReducers} from '@cdo/apps/redux';
 const commonI18n = require('@cdo/locale');
 
 const DANCE_VISUALIZATION_ID = 'dance-visualization';
@@ -13,19 +20,84 @@ const BLOCKLY_DIV_ID = 'dance-blockly-div';
 
 const useTypedSelector: TypedUseSelectorHook<{
   currentUser: CurrentUserState;
+  dance: DanceState;
+  lab: LabState & {
+    levelProperties?: DanceLevelProperties;
+    initialSources?: DanceProjectSources;
+  };
 }> = useSelector;
+
+registerReducers(reducers);
 
 /**
  * Renders the Lab2 version of Dance Lab. This separate container
  * allows us to support both Lab2 and legacy Dance.
  */
 const DanceView: React.FunctionComponent = () => {
+  const dispatch = useAppDispatch();
+
+  const useRestrictedSongs = useTypedSelector(
+    state => state.lab.levelProperties?.useRestrictedSongs || false
+  );
+  const defaultSong = useTypedSelector(
+    state => state.lab.levelProperties?.defaultSong
+  );
+  const projectSelectedSong = useTypedSelector(
+    state => state.lab.initialSources?.selectedSong
+  );
+  const isProjectLevel = useTypedSelector(
+    state => state.lab.levelProperties?.isProjectLevel || false
+  );
+  const freePlay = useTypedSelector(
+    state => state.lab.levelProperties?.freePlay || false
+  );
+  const isRunning = useTypedSelector(state => state.dance.isRunning);
+
+  const onAuthError = (songId: string) => {
+    Lab2MetricsReporter.logWarning({
+      message: 'Error loading song',
+      songId,
+    });
+  };
+
+  // Initialize song manifest and load initial song when level loads.
+  useEffect(() => {
+    dispatch(
+      initSongs({
+        useRestrictedSongs,
+        selectSongOptions: {
+          defaultSong,
+          selectedSong: projectSelectedSong,
+          isProjectLevel,
+          freePlay,
+        },
+        onAuthError,
+      })
+    );
+  }, [
+    isProjectLevel,
+    freePlay,
+    defaultSong,
+    projectSelectedSong,
+    useRestrictedSongs,
+    dispatch,
+  ]);
+
   const userType = useTypedSelector(state => state.currentUser.userType);
   const under13 = useTypedSelector(state => state.currentUser.under13);
   const [filterOn, setFilterOn] = useState<boolean>(
     getFilterStatus(userType, under13)
   );
   const turnOffFilter = useCallback(() => setFilterOn(false), []);
+
+  const selectedSong = useTypedSelector(state => state.dance.selectedSong);
+  const songData = useTypedSelector(state => state.dance.songData);
+  const onSetSong = useCallback(
+    (songId: string) => {
+      dispatch(setSong({songId, onAuthError}));
+    },
+    [dispatch]
+  );
 
   // TODO: Don't show AgeDialog if in share mode. Share view is currently
   // not supported for Lab2.
@@ -34,6 +106,13 @@ const DanceView: React.FunctionComponent = () => {
       <AgeDialog turnOffFilter={turnOffFilter} />
       <div className={moduleStyles.visualizationArea}>
         <div className={moduleStyles.visualizationColumn}>
+          <SongSelector
+            enableSongSelection={!isRunning}
+            setSong={onSetSong}
+            selectedSong={selectedSong}
+            songData={songData}
+            filterOn={filterOn}
+          />
           <div
             id={DANCE_VISUALIZATION_ID}
             className={moduleStyles.visualization}

--- a/apps/src/dance/types.ts
+++ b/apps/src/dance/types.ts
@@ -1,3 +1,5 @@
+import {LevelProperties, ProjectSources} from '../lab2/types';
+
 export type SongData = {
   [key: string]: {
     title: string;
@@ -5,3 +7,12 @@ export type SongData = {
     pg13: boolean;
   };
 };
+
+export interface DanceProjectSources extends ProjectSources {
+  selectedSong?: string;
+}
+
+export interface DanceLevelProperties extends LevelProperties {
+  defaultSong?: string;
+  useRestrictedSongs?: boolean;
+}

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -96,6 +96,7 @@ export interface LevelProperties {
   levelData?: LevelData;
   appName: AppName;
   longInstructions?: string;
+  freePlay?: boolean;
 }
 
 // Level configuration data used by project-backed labs that don't require


### PR DESCRIPTION
Integrate song loading with Lab2 Dance, using the load/select thunks that were previously extracted from Dance.js. This doesn't hook up anything to the playback system, but does successfully load the song manifest and song MP3s on Lab2 dance levels. The song to load is determined by the level or the project sources if on a standalone project level. 

Note that if you want to test this behavior locally, you'll need to override the 'useRestrictedSongs' field to true, and need to configure your locals.yml with the AWS credentials to fetch content from the restricted bucket.

Song loading on a level in a progression, where the initial song is derived from the level's "defaultSong" property

https://github.com/code-dot-org/code-dot-org/assets/85528507/6471b2e7-d4d6-4b87-af2b-425ed7feea2e

Song loading on a "standalone" level (manually adjusted this level's properties to mimic a standalone level), where the initial song is derived from the "selectedSong" property in the main.json file

https://github.com/code-dot-org/code-dot-org/assets/85528507/80d51798-aab3-4b4a-a851-d5ba6a4c4ea6

## Links

https://codedotorg.atlassian.net/browse/LABS-165

## Testing story

Tested locally on Lab2 and non-Lab2 levels. No user-facing changes on non-Lab2 levels.