### PR TITLE
Add use_restricted_songs to Dance Lab2 level properties

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -688,9 +688,7 @@ module LevelsHelper
       callback: @callback,
       sublevelCallback: @sublevel_callback,
     }
-    dev_with_credentials = rack_env?(:development) && !!CDO.cloudfront_key_pair_id
-    use_restricted_songs = CDO.cdn_enabled || dev_with_credentials || (rack_env?(:test) && ENV['CI'])
-    app_options[:useRestrictedSongs] = use_restricted_songs if @game == Game.dance
+    app_options[:useRestrictedSongs] = @game.use_restricted_songs?
     app_options[:isStartMode] = @is_start_mode || false
 
     if params[:blocks]

--- a/dashboard/app/models/game.rb
+++ b/dashboard/app/models/game.rb
@@ -263,6 +263,12 @@ class Game < ApplicationRecord
     [APPLAB, GAMELAB, WEBLAB, PIXELATION, SPRITELAB, JAVALAB, POETRY, MUSIC].include? app
   end
 
+  def use_restricted_songs?
+    return false unless [DANCE, MUSIC].include? app
+    dev_with_credentials = rack_env?(:development) && !!CDO.cloudfront_key_pair_id
+    CDO.cdn_enabled || dev_with_credentials || (rack_env?(:test) && ENV['CI'])
+  end
+
   # Format: name:app:intro_video
   # Don't change the order of existing entries! Always append to the end of the list.
   # The list contains no longer used level types in order to maintain the order

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -791,6 +791,7 @@ class Level < ApplicationRecord
     properties_camelized[:levelData] = video if video
     properties_camelized[:type] = type
     properties_camelized[:appName] = game&.app
+    properties_camelized[:useRestrictedSongs] = game.use_restricted_songs?
     properties_camelized
   end
 

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -83,7 +83,7 @@ class LevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze"}, body)
+    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false}, body)
   end
 
   test "should get filtered levels with just page param" do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -104,7 +104,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze"}, body)
+    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false}, body)
   end
 
   test 'should show script level for csp1-2020 lockable lesson with lesson plan' do

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -13,6 +13,7 @@ class LevelsHelperTest < ActionView::TestCase
 
   setup do
     @level = create(:maze)
+    @game = Game.custom_maze
 
     def request
       OpenStruct.new(


### PR DESCRIPTION
Add the `use_restricted_songs` flag to the Lab2 level properties for Dance. We were previously computing this value in `levels_helper` to add to the level's `appOptions`. This change moves that computation into `game.rb` so it can be shared and used for Lab2 as well. I was also thinking that it may be useful for Music Lab as well (we also load content from the restricted bucket in Music Lab).

## Links

https://codedotorg.atlassian.net/browse/LABS-169

## Testing story

Tested locally on Dance, Music, and other level types. Confirmed that the correct value for `useRestrictedSongs` was passed down on both legacy and Lab2 labs.