### PR TITLE
Add enrollment link to attendance error page

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/IntroPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/IntroPanel.jsx
@@ -187,6 +187,7 @@ export default class IntroPanel extends React.Component {
         break;
       }
       case 'In Progress': {
+        const signupUrl = `${location.origin}/pd/workshops/${workshopId}/enroll`;
         if (isAccountRequiredForAttendance) {
           contents = (
             <div>
@@ -210,13 +211,17 @@ export default class IntroPanel extends React.Component {
               <h4>Step 2: Take attendance</h4>
               <p>
                 After teachers have signed into their Code Studio accounts, use
-                the attendance links below to take attendance.
+                the attendance links below to take attendance. Note: Teachers
+                need to have enrolled in the workshop in order to take
+                attendance. They can enroll in the workshop using{' '}
+                <a href={signupUrl} target="_blank" rel="noopener noreferrer">
+                  {signupUrl}
+                </a>
               </p>
             </div>
           );
         } else {
           // account not required
-          const signupUrl = `${location.origin}/pd/workshops/${workshopId}/enroll`;
           contents = (
             <div>
               <p>

--- a/apps/src/code-studio/pd/workshop_dashboard/IntroPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/IntroPanel.jsx
@@ -197,9 +197,9 @@ export default class IntroPanel extends React.Component {
               </p>
               <h4>Step 1: Sign into Code Studio</h4>
               <p>
-                Tell teachers to sign into their Code Studio accounts. If they
-                do not already have an account tell them to create one by going
-                to{' '}
+                Tell workshop attendees to sign into their Code Studio accounts.
+                If they do not already have an account tell them to create one
+                by going to{' '}
                 <a
                   href={location.origin}
                   target="_blank"
@@ -210,10 +210,11 @@ export default class IntroPanel extends React.Component {
               </p>
               <h4>Step 2: Take attendance</h4>
               <p>
-                After teachers have signed into their Code Studio accounts, use
-                the attendance links below to take attendance. Note: Teachers
-                need to have enrolled in the workshop in order to take
-                attendance. They can enroll in the workshop using{' '}
+                After workshop attendees have signed into their Code Studio
+                accounts, use the attendance links below to take attendance.
+                Note: Workshop attendees need to have enrolled in the workshop
+                in order to take attendance. They can enroll in the workshop
+                using{' '}
                 <a href={signupUrl} target="_blank" rel="noopener noreferrer">
                   {signupUrl}
                 </a>
@@ -243,7 +244,7 @@ export default class IntroPanel extends React.Component {
           <div>
             <p>We hope you had a great workshop!</p>
             <p>
-              Teachers will receive an email with survey link from{' '}
+              Workshop attendees will receive an email with survey link from{' '}
               <a href="mailto:survey@code.org">survey@code.org</a>. If they do
               not receive the link ask them to check their spam. Many school
               districts block outside emails. You can also recommend they set

--- a/dashboard/app/views/pd/session_attendance/no_enrollment_match.haml
+++ b/dashboard/app/views/pd/session_attendance/no_enrollment_match.haml
@@ -1,2 +1,7 @@
 %h2 Workshop Attendance Error
-%p We don't recognize your email address in our roster. Please log in with the account associated with your workshop application and enrollment.
+%p
+  We don't recognize your email address in our roster. In order to mark attendance you must be signed into an account
+  that is associated with your workshop enrollment. If you have not enrolled in the workshop yet
+  = " "
+  %a{href: CDO.studio_url("/pd/workshops/#{@session.workshop.id}/enroll"), target: "_blank"}> click here to enroll
+  = "."


### PR DESCRIPTION
## Add Enrollment Link to Error Page
When we removed the way to mark attendance signed out, we also removed the way people got to enrollment for the workshop after the workshop was already started. This PR adds the enrollment link to the attendance error page to help clarify:

### Previously
![previously](https://github.com/code-dot-org/code-dot-org/assets/56283563/b1c5bf97-64ad-484c-acc1-720b42e88f6c)

### Now
![workshop_attendance_error](https://github.com/code-dot-org/code-dot-org/assets/56283563/74a8420e-8921-4159-85ba-9aea39da9aa6)

## Update Workshop Dashboard Text
In addition, this PR updates the text that shows in the workshop dashboard when a workshop has been started:

### Previously
![Workshop admin text update OLD](https://github.com/code-dot-org/code-dot-org/assets/56283563/7a0a5bde-10d3-49f6-8da3-227a5a9b28f6)

### Now
![updated_text](https://github.com/code-dot-org/code-dot-org/assets/56283563/ef7616fe-a24f-4e5e-8c6a-48ef137d5e4b)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/ACQ-963)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
