### PR TITLE
Send amplitude event when user is 21+

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -82,6 +82,8 @@ const EVENTS = {
   RUBRIC_CLOSED_FROM_FAB_EVENT: 'Rubric Closed From FAB',
   RUBRIC_LEARNING_GOAL_EXPANDED_EVENT: 'Rubric Learning Goal Expanded',
   RUBRIC_LEARNING_GOAL_COLLAPSED_EVENT: 'Rubric Learning Goal Collapsed',
+
+  AGE_21_SELECTED_EVENT: 'Age 21+ Selected',
 };
 
 export {EVENTS};

--- a/apps/src/templates/AgeDialog.jsx
+++ b/apps/src/templates/AgeDialog.jsx
@@ -5,6 +5,8 @@ import color from '@cdo/apps/util/color';
 import Button from '@cdo/apps/templates/Button';
 import AgeDropdown from '@cdo/apps/templates/AgeDropdown';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import i18n from '@cdo/locale';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
@@ -34,6 +36,7 @@ class AgeDialog extends Component {
     signedIn: PropTypes.bool.isRequired,
     turnOffFilter: PropTypes.func.isRequired,
     storage: PropTypes.object.isRequired,
+    unitName: PropTypes.string,
   };
 
   static defaultProps = {
@@ -62,11 +65,19 @@ class AgeDialog extends Component {
     }
 
     // Sets cookie to true when anon user is 13+. False otherwise.
-    const over13 = parseInt(value, 10) >= 13;
+    const age = parseInt(value, 10);
+    const over13 = age >= 13;
     this.setSessionStorage(over13);
 
     if (over13) {
       this.props.turnOffFilter();
+    }
+
+    // Send Amplitude event when anon user is 21+.
+    if (age >= 21) {
+      analyticsReporter.sendEvent(EVENTS.AGE_21_SELECTED_EVENT, {
+        unit_name: this.props.unitName,
+      });
     }
   };
 
@@ -153,4 +164,5 @@ export const UnconnectedAgeDialog = AgeDialog;
 
 export default connect(state => ({
   signedIn: state.currentUser.signInState === SignInState.SignedIn,
+  unitName: state.progress.scriptName,
 }))(AgeDialog);

--- a/apps/test/unit/templates/AgeDialogTest.js
+++ b/apps/test/unit/templates/AgeDialogTest.js
@@ -10,6 +10,7 @@ describe('AgeDialog', () => {
     signedIn: false,
     turnOffFilter: () => {},
     storage: new FakeStorage(),
+    unitName: 'csd-2023',
   };
 
   it('renders null if user is signed in', () => {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Send an amplitude event with the unit name, when a user submits the `AgeDialog` with an age of 21+.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [ACQ-913](https://codedotorg.atlassian.net/browse/ACQ-913)
