### PR TITLE
LTI Access Token module

### DIFF
--- a/dashboard/app/controllers/oauth_jwks_controller.rb
+++ b/dashboard/app/controllers/oauth_jwks_controller.rb
@@ -1,21 +1,10 @@
 require 'jwt'
 require 'json'
 
-include LtiAccessToken
-
 class OauthJwksController < ApplicationController
   # GET /oauth/jwks
   def jwks
     jwks_data = CDO.jwks_data
     render json: jwks_data
-  end
-
-  # TEMP: Remove before merging.
-  # Use this endpoint to invoke the get_access_token. You can configure your
-  # local LTI Integration client_id
-  def access_token
-    access_token = get_access_token("10000000000003", "https://canvas.instructure.com")
-    p access_token
-    render json: access_token
   end
 end

--- a/dashboard/app/controllers/oauth_jwks_controller.rb
+++ b/dashboard/app/controllers/oauth_jwks_controller.rb
@@ -1,10 +1,21 @@
 require 'jwt'
 require 'json'
 
+include LtiAccessToken
+
 class OauthJwksController < ApplicationController
   # GET /oauth/jwks
   def jwks
     jwks_data = CDO.jwks_data
     render json: jwks_data
+  end
+
+  # TEMP: Remove before merging.
+  # Use this endpoint to invoke the get_access_token. You can configure your
+  # local LTI Integration client_id
+  def access_token
+    access_token = get_access_token("10000000000003", "https://canvas.instructure.com")
+    p access_token
+    render json: access_token
   end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -603,10 +603,12 @@ Dashboard::Application.routes.draw do
 
     # LTI API endpoints
     match '/lti/v1/login(/:platform_id)', to: 'lti_v1#login', via: [:get, :post]
+    # TEMP: Remvoe before merging
     post '/lti/v1/authenticate', to: 'lti_v1#authenticate'
 
     # OAuth endpoints
     get '/oauth/jwks', to: 'oauth_jwks#jwks'
+    get '/oauth/access_token', to: 'oauth_jwks#access_token'
 
     get '/notes/:key', to: 'notes#index'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -603,12 +603,10 @@ Dashboard::Application.routes.draw do
 
     # LTI API endpoints
     match '/lti/v1/login(/:platform_id)', to: 'lti_v1#login', via: [:get, :post]
-    # TEMP: Remvoe before merging
     post '/lti/v1/authenticate', to: 'lti_v1#authenticate'
 
     # OAuth endpoints
     get '/oauth/jwks', to: 'oauth_jwks#jwks'
-    get '/oauth/access_token', to: 'oauth_jwks#access_token'
 
     get '/notes/:key', to: 'notes#index'
 

--- a/dashboard/lib/lti_access_token.rb
+++ b/dashboard/lib/lti_access_token.rb
@@ -50,6 +50,7 @@ module LtiAccessToken
   # See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
   # for definitions of the claims.
   def sign_jwt(payload, private_key_json = CDO.jwk_private_key_data)
+    raise ArgumentError.new('Private key required to sign JWT') unless private_key_json
     private_key_hash = private_key_json.transform_keys(&:to_sym)
     private_key = private_key_hash[:private_key]
     kid = private_key_hash[:kid]

--- a/dashboard/lib/lti_access_token.rb
+++ b/dashboard/lib/lti_access_token.rb
@@ -17,7 +17,7 @@ module LtiAccessToken
 
     # assemble JWT payload
     jwt_payload = {
-      iss: CDO.studio_url('', CDO.default_scheme),
+      iss: Policies::Lti::JWT_ISSUER,
       sub: client_id,
       aud: access_token_url,
       iat: Time.now.to_i,

--- a/dashboard/lib/lti_access_token.rb
+++ b/dashboard/lib/lti_access_token.rb
@@ -1,0 +1,56 @@
+require 'json'
+module LtiAccessToken
+  # Retrieve a JWT from the access_token_url of the LTI Integration
+  # The JWT can be used to access the LTI Advantage Services for the LTI Integration
+  # client_id and issuer are present in the id_token we cache or store as a cookie from the LTI launch
+  def get_access_token(client_id, issuer, scopes = Policies::Lti::ALL_SCOPES)
+    cache_key = "#{Policies::Lti::NAMESPACE}/#{client_id}-#{issuer}"
+
+    # check for valid access token
+    access_token = CDO.shared_cache.read(cache_key)
+    return access_token if access_token
+
+    # get access_token_url for this LTI Integration
+    integration = LtiIntegration.find_by(client_id: client_id, issuer: issuer)
+    raise "No LTI Integration found for client_id: #{client_id} and issuer: #{issuer}" unless integration
+    access_token_url = integration[:access_token_url]
+
+    # assemble JWT payload
+    jwt_payload = {
+      iss: CDO.studio_url('', CDO.default_scheme),
+      sub: client_id,
+      aud: access_token_url,
+      iat: Time.now.to_i,
+      # this can be short, since the JWT will be validated as part of the access_token request handshake.
+      exp: (5).minutes.from_now.to_i,
+      jti: SecureRandom.alphanumeric(10),
+    }
+
+    private_key_json = CDO.jwk_private_key_data
+    private_key_hash = private_key_json.transform_keys(&:to_sym)
+    private_key = private_key_hash[:private_key]
+    kid = private_key_hash[:kid]
+
+    # sign JWT
+    pri = OpenSSL::PKey::RSA.new(private_key)
+    jwt = JWT.encode(jwt_payload, pri, 'RS256', kid: kid)
+
+    query = {
+      grant_type: 'client_credentials',
+      client_assertion_type: Policies::Lti::JWT_CLIENT_ASSERTION_TYPE,
+      client_assertion: jwt,
+      scope: scopes.join(' '),
+    }
+
+    res = HTTParty.post(access_token_url, query: query, headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
+    # get access_token and exp from response
+    token_response = JSON.parse(res.body).transform_keys(&:to_sym)
+    access_token = token_response[:access_token]
+    exp = token_response[:expires_in]
+
+    # cache access_token, set expiration
+    CDO.shared_cache.write(cache_key, access_token, expires_in: exp)
+
+    return access_token
+  end
+end

--- a/dashboard/lib/lti_access_token.rb
+++ b/dashboard/lib/lti_access_token.rb
@@ -41,7 +41,7 @@ module LtiAccessToken
     exp = token_response[:expires_in]
 
     # cache access_token, set expiration
-    CDO.shared_cache.write(cache_key, access_token, expires_in: exp)
+    CDO.shared_cache.write(cache_key, access_token, expires_in: exp.to_i)
 
     return access_token
   end

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -1,0 +1,13 @@
+class Policies::Lti
+  module AccessTokenScopes
+    LINE_ITEM = 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem'.freeze
+    CONTEXT_MEMBERSHIP = 'https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly'.freeze
+  end
+
+  ALL_SCOPES = AccessTokenScopes.constants.map do |scope|
+    AccessTokenScopes.const_get(scope)
+  end
+
+  NAMESPACE = 'lti_v1_controller'.freeze
+  JWT_CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'.freeze
+end

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -10,4 +10,5 @@ class Policies::Lti
 
   NAMESPACE = 'lti_v1_controller'.freeze
   JWT_CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'.freeze
+  JWT_ISSUER = CDO.studio_url('', CDO.default_scheme).freeze
 end

--- a/dashboard/test/lib/lti_access_token_test.rb
+++ b/dashboard/test/lib/lti_access_token_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+require 'date'
+
+class LtiAccessTokenTest < ActiveSupport::TestCase
+  include LtiAccessToken
+
+  setup_all do
+    @lti_integration = create :lti_integration
+    fake_response_hash = {
+      access_token: 'fake_access_token',
+      exp: 1.hour.from_now.to_i,
+    }
+    @fake_access_token_response = OpenStruct.new({body: JSON.generate(fake_response_hash)})
+  end
+
+  test 'get_access_token calls the access_token_url from the LTI integration' do
+    HTTParty.stubs(:post).with(@lti_integration.access_token_url, anything, anything).returns(@fake_access_token_response)
+    jwt = get_access_token(@lti_integration.client_id, @lti_integration.issuer, ['test_scope', 'test_scope2'])
+    assert_equal 'fake_access_token', jwt
+  end
+
+  test 'get_access_token uses cached tokens if present' do
+    CDO.shared_cache.stubs(:read).with("#{Policies::Lti::NAMESPACE}/#{@lti_integration.client_id}-#{@lti_integration.issuer}").returns('cached_access_token')
+    jwt = get_access_token(@lti_integration.client_id, @lti_integration.issuer, ['test_scope', 'test_scope2'])
+    assert_equal 'cached_access_token', jwt
+  end
+end

--- a/dashboard/test/lib/lti_access_token_test.rb
+++ b/dashboard/test/lib/lti_access_token_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'date'
+require 'jwt'
 
 class LtiAccessTokenTest < ActiveSupport::TestCase
   include LtiAccessToken
@@ -11,6 +12,12 @@ class LtiAccessTokenTest < ActiveSupport::TestCase
       exp: 1.hour.from_now.to_i,
     }
     @fake_access_token_response = OpenStruct.new({body: JSON.generate(fake_response_hash)})
+    jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048), {use: 'sig', alg: 'RS256', kid: 'test-kid'})
+    @fake_private_key_obj = {
+      kid: jwk[:kid],
+      private_key: jwk.signing_key.to_s,
+    }
+    CDO.stubs(:jwk_private_key_data).returns(@fake_private_key_obj)
   end
 
   test 'get_access_token calls the access_token_url from the LTI integration' do

--- a/dashboard/test/lib/lti_access_token_test.rb
+++ b/dashboard/test/lib/lti_access_token_test.rb
@@ -9,7 +9,7 @@ class LtiAccessTokenTest < ActiveSupport::TestCase
     @lti_integration = create :lti_integration
     fake_response_hash = {
       access_token: 'fake_access_token',
-      exp: 1.hour.from_now.to_i,
+      expires_in: 3600,
     }
     @fake_access_token_response = OpenStruct.new({body: JSON.generate(fake_response_hash)})
     jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048), {use: 'sig', alg: 'RS256', kid: 'test-kid'})
@@ -17,10 +17,16 @@ class LtiAccessTokenTest < ActiveSupport::TestCase
       kid: jwk[:kid],
       private_key: jwk.signing_key.to_s,
     }
+    @cache_key = "#{Policies::Lti::NAMESPACE}/#{@lti_integration[:client_id]}-#{@lti_integration[:issuer]}"
   end
 
   setup do
     CDO.stubs(:jwk_private_key_data).returns(@fake_private_key_obj)
+  end
+
+  teardown do
+    Timecop.return
+    CDO.shared_cache.delete(@cache_key)
   end
 
   test 'get_access_token calls the access_token_url from the LTI integration' do
@@ -33,6 +39,21 @@ class LtiAccessTokenTest < ActiveSupport::TestCase
     CDO.shared_cache.stubs(:read).with("#{Policies::Lti::NAMESPACE}/#{@lti_integration.client_id}-#{@lti_integration.issuer}").returns('cached_access_token')
     jwt = get_access_token(@lti_integration.client_id, @lti_integration.issuer, ['test_scope', 'test_scope2'])
     assert_equal 'cached_access_token', jwt
+  end
+
+  test 'expired tokens are removed from the cache' do
+    CDO.shared_cache.write(@cache_key, 'cached_access_token', expires_in: 1.hour)
+    Timecop.travel(2.hours) # Cached JWT should be expired
+    fresh_token = {
+      access_token: 'fresh_access_token',
+      expires_in: 3600,
+    }
+    fresh_response = OpenStruct.new({body: JSON.generate(fresh_token)}) # New JWT to ensure we aren't getting a cached value
+    HTTParty.stubs(:post).with(@lti_integration.access_token_url, anything, anything).returns(fresh_response)
+    CDO.shared_cache.expects(:read).with(@cache_key).once
+
+    jwt = get_access_token(@lti_integration.client_id, @lti_integration.issuer, ['test_scope', 'test_scope2'])
+    assert_equal 'fresh_access_token', jwt
   end
 
   test 'Signs a valid JWT' do

--- a/dashboard/test/lib/lti_access_token_test.rb
+++ b/dashboard/test/lib/lti_access_token_test.rb
@@ -24,4 +24,20 @@ class LtiAccessTokenTest < ActiveSupport::TestCase
     jwt = get_access_token(@lti_integration.client_id, @lti_integration.issuer, ['test_scope', 'test_scope2'])
     assert_equal 'cached_access_token', jwt
   end
+
+  test 'Signs a valid JWT' do
+    test_claims = {
+      iss: 'https://foo-issuer.org',
+      sub: 'foo-client-id',
+      aud: 'foo-audience',
+      iat: Time.now.to_i,
+      exp: (5).minutes.from_now.to_i,
+      jti: 'foo-jwt-id',
+    }
+    jwt = sign_jwt(test_claims)
+    pk_string = CDO.jwk_private_key_data.transform_keys(&:to_sym)[:private_key]
+    pk = OpenSSL::PKey::RSA.new(pk_string)
+    decoded = JWT.decode(jwt, pk, true, {algorithm: 'RS256'})
+    assert_equal test_claims, decoded[0].transform_keys(&:to_sym)
+  end
 end

--- a/dashboard/test/lib/lti_access_token_test.rb
+++ b/dashboard/test/lib/lti_access_token_test.rb
@@ -17,6 +17,9 @@ class LtiAccessTokenTest < ActiveSupport::TestCase
       kid: jwk[:kid],
       private_key: jwk.signing_key.to_s,
     }
+  end
+
+  setup do
     CDO.stubs(:jwk_private_key_data).returns(@fake_private_key_obj)
   end
 


### PR DESCRIPTION
Adds a module for retrieving a JWT from an LTI platform. This is the JWT used for calling LTI Advantage APIs on behalf of the code.org LTI integration. This adds the module, but it isn't yet imported anywhere in the code. The first feature to take advantage of the module will be LMS roster syncing.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-314)

## Testing story

Added some unit tests - more testing can be put in place after this module is incorporated into the [rostering functionality](https://codedotorg.atlassian.net/browse/P20-405).

This can be tested locally against the Canvas sandbox as long as you have the LTI integration configured both in the sandbox and locally. Ping me for details on setting this up.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

This uses the CDO shared_cache to store JWTs. Cached tokens can be reused for any call to LTI APIs for a given integration.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
