### PR TITLE
Adding wait and refresh to these two ui tests

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/submittable_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/submittable_eyes.feature
@@ -11,6 +11,7 @@ Scenario: Submittable level
   And I click selector ".submitButton"
 
   Then I am on "http://studio.code.org/s/allthethings/lessons/9/levels/3?noautoplay=true"
+  Then I reload the page
   And I wait until element ".unsubmitButton" is visible
   And I see no difference for "submitted puzzle"
   And I close my eyes
@@ -25,7 +26,7 @@ Scenario: Lockable level
   Then I am on "http://studio.code.org/s/allthethings/lockable/1/levels/1/page/1"
   And I wait to see ".submitButton"
   And I see no difference for "locked level on level page"
-  Then I click selector ".header_popup_link"
+  Then I click selector ".header_popup_link" once I see it
   And I wait to see ".react_stage"
   And I scroll our lockable lesson into view
   Then I see no difference for "locked level popup progress"


### PR DESCRIPTION
It appears as though the causes for these two tests being flakey is as follows:

The lockable test doesn't see the header right away, so cannot click on the header popup. This pr adds a 'once I see it' in hopes of waiting long enough for the arrow to load. 

The submittable test seems to get stuck in a weird page state. Because we're navigating to the same page we were just on, I'm worried we aren't getting any refresh of the data. This test adds a reload that will hopefully present the user with the unsubmit button.

From saucelabs (lol): 
<img width="327" alt="Screenshot 2023-09-19 at 1 34 50 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/1292c37a-a6b9-4441-815e-720e6a2f78b8">



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-677

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
