### PR TITLE
Remove state_school_id unique constraint

### DIFF
--- a/dashboard/app/models/SCHOOL_DATA_README.md
+++ b/dashboard/app/models/SCHOOL_DATA_README.md
@@ -150,9 +150,6 @@ select count(*) from schools where latitude is null;
 1 row in set (1.02 sec)
 ```
 
-# State school ids need to be unique.
-Because of the duplication of schools, we only load the state ids from most recent public/charter dataset. The result is that not all public and charter schools in our DB have a state school id set.
-
 # School ids were initially imported as ints and later converted to strings, dropping leading zeros
 This only applies to public and charter schools, not private schools. 
 ```

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -26,7 +26,7 @@
 #  index_schools_on_last_known_school_year_open  (last_known_school_year_open)
 #  index_schools_on_name_and_city                (name,city)
 #  index_schools_on_school_district_id           (school_district_id)
-#  index_schools_on_state_school_id              (state_school_id) UNIQUE
+#  index_schools_on_state_school_id              (state_school_id)
 #  index_schools_on_zip                          (zip)
 #
 

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -157,13 +157,6 @@ class School < ApplicationRecord
   def self.seed_from_s3
     # NCES school data has been built up in the DB over time by pulling in different
     # data files. This seeding recreates the order in which they were incorporated.
-    # NOTE: we are intentionally not populating the state_school_id based on the
-    # 2014-2015 preliminary or 2013-2014 public/charter data sets. Those files
-    # contain duplicate entries where some schools appear to be listed more than
-    # once but with different NCES ids. Since state_school_id needs to be unique
-    # the seeding would fail if we tried to set the state ids from those files.
-    # The 2014-2015 public/charter data does not have this issue so we do load the
-    # state_school_ids from there.
     School.transaction do
       CDO.log.info "Seeding 2014-2015 PRELIMINARY public and charter school data."
       # Originally from https://nces.ed.gov/ccd/Data/zip/Sch14pre_txt.zip
@@ -500,7 +493,7 @@ class School < ApplicationRecord
             # NCES ID and state school ID are required to be unique,
             # so this error would occur if two rows with different NCES IDs
             # had the same state school ID.
-            CDO.log.info "Record with NCES ID #{csv_entry[:id]} and state school ID #{csv_entry[:state_school_id]} not unique, not added"
+            CDO.log.info "Record with NCES ID #{csv_entry[:id]} not unique, not added"
             duplicate_schools << csv_entry
           end
         elsif !db_entry.nil? && update_existing
@@ -523,7 +516,7 @@ class School < ApplicationRecord
             begin
               db_entry.update!(csv_entry)
             rescue ActiveRecord::RecordNotUnique
-              CDO.log.info "Record with NCES ID #{csv_entry[:id]} and state school ID #{csv_entry[:state_school_id]} not unique, not added"
+              CDO.log.info "Record with NCES ID #{csv_entry[:id]} not unique, not added"
               duplicate_schools << csv_entry
             end
           else

--- a/dashboard/db/migrate/20230920174014_remove_state_school_id_unique_constraint.rb
+++ b/dashboard/db/migrate/20230920174014_remove_state_school_id_unique_constraint.rb
@@ -1,0 +1,6 @@
+class RemoveStateSchoolIdUniqueConstraint < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :schools, column: :state_school_id, unique: true
+    add_index :schools, :state_school_id
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_31_145020) do
+ActiveRecord::Schema.define(version: 2023_09_20_174014) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1717,7 +1717,7 @@ ActiveRecord::Schema.define(version: 2023_08_31_145020) do
     t.index ["last_known_school_year_open"], name: "index_schools_on_last_known_school_year_open"
     t.index ["name", "city"], name: "index_schools_on_name_and_city", type: :fulltext
     t.index ["school_district_id"], name: "index_schools_on_school_district_id"
-    t.index ["state_school_id"], name: "index_schools_on_state_school_id", unique: true
+    t.index ["state_school_id"], name: "index_schools_on_state_school_id"
     t.index ["zip"], name: "index_schools_on_zip"
   end
 


### PR DESCRIPTION
## Overview
This PR removes uniqueness constraint on the `state_school_id` column in the `schools` data table.`

## Context
There are 100+ schools that are getting skipped when ingesting NCES stats data from the 2021-2022 school year. Vijaya did some digging and found that it was because the school data itself wasn’t ingested for these schools because there was an existing entry with the same State school ID, but different NCES school ID. According to the current schema constraints, the rule says every entry should have a unique NCES school ID and a unique state school ID. So, anytime the NCES school ID alone changes, that entry is ignored as duplicate.

[Vijaya discussed more with Baker](https://codedotorg.slack.com/archives/C04540KNGDQ/p1682359022125929) and found that it appears the state school ID is repurposed, so we have instances where a completely new school gets a new NCES ID but uses the same state school ID as that of a school that is potentially discontinued. There are also a few instances where minor details about the school changes, during which the state school ID changes, but not the NCES ID.

This PR removes the uniqueness constraint on the `state_school_id` column in the `schools` data table. This way, the NCES id will still be unique and a way to differentiate between what we define as a "school", while avoiding any issues when it comes to the different ways states id their schools.

## Demo
To start, I just tried seeding schools from the 2021-2022 data set. The output stated that 118 schools were skipped (the only reason a skip would occur is a duplicate NCES id or state id):
![118_skipped](https://github.com/code-dot-org/code-dot-org/assets/56283563/650e3cc9-0d88-49fb-9a15-50899e26264d)

After running the migration in this PR, the output stated 0 schools were skipped:
![0_skipped](https://github.com/code-dot-org/code-dot-org/assets/56283563/d2420f26-73df-436e-9eb4-552a5ad3e89c)

I then ran `rake seed:schools` for seedings schools from all the data sets we pull from, and saw the same output for each file of `0 schools were skipped`.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-561&assignee=60d62161f65054006980bd71)
Slack thread discussion: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1682359022125929)

## Testing story
Local testing.

## Follow-up work
1. 

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
