### PR TITLE
Add current path to 21+ amplitude event

### DIFF
--- a/apps/src/templates/AgeDialog.jsx
+++ b/apps/src/templates/AgeDialog.jsx
@@ -77,6 +77,7 @@ class AgeDialog extends Component {
     if (age >= 21) {
       analyticsReporter.sendEvent(EVENTS.AGE_21_SELECTED_EVENT, {
         unit_name: this.props.unitName,
+        current_path: document.location.pathname,
       });
     }
   };


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Add a `current_path` field with `document.location.pathname` to the "Age 21+ Selected" Amplitude event from #53847. We're missing `unit_name` in about half these events, and this might help tell us why.

![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/51d0e54d-6d65-4e6a-9ad3-c309a965b26d)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->
- jira ticket: [ACQ-913](https://codedotorg.atlassian.net/browse/ACQ-913)

