### PR TITLE
Move rubric content to new component RubricContent

### DIFF
--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -1,36 +1,14 @@
-import React, {useState} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import style from './rubrics.module.scss';
 import i18n from '@cdo/locale';
-import {
-  BodyThreeText,
-  Heading2,
-  Heading5,
-  Heading6,
-} from '@cdo/apps/componentLibrary/typography';
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import {
   reportingDataShape,
   rubricShape,
   studentLevelInfoShape,
 } from './rubricShapes';
-import LearningGoal from './LearningGoal';
-import Button from '../Button';
-import HttpClient from '@cdo/apps/util/HttpClient';
-
-const formatTimeSpent = timeSpent => {
-  const minutes = Math.floor(timeSpent / 60);
-  const seconds = timeSpent % 60;
-
-  return i18n.timeSpent({minutes, seconds});
-};
-
-const formatLastAttempt = lastAttempt => {
-  const date = new Date(lastAttempt);
-  return i18n.levelLastUpdated({
-    lastUpdatedDate: date.toLocaleDateString(),
-  });
-};
+import RubricContent from './RubricContent';
 
 export default function RubricContainer({
   rubric,
@@ -39,124 +17,18 @@ export default function RubricContainer({
   currentLevelName,
   reportingData,
 }) {
-  const onLevelForEvaluation = currentLevelName === rubric.level.name;
-  const canProvideFeedback = !!studentLevelInfo && onLevelForEvaluation;
-  const {lesson} = rubric;
-  const rubricLevel = rubric.level;
-
-  const [isSubmittingToStudent, setIsSubmittingToStudent] = useState(false);
-  const [errorSubmitting, setErrorSubmitting] = useState(false);
-  const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
-  const submitFeedbackToStudent = () => {
-    setIsSubmittingToStudent(true);
-    setErrorSubmitting(false);
-    const body = JSON.stringify({
-      student_id: studentLevelInfo.user_id,
-    });
-    const endPoint = `/rubrics/${rubric.id}/submit_evaluations`;
-    HttpClient.post(endPoint, body, true, {'Content-Type': 'application/json'})
-      .then(response => response.json())
-      .then(json => {
-        setIsSubmittingToStudent(false);
-        if (!json.submittedAt) {
-          throw new Error('Unexpected response object');
-        }
-        const lastSubmittedDateObj = new Date(json.submittedAt);
-        setLastSubmittedTimestamp(lastSubmittedDateObj.toLocaleString());
-      })
-      .catch(() => {
-        setIsSubmittingToStudent(false);
-        setErrorSubmitting(true);
-      });
-  };
-
   return (
     <div className={style.rubricContainer}>
       <div className={style.rubricHeader}>
         <Heading6>{i18n.rubrics()}</Heading6>
       </div>
-      <div className={style.rubricContent}>
-        {!!studentLevelInfo && (
-          <div className={style.studentInfo}>
-            <Heading2>{studentLevelInfo.name}</Heading2>
-            <div className={style.levelAndStudentDetails}>
-              <Heading5>
-                {i18n.lessonNumbered({
-                  lessonNumber: lesson.position,
-                  lessonName: lesson.name,
-                })}
-              </Heading5>
-              {onLevelForEvaluation && (
-                <div className={style.studentMetadata}>
-                  {studentLevelInfo.timeSpent && (
-                    <BodyThreeText className={style.singleMetadatum}>
-                      <FontAwesome icon="clock" />
-                      <span>{formatTimeSpent(studentLevelInfo.timeSpent)}</span>
-                    </BodyThreeText>
-                  )}
-                  <BodyThreeText className={style.singleMetadatum}>
-                    <FontAwesome icon="rocket" />
-                    {i18n.numAttempts({
-                      numAttempts: studentLevelInfo.attempts || 0,
-                    })}
-                  </BodyThreeText>
-                  {studentLevelInfo.lastAttempt && (
-                    <BodyThreeText className={style.singleMetadatum}>
-                      <FontAwesome icon="calendar" />
-                      <span>
-                        {formatLastAttempt(studentLevelInfo.lastAttempt)}
-                      </span>
-                    </BodyThreeText>
-                  )}
-                </div>
-              )}
-              {!onLevelForEvaluation && rubricLevel?.position && (
-                <BodyThreeText>
-                  {i18n.feedbackAvailableOnLevel({
-                    levelPosition: rubricLevel.position,
-                  })}
-                </BodyThreeText>
-              )}
-            </div>
-          </div>
-        )}
-        <div className={style.learningGoalContainer}>
-          {rubric.learningGoals.map(lg => (
-            <LearningGoal
-              key={lg.key}
-              learningGoal={lg}
-              teacherHasEnabledAi={teacherHasEnabledAi}
-              canProvideFeedback={canProvideFeedback}
-              reportingData={reportingData}
-            />
-          ))}
-        </div>
-        {canProvideFeedback && (
-          <div className={style.rubricContainerFooter}>
-            <div className={style.submitToStudentButtonAndError}>
-              <Button
-                text={i18n.submitToStudent()}
-                color={Button.ButtonColor.brandSecondaryDefault}
-                onClick={submitFeedbackToStudent}
-                className={style.submitToStudentButton}
-                disabled={isSubmittingToStudent}
-              />
-              {errorSubmitting && (
-                <BodyThreeText className={style.errorMessage}>
-                  {i18n.errorSubmittingFeedback()}
-                </BodyThreeText>
-              )}
-              {!errorSubmitting && !!lastSubmittedTimestamp && (
-                <BodyThreeText>
-                  {i18n.feedbackSubmittedAt({
-                    timestamp: lastSubmittedTimestamp,
-                  })}
-                </BodyThreeText>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
+      <RubricContent
+        rubric={rubric}
+        studentLevelInfo={studentLevelInfo}
+        teacherHasEnabledAi={teacherHasEnabledAi}
+        currentLevelName={currentLevelName}
+        reportingData={reportingData}
+      />
     </div>
   );
 }

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -1,0 +1,164 @@
+import React, {useState} from 'react';
+import PropTypes from 'prop-types';
+import style from './rubrics.module.scss';
+import i18n from '@cdo/locale';
+import {
+  BodyThreeText,
+  Heading2,
+  Heading5,
+} from '@cdo/apps/componentLibrary/typography';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import {
+  reportingDataShape,
+  rubricShape,
+  studentLevelInfoShape,
+} from './rubricShapes';
+import LearningGoal from './LearningGoal';
+import Button from '../Button';
+import HttpClient from '@cdo/apps/util/HttpClient';
+
+const formatTimeSpent = timeSpent => {
+  const minutes = Math.floor(timeSpent / 60);
+  const seconds = timeSpent % 60;
+
+  return i18n.timeSpent({minutes, seconds});
+};
+
+const formatLastAttempt = lastAttempt => {
+  const date = new Date(lastAttempt);
+  return i18n.levelLastUpdated({
+    lastUpdatedDate: date.toLocaleDateString(),
+  });
+};
+
+export default function RubricContent({
+  studentLevelInfo,
+  rubric,
+  teacherHasEnabledAi,
+  currentLevelName,
+  reportingData,
+}) {
+  const onLevelForEvaluation = currentLevelName === rubric.level.name;
+  const canProvideFeedback = !!studentLevelInfo && onLevelForEvaluation;
+  const {lesson} = rubric;
+  const rubricLevel = rubric.level;
+
+  const [isSubmittingToStudent, setIsSubmittingToStudent] = useState(false);
+  const [errorSubmitting, setErrorSubmitting] = useState(false);
+  const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
+  const submitFeedbackToStudent = () => {
+    setIsSubmittingToStudent(true);
+    setErrorSubmitting(false);
+    const body = JSON.stringify({
+      student_id: studentLevelInfo.user_id,
+    });
+    const endPoint = `/rubrics/${rubric.id}/submit_evaluations`;
+    HttpClient.post(endPoint, body, true, {'Content-Type': 'application/json'})
+      .then(response => response.json())
+      .then(json => {
+        setIsSubmittingToStudent(false);
+        if (!json.submittedAt) {
+          throw new Error('Unexpected response object');
+        }
+        const lastSubmittedDateObj = new Date(json.submittedAt);
+        setLastSubmittedTimestamp(lastSubmittedDateObj.toLocaleString());
+      })
+      .catch(() => {
+        setIsSubmittingToStudent(false);
+        setErrorSubmitting(true);
+      });
+  };
+
+  return (
+    <div className={style.rubricContent}>
+      {!!studentLevelInfo && (
+        <div className={style.studentInfo}>
+          <Heading2>{studentLevelInfo.name}</Heading2>
+          <div className={style.levelAndStudentDetails}>
+            <Heading5>
+              {i18n.lessonNumbered({
+                lessonNumber: lesson.position,
+                lessonName: lesson.name,
+              })}
+            </Heading5>
+            {onLevelForEvaluation && (
+              <div className={style.studentMetadata}>
+                {studentLevelInfo.timeSpent && (
+                  <BodyThreeText className={style.singleMetadatum}>
+                    <FontAwesome icon="clock" />
+                    <span>{formatTimeSpent(studentLevelInfo.timeSpent)}</span>
+                  </BodyThreeText>
+                )}
+                <BodyThreeText className={style.singleMetadatum}>
+                  <FontAwesome icon="rocket" />
+                  {i18n.numAttempts({
+                    numAttempts: studentLevelInfo.attempts || 0,
+                  })}
+                </BodyThreeText>
+                {studentLevelInfo.lastAttempt && (
+                  <BodyThreeText className={style.singleMetadatum}>
+                    <FontAwesome icon="calendar" />
+                    <span>
+                      {formatLastAttempt(studentLevelInfo.lastAttempt)}
+                    </span>
+                  </BodyThreeText>
+                )}
+              </div>
+            )}
+            {!onLevelForEvaluation && rubricLevel?.position && (
+              <BodyThreeText>
+                {i18n.feedbackAvailableOnLevel({
+                  levelPosition: rubricLevel.position,
+                })}
+              </BodyThreeText>
+            )}
+          </div>
+        </div>
+      )}
+      <div className={style.learningGoalContainer}>
+        {rubric.learningGoals.map(lg => (
+          <LearningGoal
+            key={lg.key}
+            learningGoal={lg}
+            teacherHasEnabledAi={teacherHasEnabledAi}
+            canProvideFeedback={canProvideFeedback}
+            reportingData={reportingData}
+          />
+        ))}
+      </div>
+      {canProvideFeedback && (
+        <div className={style.rubricContainerFooter}>
+          <div className={style.submitToStudentButtonAndError}>
+            <Button
+              text={i18n.submitToStudent()}
+              color={Button.ButtonColor.brandSecondaryDefault}
+              onClick={submitFeedbackToStudent}
+              className={style.submitToStudentButton}
+              disabled={isSubmittingToStudent}
+            />
+            {errorSubmitting && (
+              <BodyThreeText className={style.errorMessage}>
+                {i18n.errorSubmittingFeedback()}
+              </BodyThreeText>
+            )}
+            {!errorSubmitting && !!lastSubmittedTimestamp && (
+              <BodyThreeText>
+                {i18n.feedbackSubmittedAt({
+                  timestamp: lastSubmittedTimestamp,
+                })}
+              </BodyThreeText>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+RubricContent.propTypes = {
+  currentLevelName: PropTypes.string,
+  rubric: rubricShape.isRequired,
+  reportingData: reportingDataShape,
+  studentLevelInfo: studentLevelInfoShape,
+  teacherHasEnabledAi: PropTypes.bool,
+};

--- a/apps/test/unit/templates/rubrics/RubricContentTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContentTest.jsx
@@ -3,9 +3,9 @@ import {expect} from '../../../util/reconfiguredChai';
 import {mount, shallow} from 'enzyme';
 import sinon from 'sinon';
 import HttpClient from '@cdo/apps/util/HttpClient';
-import RubricContainer from '@cdo/apps/templates/rubrics/RubricContainer';
+import RubricContent from '@cdo/apps/templates/rubrics/RubricContent';
 
-describe('RubricContainer', () => {
+describe('RubricContent', () => {
   const defaultRubric = {
     learningGoals: [
       {
@@ -42,7 +42,7 @@ describe('RubricContainer', () => {
 
   it('shows learning goals with correct props when viewing student work on assessment level', () => {
     const wrapper = shallow(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{name: 'Grace Hopper', timeSpent: 706}}
       />
@@ -65,7 +65,7 @@ describe('RubricContainer', () => {
 
   it('shows learning goals with correct props when viewing student work on non assessment level', () => {
     const wrapper = shallow(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{name: 'Grace Hopper', timeSpent: 706}}
         currentLevelName="non_assessment_level"
@@ -89,7 +89,7 @@ describe('RubricContainer', () => {
 
   it('shows learning goals with correct props when not viewing student work', () => {
     const wrapper = shallow(
-      <RubricContainer {...defaultProps} studentLevelInfo={null} />
+      <RubricContent {...defaultProps} studentLevelInfo={null} />
     );
     const renderedLearningGoals = wrapper.find('LearningGoal');
     expect(renderedLearningGoals).to.have.lengthOf(2);
@@ -110,7 +110,7 @@ describe('RubricContainer', () => {
   it('shows level title', () => {
     // mount is needed in order for text() to work
     const wrapper = mount(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{
           name: 'Grace Hopper',
@@ -123,7 +123,7 @@ describe('RubricContainer', () => {
   it('shows student data if provided', () => {
     // mount is needed in order for text() to work
     const wrapper = mount(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{
           name: 'Grace Hopper',
@@ -142,7 +142,7 @@ describe('RubricContainer', () => {
   it('handles missing student data', () => {
     // mount is needed in order for text() to work
     const wrapper = mount(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{
           name: 'Grace Hopper',
@@ -158,7 +158,7 @@ describe('RubricContainer', () => {
   it('doesnt show student level data if not on level for evaluation', () => {
     // mount is needed in order for text() to work
     const wrapper = mount(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{
           name: 'Grace Hopper',
@@ -174,7 +174,7 @@ describe('RubricContainer', () => {
 
   it('shows submit button if has student data and on level for evaluation', () => {
     const wrapper = shallow(
-      <RubricContainer
+      <RubricContent
         rubric={defaultRubric}
         currentLevelName="test_level"
         studentLevelInfo={{name: 'Grace Hopper'}}
@@ -186,7 +186,7 @@ describe('RubricContainer', () => {
 
   it('handles successful submit button click', async () => {
     const wrapper = shallow(
-      <RubricContainer
+      <RubricContent
         rubric={defaultRubric}
         teacherHasEnabledAi
         currentLevelName="test_level"
@@ -214,7 +214,7 @@ describe('RubricContainer', () => {
 
   it('handles error on submit button click', async () => {
     const wrapper = shallow(
-      <RubricContainer
+      <RubricContent
         rubric={defaultRubric}
         teacherHasEnabledAi
         studentLevelInfo={{name: 'Grace Hopper'}}


### PR DESCRIPTION
First step to making a settings tab for rubrics. In particular, `RubricContainer` was getting unwieldy when I started to add multiple views, so I'm breaking the rubric view into a new component, `RubricContent` (this PR). In a future PR, I'll add a `RubricSettings` component.

This PR should have no effect -- I copied most of the logic from `RubricContainer` to `RubricContent` and simply copied the test file and updated the component names.