### PR TITLE
Setting JWT gem version needed by LTI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -209,7 +209,7 @@ gem 'execjs'
 # JavaScript runtime used by ExecJS.
 gem 'mini_racer', group: [:staging, :test, :production, :levelbuilder]
 
-gem 'jwt' # single signon for zendesk
+gem 'jwt', '~> 2.7.0'
 
 # SMS API for send-to-phone feature; 6.0 includes some breaking changes which
 # we'll need to prepare for:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,7 +493,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     jumphash (0.1.0)
-    jwt (2.5.0)
+    jwt (2.7.1)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -993,7 +993,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails (~> 6.0.1)
   jumphash
-  jwt
+  jwt (~> 2.7.0)
   kaminari
   lograge!
   loofah (~> 2.19.1)


### PR DESCRIPTION
When I tried to run `bin/generate-jwks dev` I got the following error:
```
.rbenv/versions/3.0.5/lib/ruby/gems/3.0.0/gems/jwt-2.5.0/lib/jwt/jwk.rb:17:in `create_from': wrong number of arguments (given 3, expected 1..2) (ArgumentError)
	from bin/generate-jwks:24:in `<main>'
```

Looking into it, the `generate-jwks` script uses an API in JWT gem which doesn't exist until version 2.7.0. This PR sets the minimum version of the JWT to 2.7.0.


## Testing story
* Successfully ran `bin/generate-jwks dev` on my laptop.