### PR TITLE
Don't encode versionId URL param when accessing version history in Weblab

### DIFF
--- a/dashboard/legacy/middleware/helpers/bucket_helper.rb
+++ b/dashboard/legacy/middleware/helpers/bucket_helper.rb
@@ -165,8 +165,8 @@ class BucketHelper
     owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, filename
 
-    encoded_location = ERB::Util.url_encode(@bucket + '/' + key)
-    copy_source = encoded_location + '?versionId=' + version
+    encoded_location = ERB::Util.url_encode("#{@bucket}/#{key}")
+    copy_source = "#{encoded_location}?versionId=#{version}"
     s3.copy_object(bucket: @bucket, copy_source: copy_source, key: key, metadata_directive: 'REPLACE')
   end
 

--- a/dashboard/legacy/middleware/helpers/bucket_helper.rb
+++ b/dashboard/legacy/middleware/helpers/bucket_helper.rb
@@ -165,7 +165,9 @@ class BucketHelper
     owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, filename
 
-    s3.copy_object(bucket: @bucket, copy_source: ERB::Util.url_encode("#{@bucket}/#{key}?versionId=#{version}"), key: key, metadata_directive: 'REPLACE')
+    encoded_location = ERB::Util.url_encode(@bucket + '/' + key)
+    copy_source = encoded_location + '?versionId=' + version
+    s3.copy_object(bucket: @bucket, copy_source: copy_source, key: key, metadata_directive: 'REPLACE')
   end
 
   def replace_abuse_score(encrypted_channel_id, filename, abuse_score)


### PR DESCRIPTION
We have a high volume Honeybadger error here:

https://app.honeybadger.io/projects/3240/faults/91723886

Which I believe is related to a change we made here in how we encode file locations in December:

https://github.com/code-dot-org/code-dot-org/pull/49140

Before that change, we'd get (largely unencoded?) URLs like this when restoring a file:
`cdo-v3-files/files_development/33/1128/style.css?versionId=abc123`

After that change, special characters including slashes and, crucially, question marks were also encoded:
`cdo-v3-files%2Ffiles_development%2F33%2F1128%2Fstyle.css%3FversionId%3Dabc123`

[AWS docs](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#copy_object-instance_method) specify that you need to "URL encode" the file location, but don't make clear whether you should also encode the `?versionId=abc123` part. It seems, based on trial and error, that you should not.
 
As far as I can tell, this is blocking restoring older versions of weblab projects in production. I am surprised we didn't hear about this in Zendesk -- you could still "view" the old version, so maybe people were copying over their previous versions from there?

## Links

- jira ticket: [LABS-53](https://codedotorg.atlassian.net/browse/LABS-53)

## Testing story

Tested manually that on a weblab level (/s/csd2-2022/lessons/6/levels/5) before this change, the "Restore" button did not work in the Version History dialog. After this change, it works.
