### PR TITLE
Load song metadata in redux for Lab2 Dance

### DIFF
--- a/apps/src/dance/types.ts
+++ b/apps/src/dance/types.ts
@@ -8,6 +8,25 @@ export type SongData = {
   };
 };
 
+type Analysis = {
+  beats: [boolean, boolean, boolean];
+  centroid: number;
+  energy: [number, number, number];
+  time: number;
+  volume: number;
+};
+
+export type SongMetadata = {
+  analysis: Analysis[];
+  artist: string;
+  bpm: string;
+  delay: string;
+  duration: number;
+  file: string;
+  title: string;
+  peaks: {[key: number]: number};
+};
+
 export interface DanceProjectSources extends ProjectSources {
   selectedSong?: string;
 }


### PR DESCRIPTION
In legacy Dance, the song metadata for the current song is loaded within Dance.js and it uses internal promises to manage async dependencies. For Lab2 dance, it would be cleaner to load metadata within the redux thunk, so this adds support for conditionally loading song metadata within the thunk if no other callback is provided.

<img width="1963" alt="Screenshot 2023-09-25 at 11 15 45 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/1ec02ee2-904c-41fb-842e-eae5aa3fe490">

## Testing story

Tested locally.