### PR TITLE
Add Curriculum School Level Amplitude Events back in

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/curriculum/elementary-school.haml
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/elementary-school.haml
@@ -18,3 +18,5 @@ theme: responsive_full_width
         =hoc_s(:heading_explore_curriculum_catalog)
       %a.link-button.secondary{href: "https://studio.code.org/catalog"}
         =hoc_s(:call_to_action_explore_curriculum_catalog)
+
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::ELEMENTARY_CURRICULUM_PAGE_VISITED_EVENT

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.haml
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.haml
@@ -18,3 +18,5 @@ theme: responsive_full_width
         =hoc_s(:heading_explore_curriculum_catalog)
       %a.link-button.secondary{href: "https://studio.code.org/catalog"}
         =hoc_s(:call_to_action_explore_curriculum_catalog)
+
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::HIGH_SCHOOL_CURRICULUM_PAGE_VISITED_EVENT

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.haml
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.haml
@@ -18,3 +18,5 @@ theme: responsive_full_width
         =hoc_s(:heading_explore_curriculum_catalog)
       %a.link-button.secondary{href: "https://studio.code.org/catalog"}
         =hoc_s(:call_to_action_explore_curriculum_catalog)
+
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::MIDDLE_SCHOOL_CURRICULUM_PAGE_VISITED_EVENT


### PR DESCRIPTION
This PR re-adds the Amplitude page visit events for users visiting [code.org/educate/curriculum/elementary-school](https://code.org/educate/curriculum/elementary-school), [code.org/educate/curriculum/middle-school](https://code.org/educate/curriculum/middle-school), and [https://code.org/educate/curriculum/high-school](https://code.org/educate/curriculum/high-school). They were originally removed due to those pages being changed to redirect elsewhere (which is no longer the case).

### Elementary School
Event name: [Elementary School Curriculum Page Visited](https://app.amplitude.com/data/code-org/Code.org%20Tracking%20Plan/events/main/latest/Elementary%20School%20Curriculum%20Page%20Visited?view=All&tab=DETAILS&propertyValidityFilter=All%2520Properties)
![ELEMENTARY_SCHOOL](https://github.com/code-dot-org/code-dot-org/assets/56283563/034fd6c4-3f3a-4736-8585-b5b8ff4edc77)

### Middle School
Event name: [Middle School Curriculum Page Visited](https://app.amplitude.com/data/code-org/Code.org%20Tracking%20Plan/events/main/latest/Middle%20School%20Curriculum%20Page%20Visited?view=All&tab=DETAILS&propertyValidityFilter=All%2520Properties)
![MIDDLE_SCHOOL](https://github.com/code-dot-org/code-dot-org/assets/56283563/c32548bc-69a8-4a5a-903f-ddf9051d551b)

### High School
Event name: [High School Curriculum Page Visited](https://app.amplitude.com/data/code-org/Code.org%20Tracking%20Plan/events/main/latest/High%20School%20Curriculum%20Page%20Visited?view=All&tab=DETAILS&propertyValidityFilter=All%2520Properties)
![HIGH_SCHOOL](https://github.com/code-dot-org/code-dot-org/assets/56283563/6ce923f7-3065-44b8-bbaf-adef50f7d922)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-988&assignee=60d62161f65054006980bd71)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
