### PR TITLE
Add Visit Video Library Page Event

### DIFF
--- a/pegasus/helpers/analytics_constants.rb
+++ b/pegasus/helpers/analytics_constants.rb
@@ -28,6 +28,7 @@ module AnalyticsConstants
     SELF_PACED_PL_PAGE_VISITED_EVENT = 'Self-Paced Professional Learning Page Visited'.freeze,
     RP_LANDING_PAGE_VISITED_EVENT = 'Regional Partner Landing Page Visited'.freeze,
     TEACH_PAGE_VISITED_EVENT = 'Teach Page Visited'.freeze,
-    TEACHER_LOGIN_EVENT = 'Teacher Login'.freeze
+    TEACHER_LOGIN_EVENT = 'Teacher Login'.freeze,
+    VIDEO_LIBRARY_PAGE_VISIT_EVENT = 'Video Library Page Visited'.freeze
   ].freeze
 end

--- a/pegasus/sites.v3/code.org/public/educate/resources/videos.haml
+++ b/pegasus/sites.v3/code.org/public/educate/resources/videos.haml
@@ -54,3 +54,5 @@ video_player: true
 %script{:src=>'/js/jquery.carouFredSel-6.2.1-packed.js'}
 %script{:src=>'/js/jquery.touchSwipe.min.js'}
 %script{:src=>'/js/page/video_page.js'}
+
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::VIDEO_LIBRARY_PAGE_VISIT_EVENT


### PR DESCRIPTION
Adds an Amplitude page visit event for visiting [code.org/educate/resources/videos](https://code.org/educate/resources/videos).

Event name: [Video Library Page Visited](https://app.amplitude.com/data/code-org/Code.org%20Tracking%20Plan/events/main/latest/Video%20Library%20Page%20Visited?view=All&tab=DETAILS&propertyValidityFilter=All%2520Properties)

![VIDEO_LIBRARY](https://github.com/code-dot-org/code-dot-org/assets/56283563/d1149451-2fd4-4701-9c64-731e44283180)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-954&assignee=60d62161f65054006980bd71)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
