### PR TITLE
Removing family name DCDO flags

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
@@ -94,8 +94,7 @@ class StudentTable extends React.Component {
                     />
                   )}
                   <div style={styles.name}>
-                    {student.name}
-                    {` ${student.familyName || ''}`}
+                    {`${student.name} ${student.familyName || ''}`}
                     <a
                       href={this.getRowLink(student.id)}
                       target="_blank"

--- a/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
@@ -4,7 +4,6 @@ import {connect} from 'react-redux';
 import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
-import DCDO from '@cdo/apps/dcdo';
 import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {levelWithProgress, studentShape} from './types';
@@ -96,8 +95,7 @@ class StudentTable extends React.Component {
                   )}
                   <div style={styles.name}>
                     {student.name}
-                    {!!DCDO.get('family-name-features', false) &&
-                      ` ${student.familyName || ''}`}
+                    {` ${student.familyName || ''}`}
                     <a
                       href={this.getRowLink(student.id)}
                       target="_blank"

--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -33,7 +33,6 @@ import {
   queryLockStatus,
 } from '@cdo/apps/code-studio/components/progress/teacherPanel/teacherPanelData';
 import SortByNameDropdown from '@cdo/apps/templates/SortByNameDropdown';
-import DCDO from '@cdo/apps/dcdo';
 
 const TEACHER_PANEL = 'TeacherPanel';
 
@@ -246,15 +245,13 @@ class TeacherPanel extends React.Component {
               )}
             </div>
           )}
-          {!!DCDO.get('family-name-features', false) && (
-            <SortByNameDropdown
-              sortByStyles={styles.sortBy}
-              selectStyles={styles.select}
-              sectionId={sectionId}
-              unitName={unitName}
-              source={TEACHER_PANEL}
-            />
-          )}
+          <SortByNameDropdown
+            sortByStyles={styles.sortBy}
+            selectStyles={styles.select}
+            sectionId={sectionId}
+            unitName={unitName}
+            source={TEACHER_PANEL}
+          />
           {viewAs === ViewType.Instructor && (students || []).length > 0 && (
             <StudentTable
               levelsWithProgress={levelsWithProgress}

--- a/apps/src/templates/manageStudents/AddMultipleStudents.jsx
+++ b/apps/src/templates/manageStudents/AddMultipleStudents.jsx
@@ -4,7 +4,6 @@ import {connect} from 'react-redux';
 import {addMultipleAddRows} from './manageStudentsRedux';
 import Button from '../Button';
 import i18n from '@cdo/locale';
-import DCDO from '@cdo/apps/dcdo';
 import BaseDialog from '../BaseDialog';
 import DialogFooter from '../teacherDashboard/DialogFooter';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
@@ -42,14 +41,10 @@ class AddMultipleStudents extends Component {
   add = () => {
     const value = this.refs.studentsTextBox.value;
     const studentDataArray = value.split('\n').map(line => {
-      if (!!DCDO.get('family-name-features', false)) {
-        const parts = line.split(',');
-        const name = parts[0].trim();
-        const familyName = parts.length > 1 ? parts[1].trim() : null;
-        return {name, familyName};
-      } else {
-        return {name: line, familyName: null};
-      }
+      const parts = line.split(',');
+      const name = parts[0].trim();
+      const familyName = parts.length > 1 ? parts[1].trim() : null;
+      return {name, familyName};
     });
     this.props.addMultipleStudents(studentDataArray);
     firehoseClient.putRecord(
@@ -83,11 +78,7 @@ class AddMultipleStudents extends Component {
           handleClose={this.closeDialog}
         >
           <h2>{i18n.addStudentsMultiple()}</h2>
-          <div>
-            {!!DCDO.get('family-name-features', false)
-              ? i18n.addStudentsMultipleWithFamilyNameInstructions()
-              : i18n.addStudentsMultipleInstructions()}
-          </div>
+          <div>{i18n.addStudentsMultipleWithFamilyNameInstructions()}</div>
           <textarea
             rows="15"
             cols="70"

--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -9,7 +9,6 @@ import PasswordReset from './PasswordReset';
 import ShowSecret from './ShowSecret';
 import {SectionLoginType} from '@cdo/apps/util/sharedConstants';
 import i18n from '@cdo/locale';
-import DCDO from '@cdo/apps/dcdo';
 import color from '@cdo/apps/util/color';
 import experiments from '@cdo/apps/util/experiments';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
@@ -463,11 +462,9 @@ class ManageStudentsTable extends Component {
       }),
     });
     if (
-      !!DCDO.get('family-name-features', false) &&
       this.props.participantType === 'student' &&
       selectedColumn === COLUMNS.FAMILY_NAME
     ) {
-      // Only in non-PL sections, only when DCDO flag is on.
       this.props.setSortByFamilyName(
         true,
         this.props.sectionId,
@@ -489,11 +486,9 @@ class ManageStudentsTable extends Component {
 
     const columns = [this.nameColumn(sortable)];
 
-    if (!!DCDO.get('family-name-features', false)) {
-      if (this.props.participantType === 'student') {
-        // Only in non-PL sections.
-        columns.push(this.familyNameColumn(sortable));
-      }
+    // Only include family name in non-PL sections
+    if (this.props.participantType === 'student') {
+      columns.push(this.familyNameColumn(sortable));
     }
 
     columns.push(this.ageColumn(sortable));

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -23,7 +23,6 @@ import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import ProgressViewHeader from './ProgressViewHeader';
 import logToCloud from '@cdo/apps/logToCloud';
 import SortByNameDropdown from '@cdo/apps/templates/SortByNameDropdown';
-import DCDO from '@cdo/apps/dcdo';
 import styleConstants from './progressTables/progress-table-constants.module.scss';
 
 const SECTION_PROGRESS = 'SectionProgress';
@@ -174,7 +173,7 @@ class SectionProgress extends Component {
           )}
         </div>
         <div style={styles.topRowContainer}>
-          {showProgressTable && !!DCDO.get('family-name-features', false) && (
+          {showProgressTable && (
             <SortByNameDropdown
               selectStyles={styles.sortOrderSelect}
               sectionId={sectionId}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
@@ -12,7 +12,6 @@ import styleConstants from './progress-table-constants.module.scss';
 import './progressTableStyles.scss';
 import {scriptUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import i18n from '@cdo/locale';
-import DCDO from '@cdo/apps/dcdo';
 
 export default class ProgressTableStudentList extends React.Component {
   static propTypes = {
@@ -58,14 +57,9 @@ export default class ProgressTableStudentList extends React.Component {
       scriptData.name,
       rowData.student.id
     );
-    let fullName;
-    if (!!DCDO.get('family-name-features', false)) {
-      fullName = rowData.student.familyName
-        ? `${rowData.student.name} ${rowData.student.familyName}`
-        : rowData.student.name;
-    } else {
-      fullName = rowData.student.name;
-    }
+    let fullName = rowData.student.familyName
+      ? `${rowData.student.name} ${rowData.student.familyName}`
+      : rowData.student.name;
     return (
       <ProgressTableStudentName
         name={fullName}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
@@ -57,7 +57,7 @@ export default class ProgressTableStudentList extends React.Component {
       scriptData.name,
       rowData.student.id
     );
-    let fullName = rowData.student.familyName
+    const fullName = rowData.student.familyName
       ? `${rowData.student.name} ${rowData.student.familyName}`
       : rowData.student.name;
     return (

--- a/apps/src/templates/teacherDashboard/StatsTable.jsx
+++ b/apps/src/templates/teacherDashboard/StatsTable.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
-import DCDO from '@cdo/apps/dcdo';
 import * as Table from 'reactabular-table';
 import * as sort from 'sortabular';
 import wrappedSortable from '../tables/wrapped_sortable';
@@ -64,11 +63,9 @@ class StatsTable extends Component {
   getColumns = sortable => {
     const columns = [this.nameColumn(sortable)];
 
-    if (!!DCDO.get('family-name-stats-tab', false)) {
-      if (this.props.participantType === 'student') {
-        // Only in non-PL sections.
-        columns.push(this.familyNameColumn(sortable));
-      }
+    // Only include family name in non-PL sections
+    if (this.props.participantType === 'student') {
+      columns.push(this.familyNameColumn(sortable));
     }
 
     columns.push(this.completedLevelsCountColumn(sortable));

--- a/apps/test/unit/code-studio/components/progress/teacherPanel/StudentTableTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/teacherPanel/StudentTableTest.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import DCDO from '@cdo/apps/dcdo';
 import {shallow} from 'enzyme';
 import {expect} from '../../../../../util/reconfiguredChai';
 import {UnconnectedStudentTable as StudentTable} from '@cdo/apps/code-studio/components/progress/teacherPanel/StudentTable';
@@ -90,21 +89,13 @@ describe('StudentTable', () => {
   });
 
   it('sorts by family name if toggled', () => {
-    DCDO.reset();
-    DCDO.set('family-name-features', true);
-
     const wrapper = setUp({isSortedByFamilyName: true});
 
     const firstStudentRow = wrapper.find('tr').at(1);
     expect(firstStudentRow.text()).to.match(/^Student 2 FamNameA/);
-
-    DCDO.reset();
   });
 
   it('sorts null family names last', () => {
-    DCDO.reset();
-    DCDO.set('family-name-features', true);
-
     const wrapper = setUp({
       students: [
         {id: 1, name: 'Student 1', familyName: 'FamNameB'},
@@ -118,14 +109,9 @@ describe('StudentTable', () => {
     expect(lastStudentRow.text()).to.match(/^Student 2/);
     expect(lastStudentRow.text()).to.not.match(/null/);
     expect(lastStudentRow.text()).to.not.match(/undefined/);
-
-    DCDO.reset();
   });
 
   it('ignores non-alphabetic characters in sorting', () => {
-    DCDO.reset();
-    DCDO.set('family-name-features', true);
-
     const wrapper = setUp({
       students: [
         {id: 1, name: 'Student 1', familyName: '1Brown'},
@@ -139,13 +125,9 @@ describe('StudentTable', () => {
     expect(studentRows.at(1).text()).to.match(/^Student 3/);
     expect(studentRows.at(2).text()).to.match(/^Student 1/);
     expect(studentRows.at(3).text()).to.match(/^Student 2/);
-    DCDO.reset();
   });
 
   it('sorts by name when family names are equivalent', () => {
-    DCDO.reset();
-    DCDO.set('family-name-features', true);
-
     const wrapper = setUp({
       students: [
         {id: 1, name: 'Eve', familyName: 'Carlson'},
@@ -159,6 +141,5 @@ describe('StudentTable', () => {
     expect(studentRows.at(1).text()).to.match(/^Alice/);
     expect(studentRows.at(2).text()).to.match(/^Bob/);
     expect(studentRows.at(3).text()).to.match(/^Eve/);
-    DCDO.reset();
   });
 });

--- a/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
@@ -7,7 +7,6 @@ import {
   restoreRedux,
 } from '@cdo/apps/redux';
 import i18n from '@cdo/locale';
-import DCDO from '@cdo/apps/dcdo';
 import experiments from '@cdo/apps/util/experiments';
 import {expect} from '../../../util/deprecatedChai';
 import {shallow, mount} from 'enzyme';
@@ -285,9 +284,6 @@ describe('ManageStudentsTable', () => {
     });
 
     it('renders an editable family name field in student sections', async () => {
-      DCDO.reset();
-      DCDO.set('family-name-features', true);
-
       const wrapper = mount(
         <Provider store={getStore()}>
           <ManageStudentsTable />
@@ -318,14 +314,9 @@ describe('ManageStudentsTable', () => {
 
       // Expect the input box value to have changed
       expect(nameInput().prop('value')).to.equal('z');
-
-      DCDO.reset();
     });
 
     it('does not render a family name field in PL sections', async () => {
-      DCDO.reset();
-      DCDO.set('family-name-features', true);
-
       const plSection = {...fakeSection, participant_type: 'teacher'};
       getStore().dispatch(setSections([plSection]));
       const wrapper = mount(
@@ -346,34 +337,6 @@ describe('ManageStudentsTable', () => {
 
       // Check for a family name cell with expecting initial editing props
       expect(manageStudentFamilyNameCell().exists()).to.be.false;
-
-      DCDO.reset();
-    });
-
-    it('does not render a family name field when flag is false', async () => {
-      DCDO.reset();
-      DCDO.set('family-name-features', false);
-
-      const wrapper = mount(
-        <Provider store={getStore()}>
-          <ManageStudentsTable />
-        </Provider>
-      );
-      // Begin editing the student
-      // (Using redux directly to do this requires us to trigger a manual update)
-      getStore().dispatch(startEditingStudent(fakeStudent.id));
-      wrapper.update();
-
-      const manageStudentFamilyNameCell = () =>
-        wrapper
-          .find(ManageStudentFamilyNameCell)
-          .findWhere(w => w.prop('id') === fakeStudent.id)
-          .first();
-
-      // Check for a family name cell with expecting initial editing props
-      expect(manageStudentFamilyNameCell().exists()).to.be.false;
-
-      DCDO.reset();
     });
 
     it('renders correctly if loginType is picture', () => {

--- a/apps/test/unit/templates/teacherDashboard/StatsTableTest.js
+++ b/apps/test/unit/templates/teacherDashboard/StatsTableTest.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import DCDO from '@cdo/apps/dcdo';
 import {mount} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import {UnconnectedStatsTable as StatsTable} from '@cdo/apps/templates/teacherDashboard/StatsTable';
@@ -42,9 +41,6 @@ describe('StatsTable', () => {
   });
 
   it('sorts students by the correct name upon clicking the name header cells', () => {
-    DCDO.reset();
-    DCDO.set('family-name-stats-tab', true);
-
     const wrapper = mount(
       <StatsTable
         sectionId={1}
@@ -81,14 +77,9 @@ describe('StatsTable', () => {
     expect(nameCells.at(0).text()).to.equal('Lastname C');
     expect(nameCells.at(1).text()).to.equal('Lastname B');
     expect(nameCells.at(2).text()).to.equal('Lastname A');
-
-    DCDO.reset();
   });
 
   it('does not render a family name field in PL sections', async () => {
-    DCDO.reset();
-    DCDO.set('family-name-stats-tab', true);
-
     const wrapper = mount(
       <StatsTable
         sectionId={1}
@@ -100,7 +91,5 @@ describe('StatsTable', () => {
 
     expect(wrapper.find('uitest-family-name-header').exists()).to.be.false;
     expect(wrapper.find('uitest-family-name-cell').exists()).to.be.false;
-
-    DCDO.reset();
   });
 });

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -419,7 +419,6 @@ use_local_header_color:
 
 default_hoc_mode: pre-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''      # overridden by 'hoc_launch' DCDO param, except in :test
-default_family_name_mode: true # overriden by 'family-name-features' DCDO param, except in :test
 
 # teacher_application_mode values: 'open', 'closing-soon', 'closed'
 default_teacher_application_mode: 'closed' # overridden by 'teacher_application_mode' DCDO param, except in :test

--- a/dashboard/app/models/follower.rb
+++ b/dashboard/app/models/follower.rb
@@ -62,7 +62,7 @@ class Follower < ApplicationRecord
     student_user.assign_script(section.script) if section.script
   end
 
-  after_destroy :remove_family_name, if: proc {DCDO.get('family-name-features', false)}
+  after_destroy :remove_family_name
   def remove_family_name
     # If the student is in zero sections, and has a family name set,
     # remove the family name.

--- a/dashboard/app/models/follower.rb
+++ b/dashboard/app/models/follower.rb
@@ -66,7 +66,7 @@ class Follower < ApplicationRecord
   def remove_family_name
     # If the student is in zero sections, and has a family name set,
     # remove the family name.
-    if student_user.family_name && student_user.sections_as_student.empty?
+    if student_user&.family_name && student_user.sections_as_student.empty?
       # can't remove keys from properties directly, so just set it to nil.
       student_user.family_name = nil
       student_user.save!

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1052,9 +1052,7 @@ class User < ApplicationRecord
 
     # Remove family name, in case it was set on the student account.
     # Must do this before updating user_type, to prevent validation failure.
-    if DCDO.get('family-name-features', CDO.default_family_name_mode)
-      self.family_name = nil
-    end
+    self.family_name = nil
 
     hashed_email = User.hash_email(email)
     self.user_type = TYPE_TEACHER
@@ -2080,7 +2078,7 @@ class User < ApplicationRecord
       id: id,
       name: name,
       username: username,
-      family_name: DCDO.get('family-name-features', CDO.default_family_name_mode) ? family_name : nil,
+      family_name: family_name,
       email: email,
       hashed_email: hashed_email,
       user_type: user_type,

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -436,7 +436,6 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   #
 
   test "hard-deletes all of a hard-deleted student's follower rows" do
-    DCDO.stubs(:get).with('family-name-features', false).returns(false)
     user = create :student
     section = create :section
     section.students << user
@@ -451,7 +450,6 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     assert_empty user.sections_as_student
     refute_includes section.students, user
     assert_empty Follower.with_deleted.where(student_user: user)
-    DCDO.unstub(:get)
   end
 
   #

--- a/dashboard/test/models/follower_test.rb
+++ b/dashboard/test/models/follower_test.rb
@@ -76,7 +76,6 @@ class FollowerTest < ActiveSupport::TestCase
   end
 
   test 'deleting a follower removes the associated student family name' do
-    DCDO.stubs(:get).with('family-name-features', false).returns(true)
     student = @follower.student_user
     student.family_name = 'test'
     student.save!
@@ -88,7 +87,6 @@ class FollowerTest < ActiveSupport::TestCase
     student.reload
 
     assert_nil student.family_name
-    DCDO.unstub(:get)
   end
 
   test 'deleting one of many followers keeps the associated student family name' do

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -49,8 +49,6 @@ class DCDOBase < DynamicConfigBase
       'curriculum-launch-hero-banner': DCDO.get('curriculum-launch-hero-banner', false),
       'curriculum-launch-skinny-banner': DCDO.get('curriculum-launch-skinny-banner', false),
       'ai-pl-launch-banners': DCDO.get('ai-pl-launch-banners', false),
-      'family-name-features': DCDO.get('family-name-features', true),
-      'family-name-stats-tab': DCDO.get('family-name-stats-tab', true),
       cpa_experience: DCDO.get('cpa_experience', false),
       gender: DCDO.get('gender', false),
     }


### PR DESCRIPTION
This is a clean up PR for the sort by family name project. Because we've had this feature live for a few weeks with very positive feedback (and hundreds of thousands of family names created), we are not planning to roll the feature back. 

This PR removes that mechanism- the two DCDO flags we were using: familiy-name-features and family-name-stats-tab.

Approach: 
I searched the codebase for any files that use this flag. I removed it from three categories of files:
1. The list of dcdo flags
2. Components that use the flag to determine what to show (required simplification of any if/else statements)
3. Test files that test dcdo functionality, or only work when a flag is 'on' or 'off'. I deleted the tests testing functionality while the flags were 'off', and removed the 'setting' and 'unsetting' pieces of the remaining related tests.

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-654

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
