### PR TITLE
Only report abuse to Zendesk if we have user email

### DIFF
--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -38,12 +38,12 @@ class ReportAbuseController < ApplicationController
         return head :forbidden
       end
 
-      name = current_user&.name || "User not signed in"
-      email = current_user&.email || "User not signed in"
-      age = current_user&.age || "User not signed in"
+      name = current_user&.name
+      email = current_user&.email
+      age = current_user&.age
       abuse_url = CDO.studio_url(params[:abuse_url]) # reformats url
 
-      send_abuse_report(name, email, age, abuse_url)
+      send_abuse_report(name, email, age, abuse_url) if email
       update_abuse_score
 
       return head :ok


### PR DESCRIPTION
Errors observed with our new report abuse form when trying to submit when logged out:

https://app.honeybadger.io/projects/3240/faults/100609156

![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/d3c8d0d3-21e9-4d9f-9f08-c01e71951a07)

Zendesk requires an email to submit a ticket -- skipping the Zendesk step if we don't have an email.

We may want to just hide the reporting UI for signed out users in general (or use a dummy email if we don't have one?), as I think reports from them are effectively ignored (doesn't increment abuse score, doesn't report to Zendesk). But doing this in the short term to prevent this error.