### PR TITLE
Remove params and unused code for quick view expanded card

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -26,8 +26,6 @@ const CurriculumCatalog = ({
     useState(false);
   const [expandedCardKey, setExpandedCardKey] = useState(null);
 
-  const isQuickViewDisplayed = true;
-
   useEffect(() => {
     const expandedCardFound = filteredCurricula.some(
       co => expandedCardKey === co['key']
@@ -129,7 +127,6 @@ const CurriculumCatalog = ({
                   scriptId={script_id}
                   isStandAloneUnit={is_standalone_unit}
                   onAssignSuccess={response => handleAssignSuccess(response)}
-                  quickViewDisplayed={isQuickViewDisplayed}
                   deviceCompatibility={device_compatibility}
                   description={description}
                   professionalLearningProgram={professional_learning_program}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -42,7 +42,6 @@ const CurriculumCatalogCard = ({
   topics = [],
   pathToCourse,
   onAssignSuccess,
-  quickViewDisplayed,
   deviceCompatibility,
   description,
   professionalLearningProgram,
@@ -83,7 +82,6 @@ const CurriculumCatalogCard = ({
     translationIconTitle={i18n.courseInYourLanguage()}
     pathToCourse={pathToCourse + '?viewAs=Instructor'}
     onAssignSuccess={onAssignSuccess}
-    quickViewDisplayed={quickViewDisplayed}
     deviceCompatibility={deviceCompatibility}
     description={description}
     professionalLearningProgram={professionalLearningProgram}
@@ -122,7 +120,6 @@ CurriculumCatalogCard.propTypes = {
   scriptId: PropTypes.number,
   isStandAloneUnit: PropTypes.bool,
   onAssignSuccess: PropTypes.func,
-  quickViewDisplayed: PropTypes.bool,
   deviceCompatibility: PropTypes.string,
   description: PropTypes.string,
   professionalLearningProgram: PropTypes.string,
@@ -157,7 +154,6 @@ const CustomizableCurriculumCatalogCard = ({
   isSignedOut,
   onAssignSuccess,
   courseId,
-  quickViewDisplayed,
   deviceCompatibility,
   description,
   professionalLearningProgram,
@@ -265,26 +261,13 @@ const CustomizableCurriculumCatalogCard = ({
                   : style.buttonsContainer_notEnglish
               )}
             >
-              {quickViewDisplayed ? (
-                <Button
-                  color={Button.ButtonColor.neutralDark}
-                  type="button"
-                  onClick={onQuickViewClick}
-                  aria-label={quickViewButtonDescription}
-                  text={'Quick View'}
-                />
-              ) : (
-                <Button
-                  __useDeprecatedTag
-                  color={Button.ButtonColor.neutralDark}
-                  type="button"
-                  href={pathToCourse}
-                  aria-label={i18n.quickViewDescription({
-                    course_name: courseDisplayName,
-                  })}
-                  text={i18n.learnMore()}
-                />
-              )}
+              <Button
+                color={Button.ButtonColor.neutralDark}
+                type="button"
+                onClick={onQuickViewClick}
+                aria-label={quickViewButtonDescription}
+                text={'Quick View'}
+              />
               <Button
                 color={Button.ButtonColor.brandSecondaryDefault}
                 type="button"
@@ -351,7 +334,6 @@ CustomizableCurriculumCatalogCard.propTypes = {
   quickViewButtonDescription: PropTypes.string.isRequired,
   assignButtonDescription: PropTypes.string.isRequired,
   // for expanded card
-  quickViewDisplayed: PropTypes.bool,
   deviceCompatibility: PropTypes.string,
   description: PropTypes.string,
   professionalLearningProgram: PropTypes.string,

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -266,7 +266,7 @@ const CustomizableCurriculumCatalogCard = ({
                 type="button"
                 onClick={onQuickViewClick}
                 aria-label={quickViewButtonDescription}
-                text={'Quick View'}
+                text={i18n.quickView()}
               />
               <Button
                 color={Button.ButtonColor.brandSecondaryDefault}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
@@ -25,6 +25,7 @@ const defaultArgs = {
   isEnglish: true,
   pathToCourse: '/s/course',
   isSignedOut: false,
+  onQuickViewClick: () => {},
 };
 
 export const AllOptionsCard = Template.bind({});

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -62,6 +62,7 @@ describe('CurriculumCatalogCard', () => {
       pathToCourse: '/s/course',
       scriptId: 1,
       isSignedOut: true,
+      onQuickViewClick: () => {},
     };
   });
 

--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -244,7 +244,7 @@ Feature: Curriculum Catalog Page
     And I see that "Section 2" is assigned to "Computer Science Principles" in the section table
 
     # Unassign standalone unit
-    Then I am on "http://studio.code.org/catalog?quick_view=true"
+    Then I am on "http://studio.code.org/catalog"
     And I wait until element "h4:contains(AI for Oceans)" is visible
     And I click selector "[aria-label='View details about AI for Oceans']"
 


### PR DESCRIPTION
Removes the `isQuickViewDisplayed` prop from the CurriculumCatalogCard. Also removes the conditional which checks this `quickViewDisplayed` variable and removes the use of the previous Learn More Button.

## Links


- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-956)

## Testing story
Local


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
