### PR TITLE
[Google Blockly] CT-109: Support shared functions/behaviors

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -1,21 +1,24 @@
 import _ from 'lodash';
+import {unregisterProcedureBlocks} from '@blockly/block-shareable-procedures';
+
+import experiments from '@cdo/apps/util/experiments';
+import {APP_HEIGHT} from '@cdo/apps/p5lab/constants';
+import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
+
+import cdoTheme from '../themes/cdoTheme';
+import {blocks as procedureBlocks} from '../customBlocks/googleBlockly/proceduresBlocks';
 import {
-  ToolboxType,
+  BLOCK_TYPES,
   CLAMPED_NUMBER_REGEX,
   DEFAULT_SOUND,
   stringIsXml,
+  ToolboxType,
 } from '../constants';
-import cdoTheme from '../themes/cdoTheme';
-import {APP_HEIGHT} from '@cdo/apps/p5lab/constants';
-import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
 import {
   convertXmlToJson,
   positionBlocksOnWorkspace,
 } from './cdoSerializationHelpers';
 import {parseElement as parseXmlElement} from '../../xml';
-import {unregisterProcedureBlocks} from '@blockly/block-shareable-procedures';
-import {blocks as procedureBlocks} from '../customBlocks/googleBlockly/proceduresBlocks';
-import experiments from '@cdo/apps/util/experiments';
 
 /**
  * Loads blocks to a workspace.
@@ -69,13 +72,13 @@ function loadHiddenDefinitionBlocksToWorkspace(hiddenDefinitionSource) {
 function prepareSourcesForWorkspaces(source, hiddenDefinitions) {
   let {parsedSource, parsedHiddenDefinitions, blockOrderMap} =
     parseSourceAndHiddenDefinitions(source, hiddenDefinitions);
-  // TODO: When we add behaviors, we should always hide behavior blocks.
-  const procedureTypesToHide = [];
+
+  const procedureTypesToHide = [BLOCK_TYPES.behaviorDefinition];
   if (
     Blockly.useModalFunctionEditor &&
     experiments.isEnabled(experiments.MODAL_FUNCTION_EDITOR)
   ) {
-    procedureTypesToHide.push('procedures_defnoreturn');
+    procedureTypesToHide.push(BLOCK_TYPES.procedureDefinition);
   }
   moveHiddenProcedures(
     parsedSource,

--- a/apps/src/blockly/constants.js
+++ b/apps/src/blockly/constants.js
@@ -72,9 +72,9 @@ export function stringIsXml(str) {
 
 export const BLOCK_TYPES = {
   behaviorDefinition: 'behavior_definition',
+  danceWhenSetup: 'Dancelab_whenSetup',
   procedureDefinition: 'procedures_defnoreturn',
   whenRun: 'when_run',
-  whenSetup: 'Dancelab_whenSetup',
 };
 
 // A list of block types that are procedure definitions. These are sorted
@@ -86,4 +86,4 @@ export const PROCEDURE_DEFINITION_TYPES = [
 ];
 
 // A list of block types associated with the Run button.
-export const SETUP_TYPES = [BLOCK_TYPES.whenRun, BLOCK_TYPES.whenSetup];
+export const SETUP_TYPES = [BLOCK_TYPES.whenRun, BLOCK_TYPES.danceWhenSetup];

--- a/apps/src/blockly/constants.js
+++ b/apps/src/blockly/constants.js
@@ -70,13 +70,20 @@ export function stringIsXml(str) {
   }
 }
 
+export const BLOCK_TYPES = {
+  behaviorDefinition: 'behavior_definition',
+  procedureDefinition: 'procedures_defnoreturn',
+  whenRun: 'when_run',
+  whenSetup: 'Dancelab_whenSetup',
+};
+
 // A list of block types that are procedure definitions. These are sorted
 // first when loading blocks so that we can set up the procedure map
 // correctly while using the shareable procedure blocks plugin.
 export const PROCEDURE_DEFINITION_TYPES = [
-  'behavior_definition',
-  'procedures_defnoreturn',
+  BLOCK_TYPES.behaviorDefinition,
+  BLOCK_TYPES.procedureDefinition,
 ];
 
 // A list of block types associated with the Run button.
-export const SETUP_TYPES = ['when_run', 'Dancelab_whenSetup'];
+export const SETUP_TYPES = [BLOCK_TYPES.whenRun, BLOCK_TYPES.whenSetup];

--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
@@ -184,8 +184,6 @@ export function flyoutCategory(workspace, functionEditorOpen = false) {
   } else if (useModalFunctionEditor) {
     workspace.registerButtonCallback('createNewBehavior', createNewBehavior);
     blockList.push(newBehaviorButton);
-  } else {
-    blockList.push(behaviorDefinitionBlock);
   }
 
   blockList.push(...getCustomCategoryBlocksForFlyout('Behavior'));


### PR DESCRIPTION
This PR hides behavior definition blocks to the hidden workspace by default.

Notes:
-  Because none of the existing labs that are migrated to Google Blockly use behaviors, this code will only do anything for users who are forcing Sprite Lab to use Google Blockly. There will be no impact on typical users until we flip.

## Links

Jira: https://codedotorg.atlassian.net/browse/CT-109
Sprite Lab migration doc: https://docs.google.com/document/d/17egiF9ZLJ6VVH6K6GPALOpkVcbYmf3jWxqSMEIVYsiA/edit

## Testing story

Confirmed behaviors are working as expected with sample Google Blockly and CDO projects. Furthermore, behavior definition blocks are now hidden for Google Blockly. 

![Screenshot 2023-09-26 at 12 29 10 PM](https://github.com/code-dot-org/code-dot-org/assets/26844240/888b93b4-a878-44a8-9e2e-39306e0c38a8)

When the modal function editor is not enabled, block definitions are hidden and cannot be edited.

![Screenshot 2023-10-10 at 3 07 40 PM](https://github.com/code-dot-org/code-dot-org/assets/26844240/b1859aee-5004-45c6-94c9-7cbb16922884)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work

This will unblock work to use the modal function editor to support behaviors, see: https://codedotorg.atlassian.net/browse/CT-108

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
