### PR TITLE
Fix purging student accounts with a family name.

### DIFF
--- a/dashboard/app/models/follower.rb
+++ b/dashboard/app/models/follower.rb
@@ -66,7 +66,7 @@ class Follower < ApplicationRecord
   def remove_family_name
     # If the student is in zero sections, and has a family name set,
     # remove the family name.
-    if student_user.family_name && student_user.sections_as_student.empty?
+    if student_user&.family_name && student_user&.sections_as_student&.empty?
       # can't remove keys from properties directly, so just set it to nil.
       student_user.family_name = nil
       student_user.save!

--- a/dashboard/app/models/follower.rb
+++ b/dashboard/app/models/follower.rb
@@ -64,9 +64,12 @@ class Follower < ApplicationRecord
 
   after_destroy :remove_family_name, if: proc {DCDO.get('family-name-features', false)}
   def remove_family_name
+    # Ignore a deleted student
+    return unless student_user
+
     # If the student is in zero sections, and has a family name set,
     # remove the family name.
-    if student_user&.family_name && student_user&.sections_as_student&.empty?
+    if student_user.family_name && student_user.sections_as_student.empty?
       # can't remove keys from properties directly, so just set it to nil.
       student_user.family_name = nil
       student_user.save!

--- a/dashboard/test/integration/account_purger_test.rb
+++ b/dashboard/test/integration/account_purger_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+# Here, we want to ensure that User records can be purged via
+# the AccountPurger class.
+class AccountPurgerIntegrationTest < ActionDispatch::IntegrationTest
+  NULL_STREAM = File.open File::NULL, 'w'
+
+  setup do
+    # Never actually upload logs to S3
+    PurgedAccountLog.any_instance.stubs(:upload)
+  end
+
+  # We can purge a simple but typical student account, in general.
+  test 'can purge a typical student account' do
+    user = create :young_student_with_teacher
+
+    purger = AccountPurger.new(log: NULL_STREAM)
+    purger.purge_data_for_account(user)
+  end
+
+  # We can purge a student when they have a family name.
+  test 'can purge a student account with a family name that is in a section' do
+    DCDO.stubs(:get).with('family-name-features', false).returns(true)
+    user = create :young_student_with_teacher
+
+    purger = AccountPurger.new(log: NULL_STREAM)
+    purger.purge_data_for_account(user)
+  end
+end

--- a/dashboard/test/integration/account_purger_test.rb
+++ b/dashboard/test/integration/account_purger_test.rb
@@ -12,18 +12,37 @@ class AccountPurgerIntegrationTest < ActionDispatch::IntegrationTest
 
   # We can purge a simple but typical student account, in general.
   test 'can purge a typical student account' do
+    # This will test that a typical user account can be purged.
+    # There are occasionally regressions related to on-delete hooks
+    # that assume that a user is always valid. A deleted user,
+    # however, can be both attached via foreign key to an object
+    # but not be usable (essentially acts as nil)
     user = create :young_student_with_teacher
 
+    # Delete the user
+    user.destroy!
+
+    # Now try to purge that user
     purger = AccountPurger.new(log: NULL_STREAM)
     purger.purge_data_for_account(user)
+
+    # Ensure that the purger completed
+    assert user.purged_at
   end
 
-  # We can purge a student when they have a family name.
+  # We can purge a student in a section when they have a family name.
   test 'can purge a student account with a family name that is in a section' do
     DCDO.stubs(:get).with('family-name-features', false).returns(true)
     user = create :young_student_with_teacher
 
+    # Delete the user
+    user.destroy!
+
+    # Now try to purge that user
     purger = AccountPurger.new(log: NULL_STREAM)
     purger.purge_data_for_account(user)
+
+    # Ensure that the purger completed
+    assert user.purged_at
   end
 end


### PR DESCRIPTION
In production, our `AccountPurger` queue is failing and backing up thousands of accounts due to a raised error introduced recently with the `family_name` work. The `Follower` model removes the `family_name` of a student that leaves a section, however, the student account does not exist in the account purge flow. It is deleted! Therefore, we need to, at the very least, guard the `student_user` in that method.

This also adds an integration test which will test the simple action of using the `AccountPurger` class without external mocks and adds a test that indeed fails without the fix that interrogates the `family_name` feature.

## Testing story

Manual testing.

In production, the issue was caught as such:

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/b1011d45-d11f-4101-86db-a9b9e0df8a82)

This is reproduced on a development environment and fails after the provided test is invoked:

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/b72c7582-093f-42ce-922f-9cee1bd7ff16)

This test now passes with the proposed fix.

## Follow-up work

As of right now, the queue sits at over 5k affected accounts where only 2 in the queue are __not__ this issue:

```
[production] dashboard > QueuedAccountPurge.where(reason_for_review: "undefined method `family_name' for nil:NilClass").count
=> 5046
[production] dashboard > QueuedAccountPurge.count
=> 5048
```

After the patch, we need to just resolve the purged accounts affected by the bug via this code in the production console:

```
 QueuedAccountPurge.where(reason_for_review: "undefined method `family_name' for nil:NilClass").map(&:resolve!)
```

Which will run them all in order and might take a little bit.

**I will follow up with a slight "revert" to delete the specific integration test that stubs the experiment. I'll leave the general integration test as an admittedly silly "catch" for such raised exceptions caused by on-delete hooks in the future.**

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
