### PR TITLE
Remove not-null constraint on understanding for learning_goal_teacher_evaluations

### DIFF
--- a/dashboard/app/models/learning_goal_teacher_evaluation.rb
+++ b/dashboard/app/models/learning_goal_teacher_evaluation.rb
@@ -8,7 +8,7 @@
 #  learning_goal_id :integer          not null
 #  project_id       :integer
 #  project_version  :string(255)
-#  understanding    :integer          not null
+#  understanding    :integer
 #  feedback         :text(65535)
 #  submitted_at     :datetime
 #  created_at       :datetime         not null

--- a/dashboard/db/migrate/20230927153604_allow_null_understanding_on_learning_goal_teacher_evaluations.rb
+++ b/dashboard/db/migrate/20230927153604_allow_null_understanding_on_learning_goal_teacher_evaluations.rb
@@ -1,0 +1,5 @@
+class AllowNullUnderstandingOnLearningGoalTeacherEvaluations < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :learning_goal_teacher_evaluations, :understanding, true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_21_172627) do
+ActiveRecord::Schema.define(version: 2023_09_27_153604) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -666,7 +666,7 @@ ActiveRecord::Schema.define(version: 2023_09_21_172627) do
     t.integer "learning_goal_id", null: false
     t.integer "project_id"
     t.string "project_version"
-    t.integer "understanding", null: false
+    t.integer "understanding"
     t.text "feedback"
     t.datetime "submitted_at"
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
I realized that we don't have any requirement for a teacher to select an understanding level before writing feedback (or, really, at all), so understanding can reasonably be null for `learning_goal_teacher_evaluations`. This migration removes that null constraint.

I didn't remove it for `learning_goal_ai_evaluations` as it seems like we should have an `understanding` for every row, but I'm happy to remove this constraint for that table as well if folks think that would be best. 