### PR TITLE
updated redactable-markdown version to current

### DIFF
--- a/bin/i18n/package-lock.json
+++ b/bin/i18n/package-lock.json
@@ -5,14 +5,14 @@
   "packages": {
     "": {
       "dependencies": {
-        "@code-dot-org/redactable-markdown": "0.9.1",
+        "@code-dot-org/redactable-markdown": "0.9.3",
         "@code-dot-org/remark-plugins": "^1.3.0"
       }
     },
     "node_modules/@code-dot-org/redactable-markdown": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@code-dot-org/redactable-markdown/-/redactable-markdown-0.9.1.tgz",
-      "integrity": "sha512-DBfl371Yy0lkyBsqn46rT4e92P929Dv4hC+LvCXOMkmv+pd+EZKBRf47jIYEo2qCyX860o5ClCbbKhYeZRDIsg==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@code-dot-org/redactable-markdown/-/redactable-markdown-0.9.3.tgz",
+      "integrity": "sha512-sEZT+0uMT5JZgaKCExeMmH3SOm3mLS113eXlOLkFP4BsIHHQ7nIEYUw5W/R9JDwiTrn8TNAu37bum4Hvhnz9tA==",
       "dependencies": {
         "@code-dot-org/remark-plugins": "1.2.4",
         "minimist": "^1.2.0",
@@ -30,10 +30,6 @@
         "redact": "src/bin/redact.js",
         "render": "src/bin/render.js",
         "restore": "src/bin/restore.js"
-      },
-      "engines": {
-        "node": ">=6.7",
-        "npm": "^3.10.8"
       }
     },
     "node_modules/@code-dot-org/redactable-markdown/node_modules/@code-dot-org/remark-plugins": {

--- a/bin/i18n/package.json
+++ b/bin/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@code-dot-org/redactable-markdown": "0.9.1",
+    "@code-dot-org/redactable-markdown": "0.9.3",
     "@code-dot-org/remark-plugins": "^1.3.0"
   }
 }


### PR DESCRIPTION
Updated redactable-markdown version from 0.9.1 to 0.9.3 (0.9.2 was skipped)

## Links

- jira ticket: [P20-492](https://codedotorg.atlassian.net/browse/P20-492)


## Testing story

Ran the sync-in to test that the pipeline did not break with the upgrade.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
