### PR TITLE
Default Google Drive authentication to Secret Instead of Saved Credentials

### DIFF
--- a/bin/i18n/utils/malformed_i18n_reporter.rb
+++ b/bin/i18n/utils/malformed_i18n_reporter.rb
@@ -21,6 +21,7 @@ module I18n
       # @param locale [String] the BCP 47 (IETF language tag) format (e.g., 'en-US')
       def initialize(locale)
         @locale = locale
+        @google_drive ||= Google::Drive.new
       end
 
       def worksheet_data
@@ -39,7 +40,7 @@ module I18n
       def report
         return if worksheet_data.empty?
 
-        google_drive&.update_worksheet(SPREADSHEET_NAME, locale, [WORKSHEET_HEADERS, *worksheet_data])
+        @google_drive&.update_worksheet(SPREADSHEET_NAME, locale, [WORKSHEET_HEADERS, *worksheet_data])
 
         clear_worksheet_data
       rescue
@@ -47,12 +48,6 @@ module I18n
       end
 
       private
-
-      def google_drive
-        return @google_drive if defined? @google_drive
-
-        @google_drive = CDO.gdrive_export_secret && Google::Drive.new
-      end
 
       def update_worksheet_data(key, file_name, translation)
         worksheet_data << [key, file_name, translation]

--- a/bin/i18n/utils/malformed_i18n_reporter.rb
+++ b/bin/i18n/utils/malformed_i18n_reporter.rb
@@ -51,7 +51,7 @@ module I18n
       def google_drive
         return @google_drive if defined? @google_drive
 
-        @google_drive = CDO.gdrive_export_secret && Google::Drive.new(service_account_key: CDO.gdrive_export_secret)
+        @google_drive = CDO.gdrive_export_secret && Google::Drive.new
       end
 
       def update_worksheet_data(key, file_name, translation)

--- a/lib/cdo/google/drive.rb
+++ b/lib/cdo/google/drive.rb
@@ -39,15 +39,9 @@ module Google
       @session
     end
 
-    def initialize(params = {})
+    def initialize(service_account_key = CDO.gdrive_export_secret.to_json)
       $log&.debug 'Establishing Google Drive session'
-      @session = if params[:service_account_key]
-                   account_key = params[:service_account_key]
-                   account_key = StringIO.new JSON.dump(account_key) unless account_key.is_a?(StringIO)
-                   GoogleDrive::Session.from_service_account_key account_key
-                 else
-                   GoogleDrive.saved_session(deploy_dir('.gdrive_session'))
-                 end
+      @session = GoogleDrive::Session.from_service_account_key StringIO.new(service_account_key)
     end
 
     def file(path)

--- a/lib/cdo/google/sheet.rb
+++ b/lib/cdo/google/sheet.rb
@@ -17,7 +17,7 @@ end
 module Google
   class Sheet
     def initialize(document_key)
-      @drive = Google::Drive.new service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json)
+      @drive = Google::Drive.new
       @document_key = document_key
     end
 

--- a/lib/test/cdo/google/test_drive.rb
+++ b/lib/test/cdo/google/test_drive.rb
@@ -2,13 +2,13 @@ require_relative '../../test_helper'
 require_relative '../../../cdo/google/drive'
 
 describe Google::Drive do
-  let(:google_drive) {Google::Drive.new(service_account_key: service_account_key)}
+  let(:google_drive) {Google::Drive.new(service_account_key)}
 
-  let(:service_account_key) {'expected_service_account_key'}
+  let(:service_account_key) {'expected_service_account_key_json'}
   let(:google_drive_session) {stub}
 
   before do
-    StringIO.stubs(:new).with(JSON.dump(service_account_key)).returns('expected_service_account_key_json_io')
+    StringIO.stubs(:new).with(service_account_key).returns('expected_service_account_key_json_io')
     GoogleDrive::Session.stubs(:from_service_account_key).with('expected_service_account_key_json_io').returns(google_drive_session)
   end
 

--- a/pegasus/rake/seed.rake
+++ b/pegasus/rake/seed.rake
@@ -3,12 +3,7 @@ require lib_dir 'cdo/data/google_sheet_to_csv'
 require lib_dir 'cdo/data/logging/rake_task_event_logger'
 include TimedTaskWithLogging
 
-$gdrive_ = nil
 namespace :seed do
-  def gdrive
-    $gdrive_ ||= Google::Drive.new
-  end
-
   desc 'import any CSV files that were modified since the last import'
   timed_task_with_logging :migrate do
     Dir.glob(pegasus_dir('data/*.csv')) {|i| CsvToSqlTable.new(i, PEGASUS_DB).import}


### PR DESCRIPTION
Default our `Google::Drive` wrapper Class to authenticate to Google using our credentials stored in a Secret and populated in a `CDO` configuration setting instead of conditionally falling back to using session credentials saved on the local file system. Any feature using `Google::Drive` can chose to provide a different (non-default) set of authentication credentials.

We rebuilt the staging server and `bin/cron/import_google_sheets` stopped working because it was relying on credentials that may have been manually saved on the old server. Discussion [here](https://codedotorg.slack.com/archives/C03CK49G9/p1695840531522929).


## Testing story

I haven’t yet updated the tests to account for the new authentication strategy.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
