### PR TITLE
[Google Blockly] CT-112: Remove blockArrangement for levelbuilder categories

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2119,7 +2119,6 @@ StudioApp.prototype.configureDom = function (config) {
       // Modify the arrangement of toolbox blocks so categories align left
       if (config.level.edit_blocks === TOOLBOX_EDIT_MODE) {
         this.blockYCoordinateInterval = 80;
-        config.blockArrangement = {category: {x: 20}};
       }
       // Enable if/else, param & var editing in levelbuilder, regardless of level setting
       config.level.disableIfElseEditing = false;

--- a/apps/src/blockly/addons/cdoSerializationHelpers.js
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.js
@@ -48,7 +48,7 @@ export function addPositionsToState(xmlBlocks, blockIdMap) {
   xmlBlocks.forEach(xmlBlock => {
     const blockJson = blockIdMap.get(xmlBlock.blockly_block.id);
     if (blockJson) {
-      // Do not change values if xmlBlock values are NaN (unspecified in XML)
+      // Note: If xmlBlock values are NaN, they will be ignored and blockJson values will be used
       blockJson.x = xmlBlock.x || blockJson.x;
       blockJson.y = xmlBlock.y || blockJson.y;
     }


### PR DESCRIPTION
The following PR fixes an issue in the edit blocks mode in levelbuilder where the category blocks all render at the coordinates (20, 0). Blocks lose their association with the categories if the toolbox is saved in this mode.

See Slack thread: https://codedotorg.slack.com/archives/C05DK21DAHK/p1695759122857169

Details:
- In toolbox edit mode, we have code to set `config.blockArrangement = {category: {x: 20}}` so that the category blocks are left-aligned at 20 pixels.
- However, our `isBlockLocationUnset` logic gets the block coordinates using `getRelativeToSurfaceXY`, a Blockly method that returns (20, 0) as coordinates instead of returning (20, NaN).
- We determine whether blocks need to be repositioned if their coordinates are (0, 0); since the category blocks have a non-default location, they don't get repositioned.
- Removing the `blockArrangement` config means that these blocks get auto-positioned, along with the other blocks.

Alternate approach:
- If we want to support partial overrides of location, we can modify the `isBlockLocationUnset` logic to check for `NaN` values and update the upstream code to distinguish between "unset"/`NaN` blocks and zeroes (which it does not currently do). I played around with this in a separate branch, but 1) it's a riskier change because it touches lots of block positioning logic, and 2) it may be unintended behavior, based on the original comment [here](https://github.com/code-dot-org/code-dot-org/pull/53982/files#diff-7000343f193913b80bf8722c70bcad99538ccc1bc292753218be9d8730312845L51).

## Links

Ticket: https://codedotorg.atlassian.net/browse/CT-112

## Testing story

Confirmed that this fixes the category issue on a mainline Blockly level.

<img width="892" alt="Screenshot 2023-09-27 at 10 08 07 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/41d38e80-8768-4fdb-8406-cad82a7f8f52">

Navigate to the above by clicking the edit toolbox option on http://localhost-studio.code.org:3000/s/dance/lessons/1/levels/13. 

Also checked the toolbox editing view for the "About Me" level template (not migrated to mainline Blockly yet) and confirmed that this view still renders appropriately.

![Screenshot 2023-09-28 at 1 12 53 PM](https://github.com/code-dot-org/code-dot-org/assets/26844240/5e8d64f9-9bd0-43e0-bbf4-baa4511c432c)

Navigate to the above by clicking through to the template level associated with http://localhost-studio.code.org:3000/s/coursee-2022/lessons/5/levels/5. 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
