### PR TITLE
Initialize Google::Drive directly in i18n:sync Rake task

### DIFF
--- a/pegasus/rake/i18n.rake
+++ b/pegasus/rake/i18n.rake
@@ -39,7 +39,7 @@ namespace :i18n do
   timed_task_with_logging :sync do
     gsheet = 'Data/I18n'
     path = pegasus_dir('cache/i18n/en-US.yml')
-
+    gdrive = Google::Drive.new
     file = gdrive.file(gsheet)
     raise("Google Drive file '#{gsheet}' not found.") unless file
 


### PR DESCRIPTION
Previously, the Pegasus i18n:sync rake task was relying on a global variable to use `Google::Drive` which I removed in #53979 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Manually applying this fix to staging resolves the issue with the unknown variable/method `gdrive`, but the credentials in our Secret don't seem to have permissions to the `Data\I18n` Google Sheet:

```
ubuntu@staging:~/staging/pegasus$ bundle exec rake i18n:sync RAILS_ENV=staging --trace
** Invoke i18n:sync (first_time)
** Execute i18n:sync
GetSecretValue: staging/cdo/gdrive_export_secret
rake aborted!
Google Drive file 'Data/I18n' not found.
/home/ubuntu/staging/pegasus/rake/i18n.rake:44:in `block (2 levels) in <top (required)>'
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
