### PR TITLE
Fix --> Fix Forward i18n reporter and Google Drive

### DIFF
--- a/bin/i18n/utils/malformed_i18n_reporter.rb
+++ b/bin/i18n/utils/malformed_i18n_reporter.rb
@@ -21,7 +21,6 @@ module I18n
       # @param locale [String] the BCP 47 (IETF language tag) format (e.g., 'en-US')
       def initialize(locale)
         @locale = locale
-        @google_drive ||= Google::Drive.new
       end
 
       def worksheet_data
@@ -39,12 +38,11 @@ module I18n
 
       def report
         return if worksheet_data.empty?
-
-        @google_drive&.update_worksheet(SPREADSHEET_NAME, locale, [WORKSHEET_HEADERS, *worksheet_data])
-
+        Google::Drive.new.update_worksheet(SPREADSHEET_NAME, locale, [WORKSHEET_HEADERS, *worksheet_data])
+      rescue StandardError => exception
+        puts "Failed to upload malformed restorations for #{locale} because #{exception.message}"
+      ensure
         clear_worksheet_data
-      rescue
-        puts "Failed to upload malformed restorations for #{locale}"
       end
 
       private

--- a/bin/test/i18n/utils/test_malformed_i18n_reporter.rb
+++ b/bin/test/i18n/utils/test_malformed_i18n_reporter.rb
@@ -82,13 +82,11 @@ describe I18n::Utils::MalformedI18nReporter do
 
   describe '#report' do
     let(:worksheet_data) {[%w[expected_key expected_file_name expected_translation]]}
-    let(:gdrive_export_secret) {'expected_gdrive_export_secret'}
     let(:google_drive) {stub}
 
     before do
       malformed_i18n_reporter.instance_variable_set(:@worksheet_data, worksheet_data)
-      CDO.stubs(:gdrive_export_secret).returns(gdrive_export_secret)
-      Google::Drive.stubs(:new).with(service_account_key: gdrive_export_secret).returns(google_drive)
+      Google::Drive.stubs(:new).returns(google_drive)
     end
 
     it 'updates Google spreadsheet "i18n_bad_translations" with invalid translations sheet data' do
@@ -102,10 +100,12 @@ describe I18n::Utils::MalformedI18nReporter do
     end
 
     context 'when CDO.gdrive_export_secret is not present' do
-      let(:gdrive_export_secret) {nil}
+      CDO.stubs(:gdrive_export_secret).returns(nil)
 
-      it 'does not try to update Google spreadsheet' do
-        Google::Drive.any_instance.expects(:update_worksheet).never
+      it 'does not raise error' do
+        google_drive.expects(:update_worksheet).with(
+          'i18n_bad_translations', locale, [['Key', 'File Name', 'Translation'], *worksheet_data]
+        ).once
 
         malformed_i18n_reporter.report
 

--- a/lib/cdo/google/drive.rb
+++ b/lib/cdo/google/drive.rb
@@ -41,6 +41,7 @@ module Google
 
     def initialize(service_account_key = CDO.gdrive_export_secret.to_json)
       $log&.debug 'Establishing Google Drive session'
+      raise "Google Authentication Key not provided." if service_account_key.nil?
       @session = GoogleDrive::Session.from_service_account_key StringIO.new(service_account_key)
     end
 


### PR DESCRIPTION
With #53979 and #53987 I broke some i18n tests. Explicitly raise an error if the authentication credentials for connecting to Google Drive are not available and rescue those in the i18n malformed reporter.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
