### PR TITLE
Enable Blockly source maps locally

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -310,6 +310,7 @@
     "selectize": "^0.12.4",
     "slate": "^0.81.0",
     "slate-react": "^0.81.0",
+    "source-map-loader": "^4.0.1",
     "stream-browserify": "^3.0.0",
     "survey-react": "^1.9.28",
     "timers-browserify": "^2.0.12",

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -268,6 +268,7 @@ const WEBPACK_BASE_CONFIG = {
         : []),
       ...(process.env.DEV
         ? [
+            // Enable source maps locally for Blockly for easier debugging.
             {
               test: /(blockly\/.*\.js)$/,
               use: ['source-map-loader'],
@@ -278,8 +279,8 @@ const WEBPACK_BASE_CONFIG = {
     ],
     noParse: [/html2canvas/],
   },
-  // Ignore spurious warnings from source-map-loader
-  // It can't find source maps for some Closure modules and that is expected
+  // Ignore spurious warnings from source-map-loader.
+  // It can't find source maps for some Closure modules in Blockly and that is expected.
   ignoreWarnings: [/Failed to parse source map/],
 };
 

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -97,7 +97,7 @@ function devtool({minify} = {}) {
   } else if (process.env.DEBUG_MINIFIED) {
     return 'eval-source-map';
   } else if (process.env.DEV) {
-    return 'eval-cheap-module-source-map';
+    return 'eval';
   } else {
     return 'inline-source-map';
   }
@@ -266,11 +266,13 @@ const WEBPACK_BASE_CONFIG = {
             },
           ]
         : []),
-      process.env.DEV && {
-        test: /(blockly\/.*\.js)$/,
-        use: ['source-map-loader'],
-        enforce: 'pre',
-      },
+      process.env.DEV
+        ? {
+            test: /(blockly\/.*\.js)$/,
+            use: ['source-map-loader'],
+            enforce: 'pre',
+          }
+        : {},
     ],
     noParse: [/html2canvas/],
   },

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -97,7 +97,7 @@ function devtool({minify} = {}) {
   } else if (process.env.DEBUG_MINIFIED) {
     return 'eval-source-map';
   } else if (process.env.DEV) {
-    return 'eval';
+    return 'eval-source-map';
   } else {
     return 'inline-source-map';
   }
@@ -266,13 +266,15 @@ const WEBPACK_BASE_CONFIG = {
             },
           ]
         : []),
-      process.env.DEV
-        ? {
-            test: /(blockly\/.*\.js)$/,
-            use: ['source-map-loader'],
-            enforce: 'pre',
-          }
-        : {},
+      ...(process.env.DEV
+        ? [
+            {
+              test: /(blockly\/.*\.js)$/,
+              use: ['source-map-loader'],
+              enforce: 'pre',
+            },
+          ]
+        : []),
     ],
     noParse: [/html2canvas/],
   },

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -266,9 +266,17 @@ const WEBPACK_BASE_CONFIG = {
             },
           ]
         : []),
+      process.env.DEV && {
+        test: /(blockly\/.*\.js)$/,
+        use: ['source-map-loader'],
+        enforce: 'pre',
+      },
     ],
     noParse: [/html2canvas/],
   },
+  // Ignore spurious warnings from source-map-loader
+  // It can't find source maps for some Closure modules and that is expected
+  ignoreWarnings: [/Failed to parse source map/],
 };
 
 // FIXME: figure out how to re-enable hot reloading with

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -97,7 +97,7 @@ function devtool({minify} = {}) {
   } else if (process.env.DEBUG_MINIFIED) {
     return 'eval-source-map';
   } else if (process.env.DEV) {
-    return 'inline-cheap-source-map';
+    return 'eval-cheap-module-source-map';
   } else {
     return 'inline-source-map';
   }

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -10833,7 +10833,7 @@ iconv-lite@0.4.24, iconv-lite@~0.4.13:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.6.3:
+iconv-lite@0.6.3, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -17594,6 +17594,15 @@ source-list-map@^2.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
+source-map-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-4.0.1.tgz#72f00d05f5d1f90f80974eda781cbd7107c125f2"
+  integrity sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==
+  dependencies:
+    abab "^2.0.6"
+    iconv-lite "^0.6.3"
+    source-map-js "^1.0.2"
 
 source-map-resolve@^0.5.0:
   version "0.5.1"


### PR DESCRIPTION
Enable Blockly source maps locally. This requires using the `source-map-loader` package, and changing our local `devtool` to `eval-source-map`. In my single test, `yarn start` with our previous setting `inline-cheap-source-map` took my machine 66 seconds, whereas `eval-source-map` took 61 seconds, so this should not slow things down.

My local build still works (and now blockly source maps work), and drone passed. Since these changes should only impact local builds I think it is safe, let me know if there is other testing needed here.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
