### PR TITLE
add config params for teaching assistant to access openai api

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -595,3 +595,5 @@ ec2_instance_id_endpoint: 'http://169.254.169.254/latest/meta-data/instance-id'
 # Credentials for OpenAI API
 openai_chat_completion_api_key: !Secret
 openai_chat_completion_org_id: !Secret
+openai_teaching_assistant_api_key:
+openai_teaching_assistant_org_id:

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -595,5 +595,5 @@ ec2_instance_id_endpoint: 'http://169.254.169.254/latest/meta-data/instance-id'
 # Credentials for OpenAI API
 openai_chat_completion_api_key: !Secret
 openai_chat_completion_org_id: !Secret
-openai_teaching_assistant_api_key:
-openai_teaching_assistant_org_id:
+openai_evaluate_rubric_api_key:
+openai_evaluate_rubric_org_id:


### PR DESCRIPTION
small PR to add config params for teaching assistant to access the openai api. a couple of things to note:
* per [productionize Rubric AI proposal](https://docs.google.com/document/d/1uttsY8qFzq_untRpSnvGYTvi7HLhMTNSKA7j39f0v-8/edit), we are using separate API keys for teaching assistant and chat completion / ai tutor, which is why I'm not reusing the existing keys
* I'm putting this out as it's own tiny PR to mitigate the issue where dashboard server complains when you switch branches if you have a key set in locals.yml that's not defined in config.yml.erb, and because the follow-up PR which actually uses these keys will likely be used only on adhoc for some time before it is merged to staging
* I am not using `!Secret` yet because we have not chosen an API key to add into secrets manager yet, so for now it will be set only in locals.yml
