### PR TITLE
Create Deployment Worktree with Chef

### DIFF
--- a/cookbooks/cdo-github-access/recipes/default.rb
+++ b/cookbooks/cdo-github-access/recipes/default.rb
@@ -38,18 +38,3 @@ end
     not_if {node['cdo-github-access'][file] == ''}
   end
 end
-
-# The staging server requires a special worktree at a hardcoded location in
-# order to successfully run the `deploy_to_levelbuilder` and
-# `merge_lb_to_staging` scripts.
-# TODO: remove the or case once I've verified this functionality
-if node.chef_environment == 'staging' || node.chef_environment == 'adhoc'
-  worktree_path = File.join(node[:home], 'deploy-management-repo')
-  execute 'create worktree for managing deployment scripts' do
-    command "git worktree add #{worktree_path}"
-    cwd File.join(node[:home], node.chef_environment)
-    user node[:current_user]
-    group node[:current_user]
-    not_if {File.exist? worktree_path}
-  end
-end

--- a/cookbooks/cdo-github-access/recipes/default.rb
+++ b/cookbooks/cdo-github-access/recipes/default.rb
@@ -38,3 +38,18 @@ end
     not_if {node['cdo-github-access'][file] == ''}
   end
 end
+
+# The staging server requires a special worktree at a hardcoded location in
+# order to successfully run the `deploy_to_levelbuilder` and
+# `merge_lb_to_staging` scripts.
+# TODO: remove the or case once I've verified this functionality
+if node.chef_environment == 'staging' || node.chef_environment == 'adhoc'
+  worktree_path = File.join(node[:home], 'deploy-management-repo')
+  execute 'create worktree for managing deployment scripts' do
+    command "git worktree add #{worktree_path}"
+    cwd File.join(node[:home], node.chef_environment)
+    user node[:current_user]
+    group node[:current_user]
+    not_if {File.exist? worktree_path}
+  end
+end

--- a/cookbooks/cdo-repository/recipes/default.rb
+++ b/cookbooks/cdo-repository/recipes/default.rb
@@ -50,8 +50,7 @@ end
 # The staging server requires a special worktree at a hardcoded location in
 # order to successfully run the `deploy_to_levelbuilder` and
 # `merge_lb_to_staging` scripts.
-# TODO: remove the or case once I've verified this functionality
-if node.chef_environment == 'staging' || node.chef_environment == 'adhoc'
+if node.chef_environment == 'staging'
   worktree_path = File.join(home_path, 'deploy-management-repo')
 
   execute 'create worktree for managing deployment scripts' do

--- a/cookbooks/cdo-repository/recipes/default.rb
+++ b/cookbooks/cdo-repository/recipes/default.rb
@@ -57,8 +57,8 @@ if node.chef_environment == 'staging' || node.chef_environment == 'adhoc'
   execute 'create worktree for managing deployment scripts' do
     command "git worktree add #{worktree_path}"
     cwd git_path
-    user node[:current_user]
-    group node[:current_user]
+    user node[:user]
+    group node[:user]
     not_if {File.exist? worktree_path}
   end
 end

--- a/cookbooks/cdo-repository/recipes/default.rb
+++ b/cookbooks/cdo-repository/recipes/default.rb
@@ -46,3 +46,19 @@ git git_path do
   user node[:user]
   group node[:user]
 end
+
+# The staging server requires a special worktree at a hardcoded location in
+# order to successfully run the `deploy_to_levelbuilder` and
+# `merge_lb_to_staging` scripts.
+# TODO: remove the or case once I've verified this functionality
+if node.chef_environment == 'staging' || node.chef_environment == 'adhoc'
+  worktree_path = File.join(home_path, 'deploy-management-repo')
+
+  execute 'create worktree for managing deployment scripts' do
+    command "git worktree add #{worktree_path}"
+    cwd git_path
+    user node[:current_user]
+    group node[:current_user]
+    not_if {File.exist? worktree_path}
+  end
+end


### PR DESCRIPTION
Add chef functionality for creating the worktree which is required on staging for our deployment scripts to run

## Links

See https://github.com/code-dot-org/code-dot-org/pull/45823 for more context

## Testing story

Tested on an adhoc that the worktree will be created on a new server, will not be recreated if it already exists, and can be created on an existing server.

## Deployment strategy 

The staging server currently has a manually-created worktree, which this code change should recognize and leave alone. This code change is mostly future-proofing us against having to recreate the staging server again someday.