### PR TITLE
Do not show Try Now button for Units with no Levels

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -25,6 +25,8 @@ import EndOfLessonDialog from '@cdo/apps/templates/EndOfLessonDialog';
 import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {unitHasLevels} from '@cdo/apps/templates/progress/progressHelpers';
+import {lessonShape} from '@cdo/apps/templates/lessonOverview/lessonPlanShapes';
 
 /**
  * Lesson progress component used in level header and script overview.
@@ -49,6 +51,7 @@ class UnitOverview extends React.Component {
     showAssignButton: PropTypes.bool,
     assignedSectionId: PropTypes.number,
     unitCalendarLessons: PropTypes.arrayOf(unitCalendarLesson),
+    unitLessons: PropTypes.arrayOf(lessonShape),
     weeklyInstructionalMinutes: PropTypes.number,
     showCalendar: PropTypes.bool,
     isMigrated: PropTypes.bool,
@@ -118,6 +121,7 @@ class UnitOverview extends React.Component {
       showCalendar,
       weeklyInstructionalMinutes,
       unitCalendarLessons,
+      unitLessons,
       isMigrated,
       scriptOverviewPdfUrl,
       scriptResourcesPdfUrl,
@@ -203,6 +207,7 @@ class UnitOverview extends React.Component {
             courseLink={this.props.courseLink}
             publishedState={publishedState}
             participantAudience={participantAudience}
+            isUnitWithLevels={unitHasLevels(unitLessons)}
           />
         </div>
         <ProgressTable minimal={false} />

--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -25,8 +25,6 @@ import EndOfLessonDialog from '@cdo/apps/templates/EndOfLessonDialog';
 import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
-import {unitHasLevels} from '@cdo/apps/templates/progress/progressHelpers';
-import {lessonShape} from '@cdo/apps/templates/lessonOverview/lessonPlanShapes';
 
 /**
  * Lesson progress component used in level header and script overview.
@@ -51,7 +49,7 @@ class UnitOverview extends React.Component {
     showAssignButton: PropTypes.bool,
     assignedSectionId: PropTypes.number,
     unitCalendarLessons: PropTypes.arrayOf(unitCalendarLesson),
-    unitLessons: PropTypes.arrayOf(lessonShape),
+    unitHasLevels: PropTypes.bool,
     weeklyInstructionalMinutes: PropTypes.number,
     showCalendar: PropTypes.bool,
     isMigrated: PropTypes.bool,
@@ -121,7 +119,7 @@ class UnitOverview extends React.Component {
       showCalendar,
       weeklyInstructionalMinutes,
       unitCalendarLessons,
-      unitLessons,
+      unitHasLevels,
       isMigrated,
       scriptOverviewPdfUrl,
       scriptResourcesPdfUrl,
@@ -207,7 +205,7 @@ class UnitOverview extends React.Component {
             courseLink={this.props.courseLink}
             publishedState={publishedState}
             participantAudience={participantAudience}
-            isUnitWithLevels={unitHasLevels(unitLessons)}
+            isUnitWithLevels={unitHasLevels}
           />
         </div>
         <ProgressTable minimal={false} />

--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -49,6 +49,7 @@ class UnitOverviewTopRow extends React.Component {
     publishedState: PropTypes.oneOf(Object.values(PublishedState)),
     courseLink: PropTypes.string,
     participantAudience: PropTypes.string,
+    isUnitWithLevels: PropTypes.bool,
 
     // redux provided
     sectionsForDropdown: PropTypes.arrayOf(sectionForDropdownShape).isRequired,
@@ -142,6 +143,7 @@ class UnitOverviewTopRow extends React.Component {
       isProfessionalLearningCourse,
       publishedState,
       participantAudience,
+      isUnitWithLevels,
     } = this.props;
 
     const pdfDropdownOptions = this.compilePdfDropdownOptions();
@@ -175,7 +177,7 @@ class UnitOverviewTopRow extends React.Component {
       <div style={styles.buttonRow} className="unit-overview-top-row">
         {!deeperLearningCourse && viewAs === ViewType.Participant && (
           <div style={styles.buttonsInRow}>
-            {!completedProfessionalLearningCourse && (
+            {!completedProfessionalLearningCourse && isUnitWithLevels && (
               <Button
                 __useDeprecatedTag
                 href={`/s/${scriptName}/next`}

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -97,8 +97,10 @@ function initPage() {
   // rendered on this page
   updateQueryParam('completedLessonNumber', undefined);
 
-  const unitHasLevels =
-    scriptData.lessons.reduce((n, {levels}) => n + levels.length, 0) > 0;
+  const unitHasLevels = scriptData.lessons.reduce(
+    (n, {levels}) => n || !!levels?.length,
+    false
+  );
 
   ReactDOM.render(
     <Provider store={store}>

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -125,6 +125,7 @@ function initPage() {
         showCalendar={scriptData.showCalendar}
         weeklyInstructionalMinutes={scriptData.weeklyInstructionalMinutes}
         unitCalendarLessons={scriptData.calendarLessons}
+        unitLessons={scriptData.lessons}
         isMigrated={scriptData.is_migrated}
         scriptOverviewPdfUrl={scriptData.scriptOverviewPdfUrl}
         scriptResourcesPdfUrl={scriptData.scriptResourcesPdfUrl}

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -97,6 +97,9 @@ function initPage() {
   // rendered on this page
   updateQueryParam('completedLessonNumber', undefined);
 
+  const unitHasLevels =
+    scriptData.lessons.reduce((n, {levels}) => n + levels.length, 0) > 0;
+
   ReactDOM.render(
     <Provider store={store}>
       <UnitOverview
@@ -125,7 +128,7 @@ function initPage() {
         showCalendar={scriptData.showCalendar}
         weeklyInstructionalMinutes={scriptData.weeklyInstructionalMinutes}
         unitCalendarLessons={scriptData.calendarLessons}
-        unitLessons={scriptData.lessons}
+        unitHasLevels={unitHasLevels}
         isMigrated={scriptData.is_migrated}
         scriptOverviewPdfUrl={scriptData.scriptOverviewPdfUrl}
         scriptResourcesPdfUrl={scriptData.scriptResourcesPdfUrl}

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -157,20 +157,6 @@ export function lessonHasLevels(lesson) {
 }
 
 /**
- * Checks if there are any levels in the unit
- * @param {array} list of lessons
- * @returns {bool} if the unit has any levels
- */
-export function unitHasLevels(lessons) {
-  lessons.forEach(lesson => {
-    if (lessonHasLevels(lesson)) {
-      return true;
-    }
-  });
-  return false;
-}
-
-/**
  * Determines if we should show "Keep working" and "Needs review" states for
  * progress in a unit. Unit must be either CSD or CSP.
  */

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -157,6 +157,20 @@ export function lessonHasLevels(lesson) {
 }
 
 /**
+ * Checks if there are any levels in the unit
+ * @param {array} list of lessons
+ * @returns {bool} if the unit has any levels
+ */
+export function unitHasLevels(lessons) {
+  lessons.forEach(lesson => {
+    if (lessonHasLevels(lesson)) {
+      return true;
+    }
+  });
+  return false;
+}
+
+/**
  * Determines if we should show "Keep working" and "Needs review" states for
  * progress in a unit. Unit must be either CSD or CSP.
  */

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
@@ -28,6 +28,7 @@ const defaultProps = {
   hasPerLevelResults: false,
   isProfessionalLearningCourse: false,
   publishedState: 'stable',
+  isUnitWithLevels: true,
 };
 
 describe('UnitOverviewTopRow', () => {
@@ -68,6 +69,23 @@ describe('UnitOverviewTopRow', () => {
         </div>
       )
     ).to.be.true;
+  });
+
+  it('does not render "Try Now" if unit has no levels', () => {
+    const wrapper = shallow(
+      <UnitOverviewTopRow {...defaultProps} isUnitWithLevels={false} />
+    );
+
+    expect(
+      wrapper.containsMatchingElement(
+        <Button
+          __useDeprecatedTag
+          href="/s/test-script/next"
+          text={i18n.tryNow()}
+          size={Button.ButtonSize.large}
+        />
+      )
+    ).to.be.false;
   });
 
   it('renders "Continue" for participant if has level results and not unitCompleted', () => {


### PR DESCRIPTION
Adds a quick function to calculate the level count in a unit and not render the 'Try Now' button if there are 0 levels. This will fix the issue for the AI Ethics unit as well as any other unit that has had this issue in the past. Here is what it looks like without that button:

<img width="838" alt="Screenshot 2023-09-28 at 4 36 06 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/b63f985e-49b1-4c83-9f72-6b121a72c515">

And here is what it looks like before/live on prod. The try now button currently links to a sadbee:
<img width="1005" alt="Screenshot 2023-09-29 at 9 44 16 AM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/cba330c3-9931-44bc-9ee4-681af084a7ad">

## Links


- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-675

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
