### PR TITLE
Remove 3rd party links from PL pages

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -254,11 +254,7 @@ class RegionalPartnerSearch extends Component {
               </p>
               <p>
                 All of our curriculum, tools, and courses are also available for
-                your school at no cost. Or,{' '}
-                <a href="/educate/curriculum/3rd-party">
-                  contact one of these computer science providers
-                </a>{' '}
-                for other Professional Development options in your area.
+                your school at no cost.
               </p>
               {this.shouldDisplayApplicationLink() && (
                 <StartApplicationButton

--- a/dashboard/app/views/pd/regional_partner_mini_contact_mailer/receipt.html.haml
+++ b/dashboard/app/views/pd/regional_partner_mini_contact_mailer/receipt.html.haml
@@ -17,8 +17,7 @@
   %p
     In the meantime, take a look
     = link_to 'here for the K-12 Code.org curriculum options', CDO.studio_url('/courses', CDO.default_scheme)
-    available for no cost to all schools, or check out our list of
-    = link_to 'third-party computer science resources.', CDO.code_org_url('/educate/curriculum/3rd-party', CDO.default_scheme)
+    available for no cost to all schools.
 
 - recipient_alias = @regional_partner ? 'your Regional Partner' : 'Code.org'
 %p= "Below is a confirmation of the information you sent to #{recipient_alias}:"

--- a/pegasus/sites.v3/code.org/public/professional-development-workshops/index.md.erb
+++ b/pegasus/sites.v3/code.org/public/professional-development-workshops/index.md.erb
@@ -144,8 +144,4 @@ If you’d like to set up a private workshop and you’re in the U.S., contact y
 
 Unfortunately, we do not currently offer professional development workshops outside of the U.S. If you are outside of the U.S., or you are a U.S. teacher but cannot attend a workshop, you can take a look at our [our self-paced online modules](/educate/professional-development-online) to get started at no cost. And, the curriculum, lesson plans, tools, and support are also available at no cost worldwide. [Join our forums](https://forum.code.org/) to connect with other teachers for support, teaching tips, and best practices.
 
-## Recommended courses from 3rd parties
-
-If you want to go even further with your students, or you're looking for other options, check out our [recommended third party resources](https://code.org/educate/curriculum/3rd-party) for additional courses in programming, game design, and more!
-
 <%= view :answerdash %>


### PR DESCRIPTION
We want to keep people looking at our resources when they go looking for professional learning opportunities otherwise they leave our funnels. This PR removes some links to the 3rd party resources page on pages we rely on for PL conversion. 