### PR TITLE
Delete button on Curriculum Writer Rubrics works

### DIFF
--- a/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
@@ -188,7 +188,7 @@ export default function RubricsContainer({
           <RubricEditor
             learningGoalList={learningGoalList}
             addNewConcept={addNewConceptHandler}
-            deleteItem={deleteLearningGoal}
+            deleteLearningGoal={deleteLearningGoal}
             updateLearningGoal={updateLearningGoal}
           />
           <div style={styles.bottomRow}>

--- a/apps/test/unit/lib/levelbuilder/rubrics/RubricsContainerTest.js
+++ b/apps/test/unit/lib/levelbuilder/rubrics/RubricsContainerTest.js
@@ -4,6 +4,7 @@ import {expect} from '../../../../util/reconfiguredChai';
 import RubricsContainer from '@cdo/apps/lib/levelbuilder/rubrics/RubricsContainer';
 import * as rubricHelper from '@cdo/apps/lib/levelbuilder/rubrics/rubricHelper';
 import LearningGoalItem from '@cdo/apps/lib/levelbuilder/rubrics/LearningGoalItem';
+import RubricEditor from '@cdo/apps/lib/levelbuilder/rubrics/RubricEditor';
 import Button from '@cdo/apps/templates/Button';
 import {RubricUnderstandingLevels} from '@cdo/apps/util/sharedConstants';
 import sinon from 'sinon';
@@ -88,6 +89,8 @@ describe('RubricsContainerTest', () => {
     expect(wrapper.find('select#rubric_level_id option')).to.have.length(
       defaultProps.submittableLevels.length
     );
+    expect(wrapper.find(RubricEditor)).to.have.length(1);
+    expect(wrapper.find('Button[text="Delete key concept"]')).to.have.length(1);
     expect(wrapper.find(LearningGoalItem)).to.have.length(1);
     expect(wrapper.find('Button[text="Save your rubric"]')).to.have.length(1);
   });
@@ -115,6 +118,18 @@ describe('RubricsContainerTest', () => {
     addButton.simulate('click');
     const afterAddLearningGoalItems = wrapper.find('LearningGoalItem').length;
     expect(afterAddLearningGoalItems).to.equal(initialLearningGoalItems + 1);
+  });
+
+  it('adds a deletes learning goal on "Delete Key Concept" button click', () => {
+    const wrapper = mount(<RubricsContainer {...defaultProps} />);
+    const initialLearningGoalItems = wrapper.find('LearningGoalItem').length;
+    const deleteButton = wrapper
+      .find(Button)
+      .findWhere(n => n.props().text === 'Delete key concept');
+    expect(deleteButton).to.have.length(1);
+    deleteButton.simulate('click');
+    const afterAddDeletingGoalItems = wrapper.find('LearningGoalItem').length;
+    expect(afterAddDeletingGoalItems).to.equal(initialLearningGoalItems - 1);
   });
 
   it('changes the selected level for assessment when the dropdown is changed', () => {


### PR DESCRIPTION
Somewhere along the way the "Delete Key Concept" button stopped working.  I fixed that and added a test to catch it in the future. 

<img width="889" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/d0077c84-ea45-4af6-a670-027d7f27d480">


## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?selectedIssue=AITT-208)

## Testing story

- Added a test