### PR TITLE
Create ProgramExecutor for integrating Lab2 dance with native Dance API

### DIFF
--- a/apps/src/assetManagement/assetPrefix.js
+++ b/apps/src/assetManagement/assetPrefix.js
@@ -89,7 +89,7 @@ export function fixPath(filename) {
   // image contains 'image://' in its filenmae.
   // We want to strip this starter asset prefix from the filename so that the correct
   // image file path is returned.
-  if (!state.pageConstants.isCurriculumLevel) {
+  if (!state.pageConstants?.isCurriculumLevel) {
     filename = filename.replace(STARTER_ASSET_PREFIX, '');
   }
   if (STARTER_ASSET_PREFIX_REGEX.test(filename)) {

--- a/apps/src/dance/lab2/ProgramExecutor.ts
+++ b/apps/src/dance/lab2/ProgramExecutor.ts
@@ -1,0 +1,219 @@
+import CustomMarshalingInterpreter from '@cdo/apps/lib/tools/jsinterpreter/CustomMarshalingInterpreter';
+import {SongMetadata} from '../types';
+import {commands as audioCommands} from '@cdo/apps/lib/util/audioApi';
+import * as danceMsg from '../locale';
+import Sounds from '@cdo/apps/Sounds';
+import {ASSET_BASE} from '../constants';
+import Lab2MetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
+import utils from '../utils';
+
+// TODO: The Dance Party repo currently does not export types, so we need
+// use require() to import these components. We should add declaration files
+// to the Dance Party repo and switch to using import statements.
+const DanceParty = require('@code-dot-org/dance-party/src/p5.dance');
+const DanceAPI = require('@code-dot-org/dance-party/src/api');
+const ResourceLoader = require('@code-dot-org/dance-party/src/ResourceLoader');
+const danceCode = require('@code-dot-org/dance-party/src/p5.dance.interpreted.js');
+
+type HookName = 'runUserSetup' | 'runUserEvents' | 'getCueList';
+type Handler = {code: string; args?: string[]};
+const allEvents: {[name in HookName]: Handler} = {
+  runUserSetup: {code: 'runUserSetup();'},
+  runUserEvents: {code: 'runUserEvents(events);', args: ['events']},
+  getCueList: {code: 'return getCueList();'},
+};
+
+/**
+ * Handles program execution for Dance Party and wraps the native Dance Party API.
+ *
+ * TODO: Currently only used by Lab2 Dance. Can we share with Dance.js?
+ */
+export default class ProgramExecutor {
+  private readonly nativeAPI: typeof DanceParty;
+  private hooks: {[name in HookName]?: (args?: unknown[]) => unknown};
+  private validationCode?: string;
+  private onEventsChanged?: () => void;
+
+  constructor(
+    container: string,
+    onPuzzleComplete: (result: boolean, message: string) => void,
+    isReadOnlyWorkspace: boolean,
+    recordReplayLog: boolean,
+    customHelperLibrary?: string,
+    validationCode?: string,
+    onEventsChanged?: () => void,
+    nativeAPI: typeof DanceParty = undefined // For testing
+  ) {
+    this.hooks = {};
+    this.nativeAPI =
+      nativeAPI ||
+      new DanceParty({
+        onPuzzleComplete,
+        playSound: this.playSong,
+        recordReplayLog,
+        showMeasureLabel: !isReadOnlyWorkspace,
+        onHandleEvents: (currentFrameEvents: object[]) =>
+          this.handleEvents(currentFrameEvents),
+        onInit: async (nativeAPI: typeof DanceParty) => {
+          this.init(nativeAPI, isReadOnlyWorkspace);
+        },
+        spriteConfig: new Function('World', customHelperLibrary || ''),
+        container,
+        i18n: danceMsg,
+        resourceLoader: new ResourceLoader(ASSET_BASE),
+      });
+    this.validationCode = validationCode;
+    this.onEventsChanged = onEventsChanged;
+  }
+
+  /**
+   * Execute the program. Compiles student code and hands off to the native API to run.
+   */
+  async execute(songMetadata: SongMetadata) {
+    // TODO: Dance.js checks for unwanted top blocks and duplicate variables in for loops
+    // before executing. We should do something similar here.
+
+    this.hooks = await this.compileAllCode(this.getCode());
+    if (!this.hooks.runUserSetup || !this.hooks.getCueList) {
+      Lab2MetricsReporter.logWarning('Missing required hooks in compiled code');
+      return;
+    }
+
+    this.hooks.runUserSetup();
+    const timestamps = this.hooks.getCueList();
+    this.nativeAPI.addCues(timestamps);
+
+    if (this.validationCode) {
+      this.nativeAPI.registerValidation(
+        utils.getValidationCallback(this.validationCode)
+      );
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      this.nativeAPI.play(songMetadata, (success: boolean) => {
+        success ? resolve() : reject();
+      });
+    });
+  }
+
+  /**
+   * Preview the program. Compiles student code and calls on the native API to draw the first frame.
+   */
+  async preview() {
+    this.reset();
+    this.hooks = await this.preloadSpritesAndCompileCode(
+      this.getCode(),
+      'runUserSetup'
+    );
+
+    if (!this.hooks.runUserSetup) {
+      Lab2MetricsReporter.logWarning('Missing required hook in compiled code');
+      return;
+    }
+
+    this.hooks.runUserSetup();
+    this.nativeAPI.p5_.draw();
+  }
+
+  reset() {
+    Sounds.getSingleton().stopAllAudio();
+    this.nativeAPI.reset();
+  }
+
+  getReplayLog() {
+    return this.nativeAPI.getReplayLog();
+  }
+
+  destroy() {
+    this.nativeAPI.teardown();
+  }
+
+  private async compileAllCode(studentCode: string) {
+    return this.preloadSpritesAndCompileCode(
+      studentCode,
+      'runUserSetup',
+      'getCueList',
+      'runUserEvents'
+    );
+  }
+
+  /**
+   * Prepares student code for execution. Preloads any sprites referenced in the code
+   * and compiles the program.
+   *
+   * @param code student code
+   * @param eventNames events to generate hooks for
+   * @returns Generated hooks for the compiled code.
+   */
+  private async preloadSpritesAndCompileCode(
+    code: string,
+    ...eventNames: HookName[]
+  ) {
+    const charactersReferenced = utils.computeCharactersReferenced(code);
+    await this.nativeAPI.ensureSpritesAreLoaded(charactersReferenced);
+
+    const events: {[event in HookName]?: Handler} = {};
+    eventNames.forEach(name => {
+      events[name] = allEvents[name];
+    });
+
+    const nativeAPI = this.nativeAPI;
+    const api = new DanceAPI(nativeAPI);
+
+    const fullCode = danceCode + code;
+
+    const hooks: {[name: string]: (args?: unknown[]) => unknown} = {};
+
+    CustomMarshalingInterpreter.evalWithEvents(
+      api,
+      events,
+      fullCode,
+      undefined
+    ).hooks.forEach(hook => {
+      hooks[hook.name] = hook.func as () => unknown;
+    });
+
+    return hooks;
+  }
+
+  // Temporary test code. TODO: Replace with code from Blockly workspace.
+  private getCode(): string {
+    return 'whenSetup(function () {\n  setBackgroundEffectWithPalette("kaleidoscope", "electronic");\n  setForegroundEffectExtended("raining_tacos");\n  makeNewDanceSpriteGroup(12, "ALIEN", "circle");\n  makeAnonymousDanceSprite("CAT", {x: 200, y: 200});\n});\n\natTimestamp(4, "measures", function () {\n  setBackgroundEffectWithPalette("disco_ball", "neon");\n  setForegroundEffectExtended("color_lights");\n  changeMoveEachLR(sprites, MOVES.Drop, -1);\n});\n';
+  }
+
+  private async init(
+    nativeAPI: typeof DanceParty,
+    isReadOnlyWorkspace: boolean
+  ) {
+    if (isReadOnlyWorkspace) {
+      // In the share scenario, we call ensureSpritesAreLoaded() early since the
+      // student code can't change. This way, we can start fetching assets while
+      // waiting for the user to press the Run button.
+      const charactersReferenced = utils.computeCharactersReferenced(
+        this.getCode()
+      );
+      await nativeAPI.ensureSpritesAreLoaded(charactersReferenced);
+    }
+  }
+
+  private handleEvents(currentFrameEvents: object[]) {
+    if (!this.hooks.runUserEvents) {
+      Lab2MetricsReporter.logWarning('Missing required hook in compiled code');
+      return;
+    }
+    this.hooks.runUserEvents(currentFrameEvents);
+    this.onEventsChanged?.();
+  }
+
+  private playSong(
+    url: string,
+    callback: (playSuccess: boolean) => void,
+    onEnded: () => void
+  ) {
+    audioCommands.playSound({
+      url: url,
+      callback: callback,
+      onEnded,
+    });
+  }
+}

--- a/apps/test/unit/dance/lab2/ProgramExecutorTest.ts
+++ b/apps/test/unit/dance/lab2/ProgramExecutorTest.ts
@@ -1,0 +1,158 @@
+import ProgramExecutor from '@cdo/apps/dance/lab2/ProgramExecutor';
+import {SongMetadata} from '@cdo/apps/dance/types';
+import utils from '@cdo/apps/dance/utils';
+import CustomMarshalingInterpreter from '@cdo/apps/lib/tools/jsinterpreter/CustomMarshalingInterpreter';
+import {StubFunction} from 'test/types/types';
+import {expect} from '../../../util/reconfiguredChai';
+import * as sinon from 'sinon';
+
+const DanceParty = require('@code-dot-org/dance-party/src/p5.dance');
+
+describe('ProgramExecutor', () => {
+  let nativeAPI: typeof DanceParty,
+    validationCode: string,
+    onEventsChanged,
+    evalWithEvents: StubFunction<
+      typeof CustomMarshalingInterpreter.evalWithEvents
+    >,
+    computeCharactersReferenced: StubFunction<
+      typeof utils.computeCharactersReferenced
+    >,
+    getValidationCallback: StubFunction<typeof utils.getValidationCallback>,
+    validationFunction: StubFunction<() => void>,
+    runUserSetup: StubFunction<() => void>,
+    getCueList: StubFunction<() => number[]>,
+    runUserEvents: StubFunction<() => void>,
+    currentSongMetadata: SongMetadata,
+    characters: string[],
+    timestamps: number[],
+    programExecutor: ProgramExecutor;
+
+  beforeEach(() => {
+    nativeAPI = {
+      addCues: sinon.stub(),
+      registerValidation: sinon.stub(),
+      play: sinon.stub().callsFake((songMetadata, callback) => {
+        // Automatically call the callback with success so the promise resolves.
+        callback(true);
+      }),
+      reset: sinon.stub(),
+      getReplayLog: sinon.stub(),
+      teardown: sinon.stub(),
+      ensureSpritesAreLoaded: sinon.stub(),
+      p5_: {
+        draw: sinon.stub(),
+      },
+    };
+
+    validationCode = 'validationCode';
+    onEventsChanged = sinon.stub();
+    evalWithEvents = sinon.stub(CustomMarshalingInterpreter, 'evalWithEvents');
+    getValidationCallback = sinon.stub(utils, 'getValidationCallback');
+    computeCharactersReferenced = sinon.stub(
+      utils,
+      'computeCharactersReferenced'
+    );
+    runUserSetup = sinon.stub();
+    getCueList = sinon.stub();
+    runUserEvents = sinon.stub();
+    currentSongMetadata = {
+      analysis: [],
+      artist: '',
+      bpm: '',
+      delay: '',
+      duration: 1,
+      file: '',
+      title: '',
+      peaks: {},
+    };
+
+    characters = ['character1', 'character2'];
+    computeCharactersReferenced.returns(characters);
+
+    timestamps = [1, 2, 3];
+    getCueList.returns(timestamps);
+
+    validationFunction = sinon.stub();
+    getValidationCallback.returns(validationFunction);
+
+    programExecutor = new ProgramExecutor(
+      'container',
+      () => undefined,
+      false,
+      false,
+      undefined,
+      validationCode,
+      onEventsChanged,
+      nativeAPI
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('compiles all code and calls native API on execute', async () => {
+    const expectedHooks = [
+      {name: 'runUserSetup', func: runUserSetup},
+      {name: 'getCueList', func: getCueList},
+      {name: 'runUserEvents', func: runUserEvents},
+    ];
+    evalWithEvents.returns({
+      hooks: expectedHooks,
+      interpreter: undefined as unknown as CustomMarshalingInterpreter, // unused
+    });
+
+    await programExecutor.execute(currentSongMetadata);
+
+    expect(computeCharactersReferenced).to.have.been.calledOnce;
+    expect(nativeAPI.ensureSpritesAreLoaded).to.have.been.calledWith(
+      characters
+    );
+    expect(evalWithEvents).to.have.been.calledOnce;
+    const events = evalWithEvents.firstCall.args[1];
+    expect(Object.keys(events)).to.have.members(expectedHooks.map(h => h.name));
+    expect(runUserSetup).to.have.been.calledOnce;
+    expect(getCueList).to.have.been.calledOnce;
+    expect(nativeAPI.addCues).to.have.been.calledWithExactly(timestamps);
+    expect(getValidationCallback).to.have.been.calledWith(validationCode);
+    expect(nativeAPI.registerValidation).to.have.been.calledWith(
+      validationFunction
+    );
+    expect(nativeAPI.play).to.have.been.calledWith(currentSongMetadata);
+  });
+
+  it('compiles and draws the first frame on preview', async () => {
+    const expectedHooks = [{name: 'runUserSetup', func: runUserSetup}];
+    evalWithEvents.returns({
+      hooks: expectedHooks,
+      interpreter: undefined as unknown as CustomMarshalingInterpreter, // unused
+    });
+
+    await programExecutor.preview();
+
+    expect(nativeAPI.ensureSpritesAreLoaded).to.have.been.calledOnce;
+    expect(evalWithEvents).to.have.been.calledOnce;
+    const events = evalWithEvents.firstCall.args[1];
+    expect(Object.keys(events)).to.have.members(expectedHooks.map(h => h.name));
+    expect(runUserSetup).to.have.been.calledOnce;
+    expect(nativeAPI.p5_.draw).to.have.been.calledOnce;
+  });
+
+  it('resets the native API on reset', () => {
+    programExecutor.reset();
+    expect(nativeAPI.reset).to.have.been.calledOnce;
+  });
+
+  it('gets the replay log from the native API', () => {
+    const replayLog = {};
+    nativeAPI.getReplayLog.returns(replayLog);
+    const returnedReplayLog = programExecutor.getReplayLog();
+    expect(returnedReplayLog).to.equal(replayLog);
+  });
+
+  it('tears down the native API on destroy', () => {
+    programExecutor.destroy();
+    expect(nativeAPI.teardown).to.have.been.calledOnce;
+  });
+});


### PR DESCRIPTION
This creates a `ProgramExecutor` for Dance Party which handles interfacing with the native dance API and executing student code. This PR just adds this new component (and associated test); it will be integrated into Lab2 Dance as a separate PR (just to split things out a bit).

I tried to design this class in a way that it could eventually be reused within Dance.js as well, serving as the singular program executor for all versions of Dance. That way, if/when new features are added (ex. something like preview), they only have to be added to this class, and then can be used in both versions of Dance Party. Untangling this code from Dance.js seems like it'll be an involved effort though, so this can happen later.

## Links

https://codedotorg.atlassian.net/browse/LABS-168

## Testing story

Tested locally + unit test.

## Follow-up work

- Integrate this class into DanceView
- Setup play/reset controls to invoke this API