### PR TITLE
P20-424 Adding start_libraries to i18n sync

### DIFF
--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -156,18 +156,22 @@ module I18n
               end
 
               # start_libraries
-              unless level.start_libraries.blank?
+              # These start libraries are used as short term solution to make Sample Apps translatable.
+              # Student Libraries are required to have a name, a description and at least one function.
+              # Student libraries are stringify when used in a level and stored as start_libraries.
+              # libraries that do not follow those rules will fail to load,and the level wont work.
+              if level.start_libraries.present?
                 level_libraries = JSON.parse(level.start_libraries)
                 level_libraries.each do |library|
-                  next unless /^i18n_/i.match?(library["name"])
                   library_name = library["name"]
+                  next unless /^i18n_/i.match?(library_name)
                   library_source = library["source"]
-                  translation_text = library_source.match(/var TRANSLATIONTEXT = (\{[^}]*});/m).captures
-
-                  i18n_strings['start_libraries'] = Hash.new if i18n_strings['start_libraries'].blank?
+                  translation_json = library_source[/var TRANSLATIONTEXT = (\{[^}]*});/m, 1]
+                  next if translation_json.blank?
+                  i18n_strings['start_libraries'] ||= {}
                   i18n_strings['start_libraries'][library_name] = {}
 
-                  JSON.parse(translation_text[0]).each do |key, value|
+                  JSON.parse(translation_json).each do |key, value|
                     i18n_strings['start_libraries'][library_name][key] = value
                   end
                 end

--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -304,7 +304,6 @@ module I18n
                 # Don't localize encrypted levels; the whole point of encryption is to
                 # keep the contents of certain levels secret.
                 next if level.encrypted?
-                next unless level.start_libraries
 
                 url = I18nScriptUtils.get_level_url_key(script, level)
                 script_strings[url] = get_i18n_strings(level)

--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -156,10 +156,10 @@ module I18n
               end
 
               # start_libraries
-              if level.start_libraries
+              unless level.start_libraries.blank?
                 level_libraries = JSON.parse(level.start_libraries)
                 level_libraries.each do |library|
-                  next unless /^I18n_/.match?(library["name"])
+                  next unless /^i18n_/i.match?(library["name"])
                   library_name = library["name"]
                   library_source = library["source"]
                   translation_text = library_source.match(/var TRANSLATIONTEXT = (\{[^}]*});/m).captures

--- a/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
@@ -1,5 +1,6 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../i18n/resources/dashboard/course_content/sync_in'
+require 'json'
 
 class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
   def setup
@@ -566,26 +567,30 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     assert_equal expected_result, sync_in_instance.send(:get_i18n_strings, level)
   end
 
-  def test_i18n_strings_collection_for_level_start_html
+  def test_i18n_strings_collection_for_level_start_libraries
     sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
 
     level = FactoryBot.build(:level)
 
-    level.start_html = <<-HTML.strip.gsub(/^ {6}/, '')
-      <div>
-        <h1>expected_start_html_text_1</h1>
-        <h2>expected_start_html_text_2</h2>
-      </div>
-    HTML
+    level.start_libraries = JSON.generate(
+      [{name: "I18N_library",
+        description: "Test Library that gets translated",
+        source: "var TRANSLATIONTEXT = {\n \"test_key_1\": \"expected_string_1\",\"test_key_2\": \"expected_string_2\"\n};\n\n//This library is translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"},
+       {name: "non_translated_library",
+        description: "Test Library that does not get translated",
+        source: "var TRANSLATIONTEXT = {\n \"not_translated_key\": \"not_translated_string\"\n};\n\n//This library is not translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"}]
+    )
     expected_result = {
-      'start_html' => {
-        'expected_start_html_text_1' => 'expected_start_html_text_1',
-        'expected_start_html_text_2' => 'expected_start_html_text_2',
+      'start_libraries' => {
+        'I18N_library' => {
+          'test_key_1' => 'expected_string_1',
+          'test_key_2' => 'expected_string_2',
+        }
       }
     }
     assert_equal expected_result, sync_in_instance.send(:get_i18n_strings, level)
 
-    level.start_html = ''
+    level.start_libraries = ''
     expected_result = {}
     assert_equal expected_result, sync_in_instance.send(:get_i18n_strings, level)
   end

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -92,7 +92,7 @@ class Level < ApplicationRecord
     teacher_markdown
     bubble_choice_description
     thumbnail_url
-    start_html
+    start_libraries
   )
 
   # Fix STI routing http://stackoverflow.com/a/9463495


### PR DESCRIPTION
In order to support translatability in Sample Apps, apps where student code is hidden and all students need to do is interact with the app, (**just** _sample Apps_, **NOT** _starter Apps_), @dancodedotorg has found a workaround by using student.
Curriculum writers would create a library containing a JavaScript dictionary containing key-string pairs (that can be parsed as a json object) and a translate function that returns the string for a given key. See attached image.
![image](https://github.com/code-dot-org/code-dot-org/assets/66776217/229d8b59-ed89-4a5d-90eb-731fcb723026)

This workaround is similar to our current translation system for JS/React

Curriculum writers can export these libraries, and import them in the level apps.
![translation-poc](https://github.com/code-dot-org/code-dot-org/assets/66776217/09c581d1-ad63-4063-b6a3-3efb0f9deda0)

When a level has imported libraries, those get stored in the `start_libraries` property of the level (`level.start_libraries`).

start_libraries get distributed in the sync out as the rest of the curriculum content:

<img width="200" alt="Screenshot 2023-10-03 at 09 16 44" src="https://github.com/code-dot-org/code-dot-org/assets/66776217/4ce6e62b-d142-43cd-801b-ff7de285c832">


This PR does:
- Expose start_libraries as a serialized attribute for levels.
- For levels with start libraries, check if any of the libraries are I18n-related.
- Collect the strings from `TRANSLATIONTEXT` add them to level strings and get them into the I18n sync pipeline.

This PR does not:
- Updates `blockly.rb` model to translate `start_libraries`.

## Links

- jira ticket: [P20-424](https://codedotorg.atlassian.net/browse/P20-424)

## Testing story
Manually ran the sync and check start libraries were uploaded to Crowdin and translated content was distributed to Dashboard:
<img width="1189" alt="Screenshot 2023-09-29 at 23 56 26" src="https://github.com/code-dot-org/code-dot-org/assets/66776217/19614dbb-02e9-4991-a836-a15abd5e184d">

## Follow-up work

Edit `blockly.rb` to substitute English strings by translated ones.

## PR Checklist:


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
