### PR TITLE
[Google Blockly] Update mini-toolbox xml on load

### DIFF
--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -86,34 +86,23 @@ export default function initializeBlocklyXml(blocklyWrapper) {
  */
 export function addMutationToMiniToolboxBlocks(blockElement) {
   const miniflyoutAttribute = blockElement.getAttribute('miniflyout');
-  if (!miniflyoutAttribute) {
-    return; // Not a miniflyout block
+  const existingMutationElement = blockElement.querySelector('mutation');
+  if (!miniflyoutAttribute || existingMutationElement) {
+    // The block is the wrong type or has somehow already been processed.
+    return;
   }
   // The default icon is a '+' symbol which represents a currently-closed flyout.
   const useDefaultIcon = miniflyoutAttribute === 'open' ? 'false' : 'true';
-  // We don't expect a mutation to exist yet, but check just in case.
-  const existingMutationElement = blockElement.querySelector('mutation');
 
-  if (!existingMutationElement) {
-    // The mutation element does not exist, so create it.
-    const newMutationElement =
-      blockElement.ownerDocument.createElement('mutation');
+  // The mutation element does not exist, so create it.
+  const newMutationElement =
+    blockElement.ownerDocument.createElement('mutation');
 
-    // Create new mutation attribute based on original block attribute.
-    newMutationElement.setAttribute('useDefaultIcon', useDefaultIcon);
+  // Create new mutation attribute based on original block attribute.
+  newMutationElement.setAttribute('useDefaultIcon', useDefaultIcon);
 
-    // Place mutator before fields, values, and other nested blocks.
-    blockElement.insertBefore(newMutationElement, blockElement.firstChild);
-  } else {
-    // The mutation element already exists, inspect it.
-    const existingUseDefaultIcon =
-      existingMutationElement.getAttribute('useDefaultIcon');
-
-    // If the useDefaultIcon attribute is not set, set it based on the block attribute.
-    if (existingUseDefaultIcon === null) {
-      existingMutationElement.setAttribute('useDefaultIcon', useDefaultIcon);
-    }
-  }
+  // Place mutator before fields, values, and other nested blocks.
+  blockElement.insertBefore(newMutationElement, blockElement.firstChild);
 
   // Remove the miniflyout attribute from the parent block element.
   blockElement.removeAttribute('miniflyout');

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -56,6 +56,7 @@ export default function initializeBlocklyXml(blocklyWrapper) {
     //  the rendered blocks and the coordinates in an array so that we can
     //  position them.
     partitionedBlockElements.forEach(xmlChild => {
+      addMutationToMinitoolboxBlocks(xmlChild);
       const blockly_block = Blockly.Xml.domToBlock(xmlChild, workspace);
       const x = parseInt(xmlChild.getAttribute('x'), 10);
       const y = parseInt(xmlChild.getAttribute('y'), 10);
@@ -72,6 +73,29 @@ export default function initializeBlocklyXml(blocklyWrapper) {
   blocklyWrapper.Xml.blockSpaceToDom = blocklyWrapper.Xml.workspaceToDom;
 
   blocklyWrapper.Xml.createBlockOrderMap = createBlockOrderMap;
+}
+
+/**
+ * Adds a mutation element to a block if it should have an open miniflyout.
+ * CDO Blockly uses an unsupported method for serializing miniflyout state
+ * where arbitrary block attribute could be used to manage extra state.
+ * Mainline Blockly expects a mutator. The precence of the mutation element
+ * will trigger the block's domToMutation function to run, if it exists.
+ *
+ * @param {Element} blockElement - The XML element for a single block.
+ * @returns {Map} A map with partitioned block index as key and original index in the XML as value.
+ */
+export function addMutationToMinitoolboxBlocks(blockElement) {
+  const miniflyoutAttribute = blockElement.getAttribute('miniflyout');
+  if (!miniflyoutAttribute) {
+    return; // Not a miniflyout block
+  }
+  const mutationElement = blockElement.ownerDocument.createElement('mutation');
+  // The default icon is a '+' symbol which represents a currently-closed flyout.
+  const useDefaultIcon = miniflyoutAttribute === 'open' ? 'false' : 'true';
+  mutationElement.setAttribute('useDefaultIcon', useDefaultIcon);
+  // Place mutator before fields, values, and other nested blocks.
+  blockElement.insertBefore(mutationElement, blockElement.firstChild);
 }
 
 /**

--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
@@ -135,6 +135,8 @@ export const blocks = {
     };
     this.domToMutation = function (xmlElement) {
       const useDefaultIcon =
+        // Assume default icon if no XML attribute present
+        !xmlElement.hasAttribute('useDefaultIcon') ||
         // Coerce string to Boolean
         xmlElement.getAttribute('useDefaultIcon') === 'true';
       flyoutToggleButton.setIcon(useDefaultIcon);

--- a/apps/test/unit/blockly/addons/cdoXmlTest.js
+++ b/apps/test/unit/blockly/addons/cdoXmlTest.js
@@ -2,7 +2,7 @@ import {expect} from '../../../util/reconfiguredChai';
 import {
   getPartitionedBlockElements,
   createBlockOrderMap,
-  addMutationToMinitoolboxBlocks,
+  addMutationToMiniToolboxBlocks,
 } from '@cdo/apps/blockly/addons/cdoXml';
 import {PROCEDURE_DEFINITION_TYPES} from '@cdo/apps/blockly/constants';
 
@@ -67,7 +67,7 @@ describe('createBlockOrderMap', function () {
   });
 });
 
-describe('addMutationToMinitoolboxBlocks', function () {
+describe('addMutationToMiniToolboxBlocks', function () {
   it('should add a mutation element with useDefaultIcon attribute to miniflyout block with "open" miniflyout', function () {
     // Sample mini-toolbox block XML
     const xmlData = `
@@ -80,11 +80,11 @@ describe('addMutationToMinitoolboxBlocks', function () {
         </value>
       </block>
     `;
-    const xmlDoc = new DOMParser().parseFromString(xmlData, 'text/xml');
+    const xmlDoc = parser.parseFromString(xmlData, 'text/xml');
     const blockElement = xmlDoc.documentElement;
 
     // Call the function
-    addMutationToMinitoolboxBlocks(blockElement);
+    addMutationToMiniToolboxBlocks(blockElement);
 
     // Find mutation element and useDefaultIcon attribute
     const expectedMutation = blockElement.querySelector('mutation');
@@ -95,18 +95,20 @@ describe('addMutationToMinitoolboxBlocks', function () {
     expect(expectedMutation).to.exist;
     // An open flyout will NOT use the default icon, since the default state is closed.
     expect(expectedUseDefaultIcon).to.equal('false');
+    // Ensure that the miniflyout attribute is removed.
+    expect(blockElement.getAttribute('miniflyout')).to.be.null;
   });
 
   it('should not add a mutation element to block without miniflyout attribute', function () {
     // Create a sample block element without miniflyout attribute
     const xmlData = '<block type="someBlock"></block>';
-    const xmlDoc = new DOMParser().parseFromString(xmlData, 'text/xml');
+    const xmlDoc = parser.parseFromString(xmlData, 'text/xml');
     const blockElement = xmlDoc.documentElement;
 
     // Make a copy of the original blockElement
     const originalBlockElement = blockElement.cloneNode(true);
 
-    addMutationToMinitoolboxBlocks(blockElement);
+    addMutationToMiniToolboxBlocks(blockElement);
 
     // Compare the modified blockElement with the original copy
     expect(blockElement.isEqualNode(originalBlockElement)).to.be.true;

--- a/apps/test/unit/blockly/addons/cdoXmlTest.js
+++ b/apps/test/unit/blockly/addons/cdoXmlTest.js
@@ -2,6 +2,7 @@ import {expect} from '../../../util/reconfiguredChai';
 import {
   getPartitionedBlockElements,
   createBlockOrderMap,
+  addMutationToMinitoolboxBlocks,
 } from '@cdo/apps/blockly/addons/cdoXml';
 import {PROCEDURE_DEFINITION_TYPES} from '@cdo/apps/blockly/constants';
 
@@ -63,5 +64,51 @@ describe('createBlockOrderMap', function () {
 
     // Compare the result with the expected map
     expect(blockOrderMapArray).to.deep.equal(expectedMapArray);
+  });
+});
+
+describe('addMutationToMinitoolboxBlocks', function () {
+  it('should add a mutation element with useDefaultIcon attribute to miniflyout block with "open" miniflyout', function () {
+    // Sample mini-toolbox block XML
+    const xmlData = `
+      <block type="gamelab_spriteClicked" miniflyout="open" id="whenclicked">
+        <field name="CONDITION">"when"</field>
+        <value name="SPRITE">
+          <block type="gamelab_allSpritesWithAnimation">
+            <field name="ANIMATION">"face_strawberry_1"</field>
+          </block>
+        </value>
+      </block>
+    `;
+    const xmlDoc = new DOMParser().parseFromString(xmlData, 'text/xml');
+    const blockElement = xmlDoc.documentElement;
+
+    // Call the function
+    addMutationToMinitoolboxBlocks(blockElement);
+
+    // Find mutation element and useDefaultIcon attribute
+    const expectedMutation = blockElement.querySelector('mutation');
+    const expectedUseDefaultIcon =
+      expectedMutation.getAttribute('useDefaultIcon');
+
+    // Ensure that the mutation element is added and has the correct useDefaultIcon attribute.
+    expect(expectedMutation).to.exist;
+    // An open flyout will NOT use the default icon, since the default state is closed.
+    expect(expectedUseDefaultIcon).to.equal('false');
+  });
+
+  it('should not add a mutation element to block without miniflyout attribute', function () {
+    // Create a sample block element without miniflyout attribute
+    const xmlData = '<block type="someBlock"></block>';
+    const xmlDoc = new DOMParser().parseFromString(xmlData, 'text/xml');
+    const blockElement = xmlDoc.documentElement;
+
+    // Make a copy of the original blockElement
+    const originalBlockElement = blockElement.cloneNode(true);
+
+    addMutationToMinitoolboxBlocks(blockElement);
+
+    // Compare the modified blockElement with the original copy
+    expect(blockElement.isEqualNode(originalBlockElement)).to.be.true;
   });
 });


### PR DESCRIPTION
We have already added support for serialization/deserialization of the state of a minitoolbox (open or closed) using Blockly's JSON system. (https://github.com/code-dot-org/code-dot-org/pull/52842) This pull request aims to ensure that we correctly load this state whenever a project or level is loaded from XML. 


## Background
At https://studio.code.org/s/coursef-2023/lessons/9/levels/4 you will see a level with two `when clicked` blocks. The toolbox of the one in instructions is closed, while the one provided in the start blocks on the workspace is open. 
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/5c7591e7-ed8e-48a7-b45d-561c086cb266)

This is accomplished with the following abbreviated XML:

```
<block type="gamelab_spriteClicked" miniflyout="open">
  <field name="CONDITION">"when"</field>
  <value name="SPRITE">...</value>
</block>
```

## Problem

CDO Blockly has custom logic that allows us to read the `miniflyout="open"` attribute that mainline does not support. As seen on production, when forcing Sprite Lab to use Google Blockly, all blocks with mini-toolboxes are created with the flyout closed on load, regardless of the given XML:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/ca69585a-f570-442a-823a-7fc8519aa3f4)

## Mutators

 Mainline Blockly expects developers to use mutators for this sort of extra state. With the XML system, this is done using a block's `domToMutation` (loading) and `mutationToDom` (saving) methods. [https://developers.google.com/blockly/guides/create-custom-blocks/extensions#mutationtodom_and_domtomutation]
Sprite Lab will always save with JSON once migrated, so we only need to be concerned with `domToMutation`. This method only runs when loading blocks that have a `<mutation/>` element.

We can solve our loading problem with two steps:
1. For any block that has the `miniflyout="open"` attribute, add a mutation element to the block.
2. Ensure that `domToMutation` can read the mutation element to create the block correctly.

Now, if the level configuration or project data indicates that the flyout should be open, it will work when loaded with Google Blockly:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/fa57b4c9-ec24-4cc8-ba8c-2fd30d2823a1)


Resulting XML:
```
<block type="gamelab_spriteClicked" miniflyout="open">
  <mutation useDefaultIcon="false"/>
  <field name="CONDITION">"when"</field>
  <value name="SPRITE">...</value>
</block>
```

I considered removing the `miniflyout="open"` attribute since it's a no-op in Google Blockly, but it's also not hurting anything.

I believe that we don't need to worry about blocks that are set to `miniflyout="closed"` or blocks that are missing the attribute since the default state is closed already.


## Testing story

I tested this with multiple curriculum levels by searching for any that included the `miniflyout="open"` attribute. I also saved a project with flyouts in different states using CDO Blockly/XML and confirmed that there were no changes in state when switching to Google Blockly. No regressions are expected in how we save/load using JSON sources as those methods are unchanged.

Unit tests were added for the new `addMutationToMinitoolboxBlocks` function.
