### PR TITLE
Lab2: Allow labs to perform one-time setup on mount

### DIFF
--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -5,6 +5,7 @@
  */
 import AichatView from '@cdo/apps/aichat/views/AichatView';
 import DanceView from '@cdo/apps/dance/lab2/views/DanceView';
+import {setUpBlocklyForMusicLab} from '@cdo/apps/music/blockly/setup';
 import MusicView from '@cdo/apps/music/views/MusicView';
 import StandaloneVideo from '@cdo/apps/standaloneVideo/StandaloneVideo';
 import classNames from 'classnames';
@@ -33,6 +34,11 @@ interface AppProperties {
    * to the default theme if not specified.
    */
   theme?: Theme;
+  /**
+   * Optional function to run when the lab is first mounted. This is useful
+   * for any one-time setup actions such as setting up Blockly.
+   */
+  setupFunction?: () => void;
 }
 
 const appsProperties: {[appName in AppName]?: AppProperties} = {
@@ -40,6 +46,7 @@ const appsProperties: {[appName in AppName]?: AppProperties} = {
     backgroundMode: true,
     node: <MusicView />,
     theme: Theme.DARK,
+    setupFunction: setUpBlocklyForMusicLab,
   },
   standalone_video: {
     backgroundMode: false,
@@ -67,6 +74,8 @@ const LabViewsRenderer: React.FunctionComponent = () => {
   // When navigating to a new app type, add it to the list of apps to render.
   useEffect(() => {
     if (currentAppName && !appsToRender.includes(currentAppName)) {
+      // Run the setup function for the Lab if it has one.
+      appsProperties[currentAppName]?.setupFunction?.();
       setAppsToRender([...appsToRender, currentAppName]);
     }
   }, [currentAppName, appsToRender]);

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -50,7 +50,6 @@ import UpdateTimer from './UpdateTimer';
 import ValidatorProvider from '@cdo/apps/lab2/progress/ValidatorProvider';
 import {Key} from '../utils/Notes';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {setUpBlocklyForMusicLab} from '../blockly/setup';
 import {isEqual} from 'lodash';
 import HeaderButtons from './HeaderButtons';
 
@@ -138,8 +137,6 @@ class UnconnectedMusicView extends React.Component {
       loadedLibrary: false,
       currentLibraryName: null,
     };
-
-    setUpBlocklyForMusicLab();
   }
 
   componentDidMount() {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -52,6 +52,7 @@ import {Key} from '../utils/Notes';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {isEqual} from 'lodash';
 import HeaderButtons from './HeaderButtons';
+import {setUpBlocklyForMusicLab} from '../blockly/setup';
 
 /**
  * Top-level container for Music Lab. Manages all views on the page as well as the
@@ -137,6 +138,12 @@ class UnconnectedMusicView extends React.Component {
       loadedLibrary: false,
       currentLibraryName: null,
     };
+
+    // If in incubator, we need to manually setup Blockly for Music Lab.
+    // Otherwise, this is handled by Lab2.
+    if (props.inIncubator) {
+      setUpBlocklyForMusicLab();
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
This gives Lab2 labs a way to perform one-time setup actions when they're first rendered in a progression. This is useful for actions like setting up Blockly (installing custom blocks, registering mutators, etc) that should only be performed once per page load.

## Testing story

Tested locally with Music Lab.