### PR TITLE
HoC 2023 - Update OpenGraph tags on hourofcode.com/learn

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -59,7 +59,7 @@ section.banner.homepage {
 
     .ctabutton {
       background-color: $neutral_white;
-      border: 1px solid $neutral_white;
+      border: 2px solid $neutral_white;
       color: $neutral_dark;
 
       &.secondary {

--- a/pegasus/src/social_metadata.rb
+++ b/pegasus/src/social_metadata.rb
@@ -151,9 +151,9 @@ def get_social_metadata_for_page(request)
     },
     "learn" => {
       "default" => {
-        title: hoc_s(:social_hoc_anybody),
-        description: hoc_s(:social_hoc2022_explore_play_create),
-        image: images[:hoc_2022_social]
+        title: hoc_s(:hoc2023_social_creativity_with_ai_title),
+        description: hoc_s(:hoc2023_social_creativity_with_ai_desc),
+        image: images[:hoc_2023_social]
       }
     },
     "hoc-overview" => {


### PR DESCRIPTION
Update the OpenGraph tags and image on https://hourofcode.com/learn and https://hourofcode.com/how-to pages. Also added one tiny CSS update on the homepage button.