### PR TITLE
Allows parent permission request from account email if parent created account

### DIFF
--- a/apps/src/sites/studio/pages/sessions/lockout.js
+++ b/apps/src/sites/studio/pages/sessions/lockout.js
@@ -15,7 +15,7 @@ $(document).ready(function () {
       deleteDate={
         new Date(Date.parse(element.getAttribute('data-delete-date')))
       }
-      disallowEmail={element.getAttribute('data-disallow-email')}
+      disallowedEmail={element.getAttribute('data-disallowed-email')}
     />,
     element
   );

--- a/apps/src/sites/studio/pages/sessions/lockout.js
+++ b/apps/src/sites/studio/pages/sessions/lockout.js
@@ -15,7 +15,7 @@ $(document).ready(function () {
       deleteDate={
         new Date(Date.parse(element.getAttribute('data-delete-date')))
       }
-      studentEmail={element.getAttribute('data-student-email')}
+      disallowEmail={element.getAttribute('data-disallow-email')}
     />,
     element
   );

--- a/apps/src/templates/sessions/LockoutPanel.jsx
+++ b/apps/src/templates/sessions/LockoutPanel.jsx
@@ -19,7 +19,7 @@ import {hashString} from '../../utils';
 export default function LockoutPanel(props) {
   // Determine if we think the given email matches the child email
   const isEmailDisallowed = email => {
-    return props.disallowEmail === hashString(email);
+    return props.disallowedEmail === hashString(email);
   };
 
   // Determine if the email is allowed
@@ -233,7 +233,7 @@ LockoutPanel.propTypes = {
   deleteDate: PropTypes.instanceOf(Date).isRequired,
   pendingEmail: PropTypes.string,
   requestDate: PropTypes.instanceOf(Date),
-  disallowEmail: PropTypes.string.isRequired,
+  disallowedEmail: PropTypes.string.isRequired,
 };
 
 const styles = {

--- a/apps/src/templates/sessions/LockoutPanel.jsx
+++ b/apps/src/templates/sessions/LockoutPanel.jsx
@@ -18,13 +18,13 @@ import {hashString} from '../../utils';
  */
 export default function LockoutPanel(props) {
   // Determine if we think the given email matches the child email
-  const isStudentEmail = email => {
-    return props.studentEmail === hashString(email);
+  const isEmailDisallowed = email => {
+    return props.disallowEmail === hashString(email);
   };
 
   // Determine if the email is allowed
   const validateEmail = email => {
-    return isEmail(email) && !isStudentEmail(email);
+    return isEmail(email) && !isEmailDisallowed(email);
   };
 
   // Set the disabled state of the submit button based on the validity of the
@@ -233,7 +233,7 @@ LockoutPanel.propTypes = {
   deleteDate: PropTypes.instanceOf(Date).isRequired,
   pendingEmail: PropTypes.string,
   requestDate: PropTypes.instanceOf(Date),
-  studentEmail: PropTypes.string.isRequired,
+  disallowEmail: PropTypes.string.isRequired,
 };
 
 const styles = {

--- a/apps/src/templates/sessions/LockoutPanel.jsx
+++ b/apps/src/templates/sessions/LockoutPanel.jsx
@@ -17,8 +17,14 @@ import {hashString} from '../../utils';
  * pending request for) parental permission.
  */
 export default function LockoutPanel(props) {
+  // Determine if we think the given email matches the child email
+  const isStudentEmail = email => {
+    return props.studentEmail === hashString(email);
+  };
+
+  // Determine if the email is allowed
   const validateEmail = email => {
-    return isEmail(email) && props.studentEmail !== hashString(email);
+    return isEmail(email) && !isStudentEmail(email);
   };
 
   // Set the disabled state of the submit button based on the validity of the

--- a/apps/src/templates/sessions/LockoutPanel.story.jsx
+++ b/apps/src/templates/sessions/LockoutPanel.story.jsx
@@ -12,7 +12,7 @@ const Template = args => (
   <LockoutPanel
     apiURL="/permissions"
     deleteDate={new Date(Date.now() + 6 * DAYS)}
-    studentEmail="student@test.com"
+    disallowEmail="student@test.com"
     {...args}
   />
 );

--- a/apps/src/templates/sessions/LockoutPanel.story.jsx
+++ b/apps/src/templates/sessions/LockoutPanel.story.jsx
@@ -12,7 +12,7 @@ const Template = args => (
   <LockoutPanel
     apiURL="/permissions"
     deleteDate={new Date(Date.now() + 6 * DAYS)}
-    disallowEmail="student@test.com"
+    disallowedEmail="student@test.com"
     {...args}
   />
 );

--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -71,7 +71,12 @@ class SessionsController < Devise::SessionsController
     # Basic defaults. If the @pending_email is empty, the request was never sent
     @pending_email = ''
     @request_date = DateTime.now
-    @student_email = current_user.hashed_email
+
+    # Get the student's email address (unless a parent is creating the account)
+    @student_email = ''
+    unless current_user.parent_email_preference_opt_in_required
+      @student_email = current_user.hashed_email
+    end
 
     # Determine the deletion date as the creation time of the account + 7 days
     @delete_date = current_user.created_at.since(7.days)

--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -73,9 +73,9 @@ class SessionsController < Devise::SessionsController
     @request_date = DateTime.now
 
     # Disallow the student's email address (unless a parent is creating the account)
-    @disallow_email = ''
+    @disallowed_email = ''
     unless current_user.parent_created_account?
-      @disallow_email = current_user.hashed_email
+      @disallowed_email = current_user.hashed_email
     end
 
     # Determine the deletion date as the creation time of the account + 7 days

--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -72,10 +72,10 @@ class SessionsController < Devise::SessionsController
     @pending_email = ''
     @request_date = DateTime.now
 
-    # Get the student's email address (unless a parent is creating the account)
-    @student_email = ''
-    unless current_user.parent_email_preference_opt_in_required
-      @student_email = current_user.hashed_email
+    # Disallow the student's email address (unless a parent is creating the account)
+    @disallow_email = ''
+    unless current_user.parent_created_account?
+      @disallow_email = current_user.hashed_email
     end
 
     # Determine the deletion date as the creation time of the account + 7 days

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2221,6 +2221,11 @@ class User < ApplicationRecord
     student? && parent_email.present? && hashed_email.blank?
   end
 
+  # Returns true when the parent email matches the account email.
+  def parent_created_account?
+    student? && parent_email.present? && hashed_email == User.hash_email(parent_email)
+  end
+
   # Temporary: Allow single-auth students to add a parent email so it's possible
   # to add a recovery option to their account.  Once they are on multi-auth they
   # can just add an email or another SSO, so this is no longer needed.

--- a/dashboard/app/views/sessions/lockout.html.haml
+++ b/dashboard/app/views/sessions/lockout.html.haml
@@ -7,7 +7,7 @@
       action: :child_account_consent,
       controller: :policy_compliance
     ),
-    disallow_email: @disallow_email,
+    disallowed_email: @disallowed_email,
   }
 }
 

--- a/dashboard/app/views/sessions/lockout.html.haml
+++ b/dashboard/app/views/sessions/lockout.html.haml
@@ -7,7 +7,7 @@
       action: :child_account_consent,
       controller: :policy_compliance
     ),
-    student_email: @student_email,
+    disallow_email: @disallow_email,
   }
 }
 

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -110,5 +110,19 @@ Feature: Policy Compliance and Parental Permission
     And element "#permission-status" contains text "Not Submitted"
 
     # Type in the student email as the parent email, which should disable the button
-    And I type the email for "Sally Student" into element "#parent-email"
+    And I press keys for the email for "Sally Student" into element "#parent-email"
     Then element "#lockout-submit" is disabled
+
+  Scenario: Student should be able to enter their parent's email if their parent created their account
+    Given I create as a parent a young student in Colorado who has never signed in named "Sally Student" and go home
+
+    # TODO: Can possibly get rid of this when the lockout is redirected on sign in
+    Given I am on "http://studio.code.org/lockout"
+
+    # It should not be a pending request
+    Then I wait to see "#lockout-panel-form"
+    And element "#permission-status" contains text "Not Submitted"
+
+    # Type in the student email as the parent email, which should not disable the button
+    And I press keys for the email for "Sally Student" into element "#parent-email"
+    Then element "#lockout-submit" is enabled

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -2,8 +2,6 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: New under 13 account should be able to send a parental request.
     Given I create a young student in Colorado who has never signed in named "Sally Student" and go home
-
-    # TODO: Can possibly get rid of this when the lockout is redirected on sign in
     Given I am on "http://studio.code.org/lockout"
 
     # It should not be a pending request
@@ -24,8 +22,6 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: New under 13 account should be able to elect to sign out at the lockout.
     Given I create a young student in Colorado who has never signed in named "Sally Student" and go home
-
-    # TODO: Can possibly get rid of this when the lockout is redirected on sign in
     Given I am on "http://studio.code.org/lockout"
 
     # It should not be a pending request
@@ -38,8 +34,6 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: New under 13 account should be able to resend the email
     Given I create a young student in Colorado who has never signed in named "Sally Student" and go home
-
-    # TODO: Can possibly get rid of this when the lockout is redirected on sign in
     Given I am on "http://studio.code.org/lockout"
 
     # It should not be a pending request
@@ -66,8 +60,6 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: New under 13 account should be able to send a different email
     Given I create a young student in Colorado who has never signed in named "Sally Student" and go home
-
-    # TODO: Can possibly get rid of this when the lockout is redirected on sign in
     Given I am on "http://studio.code.org/lockout"
 
     # It should not be a pending request
@@ -101,8 +93,6 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: Student should not be able to enter their own email as their parent's email
     Given I create a young student in Colorado who has never signed in named "Sally Student" and go home
-
-    # TODO: Can possibly get rid of this when the lockout is redirected on sign in
     Given I am on "http://studio.code.org/lockout"
 
     # It should not be a pending request
@@ -115,8 +105,6 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: Student should be able to enter their parent's email if their parent created their account
     Given I create as a parent a young student in Colorado who has never signed in named "Sally Student" and go home
-
-    # TODO: Can possibly get rid of this when the lockout is redirected on sign in
     Given I am on "http://studio.code.org/lockout"
 
     # It should not be a pending request

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -86,7 +86,16 @@ end
 def create_user(name, url: '/users.json', code: 201, **user_opts)
   navigate_to replace_hostname('http://studio.code.org/reset_session')
   Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, tries: 3) do
+    # Generate the user
     email, password = generate_user(name)
+
+    # Set the parent email to the user email, if we see it
+    # in the user options (we generate the email, here)
+    if user_opts.key? :parent_email_preference_email
+      user_opts[:parent_email_preference_email] = email
+    end
+
+    # Issue the update request for the user
     browser_request(
       url: url,
       method: 'POST',
@@ -107,18 +116,24 @@ def create_user(name, url: '/users.json', code: 201, **user_opts)
   end
 end
 
-And(/^I create a (young )?student( in Colorado)?( who has never signed in)? named "([^"]*)"( and go home)?$/) do |young, locked, new_account, name, home|
+And(/^I create( as a parent)? a (young )?student( in Colorado)?( who has never signed in)? named "([^"]*)"( and go home)?$/) do |parent_created, young, locked, new_account, name, home|
   age = young ? '10' : '16'
   sign_in_count = new_account ? 0 : 2
 
   user_opts = {
     age: age,
-    sign_in_count: sign_in_count
+    sign_in_count: sign_in_count,
   }
 
   if locked
     user_opts[:country_code] = "US"
     user_opts[:us_state] = "CO"
+  end
+
+  if parent_created
+    user_opts[:parent_email_preference_opt_in_required] = "1"
+    user_opts[:parent_email_preference_opt_in] = "no"
+    user_opts[:parent_email_preference_email] = "[user-email]"
   end
 
   create_user(name, **user_opts)
@@ -128,6 +143,12 @@ end
 And(/^I type the email for "([^"]*)" into element "([^"]*)"$/) do |name, element|
   steps <<~GHERKIN
     And I type "#{@users[name][:email]}" into "#{element}"
+  GHERKIN
+end
+
+And(/^I press keys for the email for "([^"]*)" into element "([^"]*)"$/) do |name, element|
+  steps <<~GHERKIN
+    And I press keys "#{@users[name][:email]}" for element "#{element}"
   GHERKIN
 end
 


### PR DESCRIPTION
This updates the `LockoutPanel` component to take, instead of a `studentEmail`, a `disallowEmail` property. This is set to the account email (as a hash since students' emails are not stored plaintext) _unless_ the parent created the account during registration via the `I'm creating this account on behalf of a child` checkbox. When this happens the `parent_email` for the `User` will be plaintext and match the account email which is encoded only in its hashed form as `user.hashed_email`. Therefore, I added a `parent_created?` method in the `User` to return `true` when the hash of the `parent_email`, if exists, matches the `hashed_email` of the account.

When this is `true`, the `/lockout` controller action does not set the `disallowEmail` data such that the `LockoutPanel` component does not have it. Thus, the component will not reject the account email address and will not disable the submit button.

I have also added a UI test that will create such a parent-created student account. Using this account, the test navigates the lockout panel and checks that the button to submit is enabled when the account email is entered. This is in contrast to another UI test that is simply a student created account, where that test successfully tests that the button is disabled in the similar situation of entering the account email.

To that end, a few little UI test steps were added or refined to make that possible. I could not simply use the "type in email" step since that bypasses the component's check for input events to enable/disable the button. We have an existing pattern of using "press keys" steps for actually simulating input, so I added one for the email in the "account steps" definitions. I augmented the prior tests to use that when necessary, which actually makes them more accurate tests.

Took the time to remove the `TODO` sections of the UI tests since they are now resolvable.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- jira ticket: [https://codedotorg.atlassian.net/browse/P20-435](P20-435)
- jira (support) ticket: [https://codedotorg.atlassian.net/browse/P20-419](P20-419)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Manual testing.

Added UI test.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
