### PR TITLE
Update the UI to accommodate updated teaches_cs values

### DIFF
--- a/apps/src/templates/census2017/CensusMapReplacement.jsx
+++ b/apps/src/templates/census2017/CensusMapReplacement.jsx
@@ -26,7 +26,7 @@ class CensusMapInfoWindow extends Component {
         break;
       case 'NO':
         censusMessage =
-          'We believe this school offers limited or no Computer Science opportunities.';
+          'We believe this school offers no Computer Science opportunities.';
         color = 'blue';
         break;
       case 'HISTORICAL_YES':
@@ -36,7 +36,7 @@ class CensusMapInfoWindow extends Component {
         break;
       case 'HISTORICAL_NO':
         censusMessage =
-          'We believe this school historically offered limited or no Computer Science opportunities.';
+          'We believe this school historically offered no Computer Science opportunities.';
         color = 'blue';
         break;
       default:
@@ -386,7 +386,7 @@ export default class CensusMapReplacement extends Component {
             <div className="color legend-offers-cs" />
             <div className="caption">Offers computer science</div>
             <div className="color legend-limited-cs" />
-            <div className="caption">Limited or no CS opportunities</div>
+            <div className="caption">No CS opportunities</div>
             <div className="color legend-no-data-cs" />
             <div className="caption">No Data</div>
           </div>
@@ -396,7 +396,7 @@ export default class CensusMapReplacement extends Component {
           <div className="color legend-offers-cs" />
           <div className="caption">Offers computer science</div>
           <div className="color legend-limited-cs" />
-          <div className="caption">Limited or no CS opportunities</div>
+          <div className="caption">No CS opportunities</div>
           <div className="color legend-no-data-cs" />
           <div className="caption">No Data</div>
         </div>

--- a/apps/src/templates/census2017/CensusMapReplacement.jsx
+++ b/apps/src/templates/census2017/CensusMapReplacement.jsx
@@ -39,11 +39,6 @@ class CensusMapInfoWindow extends Component {
           'We believe this school historically offered limited or no Computer Science opportunities.';
         color = 'blue';
         break;
-      case 'MAYBE':
-      case 'HISTORICAL_MAYBE':
-        censusMessage = 'We have conflicting data for this school.';
-        color = 'yellow';
-        break;
       default:
         censusMessage = 'We need data for this school.';
         missingCensusData = true;
@@ -226,8 +221,6 @@ export default class CensusMapReplacement extends Component {
             ['get', 'teaches_cs'],
             ['NO', 'HISTORICAL_NO'],
             '#989CF8',
-            ['MAYBE', 'HISTORICAL_MAYBE'],
-            '#FFFDA6',
             'white',
           ],
           'circle-stroke-width': 1,
@@ -394,8 +387,6 @@ export default class CensusMapReplacement extends Component {
             <div className="caption">Offers computer science</div>
             <div className="color legend-limited-cs" />
             <div className="caption">Limited or no CS opportunities</div>
-            <div className="color legend-inconclusive-cs" />
-            <div className="caption">Inconclusive data</div>
             <div className="color legend-no-data-cs" />
             <div className="caption">No Data</div>
           </div>
@@ -406,8 +397,6 @@ export default class CensusMapReplacement extends Component {
           <div className="caption">Offers computer science</div>
           <div className="color legend-limited-cs" />
           <div className="caption">Limited or no CS opportunities</div>
-          <div className="color legend-inconclusive-cs" />
-          <div className="caption">Inconclusive data</div>
           <div className="color legend-no-data-cs" />
           <div className="caption">No Data</div>
         </div>

--- a/apps/src/templates/census2017/CensusMapReplacement.jsx
+++ b/apps/src/templates/census2017/CensusMapReplacement.jsx
@@ -234,9 +234,10 @@ export default class CensusMapReplacement extends Component {
           'circle-stroke-color': '#000000',
         },
         filter: [
-          'any',
+          'all',
           ['!=', 'teaches_cs', 'YES'],
           ['!=', 'teaches_cs', 'HISTORICAL_YES'],
+          ['!=', 'teaches_cs', 'EXCLUDED'],
         ],
       });
       _this.map.addLayer({


### PR DESCRIPTION
This PR updates the [code.org/yourschool](https://code.org/yourschool) MapBox UI to remove the "maybe" `teaches_cs` value and accommodate "excluded" and "unknown" `teaches_cs` values.

## Map legend (updates the "No CS opportunities" text and removes the "Inconclusive data" value)

#### Previous legend
![LEGEND_OLD](https://github.com/code-dot-org/code-dot-org/assets/56283563/1f68d3d4-e135-4d4a-8777-1b0b226f0c83)

#### New legend
![new_map](https://github.com/code-dot-org/code-dot-org/assets/56283563/642e6242-85c7-48d6-9fd8-9418b93b974e)

## (unchanged) "Yes" values (both "Yes" and "Historical Yes")
"Yes" and "historical yes" remain unchanged!

#### Previous "Yes"
![old_YES](https://github.com/code-dot-org/code-dot-org/assets/56283563/73500fe0-2a87-4fe2-8140-8018ece4bbb9)

#### New "Yes" (unchanged)
![new_YES](https://github.com/code-dot-org/code-dot-org/assets/56283563/e92a2fb5-f075-44eb-aa75-d2eeed7d68e1)

#### Previous "Historical Yes"
![old_teaches_cs_HISTORICAL_YES](https://github.com/code-dot-org/code-dot-org/assets/56283563/e214d674-2b44-465a-b062-96bbeb9d00af)

#### New "Historical Yes" (unchanged)
![new_HISTORICAL_YES](https://github.com/code-dot-org/code-dot-org/assets/56283563/04f3ef0d-f834-4c04-9206-a532eb668f02)

## (mostly unchanged) "No" values (both "No" and "Historical No")
The behavior of "no" and "historical no" is unchanged, but the text was updated to remove "limited" phrasing.

#### Previous "No"
![old_NO](https://github.com/code-dot-org/code-dot-org/assets/56283563/022e7d6b-0672-418a-8c5f-eafa70b6673c)

#### New "No"
![new_NO](https://github.com/code-dot-org/code-dot-org/assets/56283563/63c18772-525e-4b90-a201-c0666b030bfc)

#### Previous "Historical No"
![old_HISTORICAL_NO](https://github.com/code-dot-org/code-dot-org/assets/56283563/b4beee28-3840-4d6a-8b1d-9dd34126b5e2)

#### New "Historical No"
![new_HISTORICAL_NO](https://github.com/code-dot-org/code-dot-org/assets/56283563/f2308d36-fa3a-42fa-b746-bd46c7befdcd)

## (removed) "Maybe" values (both "Maybe" and "Historical Maybe")
As per [the spec](https://docs.google.com/document/d/1ZcvnXAUfOwnmWdS8Z8JwwYDdHWTF6CrCWCmpgiKlw4U/edit#heading=h.rizng6chl91e), we are removing the values of "Maybe" and "Historical Maybe." This is already reflected in [the data](https://s3.console.aws.amazon.com/s3/object/cdo-census?region=us-east-1&prefix=access-report-data-files-2023/final_csv/final_csv_2023_09_19.csv) which contains no entries of "M" or "HM."

#### Previously
![old_MAYBE](https://github.com/code-dot-org/code-dot-org/assets/56283563/25c92b4a-796c-4ee7-a309-dfb744ee4229)

#### New
![new_NOT_MAYBE](https://github.com/code-dot-org/code-dot-org/assets/56283563/3f80a9a8-eeee-4675-97bd-43547d98588b)

## (new) "Unknown" values (replacing "No data")
As per [the spec](https://docs.google.com/document/d/1ZcvnXAUfOwnmWdS8Z8JwwYDdHWTF6CrCWCmpgiKlw4U/edit#heading=h.rizng6chl91e), "inconclusive" and "no data" are no longer options, and "unknown" is taking its place along with the white color. Because of this, and because the map defaults to white without an explicit "yes", "no", or "excluded" (just like how "no data" was treated), I don't believe any change is needed to support "unknown" values.

#### Previously
![old_NO_DATA](https://github.com/code-dot-org/code-dot-org/assets/56283563/02d37b0a-2b7b-4455-9379-da1ba3d8221f)

#### New (visually unchanged but this school is now marked as "unknown")
![NEW_UNKNOWN](https://github.com/code-dot-org/code-dot-org/assets/56283563/cdebc64e-cba9-4139-aff2-46ea64685ca6)

## (new) "Excluded" values
A new "excluded" `teaches_cs` value was added so any school with that value will be filtered out from being shown on the map.

#### Previously
![old_teaches_cs_SHOULD_BE_EXCLUDED](https://github.com/code-dot-org/code-dot-org/assets/56283563/09b67c56-4756-4560-8797-e1cbc43793d0)

#### New (now that school's point on the map is filtered out)
![new_teaches_cs_EXCLUDED](https://github.com/code-dot-org/code-dot-org/assets/56283563/3139d59d-cce3-4bec-9140-a6da835315b5)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-798&assignee=60d62161f65054006980bd71)
Spec: [here](https://docs.google.com/document/d/1ZcvnXAUfOwnmWdS8Z8JwwYDdHWTF6CrCWCmpgiKlw4U/edit#heading=h.rizng6chl91e)

## Testing story
I spun up an adhoc with this PR's changes and the changes from the [update_census_mapbox cronjob PR](https://github.com/code-dot-org/code-dot-org/pull/53972) so that I could test the UI changes on the updated map, then I found schools in the new year's data of each type of value to compare to the previous year's map.

## Follow-up work
My plan was to merge this PR and the script that updates the map close together so that the discrepencies in the map are minimized. For the most part it should be safe as the changes are being made to schools that have conflicted data, no data, or are excluded (meaning most will be shown as a white dot until the script runs and many will be excluded/recategorized).

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
