### PR TITLE
[Levelbuilder custom blocks] Determine input types list based on pool

### DIFF
--- a/apps/src/sites/studio/pages/blocks/index.js
+++ b/apps/src/sites/studio/pages/blocks/index.js
@@ -3,7 +3,8 @@ import assetUrl from '@cdo/apps/code-studio/assetUrl';
 import jsonic from 'jsonic';
 import {parseElement} from '@cdo/apps/xml';
 import {installCustomBlocks} from '@cdo/apps/block_utils';
-import {customInputTypes} from '@cdo/apps/p5lab/spritelab/blocks';
+import {customInputTypes as spriteLabInputTypes} from '@cdo/apps/p5lab/spritelab/blocks';
+import {customInputTypes as danceInputTypes} from '@cdo/apps/dance/blocks';
 import {
   valueTypeTabShapeMap,
   exampleSprites,
@@ -19,6 +20,8 @@ function renderBlock(element) {
   const config = element.getAttribute('config');
   const pool = element.getAttribute('pool');
   const parsedConfig = jsonic(config);
+  const customInputTypes =
+    pool === 'Dancelab' ? danceInputTypes : spriteLabInputTypes;
   const blocksInstalled = installCustomBlocks({
     blockly: Blockly,
     blockDefinitions: [


### PR DESCRIPTION
The initial work for the Dance Party AI modal (https://github.com/code-dot-org/code-dot-org/pull/53889) added a new custom input type for Dance blocks called `danceAi`.  This caused an unexpected regression in the form of a crash/error on the block pool's index page on levelbuilder:
![image (156)](https://github.com/code-dot-org/code-dot-org/assets/43474485/d9de3ce5-93e9-481b-9349-9fae839e42d6)

@breville summarized on Slack:

> If I traced back correctly, it seems this block list comes from [apps/src/p5lab/spritelab/blocks.js](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/p5lab/spritelab/blocks.js).  But the custom block in question (danceAi) is in [apps/src/dance/blocks.js](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/dance/blocks.js).
It seems the other custom blocks in [apps/src/dance/blocks.js](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/dance/blocks.js) (spritePicker, limitedColourPicker) have (virtually) identical duplicates in [apps/src/p5lab/spritelab/blocks.js](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/p5lab/spritelab/blocks.js).

Each lab type (Dance/SpriteLab) does have its own list of custom inputs, but as you observed, each type from Dance is also a named type in Sprite Lab (except the new danceAi type).
This is somewhat coincidental because there’s no technical assumption that these lists would align. What’s makes it even more confusing is that limitedColourPicker  means the same thing in both lab contexts, while a spritePicker is slightly different depending on the lab (see screenshots).
![image (157)](https://github.com/code-dot-org/code-dot-org/assets/43474485/38488469-c6fc-43ca-9e8e-d4dad9840305)
![image (158)](https://github.com/code-dot-org/code-dot-org/assets/43474485/e550baaa-2b67-4c7c-8490-c095f667463d)
FWIW, spritePicker blocks aren’t featured in any recommended curricula, but they are still supported in both labs. Personally, I don’t think it’s worth trying to reconcile the differences and instead we might want to focus on this problem as I see it:
When loading blocks on the index of a block pool page, we should make sure we’re finding the right list of input types, from either dance/blocks.js or /spritelab/blocks.js. Without delving into any code, my guess is that we’re always using the latter. We do already have the ability to switch things like the version of Blockly used on a block pool index, so I’d imagine it wouldn’t be too hard to fix this as well.
It seems like the reason this has never broken until now is just that each dance input type is also a sprite lab input type, regardless of any functional differences.

One solution might be to input both lists and switch based on the pool name. The Dance pool is the only pool that uses dance input types while the rest use Sprite Lab.

## Links

Slack discussion: https://codedotorg.slack.com/archives/C05DK21DAHK/p1696304921756459

I had to re-seed custom blocks (`bundle exec rake seed:blocks` from dashboard) to get the new Dance blocks to show, but confirmed that we no longer crash:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/5f9cf856-39fa-42df-9790-507cd347d90c)

No new regressions found in other block pools.