### PR TITLE
Switch Google Sheet Import to Specify Files by ID Instead of "Path"

### DIFF
--- a/lib/cdo/data/google_sheet_to_csv.rb
+++ b/lib/cdo/data/google_sheet_to_csv.rb
@@ -27,7 +27,7 @@ class GSheetToCsv
   end
 
   def import!
-    CDO.log.info "Downloading Googgle File with id: #{@gsheet_id}</b> from Google Drive."
+    CDO.log.info "Downloading Google File with id: #{@gsheet_id} from Google Drive."
 
     @file ||= (@@gdrive ||= Google::Drive.new).file(@gsheet_id)
 

--- a/lib/cdo/data/google_sheet_to_csv.rb
+++ b/lib/cdo/data/google_sheet_to_csv.rb
@@ -15,19 +15,10 @@ class GSheetToCsv
 
   def up_to_date?
     @file ||= (@@gdrive ||= Google::Drive.new).file_by_id(@gsheet_id)
-    unless @file
-      CDO.log.info "Google Drive file with id: #{@gsheet_id} not found."
-      return
-    end
 
-    begin
-      mtime = @file.mtime
-      ctime = File.mtime(@csv_path) if File.file?(@csv_path)
-      return mtime.to_s == ctime.to_s
-    rescue GoogleDrive::Error => exception
-      CDO.log.info "Error getting modified time for Google file with id: #{@gsheet_id} from Google Drive.#{exception.message}"
-      true # Assume the current thing is up to date.
-    end
+    mtime = @file.mtime
+    ctime = File.mtime(@csv_path) if File.file?(@csv_path)
+    return mtime.to_s == ctime.to_s
   end
 
   def import
@@ -39,10 +30,6 @@ class GSheetToCsv
     CDO.log.info "Downloading Googgle File with id: #{@gsheet_id}</b> from Google Drive."
 
     @file ||= (@@gdrive ||= Google::Drive.new).file(@gsheet_id)
-    unless @file
-      CDO.log.info "Google Drive file with id: #{@gsheet_id} not found."
-      return
-    end
 
     begin
       buf = @file.spreadsheet_csv

--- a/lib/cdo/google/drive.rb
+++ b/lib/cdo/google/drive.rb
@@ -1,7 +1,6 @@
 require 'json'
 require 'stringio'
 require 'google_drive'
-require 'cdo/chat_client'
 
 module Google
   class Drive
@@ -11,7 +10,7 @@ module Google
       def initialize(session, file)
         @session = session
         @file = file
-        $log&.debug "Google Drive file opened (key: #{@file.key})"
+        CDO.log.debug "Google Drive file opened (key: #{@file.key})"
       end
 
       def raw_file
@@ -40,7 +39,7 @@ module Google
     end
 
     def initialize(service_account_key = CDO.gdrive_export_secret.to_json)
-      $log&.debug 'Establishing Google Drive session'
+      CDO.log.debug 'Establishing Google Drive session'
       raise "Google Authentication Key not provided." if service_account_key.nil?
       @session = GoogleDrive::Session.from_service_account_key StringIO.new(service_account_key)
     end
@@ -49,18 +48,12 @@ module Google
       file = @session.file_by_title(path_to_title_array(path))
       return nil if file.nil?
       Google::Drive::File.new(@session, file)
-    rescue GoogleDrive::Error => exception
-      ChatClient.log "<p>Error syncing <b>#{path}<b> from Google Drive.</p><pre><code>#{exception.message}</code></pre>", color: 'yellow'
-      return nil
     end
 
     def file_by_id(id)
       file = @session.file_by_id(id)
       return nil if file.nil?
       Google::Drive::File.new(@session, file)
-    rescue GoogleDrive::Error => exception
-      CDO.log.info "Error accessing Google Drive file with id: #{id} because: #{exception.message}"
-      return nil
     end
 
     def folder(path)
@@ -74,21 +67,21 @@ module Google
       target_name = ::File.basename(target_path)
       target_folder = ::File.dirname(target_path)
 
-      $log&.debug "Uploading '#{src_path}' as '/#{temp_name}'"
+      CDO.log.debug "Uploading '#{src_path}' as '/#{temp_name}'"
       file = @session.upload_from_file(src_path, temp_name)
 
-      $log&.debug "Moving '/#{temp_name}' to '#{target_folder}/#{temp_name}'"
+      CDO.log.debug "Moving '/#{temp_name}' to '#{target_folder}/#{temp_name}'"
       folder = self.folder(target_folder)
       folder.add(file)
       @session.root_collection.remove(file)
 
       existing_file = self.file(target_path)
       unless existing_file.nil?
-        $log&.debug "Removing existing '#{target_path}'"
+        CDO.log.debug "Removing existing '#{target_path}'"
         folder.remove(existing_file.raw_file)
       end
 
-      $log&.debug "Renaming '#{temp_name}' to '#{target_name}' in '#{target_folder}'"
+      CDO.log.debug "Renaming '#{temp_name}' to '#{target_name}' in '#{target_folder}'"
       file.title = target_name
     end
 

--- a/lib/cdo/google/drive.rb
+++ b/lib/cdo/google/drive.rb
@@ -54,6 +54,15 @@ module Google
       return nil
     end
 
+    def file_by_id(id)
+      file = @session.file_by_id(id)
+      return nil if file.nil?
+      Google::Drive::File.new(@session, file)
+    rescue GoogleDrive::Error => exception
+      CDO.log.info "Error accessing Google Drive file with id: #{id} because: #{exception.message}"
+      return nil
+    end
+
     def folder(path)
       collection = @session.collection_by_title(path_to_title_array(path))
       return nil if collection.nil?

--- a/pegasus/data/cdo-beyond-tutorials.gsheet
+++ b/pegasus/data/cdo-beyond-tutorials.gsheet
@@ -1,2 +1,2 @@
-v3/cdo-beyond-tutorials
+1RZ6iutiOV8LTol1uooJ3m1GiHHPbpmssNSWkT87oTNI
 exclude_columns: ['notes_t']

--- a/pegasus/data/cdo-concepts-csf.gsheet
+++ b/pegasus/data/cdo-concepts-csf.gsheet
@@ -1,2 +1,1 @@
-v3/cdo-concepts-csf
-
+1_A_ScyqU-qFpcHXn7NowVcnu5zoQWswYQNPzlYDeicg

--- a/pegasus/data/cdo-contributors.gsheet
+++ b/pegasus/data/cdo-contributors.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-contributors
+1r62VtFxNz9tefxrcYj6HvnB14e2cd4TLTOr_owbuTAE

--- a/pegasus/data/cdo-cs-statistics.gsheet
+++ b/pegasus/data/cdo-cs-statistics.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-cs-statistics
+1xnhqPJ7D0SffLtpuefhH1N6tvHS2Aj1LWUmX-XtCpDw

--- a/pegasus/data/cdo-donor-schools.gsheet
+++ b/pegasus/data/cdo-donor-schools.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-donor-schools
+1jBpoh1a7nLC2VHMXW332v2agun0C6rFv4hONduRcy2c

--- a/pegasus/data/cdo-donors.gsheet
+++ b/pegasus/data/cdo-donors.gsheet
@@ -1,2 +1,2 @@
-v3/cdo-donors
+10-NnoDUOxdisAHmV0dxTCyT6k-CFd3MEWvcHFlSraps
 exclude_columns: ['amount_s','notes_s', 'sum_i', 'sum_f', 'twitter_sum_i', 'twitter_sum_f']

--- a/pegasus/data/cdo-glossary-csf.gsheet
+++ b/pegasus/data/cdo-glossary-csf.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-glossary-csf
+1e_yXGyOAT8hyG2mnGeayf6nBQyHS8AmFPWFIkXDjjQQ

--- a/pegasus/data/cdo-highlights.gsheet
+++ b/pegasus/data/cdo-highlights.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-highlights
+14Wk25JQQ5v-E_BViuhIR9B_cl2ADb-cwLSS6ZjnrF6w

--- a/pegasus/data/cdo-homepage-teachers.gsheet
+++ b/pegasus/data/cdo-homepage-teachers.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-homepage-teachers
+1NKfuvpXx61bkbN86BDtvcEIvHnUkVVaobbOiU90M2pg

--- a/pegasus/data/cdo-languages.gsheet
+++ b/pegasus/data/cdo-languages.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-languages
+10dS5PJKRt846ol9f9L3pKh03JfZkN7UIEcwMmiGS4i0

--- a/pegasus/data/cdo-leaders.gsheet
+++ b/pegasus/data/cdo-leaders.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-leaders
+1fLp1CNZpf4sdgVGFalgeNIHbQuEVLLcqMeGK1K6ynXM

--- a/pegasus/data/cdo-lessons.gsheet
+++ b/pegasus/data/cdo-lessons.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-lessons
+1WaHtgN92zrr7wvq4kJuRx18-w2rbtHY2zmjmpa6cKs8

--- a/pegasus/data/cdo-news-items.gsheet
+++ b/pegasus/data/cdo-news-items.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-news-items
+1osLbo8D4Rmm8OqhwJyws8ZgurXO0N6_jVnvWguFas0M

--- a/pegasus/data/cdo-partners.gsheet
+++ b/pegasus/data/cdo-partners.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-partners
+1sWyUZYlaMwk2nWswwA0bHce9taxMIvJkB8hEfHHIX4E

--- a/pegasus/data/cdo-promote-impact-statistics.gsheet
+++ b/pegasus/data/cdo-promote-impact-statistics.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-promote-impact-statistics
+1SBz4w5gUV329Os3TH3zDHBilrzo-8ZJcTbrIya-C8Qw

--- a/pegasus/data/cdo-promote-tools.gsheet
+++ b/pegasus/data/cdo-promote-tools.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-promote-tools
+1Stfj8LtcuTFISYjvkIZE_0pb8Yae4m3u-E8TUDfNSZM

--- a/pegasus/data/cdo-quotes.gsheet
+++ b/pegasus/data/cdo-quotes.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-quotes
+1zZQ1OsgQzvrxBUDin6LZ1wXhiffz9eY2j_erxxLlgPc

--- a/pegasus/data/cdo-standards.gsheet
+++ b/pegasus/data/cdo-standards.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-standards
+1RMpNbMX2RjhHly9XaG0Sz98jlmiKttHo9YGLiqj9XVg

--- a/pegasus/data/cdo-state-actions.gsheet
+++ b/pegasus/data/cdo-state-actions.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-state-actions
+1xFUvlA7XRq8SINpRVRYVGcmEz92SQx9QCu3Ii_i_hG8

--- a/pegasus/data/cdo-state-petition-data.gsheet
+++ b/pegasus/data/cdo-state-petition-data.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-state-petition-data
+1EZnH1GFtZXfwhLHTLUnN0fmhEVKU6YPvnPNpmf5ZB-0

--- a/pegasus/data/cdo-state-promote.gsheet
+++ b/pegasus/data/cdo-state-promote.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-state-promote
+17tLLpj8gkHNfwRREzqBeyM6RSVbNlEpauO-_XJNlyvk

--- a/pegasus/data/cdo-team.gsheet
+++ b/pegasus/data/cdo-team.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-team
+1MR2YDhcVBT-OJIU8jeUtXR77lsY0NIArj4trFB_hkoU

--- a/pegasus/data/cdo-tutorials-preview.gsheet
+++ b/pegasus/data/cdo-tutorials-preview.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-tutorials-preview
+1qF5PSUYnp19WLTLOdQfVy1-qwzDbuxNDvAEV6BSruP4

--- a/pegasus/data/cdo-tutorials.gsheet
+++ b/pegasus/data/cdo-tutorials.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-tutorials
+1Pt22IXYguBuv46WVAzn9aCZ86VJ5-qxPHUGiarHogpE

--- a/pegasus/data/cdo-unplugged.gsheet
+++ b/pegasus/data/cdo-unplugged.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-unplugged
+1OJ7UZRhTgnp6YtXqTIv_J3ZagnREnWzhNzS-8wNV-3w

--- a/pegasus/data/cdo-youtube-videos.gsheet
+++ b/pegasus/data/cdo-youtube-videos.gsheet
@@ -1,1 +1,1 @@
-v3/cdo-youtube-videos
+1i1-VEbyZ9VtcV8m8V_mTHILi5S4OxmDke_uJUeLlDa4

--- a/pegasus/rake/i18n.rake
+++ b/pegasus/rake/i18n.rake
@@ -2,6 +2,9 @@ require 'cdo/google/drive'
 require lib_dir 'cdo/data/logging/rake_task_event_logger'
 include TimedTaskWithLogging
 
+# Unique Google Drive file identifier for the Google Sheet named 'I18n'
+I18N_GOOGLE_SHEET_ID = '1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU'.freeze
+
 # Given a line of yml in the form of key: value, wraps unquoted strings in
 # double quotes, escaping existing quotes. Does not touch already quoted or
 # single quoted strings.
@@ -37,11 +40,9 @@ end
 namespace :i18n do
   desc 'download the latest i18n gsheet'
   timed_task_with_logging :sync do
-    gsheet = 'Data/I18n'
     path = pegasus_dir('cache/i18n/en-US.yml')
     gdrive = Google::Drive.new
-    file = gdrive.file(gsheet)
-    raise("Google Drive file '#{gsheet}' not found.") unless file
+    file = gdrive.file_by_id(I18N_GOOGLE_SHEET_ID)
 
     mtime = file.mtime
     ctime = File.mtime(path).utc if File.file?(path)

--- a/pegasus/rake/seed.rake
+++ b/pegasus/rake/seed.rake
@@ -16,7 +16,7 @@ namespace :seed do
 
   desc 'download modified Google Sheets as CSV'
   timed_task_with_logging :sync_v3 do
-    Dir.glob(pegasus_dir('data/*.gsheet')) {|i| GSheetToCsv.new(i).import}
+    Dir.glob(pegasus_dir('data/*.gsheet')) {|file| GSheetToCsv.new(file).import}
   end
 
   desc 'download modified Google Sheets as CSV, and import any modified CSVs into the database'


### PR DESCRIPTION
When we rebuilt the `staging` server we switched from using Google credentials for the `pegasus@code.org` user stored on the file system of the server to credentials in an AWS Secret for a Google service account that has permissions to the same set of Google Sheets. However, our `Google::Drive` module that wraps our usage of the `google_drive` gem identifies  files in Google Drive by their "path", which might be different for the owner of the files (`pegasus@code.org`) vs a Google Cloud service account that has permissions to read/write the same files.

Switch to using the `id` to specify which Google file to download and import.

## Testing story

``` ruby
[staging] dashboard > drive = Google::Drive.new
GetSecretValue: staging/cdo/gdrive_export_secret
=> #<Google::Drive:0x000055c47fa08d60 @session=#<GoogleDrive::Session:0x2dd5c>>
[staging] dashboard > drive.raw_session.file_by_id('1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU')
=> #<GoogleDrive::Spreadsheet id="1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU" title="I18n">
```

## Deployment strategy

## Follow-up work

If this works, we should:

- [x] make the same fixes for the `Data\I18n` Google Sheet
- [ ] login to Google Drive in a web browser as `pegasus@code.org` and move the sheets to a `System` folder in the Engineering Team Drive

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
