### PR TITLE
Update links in new teacher email

### DIFF
--- a/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
@@ -11,11 +11,11 @@
   %a{href:"https://studio.code.org/catalog"}you'll find courses for all grade levels
   \- from pre-readers to seniors in high school, and everyone in between. All our courses
   are available at no cost. Looking for a quick activity? Try starting with an
-  %a{href:"https://hourofcode.com"}Hour of Code.
+  %a{href:"https://studio.code.org/catalog?marketingInitiative=hoc"}Hour of Code.
 %h3
   Step 2: Set up your classroom section
 %p
-  %a{href:"https://studio.code.org/home"}Set up a classroom section
+  %a{href:"https://studio.code.org/home?openAddSectionDialog=true&participantType=student"}Set up a classroom section
   to view your student's progress, print login cards for your students, manage their accounts,
   and print certificates they can bring home when they finish the course.
 %h3
@@ -25,7 +25,7 @@
   your students, unplugged activities for your class you can do without a computer, and forums
   to connect to other teachers.
 
-%a{href:"https://studio.code.org/home", style: 'width: 180px; height: 36px; border: 0; color: white; background-color: #FDC62C; font: bolder 18px Arial; display: block; text-align: center; line-height: 36px; text-decoration: none; border-radius: 5px;'}
+%a{href:"https://code.org/teach", style: 'width: 180px; height: 36px; border: 0; color: white; background-color: #FDC62C; font: bolder 18px Arial; display: block; text-align: center; line-height: 36px; text-decoration: none; border-radius: 5px;'}
   Get started here
 
 - if us_ip

--- a/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
@@ -25,7 +25,7 @@
   your students, unplugged activities for your class you can do without a computer, and forums
   to connect to other teachers.
 
-%a{href:"https://code.org/teach", style: 'width: 180px; height: 36px; border: 0; color: white; background-color: #FDC62C; font: bolder 18px Arial; display: block; text-align: center; line-height: 36px; text-decoration: none; border-radius: 5px;'}
+%a{href:"https://studio.code.org/home", style: 'width: 180px; height: 36px; border: 0; color: white; background-color: #FDC62C; font: bolder 18px Arial; display: block; text-align: center; line-height: 36px; text-decoration: none; border-radius: 5px;'}
   Get started here
 
 - if us_ip


### PR DESCRIPTION
I recently set up an account for testing something and got the new teacher welcome email. I took a look at it and realized there were some links we could update to help teachers find things more easily so this PR updates two links in the new teacher welcome email. 

1) Keep people on our site to look at our Hour of Code options
2) Quick link that will automatically open section setup (thanks Meg for this!)
