### PR TITLE
Add LTI Advantage client

### DIFF
--- a/dashboard/lib/clients/lti_advantage_client.rb
+++ b/dashboard/lib/clients/lti_advantage_client.rb
@@ -1,0 +1,22 @@
+class LtiAdvantageClient
+  include LtiAccessToken
+
+  def initialize(client_id, issuer)
+    raise ArgumentError unless client_id && issuer
+    @client_id = client_id
+    @issuer = issuer
+  end
+
+  # Call the LTI Advantage API to get the membership (roster) for a given context (course/section).
+  # The URL for the API will vary between LMS platforms, and is initially contained in the launch context.
+  # See the LTI spec for details:
+  # https://www.imsglobal.org/spec/lti-nrps/v2p0/
+  def get_context_membership(url)
+    headers = {
+      'Accept' => Policies::Lti::MEMBERSHIP_CONTAINER_CONTENT_TYPE,
+    }
+    res = HTTParty.get(url, headers: headers.merge('Authorization' => "Bearer #{get_access_token(@client_id, @issuer)}"))
+    raise "Error getting context membership: #{res.code} #{res.body}" unless res.code == HTTP::Status::OK
+    JSON.parse(res, symbolize_names: true)
+  end
+end

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -11,4 +11,5 @@ class Policies::Lti
   NAMESPACE = 'lti_v1_controller'.freeze
   JWT_CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'.freeze
   JWT_ISSUER = CDO.studio_url('', CDO.default_scheme).freeze
+  MEMBERSHIP_CONTAINER_CONTENT_TYPE = 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json'.freeze
 end

--- a/dashboard/test/lib/clients/lti_advantage_client_test.rb
+++ b/dashboard/test/lib/clients/lti_advantage_client_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 require_relative '../../../lib/clients/lti_advantage_client'
 
 class LtiAdvantageClientTest < ActiveSupport::TestCase
+  include LtiAccessToken
+
   test 'throws an error if the API returns a non-200 response' do
     HTTParty.stubs(:get).returns(OpenStruct.new({code: 400}))
     LtiAccessToken.stubs(:get_access_token).returns('fake_access_token')

--- a/dashboard/test/lib/clients/lti_advantage_client_test.rb
+++ b/dashboard/test/lib/clients/lti_advantage_client_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+require_relative '../../../lib/clients/lti_advantage_client'
+
+class LtiAdvantageClientTest < ActiveSupport::TestCase
+  test 'throws an error if the API returns a non-200 response' do
+    HTTParty.stubs(:get).returns(OpenStruct.new({code: 400}))
+    LtiAccessToken.stubs(:get_access_token).returns('fake_access_token')
+    assert_raises RuntimeError do
+      LtiAdvantageClient.new('client_id', 'issuer').get_context_membership('https://foolms.com/api/sections/1')
+    end
+  end
+
+  test 'throws an error if no client_id or issuer is provided' do
+    assert_raises ArgumentError do
+      LtiAdvantageClient.new(nil, nil)
+    end
+  end
+end


### PR DESCRIPTION
Adds an http client class to call the LTI Advantage rostering API. This is the endpoint that fetches the course membership information we need to create and sync sections with an LMS.

## Links
[Jira ticket](https://codedotorg.atlassian.net/browse/P20-514)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
