### PR TITLE
Fix Violations of and Reenable `Style/HashConversion`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -271,12 +271,6 @@ Style/GlobalStdStream:
 Style/GlobalVars:
   Enabled: false
 
-# Offense count: 20
-# This cop supports safe auto-correction (--auto-correct).
-# Configuration parameters: AllowSplatArgument.
-Style/HashConversion:
-  Enabled: false
-
 # Offense count: 31
 # This cop supports unsafe auto-correction (--auto-correct-all).
 # Configuration parameters: AllowedReceivers.

--- a/bin/animation_assets/manifest_builder.rb
+++ b/bin/animation_assets/manifest_builder.rb
@@ -19,7 +19,7 @@ SPRITELAB_MANIFEST_PATH = "animation-manifests/manifests/"
 class Hash
   # Like Enumerable::map but returns a Hash instead of an Array
   def hmap(&block)
-    Hash[map {|k, v| yield k, v}]
+    map {|k, v| yield k, v}.to_h
   end
 
   # Drop a key from the hash, returning the hash (destructive)

--- a/bin/cron/hoc_signup_counts
+++ b/bin/cron/hoc_signup_counts
@@ -36,10 +36,10 @@ def main
   # Transform the data into more accessible hashes of the form
   # {'' => 1, 'Afghanistan' => 2, ...}
   country_counts = country_counts.map do |country_and_count_hash|
-    Hash[country_and_count_hash[:country], country_and_count_hash[:count]]
+    {country_and_count_hash[:country] => country_and_count_hash[:count]}
   end.reduce({}, :merge)
   us_state_counts = us_state_counts.map do |state_and_count_hash|
-    Hash[state_and_count_hash[:state], state_and_count_hash[:count]]
+    {state_and_count_hash[:state] => state_and_count_hash[:count]}
   end.reduce({}, :merge)
 
   Properties.set(

--- a/dashboard/app/controllers/admin_reports_controller.rb
+++ b/dashboard/app/controllers/admin_reports_controller.rb
@@ -97,7 +97,7 @@ class AdminReportsController < ApplicationController
       output_data[key]['Perceived Dropout'] = output_data[key]['UniqueAttempt'].to_f - output_data[key]['UniqueSuccess'].to_f
     end
 
-    page_data = Hash[GAClient.query_ga(@start_date, @end_date, 'ga:pagePath', 'ga:avgTimeOnPage', 'ga:pagePath=~^/s/|^/flappy/|^/hoc/').rows]
+    page_data = GAClient.query_ga(@start_date, @end_date, 'ga:pagePath', 'ga:avgTimeOnPage', 'ga:pagePath=~^/s/|^/flappy/|^/hoc/').rows.to_h
 
     data_array = output_data.map do |key, value|
       {'Puzzle' => key}.merge(value).merge('timeOnSite' => page_data[key]&.to_i)

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -208,7 +208,7 @@ module UsersHelper
   #   3: {}
   # }
   private def teacher_feedbacks_by_student_by_level(users, unit)
-    initial_hash = Hash[users.map {|user| [user.id, {}]}]
+    initial_hash = users.map {|user| [user.id, {}]}.to_h
     TeacherFeedback.
       get_latest_feedbacks_received(users.map(&:id), nil, unit.id).
       group_by(&:student_id).

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -242,15 +242,13 @@ class Foorm::Form < ApplicationRecord
       # but are in the submission (eg, survey config and workshop metadata).
       # Put new headers first, as they generally contain important general
       # information (eg, user_id, pd_workshop_id, etc.)
-      potential_new_headers = Hash[
-        answers.keys.map do |question_id|
+      potential_new_headers = answers.keys.map do |question_id|
           if headers.key?(question_id)
             [nil, nil]
           else
             [question_id, question_id]
           end
-        end
-      ].compact
+        end.to_h.compact
 
       headers = potential_new_headers.merge headers
 
@@ -283,9 +281,7 @@ class Foorm::Form < ApplicationRecord
 
           # Add any facilitator-specific questions as headers
           # that are in the submission but not already in the list of headers.
-          potential_new_headers = Hash[
-            facilitator_response_with_facilitator_number.keys.map {|question_id| [question_id, question_id]}
-          ]
+          potential_new_headers = facilitator_response_with_facilitator_number.keys.map {|question_id| [question_id, question_id]}.to_h
           facilitator_headers = potential_new_headers.merge facilitator_headers
 
           headers.merge! facilitator_headers
@@ -358,11 +354,9 @@ class Foorm::Form < ApplicationRecord
   end
 
   def readable_questions_with_facilitator_number(questions, number)
-    Hash[
-      questions[:facilitator].map do |question_id, question_text|
+    questions[:facilitator].map do |question_id, question_text|
         [question_id + "_#{number}", "Facilitator #{number}: " + question_text]
-      end
-    ]
+    end.to_h
   end
 
   def write_to_file?

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -243,12 +243,12 @@ class Foorm::Form < ApplicationRecord
       # Put new headers first, as they generally contain important general
       # information (eg, user_id, pd_workshop_id, etc.)
       potential_new_headers = answers.keys.map do |question_id|
-          if headers.key?(question_id)
-            [nil, nil]
-          else
-            [question_id, question_id]
-          end
-        end.to_h.compact
+        if headers.key?(question_id)
+          [nil, nil]
+        else
+          [question_id, question_id]
+        end
+      end.to_h.compact
 
       headers = potential_new_headers.merge headers
 
@@ -355,7 +355,7 @@ class Foorm::Form < ApplicationRecord
 
   def readable_questions_with_facilitator_number(questions, number)
     questions[:facilitator].map do |question_id, question_text|
-        [question_id + "_#{number}", "Facilitator #{number}: " + question_text]
+      [question_id + "_#{number}", "Facilitator #{number}: " + question_text]
     end.to_h
   end
 

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -123,11 +123,9 @@ class Foorm::Submission < ApplicationRecord
   def formatted_answers_with_facilitator_number(number)
     return {} unless workshop_metadata.facilitator_specific?
 
-    Hash[
-      formatted_answers.map do |question_id, answer_text|
+    formatted_answers.map do |question_id, answer_text|
         [question_id + "_#{number}", answer_text]
-      end
-    ]
+    end.to_h
   end
 
   # Store the JSON parsable "{}" if we attempt to store a blank submission,

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -124,7 +124,7 @@ class Foorm::Submission < ApplicationRecord
     return {} unless workshop_metadata.facilitator_specific?
 
     formatted_answers.map do |question_id, answer_text|
-        [question_id + "_#{number}", answer_text]
+      [question_id + "_#{number}", answer_text]
     end.to_h
   end
 

--- a/dashboard/app/models/paired_user_level.rb
+++ b/dashboard/app/models/paired_user_level.rb
@@ -49,7 +49,7 @@ class PairedUserLevel < ApplicationRecord
   #   3 => Set[]
   # }
   def self.pairs_by_user(users)
-    initial_hash = Hash[users.map {|user| [user.id, Set.new]}]
+    initial_hash = users.map {|user| [user.id, Set.new]}.to_h
     user_ids = users.map(&:id)
     drivers = PairedUserLevel.
       joins(:driver_user_level).

--- a/dashboard/app/models/pd/international_opt_in.rb
+++ b/dashboard/app/models/pd/international_opt_in.rb
@@ -92,7 +92,7 @@ class Pd::InternationalOptIn < ApplicationRecord
     #
     # See the definition of the "Answer" object in
     # apps/src/code-studio/pd/form_components/utils.js
-    entries = Hash[entry_keys.map do |key, values|
+    entries = entry_keys.map do |key, values|
       [key, values.map do |value|
         # Capitalize country values to be consistent with other country strings in our database
         answer = key.to_s == 'schoolCountry' ? value.titleize : value
@@ -101,7 +101,7 @@ class Pd::InternationalOptIn < ApplicationRecord
           answerValue: answer
         }
       end]
-    end]
+    end.to_h
 
     entries[:workshopOrganizer] = INTERNATIONAL_OPT_IN_PARTNERS
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1210,7 +1210,7 @@ class User < ApplicationRecord
   #   3: {}
   # }
   def self.user_levels_by_user_by_level(users, script)
-    initial_hash = Hash[users.map {|user| [user.id, {}]}]
+    initial_hash = users.map {|user| [user.id, {}]}.to_h
     UserLevel.where(
       script_id: script.id,
       user_id: users.map(&:id)

--- a/dashboard/lib/core_extensions.rb
+++ b/dashboard/lib/core_extensions.rb
@@ -4,7 +4,7 @@ module CoreExtensions
   module Hash
     module Camelizing
       def camelize_keys
-        ::Hash[map {|key, value| [key.to_s.camelize(:lower), value]}]
+        map {|key, value| [key.to_s.camelize(:lower), value]}.to_h
       end
     end
   end

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -32,7 +32,7 @@ class LevelLoader
 
     # Use a transaction because loading levels requires two separate imports.
     Level.transaction do
-      level_md5s_by_name = Hash[Level.pluck(:name, :md5)]
+      level_md5s_by_name = Level.pluck(:name, :md5).to_h
       existing_level_names = level_md5s_by_name.keys.to_set
 
       level_file_names = level_file_paths.map do |path|

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -233,7 +233,7 @@ namespace :seed do
   # explicit execution of "seed:dsls"
   timed_task_with_logging dsls: :environment do
     DSLDefined.transaction do
-      level_md5s_by_name = Hash[DSLDefined.pluck(:name, :md5)]
+      level_md5s_by_name = DSLDefined.pluck(:name, :md5).to_h
 
       # Allow developers to seed just one dsl-defined level, e.g.
       # rake seed:dsls DSL_FILENAME=k-1_Artistloops_multi1.multi

--- a/dashboard/scripts/archive/backfill_user_level_script_ids
+++ b/dashboard/scripts/archive/backfill_user_level_script_ids
@@ -6,10 +6,10 @@
 
 require_relative '../../config/environment'
 
-level_id_to_script_ids = Hash[Level.all.map do |level|
+level_id_to_script_ids = Level.all.map do |level|
   # for each level, find all scripts that it is in, except for hidden scripts (but including old hoc which is now hidden)
   [level.id, level.script_levels.collect(&:script).reject {|s| s.id != 2 && s.hidden?}.collect(&:id)]
-end]
+end.to_h
 
 UserLevel.where(script_id: nil).find_in_batches do |batch|
   created = 0

--- a/dashboard/scripts/archive/block_docs_to_i18n
+++ b/dashboard/scripts/archive/block_docs_to_i18n
@@ -84,7 +84,7 @@ def update_docs_i18n_file(functions, i18n_json_filename)
   data_hash = File.exist?(i18n_json_filename) ? JSON.parse(File.read(i18n_json_filename)) : {}
 
   modified_data_hash = data_hash.merge(new_strings)
-  sorted_data_hash = Hash[modified_data_hash.sort]
+  sorted_data_hash = modified_data_hash.sort.to_h
 
   File.write(i18n_json_filename, JSON.pretty_generate(sorted_data_hash) + "\n")
 end

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -14,7 +14,7 @@ module Api::V1::Pd
 
     setup do
       @controller.stubs(:get_score_for_workshops)
-      AWS::S3.stubs(:download_from_bucket).returns(Hash[@workshop.course.to_sym, {}].to_json)
+      AWS::S3.stubs(:download_from_bucket).returns({@workshop.course.to_sym => {}}.to_json())
     end
 
     API = '/api/v1/pd/workshops'

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -14,7 +14,7 @@ module Api::V1::Pd
 
     setup do
       @controller.stubs(:get_score_for_workshops)
-      AWS::S3.stubs(:download_from_bucket).returns({@workshop.course.to_sym => {}}.to_json())
+      AWS::S3.stubs(:download_from_bucket).returns({@workshop.course.to_sym => {}}.to_json)
     end
 
     API = '/api/v1/pd/workshops'

--- a/lib/cdo/shared_constants/pd/principal_approval_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/principal_approval_application_constants.rb
@@ -53,7 +53,7 @@ module Pd
 
     ALL_LABELS = PAGE_LABELS.merge(
       # map array of field names to hash of {field_name: nil}
-      Hash[FIELDS_WITH_DYNAMIC_LABELS.map {|field_name| [field_name, nil]}]
+      FIELDS_WITH_DYNAMIC_LABELS.map {|field_name| [field_name, nil]}.to_h
     ).freeze
   end
 end

--- a/tools/scripts/rebuildSoundLibraryManifest.rb
+++ b/tools/scripts/rebuildSoundLibraryManifest.rb
@@ -31,7 +31,7 @@ DOWNLOAD_DESTINATION = '~/cdo-sound-library'.freeze
 class Hash
   # Like Enumerable::map but returns a Hash instead of an Array
   def hmap(&block)
-    Hash[map {|k, v| yield k, v}]
+    map {|k, v| yield k, v}.to_h
   end
 
   # Drop a key from the hash, returning the hash (destructive)


### PR DESCRIPTION
> This cop checks the usage of pre-2.1 ‘[Hash](https://www.rubydoc.info/gems/rubocop/1.12.0/RuboCop/Cop/Style/args)` method of converting enumerables and sequences of values to hashes.

In our codebase, this mostly manifests as converting instance of `Hash[ary]` to `ary.to_h`, but there are also two `Hash[key, value]` to `{key => value}`

Fix applied automatically with `bundle exec rubocop --autocorrect-all --only Style/HashConversion`; I then manually corrected a few minor `Style/` violations.

Like most of the `Style/` cops, I think this one is pretty optional for us to take on; but in this case, I also can't think of a reason we'd want to continue to support the pre-2.1 method. What do y'all think?

## Links

- https://docs.rubocop.org/rubocop/cops_style.html#stylehashconversion
- https://www.rubydoc.info/gems/rubocop/1.12.0/RuboCop/Cop/Style/HashConversion