### PR TITLE
test get_all_enabled for signed out user

### DIFF
--- a/dashboard/app/models/experiments/single_section_experiment.rb
+++ b/dashboard/app/models/experiments/single_section_experiment.rb
@@ -31,6 +31,8 @@ class SingleSectionExperiment < Experiment
   belongs_to :section, optional: true
 
   def enabled?(user: nil)
+    return false unless user
+
     user.sections.include?(section) || user.sections_as_student.include?(section)
   end
 end

--- a/dashboard/test/models/experiment_test.rb
+++ b/dashboard/test/models/experiment_test.rb
@@ -153,6 +153,15 @@ class ExperimentTest < ActiveSupport::TestCase
     refute Experiment.enabled?(experiment_name: experiment.name, user: @student)
   end
 
+  test "experiments do not break get_all_enabled for signed out user" do
+    Honeybadger.stubs(:notify).raises('HoneyBadger.notify called')
+    create :user_based_experiment
+    create :teacher_based_experiment
+    create :single_user_experiment
+    create :single_section_experiment
+    Experiment.get_all_enabled
+  end
+
   test "teacher is included in single-section experiment" do
     experiment = create :single_section_experiment
     assert Experiment.enabled?(experiment_name: experiment.name, user: experiment.section.user)

--- a/dashboard/test/models/experiment_test.rb
+++ b/dashboard/test/models/experiment_test.rb
@@ -153,7 +153,7 @@ class ExperimentTest < ActiveSupport::TestCase
     refute Experiment.enabled?(experiment_name: experiment.name, user: @student)
   end
 
-  test "experiments do not break get_all_enabled for signed out user" do
+  test "creating experiments does not break get_all_enabled for signed out user" do
     Honeybadger.stubs(:notify).raises('HoneyBadger.notify called')
     create :user_based_experiment
     create :teacher_based_experiment


### PR DESCRIPTION
while going to add a check for the `ai-rubric` experiment, I noticed a problem when the user is signed out:
```
[development] dashboard > include FactoryBot::Syntax::Methods
[development] dashboard > create :single_section_experiment, name: 'ai-rubric'
[development] dashboard > Experiment.enabled?(user: nil, experiment_name: 'ai-rubric')
** [Honeybadger] Unable to send error report: API key is missing. id=b845a5c3-e64b-4a6f-8fe5-65c49b815c81 level=3 pid=17434
=> false
```

The Honeybadger warning is being hit on these lines: https://github.com/code-dot-org/code-dot-org/blob/51d2f42518a09766ce702c45ceddb0c10c4ac74f/dashboard/app/models/experiments/experiment.rb#L65-L66

If I remove this rescue clause, the original error can be seen:
```
[development] dashboard > Experiment.enabled?(user: nil, experiment_name: 'ai-rubric')
/Users/dsb/src/cdo/dashboard/app/models/experiments/single_section_experiment.rb:34:in `enabled?': undefined method `sections' for nil:NilClass (NoMethodError)
```

This PR fixes the issue by adding a null check, and adds a unit test which (if people remember to add new experiment types to this unit test) will hopefully catch this kind of problem again in the future.

## Testing story

* new unit test
* manual testing in rails console