### PR TITLE
Show schools on Hour of Code map that don't have an explicitly-defined Organization Name

### DIFF
--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -27,6 +27,8 @@ CURRENT_HOC_SIGNUP = "HocSignup#{DCDO.get('hoc_year', 2017)}".freeze
 def main
   geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
 
+  skipped = 0
+
   DB_READONLY[:forms].where(kind: CURRENT_HOC_SIGNUP).paged_each(rows_per_fetch: 10_000) do |form|
     data = JSON.parse(form[:data])
     processed_data = JSON.parse(form[:processed_data]) rescue {}
@@ -47,8 +49,14 @@ def main
         data['organization_name_s']
       end
 
-    next if organization_name.nil? || processed_data['location_p'].nil?
-    next if form[:review] != "approved" && processed_data['location_city_s'].nil?
+    if organization_name.nil? || processed_data['location_p'].nil?
+      skipped += 1
+      next
+    end
+    if form[:review] != "approved" && processed_data['location_city_s'].nil?
+      skipped += 1
+      next
+    end
 
     coordinates = processed_data['location_p'].split(',')
     long = coordinates[1].to_f
@@ -79,10 +87,13 @@ def main
     "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"hoc\" --force #{file.path}"
   )
   upload_successful = false
+  puts "Num skipped: #{skipped}"
   if tippecanoe_status.success?
+    puts "SUCCESS"
     upload_successful = upload_maptiles(tiles.path, 'hoctiles')
   end
   unless tippecanoe_status.success? && upload_successful
+    puts "FAILURE"
     Honeybadger.notify(
       error_message: "Updating HOC map on Mapbox failed",
       error_class: "HOC Map Update Failure",

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -23,6 +23,9 @@ require_relative 'upload_to_mapbox'
 
 DB_READONLY = Sequel.connect(CDO.pegasus_db_reader.sub('mysql:', 'mysql2:'))
 
+SPECIFIC_SCHOOL_ID = 7_067_343
+SPECIFIC_SCHOOL_ID_STR = '7067343'
+
 CURRENT_HOC_SIGNUP = "HocSignup#{DCDO.get('hoc_year', 2017)}".freeze
 def main
   geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
@@ -43,16 +46,39 @@ def main
     # processed location, and city. With the exception that approved special events
     # don't need a city so we can show events like the Cocos Keeling Islands.
     if data['organization_name_s'].nil?
+      if form[:id] == SPECIFIC_SCHOOL_ID || form[:id] == SPECIFIC_SCHOOL_ID_STR
+        puts 'SKIPPED ON ORG NAME'
+        puts JSON.parse(data)
+      end
       nil_org_name += 1
       next
     end
     if processed_data['location_p'].nil?
+      if form[:id] == SPECIFIC_SCHOOL_ID || form[:id] == SPECIFIC_SCHOOL_ID_STR
+        puts 'SKIPPED ON LOCATION'
+        puts JSON.parse(processed_data)
+      end
       nil_location += 1
       next
     end
     if form[:review] != "approved" && processed_data['location_city_s'].nil?
+      if form[:id] == SPECIFIC_SCHOOL_ID || form[:id] == SPECIFIC_SCHOOL_ID_STR
+        puts 'SKIPPED ON CITY AND APPROVAL'
+        puts JSON.parse(processed_data)
+        puts form[:review]
+      end
       not_approved_no_city += 1
       next
+    end
+
+    if form[:id] == SPECIFIC_SCHOOL_ID || form[:id] == SPECIFIC_SCHOOL_ID_STR
+      puts 'NOT SKIPPED'
+      puts data['organization_name_s']
+      puts processed_data['location_p']
+      puts form[:review]
+      puts processed_data['location_city_s']
+      puts JSON.parse(data)
+      puts JSON.parse(processed_data)
     end
 
     organization_name =

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -40,6 +40,15 @@ def main
     # In order to be placed on the map, all events require an organization name,
     # processed location, and city. With the exception that approved special events
     # don't need a city so we can show events like the Cocos Keeling Islands.
+    if data['organization_name_s'].nil? || processed_data['location_p'].nil?
+      skipped += 1
+      next
+    end
+    if form[:review] != "approved" && processed_data['location_city_s'].nil?
+      skipped += 1
+      next
+    end
+
     organization_name =
       if !processed_data['nces_school_name_s'].to_s.strip.empty?
         processed_data['nces_school_name_s']
@@ -48,15 +57,6 @@ def main
       else
         data['organization_name_s']
       end
-
-    if organization_name.nil? || processed_data['location_p'].nil?
-      skipped += 1
-      next
-    end
-    if form[:review] != "approved" && processed_data['location_city_s'].nil?
-      skipped += 1
-      next
-    end
 
     coordinates = processed_data['location_p'].split(',')
     long = coordinates[1].to_f

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -38,9 +38,6 @@ def main
     # In order to be placed on the map, all events require an organization name,
     # processed location, and city. With the exception that approved special events
     # don't need a city so we can show events like the Cocos Keeling Islands.
-    next if data['organization_name_s'].nil? || processed_data['location_p'].nil?
-    next if form[:review] != "approved" && processed_data['location_city_s'].nil?
-
     organization_name =
       if !processed_data['nces_school_name_s'].to_s.strip.empty?
         processed_data['nces_school_name_s']
@@ -49,6 +46,9 @@ def main
       else
         data['organization_name_s']
       end
+
+    next if organization_name.nil? || processed_data['location_p'].nil?
+    next if form[:review] != "approved" && processed_data['location_city_s'].nil?
 
     coordinates = processed_data['location_p'].split(',')
     long = coordinates[1].to_f

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -27,7 +27,9 @@ CURRENT_HOC_SIGNUP = "HocSignup#{DCDO.get('hoc_year', 2017)}".freeze
 def main
   geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
 
-  skipped = 0
+  nil_org_name = 0
+  nil_location = 0
+  not_approved_no_city = 0
 
   DB_READONLY[:forms].where(kind: CURRENT_HOC_SIGNUP).paged_each(rows_per_fetch: 10_000) do |form|
     data = JSON.parse(form[:data])
@@ -40,12 +42,16 @@ def main
     # In order to be placed on the map, all events require an organization name,
     # processed location, and city. With the exception that approved special events
     # don't need a city so we can show events like the Cocos Keeling Islands.
-    if data['organization_name_s'].nil? || processed_data['location_p'].nil?
-      skipped += 1
+    if data['organization_name_s'].nil?
+      nil_org_name += 1
+      next
+    end
+    if processed_data['location_p'].nil?
+      nil_location += 1
       next
     end
     if form[:review] != "approved" && processed_data['location_city_s'].nil?
-      skipped += 1
+      not_approved_no_city += 1
       next
     end
 
@@ -87,7 +93,9 @@ def main
     "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"hoc\" --force #{file.path}"
   )
   upload_successful = false
-  puts "Num skipped: #{skipped}"
+  puts "Num skipped due to nil organization_name: #{nil_org_name}"
+  puts "Num skipped due to nil location: #{nil_location}"
+  puts "Num skipped due to not approved nil city: #{not_approved_no_city}"
   if tippecanoe_status.success?
     puts "SUCCESS"
     upload_successful = upload_maptiles(tiles.path, 'hoctiles')

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -70,7 +70,7 @@ def main
       next
     end
 
-    if form[:id] == SPECIFIC_SCHOOL_ID || form[:id] == SPECIFIC_SCHOOL_ID_STR
+    if form[:id] == SPECIFIC_SCHOOL_ID
       puts 'NOT SKIPPED'
       puts data['organization_name_s']
       puts processed_data['location_p']

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -45,7 +45,7 @@ def main
     # processed location, and city. With the exception that approved special events
     # don't need a city so we can show events like the Cocos Keeling Islands.
     if data['organization_name_s'].nil?
-      if form[:id] == SPECIFIC_SCHOOL_ID || form[:id] == SPECIFIC_SCHOOL_ID_STR
+      if form[:id] == SPECIFIC_SCHOOL_ID
         puts 'SKIPPED ON ORG NAME'
         puts JSON.parse(data)
       end
@@ -53,7 +53,7 @@ def main
       next
     end
     if processed_data['location_p'].nil?
-      if form[:id] == SPECIFIC_SCHOOL_ID || form[:id] == SPECIFIC_SCHOOL_ID_STR
+      if form[:id] == SPECIFIC_SCHOOL_ID
         puts 'SKIPPED ON LOCATION'
         puts JSON.parse(processed_data)
       end
@@ -61,7 +61,7 @@ def main
       next
     end
     if form[:review] != "approved" && processed_data['location_city_s'].nil?
-      if form[:id] == SPECIFIC_SCHOOL_ID || form[:id] == SPECIFIC_SCHOOL_ID_STR
+      if form[:id] == SPECIFIC_SCHOOL_ID
         puts 'SKIPPED ON CITY AND APPROVAL'
         puts JSON.parse(processed_data)
         puts form[:review]

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -23,8 +23,7 @@ require_relative 'upload_to_mapbox'
 
 DB_READONLY = Sequel.connect(CDO.pegasus_db_reader.sub('mysql:', 'mysql2:'))
 
-SPECIFIC_SCHOOL_ID = 7_067_343
-SPECIFIC_SCHOOL_ID_STR = '7067343'
+SPECIFIC_SCHOOL_ID = 7067343
 
 CURRENT_HOC_SIGNUP = "HocSignup#{DCDO.get('hoc_year', 2017)}".freeze
 def main

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -23,7 +23,7 @@ require_relative 'upload_to_mapbox'
 
 DB_READONLY = Sequel.connect(CDO.pegasus_db_reader.sub('mysql:', 'mysql2:'))
 
-SPECIFIC_SCHOOL_ID = 7067343
+SPECIFIC_EMAIL = 'sofia.avila@edu.cumbresvillahermosa.com'
 
 CURRENT_HOC_SIGNUP = "HocSignup#{DCDO.get('hoc_year', 2017)}".freeze
 def main
@@ -45,7 +45,7 @@ def main
     # processed location, and city. With the exception that approved special events
     # don't need a city so we can show events like the Cocos Keeling Islands.
     if data['organization_name_s'].nil?
-      if form[:id] == SPECIFIC_SCHOOL_ID
+      if form[:email] == SPECIFIC_EMAIL
         puts 'SKIPPED ON ORG NAME'
         puts JSON.parse(data)
       end
@@ -53,7 +53,7 @@ def main
       next
     end
     if processed_data['location_p'].nil?
-      if form[:id] == SPECIFIC_SCHOOL_ID
+      if form[:email] == SPECIFIC_EMAIL
         puts 'SKIPPED ON LOCATION'
         puts JSON.parse(processed_data)
       end
@@ -61,7 +61,7 @@ def main
       next
     end
     if form[:review] != "approved" && processed_data['location_city_s'].nil?
-      if form[:id] == SPECIFIC_SCHOOL_ID
+      if form[:email] == SPECIFIC_EMAIL
         puts 'SKIPPED ON CITY AND APPROVAL'
         puts JSON.parse(processed_data)
         puts form[:review]
@@ -70,7 +70,7 @@ def main
       next
     end
 
-    if form[:id] == SPECIFIC_SCHOOL_ID
+    if form[:email] == SPECIFIC_EMAIL
       puts 'NOT SKIPPED'
       puts data['organization_name_s']
       puts processed_data['location_p']


### PR DESCRIPTION
We are seeing several [tickets on Zendesk](https://codeorg.zendesk.com/agent/tickets/463155) regarding schools/organizations/events not being shown on the [Hour of Code map](https://hourofcode.com/us) after filling out the Hour of Code event form. 

According to [our `update_hoc_map` script](https://github.com/code-dot-org/code-dot-org/blob/staging/bin/cron/update_hoc_map), "in order to be placed on the map, all events require an organization name." As per [these lines in the map update cronjob](https://github.com/code-dot-org/code-dot-org/blob/staging/bin/cron/update_hoc_map#L44-L51), the `organization_name` is considered the first non-nil value of `nces_school_name_s`, `school_name_s`, and `organization_name_s`.

Then, ideally, [this line](https://github.com/code-dot-org/code-dot-org/blob/staging/bin/cron/update_hoc_map#L41) would filter out schools without an organization name. The issue is twofold: 1) that the logic currently filters out entries that don't have a defined `organization_name_s` field rather than entries that don't have any of the 3 options of `nces_school_name_s`, `school_name_s`, and `organization_name_s`, and 2) the aformentioned filter line occurs before the definition of `organization_name` so it is filtered out before the logic checks if the entry has a `nces_school_name_s` or `school_name_s` field.

This PR updates the logic to get the `organization_name` (based on `nces_school_name_s`, `school_name_s`, and `organization_name_s`) first, then filters out the entry if all of those values are `nil`.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1030)
Zendesk ticket example: [here](https://codeorg.zendesk.com/agent/tickets/463155)

## Testing story

UNDO PUTS STATEMENTS

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
