### PR TITLE
Create eval rubric job

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -33,6 +33,10 @@ class ActivitiesController < ApplicationController
       @level = Unit.cache_find_level(params[:level_id].to_i)
     end
 
+    if ai_eval_enabled?(@script_level) && params[:submitted] == 'true'
+      EvaluateRubricJob.perform_later(user_id: current_user.id, script_level_id: @script_level.id)
+    end
+
     # Immediately return with a "Service Unavailable" status if milestone posts are
     # disabled. (A cached view might post to this action even if milestone posts
     # are disabled in the gatekeeper.)
@@ -243,5 +247,10 @@ class ActivitiesController < ApplicationController
     log_string += "\t#{request.user_agent}"
 
     milestone_logger.info log_string
+  end
+
+  private def ai_eval_enabled?(script_level)
+    # CSD 2023, Unit 3, Lesson 18, final project level
+    script_level && script_level.script.name == 'csd3-2023' && script_level.level.name == 'CSD U3 Interactive Card Final_2023'
   end
 end

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -34,7 +34,7 @@ class ActivitiesController < ApplicationController
     end
 
     # If a student is submitting work on an AI-evaluation-enabled level, trigger the AI evaluation job.
-    lesson_s3_name = EvaluateRubricJob::UNIT_AND_LEVEL_TO_LESSON_S3_NAME[@script_level&.script&.name].try(:[], @script_level&.level&.name)
+    lesson_s3_name = EvaluateRubricJob.get_lesson_s3_name(@script_level)
     if lesson_s3_name && params[:submitted] == 'true'
       EvaluateRubricJob.perform_later(user_id: current_user.id, script_level_id: @script_level.id, lesson_s3_name: lesson_s3_name)
     end

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -50,9 +50,9 @@ class ActivitiesController < ApplicationController
     end
 
     # If a student in the pilot is submitting work on an AI-enabled level, trigger the AI evaluation job.
-    if Experiment.enabled?(user: current_user, experiment_name: 'ai-rubric') &&
-        EvaluateRubricJob.ai_enabled?(@script_level) &&
-        params[:submitted] == 'true'
+    is_ai_experiment_enabled = current_user && Experiment.enabled?(user: current_user, experiment_name: 'ai-rubric')
+    is_level_ai_enabled = EvaluateRubricJob.ai_enabled?(@script_level)
+    if is_ai_experiment_enabled && is_level_ai_enabled && params[:submitted] == 'true'
       EvaluateRubricJob.perform_later(user_id: current_user.id, script_level_id: @script_level.id)
     end
 

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -50,7 +50,7 @@ class ActivitiesController < ApplicationController
     end
 
     # If a student in the pilot is submitting work on an AI-enabled level, trigger the AI evaluation job.
-    is_ai_experiment_enabled = current_user && Experiment.enabled?(user: current_user, experiment_name: 'ai-rubric')
+    is_ai_experiment_enabled = current_user && Experiment.enabled?(user: current_user, experiment_name: 'ai-rubrics')
     is_level_ai_enabled = EvaluateRubricJob.ai_enabled?(@script_level)
     if is_ai_experiment_enabled && is_level_ai_enabled && params[:submitted] == 'true'
       EvaluateRubricJob.perform_later(user_id: current_user.id, script_level_id: @script_level.id)

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -33,8 +33,10 @@ class ActivitiesController < ApplicationController
       @level = Unit.cache_find_level(params[:level_id].to_i)
     end
 
-    if ai_eval_enabled?(@script_level) && params[:submitted] == 'true'
-      EvaluateRubricJob.perform_later(user_id: current_user.id, script_level_id: @script_level.id)
+    # If a student is submitting work on an AI-evaluation-enabled level, trigger the AI evaluation job.
+    lesson_s3_name = EvaluateRubricJob::UNIT_AND_LEVEL_TO_LESSON_S3_NAME[@script_level&.script&.name].try(:[], @script_level&.level&.name)
+    if lesson_s3_name && params[:submitted] == 'true'
+      EvaluateRubricJob.perform_later(user_id: current_user.id, script_level_id: @script_level.id, lesson_s3_name: lesson_s3_name)
     end
 
     # Immediately return with a "Service Unavailable" status if milestone posts are
@@ -247,10 +249,5 @@ class ActivitiesController < ApplicationController
     log_string += "\t#{request.user_agent}"
 
     milestone_logger.info log_string
-  end
-
-  private def ai_eval_enabled?(script_level)
-    # CSD 2023, Unit 3, Lesson 18, final project level
-    script_level && script_level.script.name == 'csd3-2023' && script_level.level.name == 'CSD U3 Interactive Card Final_2023'
   end
 end

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -49,8 +49,10 @@ class ActivitiesController < ApplicationController
       return
     end
 
-    # If a student is submitting work on an AI-evaluation-enabled level, trigger the AI evaluation job.
-    if EvaluateRubricJob.ai_enabled?(@script_level) && params[:submitted] == 'true'
+    # If a student in the pilot is submitting work on an AI-enabled level, trigger the AI evaluation job.
+    if Experiment.enabled?(user: current_user, experiment_name: 'ai-rubric') &&
+        EvaluateRubricJob.ai_enabled?(@script_level) &&
+        params[:submitted] == 'true'
       EvaluateRubricJob.perform_later(user_id: current_user.id, script_level_id: @script_level.id)
     end
 

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -50,9 +50,8 @@ class ActivitiesController < ApplicationController
     end
 
     # If a student is submitting work on an AI-evaluation-enabled level, trigger the AI evaluation job.
-    lesson_s3_name = EvaluateRubricJob.get_lesson_s3_name(@script_level)
-    if lesson_s3_name && params[:submitted] == 'true'
-      EvaluateRubricJob.perform_later(user_id: current_user.id, script_level_id: @script_level.id, lesson_s3_name: lesson_s3_name)
+    if EvaluateRubricJob.ai_enabled?(@script_level) && params[:submitted] == 'true'
+      EvaluateRubricJob.perform_later(user_id: current_user.id, script_level_id: @script_level.id)
     end
 
     sharing_allowed = Gatekeeper.allows('shareEnabled', where: {script_name: script_name}, default: true)

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -1,6 +1,8 @@
 class EvaluateRubricJob < ApplicationJob
   queue_as :default
 
+  self.queue_adapter = :delayed_job
+
   rescue_from(StandardError) do |exception|
     if rack_env?(:development)
       puts "EvaluateRubricJob Error: #{exception.full_message}"

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -34,6 +34,10 @@ class EvaluateRubricJob < ApplicationJob
     puts "TODO: Implement the rest of this job"
   end
 
+  def self.ai_enabled?(script_level)
+    !!get_lesson_s3_name(script_level)
+  end
+
   # returns the path suffix of the location in S3 which contains the config
   # needed to evaluate the rubric for the given script level.
   def self.get_lesson_s3_name(script_level)

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -26,7 +26,9 @@ class EvaluateRubricJob < ApplicationJob
     user = User.find(user_id)
     script_level = ScriptLevel.find(script_level_id)
     lesson_s3_name = EvaluateRubricJob.get_lesson_s3_name(script_level)
-    puts "Evaluating rubric for user #{user.id} on script level #{script_level.id} with lesson_s3_name: #{lesson_s3_name.inspect}"
+    if rack_env?(:development)
+      puts "Evaluating rubric for user #{user.id} on script level #{script_level.id} with lesson_s3_name: #{lesson_s3_name.inspect}"
+    end
 
     raise "lesson_s3_name not found for script_level_id: #{script_level.id}" if lesson_s3_name.blank?
 

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -1,0 +1,20 @@
+class EvaluateRubricJob < ApplicationJob
+  queue_as :default
+
+  rescue_from(StandardError) do |exception|
+    if rack_env?(:development)
+      puts "EvaluateRubricJob Error: #{exception.full_message}"
+    end
+    raise
+  end
+
+  def perform(user_id:, script_level_id:)
+    user = User.find(user_id)
+    script_level = ScriptLevel.find(script_level_id)
+    puts "Evaluating rubric for user #{user.id} on script level #{script_level.id}"
+
+    raise 'CDO.openai_evaluate_rubric_api_key required' if CDO.openai_evaluate_rubric_api_key.blank?
+
+    puts "TODO: Implement the rest of this job"
+  end
+end

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -22,13 +22,20 @@ class EvaluateRubricJob < ApplicationJob
     }
   }
 
-  def perform(user_id:, script_level_id:, lesson_s3_name:)
+  def perform(user_id:, script_level_id:)
     user = User.find(user_id)
     script_level = ScriptLevel.find(script_level_id)
+    lesson_s3_name = EvaluateRubricJob.get_lesson_s3_name(script_level)
     puts "Evaluating rubric for user #{user.id} on script level #{script_level.id} with lesson_s3_name: #{lesson_s3_name.inspect}"
 
     raise 'CDO.openai_evaluate_rubric_api_key required' if CDO.openai_evaluate_rubric_api_key.blank?
 
     puts "TODO: Implement the rest of this job"
+  end
+
+  # returns the path suffix of the location in S3 which contains the config
+  # needed to evaluate the rubric for the given script level.
+  def self.get_lesson_s3_name(script_level)
+    UNIT_AND_LEVEL_TO_LESSON_S3_NAME[script_level&.script&.name].try(:[], script_level&.level&.name)
   end
 end

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -28,7 +28,6 @@ class EvaluateRubricJob < ApplicationJob
     lesson_s3_name = EvaluateRubricJob.get_lesson_s3_name(script_level)
     puts "Evaluating rubric for user #{user.id} on script level #{script_level.id} with lesson_s3_name: #{lesson_s3_name.inspect}"
 
-    raise 'CDO.openai_evaluate_rubric_api_key required' if CDO.openai_evaluate_rubric_api_key.blank?
     raise "lesson_s3_name not found for script_level_id: #{script_level.id}" if lesson_s3_name.blank?
 
     puts "TODO: Implement the rest of this job"

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -8,10 +8,24 @@ class EvaluateRubricJob < ApplicationJob
     raise
   end
 
-  def perform(user_id:, script_level_id:)
+  # 2D Map from unit name and level name, to the name of the lesson files in S3
+  # which will be used for AI evaluation.
+  # TODO: This is a temporary solution. After the pilot, we should at least make
+  # the S3 pointer editable on levelbuilder, and eventually make all of the data
+  # it points to editable there too.
+  UNIT_AND_LEVEL_TO_LESSON_S3_NAME = {
+    'csd3-2023' => {
+      'CSD U3 Interactive Card Final_2023' => 'CSD-2022-U3-L17',
+      'CSD U3 Sprites scene challenge_2023' => 'New-U3-2022-L10',
+      'CSD web project animated review_2023' => 'New-U3-2022-L13',
+      'CSD games sidescroll review_2023' => 'New-U3-2022-L20'
+    }
+  }
+
+  def perform(user_id:, script_level_id:, lesson_s3_name:)
     user = User.find(user_id)
     script_level = ScriptLevel.find(script_level_id)
-    puts "Evaluating rubric for user #{user.id} on script level #{script_level.id}"
+    puts "Evaluating rubric for user #{user.id} on script level #{script_level.id} with lesson_s3_name: #{lesson_s3_name.inspect}"
 
     raise 'CDO.openai_evaluate_rubric_api_key required' if CDO.openai_evaluate_rubric_api_key.blank?
 

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -29,6 +29,7 @@ class EvaluateRubricJob < ApplicationJob
     puts "Evaluating rubric for user #{user.id} on script level #{script_level.id} with lesson_s3_name: #{lesson_s3_name.inspect}"
 
     raise 'CDO.openai_evaluate_rubric_api_key required' if CDO.openai_evaluate_rubric_api_key.blank?
+    raise "lesson_s3_name not found for script_level_id: #{script_level.id}" if lesson_s3_name.blank?
 
     puts "TODO: Implement the rest of this job"
   end

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -1,6 +1,10 @@
 class EvaluateRubricJob < ApplicationJob
   queue_as :default
 
+  # To make this job get run in development, you have two options:
+  # 1. switch the queue_adapter value here to :async, or
+  # 2. leave the value as :delayed_job, and run the delayed job worker locally
+  #    via `dashboard/bin/delayed_job restart` or rake build
   self.queue_adapter = :delayed_job
 
   rescue_from(StandardError) do |exception|

--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -62,15 +62,6 @@ class Experiment < ApplicationRecord
         (experiment.script_id.nil? || experiment.script_id == script.try(:id)) &&
         experiment.enabled?(user: user)
     end
-  rescue => exception
-    Honeybadger.notify(
-      exception,
-      error_message: 'Error getting experiments',
-      context: {
-        user_id: user&.id
-      }
-    )
-    []
   end
 
   # Returns whether the experiment_name is enabled for the specified user,

--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -62,6 +62,15 @@ class Experiment < ApplicationRecord
         (experiment.script_id.nil? || experiment.script_id == script.try(:id)) &&
         experiment.enabled?(user: user)
     end
+  rescue => exception
+    Honeybadger.notify(
+      exception,
+      error_message: 'Error getting experiments',
+      context: {
+        user_id: user&.id
+      }
+    )
+    []
   end
 
   # Returns whether the experiment_name is enabled for the specified user,

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -65,6 +65,15 @@ class ActivitiesControllerTest < ActionController::TestCase
       app: 'test',
       program: '<hey>'
     }
+
+    @teacher = create :teacher
+    @section = create :section, teacher: @teacher
+    @student = create :student
+    create :follower, section: @section, student_user: @student
+    @milestone_rubric_params = @milestone_params.merge(
+      user_id: @student.id,
+      submitted: 'true'
+    )
   end
 
   # Ignore any additional keys in 'actual' not found in 'expected'.
@@ -1126,5 +1135,61 @@ class ActivitiesControllerTest < ActionController::TestCase
     parent_user_level = UserLevel.find_by(user: @user, level: bubble_choice, script: script)
     refute_nil parent_user_level
     assert_equal 100, parent_user_level.best_result
+  end
+
+  test 'milestone with student in experiment triggers rubric eval job' do
+    create :single_section_experiment, section: @section, name: 'ai-rubric'
+    EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
+    EvaluateRubricJob.expects(:perform_later).with(user_id: @student.id, script_level_id: @script_level.id).once
+    sign_in @student
+
+    post :milestone, params: @milestone_rubric_params
+    assert_response :success
+  end
+
+  test 'milestone with student in experiment on non ai level does not trigger rubric eval job' do
+    create :single_section_experiment, section: @section, name: 'ai-rubric'
+    EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(false)
+    EvaluateRubricJob.expects(:perform_later).never
+    sign_in @student
+
+    post :milestone, params: @milestone_rubric_params
+    assert_response :success
+  end
+
+  test 'milestone with teacher in experiment does not trigger rubric eval job' do
+    create :single_section_experiment, section: @section, name: 'ai-rubric'
+    EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
+    EvaluateRubricJob.expects(:perform_later).never
+    sign_in @teacher
+
+    @milestone_rubric_params[:user_id] = @teacher.id
+    # teachers are not shown the option to submit, and we rely on this to avoid
+    # requesting rubric evaluations for teachers
+    @milestone_rubric_params.delete(:submitted)
+
+    post :milestone, params: @milestone_rubric_params
+    assert_response :success
+  end
+
+  test 'milestone with student not in experiment does not trigger rubric eval job' do
+    # some other section is added to the experiment
+    create :single_section_experiment, name: 'ai-rubric'
+    EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
+    EvaluateRubricJob.expects(:perform_later).never
+    sign_in @student
+
+    post :milestone, params: @milestone_rubric_params
+    assert_response :success
+  end
+
+  test 'milestone on level without ai enabled does not trigger rubric eval job' do
+    create :single_section_experiment, section: @section, name: 'ai-rubric'
+    EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(false)
+    EvaluateRubricJob.expects(:perform_later).never
+    sign_in @student
+
+    post :milestone, params: @milestone_rubric_params
+    assert_response :success
   end
 end

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -66,6 +66,7 @@ class ActivitiesControllerTest < ActionController::TestCase
       program: '<hey>'
     }
 
+    # set up params for testing rubric evaluation
     @teacher = create :teacher
     @section = create :section, teacher: @teacher
     @student = create :student
@@ -74,6 +75,7 @@ class ActivitiesControllerTest < ActionController::TestCase
       user_id: @student.id,
       submitted: 'true'
     )
+    EvaluateRubricJob.expects(:perform_later).never
   end
 
   # Ignore any additional keys in 'actual' not found in 'expected'.

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -1140,7 +1140,7 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test 'milestone with student in experiment triggers rubric eval job' do
-    create :single_section_experiment, section: @section, name: 'ai-rubric'
+    create :single_section_experiment, section: @section, name: 'ai-rubrics'
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).with(user_id: @student.id, script_level_id: @script_level.id).once
     sign_in @student
@@ -1150,7 +1150,7 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test 'milestone with student in experiment on non ai level does not trigger rubric eval job' do
-    create :single_section_experiment, section: @section, name: 'ai-rubric'
+    create :single_section_experiment, section: @section, name: 'ai-rubrics'
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(false)
     EvaluateRubricJob.expects(:perform_later).never
     sign_in @student
@@ -1160,7 +1160,7 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test 'milestone with teacher in experiment does not trigger rubric eval job' do
-    create :single_section_experiment, section: @section, name: 'ai-rubric'
+    create :single_section_experiment, section: @section, name: 'ai-rubrics'
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).never
     sign_in @teacher
@@ -1176,7 +1176,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
   test 'milestone with student not in experiment does not trigger rubric eval job' do
     # some other section is added to the experiment
-    create :single_section_experiment, name: 'ai-rubric'
+    create :single_section_experiment, name: 'ai-rubrics'
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).never
     sign_in @student
@@ -1186,7 +1186,7 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test 'milestone on level without ai enabled does not trigger rubric eval job' do
-    create :single_section_experiment, section: @section, name: 'ai-rubric'
+    create :single_section_experiment, section: @section, name: 'ai-rubrics'
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(false)
     EvaluateRubricJob.expects(:perform_later).never
     sign_in @student

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -2,8 +2,6 @@ require "test_helper"
 
 class EvaluateRubricJobTest < ActiveJob::TestCase
   test "job succeeds on ai-enabled level" do
-    CDO.stubs(:openai_evaluate_rubric_api_key).returns('fake-key')
-
     user = create :user
     script_level = create :script_level
     EvaluateRubricJob.stubs(:get_lesson_s3_name).with(script_level).returns('fake-lesson-s3-name')
@@ -14,8 +12,6 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
   end
 
   test "job fails on non-ai level" do
-    CDO.stubs(:openai_evaluate_rubric_api_key).returns('fake-key')
-
     user = create :user
     script_level = create :script_level
     EvaluateRubricJob.stubs(:get_lesson_s3_name).with(script_level).returns(nil)

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class EvaluateRubricJobTest < ActiveJob::TestCase
+  test "job succeeds on ai-enabled level" do
+    CDO.stubs(:openai_evaluate_rubric_api_key).returns('fake-key')
+
+    user = create :user
+    script_level = create :script_level
+    EvaluateRubricJob.stubs(:get_lesson_s3_name).with(script_level).returns('fake-lesson-s3-name')
+
+    perform_enqueued_jobs do
+      EvaluateRubricJob.perform_later(user_id: user.id, script_level_id: script_level.id)
+    end
+  end
+
+  test "job fails on non-ai level" do
+    CDO.stubs(:openai_evaluate_rubric_api_key).returns('fake-key')
+
+    user = create :user
+    script_level = create :script_level
+    EvaluateRubricJob.stubs(:get_lesson_s3_name).with(script_level).returns(nil)
+
+    exception = assert_raises RuntimeError do
+      EvaluateRubricJob.new.perform(user_id: user.id, script_level_id: script_level.id)
+    end
+    assert_includes exception.message, 'lesson_s3_name not found'
+  end
+end


### PR DESCRIPTION
Starts https://codedotorg.atlassian.net/browse/AITT-132. 

Done in this PR:
- creates a stub job which will someday soon use openai to evaluate rubrics
- trigger the job when a student in the `ai-rubric` experiment submits an ai-enabled level
- add unit tests

For a peek at where I'm heading, you can take a look at this file, which shows the job code that's running on the adhoc: https://github.com/code-dot-org/code-dot-org/pull/53877/files#diff-ad0faf248cdfaa62c614e59c2d561fa6a2031cd9ac70d4bb722e61d7e906a0e1R7 when you do, please assume that pycall will be going away and any python will be moving to the new python service.

## Testing story

* new unit tests
* extensive existing test coverage on the milestone endpoint