### PR TITLE
[Google Blockly] Ensure function definition changes trigger re-render

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1050,6 +1050,8 @@ StudioApp.prototype.setupChangeHandlers = function () {
   if (this.isUsingBlockly()) {
     Blockly.addChangeListener(Blockly.mainBlockSpace, runAllHandlers);
     if (Blockly.getHiddenDefinitionWorkspace()) {
+      // If we have a hidden definition workspace, run change listeners on it too.
+      // This ensures code changes in the hidden workspace trigger updates.
       Blockly.addChangeListener(
         Blockly.getHiddenDefinitionWorkspace(),
         runAllHandlers

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1049,6 +1049,12 @@ StudioApp.prototype.setupChangeHandlers = function () {
   const runAllHandlers = this.runChangeHandlers.bind(this);
   if (this.isUsingBlockly()) {
     Blockly.addChangeListener(Blockly.mainBlockSpace, runAllHandlers);
+    if (Blockly.getHiddenDefinitionWorkspace()) {
+      Blockly.addChangeListener(
+        Blockly.getHiddenDefinitionWorkspace(),
+        runAllHandlers
+      );
+    }
   } else {
     this.editor.on('change', runAllHandlers);
     // Droplet doesn't automatically bubble up aceEditor changes

--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -374,6 +374,7 @@ export default class FunctionEditor {
     }
   }
 
+  // Clear the editor workspace to prepare for a new function definition.
   clearEditorWorkspace() {
     // Dispose of all top blocks. We do this manually because we want
     // to propogate the delete event to the hidden workspace for every block
@@ -394,7 +395,7 @@ export default class FunctionEditor {
       }
     }
     // Now call clear() to have Blockly handle the rest of the workspace clearing.
-    // Also disable events here to ensure we don't delete the procedure model
+    // Also disable events here to ensure we don't delete the procedure model.
     Blockly.Events.disable();
     this.editorWorkspace.clear();
     Blockly.Events.enable();


### PR DESCRIPTION
This change relates to the modal function editor for Google Blockly. Previously, edits to functions did not immediately show up in the preview or trigger "your code has changed" if code was running. This was because the edits were occurring on the hidden definition workspace, which we were not running change handlers on. Now we run the change handlers on the hidden definition workspace, if it exists.

While testing this I also discovered a bug where if you drag a block into the editor workspace that is not connected to the function definition and don't remove it before you close it, that block will stay in the hidden workspace and generate code for the student's project. However, it can never be deleted because the block won't show up again when you open the function editor (because it was not connected to the definition). To fix this I did a couple things:
- Make unconnected blocks disabled so they don't generate code (otherwise while the editor is open we will generate code due to the change handler update).
- Delete any unconnected blocks from the hidden workspace when we clear the workspace.

## Links

- jira ticket: [CT-17](https://codedotorg.atlassian.net/browse/CT-17)

## Testing story
Tested locally that the bugs are fixed and CDO Blockly is unaffected.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
