### PR TITLE
Remove loading before showing 'create a section' button

### DIFF
--- a/apps/src/templates/studioHomepages/SetUpSections.jsx
+++ b/apps/src/templates/studioHomepages/SetUpSections.jsx
@@ -12,7 +12,6 @@ const STARTED_EVENT = 'Section Setup Started';
 class SetUpSections extends Component {
   static propTypes = {
     beginEditingSection: PropTypes.func.isRequired,
-    hasSections: PropTypes.bool,
   };
 
   // Wrapped to avoid passing event args
@@ -26,20 +25,15 @@ class SetUpSections extends Component {
   };
 
   render() {
-    const headingText = this.props.hasSections
-      ? i18n.newSectionAdd()
-      : i18n.setUpClassroom();
-
     return (
       <BorderedCallToAction
         type="sections"
-        headingText={headingText}
+        headingText={i18n.newSectionAdd()}
         descriptionText={i18n.createNewClassroom()}
         buttonText={i18n.createSection()}
         className="uitest-set-up-sections"
         buttonClass="uitest-newsection"
         onClick={this.beginEditingSection}
-        solidBorder={this.props.hasSections}
       />
     );
   }

--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -37,16 +37,10 @@ class TeacherSections extends Component {
       hiddenStudentSectionIds,
     } = this.props;
 
-    const hasSections =
-      this.props.studentSectionIds?.length > 0 ||
-      this.props.plSectionIds?.length > 0;
-
     return (
       <div id="classroom-sections">
         <ContentContainer heading={i18n.createSection()}>
-          {this.props.asyncLoadComplete && (
-            <SetUpSections hasSections={hasSections} />
-          )}
+          <SetUpSections />
           {!this.props.asyncLoadComplete && (
             <Spinner size="large" style={styles.spinner} />
           )}


### PR DESCRIPTION
There is a spinner that shows usually for over a second when loading the teacher dashboard. This spinner shows while loading data for the section table, however it also blocked the `create a section` button. This PR removes all requirements for loaded data from the `create a section` button to speed up our responsiveness.

This does change the text of the create section when the user does not have any sections.

## Links
* [slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1696626552614239)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
