### PR TITLE
Add an external link icon class for text links on code.org

### DIFF
--- a/pegasus/sites.v3/code.org/public/accessibility.haml
+++ b/pegasus/sites.v3/code.org/public/accessibility.haml
@@ -35,7 +35,7 @@ theme: responsive_full_width
           .text-wrapper
             %h3.heading-sm
               =hoc_s("accessibility_efforts_card_title_#{index + 1}")
-            %p.body-three
+            %p.body-three.has-external-link
               - if index == 1
                 =hoc_s(:accessibility_efforts_card_desc_2, markdown: :inline, locals: {voluntary_url: "https://www.section508.gov/sell/vpat/"})
               - elsif index == 3
@@ -50,7 +50,7 @@ theme: responsive_full_width
       %img{src: "/images/accessibility/explore.jpg", alt: hoc_s(:accessibility_explore_title), class: "col-50"}
       .text-wrapper.col-50
         %p.heading-sm=hoc_s(:accessibility_explore_text)
-        %a{href: "https://support.code.org/hc/en-us/sections/15186591538957-Accessibility", class: "link-button", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s("accessibility_explore_title")}}
+        %a{href: "https://support.code.org/hc/en-us/sections/15186591538957-Accessibility", class: "link-button has-external-link", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s("accessibility_explore_title")}}
           =hoc_s(:accessibility_explore_button)
     .clear
 
@@ -59,7 +59,7 @@ theme: responsive_full_width
     .text-wrapper
       %h2=hoc_s(:accessibility_help_us_title)
       %p=hoc_s(:accessibility_help_us_text)
-      %a{href: "https://support.code.org/hc/en-us/sections/15186591538957-Accessibility", target: "_blank", class: "link-button", rel: "noopener noreferrer", aria:{label: hoc_s("accessibility_help_us_title")}}
+      %a{href: "https://support.code.org/hc/en-us/sections/15186591538957-Accessibility", target: "_blank", class: "link-button has-external-link", rel: "noopener noreferrer", aria:{label: hoc_s("accessibility_help_us_title")}}
         =hoc_s(:accessibility_help_us_button)
 
 %section.accessibility-commit
@@ -94,5 +94,5 @@ theme: responsive_full_width
               =accessibility_partner_levels[index]
             %p=hoc_s("accessibility_card_text_#{index + 1}")
           .content-footer
-            %a.link-button{href: accessibility_partner_links[index], target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s("accessibility_card_title_#{index + 1}")}}
+            %a.link-button.has-external-link{href: accessibility_partner_links[index], target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s("accessibility_card_title_#{index + 1}")}}
               = hoc_s(:call_to_action_learn_more)

--- a/pegasus/sites.v3/code.org/public/administrators.haml
+++ b/pegasus/sites.v3/code.org/public/administrators.haml
@@ -57,7 +57,7 @@ theme: responsive_full_width
           %i{class: "#{icon_laptop_file}"}
         .text-wrapper
           %h3 Turnkey K-12 computer science curriculum
-          %p Get a complete, free <a href="https://code.org/teach" target="_blank" rel="noopener noreferrer">open source K-12 program</a> and learning platform to introduce computer science at any grade.
+          %p Get a complete, free <a href="/teach" target="_blank" rel="noopener noreferrer">open source K-12 program</a> and learning platform to introduce computer science at any grade.
       %li
         %div
           %i{class: "#{icon_chalkboard_user}"}
@@ -153,17 +153,17 @@ theme: responsive_full_width
     %h2 Frequently Asked Questions
     %details
       %summary Why should my district teach computer science?
-      %p Computer science is foundational for all students. More than <a href="https://csedu.gallup.com/home.aspx" target="_blank" rel="noopener noreferrer">90% of parents</a> want schools to teach computer science and students rank CS as their <a href="https://docs.google.com/spreadsheets/d/15c-xozSgav1s38KcmxfLbe1CrHw4BsJdQEU3HqOFIGI/edit#gid=1309171352" target="_blank" rel="noopener noreferrer">third favorite subject behind the arts</a>. Computing occupations are now the <a href="http://www.rasmussen.edu/degrees/technology/blog/careers-in-computer-science-face-the-facts/" target="_blank" rel="noopener noreferrer">fastest-growing</a> segment of all professions and the majority of all U.S. occupations now involve <a href="https://www.brookings.edu/research/digitalization-and-the-american-workforce/" target="_blank" rel="noopener noreferrer">"moderately digital" skills</a>. Students who study computer science perform better in other subjects, excel at problem-solving, and are more likely to attend college, <a href="https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536" target="_blank" rel="noopener noreferrer">according to recent research</a>.
+      %p Computer science is foundational for all students. More than <a class="has-external-link" href="https://csedu.gallup.com/home.aspx" target="_blank" rel="noopener noreferrer">90% of parents</a> want schools to teach computer science and students rank CS as their <a class="has-external-link" href="https://docs.google.com/spreadsheets/d/15c-xozSgav1s38KcmxfLbe1CrHw4BsJdQEU3HqOFIGI/edit#gid=1309171352" target="_blank" rel="noopener noreferrer">third favorite subject behind the arts</a>. Computing occupations are now the <a class="has-external-link" href="http://www.rasmussen.edu/degrees/technology/blog/careers-in-computer-science-face-the-facts/" target="_blank" rel="noopener noreferrer">fastest-growing</a> segment of all professions and the majority of all U.S. occupations now involve <a class="has-external-link" href="https://www.brookings.edu/research/digitalization-and-the-american-workforce/" target="_blank" rel="noopener noreferrer">"moderately digital" skills</a>. Students who study computer science perform better in other subjects, excel at problem-solving, and are more likely to attend college, <a class="has-external-link" href="https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536" target="_blank" rel="noopener noreferrer">according to recent research</a>.
       %p Learn more at <a href="/stats" target="_blank" rel="noopener noreferrer">code.org/stats</a>.
     %details
       %summary Can I become a Code.org District Partner if I'm outside the United States?
-      %p Currently the Code.org District Partner program is only available for districts in the United States. If you are interested in what is happening with computer science in your country, <a href="https://hourofcode.com/us/international-partners" target="_blank" rel="noopener noreferrer">find your international Code.org partner</a>.
+      %p Currently the Code.org District Partner program is only available for districts in the United States. If you are interested in what is happening with computer science in your country, <a class="has-external-link" href="https://hourofcode.com/us/international-partners" target="_blank" rel="noopener noreferrer">find your international Code.org partner</a>.
     %details
       %summary Are Code.org's courses aligned to any standards?
       %p Yes! Specifically, our courses were written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles and CSA meet the AP Frameworks for each course. You can learn more about standards alignment for each course by visiting their specific course pages. Visit <a href="/teach" target="_blank" rel="noopener noreferrer">code.org/teach</a> to learn more.
     %details
       %summary What qualifications or certifications does a teacher need to teach computer science?
-      %p The answer will vary by state — <a href="/educate/professional-learning/contact-regional-partner" target="_blank" rel="noopener noreferrer" >contact your Regional Partner</a> for details specific to your state and district. You can also find an overview of state certification requirements <a href="https://docs.google.com/spreadsheets/d/1YtTVcpQXoZz0IchihwGOihaCNeqCz2HyLwaXYpyb2SQ/pubhtml#" target="_blank" rel="noopener noreferrer">here</a> (click on the “Certification” tab near the top).
+      %p The answer will vary by state — <a href="/educate/professional-learning/contact-regional-partner" target="_blank" rel="noopener noreferrer" >contact your Regional Partner</a> for details specific to your state and district. You can also find an overview of state certification requirements <a class="has-external-link" href="https://docs.google.com/spreadsheets/d/1YtTVcpQXoZz0IchihwGOihaCNeqCz2HyLwaXYpyb2SQ/pubhtml#" target="_blank" rel="noopener noreferrer">here</a> (click on the “Certification” tab near the top).
     %details
       %summary How much does it cost to offer computer science with Code.org?
       %p All Code.org course materials are free — now and forever. There may be a fee associated with professional development (varies by region), but every region offers scholarships and discounts that you may qualify for (<a href="/educate/professional-learning" target="_blank" rel="noopener noreferrer">check here</a>). Other costs, like devices and other classroom supplies, internet access, and administrative support, will vary by region and class size. You can take a look at hardware and internet requirements for Code.org courses here.
@@ -175,7 +175,7 @@ theme: responsive_full_width
       %p Schools and teachers have the flexibility to teach our CS Fundamentals and CS Discoveries courses in the way that best fits with their school schedules. CS Principles and CSA should be taught as full-year courses. Our PL programs provide guidance. Learn more about our various offerings at <a href="/teach" target="_blank" rel="noopener noreferrer">code.org/teach</a>.
     %details
       %summary Do high school computer science courses count toward graduation?
-      %p <a href="https://docs.google.com/spreadsheets/d/1YtTVcpQXoZz0IchihwGOihaCNeqCz2HyLwaXYpyb2SQ/pubhtml#" target="_blank" rel="noopener noreferrer">Take a look here</a> to see if your state allows computer science courses to count toward graduation (click the “Count” tab near the top).
+      %p <a class="has-external-link" href="https://docs.google.com/spreadsheets/d/1YtTVcpQXoZz0IchihwGOihaCNeqCz2HyLwaXYpyb2SQ/pubhtml#" target="_blank" rel="noopener noreferrer">Take a look here</a> to see if your state allows computer science courses to count toward graduation (click the “Count” tab near the top).
     %details
       %summary How do I or my counselors recruit students to take the class?
       %p We have a number of suggestions and materials for encouraging students to take computer science. Find them all at <a href="/educate/resources/recruit" target="_blank" rel="noopener noreferrer">code.org/recruit</a>.
@@ -197,7 +197,7 @@ theme: responsive_full_width
           %img{src: "/images/marketing/fill-400x250/2018_HoC-392.jpg", alt: ""}
           %p See how three different districts are bringing CS to their students.
         .content-footer
-          %a.link-button{href: "https://docs.google.com/document/d/102y3-j0uZBqSnqWHTiTbo81LyDUX2sZITYF9aHnZ_yc/edit#heading=h.9ub4frvyuqiy"} Learn more
+          %a.link-button.has-external-link{href: "https://docs.google.com/document/d/102y3-j0uZBqSnqWHTiTbo81LyDUX2sZITYF9aHnZ_yc/edit#heading=h.9ub4frvyuqiy"} Learn more
   .clear
 
 = view :analytics_event_log_helper, event_name: AnalyticsConstants::ADMIN_PAGE_VISITED_EVENT

--- a/pegasus/sites.v3/code.org/public/ai/index.haml
+++ b/pegasus/sites.v3/code.org/public/ai/index.haml
@@ -160,7 +160,7 @@ theme: responsive_full_width
           %img{src: "/images/ai//ai-resources-ethics-panel.png", alt: ""}
           %p=hoc_s(:ai_resources_desc_01)
         .content-footer
-          %a.link-button{href: "https://youtu.be/3oqxjPXbynE", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:ai_resources_btn_aria_label_01)}}
+          %a.link-button.has-external-link{href: "https://youtu.be/3oqxjPXbynE", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:ai_resources_btn_aria_label_01)}}
             =hoc_s(:call_to_action_watch_panel)
       .action-block.action-block--one-col.flex-space-between
         .content-wrapper
@@ -168,7 +168,7 @@ theme: responsive_full_width
           %img{src: "/images/ai/ai-resources-imagine-cup.png", alt: ""}
           %p=hoc_s(:ai_resources_desc_02)
         .content-footer
-          %a.link-button{href: "https://imaginecup.microsoft.com/en-us/junior", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:ai_resources_btn_aria_label_02)}}
+          %a.link-button.has-external-link{href: "https://imaginecup.microsoft.com/en-us/junior", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:ai_resources_btn_aria_label_02)}}
             =hoc_s(:call_to_action_learn_about_challenge)
       .action-block.action-block--one-col.flex-space-between
         .content-wrapper
@@ -176,7 +176,7 @@ theme: responsive_full_width
           %img{src: "/images/ai/ai-resources-for-teachers.png", alt: ""}
           %p=hoc_s(:ai_resources_desc_03)
         .content-footer
-          %a.link-button{href: "https://aiforteachers.org/", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:ai_resources_btn_aria_label_03)}}
+          %a.link-button.has-external-link{href: "https://aiforteachers.org/", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:ai_resources_btn_aria_label_03)}}
             =hoc_s(:call_to_action_explore_website)
 
 = view :section_divider_line

--- a/pegasus/sites.v3/code.org/public/ai/pl/101/index.haml
+++ b/pegasus/sites.v3/code.org/public/ai/pl/101/index.haml
@@ -35,7 +35,7 @@ theme: responsive_full_width
         .text-wrapper.col-50
           %h3=hoc_s(:ai_pl_101_llm_slides_title)
           %p=hoc_s(:ai_pl_101_llm_slides_desc)
-          %a.link-button{href: "https://docs.google.com/presentation/d/1WXvjG9TscUuH5Xz8Pj2okz6lMIKV__g0v6AoYVXKb40/copy", target: "_blank", rel: "noopener noreferrer"}
+          %a.link-button.has-external-link{href: "https://docs.google.com/presentation/d/1WXvjG9TscUuH5Xz8Pj2okz6lMIKV__g0v6AoYVXKb40/copy", target: "_blank", rel: "noopener noreferrer"}
             =hoc_s(:call_to_action_get_guide)
         %figure.col-45
           %iframe{allowfullscreen: "true", frameborder: "0", height: "280", mozallowfullscreen: "true", src: "https://docs.google.com/presentation/d/e/2PACX-1vRBPHqheht4zNPoFJhPPqT5T9a0b-J6Tm4MYdLRlbZSXBNaGHSFwisQmmdzJqQDs8Rl4cBZcyOLIXKy/embed?start=false&loop=false&delayms=3000", webkitallowfullscreen: "true", width: "459", style: "width: 100%;"}
@@ -74,7 +74,7 @@ theme: responsive_full_width
           %h3=hoc_s(:ai_pl_101_explore_title_4)
           %p=hoc_s(:ai_pl_101_explore__desc_4)
         .content-footer
-          %a.link-button{href: "https://www.ets.org/research/ai-labs.html", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:ai_resources_btn_aria_label_01)}}
+          %a.link-button.has-external-link{href: "https://www.ets.org/research/ai-labs.html", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:ai_resources_btn_aria_label_01)}}
             =hoc_s(:ai_pl_101_explore__button_4)
 
       .action-block.action-block--explore.action-block--one-col.flex-space-between
@@ -84,7 +84,7 @@ theme: responsive_full_width
           %h3=hoc_s(:ai_pl_101_explore_title_2)
           %p=hoc_s(:ai_pl_101_explore__desc_2)
         .content-footer
-          %a.link-button{href: "https://www.iste.org/professional-development/iste-u/artificial-intelligence", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:ai_resources_btn_aria_label_01)}}
+          %a.link-button.has-external-link{href: "https://www.iste.org/professional-development/iste-u/artificial-intelligence", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:ai_resources_btn_aria_label_01)}}
             =hoc_s(:ai_pl_101_explore__button_2)
 
       .action-block.action-block--explore.action-block--one-col.flex-space-between
@@ -94,7 +94,7 @@ theme: responsive_full_width
           %h3=hoc_s(:ai_pl_101_explore_title_1)
           %p=hoc_s(:ai_pl_101_explore__desc_1)
         .content-footer
-          %a.link-button{href: "https://blog.khanacademy.org/teacher-khanmigo/?utm_source=code.org&utm_medium=referral&utm_campaign=code.orgwebinar", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:ai_resources_btn_aria_label_01)}}
+          %a.link-button.has-external-link{href: "https://blog.khanacademy.org/teacher-khanmigo/?utm_source=code.org&utm_medium=referral&utm_campaign=code.orgwebinar", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:ai_resources_btn_aria_label_01)}}
             =hoc_s(:ai_pl_101_explore__button_1)
 
 = view :visit_partial_event_logger

--- a/pegasus/sites.v3/code.org/public/blockchain.haml
+++ b/pegasus/sites.v3/code.org/public/blockchain.haml
@@ -107,7 +107,7 @@ theme: responsive_full_width
           %img{src: "/images/blockchain-coinbase-learn.png", alt: ""}
           %p=hoc_s(:blockchain_resources_01_desc)
         .content-footer
-          %a{href: "https://www.coinbase.com/learn", class: "link-button", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:blockchain_resources_01_button_label)}}
+          %a{href: "https://www.coinbase.com/learn", class: "link-button has-external-link", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:blockchain_resources_01_button_label)}}
             =hoc_s(:call_to_action_learn_more)
       .action-block.action-block--one-col.flex-space-between
         .content-wrapper
@@ -115,7 +115,7 @@ theme: responsive_full_width
           %img{src: "/images/blockchain-resource-image-generic.png", alt: ""}
           %p=hoc_s(:blockchain_resources_02_desc)
         .content-footer
-          %a{href: "https://www.youtube.com/@WhiteboardCrypto/featured", class: "link-button", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:blockchain_resources_02_button_label)}}
+          %a{href: "https://www.youtube.com/@WhiteboardCrypto/featured", class: "link-button has-external-link", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:blockchain_resources_02_button_label)}}
             =hoc_s(:call_to_action_watch_now)
       .action-block.action-block--one-col.flex-space-between
         .content-wrapper
@@ -123,5 +123,5 @@ theme: responsive_full_width
           %img{src: "/images/blockchain-coinbase-hoc-activity.png", alt: ""}
           %p=hoc_s(:blockchain_resources_03_desc)
         .content-footer
-          %a{href: "https://coinbase.github.io/memorygame/story.html", class: "link-button", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:blockchain_resources_03_button_label)}}
+          %a{href: "https://coinbase.github.io/memorygame/story.html", class: "link-button has-external-link", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s(:blockchain_resources_03_button_label)}}
             =hoc_s(:call_to_action_try_activity)

--- a/pegasus/sites.v3/code.org/public/css/page/help-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/page/help-styles.scss
@@ -42,7 +42,7 @@ section.spread-the-word {
 
   ul.icon-bullet-list {
     margin: 0;
-    width: 55%;
+    width: 57%;
 
     @media screen and (max-width: $width-md) {
       width: 100%;

--- a/pegasus/sites.v3/code.org/public/donate/index.haml
+++ b/pegasus/sites.v3/code.org/public/donate/index.haml
@@ -20,7 +20,7 @@ theme: responsive_full_width
       %h1=hoc_s(:donate_page_top_heading)
       %p.body-one
         =hoc_s(:donate_page_top_desc)
-      %a.link-button{href: "https://donate.code.org/campaign/support-computer-science-education/c172233", target: "_blank", rel: "noopener noreferrer"}
+      %a.link-button.has-external-link{href: "https://donate.code.org/campaign/support-computer-science-education/c172233", target: "_blank", rel: "noopener noreferrer"}
         =hoc_s(:call_to_action_donate_to_cdo)
     %figure.col-45
       %img.rounded-corners.box-shadow-primary{src: "/images/donate-page-top.png", alt: "", style: "position: relative; width: 100%;"}
@@ -30,7 +30,7 @@ theme: responsive_full_width
   .wrapper.centered
     %h2=hoc_s(:donate_page_fundraise_title)
     %p=hoc_s(:donate_page_fundraise_desc)
-    %a.link-button{href: "https://donate.code.org/campaign/computer-science-education/c142257", target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button.has-external-link{href: "https://donate.code.org/campaign/computer-science-education/c142257", target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_start_fundraiser)
 
 %section.donate-options

--- a/pegasus/sites.v3/code.org/public/educate/csa.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csa.haml
@@ -11,7 +11,7 @@ theme: responsive_full_width
     .text-wrapper
       %h1{style: "color: white"}
         =hoc_s(:curriculum_name_csa)
-      %p{style: "color: white"}
+      %p.has-external-link{style: "color: white"}
         =hoc_s(:csa_page_top_desc, markdown: :inline, locals: {csa_url: "https://apcentral.collegeboard.org/media/pdf/ap-computer-science-a-course-and-exam-description.pdf?course=ap-computer-science-a"})
       %a.link-button.white{href: CDO.studio_url("/courses/csa-2023?viewAs=Instructor")}
         =hoc_s(:call_to_action_explore_course)

--- a/pegasus/sites.v3/code.org/public/educate/professional-development-online.haml
+++ b/pegasus/sites.v3/code.org/public/educate/professional-development-online.haml
@@ -231,7 +231,7 @@ theme: responsive_full_width
           %img{src: "/images/csta-action-block-tile.png", alt: "", style: "width: 100%"}
           %p=hoc_s(:self_paced_pl_resources_desc_02)
         .content-footer
-          %a.link-button{href: "https://www.csteachers.org/page/individual-membership", target: "_blank", rel: "noopener noreferrer"}
+          %a.link-button.has-external-link{href: "https://www.csteachers.org/page/individual-membership", target: "_blank", rel: "noopener noreferrer"}
             =hoc_s(:call_to_action_join_csta)
       .action-block.action-block--one-col.flex-space-between
         .content-wrapper

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.haml
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.haml
@@ -175,7 +175,7 @@ theme: responsive_full_width
           %h3 Outside the United States
           %p If you are an international teacher interested in professional learning. Learn more about what is offered in your area.
         .content-footer
-          %a{href: "https://support.code.org/hc/en-us/articles/115003865532-I-teach-outside-of-the-US-Are-there-resources-to-help-me-teach-computer-science-", class: "link-button secondary"} Learn more
+          %a{href: "https://support.code.org/hc/en-us/articles/115003865532-I-teach-outside-of-the-US-Are-there-resources-to-help-me-teach-computer-science-", class: "link-button secondary has-external-link"} Learn more
 
 = view :section_divider_line
 
@@ -186,6 +186,6 @@ theme: responsive_full_width
       .text-wrapper.col-50
         %p Your local Code.org Regional Partner provides high quality Code.org professional learning to teachers, and can help guide your school or district on implementation, certification, funding, and more. They are happy to answer any questions you may have about the program!
         = view :professional_development_workshops_regional_partner_search
-        %a{href: "https://support.code.org/", class: "link-button secondary", target: "_blank", rel: "noopener noreferrer"} Visit our support center
+        %a{href: "https://support.code.org/", class: "link-button secondary has-external-link", target: "_blank", rel: "noopener noreferrer"} Visit our support center
       %img{src: "/images/professional-learning/pl-teachers-talking.png", alt: "", class: "col-50"}
   .clear

--- a/pegasus/sites.v3/code.org/public/farsi.haml
+++ b/pegasus/sites.v3/code.org/public/farsi.haml
@@ -13,7 +13,7 @@ theme: responsive_full_width
       %div.col-60{style: "margin-bottom: 1rem"}
         %h2.heading-lg=hoc_s(:farsi_page_top_heading_02)
         %p.body-three=hoc_s(:farsi_page_top_desc)
-        %a{href: 'https://donate.code.org/CodeDotOrgInFarsi', class: "link-button", target: "_blank", rel: "noopener noreferrer"}
+        %a{href: 'https://donate.code.org/CodeDotOrgInFarsi', class: "link-button has-external-link", target: "_blank", rel: "noopener noreferrer"}
           =hoc_s(:call_to_action_support_farsi)
       %div.col-33{style: "float:right"}
         %img{src: "/images/farsi/farsi-page-students.jpg", alt: "", style: "width: 100%"}
@@ -63,7 +63,7 @@ theme: responsive_full_width
       %li Anonymous (3)
     %hr.dark
     %p=hoc_s(:farsi_page_supporters_desc_02)
-    %a{href: 'https://donate.code.org/CodeDotOrgInFarsi', class: "link-button", target: "_blank", rel: "noopener noreferrer"}
+    %a{href: 'https://donate.code.org/CodeDotOrgInFarsi', class: "link-button has-external-link", target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_support_farsi)
 
 %section.bg-neutral-light
@@ -82,10 +82,12 @@ theme: responsive_full_width
     %h2=hoc_s(:farsi_page_support_heading)
     %h3.heading-sm{style: "margin-bottom: 1rem"}
       =hoc_s(:farsi_page_support_heading_02)
-    %p=hoc_s(:farsi_page_support_get_updates, markdown: :inline, locals: {form_url: "http://go.pardot.com/l/153401/2022-05-31/pq1716"})
+    %p.has-external-link
+      =hoc_s(:farsi_page_support_get_updates, markdown: :inline, locals: {form_url: "http://go.pardot.com/l/153401/2022-05-31/pq1716"})
     %iframe.col-50{allowtransparency: "true", frameborder: "0", height: "325", scrolling: "yes", src: "http://go.pardot.com/l/153401/2022-05-31/pq1716", style: "overflow:hidden; float: none;", type: "text/html", width: "100%"}
-    %p=hoc_s(:farsi_page_support_contact_us, markdown: :inline, locals: {contact_link: "https://forms.gle/fMb9z7Wy2Qrjrowb7"})
-    %a{href: 'https://donate.code.org/CodeDotOrgInFarsi', class: "link-button", target: "_blank", rel: "noopener noreferrer"}
+    %p.has-external-link
+      =hoc_s(:farsi_page_support_contact_us, markdown: :inline, locals: {contact_link: "https://forms.gle/fMb9z7Wy2Qrjrowb7"})
+    %a{href: 'https://donate.code.org/CodeDotOrgInFarsi', class: "link-button has-external-link", target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_donate_online)
 
 %section

--- a/pegasus/sites.v3/code.org/public/help.haml
+++ b/pegasus/sites.v3/code.org/public/help.haml
@@ -18,7 +18,7 @@ theme: responsive_full_width
         %h2=hoc_s(:help_page_top_subhead)
         %p=hoc_s(:help_page_top_desc_02)
         .button-wrapper{style: "margin-bottom: 1rem"}
-          %a.link-button{href: "https://donate.code.org/campaign/support-computer-science-education/c172233", target: "_blank", rel: "noopener noreferrer"}
+          %a.link-button.has-external-link{href: "https://donate.code.org/campaign/support-computer-science-education/c172233", target: "_blank", rel: "noopener noreferrer"}
             =hoc_s(:call_to_action_make_a_donation)
           %a.link-button.secondary{href: "donate"}
             =hoc_s(:call_to_action_other_ways_to_give)
@@ -56,7 +56,7 @@ theme: responsive_full_width
       =hoc_s(:help_page_speak_for_cs_heading)
     %p{style: "color: white"}
       =hoc_s(:help_page_speak_for_cs_desc)
-    %a.link-button{href: "https://advocacy.code.org", target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button.has-external-link{href: "https://advocacy.code.org", target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_learn_about_advocacy)
 
 %section
@@ -74,7 +74,7 @@ theme: responsive_full_width
         =hoc_s(:shop_code_dot_org_heading)
       %p{style: "color: white"}
         =hoc_s(:shop_code_dot_org_desc)
-      %a.link-button{href: "https://store.code.org", target: "_blank", rel: "noopener noreferrer"}
+      %a.link-button.has-external-link{href: "https://store.code.org", target: "_blank", rel: "noopener noreferrer"}
         =hoc_s(:call_to_action_visit_store)
     .flex-container.justify-space-between.gap-1
       %img{src: "/images/help-page-shop-03.png", alt: ""}

--- a/pegasus/sites.v3/code.org/public/maker/circuitplayground.haml
+++ b/pegasus/sites.v3/code.org/public/maker/circuitplayground.haml
@@ -60,7 +60,7 @@ theme: responsive_full_width
           %i{class: "#{icon_circle_xmark}", style: "color: #E5311A"}
         .text-wrapper.no-margin-bottom
           %h3 The Circuit Playground Bluefruit
-    %p.body-three Wondering which version you have? <a href="https://learn.adafruit.com/category/circuit-playground" target="_blank" rel="noopener noreferrer">Check out Adafruit's guide</a>.
+    %p.body-three Wondering which version you have? <a class="has-external-link" href="https://learn.adafruit.com/category/circuit-playground" target="_blank" rel="noopener noreferrer">Check out Adafruit's guide</a>.
 
 %section.bg-primary-light
   .wrapper
@@ -79,15 +79,15 @@ theme: responsive_full_width
           %p Contains Circuit Playground boards and accessories necessary for using Code.org's curriculum with a class of 30 students.
           %p All educators receive a 10% discount when they apply the code <strong>ADAEDU</strong> at checkout. <em>Note:</em> The ADAEDU code only applies to orders of $250 or greater.
         .content-footer
-          %a.link-button{href: "https://www.adafruit.com/product/3399", target: "_blank", rel: "noopener noreferrer"} Get the classroom kit
+          %a.link-button.has-external-link{href: "https://www.adafruit.com/product/3399", target: "_blank", rel: "noopener noreferrer"} Get the classroom kit
       .action-block.action-block--one-col.flex-space-between
         .content-wrapper
           %h3 Circuit Playground Individual Kit
           %img{src: "/images/maker/maker-cp-individual.png", alt: "", style: "width: 100%"}
           %p For smaller classrooms, we recommend investing in a set of Circuit Playground Individual Kits. The individual kit is designed for a single student or pair of students.
         .content-footer
-          %a.link-button{href: "https://www.adafruit.com/product/3795", target: "_blank", rel: "noopener noreferrer"} Get the individual kit
-    %p.body-three.no-margin-bottom{style: "margin-top: 1em"} Out of stock? Try looking at other approved <a href="https://www.adafruit.com/distributors#North_America" target="_blank" rel="noopener noreferrer">Adafruit distributors</a>.
+          %a.link-button.has-external-link{href: "https://www.adafruit.com/product/3795", target: "_blank", rel: "noopener noreferrer"} Get the individual kit
+    %p.body-three.no-margin-bottom{style: "margin-top: 1em"} Out of stock? Try looking at other approved <a class="has-external-link"  href="https://www.adafruit.com/distributors#North_America" target="_blank" rel="noopener noreferrer">Adafruit distributors</a>.
 
 = view :section_divider_line
 

--- a/pegasus/sites.v3/code.org/public/maker/index.haml
+++ b/pegasus/sites.v3/code.org/public/maker/index.haml
@@ -64,7 +64,7 @@ theme: responsive_full_width
             %i{class: "#{icon_face_smile}"}
           .text-wrapper
             %h3 Social and emotional learning
-            %p Physical computing encourages students to work together, fostering collaboration, interpersonal skills, and active learning. (<a href="https://www.microsoft.com/en-us/research/uploads/prod/2020/04/physical-computing.pdf" target="_blank" rel="noopener noreferrer">Source</a>)
+            %p Physical computing encourages students to work together, fostering collaboration, interpersonal skills, and active learning. (<a class="has-external-link" href="https://www.microsoft.com/en-us/research/uploads/prod/2020/04/physical-computing.pdf" target="_blank" rel="noopener noreferrer">Source</a>)
       %figure.col-50
         %img{src: "/images/maker/maker-girls-with-devices.png", alt: "", style: "width: 100%"}
     .clear

--- a/pegasus/sites.v3/code.org/public/maker/microbit.haml
+++ b/pegasus/sites.v3/code.org/public/maker/microbit.haml
@@ -60,7 +60,7 @@ theme: responsive_full_width
     %figure.col-25{style: "float: right; text-align: center"}
       %img{src: "/images/maker/microbit.gif", alt: "", style: "margin: 0 auto 2em; max-width: 250px; width:100%"}
     .clear
-    %p.body-three Wondering which version you have? <a href="https://support.microbit.org/support/solutions/articles/19000119162-how-to-identify-the-version-number-of-your-micro-bit" target="_blank" rel="noopener noreferrer">Check out the micro:bit guide</a>.
+    %p.body-three Wondering which version you have? <a class="has-external-link" href="https://support.microbit.org/support/solutions/articles/19000119162-how-to-identify-the-version-number-of-your-micro-bit" target="_blank" rel="noopener noreferrer">Check out the micro:bit guide</a>.
 
 %section.bg-primary-light
   .wrapper
@@ -76,7 +76,7 @@ theme: responsive_full_width
       .text-wrapper.col-50
         %h3.heading-sm Buy the micro:bit
         %p BBC micro:bit reseller companies sell the device all around the world.
-        %a{href: "https://microbit.org/buy/", class: "link-button", target: "_blank", rel: "noopener noreferrer"} Buy the micro:bit
+        %a{href: "https://microbit.org/buy/", class: "link-button has-external-link", target: "_blank", rel: "noopener noreferrer"} Buy the micro:bit
 
 = view :section_divider_line
 

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -151,6 +151,9 @@ a:link:has(*) {
   text-decoration: none;
 }
 
+/* Adds an icon to external links
+  - apply this class to container elements or directly onto
+  an "a" tag when a link opens in a new tab or window */
 .has-external-link a::after,
 a.has-external-link::after {
   font: var(--fa-font-solid);

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -166,6 +166,17 @@ html[dir="rtl"] a.has-external-link::after {
   margin: 0 4px 0 2px;
 }
 
+.has-external-link a.link-button::after,
+a.link-button.has-external-link::after {
+  margin: 0 0 0 4px;
+}
+
+html[dir="rtl"] .has-external-link a.link-button::after,
+html[dir="rtl"] a.link-button.has-external-link::after {
+  margin: 0 4px 0 0;
+}
+
+
 strong {
   font-family: var(--gotham-bold);
 }

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -151,6 +151,18 @@ a:link:has(*) {
   text-decoration: none;
 }
 
+.has-external-link a::after,
+a.has-external-link::after {
+  font: var(--fa-font-solid);
+  content: "\f08e";
+  margin: 0 2px 0 4px;
+}
+
+html[dir="rtl"] .has-external-link a::after,
+html[dir="rtl"] a.has-external-link::after {
+  margin: 0 4px 0 2px;
+}
+
 strong {
   font-family: var(--gotham-bold);
 }

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -176,7 +176,6 @@ html[dir="rtl"] a.link-button.has-external-link::after {
   margin: 0 4px 0 0;
 }
 
-
 strong {
   font-family: var(--gotham-bold);
 }

--- a/pegasus/sites.v3/code.org/views/ai_101_videos.haml
+++ b/pegasus/sites.v3/code.org/views/ai_101_videos.haml
@@ -30,17 +30,17 @@
         %p
           %i{class: "#{icon_book}"}
           %strong=hoc_s(:ai_pl_101_resources_guide)
-          %a{href: "https://docs.google.com/presentation/d/1WXvjG9TscUuH5Xz8Pj2okz6lMIKV__g0v6AoYVXKb40/copy", target: "_blank", rel: "noopener noreferrer"}
+          %a.has-external-link{href: "https://docs.google.com/presentation/d/1WXvjG9TscUuH5Xz8Pj2okz6lMIKV__g0v6AoYVXKb40/copy", target: "_blank", rel: "noopener noreferrer"}
             =hoc_s(:ai_pl_101_llm_slides_title)
       - if index === 2
         %p
           %i{class: "#{icon_book}"}
           %strong=hoc_s(:ai_pl_101_resources_guide)
-          %a{href: "http://bit.ly/TransformLearningAI", target: "_blank", rel: "noopener noreferrer"}
+          %a.has-external-link{href: "http://bit.ly/TransformLearningAI", target: "_blank", rel: "noopener noreferrer"}
             =hoc_s(:ai_pl_101_resources_3)
       - if index === 3
         %p
           %i{class: "#{icon_book}"}
           %strong=hoc_s(:ai_pl_101_resources_guide)
-          %a{href: "http://bit.ly/AIRespUse", target: "_blank", rel: "noopener noreferrer"}
+          %a.has-external-link{href: "http://bit.ly/AIRespUse", target: "_blank", rel: "noopener noreferrer"}
             =hoc_s(:ai_pl_101_resources_5)

--- a/pegasus/sites.v3/code.org/views/faq_csd.haml
+++ b/pegasus/sites.v3/code.org/views/faq_csd.haml
@@ -30,7 +30,8 @@
 %details
   %summary=hoc_s(:csp_page_faq_question_06)
   %p=hoc_s(:csp_page_faq_answer_06_01)
-  %p=hoc_s(:csp_page_faq_answer_06_02, markdown: :inline, locals: {form_url: "https://docs.google.com/forms/d/1f5QPKi3F_3nBDR8q9BcXCqixzY7SCQd7Seob0-JYizU/viewform"})
+  %p.has-external-link
+    =hoc_s(:csp_page_faq_answer_06_02, markdown: :inline, locals: {form_url: "https://docs.google.com/forms/d/1f5QPKi3F_3nBDR8q9BcXCqixzY7SCQd7Seob0-JYizU/viewform"})
 %details
   %summary=hoc_s(:csd_page_faq_question_06)
   %p=hoc_s(:csd_page_faq_answer_06_01, markdown: :inline, locals: {csf_url: "/educate/curriculum/elementary-school", csp_url: "/educate/csp"})

--- a/pegasus/sites.v3/code.org/views/help/help_page_spread_the_word.haml
+++ b/pegasus/sites.v3/code.org/views/help/help_page_spread_the_word.haml
@@ -10,7 +10,7 @@
     .text-wrapper
       %h3=hoc_s(:follow_us_heading)
       %p=hoc_s(:follow_us_desc)
-      .flex-container.wrap{style: "gap: 1rem"}
+      .has-external-link.flex-container.wrap{style: "gap: 1rem"}
         %a{href: "https://www.facebook.com/Code.org/", target: "_blank", rel: "noopener noreferrer"}
           =hoc_s(:facebook)
         %a{href: "https://twitter.com/codeorg", target: "_blank", rel: "noopener noreferrer"}
@@ -30,7 +30,7 @@
       .flex-container.wrap{style: "gap: 1rem"}
         %a{href: "/about/hear-from-us"}
           =hoc_s(:subscribe_to_emails_heading)
-        %a{href: "http://go.pardot.com/l/153401/2018-07-20/lfw71d", target: "_blank", rel: "noopener noreferrer"}
+        %a.has-external-link{href: "http://go.pardot.com/l/153401/2018-07-20/lfw71d", target: "_blank", rel: "noopener noreferrer"}
           =hoc_s(:subscribe_to_emails_intl)
   %li
     %div

--- a/pegasus/sites.v3/code.org/views/support_and_questions_section.haml
+++ b/pegasus/sites.v3/code.org/views/support_and_questions_section.haml
@@ -4,8 +4,8 @@
   .text-wrapper.col-50
     %h3=hoc_s(:support_and_questions_section_subhead)
     %p=hoc_s(:support_and_questions_section_desc)
-    %a.link-button{href: "https://support.code.org/hc/requests/new", target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button.has-external-link{href: "https://support.code.org/hc/requests/new", target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_contact_support)
-    %a.link-button.secondary{href: "https://forum.code.org/", target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button.secondary.has-external-link{href: "https://forum.code.org/", target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_explore_teacher_forums)
   .clear

--- a/pegasus/sites.v3/code.org/views/tabs_section/donate/donate_tabs.haml
+++ b/pegasus/sites.v3/code.org/views/tabs_section/donate/donate_tabs.haml
@@ -18,7 +18,7 @@
     = view :"tabs_section/donate/donate_tabs_daf_direct"
   %div#amazon.content
     = view :"tabs_section/donate/donate_tabs_amazon"
-  %div#bitpay.content
+  %div#bitpay.content.has-external-link
     = view :"tabs_section/donate/donate_tabs_bitpay"
   %div#employee-match.content
     = view :"tabs_section/donate/donate_tabs_employee_match"
@@ -31,7 +31,7 @@
   %details.amazon
     %summary=hoc_s(:donate_tabs_tab_label_amazon)
     = view :"tabs_section/donate/donate_tabs_amazon"
-  %details.bitpay
+  %details.bitpay.has-external-link
     %summary=hoc_s(:donate_tabs_tab_label_bitpay)
     = view :"tabs_section/donate/donate_tabs_bitpay"
   %details.employee-match

--- a/pegasus/sites.v3/code.org/views/tabs_section/resources/resources_tabs_content_slides.haml
+++ b/pegasus/sites.v3/code.org/views/tabs_section/resources/resources_tabs_content_slides.haml
@@ -8,5 +8,5 @@
         =hoc_s(:resources_tabs_slides_subhead)
     %p.body-three
       =hoc_s(:resources_tabs_slides_desc)
-    %a.link-button{href: "https://docs.google.com/presentation/d/1lR2Il6bOm-OHQltTtHO5XJ_p0q2J-3dye_RiCZW-sGY/template/preview", target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button.has-external-link{href: "https://docs.google.com/presentation/d/1lR2Il6bOm-OHQltTtHO5XJ_p0q2J-3dye_RiCZW-sGY/template/preview", target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_resources_slides)


### PR DESCRIPTION
Add a CSS class that can be applied to external links and buttons that open in a new tab/window.
- The class is `.has-external-link` 
- Can be applied to any element that has an `a` text link or `a.link-button` button
- Updated existing external links on updated pages
- Works with LTR and RTL languages

**Jira ticket:** [ACQ-1044](https://codedotorg.atlassian.net/browse/ACQ-1044)

----

### Examples in use:

<img width="501" alt="Screenshot 2023-10-09 at 10 42 01 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/3b4a1952-626b-4e70-8406-9d3ae9c86cfd">

--

<img width="998" alt="Screenshot 2023-10-09 at 10 42 32 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/660f1fc1-0185-4411-a8fa-9d56f8b97ca4">

--

<img width="997" alt="Screenshot 2023-10-09 at 10 47 13 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/1f2e3ac0-2026-4d8f-92e7-62aaa3fa5e04">

--

<img width="1014" alt="Screenshot 2023-10-09 at 12 21 29 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/4573dde6-3fa4-4c8b-9083-8cfa8f6a1ff5">

### RTL language support

<img width="495" alt="Screenshot 2023-10-09 at 10 41 42 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/09987b94-b98b-4e22-a9a7-8f553335cec3">

--

<img width="992" alt="Screenshot 2023-10-09 at 10 41 34 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/fc00c55f-d5bf-4ec2-905d-678b87e2998f">
