### PR TITLE
Re-add LTI Advantage client tests

### DIFF
--- a/dashboard/test/lib/clients/lti_advantage_client_test.rb
+++ b/dashboard/test/lib/clients/lti_advantage_client_test.rb
@@ -2,18 +2,17 @@ require 'test_helper'
 require_relative '../../../lib/clients/lti_advantage_client'
 
 class LtiAdvantageClientTest < ActiveSupport::TestCase
-  include LtiAccessToken
+  # include LtiAccessToken
 
   setup do
-    CDO.stubs(:jwk_private_key_data).returns('fake_private_key')
-    CDO.shared_cache.stubs(:read).returns('fake_access_token')
-    LtiAccessToken.stubs(:get_access_token).returns('fake_access_token')
+    @lti_client = LtiAdvantageClient.new('client_id', 'issuer')
+    @lti_client.stubs(:get_access_token).returns('fake_access_token')
   end
 
   test 'throws an error if the API returns a non-200 response' do
     HTTParty.stubs(:get).returns(OpenStruct.new({code: 400}))
     assert_raises RuntimeError do
-      LtiAdvantageClient.new('client_id', 'issuer').get_context_membership('https://foolms.com/api/sections/1')
+      @lti_client.get_context_membership('https://foolms.com/api/sections/1')
     end
   end
 

--- a/dashboard/test/lib/clients/lti_advantage_client_test.rb
+++ b/dashboard/test/lib/clients/lti_advantage_client_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+require_relative '../../../lib/clients/lti_advantage_client'
+
+class LtiAdvantageClientTest < ActiveSupport::TestCase
+  include LtiAccessToken
+
+  setup do
+    CDO.stubs(:jwk_private_key_data).returns('fake_private_key')
+    CDO.shared_cache.stubs(:read).returns('fake_access_token')
+    LtiAccessToken.stubs(:get_access_token).returns('fake_access_token')
+  end
+
+  test 'throws an error if the API returns a non-200 response' do
+    HTTParty.stubs(:get).returns(OpenStruct.new({code: 400}))
+    assert_raises RuntimeError do
+      LtiAdvantageClient.new('client_id', 'issuer').get_context_membership('https://foolms.com/api/sections/1')
+    end
+  end
+
+  test 'throws an error if no client_id or issuer is provided' do
+    assert_raises ArgumentError do
+      LtiAdvantageClient.new(nil, nil)
+    end
+  end
+end

--- a/dashboard/test/lib/clients/lti_advantage_client_test.rb
+++ b/dashboard/test/lib/clients/lti_advantage_client_test.rb
@@ -27,7 +27,6 @@ class LtiAdvantageClientTest < ActiveSupport::TestCase
 
     actual_error = assert_raises(RuntimeError) {@lti_client.get_context_membership(url)}
     assert_equal "Error getting context membership: #{response_code} #{response_body}", actual_error.message
-    
   end
 
   test 'throws an error if no client_id or issuer is provided' do

--- a/dashboard/test/lib/clients/lti_advantage_client_test.rb
+++ b/dashboard/test/lib/clients/lti_advantage_client_test.rb
@@ -3,16 +3,31 @@ require_relative '../../../lib/clients/lti_advantage_client'
 
 class LtiAdvantageClientTest < ActiveSupport::TestCase
   setup do
-    @lti_client = LtiAdvantageClient.new('client_id', 'issuer')
+    @client_id = 'expected_client_id'
+    @issuer = 'expected_issuer'
+
+    @lti_client = LtiAdvantageClient.new(@client_id, @issuer)
     @lti_client.stubs(:get_access_token).returns('fake_access_token')
   end
 
   test 'throws an error if the API returns a non-200 response' do
-    HTTParty.stubs(:get).returns(OpenStruct.new({code: 400}))
+    response_code = 'non-200_response_code'
+    response_body = 'expected_response_body'
+
+    access_token = 'expected_access_token'
+    url = 'expected_url'
+    expected_headers = {
+      'Accept' => 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json',
+      'Authorization' => "Bearer #{access_token}"
+    }
+
     @lti_client.expects(:sign_jwt).never # should not be called since the get_access_token method is stubbed
-    assert_raises RuntimeError do
-      @lti_client.get_context_membership('https://foolms.com/api/sections/1')
-    end
+    @lti_client.expects(:get_access_token).with(@client_id, @issuer).once.returns(access_token)
+    HTTParty.expects(:get).with(url, headers: expected_headers).once.returns(stub(code: response_code, body: response_body))
+
+    actual_error = assert_raises(RuntimeError) {@lti_client.get_context_membership(url)}
+    assert_equal "Error getting context membership: #{response_code} #{response_body}", actual_error.message
+    
   end
 
   test 'throws an error if no client_id or issuer is provided' do

--- a/dashboard/test/lib/clients/lti_advantage_client_test.rb
+++ b/dashboard/test/lib/clients/lti_advantage_client_test.rb
@@ -2,8 +2,6 @@ require 'test_helper'
 require_relative '../../../lib/clients/lti_advantage_client'
 
 class LtiAdvantageClientTest < ActiveSupport::TestCase
-  # include LtiAccessToken
-
   setup do
     @lti_client = LtiAdvantageClient.new('client_id', 'issuer')
     @lti_client.stubs(:get_access_token).returns('fake_access_token')
@@ -11,6 +9,7 @@ class LtiAdvantageClientTest < ActiveSupport::TestCase
 
   test 'throws an error if the API returns a non-200 response' do
     HTTParty.stubs(:get).returns(OpenStruct.new({code: 400}))
+    @lti_client.expects(:sign_jwt).never # should not be called since the get_access_token method is stubbed
     assert_raises RuntimeError do
       @lti_client.get_context_membership('https://foolms.com/api/sections/1')
     end


### PR DESCRIPTION
The original tests for the LTI Advantage client were succeeding in real environments (e.g. staging, test, and local), but not in Drone. I had written the stubs incorrectly, so in real environments it was just bypassing the stubs and grabbing the real JWK to sign a test JWT. This fixes the stubs (which don't work directly on modules) and instead instantiates a new test client, then stubs the methods that get included into that client object. Seems to work now.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
