### PR TITLE
Add banner if we load JSON Blockly sources in CDO Blockly

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1245,7 +1245,7 @@
   "joinText": "join",
   "joinTextTooltip": "Create a piece of text by joining together multiple items.",
   "joinUs": "Join us",
-  "jsonInCDOBlockly": "Due to a system upgrade, your code could not be loaded. Please use Version History to recover a working version of this project, or to start over.",
+  "jsonInCdoBlockly": "Due to a system upgrade, your code could not be loaded. Please use Version History to recover a working version of this project, or to start over.",
   "jump": "jump",
   "jumpToLesson": "Jump to lesson",
   "justDidHourOfCode": "I just did the #HourOfCode - check it out! @codeorg",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1245,6 +1245,7 @@
   "joinText": "join",
   "joinTextTooltip": "Create a piece of text by joining together multiple items.",
   "joinUs": "Join us",
+  "jsonInCDOBlockly": "Due to a system upgrade, your code could not be loaded. Please use Version History to recover a working version of this project or to start over.",
   "jump": "jump",
   "jumpToLesson": "Jump to lesson",
   "justDidHourOfCode": "I just did the #HourOfCode - check it out! @codeorg",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1245,7 +1245,7 @@
   "joinText": "join",
   "joinTextTooltip": "Create a piece of text by joining together multiple items.",
   "joinUs": "Join us",
-  "jsonInCDOBlockly": "Due to a system upgrade, your code could not be loaded. Please use Version History to recover a working version of this project or to start over.",
+  "jsonInCDOBlockly": "Due to a system upgrade, your code could not be loaded. Please use Version History to recover a working version of this project, or to start over.",
   "jump": "jump",
   "jumpToLesson": "Jump to lesson",
   "justDidHourOfCode": "I just did the #HourOfCode - check it out! @codeorg",

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -250,10 +250,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
     loadBlocksToWorkspace(blockSpace, source) {
       const isXml = stringIsXml(source);
       if (!isXml) {
-        console.warn(
-          `Source string was JSON. Use Version History to recover a working version of this project.`,
-          `This likely occurred by opening a project that was last saved with Google Blockly.`
-        );
         getStore().dispatch(setHasIncompatibleSources(true));
         source = '';
       }

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -3,6 +3,8 @@ import {CLAMPED_NUMBER_REGEX, stringIsXml} from './constants';
 import {APP_HEIGHT} from '@cdo/apps/p5lab/constants';
 import customBlocks from './customBlocks/cdoBlockly/index.js';
 import {parseElement as parseXmlElement} from '../xml';
+import {getStore} from '@cdo/apps/redux';
+import {setHasIncompatibleSources} from '../redux/blockly';
 
 const INFINITE_LOOP_TRAP =
   '  executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}\n';
@@ -252,6 +254,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
           `Source string was JSON. Use Version History to recover a working version of this project.`,
           `This likely occurred by opening a project that was last saved with Google Blockly.`
         );
+        getStore().dispatch(setHasIncompatibleSources(true));
         source = '';
       }
       Blockly.Xml.domToBlockSpace(blockSpace, parseXmlElement(source));

--- a/apps/src/redux/blockly.ts
+++ b/apps/src/redux/blockly.ts
@@ -5,6 +5,8 @@ interface BlocklyState {
 }
 
 const initialState: BlocklyState = {
+  // hasIncompatibleSources is set to true if we try to load json sources in
+  // CDO Blockly, which only supports xml.
   hasIncompatibleSources: false,
 };
 

--- a/apps/src/redux/blockly.ts
+++ b/apps/src/redux/blockly.ts
@@ -1,0 +1,23 @@
+import {PayloadAction, createSlice} from '@reduxjs/toolkit';
+
+interface BlocklyState {
+  hasIncompatibleSources: boolean;
+}
+
+const initialState: BlocklyState = {
+  hasIncompatibleSources: false,
+};
+
+const blocklySlice = createSlice({
+  name: 'blockly',
+  initialState,
+  reducers: {
+    setHasIncompatibleSources(state, action: PayloadAction<boolean>) {
+      state.hasIncompatibleSources = action.payload;
+    },
+  },
+});
+
+export const {setHasIncompatibleSources} = blocklySlice.actions;
+
+export default blocklySlice.reducer;

--- a/apps/src/redux/commonReducers.js
+++ b/apps/src/redux/commonReducers.js
@@ -11,6 +11,7 @@ import instructionsDialog from './instructionsDialog';
 import watchedExpressions from './watchedExpressions';
 import feedback from './feedback';
 import studioAppActivity from './studioAppActivity';
+import blockly from './blockly';
 
 module.exports = {
   runState,
@@ -22,4 +23,5 @@ module.exports = {
   watchedExpressions,
   feedback,
   studioAppActivity,
+  blockly,
 };

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -55,6 +55,9 @@ class CodeWorkspace extends React.Component {
         // isRunning and style only affect style, and can be updated
         // workspaceAlert is involved in displaying or closing workspace alert
         // therefore this key can be updated
+        // hasIncompatibleSources is involved in displaying an alert for invalid Blockly
+        // sources. This key can be updated because it will only be set once, and it will
+        // be set after the initial render.
         if (
           key === 'isRunning' ||
           key === 'style' ||
@@ -297,7 +300,7 @@ class CodeWorkspace extends React.Component {
             id="incompatibleSourcesBanner"
             style={{...styles.topBanner, ...styles.incompatibleCodeBanner}}
           >
-            {i18n.jsonInCDOBlockly()}
+            {i18n.jsonInCdoBlockly()}
           </div>
         )}
         {props.showDebugger && (

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -42,6 +42,7 @@ class CodeWorkspace extends React.Component {
     closeWorkspaceAlert: PropTypes.func,
     workspaceAlert: PropTypes.object,
     isProjectTemplateLevel: PropTypes.bool,
+    hasIncompatibleSources: PropTypes.bool,
   };
 
   shouldComponentUpdate(nextProps) {
@@ -57,7 +58,8 @@ class CodeWorkspace extends React.Component {
         if (
           key === 'isRunning' ||
           key === 'style' ||
-          key === 'workspaceAlert'
+          key === 'workspaceAlert' ||
+          key === 'hasIncompatibleSources'
         ) {
           return;
         }
@@ -170,6 +172,7 @@ class CodeWorkspace extends React.Component {
   // assigned true (implies Droplet, not Blockly). Otherwise, it is displayed at the bottom
   // of the CodeWorkspace
   renderWorkspaceAlert(isBlocklyType) {
+    console.log('rendering workspace alert!');
     return (
       <WorkspaceAlert
         type={this.props.workspaceAlert.type}
@@ -263,7 +266,7 @@ class CodeWorkspace extends React.Component {
           </ProtectedStatefulDiv>
         )}
         {this.props.displayNotStartedBanner && !inCsfExampleSolution && (
-          <div id="notStartedBanner" style={styles.studentNotStartedWarning}>
+          <div id="notStartedBanner" style={styles.incompatibleCodeBanner}>
             {i18n.levelNotStartedWarning()}
           </div>
         )}
@@ -280,6 +283,14 @@ class CodeWorkspace extends React.Component {
                 : i18n.inStartBlocksMode()}
             </div>
           </>
+        )}
+        {this.props.hasIncompatibleSources && (
+          <div
+            id="incompatibleSourcesBanner"
+            style={{...styles.topBanner, ...styles.incompatibleCodeBanner}}
+          >
+            {i18n.jsonInCDOBlockly()}
+          </div>
         )}
         {props.showDebugger && (
           <JsDebugger
@@ -330,6 +341,16 @@ const styles = {
     opacity: 0.9,
     position: 'relative',
   },
+  topBanner: {
+    zIndex: 99,
+    padding: 5,
+    opacity: 0.9,
+    position: 'relative',
+  },
+  incompatibleCodeBanner: {
+    height: 40,
+    backgroundColor: color.lightest_red,
+  },
   chevronButton: {
     padding: 0,
     margin: 0,
@@ -373,6 +394,7 @@ export default connect(
     showMakerToggle: !!state.pageConstants.showMakerToggle,
     workspaceAlert: state.project.workspaceAlert,
     isProjectTemplateLevel: state.pageConstants.isProjectTemplateLevel,
+    hasIncompatibleSources: state.blockly.hasIncompatibleSources,
   }),
   dispatch => ({
     closeWorkspaceAlert: () => dispatch(closeWorkspaceAlert()),

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -266,18 +266,27 @@ class CodeWorkspace extends React.Component {
           </ProtectedStatefulDiv>
         )}
         {this.props.displayNotStartedBanner && !inCsfExampleSolution && (
-          <div id="notStartedBanner" style={styles.incompatibleCodeBanner}>
+          <div
+            id="notStartedBanner"
+            style={{...styles.topBanner, ...styles.studentNotStartedWarning}}
+          >
             {i18n.levelNotStartedWarning()}
           </div>
         )}
         {this.props.displayOldVersionBanner && (
-          <div id="oldVersionBanner" style={styles.oldVersionWarning}>
+          <div
+            id="oldVersionBanner"
+            style={{...styles.topBanner, ...styles.oldVersionWarning}}
+          >
             {i18n.oldVersionWarning()}
           </div>
         )}
         {this.props.inStartBlocksMode && (
           <>
-            <div id="startBlocksBanner" style={styles.startBlocksBanner}>
+            <div
+              id="startBlocksBanner"
+              style={{...styles.topBanner, ...styles.startBlocksBanner}}
+            >
               {this.props.isProjectTemplateLevel
                 ? i18n.startBlocksTemplateWarning()
                 : i18n.inStartBlocksMode()}
@@ -317,29 +326,17 @@ const styles = {
     },
   },
   oldVersionWarning: {
-    zIndex: 99,
     backgroundColor: color.lightest_red,
     textAlign: 'center',
     height: 20,
-    padding: 5,
-    opacity: 0.8,
-    position: 'relative',
   },
   studentNotStartedWarning: {
-    zIndex: 99,
     backgroundColor: color.lightest_red,
     height: 20,
-    padding: 5,
-    opacity: 0.9,
-    position: 'relative',
   },
   startBlocksBanner: {
-    zIndex: 99,
     backgroundColor: color.lighter_yellow,
     height: 20,
-    padding: 5,
-    opacity: 0.9,
-    position: 'relative',
   },
   topBanner: {
     zIndex: 99,

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -172,7 +172,6 @@ class CodeWorkspace extends React.Component {
   // assigned true (implies Droplet, not Blockly). Otherwise, it is displayed at the bottom
   // of the CodeWorkspace
   renderWorkspaceAlert(isBlocklyType) {
-    console.log('rendering workspace alert!');
     return (
       <WorkspaceAlert
         type={this.props.workspaceAlert.type}
@@ -328,24 +327,21 @@ const styles = {
   oldVersionWarning: {
     backgroundColor: color.lightest_red,
     textAlign: 'center',
-    height: 20,
   },
   studentNotStartedWarning: {
     backgroundColor: color.lightest_red,
-    height: 20,
   },
   startBlocksBanner: {
     backgroundColor: color.lighter_yellow,
-    height: 20,
   },
   topBanner: {
     zIndex: 99,
     padding: 5,
     opacity: 0.9,
     position: 'relative',
+    height: 'fit-content',
   },
   incompatibleCodeBanner: {
-    height: 40,
     backgroundColor: color.lightest_red,
   },
   chevronButton: {


### PR DESCRIPTION
In Google Blockly we now use json to store sources. If we have to revert back to CDO Blockly, those sources will not be compatible (because CDO only supports XML). This situation should be very unlikely. In this case, we set sources to an empty string. Users can then use version history to restore an xml version of their project, or start over.

This PR adds a banner instructing users to do this if they end up in this situation.

<img width="951" alt="Screenshot 2023-10-09 at 3 36 28 PM" src="https://github.com/code-dot-org/code-dot-org/assets/33666587/5782db56-af73-4961-9059-fa18db5dedfd">


## Links

- jira ticket: [CT-117](https://codedotorg.atlassian.net/browse/CT-117)


## Testing story
Tested locally.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
