### PR TITLE
hoc2023: AI output

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -14,7 +14,13 @@ import DanceParty from '@code-dot-org/dance-party/src/p5.dance';
 import DanceAPI from '@code-dot-org/dance-party/src/api';
 import ResourceLoader from '@code-dot-org/dance-party/src/ResourceLoader';
 import danceMsg from './locale';
-import {reducers, setRunIsStarting, initSongs, setSong} from './danceRedux';
+import {
+  reducers,
+  setRunIsStarting,
+  initSongs,
+  setSong,
+  setAiOutput,
+} from './danceRedux';
 import trackEvent from '../util/trackEvent';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import logToCloud from '../logToCloud';
@@ -106,6 +112,10 @@ Dance.prototype.init = function (config) {
   this.studioApp_.labUserId = config.labUserId;
   this.level.softButtons = this.level.softButtons || {};
   this.initialThumbnailCapture = true;
+
+  if (config.level.aiOutput) {
+    getStore().dispatch(setAiOutput(config.level.aiOutput));
+  }
 
   config.afterClearPuzzle = function () {
     this.studioApp_.resetButtonClick();

--- a/apps/src/dance/ai/DanceAiModal.tsx
+++ b/apps/src/dance/ai/DanceAiModal.tsx
@@ -182,7 +182,7 @@ const DanceAiModal: React.FunctionComponent<DanceAiProps> = ({onClose}) => {
     return blocksSvg;
   };
 
-  const convertBlocks = () => {
+  const handleConvertBlocks = () => {
     const blocksSvg = generateBlocksFromResult();
 
     const origBlock = currentAiModalField?.getSourceBlock();
@@ -444,16 +444,18 @@ const DanceAiModal: React.FunctionComponent<DanceAiProps> = ({onClose}) => {
           {((mode === Mode.RESULTS && typingDone) ||
             mode === Mode.RESULTS_FINAL) && (
             <div>
-              {(aiOutput === AiOutput.BLOCKS || aiOutput === AiOutput.BOTH) && (
+              {(aiOutput === AiOutput.GENERATED_BLOCKS ||
+                aiOutput === AiOutput.BOTH) && (
                 <Button
                   id="convert"
                   text={'Convert'}
-                  onClick={convertBlocks}
+                  onClick={handleConvertBlocks}
                   color={Button.ButtonColor.brandSecondaryDefault}
                   className={moduleStyles.button}
                 />
               )}
-              {(aiOutput === AiOutput.BLOCK || aiOutput === AiOutput.BOTH) && (
+              {(aiOutput === AiOutput.AI_BLOCK ||
+                aiOutput === AiOutput.BOTH) && (
                 <Button
                   id="use"
                   text={'Use'}

--- a/apps/src/dance/ai/DanceAiModal.tsx
+++ b/apps/src/dance/ai/DanceAiModal.tsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {BlockSvg} from 'blockly/core';
 import {doAi} from './utils';
+import {AiOutput} from '../types';
 import AiPreview from './AiPreview';
 const Typist = require('react-typist').default;
 
@@ -57,6 +58,10 @@ const DanceAiModal: React.FunctionComponent<DanceAiProps> = ({onClose}) => {
 
   const currentAiModalField = useSelector(
     (state: {dance: DanceState}) => state.dance.currentAiModalField
+  );
+
+  const aiOutput = useSelector(
+    (state: {dance: DanceState}) => state.dance.aiOutput
   );
 
   const [showPreview, setShowPreview] = useState<boolean>(false);
@@ -217,7 +222,7 @@ const DanceAiModal: React.FunctionComponent<DanceAiProps> = ({onClose}) => {
     }
   };
 
-  const handleDoneClick = () => {
+  const handleUseClick = () => {
     dispatch(setCurrentAiModalField(undefined));
   };
 
@@ -439,20 +444,24 @@ const DanceAiModal: React.FunctionComponent<DanceAiProps> = ({onClose}) => {
           {((mode === Mode.RESULTS && typingDone) ||
             mode === Mode.RESULTS_FINAL) && (
             <div>
-              <Button
-                id="convert"
-                text={'Convert'}
-                onClick={convertBlocks}
-                color={Button.ButtonColor.brandSecondaryDefault}
-                className={moduleStyles.button}
-              />
-              <Button
-                id="done"
-                text={'Use'}
-                onClick={handleDoneClick}
-                color={Button.ButtonColor.brandSecondaryDefault}
-                className={moduleStyles.button}
-              />
+              {(aiOutput === AiOutput.BLOCKS || aiOutput === AiOutput.BOTH) && (
+                <Button
+                  id="convert"
+                  text={'Convert'}
+                  onClick={convertBlocks}
+                  color={Button.ButtonColor.brandSecondaryDefault}
+                  className={moduleStyles.button}
+                />
+              )}
+              {(aiOutput === AiOutput.BLOCK || aiOutput === AiOutput.BOTH) && (
+                <Button
+                  id="use"
+                  text={'Use'}
+                  onClick={handleUseClick}
+                  color={Button.ButtonColor.brandSecondaryDefault}
+                  className={moduleStyles.button}
+                />
+              )}
             </div>
           )}
         </div>

--- a/apps/src/dance/danceRedux.ts
+++ b/apps/src/dance/danceRedux.ts
@@ -5,7 +5,7 @@ import {
   PayloadAction,
   ThunkDispatch,
 } from '@reduxjs/toolkit';
-import {SongData, SongMetadata} from './types';
+import {SongData, SongMetadata, AiOutput} from './types';
 import {queryParams} from '../code-studio/utils';
 import {fetchSignedCookies} from '../utils';
 import {
@@ -23,6 +23,7 @@ export interface DanceState {
   songData: SongData;
   runIsStarting: boolean;
   currentAiModalField?: GoogleBlockly.Field;
+  aiOutput?: AiOutput;
   // Fields below are used only by Lab2 Dance
   isRunning: boolean;
   currentSongMetadata: SongMetadata | undefined;
@@ -33,6 +34,7 @@ const initialState: DanceState = {
   songData: {},
   runIsStarting: false,
   currentAiModalField: undefined,
+  aiOutput: AiOutput.BLOCK,
   isRunning: false,
   currentSongMetadata: undefined,
 };
@@ -159,6 +161,9 @@ const danceSlice = createSlice({
     ) => {
       state.currentAiModalField = action.payload;
     },
+    setAiOutput: (state, action: PayloadAction<AiOutput>) => {
+      state.aiOutput = action.payload;
+    },
   },
 });
 
@@ -168,5 +173,6 @@ export const {
   setRunIsStarting,
   setCurrentSongMetadata,
   setCurrentAiModalField,
+  setAiOutput,
 } = danceSlice.actions;
 export const reducers = {dance: danceSlice.reducer};

--- a/apps/src/dance/danceRedux.ts
+++ b/apps/src/dance/danceRedux.ts
@@ -34,7 +34,7 @@ const initialState: DanceState = {
   songData: {},
   runIsStarting: false,
   currentAiModalField: undefined,
-  aiOutput: AiOutput.BLOCK,
+  aiOutput: AiOutput.AI_BLOCK,
   isRunning: false,
   currentSongMetadata: undefined,
 };

--- a/apps/src/dance/types.ts
+++ b/apps/src/dance/types.ts
@@ -37,7 +37,7 @@ export interface DanceLevelProperties extends LevelProperties {
 }
 
 export enum AiOutput {
-  BLOCK = 'block',
-  BLOCKS = 'blocks',
+  AI_BLOCK = 'ai_block',
+  GENERATED_BLOCKS = 'generated_blocks',
   BOTH = 'both',
 }

--- a/apps/src/dance/types.ts
+++ b/apps/src/dance/types.ts
@@ -35,3 +35,9 @@ export interface DanceLevelProperties extends LevelProperties {
   defaultSong?: string;
   useRestrictedSongs?: boolean;
 }
+
+export enum AiOutput {
+  BLOCK = 'block',
+  BLOCKS = 'blocks',
+  BOTH = 'both',
+}


### PR DESCRIPTION
With this change, a level can specify the output methods available for the AI modal.

The following are valid values for the `ai_output` level property in a Dance level:

- `"ai_block"` means that the AI modal will simply modify the value of the existing AI block.  This is the default if no property is provided.
- `"generated_blocks"` means that the AI modal will allow the user to convert the existing AI block into regular blocks that do the same task.
- `"both"` means that the AI modal will show both options.

### ai_block (default)

<img width="911" alt="Screenshot 2023-10-09 at 4 38 33 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/76af6acc-a96b-4a1a-8455-748bf88c76ee">

### generated_blocks

<img width="911" alt="Screenshot 2023-10-09 at 4 41 10 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/7fc61f13-f907-40c1-92f6-eb811d835212">

### both

<img width="911" alt="Screenshot 2023-10-09 at 4 54 20 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/91b50891-0a8d-4154-8250-d86638ccd0b8">

