### PR TITLE
CT-111: remove version param from progress bubble nav url

### DIFF
--- a/apps/src/templates/progress/BubbleFactory.jsx
+++ b/apps/src/templates/progress/BubbleFactory.jsx
@@ -213,6 +213,13 @@ export function getBubbleUrl(
   const params = preserveQueryParams
     ? queryString.parse(currentLocation().search)
     : {};
+
+  // We want to preserve all of the queryParams EXCEPT version because navigating
+  // between levels backed by different projects or between a project level and
+  // a non-project level puts the user in an error state since the version id doesn't
+  // exist.
+  delete params.version;
+
   if (sectionId) {
     params.section_id = sectionId;
   }

--- a/apps/test/unit/templates/progress/BubbleFactoryTest.jsx
+++ b/apps/test/unit/templates/progress/BubbleFactoryTest.jsx
@@ -237,7 +237,7 @@ describe('BubbleFactory', () => {
     it('removes version param if it exists even if other params are preserved', () => {
       const levelUrl = 'http://a-level-url.com';
       updateQueryParam('version', '456lmnop');
-      expect(currentLocation().search).to.equal('?version=456lmnop');
+      expect(currentLocation().search).to.include('version=456lmnop');
       const preserveQueryParams = true;
       const bubbleUrl = getBubbleUrl(levelUrl, null, null, preserveQueryParams);
       expect(bubbleUrl).to.equal(levelUrl);

--- a/apps/test/unit/templates/progress/BubbleFactoryTest.jsx
+++ b/apps/test/unit/templates/progress/BubbleFactoryTest.jsx
@@ -240,7 +240,7 @@ describe('BubbleFactory', () => {
       expect(currentLocation().search).to.include('version=456lmnop');
       const preserveQueryParams = true;
       const bubbleUrl = getBubbleUrl(levelUrl, null, null, preserveQueryParams);
-      expect(bubbleUrl).to.equal(levelUrl);
+      expect(bubbleUrl).to.not.include('version=456lmnop');
     });
   });
 

--- a/apps/test/unit/templates/progress/BubbleFactoryTest.jsx
+++ b/apps/test/unit/templates/progress/BubbleFactoryTest.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
+import {updateQueryParam} from '../../../../src/code-studio/utils';
+import {currentLocation} from '@cdo/apps/utils';
 import {
   BasicBubble,
   BubbleShape,
@@ -230,6 +232,15 @@ describe('BubbleFactory', () => {
     it('if there is a sectionId append the section_id to the url', () => {
       const bubbleUrl = getBubbleUrl('a-url', 1, 2);
       expect(bubbleUrl).to.equal('a-url?section_id=2&user_id=1');
+    });
+
+    it('removes version param if it exists even if other params are preserved', () => {
+      const levelUrl = 'http://a-level-url.com';
+      updateQueryParam('version', '456lmnop');
+      expect(currentLocation().search).to.equal('?version=456lmnop');
+      const preserveQueryParams = true;
+      const bubbleUrl = getBubbleUrl(levelUrl, null, null, preserveQueryParams);
+      expect(bubbleUrl).to.equal(levelUrl);
     });
   });
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

When viewing a previous version of a project-back level and then navigating to a level in that is neither backed by a project nor backed by the same project the version id in the url causes a confusing error state because the version id is project-specific. 

<img width="708" alt="Screenshot 2023-10-06 at 10 18 23 AM" src="https://github.com/code-dot-org/code-dot-org/assets/12300669/3db84efd-1007-4ad4-be05-f16b058673b4">


To alleviate this confusion, we're now removing the version param if it exists when generating the level url for a bubble.

There is a slight downside to this change in cases where users are navigating between levels that backed by the _same_ project; they could go from an old version of a project in one level to the most recent version of a project in a different level.  However, this change felt least complex to solve the majority of likely use cases and there is already a handy banner visually indicating to a user when they are viewing a project that is not the latest version. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: [CT-111](https://codedotorg.atlassian.net/browse/CT-111)
-->
 [CT-111](https://codedotorg.atlassian.net/browse/CT-111)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->
Manually confirmed that expected behavior locally. 
BEFORE 

https://github.com/code-dot-org/code-dot-org/assets/12300669/bba1f1f7-2fa1-48c5-b1e0-1068762fed19

AFTER 

https://github.com/code-dot-org/code-dot-org/assets/12300669/1e314ead-48fe-41a7-9587-e7bc5f0845f3

And added a unit test for this particular usage of `getBubbleUrl`

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
No special consideration needed. 

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->
No. 
## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->
n/a

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
