### PR TITLE
revert to default Active Job adapters

### DIFF
--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -205,7 +205,5 @@ module Dashboard
 
     # Use custom routes for error codes
     config.exceptions_app = routes
-
-    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -77,10 +77,4 @@ Dashboard::Application.configure do
   config.levelbuilder_mode = CDO.with_default(false).levelbuilder_mode
 
   config.experiment_cache_time_seconds = 0
-
-  # Override the default delayed_job queue adapter so that jobs will run even if
-  # the developer is not running a delayed_job worker. To use the delayed_job
-  # queue adapter in development, comment out this line and make sure you have
-  # run `bin/delayed_job start` or rake build.
-  config.active_job.queue_adapter = :async
 end


### PR DESCRIPTION
(very) partial revert of https://github.com/code-dot-org/code-dot-org/pull/53976 to fix a [production issue](https://codedotorg.slack.com/archives/C03DBDN67B7/p1696946868857699).

## Testing story

## Deployment strategy

## Follow-up work
