### PR TITLE
Handle no email available for Zendesk abuse reports

### DIFF
--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -1,6 +1,8 @@
 require 'json'
 require 'httparty'
 
+UNKNOWN_ACCOUNT_ZENDESK_REPORT_EMAIL = 'automated_abuse_report@code.org'
+
 class ZendeskError < StandardError
   attr_reader :error_details
 
@@ -41,9 +43,15 @@ class ReportAbuseController < ApplicationController
       name = current_user&.name
       email = current_user&.email
       age = current_user&.age
-      abuse_url = CDO.studio_url(params[:abuse_url]) # reformats url
+      abuse_url = CDO.studio_url(params[:abuse_url], CDO.default_scheme)
 
-      send_abuse_report(name, email, age, abuse_url) if email
+      # submit abuse reports from
+      # signed out users (nil) and student accounts (blank string)
+      # under generic email
+      if email.nil? || email == ''
+        email = UNKNOWN_ACCOUNT_ZENDESK_REPORT_EMAIL
+      end
+      send_abuse_report(name, email, age, abuse_url)
       update_abuse_score
 
       return head :ok
@@ -163,7 +171,7 @@ class ReportAbuseController < ApplicationController
   end
 
   private def send_abuse_report(name, email, age, abuse_url)
-    unless Rails.env.development? || Rails.env.test?
+    unless Rails.env.test?
       subject = FeaturedProject.featured_channel_id?(params[:channel_id]) ?
         'Featured Project: Abuse Reported' :
         'Abuse Reported'

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -171,7 +171,7 @@ class ReportAbuseController < ApplicationController
   end
 
   private def send_abuse_report(name, email, age, abuse_url)
-    unless Rails.env.test?
+    unless Rails.env.development? || Rails.env.test?
       subject = FeaturedProject.featured_channel_id?(params[:channel_id]) ?
         'Featured Project: Abuse Reported' :
         'Abuse Reported'


### PR DESCRIPTION
Submits abuse reports from unknown email addresses (ie, signed out users and students) with a new account that Hannah created as an "end user" manually in Zendesk (`automated_abuse_report@code.org`). Also includes the scheme (http/s) prefix in URLs in tickets, so they're clickable.

Should fix [this Honeybadger error](https://app.honeybadger.io/projects/3240/faults/100609156). Follow-up to https://github.com/code-dot-org/code-dot-org/pull/53927.

## Testing story

Tested manually that Zendesk tickets were made with this dummy email address when I submitted abuse reports locally when signed out and when signed in with a student account. Also tested that teacher emails are still included with tickets if we have it.