### PR TITLE
Move logic in RubricContainer to RubricContent

### DIFF
--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -1,36 +1,14 @@
-import React, {useState, useEffect} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import style from './rubrics.module.scss';
 import i18n from '@cdo/locale';
-import {
-  BodyThreeText,
-  Heading2,
-  Heading5,
-  Heading6,
-} from '@cdo/apps/componentLibrary/typography';
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import {
   reportingDataShape,
   rubricShape,
   studentLevelInfoShape,
 } from './rubricShapes';
-import LearningGoal from './LearningGoal';
-import Button from '../Button';
-import HttpClient from '@cdo/apps/util/HttpClient';
-
-const formatTimeSpent = timeSpent => {
-  const minutes = Math.floor(timeSpent / 60);
-  const seconds = timeSpent % 60;
-
-  return i18n.timeSpent({minutes, seconds});
-};
-
-const formatLastAttempt = lastAttempt => {
-  const date = new Date(lastAttempt);
-  return i18n.levelLastUpdated({
-    lastUpdatedDate: date.toLocaleDateString(),
-  });
-};
+import RubricContent from './RubricContent';
 
 export default function RubricContainer({
   rubric,
@@ -39,175 +17,18 @@ export default function RubricContainer({
   currentLevelName,
   reportingData,
 }) {
-  const onLevelForEvaluation = currentLevelName === rubric.level.name;
-  const canProvideFeedback = !!studentLevelInfo && onLevelForEvaluation;
-  const {lesson} = rubric;
-  const rubricLevel = rubric.level;
-
-  const [aiEvaluation, setAiEvaluations] = useState(null);
-  const [isSubmittingToStudent, setIsSubmittingToStudent] = useState(false);
-  const [errorSubmitting, setErrorSubmitting] = useState(false);
-  const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
-  const submitFeedbackToStudent = () => {
-    setIsSubmittingToStudent(true);
-    setErrorSubmitting(false);
-    const body = JSON.stringify({
-      student_id: studentLevelInfo.user_id,
-    });
-    const endPoint = `/rubrics/${rubric.id}/submit_evaluations`;
-    HttpClient.post(endPoint, body, true, {'Content-Type': 'application/json'})
-      .then(response => response.json())
-      .then(json => {
-        setIsSubmittingToStudent(false);
-        if (!json.submittedAt) {
-          throw new Error('Unexpected response object');
-        }
-        const lastSubmittedDateObj = new Date(json.submittedAt);
-        setLastSubmittedTimestamp(lastSubmittedDateObj.toLocaleString());
-      })
-      .catch(() => {
-        setIsSubmittingToStudent(false);
-        setErrorSubmitting(true);
-      });
-  };
-
-  useEffect(() => {
-    if (!!studentLevelInfo && teacherHasEnabledAi) {
-      const studentId = studentLevelInfo.user_id;
-      const rubricId = rubric.id;
-      const dataUrl = `/rubrics/${rubricId}/get_ai_evaluations?student_id=${studentId}`;
-
-      fetch(dataUrl)
-        .then(response => {
-          if (!response.ok) {
-            throw new Error('Network response was not ok');
-          }
-          return response.json();
-        })
-        .then(data => {
-          setAiEvaluations(data);
-        })
-        .catch(error => {
-          console.log(
-            'There was a problem with the fetch operation:',
-            error.message
-          );
-        });
-    }
-  }, [rubric.id, studentLevelInfo, teacherHasEnabledAi]);
-
-  const getAiUnderstanding = learningGoalId => {
-    if (!!aiEvaluation) {
-      const aiInfo = aiEvaluation.find(
-        item => item.learning_goal_id === learningGoalId
-      );
-      return aiInfo?.understanding;
-    } else {
-      return null;
-    }
-  };
-
-  const getAiConfidence = learningGoalId => {
-    if (!!aiEvaluation) {
-      const aiInfo = aiEvaluation.find(
-        item => item.learning_goal_id === learningGoalId
-      );
-      return aiInfo?.confidence;
-    } else {
-      return null;
-    }
-  };
-
   return (
     <div className={style.rubricContainer}>
       <div className={style.rubricHeader}>
         <Heading6>{i18n.rubrics()}</Heading6>
       </div>
-      <div className={style.rubricContent}>
-        {!!studentLevelInfo && (
-          <div className={style.studentInfo}>
-            <Heading2>{studentLevelInfo.name}</Heading2>
-            <div className={style.levelAndStudentDetails}>
-              <Heading5>
-                {i18n.lessonNumbered({
-                  lessonNumber: lesson.position,
-                  lessonName: lesson.name,
-                })}
-              </Heading5>
-              {onLevelForEvaluation && (
-                <div className={style.studentMetadata}>
-                  {studentLevelInfo.timeSpent && (
-                    <BodyThreeText className={style.singleMetadatum}>
-                      <FontAwesome icon="clock" />
-                      <span>{formatTimeSpent(studentLevelInfo.timeSpent)}</span>
-                    </BodyThreeText>
-                  )}
-                  <BodyThreeText className={style.singleMetadatum}>
-                    <FontAwesome icon="rocket" />
-                    {i18n.numAttempts({
-                      numAttempts: studentLevelInfo.attempts || 0,
-                    })}
-                  </BodyThreeText>
-                  {studentLevelInfo.lastAttempt && (
-                    <BodyThreeText className={style.singleMetadatum}>
-                      <FontAwesome icon="calendar" />
-                      <span>
-                        {formatLastAttempt(studentLevelInfo.lastAttempt)}
-                      </span>
-                    </BodyThreeText>
-                  )}
-                </div>
-              )}
-              {!onLevelForEvaluation && rubricLevel?.position && (
-                <BodyThreeText>
-                  {i18n.feedbackAvailableOnLevel({
-                    levelPosition: rubricLevel.position,
-                  })}
-                </BodyThreeText>
-              )}
-            </div>
-          </div>
-        )}
-        <div className={style.learningGoalContainer}>
-          {rubric.learningGoals.map(lg => (
-            <LearningGoal
-              key={lg.key}
-              learningGoal={lg}
-              teacherHasEnabledAi={teacherHasEnabledAi}
-              canProvideFeedback={canProvideFeedback}
-              reportingData={reportingData}
-              studentLevelInfo={studentLevelInfo}
-              aiUnderstanding={getAiUnderstanding(lg.id)}
-              aiConfidence={getAiConfidence(lg.id)}
-            />
-          ))}
-        </div>
-        {canProvideFeedback && (
-          <div className={style.rubricContainerFooter}>
-            <div className={style.submitToStudentButtonAndError}>
-              <Button
-                text={i18n.submitToStudent()}
-                color={Button.ButtonColor.brandSecondaryDefault}
-                onClick={submitFeedbackToStudent}
-                className={style.submitToStudentButton}
-                disabled={isSubmittingToStudent}
-              />
-              {errorSubmitting && (
-                <BodyThreeText className={style.errorMessage}>
-                  {i18n.errorSubmittingFeedback()}
-                </BodyThreeText>
-              )}
-              {!errorSubmitting && !!lastSubmittedTimestamp && (
-                <BodyThreeText>
-                  {i18n.feedbackSubmittedAt({
-                    timestamp: lastSubmittedTimestamp,
-                  })}
-                </BodyThreeText>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
+      <RubricContent
+        rubric={rubric}
+        studentLevelInfo={studentLevelInfo}
+        teacherHasEnabledAi={teacherHasEnabledAi}
+        currentLevelName={currentLevelName}
+        reportingData={reportingData}
+      />
     </div>
   );
 }

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -1,0 +1,215 @@
+import React, {useEffect, useState} from 'react';
+import PropTypes from 'prop-types';
+import style from './rubrics.module.scss';
+import i18n from '@cdo/locale';
+import {
+  BodyThreeText,
+  Heading2,
+  Heading5,
+} from '@cdo/apps/componentLibrary/typography';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import {
+  reportingDataShape,
+  rubricShape,
+  studentLevelInfoShape,
+} from './rubricShapes';
+import LearningGoal from './LearningGoal';
+import Button from '@cdo/apps/templates/Button';
+import HttpClient from '@cdo/apps/util/HttpClient';
+
+const formatTimeSpent = timeSpent => {
+  const minutes = Math.floor(timeSpent / 60);
+  const seconds = timeSpent % 60;
+
+  return i18n.timeSpent({minutes, seconds});
+};
+
+const formatLastAttempt = lastAttempt => {
+  const date = new Date(lastAttempt);
+  return i18n.levelLastUpdated({
+    lastUpdatedDate: date.toLocaleDateString(),
+  });
+};
+
+export default function RubricContent({
+  studentLevelInfo,
+  rubric,
+  teacherHasEnabledAi,
+  currentLevelName,
+  reportingData,
+}) {
+  const onLevelForEvaluation = currentLevelName === rubric.level.name;
+  const canProvideFeedback = !!studentLevelInfo && onLevelForEvaluation;
+  const {lesson} = rubric;
+  const rubricLevel = rubric.level;
+
+  const [aiEvaluation, setAiEvaluations] = useState(null);
+  const [isSubmittingToStudent, setIsSubmittingToStudent] = useState(false);
+  const [errorSubmitting, setErrorSubmitting] = useState(false);
+  const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
+  const submitFeedbackToStudent = () => {
+    setIsSubmittingToStudent(true);
+    setErrorSubmitting(false);
+    const body = JSON.stringify({
+      student_id: studentLevelInfo.user_id,
+    });
+    const endPoint = `/rubrics/${rubric.id}/submit_evaluations`;
+    HttpClient.post(endPoint, body, true, {'Content-Type': 'application/json'})
+      .then(response => response.json())
+      .then(json => {
+        setIsSubmittingToStudent(false);
+        if (!json.submittedAt) {
+          throw new Error('Unexpected response object');
+        }
+        const lastSubmittedDateObj = new Date(json.submittedAt);
+        setLastSubmittedTimestamp(lastSubmittedDateObj.toLocaleString());
+      })
+      .catch(() => {
+        setIsSubmittingToStudent(false);
+        setErrorSubmitting(true);
+      });
+  };
+
+  useEffect(() => {
+    if (!!studentLevelInfo && teacherHasEnabledAi) {
+      const studentId = studentLevelInfo.user_id;
+      const rubricId = rubric.id;
+      const dataUrl = `/rubrics/${rubricId}/get_ai_evaluations?student_id=${studentId}`;
+
+      fetch(dataUrl)
+        .then(response => {
+          if (!response.ok) {
+            throw new Error('Network response was not ok');
+          }
+          return response.json();
+        })
+        .then(data => {
+          setAiEvaluations(data);
+        })
+        .catch(error => {
+          console.log(
+            'There was a problem with the fetch operation:',
+            error.message
+          );
+        });
+    }
+  }, [rubric.id, studentLevelInfo, teacherHasEnabledAi]);
+
+  const getAiUnderstanding = learningGoalId => {
+    if (!!aiEvaluation) {
+      const aiInfo = aiEvaluation.find(
+        item => item.learning_goal_id === learningGoalId
+      );
+      return aiInfo?.understanding;
+    } else {
+      return null;
+    }
+  };
+
+  const getAiConfidence = learningGoalId => {
+    if (!!aiEvaluation) {
+      const aiInfo = aiEvaluation.find(
+        item => item.learning_goal_id === learningGoalId
+      );
+      return aiInfo?.confidence;
+    } else {
+      return null;
+    }
+  };
+
+  return (
+    <div className={style.rubricContent}>
+      {!!studentLevelInfo && (
+        <div className={style.studentInfo}>
+          <Heading2>{studentLevelInfo.name}</Heading2>
+          <div className={style.levelAndStudentDetails}>
+            <Heading5>
+              {i18n.lessonNumbered({
+                lessonNumber: lesson.position,
+                lessonName: lesson.name,
+              })}
+            </Heading5>
+            {onLevelForEvaluation && (
+              <div className={style.studentMetadata}>
+                {studentLevelInfo.timeSpent && (
+                  <BodyThreeText className={style.singleMetadatum}>
+                    <FontAwesome icon="clock" />
+                    <span>{formatTimeSpent(studentLevelInfo.timeSpent)}</span>
+                  </BodyThreeText>
+                )}
+                <BodyThreeText className={style.singleMetadatum}>
+                  <FontAwesome icon="rocket" />
+                  {i18n.numAttempts({
+                    numAttempts: studentLevelInfo.attempts || 0,
+                  })}
+                </BodyThreeText>
+                {studentLevelInfo.lastAttempt && (
+                  <BodyThreeText className={style.singleMetadatum}>
+                    <FontAwesome icon="calendar" />
+                    <span>
+                      {formatLastAttempt(studentLevelInfo.lastAttempt)}
+                    </span>
+                  </BodyThreeText>
+                )}
+              </div>
+            )}
+            {!onLevelForEvaluation && rubricLevel?.position && (
+              <BodyThreeText>
+                {i18n.feedbackAvailableOnLevel({
+                  levelPosition: rubricLevel.position,
+                })}
+              </BodyThreeText>
+            )}
+          </div>
+        </div>
+      )}
+      <div className={style.learningGoalContainer}>
+        {rubric.learningGoals.map(lg => (
+          <LearningGoal
+            key={lg.key}
+            learningGoal={lg}
+            teacherHasEnabledAi={teacherHasEnabledAi}
+            canProvideFeedback={canProvideFeedback}
+            reportingData={reportingData}
+            studentLevelInfo={studentLevelInfo}
+            aiUnderstanding={getAiUnderstanding(lg.id)}
+            aiConfidence={getAiConfidence(lg.id)}
+          />
+        ))}
+      </div>
+      {canProvideFeedback && (
+        <div className={style.rubricContainerFooter}>
+          <div className={style.submitToStudentButtonAndError}>
+            <Button
+              text={i18n.submitToStudent()}
+              color={Button.ButtonColor.brandSecondaryDefault}
+              onClick={submitFeedbackToStudent}
+              className={style.submitToStudentButton}
+              disabled={isSubmittingToStudent}
+            />
+            {errorSubmitting && (
+              <BodyThreeText className={style.errorMessage}>
+                {i18n.errorSubmittingFeedback()}
+              </BodyThreeText>
+            )}
+            {!errorSubmitting && !!lastSubmittedTimestamp && (
+              <BodyThreeText>
+                {i18n.feedbackSubmittedAt({
+                  timestamp: lastSubmittedTimestamp,
+                })}
+              </BodyThreeText>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+RubricContent.propTypes = {
+  currentLevelName: PropTypes.string,
+  rubric: rubricShape.isRequired,
+  reportingData: reportingDataShape,
+  studentLevelInfo: studentLevelInfoShape,
+  teacherHasEnabledAi: PropTypes.bool,
+};

--- a/apps/test/unit/templates/rubrics/RubricContentTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContentTest.jsx
@@ -3,10 +3,10 @@ import {expect} from '../../../util/reconfiguredChai';
 import {mount, shallow} from 'enzyme';
 import sinon from 'sinon';
 import HttpClient from '@cdo/apps/util/HttpClient';
-import RubricContainer from '@cdo/apps/templates/rubrics/RubricContainer';
+import RubricContent from '@cdo/apps/templates/rubrics/RubricContent';
 import {act} from 'react-dom/test-utils';
 
-describe('RubricContainer', () => {
+describe('RubricContent', () => {
   const defaultRubric = {
     learningGoals: [
       {
@@ -45,7 +45,7 @@ describe('RubricContainer', () => {
 
   it('shows learning goals with correct props when viewing student work on assessment level', () => {
     const wrapper = shallow(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{name: 'Grace Hopper', timeSpent: 706}}
       />
@@ -68,7 +68,7 @@ describe('RubricContainer', () => {
 
   it('shows learning goals with correct props when viewing student work on non assessment level', () => {
     const wrapper = shallow(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{name: 'Grace Hopper', timeSpent: 706}}
         currentLevelName="non_assessment_level"
@@ -92,7 +92,7 @@ describe('RubricContainer', () => {
 
   it('shows learning goals with correct props when not viewing student work', () => {
     const wrapper = shallow(
-      <RubricContainer {...defaultProps} studentLevelInfo={null} />
+      <RubricContent {...defaultProps} studentLevelInfo={null} />
     );
     const renderedLearningGoals = wrapper.find('LearningGoal');
     expect(renderedLearningGoals).to.have.lengthOf(2);
@@ -113,7 +113,7 @@ describe('RubricContainer', () => {
   it('shows level title', () => {
     // mount is needed in order for text() to work
     const wrapper = mount(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{
           name: 'Grace Hopper',
@@ -126,7 +126,7 @@ describe('RubricContainer', () => {
   it('shows student data if provided', () => {
     // mount is needed in order for text() to work
     const wrapper = mount(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{
           name: 'Grace Hopper',
@@ -145,7 +145,7 @@ describe('RubricContainer', () => {
   it('handles missing student data', () => {
     // mount is needed in order for text() to work
     const wrapper = mount(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{
           name: 'Grace Hopper',
@@ -161,7 +161,7 @@ describe('RubricContainer', () => {
   it('doesnt show student level data if not on level for evaluation', () => {
     // mount is needed in order for text() to work
     const wrapper = mount(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{
           name: 'Grace Hopper',
@@ -177,7 +177,7 @@ describe('RubricContainer', () => {
 
   it('shows submit button if has student data and on level for evaluation', () => {
     const wrapper = shallow(
-      <RubricContainer
+      <RubricContent
         rubric={defaultRubric}
         currentLevelName="test_level"
         studentLevelInfo={{name: 'Grace Hopper'}}
@@ -189,7 +189,7 @@ describe('RubricContainer', () => {
 
   it('handles successful submit button click', async () => {
     const wrapper = shallow(
-      <RubricContainer
+      <RubricContent
         rubric={defaultRubric}
         teacherHasEnabledAi
         currentLevelName="test_level"
@@ -217,7 +217,7 @@ describe('RubricContainer', () => {
 
   it('handles error on submit button click', async () => {
     const wrapper = shallow(
-      <RubricContainer
+      <RubricContent
         rubric={defaultRubric}
         teacherHasEnabledAi
         studentLevelInfo={{name: 'Grace Hopper'}}
@@ -245,7 +245,7 @@ describe('RubricContainer', () => {
     );
 
     const wrapper = mount(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         studentLevelInfo={{
           name: 'Grace Hopper',
@@ -274,7 +274,7 @@ describe('RubricContainer', () => {
 
   it('does not pass down AI analysis to components when teacher has disabled AI', () => {
     const wrapper = mount(
-      <RubricContainer
+      <RubricContent
         {...defaultProps}
         teacherHasEnabledAi={false}
         studentLevelInfo={{


### PR DESCRIPTION
In working on adding a settings tab to the rubric popup, I realized that `RubricContainer` was going to do way too much work. In this PR, I'm splitting most of the logic in `RubricContainer` into a new component `RubricContent`. Then, in a subsequent PR, I'll add header tabs and click handling to `RubricContainer`.

For this change, I simply copy-pasted most of the render function in `RubricContainer`, plus any helper functions/variables, into `RubricContent` then resolved the imports. I simply moved the test file and made the necessary name changes.

If it helps, you can see the first prototype of this in https://github.com/code-dot-org/code-dot-org/pull/53891/files (this PR likely won't be the final PR, so please don't review it).