### PR TITLE
[Google Blockly] Fix view-only mode with function definitions

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1236,7 +1236,9 @@ StudioApp.prototype.initReadonly = function (options) {
     rtl: getStore().getState().isRtl,
     scrollbars: false,
   });
-  this.loadBlocks(options.blocks);
+
+  const startHiddenDefinitions = options.level?.hiddenDefinitions;
+  this.loadBlocks(options.blocks, startHiddenDefinitions);
 };
 
 /**

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1237,8 +1237,7 @@ StudioApp.prototype.initReadonly = function (options) {
     scrollbars: false,
   });
 
-  const startHiddenDefinitions = options.level?.hiddenDefinitions;
-  this.loadBlocks(options.blocks, startHiddenDefinitions);
+  this.loadBlocks(options.blocks);
 };
 
 /**

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1236,7 +1236,6 @@ StudioApp.prototype.initReadonly = function (options) {
     rtl: getStore().getState().isRtl,
     scrollbars: false,
   });
-
   this.loadBlocks(options.blocks);
 };
 

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -774,6 +774,11 @@ var projects = (module.exports = {
         }
       } else if (current) {
         this.sourceHandler.setInitialLevelSource(currentSources.source);
+        if (currentSources.hiddenDefinitions) {
+          sourceHandler.setInitialHiddenDefinitions(
+            currentSources.hiddenDefinitions
+          );
+        }
         this.showMinimalProjectHeader();
       }
     } else if (appOptions.legacyShareStyle && this.getStandaloneApp()) {


### PR DESCRIPTION
We weren't loading hidden definition code in view only. This PR updates our loading functionality for a read-only view to also load hidden definitions. This makes it so projects with functions/behaviors can be shared.
 
## Links

- jira ticket: [CT-10](https://codedotorg.atlassian.net/browse/CT-10)


## Testing story
Tested locally. This was the only change needed to get view-only mode to work. I thought [initReadonly](https://github.com/code-dot-org/code-dot-org/blob/d7c4d92b54436fd181b8153de21954805ef8541b/apps/src/StudioApp.js#L1240) would need an update, but it does not seem to be used for any read only view I could find (share mode, view mode, block in instructions, block in block pool edit page, etc.). 


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
