### PR TITLE
P20-399: Create unit tests for Dashboard docs i18n sync-out

### DIFF
--- a/bin/i18n/resources/dashboard.rb
+++ b/bin/i18n/resources/dashboard.rb
@@ -34,6 +34,7 @@ module I18n
         CourseOfferings.sync_out
         Courses.sync_out
         CurriculumContent.sync_out
+        Docs.sync_out
       end
     end
   end

--- a/bin/i18n/resources/dashboard/docs.rb
+++ b/bin/i18n/resources/dashboard/docs.rb
@@ -1,4 +1,5 @@
 require_relative '../../i18n_script_utils'
+require_relative '../dashboard'
 
 Dir[File.expand_path('../docs/**/*.rb', __FILE__)].sort.each {|file| require file}
 
@@ -6,14 +7,23 @@ module I18n
   module Resources
     module Dashboard
       module Docs
+        # TODO: Adding spritelab and Javalab to translation pipeline
+        # Currently supporting translations for applab, gamelab and weblab. NOT translating javalab and spritelab.
+        # Javalab documentations exists in a different table because it has a different structure, more align with java.
+        # Spritelab uses translatable block names, unlike JavaScript blocks.
+        TRANSLATABLE_PROGRAMMING_ENVS = %w[applab gamelab weblab].freeze
+
         DIR_NAME = 'docs'.freeze
         I18N_SOURCE_DIR_PATH = CDO.dir(I18N_SOURCE_DIR, DIR_NAME).freeze
         I18N_BACKUP_DIR_PATH = CDO.dir(I18N_ORIGINAL_DIR, DIR_NAME).freeze
-
         REDACT_PLUGINS = %w[visualCodeBlock link resourceLink].freeze
 
         def self.sync_in
           SyncIn.perform
+        end
+
+        def self.sync_out
+          SyncOut.perform
         end
       end
     end

--- a/bin/i18n/resources/dashboard/docs.rb
+++ b/bin/i18n/resources/dashboard/docs.rb
@@ -1,9 +1,6 @@
-require 'fileutils'
-require 'json'
-
-require_relative '../../../../dashboard/config/environment'
 require_relative '../../i18n_script_utils'
-require_relative '../../redact_restore_utils'
+
+Dir[File.expand_path('../docs/**/*.rb', __FILE__)].sort.each {|file| require file}
 
 module I18n
   module Resources
@@ -11,103 +8,12 @@ module I18n
       module Docs
         DIR_NAME = 'docs'.freeze
         I18N_SOURCE_DIR_PATH = CDO.dir(I18N_SOURCE_DIR, DIR_NAME).freeze
+        I18N_BACKUP_DIR_PATH = CDO.dir(I18N_ORIGINAL_DIR, DIR_NAME).freeze
 
-        # This function localizes content in studio.code.org/docs
+        REDACT_PLUGINS = %w[visualCodeBlock link resourceLink].freeze
+
         def self.sync_in
-          puts 'Preparing docs content'
-
-          # TODO: Adding spritelab and Javalab to translation pipeline
-          # Currently supporting translations for applab, gamelab and weblab. NOT translating javalab and spritelab.
-          # Javalab documentations exists in a different table because it has a different structure, more align with java.
-          # Spritelab uses translatable block names, unlike JavaScript blocks.
-          localized_environments = %w(applab gamelab weblab)
-
-          ### Localize Programming Environments
-          # For each programming environment, name is used as key, title is used as name
-          ProgrammingEnvironment.where(name: localized_environments).sort.each do |env|
-            # In the sync-in, each environment is store in an individual file.
-            # Files are merged during the sync-out in programming_environments.{locale}.json
-            docs_content_file = File.join(I18N_SOURCE_DIR_PATH, "#{env.name}.json")
-
-            programming_env_docs = {}
-            programming_env_docs[env.name] = {
-              'name' => env.properties['title'],
-              'description' => env.properties['description'],
-              'categories' => {},
-            }
-            ### Localize Categories for Navigation
-            # Programming environment has a method defined in the programming_environment model that returns the
-            # categories for navigation. The method is used to obtain the current categories existing in the database.
-            categories_data = programming_env_docs[env.name]['categories']
-            env.categories_for_navigation.each do |category_for_navigation|
-              category_key = category_for_navigation[:key]
-              categories_data.store(
-                category_key, {
-                  'name' => category_for_navigation[:name],
-                  'expressions' => {}
-                }
-              )
-
-              ### localize Programming Expressions
-              # expression_docs.properties['syntax'] is not translated as it is the JavaScript expression syntax
-              expressions_data = categories_data[category_key]['expressions']
-
-              # TODO: Fix the block as `category_for_navigation[:docs]` can also contain ProgrammingClass
-              category_for_navigation[:docs].each do |expression|
-                expression_key = expression[:key]
-                expression_docs = ProgrammingExpression.find_by_id(expression[:id])
-                expressions_data.store(
-                  expression_key, {
-                    'content' => expression_docs.properties['content'],
-                    'examples' => ({} unless expression_docs.properties['examples'].nil?),
-                    'palette_params' => ({} unless expression_docs.properties['palette_params'].nil?),
-                    'return_value' => expression_docs.properties['return_value'],
-                    'short_description' => expression_docs.properties['short_description'],
-                    'tips' => expression_docs.properties['tips']
-                  }.compact
-                )
-
-                ### Localize Examples
-                # Programming expressions may have 0 or more examples.
-                # Only example["name"] and example["description"] are translated. example["code"] is NOT translated.
-                example_docs = expressions_data[expression_key]['examples']
-                expression_docs.properties['examples']&.each do |example|
-                  unless example['name'].nil_or_empty? && example['description'].nil_or_empty?
-                    example_docs.store(
-                      example['name'], {
-                        'name' => (example['name'] if example['name']),
-                        'description' => (example['description'] if example['description']),
-                      }.compact
-                    )
-                  end
-                end
-
-                ### localize Parameters
-                # Programming expresions may have 0 or more parameters.
-                # Parameter name (param["name"]) is not translated as it needs to match the JavaScript expression syntax.
-                param_docs = expressions_data[expression_key]['palette_params']
-                expression_docs.properties['palette_params']&.each do |param|
-                  param_docs.store(
-                    param['name'], {
-                      'type' => (param['type'] if param['type']),
-                      'description' => (param['description'] if param['description'])
-                    }.compact
-                  )
-                end
-              end
-            end
-
-            # Generate a file containing the string of each Programming Environment.
-            puts "Preparation of #{docs_content_file}"
-            FileUtils.mkdir_p(File.dirname(docs_content_file))
-            File.write(docs_content_file, JSON.pretty_generate(programming_env_docs.compact))
-
-            puts "Redaction of #{docs_content_file}"
-            backup = docs_content_file.sub('source', 'original')
-            FileUtils.mkdir_p(File.dirname(backup))
-            FileUtils.cp(docs_content_file, backup)
-            RedactRestoreUtils.redact(docs_content_file, docs_content_file, %w[visualCodeBlock link resourceLink])
-          end
+          SyncIn.perform
         end
       end
     end

--- a/bin/i18n/resources/dashboard/docs/sync_in.rb
+++ b/bin/i18n/resources/dashboard/docs/sync_in.rb
@@ -11,12 +11,6 @@ module I18n
     module Dashboard
       module Docs
         class SyncIn < I18n::Utils::SyncInBase
-          # TODO: Adding spritelab and Javalab to translation pipeline
-          # Currently supporting translations for applab, gamelab and weblab. NOT translating javalab and spritelab.
-          # Javalab documentations exists in a different table because it has a different structure, more align with java.
-          # Spritelab uses translatable block names, unlike JavaScript blocks.
-          TRANSLATABLE_PROGRAMMING_ENVS = %w[applab gamelab weblab].freeze
-
           def process
             progress_bar.total += programming_envs.size
 

--- a/bin/i18n/resources/dashboard/docs/sync_in.rb
+++ b/bin/i18n/resources/dashboard/docs/sync_in.rb
@@ -1,0 +1,124 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../../../dashboard/config/environment'
+require_relative '../../../i18n_script_utils'
+require_relative '../../../utils/sync_in_base'
+require_relative '../../../redact_restore_utils'
+require_relative '../docs'
+
+module I18n
+  module Resources
+    module Dashboard
+      module Docs
+        class SyncIn < I18n::Utils::SyncInBase
+          # TODO: Adding spritelab and Javalab to translation pipeline
+          # Currently supporting translations for applab, gamelab and weblab. NOT translating javalab and spritelab.
+          # Javalab documentations exists in a different table because it has a different structure, more align with java.
+          # Spritelab uses translatable block names, unlike JavaScript blocks.
+          TRANSLATABLE_PROGRAMMING_ENVS = %w[applab gamelab weblab].freeze
+
+          def process
+            progress_bar.total += programming_envs.size
+
+            # For each programming environment, name is used as key, title is used as name
+            programming_envs.each do |programming_env|
+              # Generate a file containing the string of each Programming Environment.
+              i18n_source_file_path = File.join(I18N_SOURCE_DIR_PATH, "#{programming_env.name}.json")
+              I18nScriptUtils.write_json_file(i18n_source_file_path, i18n_data_of(programming_env))
+
+              # Redact the file content
+              i18n_original_file_path = i18n_source_file_path.sub(I18N_SOURCE_DIR_PATH, I18N_BACKUP_DIR_PATH)
+              I18nScriptUtils.copy_file(i18n_source_file_path, i18n_original_file_path)
+              RedactRestoreUtils.redact(i18n_source_file_path, i18n_source_file_path, REDACT_PLUGINS)
+            ensure
+              progress_bar.increment
+            end
+          end
+
+          private
+
+          def programming_envs
+            @programming_envs ||= ProgrammingEnvironment.where(name: TRANSLATABLE_PROGRAMMING_ENVS).order(:name)
+          end
+
+          # TODO: refactor the programming env i18n data serialization
+          def i18n_data_of(programming_env)
+            i18n_data = {}
+
+            i18n_data[programming_env.name] = {
+              'name' => programming_env.properties['title'],
+              'description' => programming_env.properties['description'],
+              'categories' => {},
+            }
+
+            ### Localize Categories for Navigation
+            # Programming environment has a method defined in the programming_environment model that returns the
+            # categories for navigation. The method is used to obtain the current categories existing in the database.
+            categories_data = i18n_data[programming_env.name]['categories']
+            programming_env.categories_for_navigation.each do |category_for_navigation|
+              category_key = category_for_navigation[:key]
+              categories_data.store(
+                category_key, {
+                  'name' => category_for_navigation[:name],
+                  'expressions' => {}
+                }
+              )
+
+              ### localize Programming Expressions
+              # expression_docs.properties['syntax'] is not translated as it is the JavaScript expression syntax
+              expressions_data = categories_data[category_key]['expressions']
+
+              # TODO: Fix the block as `category_for_navigation[:docs]` can also contain ProgrammingClass
+              category_for_navigation[:docs].each do |expression|
+                expression_key = expression[:key]
+                expression_docs = ProgrammingExpression.find_by_id(expression[:id])
+                expressions_data.store(
+                  expression_key, {
+                    'content' => expression_docs.properties['content'],
+                    'examples' => ({} unless expression_docs.properties['examples'].nil?),
+                    'palette_params' => ({} unless expression_docs.properties['palette_params'].nil?),
+                    'return_value' => expression_docs.properties['return_value'],
+                    'short_description' => expression_docs.properties['short_description'],
+                    'tips' => expression_docs.properties['tips']
+                  }.compact
+                )
+
+                ### Localize Examples
+                # Programming expressions may have 0 or more examples.
+                # Only example["name"] and example["description"] are translated. example["code"] is NOT translated.
+                example_docs = expressions_data[expression_key]['examples']
+                expression_docs.properties['examples']&.each do |example|
+                  unless example['name'].nil_or_empty? && example['description'].nil_or_empty?
+                    example_docs.store(
+                      example['name'], {
+                        'name' => (example['name'] if example['name']),
+                        'description' => (example['description'] if example['description']),
+                      }.compact
+                    )
+                  end
+                end
+
+                ### localize Parameters
+                # Programming expresions may have 0 or more parameters.
+                # Parameter name (param["name"]) is not translated as it needs to match the JavaScript expression syntax.
+                param_docs = expressions_data[expression_key]['palette_params']
+                expression_docs.properties['palette_params']&.each do |param|
+                  param_docs.store(
+                    param['name'], {
+                      'type' => (param['type'] if param['type']),
+                      'description' => (param['description'] if param['description'])
+                    }.compact
+                  )
+                end
+              end
+            end
+
+            i18n_data.compact
+          end
+        end
+      end
+    end
+  end
+end
+
+I18n::Resources::Dashboard::Docs::SyncIn.perform if __FILE__ == $0

--- a/bin/i18n/resources/dashboard/docs/sync_out.rb
+++ b/bin/i18n/resources/dashboard/docs/sync_out.rb
@@ -1,0 +1,79 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../../../dashboard/config/environment'
+require_relative '../../../i18n_script_utils'
+require_relative '../../../utils/sync_out_base'
+require_relative '../../../redact_restore_utils'
+require_relative '../docs'
+
+module I18n
+  module Resources
+    module Dashboard
+      module Docs
+        class SyncOut < I18n::Utils::SyncOutBase
+          PROGRAMMING_ENVS_TYPE = 'programming_environments'.freeze
+
+          def process(language)
+            crowdin_locale_dir = crowdin_locale_dir_of(language)
+            return unless File.directory?(crowdin_locale_dir)
+
+            unless I18nScriptUtils.source_lang?(language)
+              distribute_localization(language)
+            end
+
+            i18n_locale_dir = I18nScriptUtils.locale_dir(language[:locale_s], DIR_NAME)
+            I18nScriptUtils.rename_dir(crowdin_locale_dir, i18n_locale_dir)
+          end
+
+          private
+
+          def crowdin_locale_dir_of(language)
+            I18nScriptUtils.locale_dir(language[:crowdin_name_s], DIR_NAME)
+          end
+
+          def new_programming_envs_i18n_data(crowdin_file_path)
+            file_subpath = crowdin_file_path.partition(DIR_NAME).last
+            original_file_path = File.join(I18N_BACKUP_DIR_PATH, file_subpath)
+            RedactRestoreUtils.restore(original_file_path, crowdin_file_path, crowdin_file_path, REDACT_PLUGINS) || {}
+          end
+
+          def programming_envs_i18n_data(target_i18n_file_path)
+            return {} unless File.exist?(target_i18n_file_path)
+
+            i18n_data = I18nScriptUtils.parse_file(target_i18n_file_path)
+            return {} if i18n_data.empty?
+
+            i18n_data.values.first.dig('data', PROGRAMMING_ENVS_TYPE) || {}
+          end
+
+          def distribute_localization(language)
+            crowdin_file_paths = Dir.glob(File.join(crowdin_locale_dir_of(language), '*.json'))
+
+            progress_bar.total += crowdin_file_paths.size
+
+            crowdin_file_paths.each do |crowdin_file_path|
+              programming_env = File.basename(crowdin_file_path, '.json')
+              next unless TRANSLATABLE_PROGRAMMING_ENVS.include?(programming_env)
+
+              target_i18n_file_path = File.join(ORIGIN_I18N_DIR_PATH, "#{PROGRAMMING_ENVS_TYPE}.#{language[:locale_s]}.json")
+
+              programming_envs_i18n_data = programming_envs_i18n_data(target_i18n_file_path)
+              programming_envs_i18n_data.merge!(new_programming_envs_i18n_data(crowdin_file_path))
+
+              # JSON files in this directory need the root key to be set to the locale
+              dashboard_i18n_data = I18nScriptUtils.to_dashboard_i18n_data(
+                language[:locale_s], PROGRAMMING_ENVS_TYPE, programming_envs_i18n_data
+              )
+
+              I18nScriptUtils.sanitize_data_and_write(dashboard_i18n_data, target_i18n_file_path)
+            ensure
+              mutex.synchronize {progress_bar.increment}
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+I18n::Resources::Dashboard::Docs::SyncOut.perform if __FILE__ == $0

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -143,9 +143,7 @@ module I18n
             elsif original_path.starts_with? "i18n/locales/original/curriculum_content"
               next # moved to I18n::Resources::Dashboard::CurriculumContent::SyncOut#restore_file_content
             elsif original_path.starts_with? "i18n/locales/original/docs"
-              plugins << 'visualCodeBlock'
-              plugins << 'link'
-              plugins << 'resourceLink'
+              next # moved to I18n::Resources::Dashboard::Docs::SyncOut
             elsif I18n::Resources::Apps::Labs::REDACTABLE_LABS.include?(File.basename(original_path, '.json'))
               next # moved to I18n::Resources::Apps::Labs::SyncOut#restore_crawding_locale_files
             end
@@ -223,26 +221,6 @@ module I18n
           else
             I18nScriptUtils.sanitize_file_and_write(loc_file, destination)
           end
-        end
-
-        ### Docs
-        Dir.glob("i18n/locales/#{locale}/docs/*.json") do |loc_file|
-          # Each programming environment file gets merged into programming_environments.{locale}.json
-          relative_path = loc_file.delete_prefix(locale_dir)
-          next unless I18nScriptUtils.file_changed?(locale, relative_path)
-
-          loc_data = JSON.parse(File.read(loc_file))
-          next if loc_data.empty?
-
-          programming_env = File.basename(loc_file, '.json')
-          destination = "dashboard/config/locales/programming_environments.#{locale}.json"
-          programming_env_data = File.exist?(destination) ?
-                                   I18nScriptUtils.parse_file(destination).dig(locale, "data", "programming_environments") || {} :
-                                   {}
-          programming_env_data[programming_env] = loc_data[programming_env]
-          # JSON files in this directory need the root key to be set to the locale
-          programming_env_data = I18nScriptUtils.to_dashboard_i18n_data(locale, 'programming_environments', programming_env_data)
-          I18nScriptUtils.sanitize_data_and_write(programming_env_data, destination)
         end
 
         ### Standards

--- a/bin/test/i18n/resources/apps/external_sources/test_sync_out.rb
+++ b/bin/test/i18n/resources/apps/external_sources/test_sync_out.rb
@@ -278,7 +278,7 @@ describe I18n::Resources::Apps::ExternalSources::SyncOut do
         end
 
         it 'distributes the Crowdin file with merged I18n source file content' do
-          expected_target_i18n_file_content = <<-JS.gsub(/^ {12}/, '')
+          expected_target_i18n_file_content = <<~JS
             Blockly.Msg.BLOCKLY_CORE = "Crowdin \\"translation\\"";
             Blockly.Msg.BLOCKLY_CORE_2 = "Source 2 \\"translation\\"";
           JS

--- a/bin/test/i18n/resources/dashboard/courses/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/courses/test_sync_in.rb
@@ -110,7 +110,7 @@ describe I18n::Resources::Dashboard::Courses::SyncIn do
     end
 
     it 'prepares the i18n source file' do
-      expected_i18n_source_file_content = <<-YAML.gsub(/^ {8}/, '')
+      expected_i18n_source_file_content = <<~YAML
         ---
         en:
           data:
@@ -139,7 +139,7 @@ describe I18n::Resources::Dashboard::Courses::SyncIn do
       end
 
       it 'prepares the i18n source file with combined i18n resources data' do
-        expected_i18n_source_file_content = <<-YAML.gsub(/^ {10}/, '')
+        expected_i18n_source_file_content = <<~YAML
           ---
           en:
             data:
@@ -211,7 +211,7 @@ describe I18n::Resources::Dashboard::Courses::SyncIn do
     end
 
     it 'redacts the i18n source data' do
-      expected_i18n_source_file_content = <<-YAML.gsub(/^ {8}/, '')
+      expected_i18n_source_file_content = <<~YAML
         ---
         en:
           data:

--- a/bin/test/i18n/resources/dashboard/courses/test_sync_out.rb
+++ b/bin/test/i18n/resources/dashboard/courses/test_sync_out.rb
@@ -194,7 +194,7 @@ describe I18n::Resources::Dashboard::Courses::SyncOut do
     end
 
     it 'fixes course urls' do
-      expected_crowdin_file_content = <<-YAML.gsub(/^ {8}/, '')
+      expected_crowdin_file_content = <<~YAML
         ---
         en:
           data:

--- a/bin/test/i18n/resources/dashboard/docs/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/docs/test_sync_in.rb
@@ -1,0 +1,181 @@
+require_relative '../../../../test_helper'
+require_relative '../../../../../i18n/resources/dashboard/docs/sync_in'
+
+describe I18n::Resources::Dashboard::Docs::SyncIn do
+  let(:described_class) {I18n::Resources::Dashboard::Docs::SyncIn}
+  let(:described_instance) {described_class.new}
+
+  around do |test|
+    DatabaseCleaner.start
+    FakeFS.with_fresh {test.call}
+    DatabaseCleaner.clean
+  end
+
+  it 'inherits from I18n::Utils::SyncInBase' do
+    assert_equal I18n::Utils::SyncInBase, described_class.superclass
+  end
+
+  describe '#process' do
+    let(:run_process) {described_instance.process}
+
+    let(:programming_env_name) {'expected_programming_env_name'}
+    let(:programming_env) {FactoryBot.build_stubbed(:programming_environment, name: programming_env_name)}
+    let(:programming_env_i18n_data) {'expected_programming_env_i18n_data'}
+
+    let(:i18n_source_file_path) {CDO.dir("i18n/locales/source/docs/#{programming_env_name}.json")}
+    let(:i18n_original_file_path) {CDO.dir("i18n/locales/original/docs/#{programming_env_name}.json")}
+
+    before do
+      described_instance.stubs(:programming_envs).returns([programming_env])
+      described_instance.stubs(:i18n_data_of).with(programming_env).returns(programming_env_i18n_data)
+    end
+
+    let(:expect_programming_env_i18n_source_file_creation) do
+      I18nScriptUtils.expects(:write_json_file).with(i18n_source_file_path, programming_env_i18n_data)
+    end
+    let(:expect_programming_env_i18n_source_file_backup_creation) do
+      I18nScriptUtils.expects(:copy_file).with(i18n_source_file_path, i18n_original_file_path)
+    end
+    let(:expect_programming_env_i18n_source_file_redaction) do
+      RedactRestoreUtils.expects(:redact).with(i18n_source_file_path, i18n_source_file_path, %w[visualCodeBlock link resourceLink])
+    end
+
+    it 'prepares the i18n source file for the Programming Environment' do
+      execution_sequence = sequence('execution')
+
+      expect_programming_env_i18n_source_file_creation.in_sequence(execution_sequence)
+      expect_programming_env_i18n_source_file_backup_creation.in_sequence(execution_sequence)
+      expect_programming_env_i18n_source_file_redaction.in_sequence(execution_sequence)
+
+      run_process
+    end
+  end
+
+  describe '#programming_envs' do
+    let(:programming_envs) {described_instance.send(:programming_envs)}
+
+    let(:translatable_programming_env_a) {FactoryBot.create(:programming_environment, name: 'a')}
+    let(:translatable_programming_env_b) {FactoryBot.create(:programming_environment, name: 'b')}
+    let(:untranslatable_programming_env) {FactoryBot.create(:programming_environment)}
+
+    before do
+      # Creates ProgrammingEnvironment records
+      untranslatable_programming_env
+      translatable_programming_env_b
+      translatable_programming_env_a
+    end
+
+    it 'returns only translatable ProgrammingEnvironment records ordered by name' do
+      described_class.stub_const(:TRANSLATABLE_PROGRAMMING_ENVS, [translatable_programming_env_b.name, translatable_programming_env_a.name]) do
+        assert_equal [translatable_programming_env_a, translatable_programming_env_b], programming_envs
+      end
+    end
+  end
+
+  describe '#i18n_data_of' do
+    let(:programming_env_i18n_data) {described_instance.send(:i18n_data_of, programming_env)}
+
+    let(:programming_env_name) {'expected-programming-env-name'}
+    let(:programming_env_title) {'expected_programming_env_title'}
+    let(:programming_env_desc) {'expected_programming_env_desc'}
+    let(:programming_env) do
+      FactoryBot.create(
+        :programming_environment,
+        name: programming_env_name,
+        title: programming_env_title,
+        description: programming_env_desc
+      )
+    end
+
+    let(:programming_env_category_name) {'expected_programming_env_category_name'}
+    let(:programming_env_category_key) {'expected_programming_env_category_key'}
+    let(:programming_env_category) do
+      FactoryBot.create(
+        :programming_environment_category,
+        programming_environment: programming_env,
+        name: programming_env_category_name,
+        key: programming_env_category_key,
+      )
+    end
+
+    let(:programming_expr_name) {'expected-programming-expr-name'}
+    let(:programming_expr_key) {'expected_programming_expr_key'}
+    let(:programming_expr_content) {'expected_programming_expr_content'}
+    let(:programming_expr_content) {'expected_programming_expr_content'}
+    let(:programming_expr_return_value) {'expected_programming_expr_return_value'}
+    let(:programming_expr_short_desc) {'expected_programming_expr_short_desc'}
+    let(:programming_expr_tips) {'expected_programming_expr_tips'}
+    let(:programming_expr_example_name) {'expected_programming_expr_example_name'}
+    let(:programming_expr_example_desc) {'expected_programming_expr_example_desc'}
+    let(:programming_expr_palette_param_name) {'expected_programming_expr_palette_param_name'}
+    let(:programming_expr_palette_param_type) {'expected_programming_expr_palette_param_type'}
+    let(:programming_expr_palette_param_desc) {'expected_programming_expr_palette_param_desc'}
+    let(:programming_expr) do
+      FactoryBot.create(
+        :programming_expression,
+        programming_environment: programming_env,
+        programming_environment_category: programming_env_category,
+        name: programming_expr_name,
+        key: programming_expr_key,
+        content: programming_expr_content,
+        return_value: programming_expr_return_value,
+        short_description: programming_expr_short_desc,
+        tips: programming_expr_tips,
+        examples: [
+          'name' => programming_expr_example_name,
+          'description' => programming_expr_example_desc
+        ],
+        palette_params: [
+          'name' => programming_expr_palette_param_name,
+          'type' => programming_expr_palette_param_type,
+          'description' => programming_expr_palette_param_desc
+        ],
+      )
+    end
+
+    before do
+      # Creates DB data
+      programming_env
+      programming_env_category
+      programming_expr
+    end
+
+    let(:expected_programming_env_i18n_data) do
+      {
+        programming_env_name => {
+          'name' => programming_env_title,
+          'description' => programming_env_desc,
+          'categories' => {
+            programming_env_category_key => {
+              'name' => programming_env_category_name,
+              'expressions' => {
+                programming_expr_key => {
+                  'content' => programming_expr_content,
+                  'examples' => {
+                    programming_expr_example_name => {
+                      'name' => programming_expr_example_name,
+                      'description' => programming_expr_example_desc
+                    }
+                  },
+                  'palette_params' => {
+                    programming_expr_palette_param_name => {
+                      'type' => programming_expr_palette_param_type,
+                      'description' => programming_expr_palette_param_desc
+                    }
+                  },
+                  'return_value' => programming_expr_return_value,
+                  'short_description' => programming_expr_short_desc,
+                  'tips' => programming_expr_tips
+                }
+              }
+            }
+          }
+        }
+      }
+    end
+
+    it 'returns i18n data for the Programming Environment' do
+      assert_equal expected_programming_env_i18n_data, programming_env_i18n_data
+    end
+  end
+end

--- a/bin/test/i18n/resources/dashboard/docs/test_sync_out.rb
+++ b/bin/test/i18n/resources/dashboard/docs/test_sync_out.rb
@@ -1,0 +1,202 @@
+require_relative '../../../../test_helper'
+require_relative '../../../../../i18n/resources/dashboard/docs/sync_out'
+
+describe I18n::Resources::Dashboard::Docs::SyncOut do
+  let(:described_class) {I18n::Resources::Dashboard::Docs::SyncOut}
+  let(:described_instance) {described_class.new}
+
+  let(:programming_env) {'expected_programming_env'}
+
+  let(:crowdin_locale) {'expected_crowdin_locale'}
+  let(:i18n_locale) {'expected_i18n_locale'}
+  let(:language) {{crowdin_name_s: crowdin_locale, locale_s: i18n_locale}}
+
+  let(:crowdin_locale_dir) {CDO.dir('i18n/locales', crowdin_locale, 'docs')}
+  let(:i18n_locale_dir) {CDO.dir('i18n/locales', i18n_locale, 'docs')}
+
+  let(:crowdin_file_path) {CDO.dir('i18n/locales', crowdin_locale, "docs/#{programming_env}.json")}
+  let(:i18n_original_file_path) {CDO.dir("i18n/locales/original/docs/#{programming_env}.json")}
+  let(:target_i18n_file_path) {CDO.dir('dashboard/config/locales', "programming_environments.#{i18n_locale}.json")}
+
+  around do |test|
+    DatabaseCleaner.start
+    FakeFS.with_fresh {test.call}
+    DatabaseCleaner.clean
+  end
+
+  it 'inherits from I18n::Utils::SyncOutBase' do
+    assert_equal I18n::Utils::SyncOutBase, described_class.superclass
+  end
+
+  describe '#progress' do
+    let(:process_language) {described_instance.process(language)}
+
+    before do
+      FileUtils.mkdir_p(crowdin_locale_dir)
+      I18nScriptUtils.stubs(:source_lang?).with(language).returns(false)
+    end
+
+    let(:expect_localization_distribution) do
+      described_instance.expects(:distribute_localization).with(language)
+    end
+    let(:expect_crowdin_files_to_i18n_locale_dir_moving) do
+      I18nScriptUtils.expects(:rename_dir).with(crowdin_locale_dir, i18n_locale_dir)
+    end
+
+    it 'distributes the language localization and then moves Crowdin files to the i18n locale dir' do
+      execution_sequence = sequence('execution')
+
+      expect_localization_distribution.in_sequence(execution_sequence)
+      expect_crowdin_files_to_i18n_locale_dir_moving.in_sequence(execution_sequence)
+
+      process_language
+    end
+
+    context 'when the language is the source language' do
+      before do
+        I18nScriptUtils.expects(:source_lang?).with(language).returns(true)
+      end
+
+      it 'does not distribute the localization' do
+        expect_localization_distribution.never
+        process_language
+      end
+
+      it 'moves Crowdin files to the i18n locale dir' do
+        expect_crowdin_files_to_i18n_locale_dir_moving.once
+        process_language
+      end
+    end
+
+    context 'when the Crowdin locale dir does not exists' do
+      before do
+        FileUtils.rm_r(crowdin_locale_dir)
+      end
+
+      it 'does not distribute the localization' do
+        expect_localization_distribution.never
+        process_language
+      end
+
+      it 'does not move Crowdin files to the i18n locale dir' do
+        expect_crowdin_files_to_i18n_locale_dir_moving.never
+        process_language
+      end
+    end
+  end
+
+  describe '#distribute_localization' do
+    let(:distribute_language_localization) {described_instance.send(:distribute_localization, language)}
+
+    let(:other_programming_env) {'other_programming_env'}
+    let(:translatable_programming_envs) {[programming_env, other_programming_env]}
+
+    let(:programming_env_i18n_data) {{programming_env => 'expected_programming_env_i18n_data'}}
+    let(:other_programming_env_i18n_data) {{other_programming_env => 'expected_other_programming_env_i18n_data'}}
+    let(:programming_envs_i18n_data) {{**programming_env_i18n_data, **other_programming_env_i18n_data}}
+    let(:new_programming_env_i18n_data) {{programming_env => 'expected_new_programming_env_i18n_data'}}
+    let(:new_programming_envs_i18n_data) {new_programming_env_i18n_data}
+
+    around do |tests|
+      described_class.stub_const(:TRANSLATABLE_PROGRAMMING_ENVS, translatable_programming_envs) {tests.call}
+    end
+
+    before do
+      FileUtils.mkdir_p File.dirname(crowdin_file_path)
+      FileUtils.touch(crowdin_file_path)
+
+      described_instance.stubs(:new_programming_envs_i18n_data).with(crowdin_file_path).returns(new_programming_envs_i18n_data)
+      described_instance.stubs(:programming_envs_i18n_data).with(target_i18n_file_path).returns(programming_envs_i18n_data)
+    end
+
+    it 'distributes the language localization' do
+      expected_dashboard_i18n_data = {
+        i18n_locale => {
+          'data' => {
+            'programming_environments' => {
+              **new_programming_env_i18n_data,
+              **other_programming_env_i18n_data,
+            }
+          }
+        }
+      }
+
+      I18nScriptUtils.expects(:sanitize_data_and_write).with(expected_dashboard_i18n_data, target_i18n_file_path).once
+
+      distribute_language_localization
+    end
+
+    context 'when the programing env is not translatable' do
+      let(:translatable_programming_envs) {[other_programming_env]}
+
+      it 'does not distribute the language localization' do
+        I18nScriptUtils.expects(:sanitize_data_and_write).with(anything, target_i18n_file_path).never
+        distribute_language_localization
+      end
+    end
+  end
+
+  describe '#new_programming_envs_i18n_data' do
+    let(:new_programming_envs_i18n_data) {described_instance.send(:new_programming_envs_i18n_data, crowdin_file_path)}
+
+    it 'returns restored Crowdin file data' do
+      expected_new_programming_envs_i18n_data = 'expected_new_programming_envs_i18n_data'
+
+      RedactRestoreUtils.expects(:restore).with(
+        i18n_original_file_path, crowdin_file_path, crowdin_file_path, %w[visualCodeBlock link resourceLink]
+      ).once.returns(expected_new_programming_envs_i18n_data)
+
+      assert_equal expected_new_programming_envs_i18n_data, new_programming_envs_i18n_data
+    end
+  end
+
+  describe '#programming_envs_i18n_data' do
+    let(:programming_envs_i18n_data) {described_instance.send(:programming_envs_i18n_data, target_i18n_file_path)}
+
+    let(:expected_programming_envs_i18n_data) {'expected_programming_envs_i18n_data'}
+    let(:target_i18n_file_data) do
+      {
+        i18n_locale => {
+          'data' => {
+            'programming_environments' => expected_programming_envs_i18n_data
+          }
+        }
+      }
+    end
+
+    before do
+      FileUtils.mkdir_p File.dirname(target_i18n_file_path)
+      File.write(target_i18n_file_path, JSON.dump(target_i18n_file_data))
+    end
+
+    it 'returns existing programming envs i18n data' do
+      assert_equal expected_programming_envs_i18n_data, programming_envs_i18n_data
+    end
+
+    context 'when the programming envs i18n data does not exist' do
+      let(:expected_programming_envs_i18n_data) {nil}
+
+      it 'returns empty hash' do
+        assert_equal({}, programming_envs_i18n_data)
+      end
+    end
+
+    context 'when the i18n data does not exist' do
+      let(:target_i18n_file_data) {{}}
+
+      it 'returns empty hash' do
+        assert_equal({}, programming_envs_i18n_data)
+      end
+    end
+
+    context 'when the target i18n file does not exist' do
+      before do
+        FileUtils.rm(target_i18n_file_path)
+      end
+
+      it 'returns empty hash' do
+        assert_equal({}, programming_envs_i18n_data)
+      end
+    end
+  end
+end

--- a/bin/test/i18n/resources/dashboard/test_docs.rb
+++ b/bin/test/i18n/resources/dashboard/test_docs.rb
@@ -1,112 +1,18 @@
 require_relative '../../../test_helper'
 require_relative '../../../../i18n/resources/dashboard/docs'
 
-class I18n::Resources::Dashboard::DocsTest < Minitest::Test
-  def test_sync_in
-    exec_seq = sequence('execution')
-    expected_programming_environments = %w[applab gamelab weblab]
-
-    ActiveRecord::Base.transaction do
-      ProgrammingEnvironment.destroy_all
-
-      expected_programming_environments.each do |env|
-        expected_source_file_path = CDO.dir("i18n/locales/source/docs/#{env}.json")
-        expected_backup_file_path = CDO.dir("i18n/locales/original/docs/#{env}.json")
-
-        generate_db_data_for(env)
-
-        # Preparation of the i18n file
-        FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/source/docs')).in_sequence(exec_seq)
-        File.expects(:write).with(expected_source_file_path, expected_docs_json_for(env)).in_sequence(exec_seq)
-
-        # Redaction of the i18n file
-        FileUtils.expects(:mkdir_p).with(CDO.dir('i18n/locales/original/docs')).in_sequence(exec_seq)
-        FileUtils.expects(:cp).with(expected_source_file_path, expected_backup_file_path).in_sequence(exec_seq)
-        RedactRestoreUtils.expects(:redact).with(expected_source_file_path, expected_source_file_path, %w[visualCodeBlock link resourceLink]).in_sequence(exec_seq)
-      end
-
-      # Should not be translated
-      generate_db_data_for('unexpected')
-      File.expects(:write).with(CDO.dir('i18n/locales/source/docs/unexpected.json'), expected_docs_json_for('unexpected')).never
-
+describe I18n::Resources::Dashboard::Docs do
+  describe '.sync_in' do
+    it 'sync-in Courses resource' do
+      I18n::Resources::Dashboard::Docs::SyncIn.expects(:perform).once
       I18n::Resources::Dashboard::Docs.sync_in
-    ensure
-      raise ActiveRecord::Rollback
     end
   end
 
-  private
-
-  def generate_db_data_for(env_name)
-    env = FactoryBot.create(
-      :programming_environment,
-      name: env_name,
-      title: "#{env_name} Env name",
-      description: "#{env_name} Env desc"
-    )
-
-    env_category = FactoryBot.create(
-      :programming_environment_category,
-      programming_environment: env,
-      name: "#{env_name} Env Category name",
-      key: "#{env_name}_env_category_key"
-    )
-
-    FactoryBot.create(
-      :programming_expression,
-      programming_environment: env,
-      programming_environment_category: env_category,
-      name: "#{env_name} Expr name",
-      key: "#{env_name}_expr_key",
-      content: "#{env_name} Expr content",
-      examples: [
-        'name' => "#{env_name} Expr example name",
-        'description' => "#{env_name} Expr example desc"
-      ],
-      palette_params: [
-        'name' => "#{env_name} Expr palette_param name",
-        'type' => "#{env_name} Expr palette_param type",
-        'description' => "#{env_name} Expr palette_param desc"
-      ],
-      return_value: "#{env_name} Expr return_value",
-      short_description: "#{env_name} Expr short_description",
-      tips: "#{env_name} Expr tips"
-    )
-  end
-
-  def expected_docs_json_for(env)
-    <<~JSON.strip
-      {
-        "#{env}": {
-          "name": "#{env} Env name",
-          "description": "#{env} Env desc",
-          "categories": {
-            "#{env}_env_category_key": {
-              "name": "#{env} Env Category name",
-              "expressions": {
-                "#{env}_expr_key": {
-                  "content": "#{env} Expr content",
-                  "examples": {
-                    "#{env} Expr example name": {
-                      "name": "#{env} Expr example name",
-                      "description": "#{env} Expr example desc"
-                    }
-                  },
-                  "palette_params": {
-                    "#{env} Expr palette_param name": {
-                      "type": "#{env} Expr palette_param type",
-                      "description": "#{env} Expr palette_param desc"
-                    }
-                  },
-                  "return_value": "#{env} Expr return_value",
-                  "short_description": "#{env} Expr short_description",
-                  "tips": "#{env} Expr tips"
-                }
-              }
-            }
-          }
-        }
-      }
-    JSON
-  end
+  # describe '.sync_out' do
+  #   it 'sync-out Courses resource' do
+  #     I18n::Resources::Dashboard::Docs::SyncOut.expects(:perform).once
+  #     I18n::Resources::Dashboard::Docs.sync_out
+  #   end
+  # end
 end

--- a/bin/test/i18n/resources/dashboard/test_docs.rb
+++ b/bin/test/i18n/resources/dashboard/test_docs.rb
@@ -3,7 +3,7 @@ require_relative '../../../../i18n/resources/dashboard/docs'
 
 describe I18n::Resources::Dashboard::Docs do
   describe '.sync_in' do
-    it 'sync-in Courses resource' do
+    it 'sync-in programming Docs' do
       I18n::Resources::Dashboard::Docs::SyncIn.expects(:perform).once
       I18n::Resources::Dashboard::Docs.sync_in
     end

--- a/bin/test/i18n/resources/dashboard/test_docs.rb
+++ b/bin/test/i18n/resources/dashboard/test_docs.rb
@@ -9,10 +9,10 @@ describe I18n::Resources::Dashboard::Docs do
     end
   end
 
-  # describe '.sync_out' do
-  #   it 'sync-out Courses resource' do
-  #     I18n::Resources::Dashboard::Docs::SyncOut.expects(:perform).once
-  #     I18n::Resources::Dashboard::Docs.sync_out
-  #   end
-  # end
+  describe '.sync_out' do
+    it 'sync-out Courses resource' do
+      I18n::Resources::Dashboard::Docs::SyncOut.expects(:perform).once
+      I18n::Resources::Dashboard::Docs.sync_out
+    end
+  end
 end

--- a/bin/test/i18n/resources/test_dashboard.rb
+++ b/bin/test/i18n/resources/test_dashboard.rb
@@ -36,6 +36,7 @@ describe I18n::Resources::Dashboard do
       I18n::Resources::Dashboard::CourseOfferings.expects(:sync_out).in_sequence(execution_sequence)
       I18n::Resources::Dashboard::Courses.expects(:sync_out).in_sequence(execution_sequence)
       I18n::Resources::Dashboard::CurriculumContent.expects(:sync_out).in_sequence(execution_sequence)
+      I18n::Resources::Dashboard::Docs.expects(:sync_out).in_sequence(execution_sequence)
 
       I18n::Resources::Dashboard.sync_out
     end


### PR DESCRIPTION
1. Refactor the Dashboard `docs` resource `sync-in` business logic
2. Updated the Dashboard `docs` resource `sync-in` unit tests
3. Modularized the Dashboard `docs` resource `sync-out`
4. Created unit tests for the Dashboard `docs` resource `sync-out`
5. Created executable script `bundle exec bin/i18n/resources/dashboard/docs/sync_in.rb`
6. Created executable script `bundle exec bin/i18n/resources/dashboard/docs/sync_out.rb`

## Links
- jira ticket: [P20-399](https://codedotorg.atlassian.net/browse/P20-399)