### PR TITLE
Adding amplitude events for haml marketing pages

### DIFF
--- a/pegasus/helpers/analytics_constants.rb
+++ b/pegasus/helpers/analytics_constants.rb
@@ -13,6 +13,8 @@ module AnalyticsConstants
     CSF_CURRICULUM_PAGE_VISITED_EVENT = 'CSF Curriculum Page Visited'.freeze,
     CSF_UNPLUGGED_PAGE_VISITED_EVENT = 'CSF Unplugged Page Visited'.freeze,
     CSP_CURRICULUM_PAGE_VISITED_EVENT = 'CSP Curriculum Page Visited'.freeze,
+    DONATE_PAGE_VISITED_EVENT = 'Donate Page Visited'.freeze,
+    HELP_US_PAGE_VISITED_EVENT = 'Help Us Page Visited'.freeze,
     PHYSICAL_COMPUTING_PAGE_VISITED_EVENT = 'Physical Computing Page Visited'.freeze,
     ELEMENTARY_CURRICULUM_PAGE_VISITED_EVENT =
       'Elementary School Curriculum Page Visited'.freeze,

--- a/pegasus/sites.v3/code.org/public/donate/index.haml
+++ b/pegasus/sites.v3/code.org/public/donate/index.haml
@@ -58,3 +58,5 @@ theme: responsive_full_width
 %section.seals
   .wrapper
     = view :about_seals
+
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::DONATE_PAGE_VISITED_EVENT

--- a/pegasus/sites.v3/code.org/public/help.haml
+++ b/pegasus/sites.v3/code.org/public/help.haml
@@ -90,3 +90,5 @@ theme: responsive_full_width
       = view :"help/help_page_spread_the_word"
       %figure.rounded-corners.col-33
     .clear
+
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::HELP_US_PAGE_VISITED_EVENT


### PR DESCRIPTION
Adds amplitude events for the help and donate pages (code.org/help and code.org/donate, respectively). These are both rendered from .haml files, so the constants are stored in the ruby AnalyticsConstants file. 

I based this off of Turner's approach in https://github.com/code-dot-org/code-dot-org/pull/49901. 

<img width="510" alt="Screenshot 2023-10-10 at 4 38 21 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/a0b33d14-7356-4716-ad87-babf0fc23782">
<img width="512" alt="Screenshot 2023-10-10 at 4 38 38 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/3d34b09b-ba64-4dde-a519-41925d2b8bdb">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1005
- https://codedotorg.atlassian.net/browse/ACQ-1045

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
