### PR TITLE
EvaluateRubricJob calls openai via aiproxy

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -597,3 +597,5 @@ openai_chat_completion_api_key: !Secret
 openai_chat_completion_org_id: !Secret
 openai_evaluate_rubric_api_key:
 openai_evaluate_rubric_org_id:
+
+ai_proxy_url:

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -598,4 +598,4 @@ openai_chat_completion_org_id: !Secret
 openai_evaluate_rubric_api_key:
 openai_evaluate_rubric_org_id:
 
-ai_proxy_url:
+ai_proxy_origin:

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -70,7 +70,7 @@ jwk_private_key_data:
 
 openai_chat_completion_api_key: ''
 
-ai_proxy_url: 'http://localhost:5000'
+ai_proxy_origin: 'http://localhost:5000'
 
 # Mapbox
 mapbox_upload_tileset:    'censustiles-dev'

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -70,5 +70,7 @@ jwk_private_key_data:
 
 openai_chat_completion_api_key: ''
 
+ai_proxy_url: 'http://localhost:5000'
+
 # Mapbox
 mapbox_upload_tileset:    'censustiles-dev'

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -112,7 +112,7 @@ class EvaluateRubricJob < ApplicationJob
   end
 
   private def get_openai_evaluations(code, prompt, rubric, examples)
-    uri = URI.parse("#{CDO.ai_proxy_url}/assessment")
+    uri = URI.parse("#{CDO.ai_proxy_origin}/assessment")
     form_data = {
       "model" => "gpt-4-0613",
       "code" => code,

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -39,9 +39,11 @@ class EvaluateRubricJob < ApplicationJob
 
     channel_id = get_channel_id(user, script_level)
     code, project_version = read_user_code(channel_id)
-    prompt = read_file_from_s3(lesson_s3_name, 'system_prompt.txt')
-    ai_rubric = read_file_from_s3(lesson_s3_name, 'standard_rubric.csv')
-    examples = read_examples(lesson_s3_name)
+
+    s3_client = AWS::S3.create_client
+    prompt = read_file_from_s3(s3_client, lesson_s3_name, 'system_prompt.txt')
+    ai_rubric = read_file_from_s3(s3_client, lesson_s3_name, 'standard_rubric.csv')
+    examples = read_examples(s3_client, lesson_s3_name)
 
     ai_evaluations =
       CDO.ai_proxy_url.present? ?
@@ -87,23 +89,23 @@ class EvaluateRubricJob < ApplicationJob
     [code, version]
   end
 
-  private def read_file_from_s3(lesson_s3_name, key_suffix)
+  private def read_file_from_s3(s3_client, lesson_s3_name, key_suffix)
     bucket = 'cdo-ai'
     key = "teaching_assistant/lessons/#{lesson_s3_name}/#{key_suffix}"
-    AWS::S3.create_client.get_object(bucket: bucket, key: key)[:body].read
+    s3_client.get_object(bucket: bucket, key: key)[:body].read
   end
 
-  private def read_examples(lesson_s3_name)
+  private def read_examples(s3_client, lesson_s3_name)
     bucket = 'cdo-ai'
     prefix = "teaching_assistant/lessons/#{lesson_s3_name}/examples/"
-    response = AWS::S3.create_client.list_objects_v2(bucket: bucket, prefix: prefix)
+    response = s3_client.list_objects_v2(bucket: bucket, prefix: prefix)
     file_names = response.contents.map(&:key)
     file_names = file_names.map {|name| name.gsub(prefix, '')}
     js_files = file_names.select {|name| name.end_with?('.js')}
     js_files.map do |file_name|
       base_name = file_name.gsub('.js', '')
-      code = AWS::S3.create_client.get_object(bucket: bucket, key: "#{prefix}#{file_name}")[:body].read
-      response = AWS::S3.create_client.get_object(bucket: bucket, key: "#{prefix}#{base_name}.tsv")[:body].read
+      code = s3_client.get_object(bucket: bucket, key: "#{prefix}#{file_name}")[:body].read
+      response = s3_client.get_object(bucket: bucket, key: "#{prefix}#{base_name}.tsv")[:body].read
       [code, response]
     end
   end

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -35,13 +35,13 @@ class EvaluateRubricJob < ApplicationJob
 
     raise "lesson_s3_name not found for script_level_id: #{script_level.id}" if lesson_s3_name.blank?
 
+    rubric = Rubric.find_by!(lesson_id: script_level.lesson.id, level_id: script_level.level.id)
+
     channel_id = get_channel_id(user, script_level)
     code, project_version = read_user_code(channel_id)
     prompt = read_file_from_s3(lesson_s3_name, 'system_prompt.txt')
     ai_rubric = read_file_from_s3(lesson_s3_name, 'standard_rubric.csv')
     examples = read_examples(lesson_s3_name)
-
-    rubric = Rubric.find_by!(lesson_id: script_level.lesson.id, level_id: script_level.level.id)
 
     ai_evaluations =
       CDO.ai_proxy_url.present? ?

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -64,7 +64,8 @@ class EvaluateRubricJob < ApplicationJob
     UNIT_AND_LEVEL_TO_LESSON_S3_NAME[script_level&.script&.name].try(:[], script_level&.level&.name)
   end
 
-  def s3_client
+  # The client for s3 access made directly by this job, not via SourceBucket.
+  private def s3_client
     @s3_client ||= AWS::S3.create_client
   end
 

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -13,6 +13,9 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     create :learning_goal, rubric: @rubric, learning_goal: 'learning-goal-1'
     create :learning_goal, rubric: @rubric, learning_goal: 'learning-goal-2'
     assert_equal 2, @rubric.learning_goals.count
+
+    # Don't actually talk to S3 when running SourceBucket.new
+    AWS::S3.stubs :create_client
   end
 
   test "job succeeds on ai-enabled level" do
@@ -87,9 +90,6 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
   # is deep inside SourceBucket, we stub out the entire SourceBucket class
   # rather than stubbing the S3 calls directly.
   private def stub_project_source_data(channel_id, code: 'fake-code', version_id: 'fake-version-id')
-    # Don't actually talk to S3 when running SourceBucket.new
-    AWS::S3.stubs :create_client
-
     fake_main_json = {source: code}.to_json
     fake_source_data = {
       status: 'FOUND',

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -75,12 +75,6 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     EvaluateRubricJob.stubs(:get_lesson_s3_name).with(@script_level).returns('fake-lesson-s3-name')
     @rubric.destroy
 
-    # create a project
-    channel_token = ChannelToken.find_or_create_channel_token(@script_level.level, @fake_ip, @storage_id, @script_level.script_id)
-    channel_id = channel_token.channel
-
-    stub_project_source_data(channel_id)
-
     exception = assert_raises ActiveRecord::RecordNotFound do
       EvaluateRubricJob.new.perform(user_id: @student.id, script_level_id: @script_level.id)
     end

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -27,6 +27,11 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
 
     stub_project_source_data(channel_id)
 
+    # stub lesson S3 lookups
+    EvaluateRubricJob.any_instance.stubs(:read_file_from_s3).with('fake-lesson-s3-name', 'system_prompt.txt').returns('fake-system-prompt')
+    EvaluateRubricJob.any_instance.stubs(:read_file_from_s3).with('fake-lesson-s3-name', 'standard_rubric.csv').returns('fake-standard-rubric')
+    EvaluateRubricJob.any_instance.stubs(:read_examples).with('fake-lesson-s3-name').returns([['fake-code-1', 'fake-response-1'], ['fake-code-2', 'fake-response-2']])
+
     # run the job
     perform_enqueued_jobs do
       EvaluateRubricJob.perform_later(user_id: @student.id, script_level_id: @script_level.id)

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -26,6 +26,8 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
 
     stub_lesson_s3_data
 
+    stub_get_openai_evaluations
+
     # run the job
     perform_enqueued_jobs do
       EvaluateRubricJob.perform_later(user_id: @student.id, script_level_id: @script_level.id)
@@ -127,6 +129,20 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     )
 
     EvaluateRubricJob.any_instance.stubs(:s3_client).returns(s3_client)
+  end
+
+  private def stub_get_openai_evaluations
+    fake_ai_evaluations = [
+      {
+        'Key Concept' => 'learning-goal-1',
+        'Grade' => 'Extensive Evidence'
+      },
+      {
+        'Key Concept' => 'learning-goal-2',
+        'Grade' => 'Extensive Evidence'
+      }
+    ]
+    HTTParty.stubs(:post).returns(stub(body: {data: fake_ai_evaluations}.to_json, success?: true))
   end
 
   # verify the job wrote the expected LearningGoalAiEvaluations to the database

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -28,9 +28,9 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     stub_project_source_data(channel_id)
 
     # stub lesson S3 lookups
-    EvaluateRubricJob.any_instance.stubs(:read_file_from_s3).with('fake-lesson-s3-name', 'system_prompt.txt').returns('fake-system-prompt')
-    EvaluateRubricJob.any_instance.stubs(:read_file_from_s3).with('fake-lesson-s3-name', 'standard_rubric.csv').returns('fake-standard-rubric')
-    EvaluateRubricJob.any_instance.stubs(:read_examples).with('fake-lesson-s3-name').returns([['fake-code-1', 'fake-response-1'], ['fake-code-2', 'fake-response-2']])
+    EvaluateRubricJob.any_instance.stubs(:read_file_from_s3).with(nil, 'fake-lesson-s3-name', 'system_prompt.txt').returns('fake-system-prompt')
+    EvaluateRubricJob.any_instance.stubs(:read_file_from_s3).with(nil, 'fake-lesson-s3-name', 'standard_rubric.csv').returns('fake-standard-rubric')
+    EvaluateRubricJob.any_instance.stubs(:read_examples).with(nil, 'fake-lesson-s3-name').returns([['fake-code-1', 'fake-response-1'], ['fake-code-2', 'fake-response-2']])
 
     # run the job
     perform_enqueued_jobs do

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -157,9 +157,9 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
         'Grade' => 'Extensive Evidence'
       }
     ]
-    ai_proxy_url = 'http://fake-ai-proxy-url'
-    CDO.stubs(:ai_proxy_url).returns(ai_proxy_url)
-    uri = URI.parse("#{ai_proxy_url}/assessment")
+    ai_proxy_origin = 'http://fake-ai-proxy-origin'
+    CDO.stubs(:ai_proxy_origin).returns(ai_proxy_origin)
+    uri = URI.parse("#{ai_proxy_origin}/assessment")
     HTTParty.stubs(:post).with(
       uri,
       body: URI.encode_www_form(expected_form_data),


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-243 (updated link) by connecting the EvaluateRubricJob to the python service to evaluate the rubric. New in this PR:
* fetch the ai rubric, prompt, and examples from S3
* send the rubric, prompt and examples to openai via the aiproxy (see https://github.com/code-dot-org/aiproxy/tree/openai-routes for how to run locally)

as a side note, getting examples working required this code change on the python side: https://github.com/code-dot-org/aiproxy/commit/1be7f4c12e553c8fab356e233d3d837addf03917

## Testing story

* manual testing end to end with locally running ai proxy
* add unit tests stubbing out s3  using stub_responses (see [docs](https://aws.amazon.com/blogs/developer/advanced-client-stubbing-in-the-aws-sdk-for-ruby-version-3/)) and by stubbing out the network call to openai