### PR TITLE
[Google Blockly] Disable unattached blocks even if dragging

### DIFF
--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -2,8 +2,8 @@ import {
   ObservableProcedureModel,
   ProcedureBase,
 } from '@blockly/block-shareable-procedures';
-import {flyoutCategory as functionsFlyoutCategory} from '../customBlocks/googleBlockly/proceduresBlocks';
-import {flyoutCategory as behaviorsFlyoutCategory} from '../customBlocks/googleBlockly/behaviorBlocks';
+import {flyoutCategory as functionsFlyoutCategory} from '@cdo/apps/blockly/customBlocks/googleBlockly/proceduresBlocks';
+import {flyoutCategory as behaviorsFlyoutCategory} from '@cdo/apps/blockly/customBlocks/googleBlockly/behaviorBlocks';
 import {
   MODAL_EDITOR_ID,
   MODAL_EDITOR_CLOSE_ID,
@@ -11,6 +11,7 @@ import {
   MODAL_EDITOR_NAME_INPUT_ID,
   MODAL_EDITOR_DESCRIPTION_INPUT_ID,
 } from './functionEditorConstants';
+import {disableOrphans} from '@cdo/apps/blockly/eventHandlers';
 
 // This class is a work in progress. It is used for the modal function editor,
 // which is used by Sprite Lab and Artist.
@@ -60,7 +61,7 @@ export default class FunctionEditor {
 
     // Disable blocks that aren't attached. We don't want these to generate
     // code in the hidden workspace.
-    this.editorWorkspace.addChangeListener(Blockly.Events.disableOrphans);
+    this.editorWorkspace.addChangeListener(disableOrphans);
 
     // Close handler
     document

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -351,11 +351,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return undefined;
   };
 
-  // CDO Blockly always generates code for events.
-  blocklyWrapper.shouldGenerateCodeForEvent = function (_) {
-    return true;
-  };
-
   return blocklyWrapper;
 }
 

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -351,6 +351,11 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return undefined;
   };
 
+  // CDO Blockly always generates code for events.
+  blocklyWrapper.shouldGenerateCodeForEvent = function (_) {
+    return true;
+  };
+
   return blocklyWrapper;
 }
 

--- a/apps/src/blockly/eventHandlers.js
+++ b/apps/src/blockly/eventHandlers.js
@@ -1,0 +1,40 @@
+// A custom version of Blockly's Events.disableOrphans that will disable orphans
+// while the workspace is dragging. This enables the preview to update as soon as
+// a block is dragged, and for a new block to not be enabled until it is attached
+// to the main block.
+export function disableOrphans(blockEvent) {
+  if (
+    blockEvent.type === Blockly.Events.BLOCK_MOVE ||
+    blockEvent.type === Blockly.Events.BLOCK_CREATE
+  ) {
+    if (!blockEvent.workspaceId) {
+      return;
+    }
+    const eventWorkspace = Blockly.Workspace.getById(blockEvent.workspaceId);
+    if (!blockEvent.blockId) {
+      throw new Error('Encountered a blockEvent without a proper blockId');
+    }
+    let block = eventWorkspace.getBlockById(blockEvent.blockId);
+    if (block) {
+      // Changing blocks as part of this event shouldn't be undoable.
+      const initialUndoFlag = Blockly.Events.getRecordUndo();
+      try {
+        Blockly.Events.setRecordUndo(false);
+        const parent = block.getParent();
+        if (parent && parent.isEnabled()) {
+          const children = block.getDescendants(false);
+          for (let i = 0, child; (child = children[i]); i++) {
+            child.setEnabled(true);
+          }
+        } else if (block.outputConnection || block.previousConnection) {
+          do {
+            block.setEnabled(false);
+            block = block.getNextBlock();
+          } while (block);
+        }
+      } finally {
+        Blockly.Events.setRecordUndo(initialUndoFlag);
+      }
+    }
+  }
+}

--- a/apps/src/blockly/eventHandlers.js
+++ b/apps/src/blockly/eventHandlers.js
@@ -1,9 +1,10 @@
 // A custom version of Blockly's Events.disableOrphans that will disable orphans
-// while the workspace is dragging. This enables the preview to update as soon as
-// a block is dragged, and for a new block to not be enabled until it is attached
-// to the main block.
-// Copied and modified from:
-// https://github.com/google/blockly/blob/1e3b5b4c76f24d2274ef4947c1fcf657f0058f11/core/events/utils.ts#L523
+// even if the workspace is dragging. This enables the preview to update as soon as
+// a block is dragged away from "when run", and for a new block to be
+// immediately disabled until it is attached to the main block.
+// Copied and modified from Blockly/core/events/utils:disableOrphans. The only change from
+// the original function was to remove a check on eventWorkspace.isDragging():
+// https://github.com/google/blockly/blob/1e3b5b4c76f24d2274ef4947c1fcf657f0058f11/core/events/utils.ts#L549
 export function disableOrphans(blockEvent) {
   if (
     blockEvent.type === Blockly.Events.BLOCK_MOVE ||

--- a/apps/src/blockly/eventHandlers.js
+++ b/apps/src/blockly/eventHandlers.js
@@ -2,6 +2,8 @@
 // while the workspace is dragging. This enables the preview to update as soon as
 // a block is dragged, and for a new block to not be enabled until it is attached
 // to the main block.
+// Copied and modified from:
+// https://github.com/google/blockly/blob/1e3b5b4c76f24d2274ef4947c1fcf657f0058f11/core/events/utils.ts#L523
 export function disableOrphans(blockEvent) {
   if (
     blockEvent.type === Blockly.Events.BLOCK_MOVE ||

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -62,6 +62,7 @@ import {
   ObservableParameterModel,
 } from '@blockly/block-shareable-procedures';
 import experiments from '@cdo/apps/util/experiments';
+import {disableOrphans} from './eventHandlers';
 
 const options = {
   contextMenu: true,
@@ -668,7 +669,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
     blocklyWrapper.navigationController.addWorkspace(workspace);
 
     if (!blocklyWrapper.isStartMode && !opt_options.isBlockEditMode) {
-      workspace.addChangeListener(Blockly.Events.disableOrphans);
+      workspace.addChangeListener(disableOrphans);
     }
 
     document.dispatchEvent(

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -738,19 +738,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return blocklyWrapper.mainBlockSpace;
   };
 
-  blocklyWrapper.shouldGenerateCodeForEvent = function (event) {
-    const codeChangeEvents = [
-      Blockly.Events.BLOCK_CHANGE,
-      Blockly.Events.BLOCK_CREATE,
-      Blockly.Events.BLOCK_DELETE,
-      Blockly.Events.BLOCK_MOVE,
-    ];
-    return (
-      !Blockly.mainBlockSpace.isDragging() &&
-      codeChangeEvents.includes(event.type)
-    );
-  };
-
   initializeBlocklyXml(blocklyWrapper);
   initializeGenerator(blocklyWrapper);
   initializeTouch(blocklyWrapper);

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -737,6 +737,19 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return blocklyWrapper.mainBlockSpace;
   };
 
+  blocklyWrapper.shouldGenerateCodeForEvent = function (event) {
+    const codeChangeEvents = [
+      Blockly.Events.BLOCK_CHANGE,
+      Blockly.Events.BLOCK_CREATE,
+      Blockly.Events.BLOCK_DELETE,
+      Blockly.Events.BLOCK_MOVE,
+    ];
+    return (
+      !Blockly.mainBlockSpace.isDragging() &&
+      codeChangeEvents.includes(event.type)
+    );
+  };
+
   initializeBlocklyXml(blocklyWrapper);
   initializeGenerator(blocklyWrapper);
   initializeTouch(blocklyWrapper);

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -401,7 +401,7 @@ export default class P5Lab {
 
       if (this.isBlockly) {
         this.currentCode = Blockly.getWorkspaceCode();
-        this.studioApp_.addChangeHandler(e => {
+        this.studioApp_.addChangeHandler(() => {
           const newCode = Blockly.getWorkspaceCode();
           if (newCode !== this.currentCode) {
             this.currentCode = newCode;

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -4,11 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {changeInterfaceMode, viewAnimationJson} from './actions';
 import {startInAnimationTab} from './stateQueries';
-import {
-  P5LabInterfaceMode,
-  APP_WIDTH,
-  //BLOCKLY_CODE_CHANGE_EVENTS,
-} from './constants';
+import {P5LabInterfaceMode, APP_WIDTH} from './constants';
 import {
   SpritelabReservedWords,
   valueTypeTabShapeMap,
@@ -406,9 +402,6 @@ export default class P5Lab {
       if (this.isBlockly) {
         this.currentCode = Blockly.getWorkspaceCode();
         this.studioApp_.addChangeHandler(e => {
-          // if (!Blockly.shouldGenerateCodeForEvent(e)) {
-          //   return;
-          // }
           const newCode = Blockly.getWorkspaceCode();
           if (newCode !== this.currentCode) {
             this.currentCode = newCode;

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -4,7 +4,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {changeInterfaceMode, viewAnimationJson} from './actions';
 import {startInAnimationTab} from './stateQueries';
-import {P5LabInterfaceMode, APP_WIDTH} from './constants';
+import {
+  P5LabInterfaceMode,
+  APP_WIDTH,
+  //BLOCKLY_CODE_CHANGE_EVENTS,
+} from './constants';
 import {
   SpritelabReservedWords,
   valueTypeTabShapeMap,
@@ -401,7 +405,10 @@ export default class P5Lab {
 
       if (this.isBlockly) {
         this.currentCode = Blockly.getWorkspaceCode();
-        this.studioApp_.addChangeHandler(() => {
+        this.studioApp_.addChangeHandler(e => {
+          if (!Blockly.shouldGenerateCodeForEvent(e)) {
+            return;
+          }
           const newCode = Blockly.getWorkspaceCode();
           if (newCode !== this.currentCode) {
             this.currentCode = newCode;

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -406,9 +406,9 @@ export default class P5Lab {
       if (this.isBlockly) {
         this.currentCode = Blockly.getWorkspaceCode();
         this.studioApp_.addChangeHandler(e => {
-          if (!Blockly.shouldGenerateCodeForEvent(e)) {
-            return;
-          }
+          // if (!Blockly.shouldGenerateCodeForEvent(e)) {
+          //   return;
+          // }
           const newCode = Blockly.getWorkspaceCode();
           if (newCode !== this.currentCode) {
             this.currentCode = newCode;


### PR DESCRIPTION
We noticed an inconsistency between CDO and Google Blockly in terms of how we update the preview panel. Google Blockly updated the preview when a block was being dragged in, before it was attached. In addition, when pulling a block off of `when run`, the preview does not update until the block finishes dragging. CDO Blockly only previews what is currently attached to `when run`.

This PR updates Google Blockly to be in line with CDO Blockly, because we don't want the preview to show blocks that aren't attached to `when run`. This is done by customizing Blockly's `disableOrphans` event to disable orphans even if the workspace is dragging.

### CDO Blockly Behavior
https://github.com/code-dot-org/code-dot-org/assets/33666587/22c67d2c-af32-4c95-8df8-4b3db7903c05

### Google Blockly Behavior (before update)
https://github.com/code-dot-org/code-dot-org/assets/33666587/1df7cc77-3d6f-48c5-b229-cf8ec4f4ab4b

### Google Blockly Behavior (after update)
https://github.com/code-dot-org/code-dot-org/assets/33666587/bca3f59f-651e-4946-879e-5284ab85535b



## Links
- jira ticket: [CT-122](https://codedotorg.atlassian.net/browse/CT-122)


## Testing story
Tested locally. This will impact Poetry, which uses live preview and Google Blockly. Curriculum has confirmed this is a preferable change.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
