### PR TITLE
[Google Blockly] [Dance] set use_modal_function_editor to false on all levels

### DIFF
--- a/dashboard/config/levels/custom/dance/2019 Dance Lab Project.level
+++ b/dashboard/config/levels/custom/dance/2019 Dance Lab Project.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "display_name": "New Dance Party Project",

--- a/dashboard/config/levels/custom/dance/CodeBreak Dance Party Challenge.level
+++ b/dashboard/config/levels/custom/dance/CodeBreak Dance Party Challenge.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_01.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_01.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_012022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_012022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_01_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_01_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_01_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_01_2023.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_02.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_02.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_022022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_022022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_02_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_02_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_02_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_02_2023.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_03.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_03.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_032022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_032022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_03_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_03_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_03_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_03_2023.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_04.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_04.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_042022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_042022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_04_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_04_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_04_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_04_2023.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_05.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_05.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_052022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_052022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_05_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_05_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_05_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_05_2023.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_06.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_06.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_062022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_062022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_06_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_06_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_06_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_06_2023.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_07.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_07.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_072022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_072022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_07_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_07_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_07_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_07_2023.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_08.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_08.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_082022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_082022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_08_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_08_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_08_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_08_2023.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_09.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_09.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_092022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_092022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_09_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_09_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_09_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_09_2023.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_10.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_10.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_102022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_102022.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_10_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_10_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_10_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_10_2023.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus1.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus1.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus12022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus12022.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus1_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus1_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus1_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus1_2023.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus3.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus3.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus32022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus32022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus3_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus3_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus3_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2020_bonus3_2023.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra1.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra1.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra10a.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra10a.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra10a_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra10a_2023.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra10b.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra10b.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra10b_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra10b_2023.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra1_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra1_2023.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_2022_lessonextra_2023.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_01.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_01.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_01_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_01_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_02.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_02.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_02_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_02_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_03.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_03.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_03_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_03_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_04.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_04.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_04_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_04_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_05.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_05.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_05_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_05_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_06.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_06.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_06_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_06_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_08.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_08.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_08_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_08_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_09.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_09.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_09_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_09_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_10.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_10.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_10_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_10_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_11.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_11.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_11_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_11_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_11_5.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_11_5.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_11_5_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_11_5_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_11b.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_11b.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_11b_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_11b_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_12.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_12.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_Dance_Party_12_2020.level
+++ b/dashboard/config/levels/custom/dance/CourseD_Dance_Party_12_2020.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/CourseD_EOC_dance.level
+++ b/dashboard/config/levels/custom/dance/CourseD_EOC_dance.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "display_name": "Create a dance",

--- a/dashboard/config/levels/custom/dance/CourseD_EOC_dance2022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_EOC_dance2022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "display_name": "Create a dance",

--- a/dashboard/config/levels/custom/dance/CourseD_EOC_dance_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_EOC_dance_2021.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "display_name": "Create a dance",

--- a/dashboard/config/levels/custom/dance/CourseD_EOC_dance_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_EOC_dance_2023.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "display_name": "Create a dance",

--- a/dashboard/config/levels/custom/dance/CourseD_EOC_dance_examples2022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_EOC_dance_examples2022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "display_name": "Disco Party",

--- a/dashboard/config/levels/custom/dance/CourseD_EOC_dance_examples_2021.level
+++ b/dashboard/config/levels/custom/dance/CourseD_EOC_dance_examples_2021.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "display_name": "Disco Party",

--- a/dashboard/config/levels/custom/dance/CourseD_EOC_dance_examples_2022.level
+++ b/dashboard/config/levels/custom/dance/CourseD_EOC_dance_examples_2022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "display_name": "Disco Party",

--- a/dashboard/config/levels/custom/dance/CourseD_EOC_dance_examples_2023.level
+++ b/dashboard/config/levels/custom/dance/CourseD_EOC_dance_examples_2023.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "display_name": "Disco Party",

--- a/dashboard/config/levels/custom/dance/Dance Lab2 Level 1.level
+++ b/dashboard/config/levels/custom/dance/Dance Lab2 Level 1.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance Lab2 Level 2.level
+++ b/dashboard/config/levels/custom/dance/Dance Lab2 Level 2.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_01.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_01.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_01_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_01_draft.level
@@ -13,7 +13,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_02.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_02.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_02_draft-dantest.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_02_draft-dantest.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_02_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_02_draft.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_03.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_03.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_03_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_03_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_04.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_04.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_04_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_04_draft.level
@@ -13,7 +13,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_05.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_05.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_05_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_05_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_06.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_06.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_06_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_06_draft.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_06_draft_backup_dance_moves.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_06_draft_backup_dance_moves.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_07.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_07.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_07_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_07_draft.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_08.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_08.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_08_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_08_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_08f.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_08f.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_09.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_09.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_09_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_09_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_10.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_10.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_10_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_10_draft.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_generate_block_choose_song.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_generate_block_choose_song.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_generate_block_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_generate_block_draft.level
@@ -13,7 +13,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_2019_setup_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_2019_setup_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Events_Example_Video.level
+++ b/dashboard/config/levels/custom/dance/Dance_Events_Example_Video.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_01.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_01.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_01_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_01_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_01_low.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_01_low.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_02.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_02.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_02_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_02_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_03.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_03.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_03_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_03_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_04.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_04.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_04_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_04_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_05.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_05.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_05_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_05_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_06.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_06.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_06_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_06_draft.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_07.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_07.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_08.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_08.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_08_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_08_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_09.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_09.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_09_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_09_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_10.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_10.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_10_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_10_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_11.5_test.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_11.5_test.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_11.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_11.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_11_5.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_11_5.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_11_5_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_11_5_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_11_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_11_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_11b.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_11b.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_11b_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_11b_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_12.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_12.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_Party_12_draft.level
+++ b/dashboard/config/levels/custom/dance/Dance_Party_12_draft.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Dance_kidzbop.level
+++ b/dashboard/config/levels/custom/dance/Dance_kidzbop.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/HOC Dance 1.level
+++ b/dashboard/config/levels/custom/dance/HOC Dance 1.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/HOC Dance 2.level
+++ b/dashboard/config/levels/custom/dance/HOC Dance 2.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/HOC Dance 3.level
+++ b/dashboard/config/levels/custom/dance/HOC Dance 3.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/HOC Dance 4.level
+++ b/dashboard/config/levels/custom/dance/HOC Dance 4.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/HOC Dance 5.level
+++ b/dashboard/config/levels/custom/dance/HOC Dance 5.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/HOC Dance 6.level
+++ b/dashboard/config/levels/custom/dance/HOC Dance 6.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/HOC Dance 7.level
+++ b/dashboard/config/levels/custom/dance/HOC Dance 7.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/HOC Dance 8.level
+++ b/dashboard/config/levels/custom/dance/HOC Dance 8.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/HOC Dance 9.level
+++ b/dashboard/config/levels/custom/dance/HOC Dance 9.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/HOC Dance Freeplay.level
+++ b/dashboard/config/levels/custom/dance/HOC Dance Freeplay.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/OPD-K5-DEvents-2021.level
+++ b/dashboard/config/levels/custom/dance/OPD-K5-DEvents-2021.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/OPD-K5-DEvents_2022.level
+++ b/dashboard/config/levels/custom/dance/OPD-K5-DEvents_2022.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/OPD-K5-DEvents_2023.level
+++ b/dashboard/config/levels/custom/dance/OPD-K5-DEvents_2023.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/Ryan_Demo.level
+++ b/dashboard/config/levels/custom/dance/Ryan_Demo.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/allthethings HOC Dance 1.level
+++ b/dashboard/config/levels/custom/dance/allthethings HOC Dance 1.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/allthethings HOC Dance 10 Measures.level
+++ b/dashboard/config/levels/custom/dance/allthethings HOC Dance 10 Measures.level
@@ -11,7 +11,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/dance_edit_test.level
+++ b/dashboard/config/levels/custom/dance/dance_edit_test.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/draft_ai_dance_party_Drag_ai_happy_debug.level
+++ b/dashboard/config/levels/custom/dance/draft_ai_dance_party_Drag_ai_happy_debug.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/draft_ai_dance_party_backup_dancers_and_moves.level
+++ b/dashboard/config/levels/custom/dance/draft_ai_dance_party_backup_dancers_and_moves.level
@@ -13,7 +13,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/draft_ai_dance_party_drag_ai_and_dance_move.level
+++ b/dashboard/config/levels/custom/dance/draft_ai_dance_party_drag_ai_and_dance_move.level
@@ -13,7 +13,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/draft_ai_dance_party_drag_ai_cosmic.level
+++ b/dashboard/config/levels/custom/dance/draft_ai_dance_party_drag_ai_cosmic.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/draft_ai_dance_party_drag_ai_sad.level
+++ b/dashboard/config/levels/custom/dance/draft_ai_dance_party_drag_ai_sad.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/draft_ai_dance_party_drag_dancer.level
+++ b/dashboard/config/levels/custom/dance/draft_ai_dance_party_drag_dancer.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/draft_ai_dance_party_free_play.level
+++ b/dashboard/config/levels/custom/dance/draft_ai_dance_party_free_play.level
@@ -13,7 +13,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/draft_ai_dance_party_key_press_events_1.level
+++ b/dashboard/config/levels/custom/dance/draft_ai_dance_party_key_press_events_1.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/draft_ai_dance_party_key_press_events_2.level
+++ b/dashboard/config/levels/custom/dance/draft_ai_dance_party_key_press_events_2.level
@@ -12,7 +12,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/draft_ai_dance_party_measure_events.level
+++ b/dashboard/config/levels/custom/dance/draft_ai_dance_party_measure_events.level
@@ -13,7 +13,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",

--- a/dashboard/config/levels/custom/dance/self-paced-example-level-dance.level
+++ b/dashboard/config/levels/custom/dance/self-paced-example-level-dance.level
@@ -7,7 +7,7 @@
     ],
     "hide_animation_mode": "true",
     "show_type_hints": "true",
-    "use_modal_function_editor": "true",
+    "use_modal_function_editor": "false",
     "embed": "false",
     "instructions_important": "false",
     "submittable": "false",


### PR DESCRIPTION
The modal function editor is not currently supported on production in Google Blockly levels, yet there was a large handful of levels that have it enabled. Of 179 level files that are set to use the modal editor:
* 160 levels do not actually have a Functions category in the toolbox
* 3 levels are drafts not used in any published curricula
* 16 levels, all used in Course D/Express lesson extras, DO have a functions category

For the 160 levels mentioned above, there is no functional change for the user. However, if a levelbuilder edited on of these levels to include functions, the behavior would match the current "no-modal" behavior that is supported. 

The 3 draft levels are updated here out of an abundance of caution.

The 16 levels used in Lesson Extras are more interesting. These levels currently include a button that creates a function by adding it to the bottom of the main workspace: 
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/5134fe71-e270-4e3c-b846-8132cbbea3e4)

We are currently building a new modal function editor experience using the experiment `modalFunctionEditor`. If this experiment is enabled, the experience is currently degraded and not desired for students:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/93b19857-24b6-422e-a3f2-7be98c45ca9a)

We aim to remove the experiment, but doing so requires we update these levels. After disabling the modal function editor in these levels, the toolbox button is replaced by a block that can be dragged to the main workspace. This is the case whether the experiment is active or not:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/db543da0-1cc7-4aed-9cdc-e20874afb4b7)

After making this change, I reseeded all custom levels locally and confirmed that the toolboxes include the function block and not the button. While this is a change in behavior for the Course D Lesson Extras levels, it is a desired change as the levels now behave as expected. Making this change ensures that all published Google Blockly levels work exactly the same way, whether the experiment is active or not. Once merged, we should be able to safely remove the experiment and continue working on the modal function editor while supporting one less use case.


