### PR TITLE
[Google Blockly] Disable edit button when in modal function editor

### DIFF
--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -122,8 +122,8 @@ export default class FunctionEditor {
     this.hide();
   }
 
-  isOpen() {
-    return this.dom.style.display === 'block';
+  getWorkspaceId() {
+    return this.editorWorkspace.id;
   }
 
   // TODO

--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -122,6 +122,10 @@ export default class FunctionEditor {
     this.hide();
   }
 
+  isOpen() {
+    return this.dom.style.display === 'block';
+  }
+
   // TODO
   renameParameter(oldName, newName) {}
 

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -129,12 +129,12 @@ const editButton = function () {
   // If we are in the modal function editor, don't add the button, due to an issue with Blockly
   // not being able to handle us clearing the block right after it has been clicked.
   // TODO: After we updgrade to Blockly v10, check if this issue has been fixed, and if it has,
-  // remove the check on functionEditor.isOpen().
+  // remove the check on functionEditor workspace id.
   if (
     useModalFunctionEditor &&
     this.inputList.length &&
     !this.workspace.isFlyout &&
-    !Blockly.functionEditor.isOpen()
+    this.workspace.id !== Blockly.functionEditor.getWorkspaceId()
   ) {
     const button = new Blockly.FieldButton({
       value: msg.edit(),

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -129,7 +129,8 @@ const editButton = function () {
   if (
     useModalFunctionEditor &&
     this.inputList.length &&
-    !this.workspace.isFlyout
+    !this.workspace.isFlyout &&
+    !Blockly.functionEditor.isOpen()
   ) {
     const button = new Blockly.FieldButton({
       value: msg.edit(),

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -126,6 +126,10 @@ export const editButtonHandler = function () {
 // This extension adds an edit button to the end of a procedure call block.
 const editButton = function () {
   // Edit buttons are used to open the modal editor. The button is appended to the last input.
+  // If we are in the modal function editor, don't add the button, due to an issue with Blockly
+  // not being able to handle us clearing the block right after it has been clicked.
+  // TODO: After we updgrade to Blockly v10, check if this issue has been fixed, and if it has,
+  // remove the check on functionEditor.isOpen().
   if (
     useModalFunctionEditor &&
     this.inputList.length &&


### PR DESCRIPTION
There is a [bug](https://github.com/google/blockly/issues/7587) in Google Blockly where if you have a click event on a block that deletes the block, Blockly crashes. This surfaced for us in the scenario where you have a function inside another function in the function editor. If you click the edit button on a function, it clears the editor workspace and puts the new function's definition inside. This causes the crash. While we wait for that to be fixed (and we will need to upgrade to v10 to get that fix), we can just not show edit buttons on functions inside the modal function editor

### Before
![Screenshot 2023-10-11 at 1 13 14 PM](https://github.com/code-dot-org/code-dot-org/assets/33666587/8d8d18ea-0dc2-49e8-be56-60ec480c1ead)


### After
![Screenshot 2023-10-11 at 1 13 38 PM](https://github.com/code-dot-org/code-dot-org/assets/33666587/2ed0c93d-ef44-4342-9f09-93a81e0c7396)


## Links

- jira ticket: [CT-115](https://codedotorg.atlassian.net/browse/CT-115)


## Testing story
Tested locally that function call blocks inside the modal function editor don't have edit buttons, but they still have edit buttons in the main workspace.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
