### PR TITLE
Adds 'requester_id' to LearningGoalAIEvaluation model (migration)

### DIFF
--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -92,6 +92,7 @@ class EvaluateRubricJob < ApplicationJob
     _owner_id, project_id = storage_decrypt_channel_id(channel_id)
 
     # record the ai evaluations to the database
+    # TODO: pass along and update the 'requester' to the correct id
     ActiveRecord::Base.transaction do
       ai_evaluations.each do |evaluation|
         learning_goal = rubric.learning_goals.all.find {|lg| lg.learning_goal == evaluation['Key Concept']}
@@ -99,6 +100,7 @@ class EvaluateRubricJob < ApplicationJob
         LearningGoalAiEvaluation.create!(
           user_id: user.id,
           learning_goal_id: learning_goal.id,
+          requester_id: user.id,
           project_id: project_id,
           project_version: project_version,
           understanding: understanding

--- a/dashboard/app/models/learning_goal_ai_evaluation.rb
+++ b/dashboard/app/models/learning_goal_ai_evaluation.rb
@@ -5,6 +5,7 @@
 #  id               :bigint           not null, primary key
 #  user_id          :integer
 #  learning_goal_id :integer
+#  requester_id     :integer
 #  project_id       :integer
 #  project_version  :string(255)
 #  understanding    :integer
@@ -15,10 +16,12 @@
 #
 #  index_learning_goal_ai_evaluations_on_learning_goal_id  (learning_goal_id)
 #  index_learning_goal_ai_evaluations_on_user_id           (user_id)
+#  index_learning_goal_ai_evaluations_on_requester_id      (requester_id)
 #
 class LearningGoalAiEvaluation < ApplicationRecord
   belongs_to :learning_goal
   belongs_to :user
+  belongs_to :requester, class_name: 'User'
 
   def summarize_for_instructor
     {

--- a/dashboard/db/migrate/20231011075239_add_requester_to_learning_goal_ai_evaluation.rb
+++ b/dashboard/db/migrate/20231011075239_add_requester_to_learning_goal_ai_evaluation.rb
@@ -1,0 +1,6 @@
+class AddRequesterToLearningGoalAiEvaluation < ActiveRecord::Migration[6.1]
+  def change
+    add_column :learning_goal_ai_evaluations, :requester_id, :integer, limit: 4
+    add_foreign_key :learning_goal_ai_evaluations, :users, column: :requester_id, name: 'index_learning_goal_ai_evaluations_on_requester_id'
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_09_175334) do
+ActiveRecord::Schema.define(version: 2023_10_11_075239) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -645,7 +645,9 @@ ActiveRecord::Schema.define(version: 2023_10_09_175334) do
     t.integer "understanding"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "requester_id"
     t.index ["learning_goal_id"], name: "index_learning_goal_ai_evaluations_on_learning_goal_id"
+    t.index ["requester_id"], name: "index_learning_goal_ai_evaluations_on_requester_id"
     t.index ["user_id"], name: "index_learning_goal_ai_evaluations_on_user_id"
   end
 
@@ -2289,6 +2291,7 @@ ActiveRecord::Schema.define(version: 2023_10_09_175334) do
   add_foreign_key "census_summaries", "schools"
   add_foreign_key "circuit_playground_discount_applications", "schools"
   add_foreign_key "hint_view_requests", "users"
+  add_foreign_key "learning_goal_ai_evaluations", "users", column: "requester_id", name: "index_learning_goal_ai_evaluations_on_requester_id"
   add_foreign_key "level_concept_difficulties", "levels"
   add_foreign_key "lti_deployments", "lti_integrations"
   add_foreign_key "lti_user_identities", "lti_integrations"

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -76,8 +76,8 @@ class RubricsControllerTest < ActionController::TestCase
     rubric = create :rubric
     learning_goal1 = create :learning_goal, rubric: rubric
     learning_goal2 = create :learning_goal, rubric: rubric
-    ai_evaluation1 = create :learning_goal_ai_evaluation, learning_goal: learning_goal1, user: student, understanding: 1
-    ai_evaluation2 = create :learning_goal_ai_evaluation, learning_goal: learning_goal2, user: student, understanding: 2
+    ai_evaluation1 = create :learning_goal_ai_evaluation, learning_goal: learning_goal1, user: student, requester: teacher, understanding: 1
+    ai_evaluation2 = create :learning_goal_ai_evaluation, learning_goal: learning_goal2, user: student, requester: teacher,  understanding: 2
 
     get :get_ai_evaluations, params: {
       id: rubric.id,
@@ -96,7 +96,7 @@ class RubricsControllerTest < ActionController::TestCase
     sign_in teacher
 
     learning_goal = create :learning_goal
-    create :learning_goal_ai_evaluation, learning_goal: learning_goal, user: student
+    create :learning_goal_ai_evaluation, learning_goal: learning_goal, user: student, requester: teacher
 
     get :get_ai_evaluations, params: {
       id: learning_goal.rubric.id,
@@ -113,9 +113,9 @@ class RubricsControllerTest < ActionController::TestCase
     sign_in teacher
 
     learning_goal = create :learning_goal
-    create :learning_goal_ai_evaluation, learning_goal: learning_goal, user: student, understanding: 1
+    create :learning_goal_ai_evaluation, learning_goal: learning_goal, user: student, requester: teacher, understanding: 1
     travel 1.minute do
-      create :learning_goal_ai_evaluation, learning_goal: learning_goal, user: student, understanding: 2
+      create :learning_goal_ai_evaluation, learning_goal: learning_goal, user: student, requester: teacher, understanding: 2
     end
 
     get :get_ai_evaluations, params: {

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1839,6 +1839,7 @@ FactoryBot.define do
   factory :learning_goal_ai_evaluation do
     association :learning_goal
     association :user, factory: :student
+    association :requester, factory: :teacher
     understanding {0}
   end
 end


### PR DESCRIPTION
Just adds the `requester_id` column to the `LearningGoalAIEvaluation` model as a required foreign key to a `User`. The intention is to make sure the student or teacher that initiated the evaluation is recorded.

## Links

- jira ticket: [AITT-241](https://codedotorg.atlassian.net/browse/AITT-241)

## Follow-Up Work

Need to ensure that this column is populated when creating such AI evaluations.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
