### PR TITLE
Fix rds:clone_cluster and rds:delete_cluster rake tasks.

### DIFF
--- a/lib/cdo/aws/rds.rb
+++ b/lib/cdo/aws/rds.rb
@@ -78,7 +78,7 @@ module Cdo
     end
 
     def self.delete_cluster(cluster_id, max_attempts = 20, delay = 60)
-      raise StandardError.new("CLUSTER_ID environment variable is required.") unless cluster_id.present?
+      raise StandardError.new("cluster_id is required") unless cluster_id.present?
       rds_client = Aws::RDS::Client.new
       begin
         existing_cluster = rds_client.describe_db_clusters({db_cluster_identifier: cluster_id}).db_clusters.first

--- a/lib/cdo/aws/rds.rb
+++ b/lib/cdo/aws/rds.rb
@@ -78,6 +78,7 @@ module Cdo
     end
 
     def self.delete_cluster(cluster_id, max_attempts = 20, delay = 60)
+      raise StandardError.new("CLUSTER_ID environment variable is required.") unless cluster_id.present?
       rds_client = Aws::RDS::Client.new
       begin
         existing_cluster = rds_client.describe_db_clusters({db_cluster_identifier: cluster_id}).db_clusters.first

--- a/lib/rake/rds.rake
+++ b/lib/rake/rds.rake
@@ -21,6 +21,7 @@ namespace :rds do
 
   desc 'Delete CLUSTER_ID'
   timed_task_with_logging :delete_cluster do
+    raise StandardError.new("CLUSTER_ID environment variable is required.") unless ENV['CLUSTER_ID'].present?
     Cdo::RDS.delete_cluster(ENV['CLUSTER_ID'])
   end
 end

--- a/lib/rake/rds.rake
+++ b/lib/rake/rds.rake
@@ -16,7 +16,7 @@ namespace :rds do
       clone_cluster_id: ENV['CLONE_CLUSTER_ID'],
       instance_type: ENV['INSTANCE_TYPE']
     }
-    Cdo::RDS.clone_cluster(options.compact)
+    Cdo::RDS.clone_cluster(**options.compact)
   end
 
   desc 'Delete CLUSTER_ID'

--- a/lib/test/cdo/aws/test_rds.rb
+++ b/lib/test/cdo/aws/test_rds.rb
@@ -238,6 +238,6 @@ class TestRDS < Minitest::Test
       cluster_id = ''
       Cdo::RDS.delete_cluster(cluster_id)
     end
-    assert_equal 'CLUSTER_ID environment variable is required.', empty_exception.message
+    assert_equal 'cluster_id is required', empty_exception.message
   end
 end

--- a/lib/test/cdo/aws/test_rds.rb
+++ b/lib/test/cdo/aws/test_rds.rb
@@ -1,5 +1,4 @@
-require 'minitest/autorun'
-require_relative 'test_helper'
+require_relative '../../test_helper'
 require 'cdo/aws/rds'
 
 class TestRDS < Minitest::Test
@@ -227,5 +226,18 @@ class TestRDS < Minitest::Test
     }
 
     Cdo::RDS.delete_cluster(@cluster_to_delete_id, 1, 0)
+  end
+
+  def test_delete_cluster_cluster_id_required
+    required_exception = assert_raises StandardError do
+      Cdo::RDS.delete_cluster
+    end
+    assert_equal 'wrong number of arguments (given 0, expected 1..3)', required_exception.message
+
+    empty_exception = assert_raises StandardError do
+      cluster_id = ''
+      Cdo::RDS.delete_cluster(cluster_id)
+    end
+    assert_equal 'CLUSTER_ID environment variable is required.', empty_exception.message
   end
 end


### PR DESCRIPTION
The `rake rds:clone_cluster` task was not compatible with Ruby 3. Fix that and also fix a defect in `rds:delete_cluster` that would delete the first cluster in the AWS Account if the `CLUSTER_ID` environment variable was not set. I had started the fix for `delete_cluster` a couple of years ago, but never completed it (#38862).

## Testing story

Moved the unit tests to the correct folder and updated to ensure that `CLUSTER_ID` is required to delete a cluster.

also manually tested:

``` bash
% bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=production-aurora-cluster CLONE_CLUSTER_ID=production-clone-test-rake-tasks
Creating clone of database cluster - production-aurora-cluster
Done creating database cluster - production-clone-test-rake-tasks
Finished rds:clone_cluster (13 minutes)

% bundle exec rake rds:delete_cluster
rake aborted!
StandardError: CLUSTER_ID environment variable is required.
/Users/suresh/code-dot-org/lib/cdo/aws/rds.rb:81:in `delete_cluster'
/Users/suresh/code-dot-org/lib/rake/rds.rake:24:in `block (2 levels) in <top (required)>'
/Users/suresh/code-dot-org/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `block in execute'
/Users/suresh/code-dot-org/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `execute'
/Users/suresh/.rbenv/versions/3.0.5/bin/bundle:23:in `load'
/Users/suresh/.rbenv/versions/3.0.5/bin/bundle:23:in `<main>'
Tasks: TOP => rds:delete_cluster
(See full trace by running task with --trace)

% bundle exec rake rds:delete_cluster CLUSTER_ID=production-clone-test-rake-tasks
Database Cluster production-clone-test-rake-tasks has been deleted. DBCluster production-clone-test-rake-tasks not found.
Finished rds:delete_cluster (20 minutes)
```

## Deployment strategy

## Follow-up work

The reason we programmatically issue AWS API calls to create/delete each Resource needed to clone an RDS cluster is that there was a defect in the CloudFormation template Resource that can clone a cluster when not using a default VPC. That defect was fixed recently, and we should switch this logic to create/delete a CloudFormation Stack.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
