### PR TITLE
Kaitie/reduced vertical space in teacher rubrics

### DIFF
--- a/apps/src/templates/rubrics/AiAssessmentBox.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentBox.jsx
@@ -2,7 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import style from './rubrics.module.scss';
-import {EmText, Heading6} from '@cdo/apps/componentLibrary/typography';
+import {
+  EmText,
+  StrongText,
+  BodyThreeText,
+} from '@cdo/apps/componentLibrary/typography';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import ReactTooltip from 'react-tooltip';
 import {RubricUnderstandingLevels} from '@cdo/apps/util/sharedConstants';
@@ -38,7 +42,9 @@ export default function AiAssessmentBox({
     <div className={boxColor()}>
       {isAiAssessed && (
         <div>
-          <Heading6>{studentAchievment()}</Heading6>
+          <BodyThreeText>
+            <StrongText>{studentAchievment()}</StrongText>
+          </BodyThreeText>
           {aiConfidence && (
             <div>
               <EmText>{i18n.aiConfidence({aiConfidence: aiConfidence})}</EmText>

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -119,50 +119,56 @@ export default function RubricContent({
 
   return (
     <div className={style.rubricContent}>
-      {!!studentLevelInfo && <Heading2>{studentLevelInfo.name}</Heading2>}
-      <Heading5>
-        {i18n.lessonNumbered({
-          lessonNumber: lesson.position,
-          lessonName: lesson.name,
-        })}
-      </Heading5>
-      {!!studentLevelInfo && (
-        <div className={style.studentInfo}>
-          <div className={style.levelAndStudentDetails}>
-            {onLevelForEvaluation && (
-              <div className={style.studentMetadata}>
-                {studentLevelInfo.timeSpent && (
+      <div>
+        {!!studentLevelInfo && (
+          <Heading2 style={{marginBottom: '8px'}}>
+            {studentLevelInfo.name}
+          </Heading2>
+        )}
+        <Heading5>
+          {i18n.lessonNumbered({
+            lessonNumber: lesson.position,
+            lessonName: lesson.name,
+          })}
+        </Heading5>
+        {!!studentLevelInfo && (
+          <div className={style.studentInfo}>
+            <div className={style.levelAndStudentDetails}>
+              {onLevelForEvaluation && (
+                <div className={style.studentMetadata}>
+                  {studentLevelInfo.timeSpent && (
+                    <BodyThreeText className={style.singleMetadatum}>
+                      <FontAwesome icon="clock" />
+                      <span>{formatTimeSpent(studentLevelInfo.timeSpent)}</span>
+                    </BodyThreeText>
+                  )}
                   <BodyThreeText className={style.singleMetadatum}>
-                    <FontAwesome icon="clock" />
-                    <span>{formatTimeSpent(studentLevelInfo.timeSpent)}</span>
+                    <FontAwesome icon="rocket" />
+                    {i18n.numAttempts({
+                      numAttempts: studentLevelInfo.attempts || 0,
+                    })}
                   </BodyThreeText>
-                )}
-                <BodyThreeText className={style.singleMetadatum}>
-                  <FontAwesome icon="rocket" />
-                  {i18n.numAttempts({
-                    numAttempts: studentLevelInfo.attempts || 0,
+                  {studentLevelInfo.lastAttempt && (
+                    <BodyThreeText className={style.singleMetadatum}>
+                      <FontAwesome icon="calendar" />
+                      <span>
+                        {formatLastAttempt(studentLevelInfo.lastAttempt)}
+                      </span>
+                    </BodyThreeText>
+                  )}
+                </div>
+              )}
+              {!onLevelForEvaluation && rubricLevel?.position && (
+                <BodyThreeText>
+                  {i18n.feedbackAvailableOnLevel({
+                    levelPosition: rubricLevel.position,
                   })}
                 </BodyThreeText>
-                {studentLevelInfo.lastAttempt && (
-                  <BodyThreeText className={style.singleMetadatum}>
-                    <FontAwesome icon="calendar" />
-                    <span>
-                      {formatLastAttempt(studentLevelInfo.lastAttempt)}
-                    </span>
-                  </BodyThreeText>
-                )}
-              </div>
-            )}
-            {!onLevelForEvaluation && rubricLevel?.position && (
-              <BodyThreeText>
-                {i18n.feedbackAvailableOnLevel({
-                  levelPosition: rubricLevel.position,
-                })}
-              </BodyThreeText>
-            )}
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
       <div className={style.learningGoalContainer}>
         {rubric.learningGoals.map(lg => (
           <LearningGoal

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -195,16 +195,11 @@ p.aiTokenText {
   color: $product_affirmative_default;
 }
 
-.expandedBorder {
-  border-top: 1px solid $neutral_dark40;
-}
-
 .learningGoalExpanded {
-  padding: 1.25rem 1rem;
-
+  padding: 1rem;
   display: flex;
-  flex-direction: row;
-  gap: 2rem;
+  flex-direction: column;
+  gap: 1.25rem;
   align-self: stretch;
 }
 
@@ -228,7 +223,7 @@ p.aiTokenText {
   display: flex;
   align-items: flex-start;
   flex-direction: column;
-  gap: 1rem;
+  gap: .5rem;
   align-self: stretch;
   flex: 1;
 
@@ -290,7 +285,7 @@ p.errorMessage {
 }
 
 .openedAiAssessment {
-  padding: 1.25rem 1rem 0 1rem;
+  padding: 1rem 1rem 0 1rem;
 }
 
 .aiAssessmentBlock {

--- a/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
+++ b/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
@@ -17,7 +17,7 @@ describe('AiAssessmentBox', () => {
   it('renders AiAssessmentBox with student information if it is assessessed by AI', () => {
     const wrapper = shallow(<AiAssessmentBox {...props} />);
     expect(wrapper.find('EmText')).to.have.lengthOf(1);
-    expect(wrapper.find('Heading6')).to.have.lengthOf(1);
+    expect(wrapper.find('BodyThreeText')).to.have.lengthOf(1);
     expect(wrapper.find('ReactTooltip')).to.have.lengthOf(1);
   });
 
@@ -28,7 +28,7 @@ describe('AiAssessmentBox', () => {
     };
     const wrapper = shallow(<AiAssessmentBox {...updatedProps} />);
     expect(wrapper.find('EmText')).to.have.lengthOf(0);
-    expect(wrapper.find('Heading6')).to.have.lengthOf(1);
+    expect(wrapper.find('BodyThreeText')).to.have.lengthOf(1);
     expect(wrapper.find('ReactTooltip')).to.have.lengthOf(0);
   });
 
@@ -68,7 +68,7 @@ describe('AiAssessmentBox', () => {
   it('renders AiAssessmentBox with notice that AI Cannot be used to assess this box when the topic is to subjective to be evaluated', () => {
     const updatedProps = {...props, isAiAssessed: false};
     const wrapper = shallow(<AiAssessmentBox {...updatedProps} />);
-    expect(wrapper.find('Heading6')).to.have.lengthOf(0);
+    expect(wrapper.find('BodyThreeText')).to.have.lengthOf(0);
     expect(wrapper.find('EmText')).to.have.lengthOf(1);
     expect(wrapper.html().includes(i18n.aiCannotAssess())).to.be.true;
     expect(wrapper.find('ReactTooltip')).to.have.lengthOf(1);


### PR DESCRIPTION
[AITT-212](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?selectedIssue=AITT-212)
- This ticket is mostly style changes.  It is worth opening up the ticket to see the various requests as well as the figma.

**OLD spacing:**
<img width="697" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/97558fd1-9f8b-4756-b3df-bd62ecea76fc">


**NEW spacing:**
<img width="692" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/87b5113d-6ea0-431b-9dae-dfc00769acef">

**OLD LearningGoal View:**
<img width="662" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/04b5edef-bf49-4d3b-85d8-d7ae282dac6e">


**NEW LearningGoal View:**
<img width="673" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/144f9537-c3fb-49b8-8f8e-3f96153c91d4">



## Testing story

- Modified existing tests
