### PR TITLE
Deflake teacher application dashboard eyes test when validating 'Admin Course View'

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application_dashboard.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application_dashboard.feature
@@ -14,6 +14,7 @@ Feature: Teacher Application Dashboard
     And I press the first ".Select-option" element
     Then I wait until element "span:contains('Withdrawn')" is visible
     And I wait until element "td:contains('Unreviewed')" is not visible
+    Then I wait until element "#quick-view" is visible
     And I see no difference for "Admin Course View"
 
     # Access the Detail View by navigating to the first row's "view application" button href


### PR DESCRIPTION
Issue: Teacher application dashboard eyes test scenario to validate admin course view intermittently hits mismatches on eyes test where the table with applications isn't loaded during the comparison.

![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/9b5e1f6c-1aad-47dc-b678-93666a0787ab)

Fix: Wait for an element with the table ID to show up before doing the eyes comparison with baseline. 

## Links

JIRA: https://codedotorg.atlassian.net/browse/ACQ-917?atlOrigin=eyJpIjoiYWM3YjU2MjcxMmQ2NGQ2ZGFjMzc4MmE2MjNlNGZhMjAiLCJwIjoiaiJ9

## Testing story

Using Drone to validate the fix is working as expected

## Deployment strategy

N/A

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A 

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
