### PR TITLE
[JIMT] limit song selection

### DIFF
--- a/apps/src/dance/danceRedux.ts
+++ b/apps/src/dance/danceRedux.ts
@@ -50,6 +50,7 @@ export const initSongs = createAsyncThunk(
         defaultSong?: string;
         isProjectLevel: boolean;
         freePlay: boolean;
+        songSelection?: Array<string>;
       };
       onAuthError: (songId: string) => void;
       onSongSelected?: (songId: string) => void;
@@ -61,9 +62,20 @@ export const initSongs = createAsyncThunk(
 
     // Check for a user-specified manifest file.
     const userManifest = queryParams('manifest') as string;
-    const songManifest = await getSongManifest(
+
+    // Build up a set from our song selection so we can filter our manifest later.
+    const filteredSongSet = new Set(selectSongOptions.songSelection || []);
+
+    const unfilteredSongManifest = await getSongManifest(
       useRestrictedSongs,
       userManifest
+    );
+
+    // a song should be included if we do NOT have a filtered song set
+    // OR if we do have a set and our song's id is in them.
+    const songManifest = unfilteredSongManifest.filter(
+      (song: {id: string}) =>
+        !filteredSongSet.size || filteredSongSet.has(song.id)
     );
     const songData = parseSongOptions(songManifest) as SongData;
     const selectedSong = getSelectedSong(songManifest, selectSongOptions);

--- a/apps/test/unit/dance/danceReduxTest.ts
+++ b/apps/test/unit/dance/danceReduxTest.ts
@@ -104,7 +104,7 @@ describe('danceRedux', function () {
       userManifest = 'user-manifest';
       queryParams.returns(userManifest);
 
-      songManifest = {};
+      songManifest = [{id: 'a'}, {id: 'b'}, {id: 'c'}];
       getSongManifest.returns(new Promise(resolve => resolve(songManifest)));
 
       parseSongOptions.returns(songData);
@@ -140,6 +140,38 @@ describe('danceRedux', function () {
         assert.isTrue(parseSongOptions.calledWithExactly(songManifest));
         assert.isTrue(
           getSelectedSong.calledWithExactly(songManifest, selectSongOptions)
+        );
+        assert.isTrue(loadSong.calledWith(selectedSong));
+        assert.isTrue(onSongSelected.calledWithExactly(selectedSong));
+
+        assert.deepEqual(store.getState().dance.songData, songData);
+        assert.deepEqual(store.getState().dance.selectedSong, selectedSong);
+      });
+
+      it('initializes filtered songs correctly', async () => {
+        const selectSongOptions = {
+          isProjectLevel,
+          freePlay,
+          defaultSong,
+          selectedSong,
+          songSelection: ['a'],
+        };
+        await dispatch(
+          initSongs({
+            useRestrictedSongs,
+            selectSongOptions,
+            onAuthError,
+            onSongSelected,
+          })
+        );
+
+        assert.isTrue(queryParams.calledWithExactly('manifest'));
+        assert.isTrue(
+          getSongManifest.calledWithExactly(useRestrictedSongs, userManifest)
+        );
+        assert.isTrue(parseSongOptions.calledWithExactly([{id: 'a'}]));
+        assert.isTrue(
+          getSelectedSong.calledWithExactly([{id: 'a'}], selectSongOptions)
         );
         assert.isTrue(loadSong.calledWith(selectedSong));
         assert.isTrue(onSongSelected.calledWithExactly(selectedSong));

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -533,6 +533,9 @@ class LevelsController < ApplicationController
 
       # Poetry-specific
       {available_poems: []},
+
+      # Dance Party-specific
+      {song_selection: []},
     ]
 
     # http://stackoverflow.com/questions/8929230/why-is-the-first-element-always-blank-in-my-rails-multi-select
@@ -545,7 +548,8 @@ class LevelsController < ApplicationController
       :play_sound_options,
       :helper_libraries,
       :block_pools,
-      :available_poems
+      :available_poems,
+      :song_selection
     ]
     multiselect_params.each do |param|
       params[:level][param].delete_if(&:empty?) if params[:level][param].is_a? Array

--- a/dashboard/app/models/levels/dancelab.rb
+++ b/dashboard/app/models/levels/dancelab.rb
@@ -27,6 +27,7 @@
 class Dancelab < GamelabJr
   serialized_attrs %w(
     default_song
+    song_selection
     uses_lab2
     uses_preview
   )

--- a/dashboard/app/views/levels/editors/_dance.html.haml
+++ b/dashboard/app/views/levels/editors/_dance.html.haml
@@ -5,8 +5,8 @@
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
 
-= render partial: 'levels/editors/fields/default_song', locals: {f: f}
 = render partial: 'levels/editors/fields/song_selection', locals: {f: f}
+= render partial: 'levels/editors/fields/default_song', locals: {f: f}
 
 = render partial: 'levels/editors/fields/debugger', locals: {f: f}
 

--- a/dashboard/app/views/levels/editors/_dance.html.haml
+++ b/dashboard/app/views/levels/editors/_dance.html.haml
@@ -6,6 +6,7 @@
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
 
 = render partial: 'levels/editors/fields/default_song', locals: {f: f}
+= render partial: 'levels/editors/fields/song_selection', locals: {f: f}
 
 = render partial: 'levels/editors/fields/debugger', locals: {f: f}
 

--- a/dashboard/app/views/levels/editors/fields/_default_song.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_default_song.html.haml
@@ -15,6 +15,8 @@
 
 #defaultSong.in.collapse
   %p Please note - If you are limiting songs in the Limit Song Selection input, the Default Song must be one of those songs.
+  If not, the first song in the list of selected songs will be used as the default song.
+  %p
   = f.label :default_song, 'Default Song'
   = f.select :default_song, options_for_select(@level.class.hoc_songs, selectedSongMap[@level.default_song] ? @level.default_song : fallbackDefaultSong)
 

--- a/dashboard/app/views/levels/editors/fields/_default_song.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_default_song.html.haml
@@ -18,6 +18,6 @@
   = f.label :default_song, 'Default Song'
   = f.select :default_song, options_for_select(@level.class.hoc_songs, selectedSongMap[@level.default_song] ? @level.default_song : fallbackDefaultSong)
 
-%p Currently chosen default song (may not match actual default if song selection was limited):
+%p Previously chosen default song (may not match actual default if song selection was limited):
 
 = songMap[@level.default_song][0]

--- a/dashboard/app/views/levels/editors/fields/_default_song.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_default_song.html.haml
@@ -2,5 +2,6 @@
   Default Song
 
 #defaultSong.in.collapse
+  %p Please note - If you are limiting songs in the Limit Song Selection input, the Default Song must be one of those songs.
   = f.label :default_song, 'Default Song'
   = f.select :default_song, options_for_select(@level.class.hoc_songs, @level.default_song)

--- a/dashboard/app/views/levels/editors/fields/_default_song.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_default_song.html.haml
@@ -1,7 +1,23 @@
+-# The logic here is a little tricky
+  songMap contains a mapping of song id -> [song id, song name] for ALL songs
+  selectedSongObjects is a list of [song id, song name] of either the selected songs OR all songs, if nothing is selected
+  selectedSongMap is the same mapping for the _selected_ songs. If no songs are selected, then it uses the full song list.
+  fallbackDefaultSong is used if the current default song is not in the list of selected songs.
+  It is defined as: If there are selected songs, then use the first one in the list. Otherwise, use the first song in the list
+  of all songs.
+- songMap = @level.class.hoc_songs.reduce({}) {|hash, song| hash[song[1]] = song; hash }
+- selectedSongObjects = @level.song_selection ? @level.song_selection.map {|s| songMap[s] } : @level.class.hoc_songs
+- selectedSongMap = selectedSongObjects.reduce({}) {|hash, song| hash[song[1]] = song; hash }
+- fallbackDefaultSong = selectedSongObjects[0]
+
 %h1.control-legend{data: {toggle: "collapse", target: "#defaultSong"}}
   Default Song
 
 #defaultSong.in.collapse
   %p Please note - If you are limiting songs in the Limit Song Selection input, the Default Song must be one of those songs.
   = f.label :default_song, 'Default Song'
-  = f.select :default_song, options_for_select(@level.class.hoc_songs, @level.default_song)
+  = f.select :default_song, options_for_select(@level.class.hoc_songs, selectedSongMap[@level.default_song] ? @level.default_song : fallbackDefaultSong)
+
+%p Currently chosen default song (may not match actual default if song selection was limited):
+
+= songMap[@level.default_song][0]

--- a/dashboard/app/views/levels/editors/fields/_song_selection.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_song_selection.html.haml
@@ -1,11 +1,8 @@
 %h1.control-legend{data: {toggle: "collapse", target: "#songSelection"}}
-  Song Selection
+  Limit Song Selection
 
 #songSelection.in.collapse
   %p
-    Select
-    %a.select_all{href: '#'} all
-    \/
-    %a.select_none{href: '#'} none
+    %a.select_none{href: '#'} Do not limit song selection
     (shift-click or cmd-click to select multiple).
   = f.select :song_selection, @level.class.hoc_songs, {}, {size: 12, multiple: true}

--- a/dashboard/app/views/levels/editors/fields/_song_selection.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_song_selection.html.haml
@@ -3,6 +3,7 @@
 
 #songSelection.in.collapse
   %p
-    %a.select_none{href: '#'} Do not limit song selection
-    (shift-click or cmd-click to select multiple).
+    Click to
+    %a.select_none{href: '#'} not limit song selection
+  %p (shift-click or cmd-click to select multiple).
   = f.select :song_selection, @level.class.hoc_songs, {}, {size: 12, multiple: true}

--- a/dashboard/app/views/levels/editors/fields/_song_selection.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_song_selection.html.haml
@@ -1,0 +1,11 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#songSelection"}}
+  Song Selection
+
+#songSelection.in.collapse
+  %p
+    Select
+    %a.select_all{href: '#'} all
+    \/
+    %a.select_none{href: '#'} none
+    (shift-click or cmd-click to select multiple).
+  = f.select :song_selection, @level.class.hoc_songs, {}, {size: 12, multiple: true}

--- a/dashboard/app/views/levels/editors/fields/_song_selection.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_song_selection.html.haml
@@ -1,3 +1,5 @@
+- songMap = @level.class.hoc_songs.reduce({}) {|hash, song| hash[song[1]] = song; hash }
+
 %h1.control-legend{data: {toggle: "collapse", target: "#songSelection"}}
   Limit Song Selection
 
@@ -6,4 +8,7 @@
     Click to
     %a.select_none{href: '#'} not limit song selection
   %p (shift-click or cmd-click to select multiple).
-  = f.select :song_selection, @level.class.hoc_songs, {}, {size: 12, multiple: true}
+  = f.select :song_selection, ((@level.song_selection || []).map {|s| songMap[s] } + @level.class.hoc_songs).uniq, {}, {size: 12, multiple: true}
+  %p Songs currently selected (does not update until level is saved):
+
+  = (@level.song_selection || []).map {|s| songMap[s][0] }

--- a/dashboard/app/views/levels/editors/fields/_song_selection.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_song_selection.html.haml
@@ -1,7 +1,7 @@
 - songMap = @level.class.hoc_songs.reduce({}) {|hash, song| hash[song[1]] = song; hash }
 
 %h1.control-legend{data: {toggle: "collapse", target: "#songSelection"}}
-  Limit Song Selection
+  Song Selection
 
 #songSelection.in.collapse
   %p


### PR DESCRIPTION
Adds a new level builder field editor to allow selection of songs for a given level.

If _no_ songs are selected, then _all_ songs are available. Otherwise, whatever songs are selected are the only options.

Trello : [Limit song selection in level builder](https://trello.com/c/80Hysupw/36-limit-song-selection-in-levelbuilder)

<img width="991" alt="Screenshot 2023-10-16 at 12 50 12 PM" src="https://github.com/code-dot-org/code-dot-org/assets/1466175/3edbaac0-9d3a-4114-8038-3a955be86ae1">


Manual testing was straightforward:
• Confirm that existing dance party levels operate w/o issue (i.e., you still get the full song list)
• Edit/create a new level and add songs to the song selection. Confirm that only those songs show up in the dropdown on the level.
• Edit that same level and change the selected songs. Confirm that the new selection shows up.
• Remove any selected songs, and confirm that all available songs return.