### PR TITLE
Add hook to ensure the section's owner is also an instructor whenever the section is created or modified (TEACH-681)

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -61,7 +61,7 @@ class Section < ApplicationRecord
   belongs_to :user, optional: true
   alias_attribute :teacher, :user
 
-  has_many :section_instructors, -> {where(status: :active)}
+  has_many :section_instructors, -> {where(status: :active)}, dependent: :destroy
   has_many :instructors, through: :section_instructors, class_name: 'User'
 
   has_many :followers, dependent: :destroy

--- a/dashboard/app/models/sections/section_instructor.rb
+++ b/dashboard/app/models/sections/section_instructor.rb
@@ -24,7 +24,7 @@ class SectionInstructor < ApplicationRecord
 
   belongs_to :instructor, class_name: 'User'
   belongs_to :invited_by, class_name: 'User', optional: true
-  belongs_to :section
+  belongs_to :section, -> {with_deleted}
 
   enum status: {
     active: 0,

--- a/dashboard/test/controllers/api/v1/section_instructors_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/section_instructors_controller_test.rb
@@ -9,10 +9,11 @@ class Api::V1::SectionInstructorsControllerTest < ActionController::TestCase
     @teacher3 = create(:teacher)
     @section = create(:section, user: @teacher, login_type: 'word')
     @section2 = create(:section, user: @teacher, login_type: 'word')
-    @si1 = create(:section_instructor, section: @section, instructor: @teacher, status: :active)
+    # These are auto-created for the section creator
+    @si1 = @section.instructors.first
+    @si2 = @section2.instructors.first
     @former_instructor = create(:section_instructor, section: @section, instructor: @teacher2, status: :removed)
     @former_instructor.destroy!
-    @si2 = create(:section_instructor, section: @section2, instructor: @teacher, status: :active)
     @si3 = create(:section_instructor, section: @section2, instructor: @teacher2, status: :active)
   end
 

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -782,6 +782,41 @@ class SectionTest < ActiveSupport::TestCase
     assert_nil @section.code_review_expires_at
   end
 
+  test 'section create adds section instructor' do
+    assert_difference 'SectionInstructor.count' do
+      section = create(:section)
+      instructor = section.instructors.first
+      assert_equal instructor, section.user
+    end
+  end
+
+  test 'section update fixes section instructor' do
+    section = create(:section)
+    si = section.section_instructors.first
+    si.status = :declined
+    si.save!
+
+    assert_empty section.instructors
+
+    section.name = 'newly renamed!'
+    section.save!
+
+    assert_equal 1, section.instructors.length
+  end
+
+  test 'section update fixes soft-deleted section instructor' do
+    section = create(:section)
+    si = section.section_instructors.first
+    si.destroy!
+
+    assert_empty section.instructors
+
+    section.name = 'newly renamed again!'
+    section.save!
+
+    assert_equal 1, section.instructors.length
+  end
+
   def set_up_code_review_groups
     # create a new section to avoid extra unassigned students
     @code_review_group_section = create(:section, user: @teacher, login_type: 'word')


### PR DESCRIPTION
This change will populate the `SectionInstructor` record for the section's owner whenever the section is created or modified.

## Links

-  [JIRA](https://codedotorg.atlassian.net/browse/TEACH-681)

## Testing story

Automated tests included

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
