### PR TITLE
Add ai confidence to learning goal ai evaluations

### DIFF
--- a/dashboard/app/models/learning_goal_ai_evaluation.rb
+++ b/dashboard/app/models/learning_goal_ai_evaluation.rb
@@ -5,18 +5,19 @@
 #  id               :bigint           not null, primary key
 #  user_id          :integer
 #  learning_goal_id :integer
-#  requester_id     :integer
 #  project_id       :integer
 #  project_version  :string(255)
 #  understanding    :integer
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  requester_id     :integer
+#  ai_confidence    :integer
 #
 # Indexes
 #
 #  index_learning_goal_ai_evaluations_on_learning_goal_id  (learning_goal_id)
-#  index_learning_goal_ai_evaluations_on_user_id           (user_id)
 #  index_learning_goal_ai_evaluations_on_requester_id      (requester_id)
+#  index_learning_goal_ai_evaluations_on_user_id           (user_id)
 #
 class LearningGoalAiEvaluation < ApplicationRecord
   belongs_to :learning_goal

--- a/dashboard/db/migrate/20231012201537_add_ai_confidence_to_learning_goal_ai_evaluations.rb
+++ b/dashboard/db/migrate/20231012201537_add_ai_confidence_to_learning_goal_ai_evaluations.rb
@@ -1,0 +1,5 @@
+class AddAiConfidenceToLearningGoalAiEvaluations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :learning_goal_ai_evaluations, :ai_confidence, :integer
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_11_075239) do
+ActiveRecord::Schema.define(version: 2023_10_12_201537) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -646,6 +646,7 @@ ActiveRecord::Schema.define(version: 2023_10_11_075239) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "requester_id"
+    t.integer "ai_confidence"
     t.index ["learning_goal_id"], name: "index_learning_goal_ai_evaluations_on_learning_goal_id"
     t.index ["requester_id"], name: "index_learning_goal_ai_evaluations_on_requester_id"
     t.index ["user_id"], name: "index_learning_goal_ai_evaluations_on_user_id"


### PR DESCRIPTION
* Depends on https://github.com/code-dot-org/code-dot-org/pull/54182

starts https://codedotorg.atlassian.net/browse/AITT-240. this PR does the DB migration to add the ai_confidence column to the learning_goal_ai_evaluations table. it also fixes the existing annotations for requester_id on this table, and we've confirmed on slack that these changes are desirable.

## Testing story

relying on the existing unit tests which cover LearningGoalAiEvaluation

