### PR TITLE
store more ai config in s3, and write confidence levels to the DB

### DIFF
--- a/dashboard/app/models/learning_goal_ai_evaluation.rb
+++ b/dashboard/app/models/learning_goal_ai_evaluation.rb
@@ -24,6 +24,14 @@ class LearningGoalAiEvaluation < ApplicationRecord
   belongs_to :user
   belongs_to :requester, class_name: 'User'
 
+  AI_CONFIDENCE_LEVEL = {
+    LOW: 1,
+    MEDIUM: 2,
+    HIGH: 3,
+  }.freeze
+
+  validates :ai_confidence, inclusion: {in: AI_CONFIDENCE_LEVEL.values}, allow_nil: true
+
   def summarize_for_instructor
     {
       id: id,

--- a/dashboard/app/models/learning_goal_ai_evaluation.rb
+++ b/dashboard/app/models/learning_goal_ai_evaluation.rb
@@ -24,13 +24,13 @@ class LearningGoalAiEvaluation < ApplicationRecord
   belongs_to :user
   belongs_to :requester, class_name: 'User'
 
-  AI_CONFIDENCE_LEVEL = {
+  AI_CONFIDENCE_LEVELS = {
     LOW: 1,
     MEDIUM: 2,
     HIGH: 3,
   }.freeze
 
-  validates :ai_confidence, inclusion: {in: AI_CONFIDENCE_LEVEL.values}, allow_nil: true
+  validates :ai_confidence, inclusion: {in: AI_CONFIDENCE_LEVELS.values}, allow_nil: true
 
   def summarize_for_instructor
     {

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -102,6 +102,10 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
   # stub out the s3 calls made from the job via read_file_from_s3 and read_examples.
   private def stub_lesson_s3_data
     s3_client = Aws::S3::Client.new(stub_responses: true)
+    fake_confidence_levels = {
+      'learning-goal-1': "MEDIUM",
+      'learning-goal-2': "MEDIUM",
+    }.to_json
     fake_params = {
       'model' => 'gpt-4-0613',
       'remove-comments' => '1',
@@ -113,6 +117,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       'teaching_assistant/lessons/fake-lesson-s3-name/system_prompt.txt' => 'fake-system-prompt',
       'teaching_assistant/lessons/fake-lesson-s3-name/standard_rubric.csv' => 'fake-standard-rubric',
       'teaching_assistant/lessons/fake-lesson-s3-name/params.json' => fake_params,
+      'teaching_assistant/lessons/fake-lesson-s3-name/confidence.json' => fake_confidence_levels,
       'teaching_assistant/lessons/fake-lesson-s3-name/examples/1.js' => 'fake-code-1',
       'teaching_assistant/lessons/fake-lesson-s3-name/examples/1.tsv' => 'fake-response-1',
       'teaching_assistant/lessons/fake-lesson-s3-name/examples/2.js' => 'fake-code-2',
@@ -190,6 +195,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       assert_equal expected_understanding, ai_eval.understanding
       assert_equal project_id, ai_eval.project_id
       assert_equal version_id, ai_eval.project_version
+      assert_equal LearningGoalAiEvaluation::AI_CONFIDENCE_LEVELS[:MEDIUM], ai_eval.ai_confidence
     end
   end
 end

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -102,9 +102,17 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
   # stub out the s3 calls made from the job via read_file_from_s3 and read_examples.
   private def stub_lesson_s3_data
     s3_client = Aws::S3::Client.new(stub_responses: true)
+    fake_params = {
+      'model' => 'gpt-4-0613',
+      'remove-comments' => '1',
+      'num-responses' => '3',
+      'num-passing-grades' => '2',
+      'temperature' => '0.2'
+    }.to_json
     bucket = {
       'teaching_assistant/lessons/fake-lesson-s3-name/system_prompt.txt' => 'fake-system-prompt',
       'teaching_assistant/lessons/fake-lesson-s3-name/standard_rubric.csv' => 'fake-standard-rubric',
+      'teaching_assistant/lessons/fake-lesson-s3-name/params.json' => fake_params,
       'teaching_assistant/lessons/fake-lesson-s3-name/examples/1.js' => 'fake-code-1',
       'teaching_assistant/lessons/fake-lesson-s3-name/examples/1.tsv' => 'fake-response-1',
       'teaching_assistant/lessons/fake-lesson-s3-name/examples/2.js' => 'fake-code-2',
@@ -138,14 +146,14 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     ]
     expected_form_data = {
       "model" => "gpt-4-0613",
+      "remove-comments" => "1",
+      "num-responses" => "3",
+      "num-passing-grades" => "2",
+      "temperature" => "0.2",
       "code" => 'fake-code',
       "prompt" => 'fake-system-prompt',
       "rubric" => 'fake-standard-rubric',
       "examples" => expected_examples.to_json,
-      "remove-comments" => "1",
-      "num-responses" => "3",
-      "num-passing-grades" => "2",
-      "temperature" => "0.2"
     }
     fake_ai_evaluations = [
       {


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-240 . Done in this PR:
* store params.json in S3 so that they are configurable on a per-lesson basis: `model`, `remove-comments`, `num-responses`, `num-passing-grades`, `temperature`
* store confidence level for each learning goal in S3 on a per-lesson basis (high, medium, low)
* write the confidence level to the `LearningGoalAiEvaluation` in the database

I have also uploaded placeholder params.json and confidence.json files to each existing lesson in s3. whoever is working on accuracy for those lessons can find and tweak them to make sure accuracy matches what they're getting in the colab

## Testing story

* updates to existing tests cover new behavior
* manual testing end to end that each lesson can be evaluated using new contents in s3
* manually verified that changing the model name to a bad value in s3://cdo-ai/teaching_assistant/lessons/CSD-2022-U3-L17/params.json causes the job to fail

## Future work

* update the colab to write these and other files from the colab to S3?