### PR TITLE
Add endpoint to request AI evaluation for user

### DIFF
--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -88,7 +88,7 @@ class RubricsController < ApplicationController
   def run_ai_evaluations_for_user
     user_id = params.transform_keys(&:underscore).require(:user_id)
     user = User.find_by(id: user_id)
-    return head :forbidden unless user && (user.student_of?(current_user) || user == current_user)
+    return head :forbidden unless user&.student_of?(current_user)
 
     is_ai_experiment_enabled = current_user && Experiment.enabled?(user: current_user, experiment_name: 'ai-rubrics')
     return head :forbidden unless is_ai_experiment_enabled

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -86,9 +86,8 @@ class RubricsController < ApplicationController
   end
 
   def run_ai_evaluations_for_user
-    permitted_params = params.transform_keys(&:underscore).permit(:id, :user_id)
-
-    user = User.find(permitted_params[:user_id]) || current_user
+    user_id = params.transform_keys(&:underscore).require(:user_id)
+    user = User.find_by(id: user_id)
     return head :forbidden unless user && (user.student_of?(current_user) || user == current_user)
 
     is_ai_experiment_enabled = current_user && Experiment.enabled?(user: current_user, experiment_name: 'ai-rubrics')

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1052,6 +1052,7 @@ Dashboard::Application.routes.draw do
       member do
         get 'get_ai_evaluations'
         get 'get_teacher_evaluations'
+        post 'run_ai_evaluations_for_user'
         post 'submit_evaluations'
       end
     end

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -244,21 +244,4 @@ class RubricsControllerTest < ActionController::TestCase
     }
     assert_response :forbidden
   end
-
-  test "can run ai evaluations for self" do
-    student = create :student
-    sign_in student
-
-    rubric = create :rubric, lesson: @lesson, level: @level
-
-    Experiment.stubs(:enabled?).with(user: student, experiment_name: 'ai-rubrics').returns(true)
-    EvaluateRubricJob.stubs(:ai_enabled?).returns(true)
-    EvaluateRubricJob.expects(:perform_later).with(user_id: student.id, script_level_id: @script_level.id).once
-
-    post :run_ai_evaluations_for_user, params: {
-      id: rubric.id,
-      userId: student.id,
-    }
-    assert_response :success
-  end
 end

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -7,7 +7,7 @@ class RubricsControllerTest < ActionController::TestCase
     @levelbuilder = create :levelbuilder
     @lesson = create(:lesson, :with_lesson_group)
     @level = create(:level)
-    create :script_level, script: @lesson.script, lesson: @lesson, levels: [@level]
+    @script_level = create :script_level, script: @lesson.script, lesson: @lesson, levels: [@level]
   end
 
   # new page is levelbuilder only
@@ -194,5 +194,71 @@ class RubricsControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal 1, json_response.length
     assert_equal submitted_teacher_evaluation.feedback, json_response[0]['feedback']
+  end
+
+  test "run ai evaluations for user calls EvaluateRubricJob" do
+    rubric = create :rubric, lesson: @lesson, level: @level
+    student = create :student
+    teacher = create :teacher
+    create :follower, student_user: student, user: teacher
+    sign_in teacher
+
+    Experiment.stubs(:enabled?).with(user: teacher, experiment_name: 'ai-rubrics').returns(true)
+    EvaluateRubricJob.stubs(:ai_enabled?).returns(true)
+    EvaluateRubricJob.expects(:perform_later).with(user_id: student.id, script_level_id: @script_level.id).once
+
+    post :run_ai_evaluations_for_user, params: {
+      id: rubric.id,
+      userId: student.id,
+    }
+    assert_response :success
+  end
+
+  test "run ai evaluations for user does not call EvaluateRubricJob if ai experiment is disabled" do
+    rubric = create :rubric, lesson: @lesson, level: @level
+    student = create :student
+    teacher = create :teacher
+    create :follower, student_user: student, user: teacher
+    sign_in teacher
+
+    Experiment.stubs(:enabled?).with(user: teacher, experiment_name: 'ai-rubrics').returns(false)
+    EvaluateRubricJob.expects(:perform_later).never
+
+    post :run_ai_evaluations_for_user, params: {
+      id: rubric.id,
+      userId: student.id,
+    }
+    assert_response :forbidden
+  end
+
+  test "cannot run ai evaluations for user if not teacher of student" do
+    student = create :student
+    teacher = create :teacher
+    sign_in teacher
+
+    rubric = create :rubric, lesson: @lesson, level: @level
+
+    post :run_ai_evaluations_for_user, params: {
+      id: rubric.id,
+      userId: student.id,
+    }
+    assert_response :forbidden
+  end
+
+  test "can run ai evaluations for self" do
+    student = create :student
+    sign_in student
+
+    rubric = create :rubric, lesson: @lesson, level: @level
+
+    Experiment.stubs(:enabled?).with(user: student, experiment_name: 'ai-rubrics').returns(true)
+    EvaluateRubricJob.stubs(:ai_enabled?).returns(true)
+    EvaluateRubricJob.expects(:perform_later).with(user_id: student.id, script_level_id: @script_level.id).once
+
+    post :run_ai_evaluations_for_user, params: {
+      id: rubric.id,
+      userId: student.id,
+    }
+    assert_response :success
   end
 end


### PR DESCRIPTION
Adds an endpoint to run the AI evaluation for a specific user, as part of https://codedotorg.atlassian.net/browse/AITT-101. Because this is run for a specific rubric, it will always run on the level of that rubric, on the user's most recent code (feel free to push back on me there). I'm also open to feedback on whether this belongs in a different controller.

This code was largely based off of https://github.com/code-dot-org/code-dot-org/pull/54086.