### PR TITLE
Log enabled experiments for user

### DIFF
--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -27,16 +27,19 @@ class AnalyticsReporter {
     }
   }
 
-  setUserProperties(userId, userType, signInState) {
+  setUserProperties(userId, userType, enabledExperiments) {
     const identifyObj = new Identify();
     const formattedUserId = this.formatUserId(userId);
+    // enabledExperiments sometimes has duplicates
+    const uniqueExperiments = [...new Set(enabledExperiments)];
     setUserId(formattedUserId);
     identifyObj.set('userType', userType);
-    identifyObj.set('signInState', signInState);
+    identifyObj.set('signInState', !!userId);
+    identifyObj.set('enabledExperiments', uniqueExperiments);
 
     if (!this.shouldPutRecord(ALWAYS_SEND)) {
       this.log(
-        `User properties: userId: ${formattedUserId}, userType: ${userType}, signInState: ${signInState}`
+        `User properties: userId: ${formattedUserId}, userType: ${userType}, signInState: ${!!userId}, enabledExperiments: ${uniqueExperiments}`
       );
     }
     identify(identifyObj);

--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -31,7 +31,7 @@ class AnalyticsReporter {
     const identifyObj = new Identify();
     const formattedUserId = this.formatUserId(userId);
     // enabledExperiments sometimes has duplicates
-    const uniqueExperiments = [...new Set(enabledExperiments)];
+    const uniqueExperiments = [...new Set(enabledExperiments)].sort();
     setUserId(formattedUserId);
     identifyObj.set('userType', userType);
     identifyObj.set('signInState', !!userId);

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -1,6 +1,7 @@
 import {makeEnum} from '../utils';
 import analyticsReport from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import experiments from '@cdo/apps/util/experiments';
 
 const SET_CURRENT_USER_NAME = 'currentUser/SET_CURRENT_USER_NAME';
 const SET_USER_SIGNED_IN = 'currentUser/SET_USER_SIGNED_IN';
@@ -134,7 +135,11 @@ export default function currentUser(state = initialState, action) {
   }
   if (action.type === SET_INITIAL_DATA) {
     const {id, username, user_type, mute_music, under_13} = action.serverUser;
-    analyticsReport.setUserProperties(id, user_type, !!id);
+    analyticsReport.setUserProperties(
+      id,
+      user_type,
+      experiments.getEnabledExperiments()
+    );
     return {
       ...state,
       userId: id,


### PR DESCRIPTION
Adds enabled experiments as a user property in Amplitude. Ideally, this will allow us to better track key metrics when piloting. The experiments that appear in the list include any pilot and any experiments enabled with the `enableExperiments` URL param.

Example of what this looks like in Amplitude from my local test event:

<img width="1142" alt="Screenshot 2023-10-13 at 8 17 05 AM" src="https://github.com/code-dot-org/code-dot-org/assets/46464143/6d799cae-f617-4522-8c2f-89c8c7f07fe6">

I did discover that the return value from `getEnabledExperiments` had a lot of repeats (I think the list was there 8 times for some reason?). I don't really have the cycles to dig into that problem, so I simply filtered out duplicates.
