### PR TITLE
Allow signed out users to access https://studio.code.org/certificates/batch

### DIFF
--- a/dashboard/app/controllers/certificates_controller.rb
+++ b/dashboard/app/controllers/certificates_controller.rb
@@ -3,8 +3,6 @@ require 'base64'
 class CertificatesController < ApplicationController
   include CertificatesHelper
 
-  before_action :authenticate_user!, only: [:batch]
-
   # GET /certificates/:encoded_params
   # encoded_params includes:
   #   name - student name (optional)
@@ -43,7 +41,7 @@ class CertificatesController < ApplicationController
   # GET /certificates/batch
   # POST /certificates/batch
   def batch
-    unless current_user.teacher?
+    if current_user&.student?
       return redirect_to root_path, alert: 'You must be signed in as a teacher to bulk print certificates.'
     end
 

--- a/dashboard/test/controllers/certificates_controller_test.rb
+++ b/dashboard/test/controllers/certificates_controller_test.rb
@@ -65,7 +65,7 @@ class CertificatesControllerTest < ActionController::TestCase
     assert_equal '//test.code.org/images/hour_of_code_certificate.jpg', response_data['imageUrl']
   end
 
-  test_user_gets_response_for :batch, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+  test_user_gets_response_for :batch, user: nil, response: :success
   test_user_gets_response_for :batch, user: :student, response: :redirect, redirected_to: '/'
   test_user_gets_response_for :batch, user: :teacher, response: :success
 


### PR DESCRIPTION
Allows signed out users to access https://studio.code.org/certificates/batch while still preventing students from accessing.

### Signed out user
<img width="1792" alt="Screenshot 2023-10-13 at 11 48 39 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/0cc1de8d-f07a-4d4b-8789-d161deffc3be">

### Signed in student denied access
<img width="1792" alt="Screenshot 2023-10-13 at 11 51 07 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/bbcacd9d-588d-4f0e-8945-6451b3e794e9">

### Signed in teacher still has access
<img width="1792" alt="Screenshot 2023-10-13 at 11 52 05 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/e32832de-762d-48bc-845b-e5dddc69e87e">

## Links
- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?selectedIssue=ACQ-1026)


## Testing story
Local



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
