### PR TITLE
Use Keyword Argument for `student_facing` in Curriculum PDFs

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -257,7 +257,7 @@ class Lesson < ApplicationRecord
 
   def student_lesson_plan_pdf_url
     if script.is_migrated && script.include_student_lesson_plans && has_lesson_plan
-      Services::CurriculumPdfs.get_lesson_plan_url(self, true)
+      Services::CurriculumPdfs.get_lesson_plan_url(self, student_facing: true)
     end
   end
 

--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -117,7 +117,7 @@ module Services
     def self.get_pdfless_lessons(script)
       script.lessons.select(&:has_lesson_plan).select do |lesson|
         !lesson_plan_pdf_exists_for?(lesson) ||
-          (script.include_student_lesson_plans && !lesson_plan_pdf_exists_for?(lesson, true))
+          (script.include_student_lesson_plans && !lesson_plan_pdf_exists_for?(lesson, student_facing: true))
       end
     end
 
@@ -162,7 +162,7 @@ module Services
           get_pdfless_lessons(script).each do |lesson|
             puts "Generating missing Lesson PDFs for #{lesson.key} (from #{script.name})"
             generate_lesson_pdf(lesson, dir)
-            generate_lesson_pdf(lesson, dir, true)
+            generate_lesson_pdf(lesson, dir, student_facing: true)
             any_pdf_generated = true
           end
 

--- a/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
+++ b/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
@@ -17,7 +17,7 @@ module Services
         # <Pathname:csp1-2021/20210216001309/teacher-lesson-plans/Welcome to CSP.pdf>
         # and this for student lesson plans
         # <Pathname:csp1-2021/20210216001309/student-lesson-plans/Welcome to CSP.pdf>
-        def get_lesson_plan_pathname(lesson, student_facing = false, versioned: true)
+        def get_lesson_plan_pathname(lesson, student_facing: false, versioned: true)
           return nil unless lesson&.script&.seeded_from
           version_number = versioned ? Time.parse(lesson.script.seeded_from).to_s(:number) : 'fallback'
           suffix = student_facing ? '-Student' : ''
@@ -29,26 +29,26 @@ module Services
         # Build the full user-facing url where a PDF can be found for the given lesson.
         #
         # Expect this to look something like this: "https://lesson-plans.code.org/csp1-2021/20210909014219/teacher-lesson-plans/Welcome+to+CSP.pdf"
-        def get_lesson_plan_url(lesson, student_facing = false)
-          versioned = lesson_plan_pdf_exists_for?(lesson, student_facing)
-          pathname = get_lesson_plan_pathname(lesson, student_facing, versioned: versioned)
+        def get_lesson_plan_url(lesson, student_facing: false)
+          versioned = lesson_plan_pdf_exists_for?(lesson, student_facing: student_facing)
+          pathname = get_lesson_plan_pathname(lesson, student_facing: student_facing, versioned: versioned)
           return nil if pathname.blank?
 
           File.join(get_base_url, pathname)
         end
 
         # Check S3 to see if we've already generated a PDF for the given lesson.
-        def lesson_plan_pdf_exists_for?(lesson, student_facing = false)
-          pathname = get_lesson_plan_pathname(lesson, student_facing).to_s
+        def lesson_plan_pdf_exists_for?(lesson, student_facing: false)
+          pathname = get_lesson_plan_pathname(lesson, student_facing: student_facing).to_s
           return pdf_exists_at?(pathname)
         end
 
         # Generate the PDF for the given lesson into the given directory. Can
         # provide either a teacher- or a student-facing version of the content.
-        def generate_lesson_pdf(lesson, directory = "/tmp/", student_facing = false)
+        def generate_lesson_pdf(lesson, directory = "/tmp/", student_facing: false)
           url = student_facing ? Rails.application.routes.url_helpers.script_lesson_student_url(lesson.script, lesson) : Rails.application.routes.url_helpers.script_lesson_url(lesson.script, lesson)
-          pathname = get_lesson_plan_pathname(lesson, student_facing)
-          fallback_pathname = get_lesson_plan_pathname(lesson, student_facing, versioned: false)
+          pathname = get_lesson_plan_pathname(lesson, student_facing: student_facing)
+          fallback_pathname = get_lesson_plan_pathname(lesson, student_facing: student_facing, versioned: false)
 
           ChatClient.log "Generating #{pathname.to_s.inspect} from #{url.inspect}" if DEBUG
 

--- a/dashboard/test/lib/services/curriculum_pdfs/lesson_plans_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs/lesson_plans_test.rb
@@ -21,11 +21,11 @@ class Services::CurriculumPdfs::LessonPlansTest < ActiveSupport::TestCase
   test 'urls are escaped' do
     script = create(:script, name: "test-escapes-script", seeded_from: Time.at(0))
     lesson = create(:lesson, script: script, name: "Some!name_with?special/characters")
-    Services::CurriculumPdfs.expects(:lesson_plan_pdf_exists_for?).with(lesson, false).returns(true)
+    Services::CurriculumPdfs.expects(:lesson_plan_pdf_exists_for?).with(lesson, student_facing: false).returns(true)
     assert_equal Pathname.new("test-escapes-script/19700101000000/teacher-lesson-plans/Some-name_with-special-characters.pdf"),
-      Services::CurriculumPdfs.get_lesson_plan_pathname(lesson, false)
+      Services::CurriculumPdfs.get_lesson_plan_pathname(lesson, student_facing: false)
     assert_equal "https://lesson-plans.code.org/test-escapes-script/19700101000000/teacher-lesson-plans/Some-name_with-special-characters.pdf",
-      Services::CurriculumPdfs.get_lesson_plan_url(lesson, false)
+      Services::CurriculumPdfs.get_lesson_plan_url(lesson, student_facing: false)
   end
 
   test 'pathnames are differentiated by audience' do
@@ -34,7 +34,7 @@ class Services::CurriculumPdfs::LessonPlansTest < ActiveSupport::TestCase
     assert_equal Pathname.new("test-pathnames-script/19700101000000/teacher-lesson-plans/test-pathnames-lesson.pdf"),
       Services::CurriculumPdfs.get_lesson_plan_pathname(lesson)
     assert_equal Pathname.new("test-pathnames-script/19700101000000/student-lesson-plans/test-pathnames-lesson-Student.pdf"),
-      Services::CurriculumPdfs.get_lesson_plan_pathname(lesson, true)
+      Services::CurriculumPdfs.get_lesson_plan_pathname(lesson, student_facing: true)
   end
 
   test 'Lesson PDFs are generated into the given directory' do
@@ -56,10 +56,10 @@ class Services::CurriculumPdfs::LessonPlansTest < ActiveSupport::TestCase
     Dir.mktmpdir('curriculum_pdfs_test') do |tmpdir|
       assert Dir.glob(File.join(tmpdir, '**/*.pdf')).empty?
       url = Rails.application.routes.url_helpers.script_lesson_student_url(script, lesson)
-      filename = File.join(tmpdir, Services::CurriculumPdfs.get_lesson_plan_pathname(lesson, true))
+      filename = File.join(tmpdir, Services::CurriculumPdfs.get_lesson_plan_pathname(lesson, student_facing: true))
       PDF.expects(:generate_from_url).with(url, filename)
       FileUtils.stubs(:cp)
-      Services::CurriculumPdfs.generate_lesson_pdf(lesson, tmpdir, true)
+      Services::CurriculumPdfs.generate_lesson_pdf(lesson, tmpdir, student_facing: true)
     end
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/54083, which fixed a variety of smaller instances of `Style/OptionalBooleanParameter` violations. This one focuses on violations in a single part of the codebase: the Curriculum PDF generation, and specifically the `student_facing` optional parameter.

Rather than invoking the various methods which can optionally express different functionality for students than for teachers like so:

```ruby
Services::CurriculumPdfs.get_lesson_plan_url(self, true)
```

With this change, we will now invoke them more verbosely and explicitly, like so:

```ruby
Services::CurriculumPdfs.get_lesson_plan_url(self, student_facing: true)
```

## Links

- https://docs.rubocop.org/rubocop/cops_style.html#styleoptionalbooleanparameter
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/OptionalBooleanParameter

## Testing story

Updated one unit tests as appropriate; generally relying on our existing test coverage to confirm that this implementation change does not break any existing functionality.