### PR TITLE
Remove Some Unused Test Helper Methods

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/workshop_attendance_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_attendance_controller_test.rb
@@ -335,23 +335,4 @@ class Api::V1::Pd::WorkshopAttendanceControllerTest < ActionDispatch::Integratio
     assert_equal 1, attendance.length
     attendance.first
   end
-
-  def params(attended = true)
-    attendances = attended ? [{id: @teacher.id}] : []
-    {
-      session_attendances: [
-        session_id: @session.id,
-        attendances: attendances
-      ]
-    }
-  end
-
-  def create_user_params(enrolled_teacher_email)
-    {
-      session_attendances: [
-        session_id: @session.id,
-        attendances: [{email: enrolled_teacher_email}]
-      ]
-    }
-  end
 end


### PR DESCRIPTION
Looks like both the `create_user_params` and `params` helper methods were refactored out of being used in https://github.com/code-dot-org/code-dot-org/pull/12071, but were not removed at that time. I stumbled across them as part of https://github.com/code-dot-org/code-dot-org/pull/54191; rather than updating the `params` method here to use a keyword argument, I think we should just remove both it and its sibling entirely.

## Testing story

Relying on existing tests to verify that no tests are actually depending on these methods.