### PR TITLE
[Google Blockly] Don't add dummy after statement input

### DIFF
--- a/apps/src/blockly/addons/blockSvgFrame.js
+++ b/apps/src/blockly/addons/blockSvgFrame.js
@@ -106,9 +106,6 @@ export default class BlockSvgFrame {
   }
 
   render(svgGroup, isRtl, minWidthAdjustment) {
-    if (!svgGroup) {
-      return;
-    }
     // Remove ourselves from the DOM and calculate the size of our
     // container, then insert ourselves into the container.
     // We do this because otherwise, the value returned by

--- a/apps/src/blockly/addons/blockSvgFrame.js
+++ b/apps/src/blockly/addons/blockSvgFrame.js
@@ -106,6 +106,9 @@ export default class BlockSvgFrame {
   }
 
   render(svgGroup, isRtl, minWidthAdjustment) {
+    if (!svgGroup) {
+      return;
+    }
     // Remove ourselves from the DOM and calculate the size of our
     // container, then insert ourselves into the container.
     // We do this because otherwise, the value returned by

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -157,8 +157,9 @@ GoogleBlockly.Extensions.register('procedure_def_mini_toolbox', function () {
     return;
   }
 
-  const flyoutToggleButton =
-    Blockly.customBlocks.initializeMiniToolbox.bind(this)(true);
+  const flyoutToggleButton = Blockly.customBlocks.initializeMiniToolbox.bind(
+    this
+  )(undefined, true);
   Blockly.customBlocks.appendMiniToolboxToggle.bind(this)(
     miniToolboxBlocks,
     flyoutToggleButton,

--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
@@ -16,6 +16,7 @@ const INPUTS = {
 export const blocks = {
   // Creates and returns a toggle button field. This field should be
   // added to the block after other inputs have been created.
+  // miniToolboxBlocks is a backwards-compatible parameter used in CDO Blockly.
   initializeMiniToolbox(miniToolboxBlocks, renderToolboxBeforeStack = false) {
     // Function to create the flyout
     const createFlyoutField = function (block) {

--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
@@ -16,7 +16,7 @@ const INPUTS = {
 export const blocks = {
   // Creates and returns a toggle button field. This field should be
   // added to the block after other inputs have been created.
-  initializeMiniToolbox(renderToolboxBeforeStack = false) {
+  initializeMiniToolbox(miniToolboxBlocks, renderToolboxBeforeStack = false) {
     // Function to create the flyout
     const createFlyoutField = function (block) {
       const flyoutKey = CdoFieldFlyout.getFlyoutId(block);

--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
@@ -99,7 +99,11 @@ export const blocks = {
     // https://github.com/google/blockly-samples/tree/master/plugins/renderer-inline-row-separators
     const lastInput = this.inputList[this.inputList.length - 1];
     // Force add a dummy input at the end of the block, if needed.
-    if (lastInput.type !== Blockly.inputTypes.DUMMY) {
+    if (
+      ![Blockly.inputTypes.DUMMY, Blockly.inputTypes.STATEMENT].includes(
+        lastInput.type
+      )
+    ) {
       this.appendDummyInput();
     }
 

--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
@@ -31,7 +31,11 @@ export const blocks = {
       // By default, the flyout is added after the stack input (at the bottom of the block).
       // This flag is used by behavior and function definitions, mainly in the modal function editor,
       // to add the flyout before the stack input (at the top of the block).
-      if (renderToolboxBeforeStack) {
+      if (
+        renderToolboxBeforeStack &&
+        block.getInput(INPUTS.FLYOUT) &&
+        block.getInput(INPUTS.STACK)
+      ) {
         block.moveInputBefore(INPUTS.FLYOUT, INPUTS.STACK);
       }
       return flyoutField;


### PR DESCRIPTION
This removes an unnecessary dummy input that was being added to the bottom of `behavior_definition` blocks.


Before:

<img width="373" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/09d58531-53ac-4851-8260-952776e5ee0b">

After:

<img width="385" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/da3a886a-3e9b-4a4c-a8c0-16c261dee1c3">

I also noticed a regression (introduced with https://github.com/code-dot-org/code-dot-org/issues/54080) that was breaking other mini-toolbox blocks due to a mismatch in the signature of `initializeMiniToolbox`. The CDO Blockly version of this function expects a `miniToolboxBlocks` argument when called in `block_utils.js`: https://github.com/code-dot-org/code-dot-org/blob/mike/behavior-flyouts/apps/src/block_utils.js#L1077

When this same call is made using the Google Blockly wrapper, the `miniToolboxBlocks` was getting misused as a truthy value for `renderToolboxBeforeStack`. We can get around this by adding the first parameter to both versions of the function and making `renderToolboxBeforeStack` the second parameter. This created a bug where we would crash because we were trying to reorder inputs that don't exist on certain blocks:
<img width="688" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/91a5c8f1-a570-4d09-8738-046bda42ddda">

This PR fixes that regression. I also double-checked that we are still adding the dummy input at the end of our minitoolbox event blocks:
<img width="565" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/272cf0d1-5161-46cf-bc94-0454808ced93">

<img width="462" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/59e70ff7-3fdd-420c-93f5-80004c66cc38">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
