### PR TITLE
Manually add tips to learning goals

### DIFF
--- a/dashboard/config/scripts_json/csd3-2023.script_json
+++ b/dashboard/config/scripts_json/csd3-2023.script_json
@@ -17,7 +17,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2023-10-04 16:17:45 UTC",
+    "serialized_at": "2023-10-16 17:31:17 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -20919,11 +20919,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "Your program either has conditionals that all respond to user input (or all using sprite properties/variables) or only has 1 conditional inside the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "041ea3a6-89aa-4746-a413-bd2cd7f40c57",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program uses at least 2 conditionals inside the draw loop - 1 that responds to user input and 1 that is triggered by a variable or sprite property.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "041ea3a6-89aa-4746-a413-bd2cd7f40c57",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program uses at least 3 conditionals inside the draw loop - 1 (or more) responds to user input and 1 (or more) is triggered by a variable or sprite property (5).\n\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "041ea3a6-89aa-4746-a413-bd2cd7f40c57",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "The project guide is incomplete or missing.",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "0bb58299-9d28-4047-b3ef-680bfb8d7982",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "The project guide is filled out, but is not complete or does not reflect the submitted project.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "0bb58299-9d28-4047-b3ef-680bfb8d7982",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "The project guide is mostly complete and is generally reflective of the submitted project.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "0bb58299-9d28-4047-b3ef-680bfb8d7982",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "The project guide is complete and reflects the project as submitted.\n\n\n\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "0bb58299-9d28-4047-b3ef-680bfb8d7982",
         "lesson.key": "Mini-Project - Flyer Game",
         "lesson_group.key": "lessonGroup-3",
@@ -20943,11 +21015,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "At least 1 sprite created. No properties updated after creation.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "0e77d5a5-1b7f-45c7-a88f-9ca19d8aff65",
+        "lesson.key": "Mini-Project - Captioned Scenes",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "At least 1 sprite created with at least one property updated after creation.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "0e77d5a5-1b7f-45c7-a88f-9ca19d8aff65",
+        "lesson.key": "Mini-Project - Captioned Scenes",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "At least 2 sprites created, each with at least one property updated after creation (2).",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "0e77d5a5-1b7f-45c7-a88f-9ca19d8aff65",
+        "lesson.key": "Mini-Project - Captioned Scenes",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "The project guide is not filled out or is unrelated to the program.",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "209798cd-e25b-4b96-bf1b-699f090bdb77",
+        "lesson.key": "Mini-Project - Captioned Scenes",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "Some elements are used as described in the project guide.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "209798cd-e25b-4b96-bf1b-699f090bdb77",
+        "lesson.key": "Mini-Project - Captioned Scenes",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Elements are generally used as described in the project guide.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "209798cd-e25b-4b96-bf1b-699f090bdb77",
+        "lesson.key": "Mini-Project - Captioned Scenes",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Elements are used as described in the project guide and clearly display a captioned scene.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "209798cd-e25b-4b96-bf1b-699f090bdb77",
         "lesson.key": "Mini-Project - Captioned Scenes",
         "lesson_group.key": "lessonGroup-2",
@@ -20967,11 +21111,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "Your program either has conditionals that all respond to user input (or all using sprite properties/variables) or only has 1 conditional inside the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "22ddc635-6856-4924-813a-9a99fb2e5548",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program uses at least 2 conditionals inside the draw loop - 1 that responds to user input and 1 that is triggered by a variable or sprite property.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "22ddc635-6856-4924-813a-9a99fb2e5548",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program uses at least 3 conditionals inside the draw loop - 1 (or more) responds to user input and 1 (or more) is triggered by a variable or sprite property (5).\n\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "22ddc635-6856-4924-813a-9a99fb2e5548",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "Errors in program sequencing are significant enough to keep the output from resembling the intended scene or the Draw loop is not used to create animation.",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "2777b8f6-5ea2-42c3-82bb-00d8f5d61823",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "You have several sequencing errors, resulting in many elements unintentionally hidden or overlapping others. Some code is improperly placed in or out of the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "2777b8f6-5ea2-42c3-82bb-00d8f5d61823",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "You property separated code in and out of the draw loop, however they have a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "2777b8f6-5ea2-42c3-82bb-00d8f5d61823",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "You sequenced the program well1  and properly separated code in and out of the draw loop (2).\n\n\n\n\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "2777b8f6-5ea2-42c3-82bb-00d8f5d61823",
         "lesson.key": "Mini-Project - Flyer Game",
         "lesson_group.key": "lessonGroup-3",
@@ -20991,11 +21207,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "A cumulative of at least a total of 3 elements are placed on the screen using the coordinate system (e.g 2 sprites & 1 line of text or 1 sprite, 1 shape, & 1 line of text).",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "2a5cc4ca-7b41-43e4-8cf9-cce00df53071",
+        "lesson.key": "Mini-Project - Animation",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "At least 1 shape, 2 sprites, and 1 line of text are placed on the screen using the coordinate system. At least 1 element moves during the program.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "2a5cc4ca-7b41-43e4-8cf9-cce00df53071",
+        "lesson.key": "Mini-Project - Animation",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "At least 2 shapes, 2 sprites, and 2 lines of text are placed correctly on the screen using the coordinate system. At least 2 elements move in different ways (4).",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "2a5cc4ca-7b41-43e4-8cf9-cce00df53071",
+        "lesson.key": "Mini-Project - Animation",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "Your program does not update any of the provided non-sprite variables during the game. ",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "2cde744a-0368-4bf0-8e2b-22e3b4d49b29",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "Your program properly updates at least one provided non-sprite variable during the game and properly updates at least one of the variable totals on the screen.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "2cde744a-0368-4bf0-8e2b-22e3b4d49b29",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program properly updates the two provided non-sprite variables during the game and properly updates at least one of the variable totals on the screen.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "2cde744a-0368-4bf0-8e2b-22e3b4d49b29",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program properly updates the two provided non-sprite variables during the game and properly displays the variable totals on the screen.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "2cde744a-0368-4bf0-8e2b-22e3b4d49b29",
         "lesson.key": "Mini-Project - Side Scroller",
         "lesson_group.key": "lessonGroup-3",
@@ -21015,11 +21303,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "Your program includes simple, independent movement (8).\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "399be9ff-d418-4b73-8776-a2564b5c3c95",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program includes at least one instance of complex movement.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "399be9ff-d418-4b73-8776-a2564b5c3c95",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program includes at least two instances of complex movement (7).",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "399be9ff-d418-4b73-8776-a2564b5c3c95",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "You did not give feedback to peers",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "3a264bf8-ae90-4eba-8442-0adee5613bd1",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "You gave some feedback to peers.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "3a264bf8-ae90-4eba-8442-0adee5613bd1",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "You gave and responded to peer feedback.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "3a264bf8-ae90-4eba-8442-0adee5613bd1",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "You gave thoughtful feedback to peers and you responded to peer feedback by making appropriate changes to program.You sequenced the program well1  and properly separated code in and out of the draw loop2.\nYou property separated code in and out of the draw loop, however they have a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.\nYou have several sequencing errors, resulting in many elements unintentionally hidden or overlapping others. Some code is improperly placed in or out of the loop.\nErrors in program sequencing are significant enough to keep the output from resembling the intended scene or the Draw loop is not used to create animation\n\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "3a264bf8-ae90-4eba-8442-0adee5613bd1",
         "lesson.key": "Project - Interactive Card",
         "lesson_group.key": "lessonGroup-2",
@@ -21039,11 +21399,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "At least 1 sprite created. No properties updated inside the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "44ad9d40-4f3a-4ed7-91ab-cf6e86315b7f",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "At least 1 sprite created with at least one property updated inside the draw loop.\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "44ad9d40-4f3a-4ed7-91ab-cf6e86315b7f",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "At least 3 sprites created, each with at least one property updating in the draw loop (3).",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "44ad9d40-4f3a-4ed7-91ab-cf6e86315b7f",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "Your program does not create or update any non-sprite variables. ",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "4adf5a99-20ce-442f-859a-acf0b7989e47",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "Your program properly creates at least 1 non-sprite variable and updates it during the game but it either is not displayed or does not affect the way the game is played.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "4adf5a99-20ce-442f-859a-acf0b7989e47",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program properly creates at least 1 non-sprite variable that is displayed and updated during the game and affects the way the game is played.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "4adf5a99-20ce-442f-859a-acf0b7989e47",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program properly creates at least 2 non-sprite variables, such as score or health, that are displayed and updated during the game and affect how the game is played (9).\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "4adf5a99-20ce-442f-859a-acf0b7989e47",
         "lesson.key": "Project - Design a Game",
         "lesson_group.key": "lessonGroup-3",
@@ -21063,11 +21495,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "Your program code has multiple backgrounds but only one is ever displayed during run time.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "54e8c420-ae5b-4c43-9030-1686cc588f73",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your game has at least two backgrounds that are displayed during run time.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "54e8c420-ae5b-4c43-9030-1686cc588f73",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your game has at least three backgrounds that are displayed during run time (3). At least one of these backgrounds is triggered automatically through a variable (4).\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "54e8c420-ae5b-4c43-9030-1686cc588f73",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "Your entire program code is within the draw loop. ",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "57428b8b-954f-4e25-b6cf-1dd6338ef623",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "You have significant sequencing errors, which include either sprites created within the draw loop or functions created within the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "57428b8b-954f-4e25-b6cf-1dd6338ef623",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program effectively creates sprites and defines functions outside of the draw loop, however there are multiple code segments within the draw loop that should be situated within their own functions outside the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "57428b8b-954f-4e25-b6cf-1dd6338ef623",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "You sequenced the program well1  and properly separated code in and out of the draw loop (2).",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "57428b8b-954f-4e25-b6cf-1dd6338ef623",
         "lesson.key": "Project - Design a Game",
         "lesson_group.key": "lessonGroup-3",
@@ -21087,11 +21591,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "At least 2 sprites created and animations set. The x velocity of the target or obstacle not set or set inside the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "57e3c214-b967-4f74-8567-b5e3903ab35e",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "At least 2 sprites created and animations set properly. The x velocity of the target or obstacle properly set outside the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "57e3c214-b967-4f74-8567-b5e3903ab35e",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "At least 3 sprites created and animations set3 properly. The x velocity of the target and obstacle properly set outside the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "57e3c214-b967-4f74-8567-b5e3903ab35e",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "Your program does not have conditionals to respond to user input. ",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "60e95a3f-7aa8-4742-b0ca-ac95e0129c9b",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "Your program does not have conditionals to respond to user input. ",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "60e95a3f-7aa8-4742-b0ca-ac95e0129c9b",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program has conditionals to respond to multiple types of user input that are meant to control the player sprite’s movement, however the sprite does not respond as expected (5). ",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "60e95a3f-7aa8-4742-b0ca-ac95e0129c9b",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program has conditionals to respond to multiple types of user input that control the player sprite’s movement (4) inside the draw loop. ",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "60e95a3f-7aa8-4742-b0ca-ac95e0129c9b",
         "lesson.key": "Mini-Project - Flyer Game",
         "lesson_group.key": "lessonGroup-3",
@@ -21111,11 +21687,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "Your program either does not have a conditional in the draw loop required to control player interactions with the target, or has the required conditional but it does not work as expected.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "77f2629f-82e1-448c-858f-aee5228f0f79",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program has a conditional and at least 1 collision detection block in the draw loop meant to control multiple sprite interactions with the player, however one of them does not work as expected.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "77f2629f-82e1-448c-858f-aee5228f0f79",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program has a conditional and at least 2 collision detection blocks to control multiple sprite interactions (7) with the player inside the draw loop. \n\n\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "77f2629f-82e1-448c-858f-aee5228f0f79",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "No elements (sprites or shapes) are placed on the screen using the coordinate system.",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "7d31cf32-6a46-4118-885b-0bf347af51a6",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "At least one element is placed on the screen using the coordinate system.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "7d31cf32-6a46-4118-885b-0bf347af51a6",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "At least 2 sprites and 1 other element is placed on the screen using the coordinate system. The sprites move during the program.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "7d31cf32-6a46-4118-885b-0bf347af51a6",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "At least 3 sprites and at least 2 other elements are placed on the screen using the coordinate system. The sprites move in different ways (6).",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "7d31cf32-6a46-4118-885b-0bf347af51a6",
         "lesson.key": "Project - Interactive Card",
         "lesson_group.key": "lessonGroup-2",
@@ -21135,11 +21783,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "A cumulative of at least a total of 3 elements are placed on the screen using the coordinate system (e.g 2 sprites & 1 line of text or 1 sprite, 1 shape, & 1 line of text)",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "846752b3-e04d-466c-818b-1215a9d280ff",
+        "lesson.key": "Mini-Project - Captioned Scenes",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "At least 1 shape, 2 sprites, and 1 line of text are placed on the screen using the coordinate system.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "846752b3-e04d-466c-818b-1215a9d280ff",
+        "lesson.key": "Mini-Project - Captioned Scenes",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "At least 2 shapes, 2 sprites, and 2 lines of text are placed correctly on the screen using the coordinate system.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "846752b3-e04d-466c-818b-1215a9d280ff",
+        "lesson.key": "Mini-Project - Captioned Scenes",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "There are no functions created outside the draw loop and used in your program.",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "8b861c07-599f-490d-b0c9-1b9bbfc66a5d",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "At least one function is created outside the draw loop and used in your program.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "8b861c07-599f-490d-b0c9-1b9bbfc66a5d",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "At least two functions are created outside the draw loop and used in your program to organize your code into logical segments.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "8b861c07-599f-490d-b0c9-1b9bbfc66a5d",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "At least three functions are created outside the draw loop and used to organize your code into logical segments.  At least one of these functions is called multiple times in your program. \n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "8b861c07-599f-490d-b0c9-1b9bbfc66a5d",
         "lesson.key": "Project - Design a Game",
         "lesson_group.key": "lessonGroup-3",
@@ -21159,11 +21879,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "Your program either does not have multiple conditionals to control complex sprite interactions, or has multiple conditionals but none of them work as expected.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "925dbfb9-3410-40e8-a9a7-f8d2eef26608",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program has multiple conditionals meant to control complex sprite interactions, however one of them does not work as expected.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "925dbfb9-3410-40e8-a9a7-f8d2eef26608",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program includes multiple conditionals to control complex interactions between sprites (6) which either affect the sprites themselves, such as resetting their location, or affect the gameplay, such as increasing or decreasing the score. \n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "925dbfb9-3410-40e8-a9a7-f8d2eef26608",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "No elements (sprites or shapes) are placed on the screen using the coordinate system.",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "At least one element is placed on the screen using the coordinate system.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "At least 2 sprites and 1 other element is placed on the screen using the coordinate system. The sprites move during the program.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "At least 3 sprites and at least 2 other elements are placed on the screen using the coordinate system. The sprites move in different ways (6).",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
         "lesson.key": "Project - Interactive Card",
         "lesson_group.key": "lessonGroup-2",
@@ -21183,11 +21975,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "Your program either does not have all conditionals in the draw loop needed to control the obstacle sprites’ looping behavior, or has required conditionals but none of them work as expected.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "99c5fae6-a61c-42c0-88d5-616f5abf4a22",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program has conditionals in the draw loop meant to control the obstacle sprites’ looping behavior, however one of the obstacles does not behave as expected.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "99c5fae6-a61c-42c0-88d5-616f5abf4a22",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program has conditionals to control the obstacle sprites’ looping behavior6 inside the draw loop. \n\n\n\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "99c5fae6-a61c-42c0-88d5-616f5abf4a22",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "Your program does not use any code for detecting user input, such as keyDown() or mouseDown().",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "9a4d1dbd-81a3-42af-bc35-f6e3cfa4d8ea",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "Your program contains code for detecting user input, such as keyDown(), but it is not used correctly and the program does not respond. ",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "9a4d1dbd-81a3-42af-bc35-f6e3cfa4d8ea",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program responds to 1 type of user input.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "9a4d1dbd-81a3-42af-bc35-f6e3cfa4d8ea",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program responds to at least 2 different types of user input (5). ",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "9a4d1dbd-81a3-42af-bc35-f6e3cfa4d8ea",
         "lesson.key": "Project - Design a Game",
         "lesson_group.key": "lessonGroup-3",
@@ -21207,11 +22071,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "Your program either does not have all conditionals in the draw loop needed to control multiple sprites’ looping behavior, or has required conditionals but none of them work as expected.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "a152d8e7-212a-4765-be3f-1a94b70e54cb",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program has conditionals in the draw loop meant to control multiple sprites’ looping behavior, however one of them does not work as expected.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "a152d8e7-212a-4765-be3f-1a94b70e54cb",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program has conditionals to control multiple sprites’ looping behavior (6) inside the draw loop. ",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "a152d8e7-212a-4765-be3f-1a94b70e54cb",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "No sprites are used in the program.",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "aa66e9b9-1889-4e6d-bfda-ceba0933b50a",
+        "lesson.key": "Mini-Project - Animation",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "At least 1 sprite created. No properties updated inside the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "aa66e9b9-1889-4e6d-bfda-ceba0933b50a",
+        "lesson.key": "Mini-Project - Animation",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "At least 1 sprite created with at least one property updated inside the draw loop",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "aa66e9b9-1889-4e6d-bfda-ceba0933b50a",
+        "lesson.key": "Mini-Project - Animation",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "At least 2 sprites created, each with at least one property updating in the draw loop (3).",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "aa66e9b9-1889-4e6d-bfda-ceba0933b50a",
         "lesson.key": "Mini-Project - Animation",
         "lesson_group.key": "lessonGroup-2",
@@ -21231,11 +22167,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "Your program either does not have all conditionals in the draw loop required to control multiple sprite interactions, or has required conditionals but none of them work as expected.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "aeccf857-12f6-45c5-a8c0-32ddf3b4e5db",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program has conditionals in the draw loop meant to control multiple sprite interactions, however one of them does not work as expected.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "aeccf857-12f6-45c5-a8c0-32ddf3b4e5db",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program has conditionals to control multiple sprite interactions (7) inside the draw loop. ",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "aeccf857-12f6-45c5-a8c0-32ddf3b4e5db",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "The project guide is incomplete or missing.",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "afe3bcb1-c5f1-4405-b402-f6e0718b1ae8",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "The project guide is filled out, but is not complete or does not reflect the submitted project.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "afe3bcb1-c5f1-4405-b402-f6e0718b1ae8",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "The project guide is mostly complete and is generally reflective of the submitted project.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "afe3bcb1-c5f1-4405-b402-f6e0718b1ae8",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "The project guide is complete and reflects the project as submitted.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "afe3bcb1-c5f1-4405-b402-f6e0718b1ae8",
         "lesson.key": "Mini-Project - Side Scroller",
         "lesson_group.key": "lessonGroup-3",
@@ -21255,11 +22263,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "You have several sequencing errors, resulting in many elements unintentionally hidden or overlapping others. Some code is improperly placed in or out of the loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "b747206d-550a-4bc5-8fb4-3f104909e68c",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "You property separated code in and out of the draw loop, however they have a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "b747206d-550a-4bc5-8fb4-3f104909e68c",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "You sequenced the program well1  and properly separated code in and out of the draw loop (2).",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "b747206d-550a-4bc5-8fb4-3f104909e68c",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "Errors in program sequencing are significant enough to keep the output from resembling the intended scene or the Draw loop is not used to create animation",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "cc7a008d-06d3-4754-8c72-07d620a48b8a",
+        "lesson.key": "Mini-Project - Animation",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "You have several sequencing errors, resulting in many elements unintentionally hidden or overlapping others. Some code is improperly placed in or out of the loop",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "cc7a008d-06d3-4754-8c72-07d620a48b8a",
+        "lesson.key": "Mini-Project - Animation",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "You properly separated code in and out of the draw loop, however they have a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "cc7a008d-06d3-4754-8c72-07d620a48b8a",
+        "lesson.key": "Mini-Project - Animation",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "You sequenced the program well (1)  and properly separated code in and out of the draw loop (2).",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "cc7a008d-06d3-4754-8c72-07d620a48b8a",
         "lesson.key": "Mini-Project - Animation",
         "lesson_group.key": "lessonGroup-2",
@@ -21279,11 +22359,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "Your program has significant sequencing errors, resulting in many elements unintentionally hidden or overlapping others.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "db5da8f8-e85a-40de-82bf-d53b36c883cd",
+        "lesson.key": "Mini-Project - Captioned Scenes",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program may contain a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "db5da8f8-e85a-40de-82bf-d53b36c883cd",
+        "lesson.key": "Mini-Project - Captioned Scenes",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "You sequenced the program well(1) and and all elements on the screen appear as intended.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "db5da8f8-e85a-40de-82bf-d53b36c883cd",
+        "lesson.key": "Mini-Project - Captioned Scenes",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "No non-sprite variables are created and used.",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "de31137f-f4d5-4cbe-91d2-961a4733d916",
+        "lesson.key": "Mini-Project - Animation",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "At least 1 non-sprite variable is created and used in the program but does not update in the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "de31137f-f4d5-4cbe-91d2-961a4733d916",
+        "lesson.key": "Mini-Project - Animation",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "At least 1 non-sprite variable is created and its value is updated in the draw loop and affects the program output.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "de31137f-f4d5-4cbe-91d2-961a4733d916",
+        "lesson.key": "Mini-Project - Animation",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "At least 2 non-sprite variables are created and their values are updated in the draw loop and affect the program output.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "de31137f-f4d5-4cbe-91d2-961a4733d916",
         "lesson.key": "Mini-Project - Animation",
         "lesson_group.key": "lessonGroup-2",
@@ -21303,11 +22455,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "At least 2 sprites created and animations set. The x velocity of the target or obstacle not set or set inside the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "e6499f15-3c43-4c46-8630-b723212a2ccb",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "At least 2 sprites created and animations set properly. The x velocity of the target or obstacle properly set outside the draw loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "e6499f15-3c43-4c46-8630-b723212a2ccb",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "At least 4 sprites are created and their animations are set properly (3) . The velocities of the obstacles are properly set outside the draw loop.\n\n\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "e6499f15-3c43-4c46-8630-b723212a2ccb",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "Your program does not have user input. ",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "e89407ff-10e2-400c-868e-aeb0c6d5b1e7",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "Your program contains code, such as keyDown(), for user input but it is not used correctly and the program does not respond. ",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "e89407ff-10e2-400c-868e-aeb0c6d5b1e7",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program responds to 1 type of user input.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "e89407ff-10e2-400c-868e-aeb0c6d5b1e7",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program responds to at least 2 different types of user input (4). ",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "e89407ff-10e2-400c-868e-aeb0c6d5b1e7",
         "lesson.key": "Project - Interactive Card",
         "lesson_group.key": "lessonGroup-2",
@@ -21327,11 +22551,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "Your program properly creates at least 1 non-sprite variable and updates it during the game but does not properly display the variable total on the screen.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "eb5b242e-1dcc-4235-bd75-0c3396b4be8a",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program properly creates at least 1 non-sprite variable, updates it during the game, and properly displays the variable total on the screen.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "eb5b242e-1dcc-4235-bd75-0c3396b4be8a",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program properly creates at least 2 non-sprite variables (such as score or health), updates them  during the game, and properly displays the variable totals on the screen.\n\n\n",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "eb5b242e-1dcc-4235-bd75-0c3396b4be8a",
+        "lesson.key": "Mini-Project - Flyer Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "Your program does not have conditionals to respond to user input. ",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "ed0eab24-0c22-48e8-9517-4d7e2f88b665",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "Your program responds to the up key but does not have the additional conditionals to control the sprite jumping movement.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "ed0eab24-0c22-48e8-9517-4d7e2f88b665",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your program has conditionals meant to control the player sprite’s jumping, however the sprite does not respond as expected (5). ",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "ed0eab24-0c22-48e8-9517-4d7e2f88b665",
+        "lesson.key": "Mini-Project - Side Scroller",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your program has conditionals to control the player sprite’s jumping4 inside the draw loop. ",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "ed0eab24-0c22-48e8-9517-4d7e2f88b665",
         "lesson.key": "Mini-Project - Side Scroller",
         "lesson_group.key": "lessonGroup-3",
@@ -21351,11 +22647,83 @@
       }
     },
     {
+      "understanding": 1,
+      "teacher_description": "You have several sequencing errors, resulting in many elements unintentionally hidden or overlapping others. Some code is improperly placed in or out of the loop.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "f7799b1e-f81e-46a3-a206-8b2ec055555e",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "You property separated code in and out of the draw loop, however they have a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "f7799b1e-f81e-46a3-a206-8b2ec055555e",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "You sequenced the program well1  and properly separated code in and out of the draw loop (2).",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "f7799b1e-f81e-46a3-a206-8b2ec055555e",
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
       "understanding": 0,
       "teacher_description": "Your project guide is incomplete or missing.\n\n",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 0,
+        "learning_goal.key": "fc9bb015-0caa-4443-afb9-ea54ae7baede",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "Your project guide is filled out, but is not complete or does not reflect the submitted project.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "fc9bb015-0caa-4443-afb9-ea54ae7baede",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Your project guide is mostly complete and is generally reflective of the submitted project.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "fc9bb015-0caa-4443-afb9-ea54ae7baede",
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "lessonGroup-3",
+        "script.name": "csd3-2023"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Your project guide is complete and reflects the project as submitted.",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
         "learning_goal.key": "fc9bb015-0caa-4443-afb9-ea54ae7baede",
         "lesson.key": "Project - Design a Game",
         "lesson_group.key": "lessonGroup-3",
@@ -21376,462 +22744,6 @@
     },
     {
       "understanding": 1,
-      "teacher_description": "Your program either has conditionals that all respond to user input (or all using sprite properties/variables) or only has 1 conditional inside the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "041ea3a6-89aa-4746-a413-bd2cd7f40c57",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "The project guide is filled out, but is not complete or does not reflect the submitted project.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "0bb58299-9d28-4047-b3ef-680bfb8d7982",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "At least 1 sprite created. No properties updated after creation.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "0e77d5a5-1b7f-45c7-a88f-9ca19d8aff65",
-        "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Some elements are used as described in the project guide.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "209798cd-e25b-4b96-bf1b-699f090bdb77",
-        "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program either has conditionals that all respond to user input (or all using sprite properties/variables) or only has 1 conditional inside the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "22ddc635-6856-4924-813a-9a99fb2e5548",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "You have several sequencing errors, resulting in many elements unintentionally hidden or overlapping others. Some code is improperly placed in or out of the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "2777b8f6-5ea2-42c3-82bb-00d8f5d61823",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "A cumulative of at least a total of 3 elements are placed on the screen using the coordinate system (e.g 2 sprites & 1 line of text or 1 sprite, 1 shape, & 1 line of text).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "2a5cc4ca-7b41-43e4-8cf9-cce00df53071",
-        "lesson.key": "Mini-Project - Animation",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program properly updates at least one provided non-sprite variable during the game and properly updates at least one of the variable totals on the screen.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "2cde744a-0368-4bf0-8e2b-22e3b4d49b29",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program includes simple, independent movement (8).\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "399be9ff-d418-4b73-8776-a2564b5c3c95",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "You gave some feedback to peers.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "3a264bf8-ae90-4eba-8442-0adee5613bd1",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "At least 1 sprite created. No properties updated inside the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "44ad9d40-4f3a-4ed7-91ab-cf6e86315b7f",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program properly creates at least 1 non-sprite variable and updates it during the game but it either is not displayed or does not affect the way the game is played.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "4adf5a99-20ce-442f-859a-acf0b7989e47",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program code has multiple backgrounds but only one is ever displayed during run time.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "54e8c420-ae5b-4c43-9030-1686cc588f73",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "You have significant sequencing errors, which include either sprites created within the draw loop or functions created within the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "57428b8b-954f-4e25-b6cf-1dd6338ef623",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "At least 2 sprites created and animations set. The x velocity of the target or obstacle not set or set inside the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "57e3c214-b967-4f74-8567-b5e3903ab35e",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program does not have conditionals to respond to user input. ",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "60e95a3f-7aa8-4742-b0ca-ac95e0129c9b",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program either does not have a conditional in the draw loop required to control player interactions with the target, or has the required conditional but it does not work as expected.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "77f2629f-82e1-448c-858f-aee5228f0f79",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "At least one element is placed on the screen using the coordinate system.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "7d31cf32-6a46-4118-885b-0bf347af51a6",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "A cumulative of at least a total of 3 elements are placed on the screen using the coordinate system (e.g 2 sprites & 1 line of text or 1 sprite, 1 shape, & 1 line of text)",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "846752b3-e04d-466c-818b-1215a9d280ff",
-        "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "At least one function is created outside the draw loop and used in your program.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "8b861c07-599f-490d-b0c9-1b9bbfc66a5d",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program either does not have multiple conditionals to control complex sprite interactions, or has multiple conditionals but none of them work as expected.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "925dbfb9-3410-40e8-a9a7-f8d2eef26608",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "At least one element is placed on the screen using the coordinate system.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program either does not have all conditionals in the draw loop needed to control the obstacle sprites’ looping behavior, or has required conditionals but none of them work as expected.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "99c5fae6-a61c-42c0-88d5-616f5abf4a22",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program contains code for detecting user input, such as keyDown(), but it is not used correctly and the program does not respond. ",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "9a4d1dbd-81a3-42af-bc35-f6e3cfa4d8ea",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program either does not have all conditionals in the draw loop needed to control multiple sprites’ looping behavior, or has required conditionals but none of them work as expected.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "a152d8e7-212a-4765-be3f-1a94b70e54cb",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "At least 1 sprite created. No properties updated inside the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "aa66e9b9-1889-4e6d-bfda-ceba0933b50a",
-        "lesson.key": "Mini-Project - Animation",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program either does not have all conditionals in the draw loop required to control multiple sprite interactions, or has required conditionals but none of them work as expected.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "aeccf857-12f6-45c5-a8c0-32ddf3b4e5db",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "The project guide is filled out, but is not complete or does not reflect the submitted project.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "afe3bcb1-c5f1-4405-b402-f6e0718b1ae8",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "You have several sequencing errors, resulting in many elements unintentionally hidden or overlapping others. Some code is improperly placed in or out of the loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "b747206d-550a-4bc5-8fb4-3f104909e68c",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "You have several sequencing errors, resulting in many elements unintentionally hidden or overlapping others. Some code is improperly placed in or out of the loop",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "cc7a008d-06d3-4754-8c72-07d620a48b8a",
-        "lesson.key": "Mini-Project - Animation",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program has significant sequencing errors, resulting in many elements unintentionally hidden or overlapping others.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "db5da8f8-e85a-40de-82bf-d53b36c883cd",
-        "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "At least 1 non-sprite variable is created and used in the program but does not update in the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "de31137f-f4d5-4cbe-91d2-961a4733d916",
-        "lesson.key": "Mini-Project - Animation",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "At least 2 sprites created and animations set. The x velocity of the target or obstacle not set or set inside the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "e6499f15-3c43-4c46-8630-b723212a2ccb",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program contains code, such as keyDown(), for user input but it is not used correctly and the program does not respond. ",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "e89407ff-10e2-400c-868e-aeb0c6d5b1e7",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program properly creates at least 1 non-sprite variable and updates it during the game but does not properly display the variable total on the screen.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "eb5b242e-1dcc-4235-bd75-0c3396b4be8a",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program responds to the up key but does not have the additional conditionals to control the sprite jumping movement.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "ed0eab24-0c22-48e8-9517-4d7e2f88b665",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "You have several sequencing errors, resulting in many elements unintentionally hidden or overlapping others. Some code is improperly placed in or out of the loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "f7799b1e-f81e-46a3-a206-8b2ec055555e",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your project guide is filled out, but is not complete or does not reflect the submitted project.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "fc9bb015-0caa-4443-afb9-ea54ae7baede",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
       "teacher_description": "Your program code has few comments beyond starter code.",
       "ai_prompt": "",
       "seeding_key": {
@@ -21844,923 +22756,11 @@
     },
     {
       "understanding": 2,
-      "teacher_description": "Your program uses at least 2 conditionals inside the draw loop - 1 that responds to user input and 1 that is triggered by a variable or sprite property.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "041ea3a6-89aa-4746-a413-bd2cd7f40c57",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "The project guide is mostly complete and is generally reflective of the submitted project.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "0bb58299-9d28-4047-b3ef-680bfb8d7982",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "At least 1 sprite created with at least one property updated after creation.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "0e77d5a5-1b7f-45c7-a88f-9ca19d8aff65",
-        "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Elements are generally used as described in the project guide.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "209798cd-e25b-4b96-bf1b-699f090bdb77",
-        "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program uses at least 2 conditionals inside the draw loop - 1 that responds to user input and 1 that is triggered by a variable or sprite property.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "22ddc635-6856-4924-813a-9a99fb2e5548",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "You property separated code in and out of the draw loop, however they have a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "2777b8f6-5ea2-42c3-82bb-00d8f5d61823",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "At least 1 shape, 2 sprites, and 1 line of text are placed on the screen using the coordinate system. At least 1 element moves during the program.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "2a5cc4ca-7b41-43e4-8cf9-cce00df53071",
-        "lesson.key": "Mini-Project - Animation",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program properly updates the two provided non-sprite variables during the game and properly updates at least one of the variable totals on the screen.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "2cde744a-0368-4bf0-8e2b-22e3b4d49b29",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program includes at least one instance of complex movement.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "399be9ff-d418-4b73-8776-a2564b5c3c95",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "You gave and responded to peer feedback.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "3a264bf8-ae90-4eba-8442-0adee5613bd1",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "At least 1 sprite created with at least one property updated inside the draw loop.\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "44ad9d40-4f3a-4ed7-91ab-cf6e86315b7f",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program properly creates at least 1 non-sprite variable that is displayed and updated during the game and affects the way the game is played.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "4adf5a99-20ce-442f-859a-acf0b7989e47",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your game has at least two backgrounds that are displayed during run time.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "54e8c420-ae5b-4c43-9030-1686cc588f73",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program effectively creates sprites and defines functions outside of the draw loop, however there are multiple code segments within the draw loop that should be situated within their own functions outside the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "57428b8b-954f-4e25-b6cf-1dd6338ef623",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "At least 2 sprites created and animations set properly. The x velocity of the target or obstacle properly set outside the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "57e3c214-b967-4f74-8567-b5e3903ab35e",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program has conditionals to respond to multiple types of user input that are meant to control the player sprite’s movement, however the sprite does not respond as expected (5). ",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "60e95a3f-7aa8-4742-b0ca-ac95e0129c9b",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program has a conditional and at least 1 collision detection block in the draw loop meant to control multiple sprite interactions with the player, however one of them does not work as expected.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "77f2629f-82e1-448c-858f-aee5228f0f79",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "At least 2 sprites and 1 other element is placed on the screen using the coordinate system. The sprites move during the program.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "7d31cf32-6a46-4118-885b-0bf347af51a6",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "At least 1 shape, 2 sprites, and 1 line of text are placed on the screen using the coordinate system.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "846752b3-e04d-466c-818b-1215a9d280ff",
-        "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "At least two functions are created outside the draw loop and used in your program to organize your code into logical segments.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "8b861c07-599f-490d-b0c9-1b9bbfc66a5d",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program has multiple conditionals meant to control complex sprite interactions, however one of them does not work as expected.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "925dbfb9-3410-40e8-a9a7-f8d2eef26608",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "At least 2 sprites and 1 other element is placed on the screen using the coordinate system. The sprites move during the program.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program has conditionals in the draw loop meant to control the obstacle sprites’ looping behavior, however one of the obstacles does not behave as expected.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "99c5fae6-a61c-42c0-88d5-616f5abf4a22",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program responds to 1 type of user input.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "9a4d1dbd-81a3-42af-bc35-f6e3cfa4d8ea",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program has conditionals in the draw loop meant to control multiple sprites’ looping behavior, however one of them does not work as expected.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "a152d8e7-212a-4765-be3f-1a94b70e54cb",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "At least 1 sprite created with at least one property updated inside the draw loop",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "aa66e9b9-1889-4e6d-bfda-ceba0933b50a",
-        "lesson.key": "Mini-Project - Animation",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program has conditionals in the draw loop meant to control multiple sprite interactions, however one of them does not work as expected.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "aeccf857-12f6-45c5-a8c0-32ddf3b4e5db",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "The project guide is mostly complete and is generally reflective of the submitted project.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "afe3bcb1-c5f1-4405-b402-f6e0718b1ae8",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "You property separated code in and out of the draw loop, however they have a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "b747206d-550a-4bc5-8fb4-3f104909e68c",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "You properly separated code in and out of the draw loop, however they have a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "cc7a008d-06d3-4754-8c72-07d620a48b8a",
-        "lesson.key": "Mini-Project - Animation",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program may contain a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "db5da8f8-e85a-40de-82bf-d53b36c883cd",
-        "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "At least 1 non-sprite variable is created and its value is updated in the draw loop and affects the program output.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "de31137f-f4d5-4cbe-91d2-961a4733d916",
-        "lesson.key": "Mini-Project - Animation",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "At least 2 sprites created and animations set properly. The x velocity of the target or obstacle properly set outside the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "e6499f15-3c43-4c46-8630-b723212a2ccb",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program responds to 1 type of user input.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "e89407ff-10e2-400c-868e-aeb0c6d5b1e7",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program properly creates at least 1 non-sprite variable, updates it during the game, and properly displays the variable total on the screen.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "eb5b242e-1dcc-4235-bd75-0c3396b4be8a",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program has conditionals meant to control the player sprite’s jumping, however the sprite does not respond as expected (5). ",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "ed0eab24-0c22-48e8-9517-4d7e2f88b665",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "You property separated code in and out of the draw loop, however they have a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "f7799b1e-f81e-46a3-a206-8b2ec055555e",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your project guide is mostly complete and is generally reflective of the submitted project.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "fc9bb015-0caa-4443-afb9-ea54ae7baede",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
       "teacher_description": "Your program code makes use of additional comments throughout the program.",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 2,
         "learning_goal.key": "fd25331c-d1b5-42d5-84b7-c0c9b6a78bd9",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program uses at least 3 conditionals inside the draw loop - 1 (or more) responds to user input and 1 (or more) is triggered by a variable or sprite property (5).\n\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "041ea3a6-89aa-4746-a413-bd2cd7f40c57",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "The project guide is complete and reflects the project as submitted.\n\n\n\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "0bb58299-9d28-4047-b3ef-680bfb8d7982",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "At least 2 sprites created, each with at least one property updated after creation (2).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "0e77d5a5-1b7f-45c7-a88f-9ca19d8aff65",
-        "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Elements are used as described in the project guide and clearly display a captioned scene.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "209798cd-e25b-4b96-bf1b-699f090bdb77",
-        "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program uses at least 3 conditionals inside the draw loop - 1 (or more) responds to user input and 1 (or more) is triggered by a variable or sprite property (5).\n\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "22ddc635-6856-4924-813a-9a99fb2e5548",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "You sequenced the program well1  and properly separated code in and out of the draw loop (2).\n\n\n\n\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "2777b8f6-5ea2-42c3-82bb-00d8f5d61823",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "At least 2 shapes, 2 sprites, and 2 lines of text are placed correctly on the screen using the coordinate system. At least 2 elements move in different ways (4).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "2a5cc4ca-7b41-43e4-8cf9-cce00df53071",
-        "lesson.key": "Mini-Project - Animation",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program properly updates the two provided non-sprite variables during the game and properly displays the variable totals on the screen.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "2cde744a-0368-4bf0-8e2b-22e3b4d49b29",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program includes at least two instances of complex movement (7).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "399be9ff-d418-4b73-8776-a2564b5c3c95",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "You gave thoughtful feedback to peers and you responded to peer feedback by making appropriate changes to program.You sequenced the program well1  and properly separated code in and out of the draw loop2.\nYou property separated code in and out of the draw loop, however they have a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.\nYou have several sequencing errors, resulting in many elements unintentionally hidden or overlapping others. Some code is improperly placed in or out of the loop.\nErrors in program sequencing are significant enough to keep the output from resembling the intended scene or the Draw loop is not used to create animation\n\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "3a264bf8-ae90-4eba-8442-0adee5613bd1",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "At least 3 sprites created, each with at least one property updating in the draw loop (3).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "44ad9d40-4f3a-4ed7-91ab-cf6e86315b7f",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program properly creates at least 2 non-sprite variables, such as score or health, that are displayed and updated during the game and affect how the game is played (9).\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "4adf5a99-20ce-442f-859a-acf0b7989e47",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your game has at least three backgrounds that are displayed during run time (3). At least one of these backgrounds is triggered automatically through a variable (4).\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "54e8c420-ae5b-4c43-9030-1686cc588f73",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "You sequenced the program well1  and properly separated code in and out of the draw loop (2).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "57428b8b-954f-4e25-b6cf-1dd6338ef623",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "At least 3 sprites created and animations set3 properly. The x velocity of the target and obstacle properly set outside the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "57e3c214-b967-4f74-8567-b5e3903ab35e",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program has conditionals to respond to multiple types of user input that control the player sprite’s movement (4) inside the draw loop. ",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "60e95a3f-7aa8-4742-b0ca-ac95e0129c9b",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program has a conditional and at least 2 collision detection blocks to control multiple sprite interactions (7) with the player inside the draw loop. \n\n\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "77f2629f-82e1-448c-858f-aee5228f0f79",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "At least 3 sprites and at least 2 other elements are placed on the screen using the coordinate system. The sprites move in different ways (6).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "7d31cf32-6a46-4118-885b-0bf347af51a6",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "At least 2 shapes, 2 sprites, and 2 lines of text are placed correctly on the screen using the coordinate system.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "846752b3-e04d-466c-818b-1215a9d280ff",
-        "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "At least three functions are created outside the draw loop and used to organize your code into logical segments.  At least one of these functions is called multiple times in your program. \n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "8b861c07-599f-490d-b0c9-1b9bbfc66a5d",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program includes multiple conditionals to control complex interactions between sprites (6) which either affect the sprites themselves, such as resetting their location, or affect the gameplay, such as increasing or decreasing the score. \n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "925dbfb9-3410-40e8-a9a7-f8d2eef26608",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "At least 3 sprites and at least 2 other elements are placed on the screen using the coordinate system. The sprites move in different ways (6).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program has conditionals to control the obstacle sprites’ looping behavior6 inside the draw loop. \n\n\n\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "99c5fae6-a61c-42c0-88d5-616f5abf4a22",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program responds to at least 2 different types of user input (5). ",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "9a4d1dbd-81a3-42af-bc35-f6e3cfa4d8ea",
-        "lesson.key": "Project - Design a Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program has conditionals to control multiple sprites’ looping behavior (6) inside the draw loop. ",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "a152d8e7-212a-4765-be3f-1a94b70e54cb",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "At least 2 sprites created, each with at least one property updating in the draw loop (3).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "aa66e9b9-1889-4e6d-bfda-ceba0933b50a",
-        "lesson.key": "Mini-Project - Animation",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program has conditionals to control multiple sprite interactions (7) inside the draw loop. ",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "aeccf857-12f6-45c5-a8c0-32ddf3b4e5db",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "The project guide is complete and reflects the project as submitted.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "afe3bcb1-c5f1-4405-b402-f6e0718b1ae8",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "You sequenced the program well1  and properly separated code in and out of the draw loop (2).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "b747206d-550a-4bc5-8fb4-3f104909e68c",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "You sequenced the program well (1)  and properly separated code in and out of the draw loop (2).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "cc7a008d-06d3-4754-8c72-07d620a48b8a",
-        "lesson.key": "Mini-Project - Animation",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "You sequenced the program well(1) and and all elements on the screen appear as intended.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "db5da8f8-e85a-40de-82bf-d53b36c883cd",
-        "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "At least 2 non-sprite variables are created and their values are updated in the draw loop and affect the program output.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "de31137f-f4d5-4cbe-91d2-961a4733d916",
-        "lesson.key": "Mini-Project - Animation",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "At least 4 sprites are created and their animations are set properly (3) . The velocities of the obstacles are properly set outside the draw loop.\n\n\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "e6499f15-3c43-4c46-8630-b723212a2ccb",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program responds to at least 2 different types of user input (4). ",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "e89407ff-10e2-400c-868e-aeb0c6d5b1e7",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program properly creates at least 2 non-sprite variables (such as score or health), updates them  during the game, and properly displays the variable totals on the screen.\n\n\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "eb5b242e-1dcc-4235-bd75-0c3396b4be8a",
-        "lesson.key": "Mini-Project - Flyer Game",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program has conditionals to control the player sprite’s jumping4 inside the draw loop. ",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "ed0eab24-0c22-48e8-9517-4d7e2f88b665",
-        "lesson.key": "Mini-Project - Side Scroller",
-        "lesson_group.key": "lessonGroup-3",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "You sequenced the program well1  and properly separated code in and out of the draw loop (2).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "f7799b1e-f81e-46a3-a206-8b2ec055555e",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your project guide is complete and reflects the project as submitted.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "fc9bb015-0caa-4443-afb9-ea54ae7baede",
         "lesson.key": "Project - Design a Game",
         "lesson_group.key": "lessonGroup-3",
         "script.name": "csd3-2023"

--- a/dashboard/config/scripts_json/csd3-2023.script_json
+++ b/dashboard/config/scripts_json/csd3-2023.script_json
@@ -17,7 +17,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2023-10-16 17:31:17 UTC",
+    "serialized_at": "2023-10-16 17:36:32 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -20402,7 +20402,7 @@
       "position": 5,
       "learning_goal": "Algorithms and Control - Conditionals",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(5) **Triggered by a variable or sprite property**\n- A conditional should have a boolean statement that uses a variable, such as `(count > 10)`, or a sprite property, such as `(sprite.scale > 50)`. \n- Using `World.mouseX` or `World.mouseY` can also count for this conditional.",
       "seeding_key": {
         "learning_goal.key": "041ea3a6-89aa-4746-a413-bd2cd7f40c57",
         "lesson.key": "Project - Interactive Card",
@@ -20428,7 +20428,7 @@
       "position": 2,
       "learning_goal": "Modularity - Sprites and Sprite Properties",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(2) **Updated after creation**\n  - Sprites are created with these two lines of code: \n    ```\n    var sprite = createSprite(200, 200); \n    sprite.setAnimation(\"animation_1\");\n    ```\n  - After the above two lines, a sprite property listed below should be updated\n    - `rotation`\n    - `scale`\n    - `tint`\n    - `alpha`\n    - `width`\n    - `height`",
       "seeding_key": {
         "learning_goal.key": "0e77d5a5-1b7f-45c7-a88f-9ca19d8aff65",
         "lesson.key": "Mini-Project - Captioned Scenes",
@@ -20450,24 +20450,11 @@
       }
     },
     {
-      "key": "22ddc635-6856-4924-813a-9a99fb2e5548",
-      "position": 5,
-      "learning_goal": "Algorithms and Control - Conditionals",
-      "ai_enabled": true,
-      "tips": null,
-      "seeding_key": {
-        "learning_goal.key": "22ddc635-6856-4924-813a-9a99fb2e5548",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
       "key": "2777b8f6-5ea2-42c3-82bb-00d8f5d61823",
       "position": 2,
       "learning_goal": "Program Development - Program Sequence",
       "ai_enabled": false,
-      "tips": null,
+      "tips": "(1) **Sequenced the program well**\n- If the program code is not sequenced correctly, some elements, such as shapes, sprites, and text, may be unintentionally hidden behind others. \n- In the specific case of sprites, if the `drawSprites()` code is not sequenced correctly, some or all sprites may not appear on the screen.\n\n(2) **Code in and out of the draw loop**\n- Code outside the draw loop is used to set up the program and its starting elements (creating sprites, setting starting properties, sprite velocities that won’t change, etc). \n- Code inside the draw loop is for things that are changing as the program is running, such as user interaction. This also includes updating properties or non-sprite variables as well as any shapes for the background, text, and the `drawSprites()` block.\n",
       "seeding_key": {
         "learning_goal.key": "2777b8f6-5ea2-42c3-82bb-00d8f5d61823",
         "lesson.key": "Mini-Project - Flyer Game",
@@ -20480,7 +20467,7 @@
       "position": 3,
       "learning_goal": "Position and Movement",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(4) **Move in different ways**\n- One element should have random movement using `randomNumber()`\n- One element should move using the **counter pattern** `(x = x + 1)`",
       "seeding_key": {
         "learning_goal.key": "2a5cc4ca-7b41-43e4-8cf9-cce00df53071",
         "lesson.key": "Mini-Project - Animation",
@@ -20506,7 +20493,7 @@
       "position": 8,
       "learning_goal": "Position and Movement",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(7) **Instances of complex movement**\n- This includes code that simulates movement such as acceleration, moving in a curve, looping from one side of the screen to the other, or jumping \n\n(8) **Simple, independent movement**\n- This includes movement such as moving in a straight line or rotation\n",
       "seeding_key": {
         "learning_goal.key": "399be9ff-d418-4b73-8776-a2564b5c3c95",
         "lesson.key": "Project - Design a Game",
@@ -20519,7 +20506,7 @@
       "position": 1,
       "learning_goal": "Program Development - Peer Feedback",
       "ai_enabled": false,
-      "tips": null,
+      "tips": "(1) **Sequenced the program well**\n- If the program code is not sequenced correctly, some elements, such as shapes, sprites, and text, may be unintentionally hidden behind others. \n- In the specific case of sprites, if the `drawSprites()` code is not sequenced correctly, some or all sprites may not appear on the screen.\n\n(2) **Code in and out of the draw loop**\n- Code outside the draw loop is used to set up the program and its starting elements (creating sprites, setting sprite properties that won’t change, etc). \n- Code inside the draw loop is for things that are changing as the program is running. This includes updating properties or non-sprite variables as well as any shapes for the background, text, and the `drawSprites()` block.",
       "seeding_key": {
         "learning_goal.key": "3a264bf8-ae90-4eba-8442-0adee5613bd1",
         "lesson.key": "Project - Interactive Card",
@@ -20532,7 +20519,7 @@
       "position": 3,
       "learning_goal": "Modularity - Multiple Sprites",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(3) **Updating in the draw loop**\n- Sprites are created with these two lines of code outside of the draw loop: \n  ```\n  var sprite = createSprite(200, 200); \n  sprite.setAnimation(\"animation_1\");\n  ```\n- After the above two lines, a sprite property, such as the ones listed below, should be **updating inside** the draw loop.\n  - x\n  - y\n  - rotation\n  - scale\n  - tint\n  - alpha\n  - width\n  - height\n  - visible\n- Assigning value to a sprite property inside the draw loop, such as `sprite.scale = 0.4`, does not count as updating a property unless it is in a conditional. \n",
       "seeding_key": {
         "learning_goal.key": "44ad9d40-4f3a-4ed7-91ab-cf6e86315b7f",
         "lesson.key": "Project - Interactive Card",
@@ -20545,7 +20532,7 @@
       "position": 9,
       "learning_goal": "Variables",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(9) **Affect how the game is played**\n- Examples include (but are not limited to): moving to a different level at a certain point value, losing the game at a certain score value,  game play becomes harder or speeds up at a certain variable value, etc.\n",
       "seeding_key": {
         "learning_goal.key": "4adf5a99-20ce-442f-859a-acf0b7989e47",
         "lesson.key": "Project - Design a Game",
@@ -20558,7 +20545,7 @@
       "position": 5,
       "learning_goal": "Algorithms and Control - Backgrounds and Variables",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(3) **Three backgrounds that are displayed during run time**\n- Three different backgrounds should appear during a single play of the game.\n- Example backgrounds include (but are not limited to): an instructions screen, different backgrounds for various difficulty levels, win screen, lose screen, etc. \n\n(4) **Backgrounds is triggered automatically through a variable**\n- For example, the game play background is changed to a _“You lose”_ background when the variable named “score” reaches the value of 0.\n",
       "seeding_key": {
         "learning_goal.key": "54e8c420-ae5b-4c43-9030-1686cc588f73",
         "lesson.key": "Project - Design a Game",
@@ -20571,7 +20558,7 @@
       "position": 3,
       "learning_goal": "Program Development - Program Sequence",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(1) **Sequenced the program well**\n- If the program code is not sequenced correctly, some elements, such as shapes, sprites, and text, may be unintentionally hidden behind others. \n- In the specific case of sprites, if the `drawSprites()` code is not sequenced correctly, some or all sprites may not appear on the screen.\n\n(2) **Code in and out of the draw loop**\n- Code outside the draw loop is used to set up the program, its starting elements, and all created functions. \n- Code inside the draw loop at this point should be primarily function calls and perhaps some conditionals used with function calls in addition to the `drawSprites()` block.",
       "seeding_key": {
         "learning_goal.key": "57428b8b-954f-4e25-b6cf-1dd6338ef623",
         "lesson.key": "Project - Design a Game",
@@ -20584,7 +20571,7 @@
       "position": 3,
       "learning_goal": "Modularity - Multiple Sprites",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(3) **Sprites created and animations set**\n- Sprites are created and their animations are set with these two lines of code **outside** of the draw loop: \n  ```\n  var sprite = createSprite(200, 200); \n  sprite.setAnimation(\"animation_1\");\n```\n",
       "seeding_key": {
         "learning_goal.key": "57e3c214-b967-4f74-8567-b5e3903ab35e",
         "lesson.key": "Mini-Project - Side Scroller",
@@ -20597,7 +20584,7 @@
       "position": 4,
       "learning_goal": "Algorithms and Control - Player Control Conditionals",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(4) **Conditionals to respond to multiple types of user input that control the player sprite’s movement**\n- This includes the use of 3 conditionals that use different keyboard input (left arrow and right arrow) and/or mouse input.\n- This also includes using the counter pattern with the sprite’s y velocity in order to create the complex acceleration movement (i.e. falling behavior)\n\n(5) **Sprite does not respond as expected**\n- The sprite’s movement should simulate the player going up when the “up” key is pressed, followed by the sprite accelerating falling back down the screen on its own. The sprite should also move left and right when those keys are pressed.",
       "seeding_key": {
         "learning_goal.key": "60e95a3f-7aa8-4742-b0ca-ac95e0129c9b",
         "lesson.key": "Mini-Project - Flyer Game",
@@ -20610,7 +20597,7 @@
       "position": 6,
       "learning_goal": "Algorithms and Control - Interaction Conditionals & Collision Detection",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(7) **Conditional and at least 2 collision detection blocks to control multiple sprite interactions**\n- This includes the use of at least 1 conditional that checks if the player sprite is touching the target sprite and then moves the target to a random location\n- This also includes the use of at least two collision detection blocks, such as `collide()` or `bounceOff()`, to have the obstacles interact with the player sprite ",
       "seeding_key": {
         "learning_goal.key": "77f2629f-82e1-448c-858f-aee5228f0f79",
         "lesson.key": "Mini-Project - Flyer Game",
@@ -20620,10 +20607,10 @@
     },
     {
       "key": "7d31cf32-6a46-4118-885b-0bf347af51a6",
-      "position": 6,
+      "position": 7,
       "learning_goal": "Position and Movement",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(6) **Move in different ways**\n- Both types of the following movement should be used:\n  - Random movement using `randomNumber()`\n  - Smooth movement using the **counter pattern** `(sprite.x = sprite.x + 1)`",
       "seeding_key": {
         "learning_goal.key": "7d31cf32-6a46-4118-885b-0bf347af51a6",
         "lesson.key": "Project - Interactive Card",
@@ -20662,7 +20649,7 @@
       "position": 7,
       "learning_goal": "Algorithms and Control - Interaction Conditionals",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(6) **Complex interactions between sprites**\n- The use of a single collision block, such as `collide()` or `displace()`, without the use of a conditional does not count as complex interactions",
       "seeding_key": {
         "learning_goal.key": "925dbfb9-3410-40e8-a9a7-f8d2eef26608",
         "lesson.key": "Project - Design a Game",
@@ -20671,24 +20658,11 @@
       }
     },
     {
-      "key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
-      "position": 6,
-      "learning_goal": "Position and Movement",
-      "ai_enabled": true,
-      "tips": null,
-      "seeding_key": {
-        "learning_goal.key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
       "key": "99c5fae6-a61c-42c0-88d5-616f5abf4a22",
       "position": 5,
       "learning_goal": "Algorithms and Control - Looping Conditionals",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(6) **Conditionals to control the obstacle sprites’ looping behavior**\nThis includes the use of at least 1 conditional per obstacle sprite to control the looping on both the x and y axis.\n",
       "seeding_key": {
         "learning_goal.key": "99c5fae6-a61c-42c0-88d5-616f5abf4a22",
         "lesson.key": "Mini-Project - Flyer Game",
@@ -20701,7 +20675,7 @@
       "position": 6,
       "learning_goal": "Algorithms and Control - User Input",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(5) **Different types of user input**\n- This includes keyboard and mouse inputs. \n- Different types can include two different keyboard inputs such as `keyDown(“left”)` and `keyDown(“space”)`",
       "seeding_key": {
         "learning_goal.key": "9a4d1dbd-81a3-42af-bc35-f6e3cfa4d8ea",
         "lesson.key": "Project - Design a Game",
@@ -20714,7 +20688,7 @@
       "position": 5,
       "learning_goal": "Algorithms and Control - Looping Conditionals",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(6) **Conditionals to control multiple sprites’ looping behavior**\n- This includes the use of at least 1 conditional for the target sprite and at least 1 conditional for the obstacle sprite.\n- Examples:\n  - _The conditional for the target sprite should check if the sprite’s x value has reached the left side of the screen and then reset it’s x value to the right side of the screen_\n  - _The conditional for the obstacle sprite should also check if the sprite’s x value has reached the left side of the screen and then reset it’s x value to the right side of the screen_\n",
       "seeding_key": {
         "learning_goal.key": "a152d8e7-212a-4765-be3f-1a94b70e54cb",
         "lesson.key": "Mini-Project - Side Scroller",
@@ -20727,7 +20701,7 @@
       "position": 2,
       "learning_goal": "Modularity - Sprites and Sprite Properties",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(3) **Updating in the draw loop**\n- Sprites are created with these two lines of code outside of the draw loop: \n  ```\nvar sprite = createSprite(200, 200); \nsprite.setAnimation(\"animation_1\");\n```\n- After the above two lines, a sprite property, such as the ones listed below, should be continuously updating inside the draw loop\n  - x \n  - y\n  - rotation\n  - scale\n  - tint\n  - alpha\n  - width\n  - height",
       "seeding_key": {
         "learning_goal.key": "aa66e9b9-1889-4e6d-bfda-ceba0933b50a",
         "lesson.key": "Mini-Project - Animation",
@@ -20740,7 +20714,7 @@
       "position": 6,
       "learning_goal": "Algorithms and Control - Interaction Conditionals",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(7) **Conditionals to control multiple sprite interactions**\n- This includes the use of at least 1 conditional for the target sprite and at least 1 conditional for the obstacle sprite. \n- _Examples:_\n  - _The conditional for the target sprite should use the `isTouching()` to detect interaction between the player sprite and target sprite._\n     - _If the two sprites touch, the score variable should increase and the x value of the target sprite should reset to the right side of the screen_\n  - _The conditional for the obstacle sprite should also use the `isTouching()` to detect interaction between the player sprite and the obstacle sprite._\n    - _If the two sprites touch, the health variable should decrease and the obstacle sprite should change in some way_\n      - _For example, the obstacle sprite’s rotation property could change to make the sprite appear to be knocked over or the tint property of the obstacle sprite could change to make the sprite appear red indicating it was touched)._\n",
       "seeding_key": {
         "learning_goal.key": "aeccf857-12f6-45c5-a8c0-32ddf3b4e5db",
         "lesson.key": "Mini-Project - Side Scroller",
@@ -20766,7 +20740,7 @@
       "position": 2,
       "learning_goal": "Program Development - Program Sequence",
       "ai_enabled": false,
-      "tips": null,
+      "tips": "(1) **Sequenced the program well**\n- If the program code is not sequenced correctly, some elements, such as shapes, sprites, and text, may be unintentionally hidden behind others. \n- In the specific case of sprites, if the `drawSprites()` code is not sequenced correctly, some or all sprites may not appear on the screen.\n\n(2) **Code in and out of the draw loop**\n- Code outside the draw loop is used to set up the program and its starting elements (creating sprites, setting sprite properties that won’t change, etc). \n- Code inside the draw loop is for things that are changing as the program is running. This includes updating properties or non-sprite variables as well as any shapes for the background, text, and the `drawSprites()` block.",
       "seeding_key": {
         "learning_goal.key": "b747206d-550a-4bc5-8fb4-3f104909e68c",
         "lesson.key": "Mini-Project - Side Scroller",
@@ -20779,7 +20753,7 @@
       "position": 1,
       "learning_goal": "Program Development - Program Sequence",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(1) **Sequenced the program well**\nIf the program code is not sequenced correctly, some elements, such as shapes, sprites, and text, may be unintentionally hidden behind others. \nIn the specific case of sprites, if the `drawSprites()` code is not sequenced correctly, some or all sprites may not appear on the screen.\n\n(2) **Code in and out of the draw loop**\nCode inside the draw loop is for things that are changing as the program is running. This includes updating properties or non-sprite variables as well as any shapes for the background, text, and the `drawSprites()` block.\n",
       "seeding_key": {
         "learning_goal.key": "cc7a008d-06d3-4754-8c72-07d620a48b8a",
         "lesson.key": "Mini-Project - Animation",
@@ -20792,7 +20766,7 @@
       "position": 1,
       "learning_goal": "Program Development - Program Sequence",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(1) **Sequenced the program well**\n- If the program code is not sequenced correctly, some elements, such as shapes, sprites, and text, may be unintentionally hidden behind others\n- In the specific case of sprites, if the `drawSprites()` code is not sequenced correctly, some or all sprites may not appear on the screen.",
       "seeding_key": {
         "learning_goal.key": "db5da8f8-e85a-40de-82bf-d53b36c883cd",
         "lesson.key": "Mini-Project - Captioned Scenes",
@@ -20818,7 +20792,7 @@
       "position": 3,
       "learning_goal": "Modularity - Multiple Sprites",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(3) **Sprites are created and their animations are set properly**\n- Sprites are created and their animations are set with these two lines of code outside of the draw loop: \n  ```\n  var sprite = createSprite(200, 200); \n  sprite.setAnimation(\"animation_1\");\n  ```",
       "seeding_key": {
         "learning_goal.key": "e6499f15-3c43-4c46-8630-b723212a2ccb",
         "lesson.key": "Mini-Project - Flyer Game",
@@ -20831,7 +20805,7 @@
       "position": 4,
       "learning_goal": "Algorithms and Control - User Input",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(4) **Different types of user input**\n- This includes keyboard and mouse inputs. \n- Two different types can include two different keyboard inputs such as `keyDown(“left”)` and `keyDown(“space”)`",
       "seeding_key": {
         "learning_goal.key": "e89407ff-10e2-400c-868e-aeb0c6d5b1e7",
         "lesson.key": "Project - Interactive Card",
@@ -20857,7 +20831,7 @@
       "position": 4,
       "learning_goal": "Algorithms and Control - Player Control Conditionals",
       "ai_enabled": true,
-      "tips": null,
+      "tips": "(4) **Conditionals to control the player sprite’s jumping**\n- This includes the use of at least 3 conditionals (at least one of which utilizes user input)\n- Examples:\n  - _One responding to user input with the keyDown(“up”) to change the sprite’s y velocity_\n  - _One checking the y value of the player sprite to see if it has reached the “top” of it’s jump and then send the sprite back down the screen_\n  - _One checking the y value of the player sprite to see if it is “on the ground” and then stop the sprite from falling_\n\n(5) **Sprite does not respond as expected**\n- The sprite’s movement should simulate the player jumping up when the “up” key is pressed, followed by the sprite coming back down to the ground on its own once it reaches the height of its jump. The sprite should also “land” back on the ground where it started.\n",
       "seeding_key": {
         "learning_goal.key": "ed0eab24-0c22-48e8-9517-4d7e2f88b665",
         "lesson.key": "Mini-Project - Side Scroller",
@@ -21094,54 +21068,6 @@
         "understanding": 3,
         "learning_goal.key": "209798cd-e25b-4b96-bf1b-699f090bdb77",
         "lesson.key": "Mini-Project - Captioned Scenes",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 0,
-      "teacher_description": "Your program does not use any conditionals.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 0,
-        "learning_goal.key": "22ddc635-6856-4924-813a-9a99fb2e5548",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "Your program either has conditionals that all respond to user input (or all using sprite properties/variables) or only has 1 conditional inside the draw loop.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "22ddc635-6856-4924-813a-9a99fb2e5548",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "Your program uses at least 2 conditionals inside the draw loop - 1 that responds to user input and 1 that is triggered by a variable or sprite property.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "22ddc635-6856-4924-813a-9a99fb2e5548",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "Your program uses at least 3 conditionals inside the draw loop - 1 (or more) responds to user input and 1 (or more) is triggered by a variable or sprite property (5).\n\n",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "22ddc635-6856-4924-813a-9a99fb2e5548",
-        "lesson.key": "Project - Interactive Card",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csd3-2023"
       }
@@ -21568,7 +21494,7 @@
     },
     {
       "understanding": 3,
-      "teacher_description": "You sequenced the program well1  and properly separated code in and out of the draw loop (2).",
+      "teacher_description": "You sequenced the program well (1)  and properly separated code in and out of the draw loop (2).",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 3,
@@ -21916,54 +21842,6 @@
     },
     {
       "understanding": 0,
-      "teacher_description": "No elements (sprites or shapes) are placed on the screen using the coordinate system.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 0,
-        "learning_goal.key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 1,
-      "teacher_description": "At least one element is placed on the screen using the coordinate system.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 1,
-        "learning_goal.key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 2,
-      "teacher_description": "At least 2 sprites and 1 other element is placed on the screen using the coordinate system. The sprites move during the program.",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 2,
-        "learning_goal.key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 3,
-      "teacher_description": "At least 3 sprites and at least 2 other elements are placed on the screen using the coordinate system. The sprites move in different ways (6).",
-      "ai_prompt": "",
-      "seeding_key": {
-        "understanding": 3,
-        "learning_goal.key": "92b1b85f-71a8-4b74-a795-f244bd269b9a",
-        "lesson.key": "Project - Interactive Card",
-        "lesson_group.key": "lessonGroup-2",
-        "script.name": "csd3-2023"
-      }
-    },
-    {
-      "understanding": 0,
       "teacher_description": "Your program does not use any conditionals to control looping behavior.",
       "ai_prompt": "",
       "seeding_key": {
@@ -22000,7 +21878,7 @@
     },
     {
       "understanding": 3,
-      "teacher_description": "Your program has conditionals to control the obstacle sprites’ looping behavior6 inside the draw loop. \n\n\n\n",
+      "teacher_description": "Your program has conditionals to control the obstacle sprites’ looping behavior (6) inside the draw loop. \n\n\n\n",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 3,
@@ -22288,7 +22166,7 @@
     },
     {
       "understanding": 3,
-      "teacher_description": "You sequenced the program well1  and properly separated code in and out of the draw loop (2).",
+      "teacher_description": "You sequenced the program well(1)  and properly separated code in and out of the draw loop (2).",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 3,


### PR DESCRIPTION
I copied the tips in the rubrics linked from [this spreadsheet](https://docs.google.com/spreadsheets/d/1kWOhG_957wnOY9PO0bCKIF5w7YVnKbTB1M5uJsrklyQ/edit#gid=134779350) and added them to the learning goals. I ended up creating an editor to do this locally, so I'll clean that up and send it out for review later this week (it needs some styling and currently breaks creating a new rubric 😅).

The UI for this already existed, but this is how one set of tips looks:

![Screenshot 2023-10-16 at 1 26 45 PM](https://github.com/code-dot-org/code-dot-org/assets/46464143/dbd0f2af-0285-47e8-bb41-ccdc549f983c)

This is a messy diff, so I'd recommend reviewing each commit individually:
- 37993bd47ebc898f8e3234eaee96dc982068129d is the diff caused by me running `Unit.find_by_name('csd3-2023').write_script_json` immediately after running `bundle exec rake seed:single_script SCRIPT_NAME='csd3-2023'` locally. It is essentially the diff caused by the work in https://github.com/code-dot-org/code-dot-org/pull/54098 to make the order of evidence levels more stable. It likely doesn't need a close review.
- 8fdc994a48cfc6a9590301e9aafa886e61388d0e adds tips, removes two duplicate learning goals (and their evidence levels), and fixes a couple of small typos. This is the actual bulk of this change.