### PR TITLE
Add video to Young Women in CS landing page

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -160,15 +160,19 @@ input[type=submit] {
   background-color: $brand_secondary_default;
   border: 2px solid $brand_secondary_default;
   border-radius: $border-radius;
-  padding: .625rem 1rem;
+  padding: .75rem 1rem;
   margin: 0.5rem 0;
   font-size: 1rem;
   font-family: var(--main-font);
   font-weight: var(--semi-bold-font-weight);
-  line-height: 1.2;
+  line-height: 1.05;
   text-decoration: none;
   text-align: center;
   transition: all ease-in-out .2s;
+
+  @media screen and (max-width: $width-sm) {
+    line-height: 1.2;
+  }
 
   &:hover {
     color: white;

--- a/pegasus/sites.v3/code.org/public/css/page/young-women-in-cs-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/page/young-women-in-cs-styles.scss
@@ -27,7 +27,7 @@
       width: 100%;
       height: 100%;
       background-image: url("/images/banners/banner-bg-mesh-dots-light.png"), url("/images/yw-page-top.png");
-      background-position: center, 90% bottom;
+      background-position: center, 82% bottom;
       background-repeat: repeat, no-repeat;
       background-size: contain, 580px;
       z-index: 2;
@@ -36,7 +36,7 @@
         transform: scaleX(-1);
       }
 
-      @media screen and (min-width: $width-xl) {
+      @media screen and (min-width: 1605px) {
         background-position: center, 70% bottom;
       }
 

--- a/pegasus/sites.v3/code.org/public/youngwomen.haml
+++ b/pegasus/sites.v3/code.org/public/youngwomen.haml
@@ -19,8 +19,9 @@ theme: responsive_full_width
 %section.intro
   .wrapper
     .flex-container.justify-space-between.wrap-reverse
-      %figure.img-wrapper.rounded-corners.col-45
-      .text-wrapper.col-50
+      %div.col-50
+        = view :display_video_thumbnail, id: "intro_csf", video_code: "t7sJiOOP12Y", play_button: 'center', letterbox: 'false', download_path: "//videos.code.org/young-women-in-cs/young-women-in-cs-v1.mp4"
+      .text-wrapper.col-45{style: "margin-bottom: 1rem"}
         %h2=hoc_s(:heading_cs_ambassador_program)
         %p.heading-xs
           =hoc_s(:cs_ambassador_subhead)


### PR DESCRIPTION
Adding the first version of the Young Women in CS video to https://code.org/youngwomen
- Also updated responsive styles on the hero banner image
- Fixed line-height issue on buttons site-wide

**Jira ticket:** [ACQ-1053](https://codedotorg.atlassian.net/browse/ACQ-1053)

----

## Before
<img width="1268" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/e8bacec8-8195-44a6-b524-1cd7be48a59e">

## After
<img width="1265" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/17dd4d75-9e44-4d5d-8be5-b6bd287e8ef6">
