### PR TITLE
Add deleted_at to LtiUserIdentitiy migration

### DIFF
--- a/dashboard/app/models/lti_user_identity.rb
+++ b/dashboard/app/models/lti_user_identity.rb
@@ -8,14 +8,17 @@
 #  user_id            :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  deleted_at         :datetime
 #
 # Indexes
 #
+#  index_lti_user_identities_on_deleted_at          (deleted_at)
 #  index_lti_user_identities_on_lti_integration_id  (lti_integration_id)
 #  index_lti_user_identities_on_subject             (subject)
 #  index_lti_user_identities_on_user_id             (user_id)
 #
 class LtiUserIdentity < ApplicationRecord
+  acts_as_paranoid
   belongs_to :lti_integration
   belongs_to :user
 

--- a/dashboard/db/migrate/20231013232502_add_deleted_at_to_lti_user_identities.rb
+++ b/dashboard/db/migrate/20231013232502_add_deleted_at_to_lti_user_identities.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToLtiUserIdentities < ActiveRecord::Migration[6.1]
+  def change
+    add_column :lti_user_identities, :deleted_at, :datetime
+    add_index :lti_user_identities, :deleted_at
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -885,6 +885,8 @@ ActiveRecord::Schema.define(version: 2023_11_07_182805) do
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_lti_user_identities_on_deleted_at"
     t.index ["lti_integration_id"], name: "index_lti_user_identities_on_lti_integration_id"
     t.index ["subject"], name: "index_lti_user_identities_on_subject"
     t.index ["user_id"], name: "index_lti_user_identities_on_user_id"

--- a/dashboard/db/schema_cache.yml
+++ b/dashboard/db/schema_cache.yml
@@ -130,7 +130,7 @@ columns:
     default_function:
     collation:
     comment:
-  - &9 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &43 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: key
     sql_type_metadata: *3
     'null': false
@@ -238,7 +238,7 @@ columns:
   - *8
   - &22 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_id
-    sql_type_metadata: &107 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+    sql_type_metadata: &108 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: varchar(12)
         type: :string
@@ -254,7 +254,14 @@ columns:
   - *6
   - *7
   ar_internal_metadata:
-  - *9
+  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+    name: key
+    sql_type_metadata: *3
+    'null': false
+    default:
+    default_function:
+    collation: utf8mb4_unicode_ci
+    comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: value
     sql_type_metadata: *3
@@ -263,8 +270,29 @@ columns:
     default_function:
     collation: utf8mb4_unicode_ci
     comment:
-  - *6
-  - *7
+  - &28 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+    name: created_at
+    sql_type_metadata: &9 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+        sql_type: datetime(6)
+        type: :datetime
+        limit:
+        precision: 6
+        scale:
+      extra: ''
+    'null': false
+    default:
+    default_function:
+    collation:
+    comment:
+  - &29 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+    name: updated_at
+    sql_type_metadata: *9
+    'null': false
+    default:
+    default_function:
+    collation:
+    comment:
   assessment_activities:
   - *5
   - &13 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -283,7 +311,7 @@ columns:
     default_function:
     collation:
     comment:
-  - &31 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &32 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: script_id
     sql_type_metadata: *2
     'null': false
@@ -294,7 +322,7 @@ columns:
   - &62 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: level_source_id
     sql_type_metadata: &15 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: &133 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+      delegate_dc_obj: &65 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
@@ -312,7 +340,7 @@ columns:
   - *7
   authentication_options:
   - *5
-  - &139 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &140 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: email
     sql_type_metadata: *3
     'null': false
@@ -501,7 +529,7 @@ columns:
   - &27 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: &29 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+      delegate_dc_obj: &30 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: bigint(20)
         type: :integer
         limit: 8
@@ -745,7 +773,7 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: other_classes_under_20_hours
     sql_type_metadata: &20 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: &38 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+      delegate_dc_obj: &37 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: tinyint(1)
         type: :boolean
         limit:
@@ -905,7 +933,7 @@ columns:
     comment:
   census_submissions_school_infos:
   - *21
-  - &135 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &136 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_info_id
     sql_type_metadata: *2
     'null': false
@@ -921,7 +949,7 @@ columns:
   - *23
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: teaches_cs
-    sql_type_metadata: &109 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+    sql_type_metadata: &110 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: varchar(2)
         type: :string
@@ -950,7 +978,7 @@ columns:
   - *25
   - *18
   - *19
-  - &36 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &35 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: storage_id
     sql_type_metadata: *2
     'null': false
@@ -1107,34 +1135,13 @@ columns:
     collation: utf8mb4_unicode_520_ci
     comment:
   - *16
-  - &32 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: created_at
-    sql_type_metadata: &28 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: datetime(6)
-        type: :datetime
-        limit:
-        precision: 6
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &33 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: updated_at
-    sql_type_metadata: *28
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+  - *28
+  - *29
   code_review_group_members:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: code_review_group_id
-    sql_type_metadata: &30 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: *29
+    sql_type_metadata: &31 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+      delegate_dc_obj: *30
       extra: ''
     'null': false
     default:
@@ -1143,7 +1150,7 @@ columns:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: follower_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': false
     default:
     default_function:
@@ -1155,13 +1162,13 @@ columns:
   - *27
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: section_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': false
     default:
     default_function:
     collation:
     comment:
-  - &40 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &39 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
     sql_type_metadata: *3
     'null': true
@@ -1174,9 +1181,9 @@ columns:
   code_review_requests:
   - *27
   - *13
-  - *31
+  - *32
   - *25
-  - &34 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &33 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: project_id
     sql_type_metadata: *2
     'null': false
@@ -1184,7 +1191,7 @@ columns:
     default_function:
     collation:
     comment:
-  - &35 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &34 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: project_version
     sql_type_metadata: *3
     'null': false
@@ -1192,7 +1199,7 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - &37 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &36 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: closed_at
     sql_type_metadata: *4
     'null': true
@@ -1201,13 +1208,13 @@ columns:
     collation:
     comment:
   - *16
-  - *32
-  - *33
+  - *28
+  - *29
   code_reviews:
   - *27
   - *13
-  - *34
-  - *31
+  - *33
+  - *32
   - *25
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: project_level_id
@@ -1217,16 +1224,16 @@ columns:
     default_function:
     collation:
     comment:
+  - *34
   - *35
   - *36
-  - *37
   - *16
-  - *32
-  - *33
+  - *28
+  - *29
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: active
-    sql_type_metadata: &39 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: *38
+    sql_type_metadata: &38 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+      delegate_dc_obj: *37
       extra: VIRTUAL GENERATED
     'null': true
     default:
@@ -1235,7 +1242,7 @@ columns:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: open
-    sql_type_metadata: *39
+    sql_type_metadata: *38
     'null': true
     default:
     default_function:
@@ -1243,7 +1250,7 @@ columns:
     comment:
   concepts:
   - *5
-  - *40
+  - *39
   - *18
   - *19
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -1267,7 +1274,7 @@ columns:
   - *14
   contact_rollups_final:
   - *5
-  - &41 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &40 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: email
     sql_type_metadata: *3
     'null': false
@@ -1275,9 +1282,9 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - &43 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &42 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
-    sql_type_metadata: &42 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+    sql_type_metadata: &41 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: json
         type: :json
@@ -1294,7 +1301,7 @@ columns:
   - *7
   contact_rollups_pardot_memory:
   - *5
-  - *41
+  - *40
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pardot_id
     sql_type_metadata: *2
@@ -1313,7 +1320,7 @@ columns:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data_synced
-    sql_type_metadata: *42
+    sql_type_metadata: *41
     'null': true
     default:
     default_function:
@@ -1355,13 +1362,13 @@ columns:
   - *7
   contact_rollups_processed:
   - *5
-  - *41
-  - *43
+  - *40
+  - *42
   - *6
   - *7
   contact_rollups_raw:
   - *5
-  - *41
+  - *40
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: sources
     sql_type_metadata: *3
@@ -1372,7 +1379,7 @@ columns:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
-    sql_type_metadata: *42
+    sql_type_metadata: *41
     'null': true
     default:
     default_function:
@@ -1471,7 +1478,7 @@ columns:
     comment:
   course_offerings:
   - *5
-  - *9
+  - *43
   - &45 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: display_name
     sql_type_metadata: *3
@@ -1620,7 +1627,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *31
+  - *32
   - *44
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: experiment_name
@@ -1643,7 +1650,7 @@ columns:
       (those that show up without experiments).
   course_versions:
   - *5
-  - *9
+  - *43
   - *45
   - *46
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -1672,7 +1679,7 @@ columns:
     default_function:
     collation:
     comment:
-  - &117 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &118 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: published_state
     sql_type_metadata: *3
     'null': true
@@ -1682,7 +1689,7 @@ columns:
     comment:
   courses:
   - *5
-  - *40
+  - *39
   - *46
   - *6
   - *7
@@ -1698,8 +1705,8 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - *32
-  - *33
+  - *28
+  - *29
   delayed_jobs:
   - *27
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -1710,7 +1717,7 @@ columns:
     default_function:
     collation:
     comment:
-  - &134 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &135 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: attempts
     sql_type_metadata: *2
     'null': false
@@ -1776,7 +1783,7 @@ columns:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
-    sql_type_metadata: *28
+    sql_type_metadata: *9
     'null': true
     default:
     default_function:
@@ -1784,7 +1791,7 @@ columns:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: updated_at
-    sql_type_metadata: *28
+    sql_type_metadata: *9
     'null': true
     default:
     default_function:
@@ -1792,7 +1799,7 @@ columns:
     comment:
   donor_schools:
   - *5
-  - *40
+  - *39
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: nces_id
     sql_type_metadata: *3
@@ -1805,7 +1812,7 @@ columns:
   - *7
   donors:
   - *5
-  - *40
+  - *39
   - *47
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: show
@@ -1858,7 +1865,7 @@ columns:
   - *7
   email_preferences:
   - *5
-  - *41
+  - *40
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: opt_in
     sql_type_metadata: *20
@@ -2094,7 +2101,7 @@ columns:
   - *53
   foorm_simple_survey_forms:
   - *27
-  - &119 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &120 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: path
     sql_type_metadata: *3
     'null': false
@@ -2102,7 +2109,7 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - &125 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &126 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: kind
     sql_type_metadata: *3
     'null': true
@@ -2142,7 +2149,7 @@ columns:
   - *54
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: simple_survey_form_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': true
     default:
     default_function:
@@ -2181,7 +2188,7 @@ columns:
   - *7
   frameworks:
   - *27
-  - &123 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &124 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: shortcode
     sql_type_metadata: *3
     'null': false
@@ -2195,7 +2202,7 @@ columns:
   - *7
   games:
   - *5
-  - *40
+  - *39
   - *18
   - *19
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -2495,32 +2502,6 @@ columns:
     default_function:
     collation:
     comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: learning_goal_id
-    sql_type_metadata: *30
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &58 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: understanding
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: ai_confidence
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *32
-  - *33
   learning_goal_evidence_levels:
   - *27
   - &57 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -2555,12 +2536,12 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - *32
-  - *33
+  - *28
+  - *29
   learning_goal_teacher_evaluations:
   - *27
   - *13
-  - &126 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &127 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: teacher_id
     sql_type_metadata: *2
     'null': false
@@ -2602,8 +2583,8 @@ columns:
     default_function:
     collation:
     comment:
-  - *32
-  - *33
+  - *28
+  - *29
   learning_goals:
   - *27
   - *9
@@ -2647,8 +2628,8 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - *32
-  - *33
+  - *28
+  - *29
   lesson_activities:
   - *5
   - &61 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -2659,15 +2640,15 @@ columns:
     default_function:
     collation:
     comment:
-  - *9
+  - *43
   - *44
   - *46
   - *6
   - *7
   lesson_groups:
   - *5
-  - *9
-  - *31
+  - *43
+  - *32
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: user_facing
     sql_type_metadata: *20
@@ -2683,7 +2664,7 @@ columns:
   lessons_opportunity_standards:
   - &60 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: lesson_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': false
     default:
     default_function:
@@ -2691,18 +2672,17 @@ columns:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: standard_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': false
     default:
     default_function:
     collation:
     comment:
-  - *27
   lessons_programming_expressions:
   - *60
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: programming_expression_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': false
     default:
     default_function:
@@ -2722,7 +2702,7 @@ columns:
   - *60
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: vocabulary_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': false
     default:
     default_function:
@@ -2834,15 +2814,10 @@ columns:
   - *18
   - *19
   level_sources:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &134 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(11) unsigned
-        type: :integer
-        limit: 8
-        precision:
-        scale:
+      delegate_dc_obj: *65
       extra: auto_increment
     'null': false
     default:
@@ -3086,7 +3061,7 @@ columns:
   - *33
   lti_integrations:
   - *27
-  - *40
+  - *39
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: platform_id
     sql_type_metadata: &68 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
@@ -3200,8 +3175,8 @@ columns:
     comment:
   - *65
   - *13
-  - *32
-  - *33
+  - *28
+  - *29
   metrics:
   - *5
   - *6
@@ -3283,7 +3258,7 @@ columns:
     comment:
   - *6
   - *7
-  - *9
+  - *43
   paired_user_levels:
   - *5
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -3358,8 +3333,8 @@ columns:
     default_function:
     collation:
     comment:
-  - *32
-  - *33
+  - *28
+  - *29
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: resends_sent
     sql_type_metadata: *2
@@ -3552,7 +3527,7 @@ columns:
   - *27
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pd_application_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': false
     default:
     default_function:
@@ -3585,7 +3560,7 @@ columns:
     default_function:
     collation:
     comment:
-  - &127 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &128 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: teacher_id
     sql_type_metadata: *2
     'null': true
@@ -3626,7 +3601,7 @@ columns:
   - *72
   pd_district_payment_terms:
   - *5
-  - &106 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &107 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_district_id
     sql_type_metadata: *2
     'null': true
@@ -3670,7 +3645,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *40
+  - *39
   pd_enrollments:
   - *5
   - &87 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -3681,7 +3656,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *40
+  - *39
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: first_name
     sql_type_metadata: *3
@@ -3698,10 +3673,10 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - *41
+  - *40
   - *18
   - *19
-  - &142 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &143 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school
     sql_type_metadata: *3
     'null': true
@@ -3734,7 +3709,7 @@ columns:
     default_function:
     collation:
     comment:
-  - &143 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &144 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_info_id
     sql_type_metadata: *2
     'null': true
@@ -4192,7 +4167,7 @@ columns:
   - *5
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: form_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': true
     default:
     default_function:
@@ -4210,7 +4185,7 @@ columns:
   - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_submission_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': true
     default:
     default_function:
@@ -4399,7 +4374,7 @@ columns:
     comment:
   - *71
   - *51
-  - &136 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &137 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: started_at
     sql_type_metadata: *4
     'null': true
@@ -4489,7 +4464,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *31
+  - *32
   - *25
   - *93
   - *63
@@ -4575,7 +4550,7 @@ columns:
   - *5
   - *6
   - *7
-  - &121 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &122 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course_id
     sql_type_metadata: *2
     'null': true
@@ -4628,7 +4603,7 @@ columns:
   - *54
   plc_learning_modules:
   - *5
-  - *40
+  - *39
   - *6
   - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -4647,7 +4622,7 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - &116 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &117 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: stage_id
     sql_type_metadata: *2
     'null': true
@@ -4764,8 +4739,8 @@ columns:
     default_function:
     collation:
     comment:
-  - *9
-  - *40
+  - *43
+  - *39
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: color
     sql_type_metadata: *3
@@ -4791,7 +4766,7 @@ columns:
   - *46
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: programming_environment_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': false
     default:
     default_function:
@@ -4908,7 +4883,7 @@ columns:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: state
-    sql_type_metadata: &113 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+    sql_type_metadata: &114 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: varchar(50)
         type: :string
@@ -5000,10 +4975,10 @@ columns:
   - *7
   reference_guides:
   - *27
-  - *9
+  - *43
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course_version_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': false
     default:
     default_function:
@@ -5083,7 +5058,7 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - &129 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &130 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: city
     sql_type_metadata: *3
     'null': true
@@ -5142,7 +5117,7 @@ columns:
     comment: Days that the workshop will take place
   resources:
   - *5
-  - *40
+  - *39
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: url
     sql_type_metadata: *3
@@ -5151,7 +5126,7 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - *9
+  - *43
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
     sql_type_metadata: *3
@@ -5198,8 +5173,8 @@ columns:
   - *27
   - *61
   - *25
-  - *32
-  - *33
+  - *28
+  - *29
   schema_migrations:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: version
@@ -5207,12 +5182,12 @@ columns:
     'null': false
     default:
     default_function:
-    collation: utf8_unicode_ci
+    collation: utf8mb4_unicode_ci
     comment:
   school_districts:
   - *5
   - *49
-  - &110 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &111 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: city
     sql_type_metadata: *3
     'null': false
@@ -5220,7 +5195,7 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - &111 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &112 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: state
     sql_type_metadata: *3
     'null': false
@@ -5228,7 +5203,7 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - &112 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &113 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: zip
     sql_type_metadata: *3
     'null': false
@@ -5236,9 +5211,9 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - &115 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &116 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_known_school_year_open
-    sql_type_metadata: &108 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+    sql_type_metadata: &109 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: varchar(9)
         type: :string
@@ -5255,7 +5230,7 @@ columns:
   - *7
   school_infos:
   - *5
-  - &130 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &131 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: country
     sql_type_metadata: *3
     'null': true
@@ -5299,7 +5274,7 @@ columns:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_id
-    sql_type_metadata: *107
+    sql_type_metadata: *108
     'null': true
     default:
     default_function:
@@ -5346,7 +5321,7 @@ columns:
   school_stats_by_years:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_id
-    sql_type_metadata: *107
+    sql_type_metadata: *108
     'null': false
     default:
     default_function:
@@ -5354,7 +5329,7 @@ columns:
     comment: NCES public school ID
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_year
-    sql_type_metadata: *108
+    sql_type_metadata: *109
     'null': false
     default:
     default_function:
@@ -5362,7 +5337,7 @@ columns:
     comment: School Year
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: grades_offered_lo
-    sql_type_metadata: *109
+    sql_type_metadata: *110
     'null': true
     default:
     default_function:
@@ -5370,7 +5345,7 @@ columns:
     comment: Grades Offered - Lowest
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: grades_offered_hi
-    sql_type_metadata: *109
+    sql_type_metadata: *110
     'null': true
     default:
     default_function:
@@ -5577,7 +5552,7 @@ columns:
     comment: All Students - Two or More Races
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: title_i_status
-    sql_type_metadata: &140 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+    sql_type_metadata: &141 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: varchar(1)
         type: :string
@@ -5602,7 +5577,7 @@ columns:
   - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: community_type
-    sql_type_metadata: &141 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+    sql_type_metadata: &142 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: varchar(16)
         type: :string
@@ -5618,17 +5593,17 @@ columns:
   schools:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
-    sql_type_metadata: *107
+    sql_type_metadata: *108
     'null': false
     default:
     default_function:
     collation: utf8_unicode_ci
     comment: NCES public school ID
-  - *106
+  - *107
   - *49
-  - *110
   - *111
   - *112
+  - *113
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_type
     sql_type_metadata: *3
@@ -5641,7 +5616,7 @@ columns:
   - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: address_line1
-    sql_type_metadata: *113
+    sql_type_metadata: *114
     'null': true
     default:
     default_function:
@@ -5649,7 +5624,7 @@ columns:
     comment: Location address, street 1
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: address_line2
-    sql_type_metadata: &114 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+    sql_type_metadata: &115 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: varchar(30)
         type: :string
@@ -5664,7 +5639,7 @@ columns:
     comment: Location address, street 2
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: address_line3
-    sql_type_metadata: *114
+    sql_type_metadata: *115
     'null': true
     default:
     default_function:
@@ -5672,7 +5647,7 @@ columns:
     comment: Location address, street 3
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: latitude
-    sql_type_metadata: &131 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+    sql_type_metadata: &132 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: decimal(8,6)
         type: :decimal
@@ -5687,7 +5662,7 @@ columns:
     comment: Location latitude
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: longitude
-    sql_type_metadata: &132 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+    sql_type_metadata: &133 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
         sql_type: decimal(9,6)
         type: :decimal
@@ -5708,10 +5683,10 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - *115
+  - *116
   script_levels:
   - *5
-  - *31
+  - *32
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: chapter
     sql_type_metadata: *2
@@ -5812,7 +5787,7 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - *117
+  - *118
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: instruction_type
     sql_type_metadata: *3
@@ -5839,7 +5814,7 @@ columns:
     comment:
   scripts_resources:
   - *26
-  - &118 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &119 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: resource_id
     sql_type_metadata: *2
     'null': true
@@ -5850,11 +5825,11 @@ columns:
   scripts_student_resources:
   - *27
   - *26
-  - *118
+  - *119
   secret_pictures:
   - *5
   - *49
-  - *119
+  - *120
   - *18
   - *19
   secret_words:
@@ -5875,8 +5850,8 @@ columns:
   - *31
   section_hidden_stages:
   - *5
-  - *120
-  - &122 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - *121
+  - &123 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: stage_id
     sql_type_metadata: *2
     'null': false
@@ -5894,8 +5869,8 @@ columns:
     default_function:
     collation:
     comment:
-  - *120
-  - &145 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - *121
+  - &146 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invited_by_id
     sql_type_metadata: *2
     'null': true
@@ -5912,17 +5887,17 @@ columns:
     default_function:
     collation:
     comment:
-  - *32
-  - *33
+  - *28
+  - *29
   sections:
   - *5
   - *13
-  - *40
+  - *39
   - *18
   - *19
   - *86
   - *26
-  - *121
+  - *122
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: grade
     sql_type_metadata: *3
@@ -6096,7 +6071,7 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - &124 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &125 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: description
     sql_type_metadata: *12
     'null': true
@@ -6150,7 +6125,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *31
+  - *32
   - *18
   - *19
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -6178,7 +6153,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *9
+  - *43
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: has_lesson_plan
     sql_type_metadata: *20
@@ -6188,7 +6163,7 @@ columns:
     collation:
     comment:
   stages_standards:
-  - *122
+  - *123
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: standard_id
     sql_type_metadata: *2
@@ -6201,7 +6176,7 @@ columns:
   - *7
   standard_categories:
   - *27
-  - *123
+  - *124
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: framework_id
     sql_type_metadata: *2
@@ -6231,10 +6206,10 @@ columns:
   - *7
   standards:
   - *5
-  - *124
+  - *125
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: category_id
-    sql_type_metadata: *30
+    sql_type_metadata: *31
     'null': true
     default:
     default_function:
@@ -6271,7 +6246,7 @@ columns:
   survey_results:
   - *5
   - *54
-  - *125
+  - *126
   - *46
   - *6
   - *7
@@ -6294,7 +6269,7 @@ columns:
     collation:
     comment:
   - *25
-  - *126
+  - *127
   - *6
   - *7
   - *16
@@ -6338,7 +6313,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *31
+  - *32
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: analytics_section_id
     sql_type_metadata: *2
@@ -6357,7 +6332,7 @@ columns:
     comment:
   teacher_profiles:
   - *5
-  - &138 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &139 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: studio_person_id
     sql_type_metadata: *2
     'null': true
@@ -6419,7 +6394,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *127
+  - *128
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: score
     sql_type_metadata: *2
@@ -6432,7 +6407,7 @@ columns:
   - *7
   unit_groups:
   - *5
-  - *40
+  - *39
   - *46
   - *6
   - *7
@@ -6469,7 +6444,7 @@ columns:
     collation: utf8_unicode_ci
     comment:
   unit_groups_resources:
-  - &128 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &129 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: unit_group_id
     sql_type_metadata: *2
     'null': true
@@ -6477,11 +6452,11 @@ columns:
     default_function:
     collation:
     comment:
-  - *118
+  - *119
   unit_groups_student_resources:
   - *27
-  - *128
-  - *118
+  - *129
+  - *119
   user_geos:
   - *5
   - *13
@@ -6506,6 +6481,8 @@ columns:
   - *129
   - *83
   - *130
+  - *86
+  - *131
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: postal_code
     sql_type_metadata: *3
@@ -6516,7 +6493,7 @@ columns:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: latitude
-    sql_type_metadata: *131
+    sql_type_metadata: *132
     'null': true
     default:
     default_function:
@@ -6524,26 +6501,17 @@ columns:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: longitude
-    sql_type_metadata: *132
+    sql_type_metadata: *133
     'null': true
     default:
     default_function:
     collation:
     comment:
   user_levels:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: id
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: *133
-      extra: auto_increment
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+  - *134
   - *13
   - *25
-  - *134
+  - *135
   - *18
   - *19
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -6601,9 +6569,9 @@ columns:
     default_function:
     collation: utf8_unicode_ci
     comment:
-  - *40
+  - *39
   - *16
-  - &144 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &145 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: purged_at
     sql_type_metadata: *4
     'null': true
@@ -6658,7 +6626,7 @@ columns:
   - *13
   - *6
   - *7
-  - &137 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+  - &138 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_progress_at
     sql_type_metadata: *4
     'null': true
@@ -7096,7 +7064,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *135
+  - *136
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_confirmation_date
     sql_type_metadata: *4
@@ -7110,8 +7078,8 @@ columns:
   user_scripts:
   - *5
   - *13
-  - *31
-  - *136
+  - *32
+  - *137
   - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: completed_at
     sql_type_metadata: *4
@@ -7128,14 +7096,13 @@ columns:
     default_function:
     collation:
     comment:
-  - *137
+  - *138
   - *18
   - *19
   - *46
   - *16
   users:
   - *5
-  - *138
   - *139
   - &147 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: parent_email
@@ -7253,7 +7220,7 @@ columns:
     comment:
   - &159 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: gender
-    sql_type_metadata: *140
+    sql_type_metadata: *141
     'null': true
     default:
     default_function:
@@ -8155,10 +8122,10 @@ indexes:
   backpacks:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: backpacks
-    name: index_backpacks_on_user_id
+    name: index_backpacks_on_storage_app_id
     unique: true
     columns:
-    - user_id
+    - storage_app_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -8168,10 +8135,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: backpacks
-    name: index_backpacks_on_storage_app_id
+    name: index_backpacks_on_user_id
     unique: true
     columns:
-    - storage_app_id
+    - user_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -9483,10 +9450,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: levels
-    name: index_levels_on_name
+    name: index_levels_on_level_num
     unique: false
     columns:
-    - name
+    - level_num
     lengths: {}
     orders: {}
     opclasses: {}
@@ -9496,10 +9463,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: levels
-    name: index_levels_on_level_num
+    name: index_levels_on_name
     unique: false
     columns:
-    - level_num
+    - name
     lengths: {}
     orders: {}
     opclasses: {}
@@ -9607,19 +9574,6 @@ indexes:
   lti_deployments:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: lti_deployments
-    name: index_lti_deployments_on_lti_integration_id
-    unique: false
-    columns:
-    - lti_integration_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_deployments
     name: index_lti_deployments_on_deployment_id
     unique: false
     columns:
@@ -9631,13 +9585,26 @@ indexes:
     type:
     using: :btree
     comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: lti_deployments
+    name: index_lti_deployments_on_lti_integration_id
+    unique: false
+    columns:
+    - lti_integration_id
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using: :btree
+    comment:
   lti_integrations:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: lti_integrations
-    name: index_lti_integrations_on_platform_id
+    name: index_lti_integrations_on_client_id
     unique: false
     columns:
-    - platform_id
+    - client_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -9660,10 +9627,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: lti_integrations
-    name: index_lti_integrations_on_client_id
+    name: index_lti_integrations_on_platform_id
     unique: false
     columns:
-    - client_id
+    - platform_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -9714,10 +9681,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: lti_user_identities
-    name: index_lti_user_identities_on_user_id
+    name: index_lti_user_identities_on_subject
     unique: false
     columns:
-    - user_id
+    - subject
     lengths: {}
     orders: {}
     opclasses: {}
@@ -9727,10 +9694,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: lti_user_identities
-    name: index_lti_user_identities_on_subject
+    name: index_lti_user_identities_on_user_id
     unique: false
     columns:
-    - subject
+    - user_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -11269,11 +11236,11 @@ indexes:
   programming_classes:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: programming_classes
-    name: index_programming_classes_on_key_and_programming_environment_id
+    name: index_programming_classes_on_key_and_category_id
     unique: true
     columns:
     - key
-    - programming_environment_id
+    - programming_environment_category_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -11283,11 +11250,11 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: programming_classes
-    name: index_programming_classes_on_key_and_category_id
+    name: index_programming_classes_on_key_and_programming_environment_id
     unique: true
     columns:
     - key
-    - programming_environment_category_id
+    - programming_environment_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -11354,10 +11321,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: programming_expressions
-    name: index_programming_expressions_on_programming_environment_id
+    name: index_programming_expressions_on_environment_category_id
     unique: false
     columns:
-    - programming_environment_id
+    - programming_environment_category_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -11367,10 +11334,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: programming_expressions
-    name: index_programming_expressions_on_environment_category_id
+    name: index_programming_expressions_on_programming_environment_id
     unique: false
     columns:
-    - programming_environment_category_id
+    - programming_environment_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -11452,11 +11419,11 @@ indexes:
   projects:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: projects
-    name: storage_apps_storage_id_index
+    name: storage_apps_project_type_index
     unique: false
     columns:
-    - storage_id
-    lengths: {}
+    - project_type
+    lengths: 191
     orders: {}
     opclasses: {}
     where:
@@ -11491,11 +11458,12 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: projects
-    name: storage_apps_project_type_index
+    name: storage_apps_storage_id_state_index
     unique: false
     columns:
-    - project_type
-    lengths: 191
+    - storage_id
+    - state
+    lengths: {}
     orders: {}
     opclasses: {}
     where:
@@ -11504,11 +11472,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: projects
-    name: storage_apps_storage_id_state_index
+    name: storage_apps_storage_id_index
     unique: false
     columns:
     - storage_id
-    - state
     lengths: {}
     orders: {}
     opclasses: {}
@@ -11814,6 +11781,19 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: schools
+    name: index_schools_on_last_known_school_year_open
+    unique: false
+    columns:
+    - last_known_school_year_open
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using: :btree
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: schools
     name: index_schools_on_school_district_id
     unique: false
     columns:
@@ -11831,19 +11811,6 @@ indexes:
     unique: false
     columns:
     - zip
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: schools
-    name: index_schools_on_last_known_school_year_open
-    unique: false
-    columns:
-    - last_known_school_year_open
     lengths: {}
     orders: {}
     opclasses: {}
@@ -11960,32 +11927,6 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: scripts
-    name: index_scripts_on_wrapup_video_id
-    unique: false
-    columns:
-    - wrapup_video_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
-    name: index_scripts_on_published_state
-    unique: false
-    columns:
-    - published_state
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
     name: index_scripts_on_instruction_type
     unique: false
     columns:
@@ -12016,6 +11957,32 @@ indexes:
     unique: false
     columns:
     - participant_audience
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using: :btree
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: scripts
+    name: index_scripts_on_published_state
+    unique: false
+    columns:
+    - published_state
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using: :btree
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: scripts
+    name: index_scripts_on_wrapup_video_id
+    unique: false
+    columns:
+    - wrapup_video_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -12193,10 +12160,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: section_instructors
-    name: index_section_instructors_on_instructor_id
+    name: index_section_instructors_on_deleted_at
     unique: false
     columns:
-    - instructor_id
+    - deleted_at
     lengths: {}
     orders: {}
     opclasses: {}
@@ -12206,10 +12173,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: section_instructors
-    name: index_section_instructors_on_section_id
+    name: index_section_instructors_on_instructor_id
     unique: false
     columns:
-    - section_id
+    - instructor_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -12232,10 +12199,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: section_instructors
-    name: index_section_instructors_on_deleted_at
+    name: index_section_instructors_on_section_id
     unique: false
     columns:
-    - deleted_at
+    - section_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -12567,32 +12534,6 @@ indexes:
   unit_groups:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: unit_groups
-    name: index_unit_groups_on_name
-    unique: false
-    columns:
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups
-    name: index_unit_groups_on_published_state
-    unique: false
-    columns:
-    - published_state
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups
     name: index_unit_groups_on_instruction_type
     unique: false
     columns:
@@ -12619,10 +12560,36 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: unit_groups
+    name: index_unit_groups_on_name
+    unique: false
+    columns:
+    - name
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using: :btree
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: unit_groups
     name: index_unit_groups_on_participant_audience
     unique: false
     columns:
     - participant_audience
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using: :btree
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: unit_groups
+    name: index_unit_groups_on_published_state
+    unique: false
+    columns:
+    - published_state
     lengths: {}
     orders: {}
     opclasses: {}
@@ -12735,10 +12702,10 @@ indexes:
   user_ml_models:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: user_ml_models
-    name: index_user_ml_models_on_user_id
+    name: index_user_ml_models_on_model_id
     unique: false
     columns:
-    - user_id
+    - model_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -12748,10 +12715,10 @@ indexes:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: user_ml_models
-    name: index_user_ml_models_on_model_id
+    name: index_user_ml_models_on_user_id
     unique: false
     columns:
-    - model_id
+    - user_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -13137,5 +13104,5 @@ database_version: !ruby/object:ActiveRecord::ConnectionAdapters::AbstractAdapter
   version:
   - 5
   - 7
-  - 12
-  full_version_string: 5.7.12-log
+  - 42
+  full_version_string: 5.7.42

--- a/dashboard/db/schema_cache.yml
+++ b/dashboard/db/schema_cache.yml
@@ -1,7519 +1,7637 @@
---- !ruby/object:ActiveRecord::ConnectionAdapters::SchemaCache
+---
+!ruby/object:ActiveRecord::ConnectionAdapters::SchemaCache
 columns:
   activities:
-  - &5 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: id
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: &1 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
-        type: :integer
-        limit: 4
-        precision:
-        scale:
-      extra: auto_increment
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &54 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: user_id
-    sql_type_metadata: &2 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: *1
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &14 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: level_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: action
-    sql_type_metadata: &3 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(255)
-        type: :string
-        limit: 255
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &47 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: url
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &18 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: created_at
-    sql_type_metadata: &4 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: datetime
-        type: :datetime
-        limit:
-        precision: 0
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &19 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: updated_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &10 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: attempt
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: time
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &11 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: test_result
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: level_source_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lines
-    sql_type_metadata: *2
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &5
+      name: id
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata &1
+          sql_type: int(11)
+          type: :integer
+          limit: 4
+          precision:
+          scale:
+        extra: auto_increment
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &54
+      name: user_id
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &2
+        delegate_dc_obj: *1
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &14
+      name: level_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: action
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &3
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(255)
+          type: :string
+          limit: 255
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &47
+      name: url
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &18
+      name: created_at
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &4
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: datetime
+          type: :datetime
+          limit:
+          precision: 0
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &19
+      name: updated_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &10
+      name: attempt
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: time
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &11
+      name: test_result
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: level_source_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: lines
+      sql_type_metadata: *2
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
   activity_sections:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lesson_activity_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &43 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: key
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &44 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: position
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &46 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: properties
-    sql_type_metadata: &12 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: text
-        type: :text
-        limit: 65535
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &6 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: created_at
-    sql_type_metadata: *4
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &7 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: updated_at
-    sql_type_metadata: *4
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: lesson_activity_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &9
+      name: key
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &44
+      name: position
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &46
+      name: properties
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &12
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: text
+          type: :text
+          limit: 65535
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &6
+      name: created_at
+      sql_type_metadata: *4
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &7
+      name: updated_at
+      sql_type_metadata: *4
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   ap_cs_offerings:
-  - *5
-  - &8 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_code
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(6)
-        type: :string
-        limit: 6
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: course
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(3)
-        type: :string
-        limit: 3
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &23 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_year
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: smallint(6)
-        type: :integer
-        limit: 2
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &8
+      name: school_code
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(6)
+          type: :string
+          limit: 6
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: course
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(3)
+          type: :string
+          limit: 3
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &23
+      name: school_year
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: smallint(6)
+          type: :integer
+          limit: 2
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   ap_school_codes:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_year
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *8
-  - &22 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_id
-    sql_type_metadata: &108 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(12)
-        type: :string
-        limit: 12
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_year
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *8
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &22
+      name: school_id
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &107
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(12)
+          type: :string
+          limit: 12
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
   ar_internal_metadata:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: key
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8mb4_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: value
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8mb4_unicode_ci
-    comment:
-  - &28 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: created_at
-    sql_type_metadata: &9 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: datetime(6)
-        type: :datetime
-        limit:
-        precision: 6
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &29 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: updated_at
-    sql_type_metadata: *9
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *9
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: value
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8mb4_unicode_ci
+      comment:
+    - *6
+    - *7
   assessment_activities:
-  - *5
-  - &13 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: user_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &25 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: level_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &32 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: script_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &62 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: level_source_id
-    sql_type_metadata: &15 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: &65 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
-        type: :integer
-        limit: 8
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *10
-  - *11
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &13
+      name: user_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &25
+      name: level_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &31
+      name: script_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &62
+      name: level_source_id
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &15
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata &133
+          sql_type: bigint(20) unsigned
+          type: :integer
+          limit: 8
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *10
+    - *11
+    - *6
+    - *7
   authentication_options:
-  - *5
-  - &140 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: email
-    sql_type_metadata: *3
-    'null': false
-    default: ''
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: hashed_email
-    sql_type_metadata: *3
-    'null': false
-    default: ''
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: credential_type
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: authentication_id
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &63 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: data
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &16 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: deleted_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *13
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &139
+      name: email
+      sql_type_metadata: *3
+      "null": false
+      default: ""
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: hashed_email
+      sql_type_metadata: *3
+      "null": false
+      default: ""
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: credential_type
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: authentication_id
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &63
+      name: data
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &16
+      name: deleted_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *13
+    - *6
+    - *7
   authored_hint_view_requests:
-  - *5
-  - *13
-  - &26 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: script_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *14
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: hint_id
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: hint_class
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: hint_type
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: prev_time
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: prev_attempt
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: prev_test_result
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: prev_level_source_id
-    sql_type_metadata: *15
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: next_time
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: next_attempt
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: next_test_result
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: next_level_source_id
-    sql_type_metadata: *15
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: final_time
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: final_attempt
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: final_test_result
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: final_level_source_id
-    sql_type_metadata: *15
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &26
+      name: script_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *14
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: hint_id
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: hint_class
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: hint_type
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: prev_time
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: prev_attempt
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: prev_test_result
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: prev_level_source_id
+      sql_type_metadata: *15
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: next_time
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: next_attempt
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: next_test_result
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: next_level_source_id
+      sql_type_metadata: *15
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: final_time
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: final_attempt
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: final_test_result
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: final_level_source_id
+      sql_type_metadata: *15
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   backpacks:
-  - &27 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: id
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: &30 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
-        type: :integer
-        limit: 8
-        precision:
-        scale:
-      extra: auto_increment
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *13
-  - &24 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: storage_app_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &27
+      name: id
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata &29
+          sql_type: bigint(20)
+          type: :integer
+          limit: 8
+          precision:
+          scale:
+        extra: auto_increment
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &24
+      name: storage_app_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   blocks:
-  - *5
-  - &49 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: name
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pool
-    sql_type_metadata: *3
-    'null': false
-    default: ''
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &98 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: category
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: config
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: helper_code
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
-  - *16
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &49
+      name: name
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: pool
+      sql_type_metadata: *3
+      "null": false
+      default: ""
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &98
+      name: category
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: config
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: helper_code
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
+    - *16
   callouts:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: element_id
-    sql_type_metadata: &17 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(1024)
-        type: :string
-        limit: 1024
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: localization_key
-    sql_type_metadata: *17
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *18
-  - *19
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: script_level_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: qtip_config
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: 'on'
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: callout_text
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: element_id
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &17
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(1024)
+          type: :string
+          limit: 1024
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: localization_key
+      sql_type_metadata: *17
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: script_level_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: qtip_config
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: "on"
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: callout_text
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   census_state_course_codes:
-  - *5
-  - &83 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: state
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &67 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: course
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &83
+      name: state
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &67
+      name: course
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
   census_submission_form_maps:
-  - *5
-  - &21 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: census_submission_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: form_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &21
+      name: census_submission_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: form_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   census_submissions:
-  - *5
-  - &50 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: type
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: submitter_email_address
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: submitter_name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: submitter_role
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_year
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: how_many_do_hoc
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: how_many_after_school
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: how_many_10_hours
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: how_many_20_hours
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: other_classes_under_20_hours
-    sql_type_metadata: &20 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: &37 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: tinyint(1)
-        type: :boolean
-        limit:
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic_blocks
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic_text
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic_robots
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic_internet
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic_security
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic_data
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic_web_design
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic_game_design
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic_other
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic_other_description
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic_do_not_know
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: class_frequency
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: tell_us_more
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pledged
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: share_with_regional_partners
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic_ethical_social
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Survey option for school courses including ethical and social issues
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: inaccuracy_reported
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: inaccuracy_comment
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &50
+      name: type
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: submitter_email_address
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: submitter_name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: submitter_role
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_year
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: how_many_do_hoc
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: how_many_after_school
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: how_many_10_hours
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: how_many_20_hours
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: other_classes_under_20_hours
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &20
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata &38
+          sql_type: tinyint(1)
+          type: :boolean
+          limit:
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic_blocks
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic_text
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic_robots
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic_internet
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic_security
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic_data
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic_web_design
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic_game_design
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic_other
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic_other_description
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic_do_not_know
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: class_frequency
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: tell_us_more
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: pledged
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: share_with_regional_partners
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic_ethical_social
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Survey option for school courses including ethical and social issues
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: inaccuracy_reported
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: inaccuracy_comment
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   census_submissions_school_infos:
-  - *21
-  - &136 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_info_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *21
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &135
+      name: school_info_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   census_summaries:
-  - *5
-  - *22
-  - *23
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: teaches_cs
-    sql_type_metadata: &110 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(2)
-        type: :string
-        limit: 2
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: audit_data
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
+    - *5
+    - *22
+    - *23
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: teaches_cs
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &109
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(2)
+          type: :string
+          limit: 2
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: audit_data
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
   channel_tokens:
-  - *5
-  - *24
-  - *25
-  - *18
-  - *19
-  - &35 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: storage_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *26
-  - *16
+    - *5
+    - *24
+    - *25
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &36
+      name: storage_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *26
+    - *16
   circuit_playground_discount_applications:
-  - *5
-  - *13
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: unit_6_intention
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: full_discount
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: admin_set_status
-    sql_type_metadata: *20
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: signature
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: signed_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: circuit_playground_discount_code_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_id
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: unit_6_intention
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: full_discount
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: admin_set_status
+      sql_type_metadata: *20
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: signature
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: signed_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: circuit_playground_discount_code_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_id
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   circuit_playground_discount_codes:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: code
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: full_discount
-    sql_type_metadata: *20
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: expiration
-    sql_type_metadata: *4
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: claimed_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: voided_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: code
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: full_discount
+      sql_type_metadata: *20
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: expiration
+      sql_type_metadata: *4
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: claimed_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: voided_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   code_review_comments:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: code_review_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: commenter_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: is_resolved
-    sql_type_metadata: *20
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: comment
-    sql_type_metadata: &56 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: mediumtext
-        type: :text
-        limit: 16777215
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation: utf8mb4_unicode_520_ci
-    comment:
-  - *16
-  - *28
-  - *29
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: code_review_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: commenter_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: is_resolved
+      sql_type_metadata: *20
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: comment
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &56
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: mediumtext
+          type: :text
+          limit: 16777215
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation: utf8mb4_unicode_520_ci
+      comment:
+    - *16
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &32
+      name: created_at
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &28
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: datetime(6)
+          type: :datetime
+          limit:
+          precision: 6
+          scale:
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &33
+      name: updated_at
+      sql_type_metadata: *28
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   code_review_group_members:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: code_review_group_id
-    sql_type_metadata: &31 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: *30
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: follower_id
-    sql_type_metadata: *31
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: code_review_group_id
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &30
+        delegate_dc_obj: *29
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: follower_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   code_review_groups:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: section_id
-    sql_type_metadata: *31
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &39 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: section_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &40
+      name: name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
   code_review_requests:
-  - *27
-  - *13
-  - *32
-  - *25
-  - &33 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: project_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &34 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: project_version
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &36 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: closed_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *16
-  - *28
-  - *29
+    - *27
+    - *13
+    - *31
+    - *25
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &34
+      name: project_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &35
+      name: project_version
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &37
+      name: closed_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *16
+    - *32
+    - *33
   code_reviews:
-  - *27
-  - *13
-  - *33
-  - *32
-  - *25
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: project_level_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *34
-  - *35
-  - *36
-  - *16
-  - *28
-  - *29
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: active
-    sql_type_metadata: &38 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: *37
-      extra: VIRTUAL GENERATED
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: open
-    sql_type_metadata: *38
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *27
+    - *13
+    - *34
+    - *31
+    - *25
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: project_level_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *35
+    - *36
+    - *37
+    - *16
+    - *32
+    - *33
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: active
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &39
+        delegate_dc_obj: *38
+        extra: VIRTUAL GENERATED
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: open
+      sql_type_metadata: *39
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   concepts:
-  - *5
-  - *39
-  - *18
-  - *19
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: video_key
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - *40
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: video_key
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   concepts_levels:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: concept_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *14
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: concept_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *14
   contact_rollups_final:
-  - *5
-  - &40 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: email
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &42 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: data
-    sql_type_metadata: &41 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: json
-        type: :json
-        limit:
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &41
+      name: email
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &43
+      name: data
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &42
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: json
+          type: :json
+          limit:
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   contact_rollups_pardot_memory:
-  - *5
-  - *40
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pardot_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pardot_id_updated_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: data_synced
-    sql_type_metadata: *41
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: data_synced_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: data_rejected_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: data_rejected_reason
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: marked_for_deletion_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - *41
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: pardot_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: pardot_id_updated_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: data_synced
+      sql_type_metadata: *42
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: data_synced_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: data_rejected_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: data_rejected_reason
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: marked_for_deletion_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   contact_rollups_processed:
-  - *5
-  - *40
-  - *42
-  - *6
-  - *7
+    - *5
+    - *41
+    - *43
+    - *6
+    - *7
   contact_rollups_raw:
-  - *5
-  - *40
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: sources
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: data
-    sql_type_metadata: *41
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: data_updated_at
-    sql_type_metadata: *4
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - *41
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: sources
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: data
+      sql_type_metadata: *42
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: data_updated_at
+      sql_type_metadata: *4
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   contained_level_answers:
-  - *5
-  - *6
-  - *7
-  - *25
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: answer_number
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: answer_text
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: correct
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *6
+    - *7
+    - *25
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: answer_number
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: answer_text
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: correct
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   contained_levels:
-  - *5
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: level_group_level_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: contained_level_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: contained_level_type
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: contained_level_page
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: contained_level_position
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: contained_level_text
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: level_group_level_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: contained_level_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: contained_level_type
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: contained_level_page
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: contained_level_position
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: contained_level_text
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   course_offerings:
-  - *5
-  - *43
-  - &45 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: display_name
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: category
-    sql_type_metadata: *3
-    'null': false
-    default: other
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: is_featured
-    sql_type_metadata: *20
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: assignable
-    sql_type_metadata: *20
-    'null': false
-    default: '1'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: curriculum_type
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: marketing_initiative
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_levels
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: header
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: image
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: cs_topic
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_subject
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: device_compatibility
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: description
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: professional_learning_program
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: video
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: published_date
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: self_paced_pl_course_offering_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *9
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &45
+      name: display_name
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: category
+      sql_type_metadata: *3
+      "null": false
+      default: other
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: is_featured
+      sql_type_metadata: *20
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: assignable
+      sql_type_metadata: *20
+      "null": false
+      default: "1"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: curriculum_type
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: marketing_initiative
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_levels
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: header
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: image
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: cs_topic
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_subject
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: device_compatibility
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: description
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: professional_learning_program
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: video
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: published_date
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: self_paced_pl_course_offering_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   course_scripts:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: course_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *32
-  - *44
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: experiment_name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: If present, the SingleTeacherExperiment with this name must be enabled
-      in order for a teacher or their students to see this script.
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: default_script_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: If present, indicates the default script which this script will replace
-      when the corresponding experiment is enabled. Should be null for default scripts
-      (those that show up without experiments).
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: course_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *31
+    - *44
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: experiment_name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+        If present, the SingleTeacherExperiment with this name must be enabled
+        in order for a teacher or their students to see this script.
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: default_script_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+        If present, indicates the default script which this script will replace
+        when the corresponding experiment is enabled. Should be null for default scripts
+        (those that show up without experiments).
   course_versions:
-  - *5
-  - *43
-  - *45
-  - *46
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: content_root_type
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: content_root_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: course_offering_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &118 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: published_state
-    sql_type_metadata: *3
-    'null': true
-    default: in_development
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - *9
+    - *45
+    - *46
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: content_root_type
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: content_root_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: course_offering_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &117
+      name: published_state
+      sql_type_metadata: *3
+      "null": true
+      default: in_development
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   courses:
-  - *5
-  - *39
-  - *46
-  - *6
-  - *7
+    - *5
+    - *40
+    - *46
+    - *6
+    - *7
   data_docs:
-  - *27
-  - *9
-  - *40
-  - &64 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: content
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *28
-  - *29
+    - *27
+    - *9
+    - *40
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &64
+      name: content
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *32
+    - *33
   delayed_jobs:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: priority
-    sql_type_metadata: *2
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - &135 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: attempts
-    sql_type_metadata: *2
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: handler
-    sql_type_metadata: *12
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: last_error
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: run_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &70 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: locked_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: failed_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: locked_by
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: queue
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: created_at
-    sql_type_metadata: *9
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: updated_at
-    sql_type_metadata: *9
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: priority
+      sql_type_metadata: *2
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &134
+      name: attempts
+      sql_type_metadata: *2
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: handler
+      sql_type_metadata: *12
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: last_error
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: run_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &70
+      name: locked_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: failed_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: locked_by
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: queue
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: created_at
+      sql_type_metadata: *28
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: updated_at
+      sql_type_metadata: *28
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   donor_schools:
-  - *5
-  - *39
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: nces_id
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
+    - *5
+    - *40
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: nces_id
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
   donors:
-  - *5
-  - *39
-  - *47
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: show
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: twitter
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: level
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: weight
-    sql_type_metadata: &48 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: float
-        type: :float
-        limit: 24
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: twitter_weight
-    sql_type_metadata: *48
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - *40
+    - *47
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: show
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: twitter
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: level
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: weight
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &48
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: float
+          type: :float
+          limit: 24
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: twitter_weight
+      sql_type_metadata: *48
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   email_preferences:
-  - *5
-  - *40
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: opt_in
-    sql_type_metadata: *20
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: ip_address
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: source
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: form_kind
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
+    - *5
+    - *41
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: opt_in
+      sql_type_metadata: *20
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: ip_address
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: source
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: form_kind
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
   experiments:
-  - *5
-  - *6
-  - *7
-  - *49
-  - *50
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: start_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: end_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &51 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: section_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: min_user_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: max_user_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: overflow_max_user_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: earliest_section_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: latest_section_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *26
+    - *5
+    - *6
+    - *7
+    - *49
+    - *50
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: start_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: end_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &51
+      name: section_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: min_user_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: max_user_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: overflow_max_user_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: earliest_section_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: latest_section_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *26
   featured_projects:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: storage_app_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: featured_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: unfeatured_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: topic
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: storage_app_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: featured_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: unfeatured_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: topic
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   followers:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: student_user_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *18
-  - *19
-  - *51
-  - *16
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: student_user_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *18
+    - *19
+    - *51
+    - *16
   foorm_forms:
-  - *5
-  - *49
-  - &52 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: version
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: questions
-    sql_type_metadata: *12
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
-  - &53 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: published
-    sql_type_metadata: *20
-    'null': false
-    default: '1'
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *49
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &52
+      name: version
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: questions
+      sql_type_metadata: *12
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &53
+      name: published
+      sql_type_metadata: *20
+      "null": false
+      default: "1"
+      default_function:
+      collation:
+      comment:
   foorm_libraries:
-  - *27
-  - *49
-  - *52
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: published
-    sql_type_metadata: *20
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *27
+    - *49
+    - *52
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: published
+      sql_type_metadata: *20
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   foorm_library_questions:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: library_name
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: library_version
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: question_name
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: question
-    sql_type_metadata: *12
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
-  - *53
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: library_name
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: library_version
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: question_name
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: question
+      sql_type_metadata: *12
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
+    - *53
   foorm_simple_survey_forms:
-  - *27
-  - &120 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: path
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &126 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: kind
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: form_name
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &55 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: form_version
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *46
-  - *6
-  - *7
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &119
+      name: path
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &125
+      name: kind
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: form_name
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &55
+      name: form_version
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *46
+    - *6
+    - *7
   foorm_simple_survey_submissions:
-  - *5
-  - &90 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: foorm_submission_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *54
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: simple_survey_form_id
-    sql_type_metadata: *31
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: misc_form_path
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &90
+      name: foorm_submission_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *54
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: simple_survey_form_id
+      sql_type_metadata: *30
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: misc_form_path
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
   foorm_submissions:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: form_name
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8mb4_bin
-    comment:
-  - *55
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: answers
-    sql_type_metadata: *56
-    'null': false
-    default:
-    default_function:
-    collation: utf8mb4_bin
-    comment:
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: form_name
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8mb4_bin
+      comment:
+    - *55
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: answers
+      sql_type_metadata: *56
+      "null": false
+      default:
+      default_function:
+      collation: utf8mb4_bin
+      comment:
+    - *6
+    - *7
   frameworks:
-  - *27
-  - &124 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: shortcode
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *49
-  - *46
-  - *6
-  - *7
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &123
+      name: shortcode
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *49
+    - *46
+    - *6
+    - *7
   games:
-  - *5
-  - *39
-  - *18
-  - *19
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: app
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: intro_video_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *40
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: app
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: intro_video_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   google_sheets_shared_cdo_donors:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: name_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: url_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: show_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: twitter_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: level_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: weight_f
-    sql_type_metadata: *48
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: twitter_weight_f
-    sql_type_metadata: *48
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: name_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: url_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: show_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: twitter_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: level_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: weight_f
+      sql_type_metadata: *48
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: twitter_weight_f
+      sql_type_metadata: *48
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   google_sheets_shared_cdo_languages:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: code_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: unique_language_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: language_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: locale_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: native_name_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: english_name_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: supported_codeorg_b
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: supported_hoc_b
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: crowdin_code_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: crowdin_name_s
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: csf_b
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: frozen_b
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: starwars_b
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: minecraft_adventurer_b
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: minecraft_designer_b
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: code_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: unique_language_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: language_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: locale_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: native_name_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: english_name_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: supported_codeorg_b
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: supported_hoc_b
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: crowdin_code_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: crowdin_name_s
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: csf_b
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: frozen_b
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: starwars_b
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: minecraft_adventurer_b
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: minecraft_designer_b
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   hint_view_requests:
-  - *5
-  - *54
-  - *26
-  - *14
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: feedback_type
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: feedback_xml
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
+    - *5
+    - *54
+    - *26
+    - *14
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: feedback_type
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: feedback_xml
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
   learning_goal_ai_evaluation_feedbacks:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: learning_goal_ai_evaluation_id
-    sql_type_metadata: *30
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: teacher_id
-    sql_type_metadata: *30
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: ai_feedback_approval
-    sql_type_metadata: *20
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: false_positive
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: false_negative
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: vague
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: feedback_other
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: other_content
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *32
-  - *33
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: learning_goal_ai_evaluation_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: teacher_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: ai_feedback_approval
+      sql_type_metadata: *20
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: false_positive
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: false_negative
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: vague
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: feedback_other
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: other_content
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *32
+    - *33
   learning_goal_ai_evaluations:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: rubric_ai_evaluation_id
-    sql_type_metadata: *30
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: rubric_ai_evaluation_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: learning_goal_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &58
+      name: understanding
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: ai_confidence
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *32
+    - *33
   learning_goal_evidence_levels:
-  - *27
-  - &57 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: learning_goal_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: understanding
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: teacher_description
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: ai_prompt
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *28
-  - *29
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &57
+      name: learning_goal_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: understanding
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: teacher_description
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: ai_prompt
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *32
+    - *33
   learning_goal_teacher_evaluations:
-  - *27
-  - *13
-  - &127 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: teacher_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *57
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: project_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &104 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: project_version
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *58
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: feedback
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: submitted_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *28
-  - *29
+    - *27
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &126
+      name: teacher_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *57
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: project_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &104
+      name: project_version
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *58
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: feedback
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: submitted_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *32
+    - *33
   learning_goals:
-  - *27
-  - *9
-  - &59 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: position
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: rubric_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: learning_goal
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: ai_enabled
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &96 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: tips
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *28
-  - *29
+    - *27
+    - *9
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &59
+      name: position
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: rubric_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: learning_goal
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: ai_enabled
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &96
+      name: tips
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *32
+    - *33
   lesson_activities:
-  - *5
-  - &61 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lesson_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *43
-  - *44
-  - *46
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &61
+      name: lesson_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *9
+    - *44
+    - *46
+    - *6
+    - *7
   lesson_groups:
-  - *5
-  - *43
-  - *32
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: user_facing
-    sql_type_metadata: *20
-    'null': false
-    default: '1'
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
-  - *59
-  - *46
+    - *5
+    - *9
+    - *31
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: user_facing
+      sql_type_metadata: *20
+      "null": false
+      default: "1"
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
+    - *59
+    - *46
   lessons_opportunity_standards:
-  - &60 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lesson_id
-    sql_type_metadata: *31
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: standard_id
-    sql_type_metadata: *31
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &60
+      name: lesson_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: standard_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *27
   lessons_programming_expressions:
-  - *60
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: programming_expression_id
-    sql_type_metadata: *31
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *60
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: programming_expression_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   lessons_resources:
-  - *61
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: resource_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *61
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: resource_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   lessons_vocabularies:
-  - *60
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: vocabulary_id
-    sql_type_metadata: *31
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *60
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: vocabulary_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   level_concept_difficulties:
-  - *5
-  - *14
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: sequencing
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: debugging
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: repeat_loops
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: repeat_until_while
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: for_loops
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: events
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: variables
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: functions
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: functions_with_params
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: conditionals
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *14
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: sequencing
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: debugging
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: repeat_loops
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: repeat_until_while
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: for_loops
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: events
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: variables
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: functions
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: functions_with_params
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: conditionals
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   level_source_images:
-  - *5
-  - *62
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: image
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: mediumblob
-        type: :binary
-        limit: 16777215
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *18
-  - *19
+    - *5
+    - *62
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: image
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: mediumblob
+          type: :binary
+          limit: 16777215
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *18
+    - *19
   level_sources:
-  - &134 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: id
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: *65
-      extra: auto_increment
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *14
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: md5
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(32)
-        type: :string
-        limit: 32
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: data
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(20000)
-        type: :string
-        limit: 20000
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *18
-  - *19
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: hidden
-    sql_type_metadata: *20
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: id
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: bigint(11) unsigned
+          type: :integer
+          limit: 8
+          precision:
+          scale:
+        extra: auto_increment
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *14
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: md5
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(32)
+          type: :string
+          limit: 32
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: data
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(20000)
+          type: :string
+          limit: 20000
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: hidden
+      sql_type_metadata: *20
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
   level_sources_multi_types:
-  - *5
-  - &93 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: level_source_id
-    sql_type_metadata: *15
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *25
-  - *63
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: md5
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: hidden
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &93
+      name: level_source_id
+      sql_type_metadata: *15
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *25
+    - *63
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: md5
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: hidden
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   levels:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: game_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *49
-  - *18
-  - *19
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: level_num
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: ideal_level_source_id
-    sql_type_metadata: *15
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *54
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: properties
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: longtext
-        type: :text
-        limit: 4294967295
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation: utf8mb4_unicode_520_ci
-    comment:
-  - &92 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: type
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: md5
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &97 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: published
-    sql_type_metadata: *20
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - &71 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: notes
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: audit_log
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: game_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *49
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: level_num
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: ideal_level_source_id
+      sql_type_metadata: *15
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *54
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: properties
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: longtext
+          type: :text
+          limit: 4294967295
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation: utf8mb4_unicode_520_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &92
+      name: type
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: md5
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &97
+      name: published
+      sql_type_metadata: *20
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &71
+      name: notes
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: audit_log
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   levels_script_levels:
-  - *25
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: script_level_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *25
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: script_level_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   libraries:
-  - *5
-  - *49
-  - *64
-  - *6
-  - *7
+    - *5
+    - *49
+    - *64
+    - *6
+    - *7
   lti_courses:
-  - *27
-  - &65 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lti_integration_id
-    sql_type_metadata: *30
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lti_deployment_id
-    sql_type_metadata: *30
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: context_id
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: course_id
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: nrps_url
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: resource_link_id
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *32
-  - *33
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &65
+      name: lti_integration_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: lti_deployment_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: context_id
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: course_id
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: nrps_url
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: resource_link_id
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *32
+    - *33
   lti_deployments:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: deployment_id
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *65
-  - *32
-  - *33
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: deployment_id
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *65
+    - *32
+    - *33
   lti_integrations:
-  - *27
-  - *39
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: platform_id
-    sql_type_metadata: &68 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(36)
-        type: :string
-        limit: 36
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: issuer
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: client_id
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: platform_name
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: auth_redirect_url
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: jwks_url
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: access_token_url
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: admin_email
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *32
-  - *33
+    - *27
+    - *40
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: platform_id
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &68
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(36)
+          type: :string
+          limit: 36
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: issuer
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: client_id
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: platform_name
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: auth_redirect_url
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: jwks_url
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: access_token_url
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: admin_email
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *32
+    - *33
   lti_sections:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lti_course_id
-    sql_type_metadata: *30
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &120 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: section_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lms_section_id
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *32
-  - *33
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: lti_course_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &120
+      name: section_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: lms_section_id
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *32
+    - *33
   lti_user_identities:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: subject
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *65
-  - *13
-  - *28
-  - *29
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: subject
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *65
+    - *13
+    - *32
+    - *33
   metrics:
-  - *5
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: computed_on
-    sql_type_metadata: &66 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: date
-        type: :date
-        limit:
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: computed_by
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: metric_on
-    sql_type_metadata: *66
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *67
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: breakdown
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: metric
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: submetric
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: value
-    sql_type_metadata: *48
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: computed_on
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &66
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: date
+          type: :date
+          limit:
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: computed_by
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: metric_on
+      sql_type_metadata: *66
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *67
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: breakdown
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: metric
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: submetric
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: value
+      sql_type_metadata: *48
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   objectives:
-  - *5
-  - *46
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lesson_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
-  - *43
+    - *5
+    - *46
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: lesson_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
+    - *9
   paired_user_levels:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: driver_user_level_id
-    sql_type_metadata: *15
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: navigator_user_level_id
-    sql_type_metadata: *15
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: driver_user_level_id
+      sql_type_metadata: *15
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: navigator_user_level_id
+      sql_type_metadata: *15
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   parent_levels_child_levels:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: parent_level_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: child_level_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *59
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: kind
-    sql_type_metadata: *3
-    'null': false
-    default: sublevel
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: parent_level_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: child_level_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *59
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: kind
+      sql_type_metadata: *3
+      "null": false
+      default: sublevel
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   parental_permission_requests:
-  - *27
-  - *13
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: parent_email
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: uuid
-    sql_type_metadata: *68
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: reminders_sent
-    sql_type_metadata: *2
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - *28
-  - *29
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: resends_sent
-    sql_type_metadata: *2
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
+    - *27
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: parent_email
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: uuid
+      sql_type_metadata: *68
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: reminders_sent
+      sql_type_metadata: *2
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - *32
+    - *33
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: resends_sent
+      sql_type_metadata: *2
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
   pd_accepted_programs:
-  - *5
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: workshop_name
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &72 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: course
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *13
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: teacher_application_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: workshop_name
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &72
+      name: course
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: teacher_application_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   pd_application_emails:
-  - *5
-  - &69 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd_application_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: application_status
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: email_type
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: to
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: sent_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &69
+      name: pd_application_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: application_status
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: email_type
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: to
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: sent_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   pd_application_tags:
-  - *5
-  - *49
-  - *6
-  - *7
+    - *5
+    - *49
+    - *6
+    - *7
   pd_application_tags_applications:
-  - *69
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd_application_tag_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *69
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: pd_application_tag_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   pd_applications:
-  - *5
-  - *54
-  - *50
-  - &84 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: application_year
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: application_type
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &81 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: regional_partner_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &94 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: status
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *70
-  - *71
-  - &75 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: form_data
-    sql_type_metadata: *12
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
-  - *67
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: response_scores
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: Scores given to certain responses
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: application_guid
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: accepted_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *46
-  - *16
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: status_timestamp_change_log
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: applied_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *54
+    - *50
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &84
+      name: application_year
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: application_type
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &81
+      name: regional_partner_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &94
+      name: status
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *70
+    - *71
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &75
+      name: form_data
+      sql_type_metadata: *12
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
+    - *67
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: response_scores
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: Scores given to certain responses
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: application_guid
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: accepted_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *46
+    - *16
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: status_timestamp_change_log
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: applied_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   pd_applications_status_logs:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd_application_id
-    sql_type_metadata: *31
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: status
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: timestamp
-    sql_type_metadata: *4
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *44
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: pd_application_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: status
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: timestamp
+      sql_type_metadata: *4
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *44
   pd_attendances:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd_session_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &128 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: teacher_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *18
-  - *19
-  - *16
-  - &85 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd_enrollment_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: marked_by_user_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: User id for the partner or admin who marked this teacher in attendance,
-      or nil if the teacher self-attended.
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: pd_session_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &127
+      name: teacher_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *18
+    - *19
+    - *16
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &85
+      name: pd_enrollment_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: marked_by_user_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+        User id for the partner or admin who marked this teacher in attendance,
+        or nil if the teacher self-attended.
   pd_course_facilitators:
-  - *5
-  - &89 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: facilitator_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *72
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &89
+      name: facilitator_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *72
   pd_district_payment_terms:
-  - *5
-  - &107 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_district_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *72
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: rate_type
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: rate
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: decimal(8,2)
-        type: :decimal
-        limit:
-        precision: 8
-        scale: 2
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &106
+      name: school_district_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *72
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: rate_type
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: rate
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: decimal(8,2)
+          type: :decimal
+          limit:
+          precision: 8
+          scale: 2
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   pd_enrollment_notifications:
-  - *5
-  - *6
-  - *7
-  - &80 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd_enrollment_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *39
+    - *5
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &80
+      name: pd_enrollment_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *40
   pd_enrollments:
-  - *5
-  - &87 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd_workshop_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *39
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: first_name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: last_name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *40
-  - *18
-  - *19
-  - &143 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &86 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: code
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *54
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: survey_sent_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: completed_survey_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &144 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_info_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *16
-  - *46
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: application_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &87
+      name: pd_workshop_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *40
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: first_name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: last_name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *41
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &142
+      name: school
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &86
+      name: code
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *54
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: survey_sent_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: completed_survey_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &143
+      name: school_info_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *16
+    - *46
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: application_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   pd_facilitator_program_registrations:
-  - *5
-  - *13
-  - &73 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: form_data
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: teachercon
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &73
+      name: form_data
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: teachercon
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   pd_facilitator_teachercon_attendances:
-  - *5
-  - *13
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: tc1_arrive
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: tc1_depart
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: fit1_arrive
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: fit1_depart
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: fit1_course
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: tc2_arrive
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: tc2_depart
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: fit2_arrive
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: fit2_depart
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: fit2_course
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: tc3_arrive
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: tc3_depart
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: fit3_arrive
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: fit3_depart
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: fit3_course
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: tc1_arrive
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: tc1_depart
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: fit1_arrive
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: fit1_depart
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: fit1_course
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: tc2_arrive
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: tc2_depart
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: fit2_arrive
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: fit2_depart
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: fit2_course
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: tc3_arrive
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: tc3_depart
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: fit3_arrive
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: fit3_depart
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: fit3_course
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   pd_fit_weekend1819_registrations:
-  - *5
-  - &74 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd_application_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *73
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &74
+      name: pd_application_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *73
+    - *6
+    - *7
   pd_fit_weekend_registrations:
-  - *5
-  - *74
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: registration_year
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *73
-  - *6
-  - *7
+    - *5
+    - *74
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: registration_year
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *73
+    - *6
+    - *7
   pd_international_opt_ins:
-  - *5
-  - *13
-  - *75
-  - *6
-  - *7
+    - *5
+    - *13
+    - *75
+    - *6
+    - *7
   pd_legacy_survey_summaries:
-  - *5
-  - &91 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: facilitator_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *67
-  - &76 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: subject
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *63
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &91
+      name: facilitator_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *67
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &76
+      name: subject
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *63
+    - *6
+    - *7
   pd_misc_surveys:
-  - *5
-  - &77 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: form_id
-    sql_type_metadata: *30
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &78 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: submission_id
-    sql_type_metadata: *30
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - &79 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: answers
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *54
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &77
+      name: form_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &78
+      name: submission_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &79
+      name: answers
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *54
+    - *6
+    - *7
   pd_payment_terms:
-  - *5
-  - &82 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: regional_partner_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: start_date
-    sql_type_metadata: *66
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: end_date
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *67
-  - *76
-  - *46
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &82
+      name: regional_partner_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: start_date
+      sql_type_metadata: *66
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: end_date
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *67
+    - *76
+    - *46
+    - *6
+    - *7
   pd_post_course_surveys:
-  - *5
-  - *77
-  - *78
-  - *79
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: year
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *13
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: course
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: csd or csp
-  - *6
-  - *7
+    - *5
+    - *77
+    - *78
+    - *79
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: year
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: course
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: csd or csp
+    - *6
+    - *7
   pd_pre_workshop_surveys:
-  - *5
-  - *80
-  - *75
-  - *6
-  - *7
+    - *5
+    - *80
+    - *75
+    - *6
+    - *7
   pd_regional_partner_cohorts:
-  - *5
-  - *81
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: role
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: teacher or facilitator
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: year
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: free-form text year range, YYYY-YYYY, e.g. 2016-2017
-  - *72
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: Human readable name of cohort (not required, used to support large partners
-      with multiple cohorts)
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: size
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Number of people permitted in the cohort
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: summer_workshop_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - *81
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: role
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: teacher or facilitator
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: year
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: free-form text year range, YYYY-YYYY, e.g. 2016-2017
+    - *72
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+        Human readable name of cohort (not required, used to support large partners
+        with multiple cohorts)
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: size
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Number of people permitted in the cohort
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: summer_workshop_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   pd_regional_partner_cohorts_users:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd_regional_partner_cohort_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: pd_regional_partner_cohort_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *13
   pd_regional_partner_contacts:
-  - *5
-  - *54
-  - *81
-  - *73
-  - *6
-  - *7
+    - *5
+    - *54
+    - *81
+    - *73
+    - *6
+    - *7
   pd_regional_partner_mappings:
-  - *5
-  - *82
-  - *83
-  - &103 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: zip_code
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
-  - *16
+    - *5
+    - *82
+    - *83
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &103
+      name: zip_code
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
+    - *16
   pd_regional_partner_mini_contacts:
-  - *5
-  - *54
-  - *81
-  - *73
-  - *6
-  - *7
+    - *5
+    - *54
+    - *81
+    - *73
+    - *6
+    - *7
   pd_regional_partner_program_registrations:
-  - *5
-  - *13
-  - *73
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: teachercon
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - *13
+    - *73
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: teachercon
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   pd_scholarship_infos:
-  - *5
-  - *13
-  - *84
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: scholarship_status
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *74
-  - *85
-  - *6
-  - *7
-  - *72
+    - *5
+    - *13
+    - *84
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: scholarship_status
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *74
+    - *85
+    - *6
+    - *7
+    - *72
   pd_sessions:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd_workshop_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: start
-    sql_type_metadata: *4
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: end
-    sql_type_metadata: *4
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *18
-  - *19
-  - *16
-  - *86
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: pd_workshop_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: start
+      sql_type_metadata: *4
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: end
+      sql_type_metadata: *4
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *18
+    - *19
+    - *16
+    - *86
   pd_survey_questions:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: form_id
-    sql_type_metadata: *31
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: questions
-    sql_type_metadata: *12
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: JSON Question data for this JotForm form.
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: last_submission_id
-    sql_type_metadata: *31
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Last successfully processed submission id. Sync will only pull submissions
-      with ids greater than this value.
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: form_id
+      sql_type_metadata: *30
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: questions
+      sql_type_metadata: *12
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: JSON Question data for this JotForm form.
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: last_submission_id
+      sql_type_metadata: *30
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+        Last successfully processed submission id. Sync will only pull submissions
+        with ids greater than this value.
   pd_teacher_applications:
-  - *5
-  - *6
-  - *7
-  - *13
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: primary_email
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: secondary_email
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: application
-    sql_type_metadata: *12
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: regional_partner_override
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: program_registration_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: 'Id in the Pegasus forms table for the associated registration (kind:
-      PdProgramRegistration), populated when that form is processed.'
+    - *5
+    - *6
+    - *7
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: primary_email
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: secondary_email
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: application
+      sql_type_metadata: *12
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: regional_partner_override
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: program_registration_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+        "Id in the Pegasus forms table for the associated registration (kind:
+        PdProgramRegistration), populated when that form is processed."
   pd_teachercon1819_registrations:
-  - *5
-  - *74
-  - *73
-  - *6
-  - *7
-  - *81
-  - *54
+    - *5
+    - *74
+    - *73
+    - *6
+    - *7
+    - *81
+    - *54
   pd_teachercon_surveys:
-  - *5
-  - *80
-  - *75
-  - *6
-  - *7
+    - *5
+    - *80
+    - *75
+    - *6
+    - *7
   pd_workshop_daily_surveys:
-  - *5
-  - *77
-  - *78
-  - *13
-  - &88 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd_session_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *87
-  - *79
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: day
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment: Day of the workshop (1-based), or zero for the pre-workshop survey
-  - *6
-  - *7
+    - *5
+    - *77
+    - *78
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &88
+      name: pd_session_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *87
+    - *79
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: day
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment: Day of the workshop (1-based), or zero for the pre-workshop survey
+    - *6
+    - *7
   pd_workshop_facilitator_daily_surveys:
-  - *5
-  - *77
-  - *78
-  - *13
-  - *88
-  - *87
-  - *89
-  - *79
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: day
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment: Day of the workshop (1-based)
-  - *6
-  - *7
+    - *5
+    - *77
+    - *78
+    - *13
+    - *88
+    - *87
+    - *89
+    - *79
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: day
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment: Day of the workshop (1-based)
+    - *6
+    - *7
   pd_workshop_survey_foorm_submissions:
-  - *5
-  - *90
-  - *13
-  - *88
-  - *87
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: day
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
-  - *91
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: workshop_agenda
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - *90
+    - *13
+    - *88
+    - *87
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: day
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
+    - *91
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: workshop_agenda
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   pd_workshop_surveys:
-  - *5
-  - *80
-  - *75
-  - *6
-  - *7
-  - *92
+    - *5
+    - *80
+    - *75
+    - *6
+    - *7
+    - *92
   pd_workshops:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: organizer_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: location_name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: location_address
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: processed_location
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *72
-  - *76
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: capacity
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *71
-  - *51
-  - &137 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: started_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: ended_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *18
-  - *19
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: processed_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *16
-  - *81
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: on_map
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Should this workshop appear on the 'Find a Workshop' map?
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: funded
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Should this workshop's attendees be reimbursed?
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: funding_type
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *46
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: module
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: organizer_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: location_name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: location_address
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: processed_location
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *72
+    - *76
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: capacity
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *71
+    - *51
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &136
+      name: started_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: ended_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: processed_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *16
+    - *81
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: on_map
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Should this workshop appear on the 'Find a Workshop' map?
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: funded
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Should this workshop's attendees be reimbursed?
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: funding_type
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *46
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: module
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   pd_workshops_facilitators:
-  - *87
-  - *13
+    - *87
+    - *13
   peer_reviews:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: submitter_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: reviewer_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: from_instructor
-    sql_type_metadata: *20
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - *32
-  - *25
-  - *93
-  - *63
-  - &105 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: status
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: audit_trail
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: Human-readable (never machine-parsed) audit trail of assignments and
-      status changes with timestamps for the life of the peer review.
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: submitter_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: reviewer_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: from_instructor
+      sql_type_metadata: *20
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - *31
+    - *25
+    - *93
+    - *63
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &105
+      name: status
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: audit_trail
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+        Human-readable (never machine-parsed) audit trail of assignments and
+        status changes with timestamps for the life of the peer review.
   pilots:
-  - *27
-  - *49
-  - *45
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: allow_joining_via_url
-    sql_type_metadata: *20
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *27
+    - *49
+    - *45
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: allow_joining_via_url
+      sql_type_metadata: *20
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   plc_course_units:
-  - *5
-  - &95 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: plc_course_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: unit_name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: unit_description
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: unit_order
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
-  - *26
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: started
-    sql_type_metadata: *20
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &95
+      name: plc_course_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: unit_name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: unit_description
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: unit_order
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
+    - *26
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: started
+      sql_type_metadata: *20
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
   plc_courses:
-  - *5
-  - *6
-  - *7
-  - &122 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: course_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &121
+      name: course_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   plc_enrollment_module_assignments:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: plc_enrollment_unit_assignment_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: plc_learning_module_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
-  - *54
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: plc_enrollment_unit_assignment_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: plc_learning_module_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
+    - *54
   plc_enrollment_unit_assignments:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: plc_user_course_enrollment_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: plc_course_unit_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *94
-  - *6
-  - *7
-  - *54
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: plc_user_course_enrollment_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: plc_course_unit_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *94
+    - *6
+    - *7
+    - *54
   plc_learning_modules:
-  - *5
-  - *39
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: plc_course_unit_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: module_type
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &117 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: stage_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *40
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: plc_course_unit_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: module_type
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &116
+      name: stage_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   plc_user_course_enrollments:
-  - *5
-  - *94
-  - *95
-  - *54
-  - *6
-  - *7
+    - *5
+    - *94
+    - *95
+    - *54
+    - *6
+    - *7
   potential_teachers:
-  - *27
-  - *40
-  - &146 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: email
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: source_course_offering_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *32
-  - *33
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: receives_marketing
-    sql_type_metadata: *20
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
+    - *27
+    - *40
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &146
+      name: email
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: source_course_offering_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *32
+    - *33
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: receives_marketing
+      sql_type_metadata: *20
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
   programming_classes:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: programming_environment_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &99 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: programming_environment_category_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &100 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: key
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *40
-  - *64
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: fields
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &101 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: examples
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *96
-  - &102 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: syntax
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: external_documentation
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: programming_environment_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &99
+      name: programming_environment_category_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &100
+      name: key
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *40
+    - *64
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: fields
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &101
+      name: examples
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *96
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &102
+      name: syntax
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: external_documentation
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
   programming_environment_categories:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: programming_environment_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *43
-  - *39
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: color
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
-  - *59
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: programming_environment_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *9
+    - *40
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: color
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
+    - *59
   programming_environments:
-  - *27
-  - *49
-  - *46
-  - *6
-  - *7
-  - *97
+    - *27
+    - *49
+    - *46
+    - *6
+    - *7
+    - *97
   programming_expressions:
-  - *27
-  - *49
-  - *98
-  - *46
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: programming_environment_id
-    sql_type_metadata: *31
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
-  - *9
-  - *99
+    - *27
+    - *49
+    - *98
+    - *46
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: programming_environment_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
+    - *9
+    - *99
   programming_methods:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: programming_class_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *100
-  - *59
-  - *40
-  - *64
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: parameters
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *101
-  - *102
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: external_link
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: overload_of
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: return_value
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: programming_class_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *100
+    - *59
+    - *40
+    - *64
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: parameters
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *101
+    - *102
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: external_link
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: overload_of
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: return_value
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   project_commits:
-  - *27
-  - *24
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: object_version_id
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8mb4_bin
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: comment
-    sql_type_metadata: *56
-    'null': true
-    default:
-    default_function:
-    collation: utf8mb4_bin
-    comment:
-  - *6
-  - *7
+    - *27
+    - *24
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: object_version_id
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8mb4_bin
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: comment
+      sql_type_metadata: *56
+      "null": true
+      default:
+      default_function:
+      collation: utf8mb4_bin
+      comment:
+    - *6
+    - *7
   projects:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: storage_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: value
-    sql_type_metadata: *56
-    'null': true
-    default:
-    default_function:
-    collation: utf8mb4_general_ci
-    comment:
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: updated_ip
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(39)
-        type: :string
-        limit: 39
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default:
-    default_function:
-    collation: utf8mb4_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: state
-    sql_type_metadata: &114 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(50)
-        type: :string
-        limit: 50
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default: active
-    default_function:
-    collation: utf8mb4_general_ci
-    comment:
-  - *18
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: abuse_score
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: project_type
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8mb4_general_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: published_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: standalone
-    sql_type_metadata: *20
-    'null': true
-    default: '1'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: remix_parent_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: skip_content_moderation
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: storage_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: value
+      sql_type_metadata: *56
+      "null": true
+      default:
+      default_function:
+      collation: utf8mb4_general_ci
+      comment:
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: updated_ip
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(39)
+          type: :string
+          limit: 39
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default:
+      default_function:
+      collation: utf8mb4_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: state
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &113
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(50)
+          type: :string
+          limit: 50
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default: active
+      default_function:
+      collation: utf8mb4_general_ci
+      comment:
+    - *18
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: abuse_score
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: project_type
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8mb4_general_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: published_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: standalone
+      sql_type_metadata: *20
+      "null": true
+      default: "1"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: remix_parent_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: skip_content_moderation
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   puzzle_ratings:
-  - *5
-  - *54
-  - *26
-  - *14
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: rating
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - *54
+    - *26
+    - *14
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: rating
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   queued_account_purges:
-  - *5
-  - *13
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: reason_for_review
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
+    - *5
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: reason_for_review
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
   reference_guides:
-  - *27
-  - *43
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: course_version_id
-    sql_type_metadata: *31
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: parent_reference_guide_key
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: display_name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *64
-  - *44
-  - *6
-  - *7
+    - *27
+    - *9
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: course_version_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: parent_reference_guide_key
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: display_name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *64
+    - *44
+    - *6
+    - *7
   regional_partner_program_managers:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: program_manager_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *82
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: program_manager_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *82
   regional_partners:
-  - *5
-  - *49
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: group
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: urban
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: attention
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: street
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: apartment_or_suite
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &130 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: city
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *83
-  - *103
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: phone_number
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *71
-  - *6
-  - *7
-  - *16
-  - *46
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: is_active
-    sql_type_metadata: *20
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *49
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: group
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: urban
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: attention
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: street
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: apartment_or_suite
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &129
+      name: city
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *83
+    - *103
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: phone_number
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *71
+    - *6
+    - *7
+    - *16
+    - *46
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: is_active
+      sql_type_metadata: *20
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   regional_partners_school_districts:
-  - *82
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_district_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: course
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: Course for a given workshop
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: workshop_days
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: Days that the workshop will take place
+    - *82
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_district_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: course
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: Course for a given workshop
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: workshop_days
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: Days that the workshop will take place
   resources:
-  - *5
-  - *39
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: url
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *43
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: properties
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
-  - &181 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: course_version_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *40
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: url
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *9
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: properties
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &181
+      name: course_version_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   rubric_ai_evaluations:
-  - *27
-  - *13
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: requester_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: rubric_id
-    sql_type_metadata: *30
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *34
-  - *104
-  - *105
-  - *32
-  - *33
+    - *27
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: requester_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: rubric_id
+      sql_type_metadata: *30
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *34
+    - *104
+    - *105
+    - *32
+    - *33
   rubrics:
-  - *27
-  - *61
-  - *25
-  - *28
-  - *29
+    - *27
+    - *61
+    - *25
+    - *32
+    - *33
   schema_migrations:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: version
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8mb4_unicode_ci
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: version
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   school_districts:
-  - *5
-  - *49
-  - &111 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: city
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &112 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: state
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &113 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: zip
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &116 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: last_known_school_year_open
-    sql_type_metadata: &109 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(9)
-        type: :string
-        limit: 9
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
+    - *5
+    - *49
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &110
+      name: city
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &111
+      name: state
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &112
+      name: zip
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &115
+      name: last_known_school_year_open
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &108
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(9)
+          type: :string
+          limit: 9
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
   school_infos:
-  - *5
-  - &131 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: country
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_type
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: zip
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *83
-  - *106
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_district_other
-    sql_type_metadata: *20
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_district_name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_id
-    sql_type_metadata: *108
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_other
-    sql_type_metadata: *20
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: This column appears to be redundant with pd_enrollments.school and users.school,
-      therefore validation rules must be used to ensure that any user or enrollment
-      with a school_info has its school name stored in the correct place.
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: full_address
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: This column appears to be redundant with users.full_address, therefore
-      validation rules must be used to ensure that any user with a school_info has
-      its school address stored in the correct place.
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: validation_type
-    sql_type_metadata: *3
-    'null': false
-    default: full
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &130
+      name: country
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_type
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: zip
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *83
+    - *106
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_district_other
+      sql_type_metadata: *20
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_district_name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_id
+      sql_type_metadata: *107
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_other
+      sql_type_metadata: *20
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+        This column appears to be redundant with pd_enrollments.school and users.school,
+        therefore validation rules must be used to ensure that any user or enrollment
+        with a school_info has its school name stored in the correct place.
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: full_address
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+        This column appears to be redundant with users.full_address, therefore
+        validation rules must be used to ensure that any user with a school_info has
+        its school address stored in the correct place.
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: validation_type
+      sql_type_metadata: *3
+      "null": false
+      default: full
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   school_stats_by_years:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_id
-    sql_type_metadata: *108
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: NCES public school ID
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_year
-    sql_type_metadata: *109
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: School Year
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grades_offered_lo
-    sql_type_metadata: *110
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: Grades Offered - Lowest
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grades_offered_hi
-    sql_type_metadata: *110
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: Grades Offered - Highest
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_pk_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: PK Grade Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_kg_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: KG Grade Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_01_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 01 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_02_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 02 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_03_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 03 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_04_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 04 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_05_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 05 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_06_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 06 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_07_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 07 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_08_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 08 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_09_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 09 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_10_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 10 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_11_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 11 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_12_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 12 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade_13_offered
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Grade 13 Offered
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: virtual_status
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(14)
-        type: :string
-        limit: 14
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: Virtual School Status
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: students_total
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Total students, all grades (includes AE)
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: student_am_count
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: All Students - American Indian/Alaska Native
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: student_as_count
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: All Students - Asian
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: student_hi_count
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: All Students - Hispanic
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: student_bl_count
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: All Students - Black
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: student_wh_count
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: All Students - White
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: student_hp_count
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: All Students - Hawaiian Native/Pacific Islander
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: student_tr_count
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: All Students - Two or More Races
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: title_i_status
-    sql_type_metadata: &141 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(1)
-        type: :string
-        limit: 1
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: TITLE I status (code)
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: frl_eligible_total
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Total of free and reduced-price lunch eligible
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: community_type
-    sql_type_metadata: &142 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(16)
-        type: :string
-        limit: 16
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: Urban-centric community type
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_id
+      sql_type_metadata: *107
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: NCES public school ID
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_year
+      sql_type_metadata: *108
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: School Year
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grades_offered_lo
+      sql_type_metadata: *109
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: Grades Offered - Lowest
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grades_offered_hi
+      sql_type_metadata: *109
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: Grades Offered - Highest
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_pk_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: PK Grade Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_kg_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: KG Grade Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_01_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 01 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_02_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 02 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_03_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 03 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_04_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 04 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_05_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 05 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_06_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 06 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_07_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 07 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_08_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 08 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_09_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 09 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_10_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 10 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_11_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 11 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_12_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 12 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade_13_offered
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Grade 13 Offered
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: virtual_status
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(14)
+          type: :string
+          limit: 14
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: Virtual School Status
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: students_total
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Total students, all grades (includes AE)
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: student_am_count
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: All Students - American Indian/Alaska Native
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: student_as_count
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: All Students - Asian
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: student_hi_count
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: All Students - Hispanic
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: student_bl_count
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: All Students - Black
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: student_wh_count
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: All Students - White
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: student_hp_count
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: All Students - Hawaiian Native/Pacific Islander
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: student_tr_count
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: All Students - Two or More Races
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: title_i_status
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &140
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(1)
+          type: :string
+          limit: 1
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: TITLE I status (code)
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: frl_eligible_total
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Total of free and reduced-price lunch eligible
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: community_type
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &141
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(16)
+          type: :string
+          limit: 16
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: Urban-centric community type
   schools:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: id
-    sql_type_metadata: *108
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: NCES public school ID
-  - *107
-  - *49
-  - *111
-  - *112
-  - *113
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_type
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: address_line1
-    sql_type_metadata: *114
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: Location address, street 1
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: address_line2
-    sql_type_metadata: &115 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(30)
-        type: :string
-        limit: 30
-        precision:
-        scale:
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: Location address, street 2
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: address_line3
-    sql_type_metadata: *115
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment: Location address, street 3
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: latitude
-    sql_type_metadata: &132 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: decimal(8,6)
-        type: :decimal
-        limit:
-        precision: 8
-        scale: 6
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Location latitude
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: longitude
-    sql_type_metadata: &133 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: decimal(9,6)
-        type: :decimal
-        limit:
-        precision: 9
-        scale: 6
-      extra: ''
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment: Location longitude
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: school_category
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *116
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: id
+      sql_type_metadata: *107
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: NCES public school ID
+    - *106
+    - *49
+    - *110
+    - *111
+    - *112
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_type
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: address_line1
+      sql_type_metadata: *113
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: Location address, street 1
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: address_line2
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &114
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(30)
+          type: :string
+          limit: 30
+          precision:
+          scale:
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: Location address, street 2
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: address_line3
+      sql_type_metadata: *114
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment: Location address, street 3
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: latitude
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &131
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: decimal(8,6)
+          type: :decimal
+          limit:
+          precision: 8
+          scale: 6
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Location latitude
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: longitude
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata &132
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: decimal(9,6)
+          type: :decimal
+          limit:
+          precision: 9
+          scale: 6
+        extra: ""
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment: Location longitude
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: school_category
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *115
   script_levels:
-  - *5
-  - *32
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: chapter
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *18
-  - *19
-  - *116
-  - *59
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: assessment
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *46
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: named_level
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: bonus
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: activity_section_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: seed_key
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: activity_section_position
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *31
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: chapter
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *18
+    - *19
+    - *116
+    - *59
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: assessment
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *46
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: named_level
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: bonus
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: activity_section_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: seed_key
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: activity_section_position
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   scripts:
-  - *5
-  - *49
-  - *18
-  - *19
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: wrapup_video_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *54
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: login_required
-    sql_type_metadata: *20
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - *46
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: new_name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: family_name
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *118
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: instruction_type
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: instructor_audience
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: participant_audience
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - *49
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: wrapup_video_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *54
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: login_required
+      sql_type_metadata: *20
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - *46
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: new_name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: family_name
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *117
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: instruction_type
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: instructor_audience
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: participant_audience
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   scripts_resources:
-  - *26
-  - &119 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: resource_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *26
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &118
+      name: resource_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   scripts_student_resources:
-  - *27
-  - *26
-  - *119
+    - *27
+    - *26
+    - *118
   secret_pictures:
-  - *5
-  - *49
-  - *120
-  - *18
-  - *19
+    - *5
+    - *49
+    - *119
+    - *18
+    - *19
   secret_words:
-  - *5
-  - &180 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: word
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *18
-  - *19
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &180
+      name: word
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *18
+    - *19
   section_hidden_scripts:
-  - *5
-  - *120
-  - *31
+    - *5
+    - *120
+    - *31
   section_hidden_stages:
-  - *5
-  - *121
-  - &123 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: stage_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *120
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &122
+      name: stage_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   section_instructors:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: instructor_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *121
-  - &146 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: invited_by_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *16
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: status
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *28
-  - *29
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: instructor_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *120
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &145
+      name: invited_by_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *16
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: status
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *32
+    - *33
   sections:
-  - *5
-  - *13
-  - *39
-  - *18
-  - *19
-  - *86
-  - *26
-  - *122
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: grade
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: login_type
-    sql_type_metadata: *3
-    'null': false
-    default: email
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *16
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: stage_extras
-    sql_type_metadata: *20
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: section_type
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: first_activity_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pairing_allowed
-    sql_type_metadata: *20
-    'null': false
-    default: '1'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: sharing_disabled
-    sql_type_metadata: *20
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment: Flag indicates the default sharing setting for a section and is used
-      to determine students share setting when adding a new student to the section.
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: hidden
-    sql_type_metadata: *20
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: tts_autoplay_enabled
-    sql_type_metadata: *20
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: restrict_section
-    sql_type_metadata: *20
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - *46
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: participant_type
-    sql_type_metadata: *3
-    'null': false
-    default: student
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lti_integration_id
-    sql_type_metadata: *30
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: ai_tutor_enabled
-    sql_type_metadata: *20
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *13
+    - *40
+    - *18
+    - *19
+    - *86
+    - *26
+    - *121
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: grade
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: login_type
+      sql_type_metadata: *3
+      "null": false
+      default: email
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *16
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: stage_extras
+      sql_type_metadata: *20
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: section_type
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: first_activity_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: pairing_allowed
+      sql_type_metadata: *20
+      "null": false
+      default: "1"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: sharing_disabled
+      sql_type_metadata: *20
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+        Flag indicates the default sharing setting for a section and is used
+        to determine students share setting when adding a new student to the section.
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: hidden
+      sql_type_metadata: *20
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: tts_autoplay_enabled
+      sql_type_metadata: *20
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: restrict_section
+      sql_type_metadata: *20
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - *46
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: participant_type
+      sql_type_metadata: *3
+      "null": false
+      default: student
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: lti_integration_id
+      sql_type_metadata: *30
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: ai_tutor_enabled
+      sql_type_metadata: *20
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
   seed_info:
-  - *27
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: table
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: mtime
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *27
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: table
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: mtime
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   seeded_s3_objects:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: bucket
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *100
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: etag
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: bucket
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *100
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: etag
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *6
+    - *7
   shared_blockly_functions:
-  - *5
-  - *49
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: level_type
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: block_type
-    sql_type_metadata: *2
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: return
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &125 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: description
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: arguments
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: stack
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - *49
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: level_type
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: block_type
+      sql_type_metadata: *2
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: return
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &124
+      name: description
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: arguments
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: stack
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   sign_ins:
-  - *5
-  - *13
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: sign_in_at
-    sql_type_metadata: *4
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: sign_in_count
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: sign_in_at
+      sql_type_metadata: *4
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: sign_in_count
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   stages:
-  - *5
-  - *49
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: absolute_position
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *32
-  - *18
-  - *19
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lockable
-    sql_type_metadata: *20
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: relative_position
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *46
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lesson_group_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *43
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: has_lesson_plan
-    sql_type_metadata: *20
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *49
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: absolute_position
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *31
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: lockable
+      sql_type_metadata: *20
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: relative_position
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *46
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: lesson_group_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *9
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: has_lesson_plan
+      sql_type_metadata: *20
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
   stages_standards:
-  - *123
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: standard_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *122
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: standard_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   standard_categories:
-  - *27
-  - *124
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: framework_id
-    sql_type_metadata: *2
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: parent_category_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: category_type
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *46
-  - *6
-  - *7
+    - *27
+    - *123
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: framework_id
+      sql_type_metadata: *2
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: parent_category_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: category_type
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *46
+    - *6
+    - *7
   standards:
-  - *5
-  - *125
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: category_id
-    sql_type_metadata: *31
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: framework_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: shortcode
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - *124
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: category_id
+      sql_type_metadata: *30
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: framework_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: shortcode
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   studio_people:
-  - *5
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: emails
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: emails
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   survey_results:
-  - *5
-  - *54
-  - *126
-  - *46
-  - *6
-  - *7
+    - *5
+    - *54
+    - *125
+    - *46
+    - *6
+    - *7
   teacher_feedbacks:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: comment
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: student_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *25
-  - *127
-  - *6
-  - *7
-  - *16
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: performance
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: student_visit_count
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: student_first_visited_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: student_last_visited_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: seen_on_feedback_page_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *32
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: analytics_section_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: review_state
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: comment
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: student_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *25
+    - *126
+    - *6
+    - *7
+    - *16
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: performance
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: student_visit_count
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: student_first_visited_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: student_last_visited_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: seen_on_feedback_page_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *31
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: analytics_section_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: review_state
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   teacher_profiles:
-  - *5
-  - &139 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: studio_person_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
-  - *72
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: facilitator
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: teaching
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd_year
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: pd
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: other_pd
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *46
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &138
+      name: studio_person_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
+    - *72
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: facilitator
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: teaching
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: pd_year
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: pd
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: other_pd
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *46
   teacher_scores:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: user_level_id
-    sql_type_metadata: *15
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *128
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: score
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: user_level_id
+      sql_type_metadata: *15
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *127
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: score
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   unit_groups:
-  - *5
-  - *39
-  - *46
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: published_state
-    sql_type_metadata: *3
-    'null': false
-    default: in_development
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: instruction_type
-    sql_type_metadata: *3
-    'null': false
-    default: teacher_led
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: instructor_audience
-    sql_type_metadata: *3
-    'null': false
-    default: teacher
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: participant_audience
-    sql_type_metadata: *3
-    'null': false
-    default: student
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - *40
+    - *46
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: published_state
+      sql_type_metadata: *3
+      "null": false
+      default: in_development
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: instruction_type
+      sql_type_metadata: *3
+      "null": false
+      default: teacher_led
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: instructor_audience
+      sql_type_metadata: *3
+      "null": false
+      default: teacher
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: participant_audience
+      sql_type_metadata: *3
+      "null": false
+      default: student
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   unit_groups_resources:
-  - &129 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: unit_group_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *119
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &128
+      name: unit_group_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *118
   unit_groups_student_resources:
-  - *27
-  - *129
-  - *119
+    - *27
+    - *128
+    - *118
   user_geos:
-  - *5
-  - *13
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: indexed_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: ip_address
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *129
-  - *83
-  - *130
-  - *86
-  - *131
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: postal_code
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: latitude
-    sql_type_metadata: *132
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: longitude
-    sql_type_metadata: *133
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *13
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: indexed_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: ip_address
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *129
+    - *83
+    - *130
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: postal_code
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: latitude
+      sql_type_metadata: *131
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: longitude
+      sql_type_metadata: *132
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   user_levels:
-  - *134
-  - *13
-  - *25
-  - *135
-  - *18
-  - *19
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: best_result
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *26
-  - *62
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: submitted
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: readonly_answers
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: unlocked_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: time_spent
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *16
-  - *46
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: id
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj: *133
+        extra: auto_increment
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *13
+    - *25
+    - *134
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: best_result
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *26
+    - *62
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: submitted
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: readonly_answers
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: unlocked_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: time_spent
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *16
+    - *46
   user_ml_models:
-  - *27
-  - *54
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: model_id
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *39
-  - *16
-  - &145 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: purged_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: metadata
-    sql_type_metadata: *12
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *27
+    - *54
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: model_id
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *40
+    - *16
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &144
+      name: purged_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: metadata
+      sql_type_metadata: *12
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   user_module_task_assignments:
-  - *5
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: user_enrollment_module_assignment_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: professional_learning_task_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *94
+    - *5
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: user_enrollment_module_assignment_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: professional_learning_task_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *94
   user_permissions:
-  - *5
-  - *13
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: permission
-    sql_type_metadata: *3
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *18
-  - *19
+    - *5
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: permission
+      sql_type_metadata: *3
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *18
+    - *19
   user_proficiencies:
-  - *5
-  - *13
-  - *6
-  - *7
-  - &138 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: last_progress_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: sequencing_d1_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: sequencing_d2_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: sequencing_d3_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: sequencing_d4_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: sequencing_d5_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: debugging_d1_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: debugging_d2_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: debugging_d3_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: debugging_d4_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: debugging_d5_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: repeat_loops_d1_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: repeat_loops_d2_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: repeat_loops_d3_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: repeat_loops_d4_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: repeat_loops_d5_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: repeat_until_while_d1_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: repeat_until_while_d2_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: repeat_until_while_d3_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: repeat_until_while_d4_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: repeat_until_while_d5_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: for_loops_d1_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: for_loops_d2_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: for_loops_d3_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: for_loops_d4_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: for_loops_d5_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: events_d1_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: events_d2_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: events_d3_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: events_d4_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: events_d5_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: variables_d1_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: variables_d2_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: variables_d3_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: variables_d4_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: variables_d5_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: functions_d1_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: functions_d2_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: functions_d3_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: functions_d4_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: functions_d5_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: functions_with_params_d1_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: functions_with_params_d2_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: functions_with_params_d3_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: functions_with_params_d4_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: functions_with_params_d5_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: conditionals_d1_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: conditionals_d2_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: conditionals_d3_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: conditionals_d4_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: conditionals_d5_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: basic_proficiency_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *13
+    - *6
+    - *7
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &137
+      name: last_progress_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: sequencing_d1_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: sequencing_d2_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: sequencing_d3_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: sequencing_d4_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: sequencing_d5_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: debugging_d1_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: debugging_d2_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: debugging_d3_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: debugging_d4_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: debugging_d5_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: repeat_loops_d1_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: repeat_loops_d2_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: repeat_loops_d3_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: repeat_loops_d4_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: repeat_loops_d5_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: repeat_until_while_d1_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: repeat_until_while_d2_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: repeat_until_while_d3_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: repeat_until_while_d4_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: repeat_until_while_d5_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: for_loops_d1_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: for_loops_d2_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: for_loops_d3_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: for_loops_d4_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: for_loops_d5_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: events_d1_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: events_d2_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: events_d3_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: events_d4_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: events_d5_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: variables_d1_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: variables_d2_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: variables_d3_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: variables_d4_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: variables_d5_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: functions_d1_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: functions_d2_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: functions_d3_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: functions_d4_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: functions_d5_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: functions_with_params_d1_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: functions_with_params_d2_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: functions_with_params_d3_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: functions_with_params_d4_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: functions_with_params_d5_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: conditionals_d1_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: conditionals_d2_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: conditionals_d3_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: conditionals_d4_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: conditionals_d5_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: basic_proficiency_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   user_project_storage_ids:
-  - *5
-  - *54
+    - *5
+    - *54
   user_school_infos:
-  - *5
-  - *13
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: start_date
-    sql_type_metadata: *4
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: end_date
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *136
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: last_confirmation_date
-    sql_type_metadata: *4
-    'null': false
-    default:
-    default_function:
-    collation:
-    comment:
-  - *6
-  - *7
+    - *5
+    - *13
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: start_date
+      sql_type_metadata: *4
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: end_date
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *135
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: last_confirmation_date
+      sql_type_metadata: *4
+      "null": false
+      default:
+      default_function:
+      collation:
+      comment:
+    - *6
+    - *7
   user_scripts:
-  - *5
-  - *13
-  - *32
-  - *137
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: completed_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: assigned_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *138
-  - *18
-  - *19
-  - *46
-  - *16
+    - *5
+    - *13
+    - *31
+    - *136
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: completed_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: assigned_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *137
+    - *18
+    - *19
+    - *46
+    - *16
   users:
-  - *5
-  - *139
-  - &147 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: parent_email
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &148 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: encrypted_password
-    sql_type_metadata: *3
-    'null': true
-    default: ''
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &149 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: reset_password_token
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &150 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: reset_password_sent_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &151 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: remember_created_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &152 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: sign_in_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - &153 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: current_sign_in_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &154 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: last_sign_in_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &155 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: current_sign_in_ip
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &156 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: last_sign_in_ip
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *18
-  - *19
-  - &157 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: username
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &158 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: provider
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: uid
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: admin
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &159 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: gender
-    sql_type_metadata: *141
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *40
-  - &160 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: locale
-    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
-      delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: varchar(10)
-        type: :string
-        limit: 10
-        precision:
-        scale:
-      extra: ''
-    'null': false
-    default: en-US
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &161 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: birthday
-    sql_type_metadata: *66
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &162 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: user_type
-    sql_type_metadata: *141
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *142
-  - &163 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: full_address
-    sql_type_metadata: *17
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *143
-  - &164 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: total_lines
-    sql_type_metadata: *2
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - &165 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: secret_picture_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &166 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: active
-    sql_type_metadata: *20
-    'null': false
-    default: '1'
-    default_function:
-    collation:
-    comment:
-  - &167 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: hashed_email
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *16
-  - *144
-  - &168 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: secret_words
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *46
-  - &169 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: invitation_token
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &170 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: invitation_created_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &171 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: invitation_sent_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &172 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: invitation_accepted_at
-    sql_type_metadata: *4
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &173 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: invitation_limit
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *145
-  - &174 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: invited_by_type
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &175 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: invitations_count
-    sql_type_metadata: *2
-    'null': true
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - &176 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: terms_of_service_version
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &177 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: urm
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - &178 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: races
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - &179 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: primary_contact_info_id
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
+    - *5
+    - *138
+    - *139
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &147
+      name: parent_email
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &148
+      name: encrypted_password
+      sql_type_metadata: *3
+      "null": true
+      default: ""
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &149
+      name: reset_password_token
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &150
+      name: reset_password_sent_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &151
+      name: remember_created_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &152
+      name: sign_in_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &153
+      name: current_sign_in_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &154
+      name: last_sign_in_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &155
+      name: current_sign_in_ip
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &156
+      name: last_sign_in_ip
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &157
+      name: username
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &158
+      name: provider
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: uid
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: admin
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &159
+      name: gender
+      sql_type_metadata: *140
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *40
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &160
+      name: locale
+      sql_type_metadata:
+        !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
+        delegate_dc_obj:
+          !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+          sql_type: varchar(10)
+          type: :string
+          limit: 10
+          precision:
+          scale:
+        extra: ""
+      "null": false
+      default: en-US
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &161
+      name: birthday
+      sql_type_metadata: *66
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &162
+      name: user_type
+      sql_type_metadata: *141
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *142
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &163
+      name: full_address
+      sql_type_metadata: *17
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *143
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &164
+      name: total_lines
+      sql_type_metadata: *2
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &165
+      name: secret_picture_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &166
+      name: active
+      sql_type_metadata: *20
+      "null": false
+      default: "1"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &167
+      name: hashed_email
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *16
+    - *144
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &168
+      name: secret_words
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *46
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &169
+      name: invitation_token
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &170
+      name: invitation_created_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &171
+      name: invitation_sent_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &172
+      name: invitation_accepted_at
+      sql_type_metadata: *4
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &173
+      name: invitation_limit
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *145
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &174
+      name: invited_by_type
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &175
+      name: invitations_count
+      sql_type_metadata: *2
+      "null": true
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &176
+      name: terms_of_service_version
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &177
+      name: urm
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &178
+      name: races
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column &179
+      name: primary_contact_info_id
+      sql_type_metadata: *2
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
   users_view:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: id
-    sql_type_metadata: *2
-    'null': false
-    default: '0'
-    default_function:
-    collation:
-    comment:
-  - *138
-  - *146
-  - *147
-  - *148
-  - *149
-  - *150
-  - *151
-  - *152
-  - *153
-  - *154
-  - *155
-  - *156
-  - *18
-  - *19
-  - *157
-  - *158
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: UID
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: ADMIN
-    sql_type_metadata: *20
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - *159
-  - *40
-  - *160
-  - *161
-  - *162
-  - *142
-  - *163
-  - *143
-  - *164
-  - *165
-  - *166
-  - *167
-  - *16
-  - *144
-  - *168
-  - *46
-  - *169
-  - *170
-  - *171
-  - *172
-  - *173
-  - *145
-  - *174
-  - *175
-  - *176
-  - *177
-  - *178
-  - *179
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: id
+      sql_type_metadata: *2
+      "null": false
+      default: "0"
+      default_function:
+      collation:
+      comment:
+    - *138
+    - *146
+    - *147
+    - *148
+    - *149
+    - *150
+    - *151
+    - *152
+    - *153
+    - *154
+    - *155
+    - *156
+    - *18
+    - *19
+    - *157
+    - *158
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: UID
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: ADMIN
+      sql_type_metadata: *20
+      "null": true
+      default:
+      default_function:
+      collation:
+      comment:
+    - *159
+    - *40
+    - *160
+    - *161
+    - *162
+    - *142
+    - *163
+    - *143
+    - *164
+    - *165
+    - *166
+    - *167
+    - *16
+    - *144
+    - *168
+    - *46
+    - *169
+    - *170
+    - *171
+    - *172
+    - *173
+    - *145
+    - *174
+    - *175
+    - *176
+    - *177
+    - *178
+    - *179
   videos:
-  - *5
-  - *100
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: youtube_code
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *18
-  - *19
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: download
-    sql_type_metadata: *3
-    'null': true
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: locale
-    sql_type_metadata: *3
-    'null': false
-    default: en-US
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
+    - *5
+    - *100
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: youtube_code
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *18
+    - *19
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: download
+      sql_type_metadata: *3
+      "null": true
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: locale
+      sql_type_metadata: *3
+      "null": false
+      default: en-US
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
   vocabularies:
-  - *27
-  - *9
-  - *180
-  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: definition
-    sql_type_metadata: *12
-    'null': false
-    default:
-    default_function:
-    collation: utf8_unicode_ci
-    comment:
-  - *181
-  - *6
-  - *7
-  - *46
+    - *27
+    - *9
+    - *180
+    - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+      name: definition
+      sql_type_metadata: *12
+      "null": false
+      default:
+      default_function:
+      collation: utf8_unicode_ci
+      comment:
+    - *181
+    - *6
+    - *7
+    - *46
 primary_keys:
   activities: id
   activity_sections: id
@@ -7666,8 +7784,8 @@ primary_keys:
   school_districts: id
   school_infos: id
   school_stats_by_years:
-  - school_id
-  - school_year
+    - school_id
+    - school_year
   schools:
   script_levels: id
   scripts: id
@@ -7902,5207 +8020,5208 @@ data_sources:
   vocabularies: true
 indexes:
   activities:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: activities
-    name: index_activities_on_level_source_id
-    unique: false
-    columns:
-    - level_source_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: activities
-    name: index_activities_on_user_id_and_level_id
-    unique: false
-    columns:
-    - user_id
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: activities
+      name: index_activities_on_level_source_id
+      unique: false
+      columns:
+        - level_source_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: activities
+      name: index_activities_on_user_id_and_level_id
+      unique: false
+      columns:
+        - user_id
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   activity_sections:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: activity_sections
-    name: index_activity_sections_on_key
-    unique: true
-    columns:
-    - key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: activity_sections
-    name: index_activity_sections_on_lesson_activity_id
-    unique: false
-    columns:
-    - lesson_activity_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: activity_sections
+      name: index_activity_sections_on_key
+      unique: true
+      columns:
+        - key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: activity_sections
+      name: index_activity_sections_on_lesson_activity_id
+      unique: false
+      columns:
+        - lesson_activity_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   ap_cs_offerings:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: ap_cs_offerings
-    name: index_ap_cs_offerings_on_school_code_and_school_year_and_course
-    unique: true
-    columns:
-    - school_code
-    - school_year
-    - course
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: ap_cs_offerings
+      name: index_ap_cs_offerings_on_school_code_and_school_year_and_course
+      unique: true
+      columns:
+        - school_code
+        - school_year
+        - course
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   ap_school_codes:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: ap_school_codes
-    name: index_ap_school_codes_on_school_code_and_school_year
-    unique: true
-    columns:
-    - school_code
-    - school_year
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: ap_school_codes
-    name: fk_rails_08d2269647
-    unique: false
-    columns:
-    - school_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: ap_school_codes
+      name: index_ap_school_codes_on_school_code_and_school_year
+      unique: true
+      columns:
+        - school_code
+        - school_year
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: ap_school_codes
+      name: fk_rails_08d2269647
+      unique: false
+      columns:
+        - school_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   ar_internal_metadata: []
   assessment_activities:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: assessment_activities
-    name: index_assessment_activities_on_user_and_level_and_script
-    unique: false
-    columns:
-    - user_id
-    - level_id
-    - script_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: assessment_activities
+      name: index_assessment_activities_on_user_and_level_and_script
+      unique: false
+      columns:
+        - user_id
+        - level_id
+        - script_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   authentication_options:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: authentication_options
-    name: index_auth_on_cred_type_and_auth_id
-    unique: true
-    columns:
-    - credential_type
-    - authentication_id
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: authentication_options
-    name: index_authentication_options_on_email_and_deleted_at
-    unique: false
-    columns:
-    - email
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: authentication_options
-    name: index_authentication_options_on_hashed_email_and_deleted_at
-    unique: false
-    columns:
-    - hashed_email
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: authentication_options
-    name: index_authentication_options_on_user_id_and_deleted_at
-    unique: false
-    columns:
-    - user_id
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: authentication_options
+      name: index_auth_on_cred_type_and_auth_id
+      unique: true
+      columns:
+        - credential_type
+        - authentication_id
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: authentication_options
+      name: index_authentication_options_on_email_and_deleted_at
+      unique: false
+      columns:
+        - email
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: authentication_options
+      name: index_authentication_options_on_hashed_email_and_deleted_at
+      unique: false
+      columns:
+        - hashed_email
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: authentication_options
+      name: index_authentication_options_on_user_id_and_deleted_at
+      unique: false
+      columns:
+        - user_id
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   authored_hint_view_requests:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: authored_hint_view_requests
-    name: fk_rails_8f51960e09
-    unique: false
-    columns:
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: authored_hint_view_requests
-    name: index_authored_hint_view_requests_on_script_id_and_level_id
-    unique: false
-    columns:
-    - script_id
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: authored_hint_view_requests
-    name: index_authored_hint_view_requests_on_all_related_ids
-    unique: false
-    columns:
-    - user_id
-    - script_id
-    - level_id
-    - hint_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: authored_hint_view_requests
+      name: fk_rails_8f51960e09
+      unique: false
+      columns:
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: authored_hint_view_requests
+      name: index_authored_hint_view_requests_on_script_id_and_level_id
+      unique: false
+      columns:
+        - script_id
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: authored_hint_view_requests
+      name: index_authored_hint_view_requests_on_all_related_ids
+      unique: false
+      columns:
+        - user_id
+        - script_id
+        - level_id
+        - hint_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   backpacks:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: backpacks
-    name: index_backpacks_on_storage_app_id
-    unique: true
-    columns:
-    - storage_app_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: backpacks
-    name: index_backpacks_on_user_id
-    unique: true
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: backpacks
+      name: index_backpacks_on_user_id
+      unique: true
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: backpacks
+      name: index_backpacks_on_storage_app_id
+      unique: true
+      columns:
+        - storage_app_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   blocks:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: blocks
-    name: index_blocks_on_pool_and_name
-    unique: true
-    columns:
-    - pool
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: blocks
-    name: index_blocks_on_deleted_at
-    unique: false
-    columns:
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: blocks
+      name: index_blocks_on_pool_and_name
+      unique: true
+      columns:
+        - pool
+        - name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: blocks
+      name: index_blocks_on_deleted_at
+      unique: false
+      columns:
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   callouts: []
   census_state_course_codes:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: census_state_course_codes
-    name: index_census_state_course_codes_on_state_and_course
-    unique: true
-    columns:
-    - state
-    - course
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: census_state_course_codes
+      name: index_census_state_course_codes_on_state_and_course
+      unique: true
+      columns:
+        - state
+        - course
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   census_submission_form_maps:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: census_submission_form_maps
-    name: index_census_submission_form_maps_on_census_submission_id
-    unique: false
-    columns:
-    - census_submission_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: census_submission_form_maps
-    name: index_census_submission_form_maps_on_form_id
-    unique: false
-    columns:
-    - form_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: census_submission_form_maps
+      name: index_census_submission_form_maps_on_census_submission_id
+      unique: false
+      columns:
+        - census_submission_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: census_submission_form_maps
+      name: index_census_submission_form_maps_on_form_id
+      unique: false
+      columns:
+        - form_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   census_submissions:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: census_submissions
-    name: index_census_submissions_on_school_year_and_id
-    unique: false
-    columns:
-    - school_year
-    - id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: census_submissions
+      name: index_census_submissions_on_school_year_and_id
+      unique: false
+      columns:
+        - school_year
+        - id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   census_submissions_school_infos:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: census_submissions_school_infos
-    name: census_submission_school_info_id
-    unique: true
-    columns:
-    - census_submission_id
-    - school_info_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: census_submissions_school_infos
-    name: school_info_id_census_submission
-    unique: true
-    columns:
-    - school_info_id
-    - census_submission_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: census_submissions_school_infos
+      name: census_submission_school_info_id
+      unique: true
+      columns:
+        - census_submission_id
+        - school_info_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: census_submissions_school_infos
+      name: school_info_id_census_submission
+      unique: true
+      columns:
+        - school_info_id
+        - census_submission_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   census_summaries:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: census_summaries
-    name: index_census_summaries_on_school_id_and_school_year
-    unique: true
-    columns:
-    - school_id
-    - school_year
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: census_summaries
+      name: index_census_summaries_on_school_id_and_school_year
+      unique: true
+      columns:
+        - school_id
+        - school_year
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   channel_tokens:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: channel_tokens
-    name: index_channel_tokens_unique
-    unique: true
-    columns:
-    - storage_id
-    - level_id
-    - script_id
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: channel_tokens
-    name: index_channel_tokens_on_storage_app_id
-    unique: false
-    columns:
-    - storage_app_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: channel_tokens
-    name: index_channel_tokens_on_storage_id
-    unique: false
-    columns:
-    - storage_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: channel_tokens
+      name: index_channel_tokens_unique
+      unique: true
+      columns:
+        - storage_id
+        - level_id
+        - script_id
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: channel_tokens
+      name: index_channel_tokens_on_storage_app_id
+      unique: false
+      columns:
+        - storage_app_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: channel_tokens
+      name: index_channel_tokens_on_storage_id
+      unique: false
+      columns:
+        - storage_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   circuit_playground_discount_applications:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: circuit_playground_discount_applications
-    name: index_circuit_playground_discount_applications_on_user_id
-    unique: true
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: circuit_playground_discount_applications
-    name: index_circuit_playground_applications_on_code_id
-    unique: false
-    columns:
-    - circuit_playground_discount_code_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: circuit_playground_discount_applications
-    name: index_circuit_playground_discount_applications_on_school_id
-    unique: false
-    columns:
-    - school_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: circuit_playground_discount_applications
+      name: index_circuit_playground_discount_applications_on_user_id
+      unique: true
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: circuit_playground_discount_applications
+      name: index_circuit_playground_applications_on_code_id
+      unique: false
+      columns:
+        - circuit_playground_discount_code_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: circuit_playground_discount_applications
+      name: index_circuit_playground_discount_applications_on_school_id
+      unique: false
+      columns:
+        - school_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   circuit_playground_discount_codes: []
   code_review_comments:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: code_review_comments
-    name: index_code_review_comments_on_code_review_id
-    unique: false
-    columns:
-    - code_review_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: code_review_comments
+      name: index_code_review_comments_on_code_review_id
+      unique: false
+      columns:
+        - code_review_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   code_review_group_members:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: code_review_group_members
-    name: index_code_review_group_members_on_code_review_group_id
-    unique: false
-    columns:
-    - code_review_group_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: code_review_group_members
-    name: index_code_review_group_members_on_follower_id
-    unique: false
-    columns:
-    - follower_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: code_review_group_members
+      name: index_code_review_group_members_on_code_review_group_id
+      unique: false
+      columns:
+        - code_review_group_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: code_review_group_members
+      name: index_code_review_group_members_on_follower_id
+      unique: false
+      columns:
+        - follower_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   code_review_groups:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: code_review_groups
-    name: index_code_review_groups_on_section_id
-    unique: false
-    columns:
-    - section_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: code_review_groups
+      name: index_code_review_groups_on_section_id
+      unique: false
+      columns:
+        - section_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   code_review_requests:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: code_review_requests
-    name: index_code_review_requests_unique
-    unique: true
-    columns:
-    - user_id
-    - script_id
-    - level_id
-    - closed_at
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: code_review_requests
+      name: index_code_review_requests_unique
+      unique: true
+      columns:
+        - user_id
+        - script_id
+        - level_id
+        - closed_at
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   code_reviews:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: code_reviews
-    name: index_code_reviews_unique
-    unique: true
-    columns:
-    - user_id
-    - project_id
-    - open
-    - active
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: code_reviews
-    name: index_code_reviews_on_project_id_and_deleted_at
-    unique: false
-    columns:
-    - project_id
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: code_reviews
-    name: index_code_reviews_for_peer_lookup
-    unique: false
-    columns:
-    - user_id
-    - script_id
-    - project_level_id
-    - closed_at
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: code_reviews
+      name: index_code_reviews_unique
+      unique: true
+      columns:
+        - user_id
+        - project_id
+        - open
+        - active
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: code_reviews
+      name: index_code_reviews_on_project_id_and_deleted_at
+      unique: false
+      columns:
+        - project_id
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: code_reviews
+      name: index_code_reviews_for_peer_lookup
+      unique: false
+      columns:
+        - user_id
+        - script_id
+        - project_level_id
+        - closed_at
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   concepts:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: concepts
-    name: index_concepts_on_video_key
-    unique: false
-    columns:
-    - video_key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: concepts
+      name: index_concepts_on_video_key
+      unique: false
+      columns:
+        - video_key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   concepts_levels:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: concepts_levels
-    name: index_concepts_levels_on_concept_id
-    unique: false
-    columns:
-    - concept_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: concepts_levels
-    name: index_concepts_levels_on_level_id
-    unique: false
-    columns:
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: concepts_levels
+      name: index_concepts_levels_on_concept_id
+      unique: false
+      columns:
+        - concept_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: concepts_levels
+      name: index_concepts_levels_on_level_id
+      unique: false
+      columns:
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   contact_rollups_final:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: contact_rollups_final
-    name: index_contact_rollups_final_on_email
-    unique: true
-    columns:
-    - email
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: contact_rollups_final
+      name: index_contact_rollups_final_on_email
+      unique: true
+      columns:
+        - email
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   contact_rollups_pardot_memory:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: contact_rollups_pardot_memory
-    name: index_contact_rollups_pardot_memory_on_email
-    unique: true
-    columns:
-    - email
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: contact_rollups_pardot_memory
-    name: index_contact_rollups_pardot_memory_on_pardot_id
-    unique: true
-    columns:
-    - pardot_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: contact_rollups_pardot_memory
-    name: index_contact_rollups_pardot_memory_on_marked_for_deletion_at
-    unique: false
-    columns:
-    - marked_for_deletion_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: contact_rollups_pardot_memory
+      name: index_contact_rollups_pardot_memory_on_email
+      unique: true
+      columns:
+        - email
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: contact_rollups_pardot_memory
+      name: index_contact_rollups_pardot_memory_on_pardot_id
+      unique: true
+      columns:
+        - pardot_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: contact_rollups_pardot_memory
+      name: index_contact_rollups_pardot_memory_on_marked_for_deletion_at
+      unique: false
+      columns:
+        - marked_for_deletion_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   contact_rollups_processed:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: contact_rollups_processed
-    name: index_contact_rollups_processed_on_email
-    unique: true
-    columns:
-    - email
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: contact_rollups_processed
+      name: index_contact_rollups_processed_on_email
+      unique: true
+      columns:
+        - email
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   contact_rollups_raw: []
   contained_level_answers:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: contained_level_answers
-    name: index_contained_level_answers_on_level_id
-    unique: false
-    columns:
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: contained_level_answers
+      name: index_contained_level_answers_on_level_id
+      unique: false
+      columns:
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   contained_levels:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: contained_levels
-    name: index_contained_levels_on_contained_level_id
-    unique: false
-    columns:
-    - contained_level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: contained_levels
-    name: index_contained_levels_on_level_group_level_id
-    unique: false
-    columns:
-    - level_group_level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: contained_levels
+      name: index_contained_levels_on_contained_level_id
+      unique: false
+      columns:
+        - contained_level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: contained_levels
+      name: index_contained_levels_on_level_group_level_id
+      unique: false
+      columns:
+        - level_group_level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   course_offerings:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: course_offerings
-    name: index_course_offerings_on_key
-    unique: true
-    columns:
-    - key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: course_offerings
+      name: index_course_offerings_on_key
+      unique: true
+      columns:
+        - key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   course_scripts:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: course_scripts
-    name: index_course_scripts_on_course_id
-    unique: false
-    columns:
-    - course_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: course_scripts
-    name: index_course_scripts_on_default_script_id
-    unique: false
-    columns:
-    - default_script_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: course_scripts
-    name: index_course_scripts_on_script_id
-    unique: false
-    columns:
-    - script_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: course_scripts
+      name: index_course_scripts_on_course_id
+      unique: false
+      columns:
+        - course_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: course_scripts
+      name: index_course_scripts_on_default_script_id
+      unique: false
+      columns:
+        - default_script_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: course_scripts
+      name: index_course_scripts_on_script_id
+      unique: false
+      columns:
+        - script_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   course_versions:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: course_versions
-    name: index_course_versions_on_offering_id_and_key_and_type
-    unique: true
-    columns:
-    - course_offering_id
-    - key
-    - content_root_type
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: course_versions
-    name: index_course_versions_on_content_root_type_and_content_root_id
-    unique: false
-    columns:
-    - content_root_type
-    - content_root_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: course_versions
-    name: index_course_versions_on_course_offering_id
-    unique: false
-    columns:
-    - course_offering_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: course_versions
+      name: index_course_versions_on_offering_id_and_key_and_type
+      unique: true
+      columns:
+        - course_offering_id
+        - key
+        - content_root_type
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: course_versions
+      name: index_course_versions_on_content_root_type_and_content_root_id
+      unique: false
+      columns:
+        - content_root_type
+        - content_root_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: course_versions
+      name: index_course_versions_on_course_offering_id
+      unique: false
+      columns:
+        - course_offering_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   courses:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: courses
-    name: index_courses_on_name
-    unique: false
-    columns:
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: courses
+      name: index_courses_on_name
+      unique: false
+      columns:
+        - name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   data_docs:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: data_docs
-    name: index_data_docs_on_key
-    unique: true
-    columns:
-    - key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: data_docs
-    name: index_data_docs_on_name
-    unique: false
-    columns:
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: data_docs
+      name: index_data_docs_on_key
+      unique: true
+      columns:
+        - key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: data_docs
+      name: index_data_docs_on_name
+      unique: false
+      columns:
+        - name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   delayed_jobs:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: delayed_jobs
-    name: delayed_jobs_priority
-    unique: false
-    columns:
-    - priority
-    - run_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: delayed_jobs
+      name: delayed_jobs_priority
+      unique: false
+      columns:
+        - priority
+        - run_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   donor_schools: []
   donors: []
   email_preferences:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: email_preferences
-    name: index_email_preferences_on_email
-    unique: true
-    columns:
-    - email
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: email_preferences
+      name: index_email_preferences_on_email
+      unique: true
+      columns:
+        - email
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   experiments:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: experiments
-    name: index_experiments_on_end_at
-    unique: false
-    columns:
-    - end_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: experiments
-    name: index_experiments_on_max_user_id
-    unique: false
-    columns:
-    - max_user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: experiments
-    name: index_experiments_on_min_user_id
-    unique: false
-    columns:
-    - min_user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: experiments
-    name: index_experiments_on_overflow_max_user_id
-    unique: false
-    columns:
-    - overflow_max_user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: experiments
-    name: index_experiments_on_section_id
-    unique: false
-    columns:
-    - section_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: experiments
-    name: index_experiments_on_start_at
-    unique: false
-    columns:
-    - start_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: experiments
+      name: index_experiments_on_end_at
+      unique: false
+      columns:
+        - end_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: experiments
+      name: index_experiments_on_max_user_id
+      unique: false
+      columns:
+        - max_user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: experiments
+      name: index_experiments_on_min_user_id
+      unique: false
+      columns:
+        - min_user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: experiments
+      name: index_experiments_on_overflow_max_user_id
+      unique: false
+      columns:
+        - overflow_max_user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: experiments
+      name: index_experiments_on_section_id
+      unique: false
+      columns:
+        - section_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: experiments
+      name: index_experiments_on_start_at
+      unique: false
+      columns:
+        - start_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   featured_projects:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: featured_projects
-    name: index_featured_projects_on_storage_app_id
-    unique: true
-    columns:
-    - storage_app_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: featured_projects
-    name: index_featured_projects_on_topic
-    unique: false
-    columns:
-    - topic
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: featured_projects
+      name: index_featured_projects_on_storage_app_id
+      unique: true
+      columns:
+        - storage_app_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: featured_projects
+      name: index_featured_projects_on_topic
+      unique: false
+      columns:
+        - topic
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   followers:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: followers
-    name: index_followers_on_section_id_and_student_user_id
-    unique: false
-    columns:
-    - section_id
-    - student_user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: followers
-    name: index_followers_on_student_user_id
-    unique: false
-    columns:
-    - student_user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: followers
+      name: index_followers_on_section_id_and_student_user_id
+      unique: false
+      columns:
+        - section_id
+        - student_user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: followers
+      name: index_followers_on_student_user_id
+      unique: false
+      columns:
+        - student_user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   foorm_forms:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: foorm_forms
-    name: index_foorm_forms_on_name_and_version
-    unique: true
-    columns:
-    - name
-    - version
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: foorm_forms
+      name: index_foorm_forms_on_name_and_version
+      unique: true
+      columns:
+        - name
+        - version
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   foorm_libraries:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: foorm_libraries
-    name: index_foorm_libraries_on_multiple_fields
-    unique: true
-    columns:
-    - name
-    - version
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: foorm_libraries
+      name: index_foorm_libraries_on_multiple_fields
+      unique: true
+      columns:
+        - name
+        - version
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   foorm_library_questions:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: foorm_library_questions
-    name: index_foorm_library_questions_on_multiple_fields
-    unique: true
-    columns:
-    - library_name
-    - library_version
-    - question_name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: foorm_library_questions
+      name: index_foorm_library_questions_on_multiple_fields
+      unique: true
+      columns:
+        - library_name
+        - library_version
+        - question_name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   foorm_simple_survey_forms:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: foorm_simple_survey_forms
-    name: index_foorm_simple_survey_forms_on_path
-    unique: false
-    columns:
-    - path
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: foorm_simple_survey_forms
+      name: index_foorm_simple_survey_forms_on_path
+      unique: false
+      columns:
+        - path
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   foorm_simple_survey_submissions:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: foorm_simple_survey_submissions
-    name: index_foorm_simple_survey_submissions_on_foorm_submission_id
-    unique: true
-    columns:
-    - foorm_submission_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: foorm_simple_survey_submissions
-    name: index_foorm_simple_survey_submissions_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: foorm_simple_survey_submissions
+      name: index_foorm_simple_survey_submissions_on_foorm_submission_id
+      unique: true
+      columns:
+        - foorm_submission_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: foorm_simple_survey_submissions
+      name: index_foorm_simple_survey_submissions_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   foorm_submissions: []
   frameworks:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: frameworks
-    name: index_frameworks_on_shortcode
-    unique: true
-    columns:
-    - shortcode
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: frameworks
+      name: index_frameworks_on_shortcode
+      unique: true
+      columns:
+        - shortcode
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   games:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: games
-    name: index_games_on_intro_video_id
-    unique: false
-    columns:
-    - intro_video_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: games
+      name: index_games_on_intro_video_id
+      unique: false
+      columns:
+        - intro_video_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   google_sheets_shared_cdo_donors: []
   google_sheets_shared_cdo_languages:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: google_sheets_shared_cdo_languages
-    name: code_s
-    unique: true
-    columns:
-    - code_s
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: google_sheets_shared_cdo_languages
-    name: google_sheets_shared_cdo_languages_supported_codeorg_b_index
-    unique: false
-    columns:
-    - supported_codeorg_b
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: google_sheets_shared_cdo_languages
+      name: code_s
+      unique: true
+      columns:
+        - code_s
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: google_sheets_shared_cdo_languages
+      name: google_sheets_shared_cdo_languages_supported_codeorg_b_index
+      unique: false
+      columns:
+        - supported_codeorg_b
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   hint_view_requests:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: hint_view_requests
-    name: index_hint_view_requests_on_script_id_and_level_id
-    unique: false
-    columns:
-    - script_id
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: hint_view_requests
-    name: index_hint_view_requests_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: hint_view_requests
+      name: index_hint_view_requests_on_script_id_and_level_id
+      unique: false
+      columns:
+        - script_id
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: hint_view_requests
+      name: index_hint_view_requests_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   learning_goal_ai_evaluation_feedbacks:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: learning_goal_ai_evaluation_feedbacks
-    name: index_feedback_on_learning_goal_ai_evaluation
-    unique: false
-    columns:
-    - learning_goal_ai_evaluation_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: learning_goal_ai_evaluation_feedbacks
+      name: index_feedback_on_learning_goal_ai_evaluation
+      unique: false
+      columns:
+        - learning_goal_ai_evaluation_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   learning_goal_ai_evaluations:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: learning_goal_ai_evaluations
-    name: index_learning_goal_ai_evaluations_on_rubric_ai_evaluation_id
-    unique: false
-    columns:
-    - rubric_ai_evaluation_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: learning_goal_ai_evaluations
-    name: index_learning_goal_ai_evaluations_on_learning_goal_id
-    unique: false
-    columns:
-    - learning_goal_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: learning_goal_ai_evaluations
+      name: index_learning_goal_ai_evaluations_on_rubric_ai_evaluation_id
+      unique: false
+      columns:
+        - rubric_ai_evaluation_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: learning_goal_ai_evaluations
+      name: index_learning_goal_ai_evaluations_on_learning_goal_id
+      unique: false
+      columns:
+        - learning_goal_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   learning_goal_evidence_levels:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: learning_goal_evidence_levels
-    name: index_learning_goal_evidence_levels_on_lg_id_and_understanding
-    unique: true
-    columns:
-    - learning_goal_id
-    - understanding
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: learning_goal_evidence_levels
+      name: index_learning_goal_evidence_levels_on_lg_id_and_understanding
+      unique: true
+      columns:
+        - learning_goal_id
+        - understanding
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   learning_goal_teacher_evaluations:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: learning_goal_teacher_evaluations
-    name: index_learning_goal_teacher_evaluations_on_learning_goal_id
-    unique: false
-    columns:
-    - learning_goal_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: learning_goal_teacher_evaluations
-    name: index_learning_goal_teacher_evaluations_on_user_and_teacher_id
-    unique: false
-    columns:
-    - user_id
-    - teacher_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: learning_goal_teacher_evaluations
+      name: index_learning_goal_teacher_evaluations_on_learning_goal_id
+      unique: false
+      columns:
+        - learning_goal_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: learning_goal_teacher_evaluations
+      name: index_learning_goal_teacher_evaluations_on_user_and_teacher_id
+      unique: false
+      columns:
+        - user_id
+        - teacher_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   learning_goals:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: learning_goals
-    name: index_learning_goals_on_rubric_id_and_key
-    unique: true
-    columns:
-    - rubric_id
-    - key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: learning_goals
+      name: index_learning_goals_on_rubric_id_and_key
+      unique: true
+      columns:
+        - rubric_id
+        - key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   lesson_activities:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lesson_activities
-    name: index_lesson_activities_on_key
-    unique: true
-    columns:
-    - key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lesson_activities
-    name: index_lesson_activities_on_lesson_id
-    unique: false
-    columns:
-    - lesson_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lesson_activities
+      name: index_lesson_activities_on_key
+      unique: true
+      columns:
+        - key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lesson_activities
+      name: index_lesson_activities_on_lesson_id
+      unique: false
+      columns:
+        - lesson_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   lesson_groups:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lesson_groups
-    name: index_lesson_groups_on_script_id_and_key
-    unique: true
-    columns:
-    - script_id
-    - key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lesson_groups
+      name: index_lesson_groups_on_script_id_and_key
+      unique: true
+      columns:
+        - script_id
+        - key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   lessons_opportunity_standards:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lessons_opportunity_standards
-    name: index_lessons_opportunity_standards_on_lesson_id_and_standard_id
-    unique: true
-    columns:
-    - lesson_id
-    - standard_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lessons_opportunity_standards
-    name: index_lessons_opportunity_standards_on_standard_id_and_lesson_id
-    unique: false
-    columns:
-    - standard_id
-    - lesson_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lessons_opportunity_standards
+      name: index_lessons_opportunity_standards_on_lesson_id_and_standard_id
+      unique: true
+      columns:
+        - lesson_id
+        - standard_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lessons_opportunity_standards
+      name: index_lessons_opportunity_standards_on_standard_id_and_lesson_id
+      unique: false
+      columns:
+        - standard_id
+        - lesson_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   lessons_programming_expressions:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lessons_programming_expressions
-    name: lesson_programming_expression
-    unique: true
-    columns:
-    - lesson_id
-    - programming_expression_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lessons_programming_expressions
-    name: programming_expression_lesson
-    unique: false
-    columns:
-    - programming_expression_id
-    - lesson_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lessons_programming_expressions
+      name: lesson_programming_expression
+      unique: true
+      columns:
+        - lesson_id
+        - programming_expression_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lessons_programming_expressions
+      name: programming_expression_lesson
+      unique: false
+      columns:
+        - programming_expression_id
+        - lesson_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   lessons_resources:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lessons_resources
-    name: index_lessons_resources_on_lesson_id_and_resource_id
-    unique: true
-    columns:
-    - lesson_id
-    - resource_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lessons_resources
-    name: index_lessons_resources_on_resource_id_and_lesson_id
-    unique: false
-    columns:
-    - resource_id
-    - lesson_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lessons_resources
+      name: index_lessons_resources_on_lesson_id_and_resource_id
+      unique: true
+      columns:
+        - lesson_id
+        - resource_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lessons_resources
+      name: index_lessons_resources_on_resource_id_and_lesson_id
+      unique: false
+      columns:
+        - resource_id
+        - lesson_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   lessons_vocabularies:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lessons_vocabularies
-    name: index_lessons_vocabularies_on_lesson_id_and_vocabulary_id
-    unique: true
-    columns:
-    - lesson_id
-    - vocabulary_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lessons_vocabularies
-    name: index_lessons_vocabularies_on_vocabulary_id_and_lesson_id
-    unique: false
-    columns:
-    - vocabulary_id
-    - lesson_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lessons_vocabularies
+      name: index_lessons_vocabularies_on_lesson_id_and_vocabulary_id
+      unique: true
+      columns:
+        - lesson_id
+        - vocabulary_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lessons_vocabularies
+      name: index_lessons_vocabularies_on_vocabulary_id_and_lesson_id
+      unique: false
+      columns:
+        - vocabulary_id
+        - lesson_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   level_concept_difficulties:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: level_concept_difficulties
-    name: index_level_concept_difficulties_on_level_id
-    unique: false
-    columns:
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: level_concept_difficulties
+      name: index_level_concept_difficulties_on_level_id
+      unique: false
+      columns:
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   level_source_images:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: level_source_images
-    name: index_level_source_images_on_level_source_id
-    unique: false
-    columns:
-    - level_source_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: level_source_images
+      name: index_level_source_images_on_level_source_id
+      unique: false
+      columns:
+        - level_source_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   level_sources:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: level_sources
-    name: index_level_sources_on_level_id_and_md5
-    unique: false
-    columns:
-    - level_id
-    - md5
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: level_sources
+      name: index_level_sources_on_level_id_and_md5
+      unique: false
+      columns:
+        - level_id
+        - md5
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   level_sources_multi_types:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: level_sources_multi_types
-    name: index_level_sources_multi_types_on_level_id
-    unique: false
-    columns:
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: level_sources_multi_types
-    name: index_level_sources_multi_types_on_level_source_id
-    unique: false
-    columns:
-    - level_source_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: level_sources_multi_types
+      name: index_level_sources_multi_types_on_level_id
+      unique: false
+      columns:
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: level_sources_multi_types
+      name: index_level_sources_multi_types_on_level_source_id
+      unique: false
+      columns:
+        - level_source_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   levels:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: levels
-    name: index_levels_on_game_id
-    unique: false
-    columns:
-    - game_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: levels
-    name: index_levels_on_level_num
-    unique: false
-    columns:
-    - level_num
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: levels
-    name: index_levels_on_name
-    unique: false
-    columns:
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: levels
+      name: index_levels_on_game_id
+      unique: false
+      columns:
+        - game_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: levels
+      name: index_levels_on_name
+      unique: false
+      columns:
+        - name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: levels
+      name: index_levels_on_level_num
+      unique: false
+      columns:
+        - level_num
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   levels_script_levels:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: levels_script_levels
-    name: index_levels_script_levels_on_script_level_id_and_level_id
-    unique: true
-    columns:
-    - script_level_id
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: levels_script_levels
-    name: index_levels_script_levels_on_level_id
-    unique: false
-    columns:
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: levels_script_levels
-    name: index_levels_script_levels_on_script_level_id
-    unique: false
-    columns:
-    - script_level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: levels_script_levels
+      name: index_levels_script_levels_on_script_level_id_and_level_id
+      unique: true
+      columns:
+        - script_level_id
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: levels_script_levels
+      name: index_levels_script_levels_on_level_id
+      unique: false
+      columns:
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: levels_script_levels
+      name: index_levels_script_levels_on_script_level_id
+      unique: false
+      columns:
+        - script_level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   libraries: []
   lti_courses:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_courses
-    name: index_lti_courses_on_lti_integration_id
-    unique: false
-    columns:
-    - lti_integration_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_courses
-    name: fk_rails_19886eb632
-    unique: false
-    columns:
-    - lti_deployment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_courses
-    name: index_on_context_id_and_lti_integration_id
-    unique: false
-    columns:
-    - context_id
-    - lti_integration_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_courses
-    name: index_on_course_id_and_lti_integration_id
-    unique: false
-    columns:
-    - course_id
-    - lti_integration_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_courses
+      name: index_lti_courses_on_lti_integration_id
+      unique: false
+      columns:
+        - lti_integration_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_courses
+      name: fk_rails_19886eb632
+      unique: false
+      columns:
+        - lti_deployment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_courses
+      name: index_on_context_id_and_lti_integration_id
+      unique: false
+      columns:
+        - context_id
+        - lti_integration_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_courses
+      name: index_on_course_id_and_lti_integration_id
+      unique: false
+      columns:
+        - course_id
+        - lti_integration_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   lti_deployments:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_deployments
-    name: index_lti_deployments_on_deployment_id
-    unique: false
-    columns:
-    - deployment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_deployments
-    name: index_lti_deployments_on_lti_integration_id
-    unique: false
-    columns:
-    - lti_integration_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_deployments
+      name: index_lti_deployments_on_lti_integration_id
+      unique: false
+      columns:
+        - lti_integration_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_deployments
+      name: index_lti_deployments_on_deployment_id
+      unique: false
+      columns:
+        - deployment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   lti_integrations:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_integrations
-    name: index_lti_integrations_on_client_id
-    unique: false
-    columns:
-    - client_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_integrations
-    name: index_lti_integrations_on_issuer
-    unique: false
-    columns:
-    - issuer
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_integrations
-    name: index_lti_integrations_on_platform_id
-    unique: false
-    columns:
-    - platform_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_integrations
+      name: index_lti_integrations_on_platform_id
+      unique: false
+      columns:
+        - platform_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_integrations
+      name: index_lti_integrations_on_issuer
+      unique: false
+      columns:
+        - issuer
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_integrations
+      name: index_lti_integrations_on_client_id
+      unique: false
+      columns:
+        - client_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   lti_sections:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_sections
-    name: index_lti_sections_on_lti_course_id
-    unique: false
-    columns:
-    - lti_course_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_sections
-    name: index_lti_sections_on_section_id
-    unique: false
-    columns:
-    - section_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_sections
+      name: index_lti_sections_on_lti_course_id
+      unique: false
+      columns:
+        - lti_course_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_sections
+      name: index_lti_sections_on_section_id
+      unique: false
+      columns:
+        - section_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   lti_user_identities:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_user_identities
-    name: index_lti_user_identities_on_lti_integration_id
-    unique: false
-    columns:
-    - lti_integration_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_user_identities
-    name: index_lti_user_identities_on_subject
-    unique: false
-    columns:
-    - subject
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: lti_user_identities
-    name: index_lti_user_identities_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_user_identities
+      name: index_lti_user_identities_on_lti_integration_id
+      unique: false
+      columns:
+        - lti_integration_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_user_identities
+      name: index_lti_user_identities_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: lti_user_identities
+      name: index_lti_user_identities_on_subject
+      unique: false
+      columns:
+        - subject
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   metrics: []
   objectives:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: objectives
-    name: index_objectives_on_key
-    unique: true
-    columns:
-    - key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: objectives
-    name: index_objectives_on_lesson_id
-    unique: false
-    columns:
-    - lesson_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: objectives
+      name: index_objectives_on_key
+      unique: true
+      columns:
+        - key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: objectives
+      name: index_objectives_on_lesson_id
+      unique: false
+      columns:
+        - lesson_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   paired_user_levels:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: paired_user_levels
-    name: index_paired_user_levels_on_driver_user_level_id
-    unique: false
-    columns:
-    - driver_user_level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: paired_user_levels
-    name: index_paired_user_levels_on_navigator_user_level_id
-    unique: false
-    columns:
-    - navigator_user_level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: paired_user_levels
+      name: index_paired_user_levels_on_driver_user_level_id
+      unique: false
+      columns:
+        - driver_user_level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: paired_user_levels
+      name: index_paired_user_levels_on_navigator_user_level_id
+      unique: false
+      columns:
+        - navigator_user_level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   parent_levels_child_levels:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: parent_levels_child_levels
-    name: index_parent_levels_child_levels_on_child_level_id
-    unique: false
-    columns:
-    - child_level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: parent_levels_child_levels
-    name: index_parent_levels_child_levels_on_parent_level_id
-    unique: false
-    columns:
-    - parent_level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: parent_levels_child_levels
+      name: index_parent_levels_child_levels_on_child_level_id
+      unique: false
+      columns:
+        - child_level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: parent_levels_child_levels
+      name: index_parent_levels_child_levels_on_parent_level_id
+      unique: false
+      columns:
+        - parent_level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   parental_permission_requests:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: parental_permission_requests
-    name: index_parental_permission_requests_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: parental_permission_requests
-    name: index_parental_permission_requests_on_uuid
-    unique: false
-    columns:
-    - uuid
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: parental_permission_requests
+      name: index_parental_permission_requests_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: parental_permission_requests
+      name: index_parental_permission_requests_on_uuid
+      unique: false
+      columns:
+        - uuid
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_accepted_programs: []
   pd_application_emails:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_application_emails
-    name: index_pd_application_emails_on_pd_application_id
-    unique: false
-    columns:
-    - pd_application_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_application_emails
+      name: index_pd_application_emails_on_pd_application_id
+      unique: false
+      columns:
+        - pd_application_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_application_tags:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_application_tags
-    name: index_pd_application_tags_on_name
-    unique: true
-    columns:
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_application_tags
+      name: index_pd_application_tags_on_name
+      unique: true
+      columns:
+        - name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_application_tags_applications:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_application_tags_applications
-    name: index_pd_application_tags_applications_on_pd_application_id
-    unique: false
-    columns:
-    - pd_application_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_application_tags_applications
-    name: index_pd_application_tags_applications_on_pd_application_tag_id
-    unique: false
-    columns:
-    - pd_application_tag_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_application_tags_applications
+      name: index_pd_application_tags_applications_on_pd_application_id
+      unique: false
+      columns:
+        - pd_application_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_application_tags_applications
+      name: index_pd_application_tags_applications_on_pd_application_tag_id
+      unique: false
+      columns:
+        - pd_application_tag_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_applications:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_applications
-    name: index_pd_applications_on_application_guid
-    unique: false
-    columns:
-    - application_guid
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_applications
-    name: index_pd_applications_on_application_type
-    unique: false
-    columns:
-    - application_type
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_applications
-    name: index_pd_applications_on_application_year
-    unique: false
-    columns:
-    - application_year
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_applications
-    name: index_pd_applications_on_course
-    unique: false
-    columns:
-    - course
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_applications
-    name: index_pd_applications_on_regional_partner_id
-    unique: false
-    columns:
-    - regional_partner_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_applications
-    name: index_pd_applications_on_status
-    unique: false
-    columns:
-    - status
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_applications
-    name: index_pd_applications_on_type
-    unique: false
-    columns:
-    - type
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_applications
-    name: index_pd_applications_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_applications
+      name: index_pd_applications_on_application_guid
+      unique: false
+      columns:
+        - application_guid
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_applications
+      name: index_pd_applications_on_application_type
+      unique: false
+      columns:
+        - application_type
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_applications
+      name: index_pd_applications_on_application_year
+      unique: false
+      columns:
+        - application_year
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_applications
+      name: index_pd_applications_on_course
+      unique: false
+      columns:
+        - course
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_applications
+      name: index_pd_applications_on_regional_partner_id
+      unique: false
+      columns:
+        - regional_partner_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_applications
+      name: index_pd_applications_on_status
+      unique: false
+      columns:
+        - status
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_applications
+      name: index_pd_applications_on_type
+      unique: false
+      columns:
+        - type
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_applications
+      name: index_pd_applications_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_applications_status_logs: []
   pd_attendances:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_attendances
-    name: index_pd_attendances_on_pd_session_id_and_teacher_id
-    unique: true
-    columns:
-    - pd_session_id
-    - teacher_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_attendances
-    name: index_pd_attendances_on_marked_by_user_id
-    unique: false
-    columns:
-    - marked_by_user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_attendances
-    name: index_pd_attendances_on_pd_enrollment_id
-    unique: false
-    columns:
-    - pd_enrollment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_attendances
-    name: index_pd_attendances_on_teacher_id
-    unique: false
-    columns:
-    - teacher_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_attendances
+      name: index_pd_attendances_on_pd_session_id_and_teacher_id
+      unique: true
+      columns:
+        - pd_session_id
+        - teacher_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_attendances
+      name: index_pd_attendances_on_marked_by_user_id
+      unique: false
+      columns:
+        - marked_by_user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_attendances
+      name: index_pd_attendances_on_pd_enrollment_id
+      unique: false
+      columns:
+        - pd_enrollment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_attendances
+      name: index_pd_attendances_on_teacher_id
+      unique: false
+      columns:
+        - teacher_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_course_facilitators:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_course_facilitators
-    name: index_pd_course_facilitators_on_facilitator_id_and_course
-    unique: true
-    columns:
-    - facilitator_id
-    - course
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_course_facilitators
-    name: index_pd_course_facilitators_on_course
-    unique: false
-    columns:
-    - course
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_course_facilitators
+      name: index_pd_course_facilitators_on_facilitator_id_and_course
+      unique: true
+      columns:
+        - facilitator_id
+        - course
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_course_facilitators
+      name: index_pd_course_facilitators_on_course
+      unique: false
+      columns:
+        - course
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_district_payment_terms:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_district_payment_terms
-    name: index_pd_district_payment_terms_school_district_course
-    unique: false
-    columns:
-    - school_district_id
-    - course
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_district_payment_terms
+      name: index_pd_district_payment_terms_school_district_course
+      unique: false
+      columns:
+        - school_district_id
+        - course
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_enrollment_notifications:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_enrollment_notifications
-    name: index_pd_enrollment_notifications_on_pd_enrollment_id
-    unique: false
-    columns:
-    - pd_enrollment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_enrollment_notifications
+      name: index_pd_enrollment_notifications_on_pd_enrollment_id
+      unique: false
+      columns:
+        - pd_enrollment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_enrollments:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_enrollments
-    name: index_pd_enrollments_on_code
-    unique: true
-    columns:
-    - code
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_enrollments
-    name: index_pd_enrollments_on_email
-    unique: false
-    columns:
-    - email
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_enrollments
-    name: index_pd_enrollments_on_pd_workshop_id
-    unique: false
-    columns:
-    - pd_workshop_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_enrollments
+      name: index_pd_enrollments_on_code
+      unique: true
+      columns:
+        - code
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_enrollments
+      name: index_pd_enrollments_on_email
+      unique: false
+      columns:
+        - email
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_enrollments
+      name: index_pd_enrollments_on_pd_workshop_id
+      unique: false
+      columns:
+        - pd_workshop_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_facilitator_program_registrations:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_facilitator_program_registrations
-    name: index_pd_fac_prog_reg_on_user_id_and_teachercon
-    unique: true
-    columns:
-    - user_id
-    - teachercon
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_facilitator_program_registrations
+      name: index_pd_fac_prog_reg_on_user_id_and_teachercon
+      unique: true
+      columns:
+        - user_id
+        - teachercon
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_facilitator_teachercon_attendances:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_facilitator_teachercon_attendances
-    name: index_pd_facilitator_teachercon_attendances_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_facilitator_teachercon_attendances
+      name: index_pd_facilitator_teachercon_attendances_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_fit_weekend1819_registrations:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_fit_weekend1819_registrations
-    name: index_pd_fit_weekend1819_registrations_on_pd_application_id
-    unique: false
-    columns:
-    - pd_application_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_fit_weekend1819_registrations
+      name: index_pd_fit_weekend1819_registrations_on_pd_application_id
+      unique: false
+      columns:
+        - pd_application_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_fit_weekend_registrations:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_fit_weekend_registrations
-    name: index_pd_fit_weekend_registrations_on_pd_application_id
-    unique: false
-    columns:
-    - pd_application_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_fit_weekend_registrations
-    name: index_pd_fit_weekend_registrations_on_registration_year
-    unique: false
-    columns:
-    - registration_year
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_fit_weekend_registrations
+      name: index_pd_fit_weekend_registrations_on_pd_application_id
+      unique: false
+      columns:
+        - pd_application_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_fit_weekend_registrations
+      name: index_pd_fit_weekend_registrations_on_registration_year
+      unique: false
+      columns:
+        - registration_year
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_international_opt_ins:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_international_opt_ins
-    name: index_pd_international_opt_ins_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_international_opt_ins
+      name: index_pd_international_opt_ins_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_legacy_survey_summaries: []
   pd_misc_surveys:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_misc_surveys
-    name: index_pd_misc_surveys_on_submission_id
-    unique: true
-    columns:
-    - submission_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_misc_surveys
-    name: index_pd_misc_surveys_on_form_id
-    unique: false
-    columns:
-    - form_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_misc_surveys
-    name: index_pd_misc_surveys_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_misc_surveys
+      name: index_pd_misc_surveys_on_submission_id
+      unique: true
+      columns:
+        - submission_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_misc_surveys
+      name: index_pd_misc_surveys_on_form_id
+      unique: false
+      columns:
+        - form_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_misc_surveys
+      name: index_pd_misc_surveys_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_payment_terms:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_payment_terms
-    name: index_pd_payment_terms_on_regional_partner_id
-    unique: false
-    columns:
-    - regional_partner_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_payment_terms
+      name: index_pd_payment_terms_on_regional_partner_id
+      unique: false
+      columns:
+        - regional_partner_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_post_course_surveys:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_post_course_surveys
-    name: index_pd_post_course_surveys_on_submission_id
-    unique: true
-    columns:
-    - submission_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_post_course_surveys
-    name: index_pd_post_course_surveys_on_user_form_year_course
-    unique: true
-    columns:
-    - user_id
-    - form_id
-    - year
-    - course
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_post_course_surveys
-    name: index_pd_post_course_surveys_on_form_id
-    unique: false
-    columns:
-    - form_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_post_course_surveys
-    name: index_pd_post_course_surveys_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_post_course_surveys
+      name: index_pd_post_course_surveys_on_submission_id
+      unique: true
+      columns:
+        - submission_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_post_course_surveys
+      name: index_pd_post_course_surveys_on_user_form_year_course
+      unique: true
+      columns:
+        - user_id
+        - form_id
+        - year
+        - course
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_post_course_surveys
+      name: index_pd_post_course_surveys_on_form_id
+      unique: false
+      columns:
+        - form_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_post_course_surveys
+      name: index_pd_post_course_surveys_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_pre_workshop_surveys:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_pre_workshop_surveys
-    name: index_pd_pre_workshop_surveys_on_pd_enrollment_id
-    unique: true
-    columns:
-    - pd_enrollment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_pre_workshop_surveys
+      name: index_pd_pre_workshop_surveys_on_pd_enrollment_id
+      unique: true
+      columns:
+        - pd_enrollment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_regional_partner_cohorts:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_regional_partner_cohorts
-    name: index_pd_regional_partner_cohorts_on_regional_partner_id
-    unique: false
-    columns:
-    - regional_partner_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_regional_partner_cohorts
-    name: index_pd_regional_partner_cohorts_on_summer_workshop_id
-    unique: false
-    columns:
-    - summer_workshop_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_regional_partner_cohorts
+      name: index_pd_regional_partner_cohorts_on_regional_partner_id
+      unique: false
+      columns:
+        - regional_partner_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_regional_partner_cohorts
+      name: index_pd_regional_partner_cohorts_on_summer_workshop_id
+      unique: false
+      columns:
+        - summer_workshop_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_regional_partner_cohorts_users:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_regional_partner_cohorts_users
-    name: index_pd_regional_partner_cohorts_users_on_cohort_id
-    unique: false
-    columns:
-    - pd_regional_partner_cohort_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_regional_partner_cohorts_users
-    name: index_pd_regional_partner_cohorts_users_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_regional_partner_cohorts_users
+      name: index_pd_regional_partner_cohorts_users_on_cohort_id
+      unique: false
+      columns:
+        - pd_regional_partner_cohort_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_regional_partner_cohorts_users
+      name: index_pd_regional_partner_cohorts_users_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_regional_partner_contacts:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_regional_partner_contacts
-    name: index_pd_regional_partner_contacts_on_regional_partner_id
-    unique: false
-    columns:
-    - regional_partner_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_regional_partner_contacts
-    name: index_pd_regional_partner_contacts_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_regional_partner_contacts
+      name: index_pd_regional_partner_contacts_on_regional_partner_id
+      unique: false
+      columns:
+        - regional_partner_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_regional_partner_contacts
+      name: index_pd_regional_partner_contacts_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_regional_partner_mappings:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_regional_partner_mappings
-    name: index_pd_regional_partner_mappings_on_id_and_state_and_zip_code
-    unique: true
-    columns:
-    - regional_partner_id
-    - state
-    - zip_code
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_regional_partner_mappings
-    name: index_pd_regional_partner_mappings_on_regional_partner_id
-    unique: false
-    columns:
-    - regional_partner_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_regional_partner_mappings
+      name: index_pd_regional_partner_mappings_on_id_and_state_and_zip_code
+      unique: true
+      columns:
+        - regional_partner_id
+        - state
+        - zip_code
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_regional_partner_mappings
+      name: index_pd_regional_partner_mappings_on_regional_partner_id
+      unique: false
+      columns:
+        - regional_partner_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_regional_partner_mini_contacts:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_regional_partner_mini_contacts
-    name: index_pd_regional_partner_mini_contacts_on_regional_partner_id
-    unique: false
-    columns:
-    - regional_partner_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_regional_partner_mini_contacts
-    name: index_pd_regional_partner_mini_contacts_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_regional_partner_mini_contacts
+      name: index_pd_regional_partner_mini_contacts_on_regional_partner_id
+      unique: false
+      columns:
+        - regional_partner_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_regional_partner_mini_contacts
+      name: index_pd_regional_partner_mini_contacts_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_regional_partner_program_registrations:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_regional_partner_program_registrations
-    name: index_pd_reg_part_prog_reg_on_user_id_and_teachercon
-    unique: false
-    columns:
-    - user_id
-    - teachercon
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_regional_partner_program_registrations
+      name: index_pd_reg_part_prog_reg_on_user_id_and_teachercon
+      unique: false
+      columns:
+        - user_id
+        - teachercon
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_scholarship_infos:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_scholarship_infos
-    name: index_pd_scholarship_infos_on_user_id_and_app_year_and_course
-    unique: true
-    columns:
-    - user_id
-    - application_year
-    - course
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_scholarship_infos
-    name: index_pd_scholarship_infos_on_pd_application_id
-    unique: false
-    columns:
-    - pd_application_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_scholarship_infos
-    name: index_pd_scholarship_infos_on_pd_enrollment_id
-    unique: false
-    columns:
-    - pd_enrollment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_scholarship_infos
-    name: index_pd_scholarship_infos_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_scholarship_infos
+      name: index_pd_scholarship_infos_on_user_id_and_app_year_and_course
+      unique: true
+      columns:
+        - user_id
+        - application_year
+        - course
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_scholarship_infos
+      name: index_pd_scholarship_infos_on_pd_application_id
+      unique: false
+      columns:
+        - pd_application_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_scholarship_infos
+      name: index_pd_scholarship_infos_on_pd_enrollment_id
+      unique: false
+      columns:
+        - pd_enrollment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_scholarship_infos
+      name: index_pd_scholarship_infos_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_sessions:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_sessions
-    name: index_pd_sessions_on_code
-    unique: true
-    columns:
-    - code
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_sessions
-    name: index_pd_sessions_on_pd_workshop_id
-    unique: false
-    columns:
-    - pd_workshop_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_sessions
+      name: index_pd_sessions_on_code
+      unique: true
+      columns:
+        - code
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_sessions
+      name: index_pd_sessions_on_pd_workshop_id
+      unique: false
+      columns:
+        - pd_workshop_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_survey_questions:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_survey_questions
-    name: index_pd_survey_questions_on_form_id
-    unique: true
-    columns:
-    - form_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_survey_questions
+      name: index_pd_survey_questions_on_form_id
+      unique: true
+      columns:
+        - form_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_teacher_applications:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_teacher_applications
-    name: index_pd_teacher_applications_on_user_id
-    unique: true
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_teacher_applications
-    name: index_pd_teacher_applications_on_primary_email
-    unique: false
-    columns:
-    - primary_email
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_teacher_applications
-    name: index_pd_teacher_applications_on_secondary_email
-    unique: false
-    columns:
-    - secondary_email
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_teacher_applications
+      name: index_pd_teacher_applications_on_user_id
+      unique: true
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_teacher_applications
+      name: index_pd_teacher_applications_on_primary_email
+      unique: false
+      columns:
+        - primary_email
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_teacher_applications
+      name: index_pd_teacher_applications_on_secondary_email
+      unique: false
+      columns:
+        - secondary_email
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_teachercon1819_registrations:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_teachercon1819_registrations
-    name: index_pd_teachercon1819_registrations_on_pd_application_id
-    unique: false
-    columns:
-    - pd_application_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_teachercon1819_registrations
-    name: index_pd_teachercon1819_registrations_on_regional_partner_id
-    unique: false
-    columns:
-    - regional_partner_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_teachercon1819_registrations
-    name: index_pd_teachercon1819_registrations_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_teachercon1819_registrations
+      name: index_pd_teachercon1819_registrations_on_pd_application_id
+      unique: false
+      columns:
+        - pd_application_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_teachercon1819_registrations
+      name: index_pd_teachercon1819_registrations_on_regional_partner_id
+      unique: false
+      columns:
+        - regional_partner_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_teachercon1819_registrations
+      name: index_pd_teachercon1819_registrations_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_teachercon_surveys:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_teachercon_surveys
-    name: index_pd_teachercon_surveys_on_pd_enrollment_id
-    unique: true
-    columns:
-    - pd_enrollment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_teachercon_surveys
+      name: index_pd_teachercon_surveys_on_pd_enrollment_id
+      unique: true
+      columns:
+        - pd_enrollment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_workshop_daily_surveys:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_daily_surveys
-    name: index_pd_workshop_daily_surveys_on_submission_id
-    unique: true
-    columns:
-    - submission_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_daily_surveys
-    name: index_pd_workshop_daily_surveys_on_user_workshop_day_form
-    unique: true
-    columns:
-    - user_id
-    - pd_workshop_id
-    - day
-    - form_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_daily_surveys
-    name: index_pd_workshop_daily_surveys_on_form_id
-    unique: false
-    columns:
-    - form_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_daily_surveys
-    name: index_pd_workshop_daily_surveys_on_pd_session_id
-    unique: false
-    columns:
-    - pd_session_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_daily_surveys
-    name: index_pd_workshop_daily_surveys_on_pd_workshop_id
-    unique: false
-    columns:
-    - pd_workshop_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_daily_surveys
-    name: index_pd_workshop_daily_surveys_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_daily_surveys
+      name: index_pd_workshop_daily_surveys_on_submission_id
+      unique: true
+      columns:
+        - submission_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_daily_surveys
+      name: index_pd_workshop_daily_surveys_on_user_workshop_day_form
+      unique: true
+      columns:
+        - user_id
+        - pd_workshop_id
+        - day
+        - form_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_daily_surveys
+      name: index_pd_workshop_daily_surveys_on_form_id
+      unique: false
+      columns:
+        - form_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_daily_surveys
+      name: index_pd_workshop_daily_surveys_on_pd_session_id
+      unique: false
+      columns:
+        - pd_session_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_daily_surveys
+      name: index_pd_workshop_daily_surveys_on_pd_workshop_id
+      unique: false
+      columns:
+        - pd_workshop_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_daily_surveys
+      name: index_pd_workshop_daily_surveys_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_workshop_facilitator_daily_surveys:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_facilitator_daily_surveys
-    name: index_pd_workshop_facilitator_daily_surveys_on_submission_id
-    unique: true
-    columns:
-    - submission_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_facilitator_daily_surveys
-    name: index_pd_workshop_facilitator_daily_surveys_unique
-    unique: true
-    columns:
-    - form_id
-    - user_id
-    - pd_session_id
-    - facilitator_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_facilitator_daily_surveys
-    name: index_pd_workshop_facilitator_daily_surveys_on_day
-    unique: false
-    columns:
-    - day
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_facilitator_daily_surveys
-    name: index_pd_workshop_facilitator_daily_surveys_on_form_id
-    unique: false
-    columns:
-    - form_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_facilitator_daily_surveys
-    name: index_pd_workshop_facilitator_daily_surveys_on_pd_session_id
-    unique: false
-    columns:
-    - pd_session_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_facilitator_daily_surveys
-    name: index_pd_workshop_facilitator_daily_surveys_on_pd_workshop_id
-    unique: false
-    columns:
-    - pd_workshop_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_facilitator_daily_surveys
-    name: index_pd_workshop_facilitator_daily_surveys_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_facilitator_daily_surveys
+      name: index_pd_workshop_facilitator_daily_surveys_on_submission_id
+      unique: true
+      columns:
+        - submission_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_facilitator_daily_surveys
+      name: index_pd_workshop_facilitator_daily_surveys_unique
+      unique: true
+      columns:
+        - form_id
+        - user_id
+        - pd_session_id
+        - facilitator_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_facilitator_daily_surveys
+      name: index_pd_workshop_facilitator_daily_surveys_on_day
+      unique: false
+      columns:
+        - day
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_facilitator_daily_surveys
+      name: index_pd_workshop_facilitator_daily_surveys_on_form_id
+      unique: false
+      columns:
+        - form_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_facilitator_daily_surveys
+      name: index_pd_workshop_facilitator_daily_surveys_on_pd_session_id
+      unique: false
+      columns:
+        - pd_session_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_facilitator_daily_surveys
+      name: index_pd_workshop_facilitator_daily_surveys_on_pd_workshop_id
+      unique: false
+      columns:
+        - pd_workshop_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_facilitator_daily_surveys
+      name: index_pd_workshop_facilitator_daily_surveys_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_workshop_survey_foorm_submissions:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_survey_foorm_submissions
-    name: index_workshop_survey_foorm_submissions_on_foorm_id
-    unique: true
-    columns:
-    - foorm_submission_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_survey_foorm_submissions
-    name: index_pd_workshop_survey_foorm_submissions_on_pd_session_id
-    unique: false
-    columns:
-    - pd_session_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_survey_foorm_submissions
-    name: index_pd_workshop_survey_foorm_submissions_on_pd_workshop_id
-    unique: false
-    columns:
-    - pd_workshop_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_survey_foorm_submissions
-    name: index_pd_workshop_survey_foorm_submissions_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_survey_foorm_submissions
+      name: index_workshop_survey_foorm_submissions_on_foorm_id
+      unique: true
+      columns:
+        - foorm_submission_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_survey_foorm_submissions
+      name: index_pd_workshop_survey_foorm_submissions_on_pd_session_id
+      unique: false
+      columns:
+        - pd_session_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_survey_foorm_submissions
+      name: index_pd_workshop_survey_foorm_submissions_on_pd_workshop_id
+      unique: false
+      columns:
+        - pd_workshop_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_survey_foorm_submissions
+      name: index_pd_workshop_survey_foorm_submissions_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_workshop_surveys:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshop_surveys
-    name: index_pd_workshop_surveys_on_pd_enrollment_id
-    unique: true
-    columns:
-    - pd_enrollment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshop_surveys
+      name: index_pd_workshop_surveys_on_pd_enrollment_id
+      unique: true
+      columns:
+        - pd_enrollment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_workshops:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshops
-    name: index_pd_workshops_on_organizer_id
-    unique: false
-    columns:
-    - organizer_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshops
-    name: index_pd_workshops_on_regional_partner_id
-    unique: false
-    columns:
-    - regional_partner_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshops
+      name: index_pd_workshops_on_organizer_id
+      unique: false
+      columns:
+        - organizer_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshops
+      name: index_pd_workshops_on_regional_partner_id
+      unique: false
+      columns:
+        - regional_partner_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pd_workshops_facilitators:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshops_facilitators
-    name: index_pd_workshops_facilitators_on_pd_workshop_id
-    unique: false
-    columns:
-    - pd_workshop_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pd_workshops_facilitators
-    name: index_pd_workshops_facilitators_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshops_facilitators
+      name: index_pd_workshops_facilitators_on_pd_workshop_id
+      unique: false
+      columns:
+        - pd_workshop_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pd_workshops_facilitators
+      name: index_pd_workshops_facilitators_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   peer_reviews:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: peer_reviews
-    name: index_peer_reviews_on_level_id
-    unique: false
-    columns:
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: peer_reviews
-    name: index_peer_reviews_on_level_source_id
-    unique: false
-    columns:
-    - level_source_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: peer_reviews
-    name: index_peer_reviews_on_reviewer_id
-    unique: false
-    columns:
-    - reviewer_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: peer_reviews
-    name: index_peer_reviews_on_script_id
-    unique: false
-    columns:
-    - script_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: peer_reviews
-    name: index_peer_reviews_on_submitter_id
-    unique: false
-    columns:
-    - submitter_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: peer_reviews
+      name: index_peer_reviews_on_level_id
+      unique: false
+      columns:
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: peer_reviews
+      name: index_peer_reviews_on_level_source_id
+      unique: false
+      columns:
+        - level_source_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: peer_reviews
+      name: index_peer_reviews_on_reviewer_id
+      unique: false
+      columns:
+        - reviewer_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: peer_reviews
+      name: index_peer_reviews_on_script_id
+      unique: false
+      columns:
+        - script_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: peer_reviews
+      name: index_peer_reviews_on_submitter_id
+      unique: false
+      columns:
+        - submitter_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   pilots:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: pilots
-    name: index_pilots_on_name
-    unique: true
-    columns:
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: pilots
+      name: index_pilots_on_name
+      unique: true
+      columns:
+        - name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   plc_course_units:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_course_units
-    name: index_plc_course_units_on_plc_course_id
-    unique: false
-    columns:
-    - plc_course_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_course_units
-    name: index_plc_course_units_on_script_id
-    unique: false
-    columns:
-    - script_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_course_units
+      name: index_plc_course_units_on_plc_course_id
+      unique: false
+      columns:
+        - plc_course_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_course_units
+      name: index_plc_course_units_on_script_id
+      unique: false
+      columns:
+        - script_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   plc_courses:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_courses
-    name: fk_rails_d5fc777f73
-    unique: false
-    columns:
-    - course_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_courses
+      name: fk_rails_d5fc777f73
+      unique: false
+      columns:
+        - course_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   plc_enrollment_module_assignments:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_enrollment_module_assignments
-    name: module_assignment_enrollment_index
-    unique: false
-    columns:
-    - plc_enrollment_unit_assignment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_enrollment_module_assignments
-    name: module_assignment_lm_index
-    unique: false
-    columns:
-    - plc_learning_module_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_enrollment_module_assignments
-    name: index_plc_enrollment_module_assignments_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_enrollment_module_assignments
+      name: module_assignment_enrollment_index
+      unique: false
+      columns:
+        - plc_enrollment_unit_assignment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_enrollment_module_assignments
+      name: module_assignment_lm_index
+      unique: false
+      columns:
+        - plc_learning_module_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_enrollment_module_assignments
+      name: index_plc_enrollment_module_assignments_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   plc_enrollment_unit_assignments:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_enrollment_unit_assignments
-    name: enrollment_unit_assignment_course_unit_index
-    unique: false
-    columns:
-    - plc_course_unit_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_enrollment_unit_assignments
-    name: enrollment_unit_assignment_course_enrollment_index
-    unique: false
-    columns:
-    - plc_user_course_enrollment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_enrollment_unit_assignments
-    name: index_plc_enrollment_unit_assignments_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_enrollment_unit_assignments
+      name: enrollment_unit_assignment_course_unit_index
+      unique: false
+      columns:
+        - plc_course_unit_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_enrollment_unit_assignments
+      name: enrollment_unit_assignment_course_enrollment_index
+      unique: false
+      columns:
+        - plc_user_course_enrollment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_enrollment_unit_assignments
+      name: index_plc_enrollment_unit_assignments_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   plc_learning_modules:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_learning_modules
-    name: index_plc_learning_modules_on_plc_course_unit_id
-    unique: false
-    columns:
-    - plc_course_unit_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_learning_modules
-    name: index_plc_learning_modules_on_stage_id
-    unique: false
-    columns:
-    - stage_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_learning_modules
+      name: index_plc_learning_modules_on_plc_course_unit_id
+      unique: false
+      columns:
+        - plc_course_unit_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_learning_modules
+      name: index_plc_learning_modules_on_stage_id
+      unique: false
+      columns:
+        - stage_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   plc_user_course_enrollments:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_user_course_enrollments
-    name: index_plc_user_course_enrollments_on_user_id_and_plc_course_id
-    unique: true
-    columns:
-    - user_id
-    - plc_course_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: plc_user_course_enrollments
-    name: index_plc_user_course_enrollments_on_plc_course_id
-    unique: false
-    columns:
-    - plc_course_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_user_course_enrollments
+      name: index_plc_user_course_enrollments_on_user_id_and_plc_course_id
+      unique: true
+      columns:
+        - user_id
+        - plc_course_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: plc_user_course_enrollments
+      name: index_plc_user_course_enrollments_on_plc_course_id
+      unique: false
+      columns:
+        - plc_course_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   potential_teachers: []
   programming_classes:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: programming_classes
-    name: index_programming_classes_on_key_and_category_id
-    unique: true
-    columns:
-    - key
-    - programming_environment_category_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: programming_classes
-    name: index_programming_classes_on_key_and_programming_environment_id
-    unique: true
-    columns:
-    - key
-    - programming_environment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: programming_classes
+      name: index_programming_classes_on_key_and_programming_environment_id
+      unique: true
+      columns:
+        - key
+        - programming_environment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: programming_classes
+      name: index_programming_classes_on_key_and_category_id
+      unique: true
+      columns:
+        - key
+        - programming_environment_category_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   programming_environment_categories:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: programming_environment_categories
-    name: index_programming_environment_categories_on_key_and_env_id
-    unique: true
-    columns:
-    - key
-    - programming_environment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: programming_environment_categories
-    name: index_programming_environment_categories_on_environment_id
-    unique: false
-    columns:
-    - programming_environment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: programming_environment_categories
+      name: index_programming_environment_categories_on_key_and_env_id
+      unique: true
+      columns:
+        - key
+        - programming_environment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: programming_environment_categories
+      name: index_programming_environment_categories_on_environment_id
+      unique: false
+      columns:
+        - programming_environment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   programming_environments:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: programming_environments
-    name: index_programming_environments_on_name
-    unique: true
-    columns:
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: programming_environments
+      name: index_programming_environments_on_name
+      unique: true
+      columns:
+        - name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   programming_expressions:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: programming_expressions
-    name: programming_environment_key
-    unique: true
-    columns:
-    - programming_environment_id
-    - key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: programming_expressions
-    name: index_programming_expressions_on_environment_category_id
-    unique: false
-    columns:
-    - programming_environment_category_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: programming_expressions
-    name: index_programming_expressions_on_programming_environment_id
-    unique: false
-    columns:
-    - programming_environment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: programming_expressions
-    name: index_programming_expressions_on_name_and_category
-    unique: false
-    columns:
-    - name
-    - category
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type: :fulltext
-    using:
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: programming_expressions
+      name: programming_environment_key
+      unique: true
+      columns:
+        - programming_environment_id
+        - key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: programming_expressions
+      name: index_programming_expressions_on_programming_environment_id
+      unique: false
+      columns:
+        - programming_environment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: programming_expressions
+      name: index_programming_expressions_on_environment_category_id
+      unique: false
+      columns:
+        - programming_environment_category_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: programming_expressions
+      name: index_programming_expressions_on_name_and_category
+      unique: false
+      columns:
+        - name
+        - category
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type: :fulltext
+      using:
+      comment:
   programming_methods:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: programming_methods
-    name: index_programming_methods_on_key_and_programming_class_id
-    unique: true
-    columns:
-    - key
-    - programming_class_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: programming_methods
-    name: index_programming_methods_on_class_id_and_overload_of
-    unique: false
-    columns:
-    - programming_class_id
-    - overload_of
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: programming_methods
+      name: index_programming_methods_on_key_and_programming_class_id
+      unique: true
+      columns:
+        - key
+        - programming_class_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: programming_methods
+      name: index_programming_methods_on_class_id_and_overload_of
+      unique: false
+      columns:
+        - programming_class_id
+        - overload_of
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   project_commits:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: project_commits
-    name: index_project_commits_on_storage_app_id_and_object_version_id
-    unique: true
-    columns:
-    - storage_app_id
-    - object_version_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: project_commits
-    name: index_project_commits_on_storage_app_id
-    unique: false
-    columns:
-    - storage_app_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: project_commits
+      name: index_project_commits_on_storage_app_id_and_object_version_id
+      unique: true
+      columns:
+        - storage_app_id
+        - object_version_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: project_commits
+      name: index_project_commits_on_storage_app_id
+      unique: false
+      columns:
+        - storage_app_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   projects:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: projects
-    name: storage_apps_project_type_index
-    unique: false
-    columns:
-    - project_type
-    lengths: 191
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: projects
-    name: storage_apps_published_at_index
-    unique: false
-    columns:
-    - published_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: projects
-    name: storage_apps_standalone_index
-    unique: false
-    columns:
-    - standalone
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: projects
-    name: storage_apps_storage_id_state_index
-    unique: false
-    columns:
-    - storage_id
-    - state
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: projects
-    name: storage_apps_storage_id_index
-    unique: false
-    columns:
-    - storage_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: projects
+      name: storage_apps_storage_id_index
+      unique: false
+      columns:
+        - storage_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: projects
+      name: storage_apps_published_at_index
+      unique: false
+      columns:
+        - published_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: projects
+      name: storage_apps_standalone_index
+      unique: false
+      columns:
+        - standalone
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: projects
+      name: storage_apps_project_type_index
+      unique: false
+      columns:
+        - project_type
+      lengths: 191
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: projects
+      name: storage_apps_storage_id_state_index
+      unique: false
+      columns:
+        - storage_id
+        - state
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   puzzle_ratings:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: puzzle_ratings
-    name: index_puzzle_ratings_on_user_id_and_script_id_and_level_id
-    unique: true
-    columns:
-    - user_id
-    - script_id
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: puzzle_ratings
-    name: index_puzzle_ratings_on_script_id_and_level_id
-    unique: false
-    columns:
-    - script_id
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: puzzle_ratings
+      name: index_puzzle_ratings_on_user_id_and_script_id_and_level_id
+      unique: true
+      columns:
+        - user_id
+        - script_id
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: puzzle_ratings
+      name: index_puzzle_ratings_on_script_id_and_level_id
+      unique: false
+      columns:
+        - script_id
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   queued_account_purges:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: queued_account_purges
-    name: index_queued_account_purges_on_user_id
-    unique: true
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: queued_account_purges
+      name: index_queued_account_purges_on_user_id
+      unique: true
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   reference_guides:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: reference_guides
-    name: index_reference_guides_on_course_version_id_and_key
-    unique: true
-    columns:
-    - course_version_id
-    - key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: reference_guides
-    name: index_reference_guides_on_course_version_id_and_parent_key
-    unique: false
-    columns:
-    - course_version_id
-    - parent_reference_guide_key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: reference_guides
+      name: index_reference_guides_on_course_version_id_and_key
+      unique: true
+      columns:
+        - course_version_id
+        - key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: reference_guides
+      name: index_reference_guides_on_course_version_id_and_parent_key
+      unique: false
+      columns:
+        - course_version_id
+        - parent_reference_guide_key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   regional_partner_program_managers:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: regional_partner_program_managers
-    name: index_regional_partner_program_managers_on_program_manager_id
-    unique: false
-    columns:
-    - program_manager_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: regional_partner_program_managers
-    name: index_regional_partner_program_managers_on_regional_partner_id
-    unique: false
-    columns:
-    - regional_partner_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: regional_partner_program_managers
+      name: index_regional_partner_program_managers_on_program_manager_id
+      unique: false
+      columns:
+        - program_manager_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: regional_partner_program_managers
+      name: index_regional_partner_program_managers_on_regional_partner_id
+      unique: false
+      columns:
+        - regional_partner_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   regional_partners: []
   regional_partners_school_districts:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: regional_partners_school_districts
-    name: index_regional_partners_school_districts_on_partner_id
-    unique: false
-    columns:
-    - regional_partner_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: regional_partners_school_districts
-    name: index_regional_partners_school_districts_on_school_district_id
-    unique: false
-    columns:
-    - school_district_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: regional_partners_school_districts
+      name: index_regional_partners_school_districts_on_partner_id
+      unique: false
+      columns:
+        - regional_partner_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: regional_partners_school_districts
+      name: index_regional_partners_school_districts_on_school_district_id
+      unique: false
+      columns:
+        - school_district_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   resources:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: resources
-    name: index_resources_on_course_version_id_and_key
-    unique: true
-    columns:
-    - course_version_id
-    - key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: resources
-    name: index_resources_on_name_and_url
-    unique: false
-    columns:
-    - name
-    - url
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type: :fulltext
-    using:
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: resources
+      name: index_resources_on_course_version_id_and_key
+      unique: true
+      columns:
+        - course_version_id
+        - key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: resources
+      name: index_resources_on_name_and_url
+      unique: false
+      columns:
+        - name
+        - url
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type: :fulltext
+      using:
+      comment:
   rubric_ai_evaluations:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: rubric_ai_evaluations
-    name: index_rubric_ai_evaluations_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: rubric_ai_evaluations
-    name: rubric_ai_evaluation_requester_index
-    unique: false
-    columns:
-    - requester_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: rubric_ai_evaluations
-    name: rubric_ai_evaluation_rubric_index
-    unique: false
-    columns:
-    - rubric_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: rubric_ai_evaluations
+      name: index_rubric_ai_evaluations_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: rubric_ai_evaluations
+      name: rubric_ai_evaluation_requester_index
+      unique: false
+      columns:
+        - requester_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: rubric_ai_evaluations
+      name: rubric_ai_evaluation_rubric_index
+      unique: false
+      columns:
+        - rubric_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   rubrics:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: rubrics
-    name: index_rubrics_on_lesson_id_and_level_id
-    unique: true
-    columns:
-    - lesson_id
-    - level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: rubrics
+      name: index_rubrics_on_lesson_id_and_level_id
+      unique: true
+      columns:
+        - lesson_id
+        - level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   schema_migrations: []
   school_districts:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: school_districts
-    name: index_school_districts_on_state
-    unique: false
-    columns:
-    - state
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: school_districts
-    name: index_school_districts_on_name_and_city
-    unique: false
-    columns:
-    - name
-    - city
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type: :fulltext
-    using:
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: school_districts
+      name: index_school_districts_on_state
+      unique: false
+      columns:
+        - state
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: school_districts
+      name: index_school_districts_on_name_and_city
+      unique: false
+      columns:
+        - name
+        - city
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type: :fulltext
+      using:
+      comment:
   school_infos:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: school_infos
-    name: fk_rails_951bceb7e3
-    unique: false
-    columns:
-    - school_district_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: school_infos
-    name: index_school_infos_on_school_id
-    unique: false
-    columns:
-    - school_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: school_infos
+      name: fk_rails_951bceb7e3
+      unique: false
+      columns:
+        - school_district_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: school_infos
+      name: index_school_infos_on_school_id
+      unique: false
+      columns:
+        - school_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   school_stats_by_years:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: school_stats_by_years
-    name: index_school_stats_by_years_on_school_id
-    unique: false
-    columns:
-    - school_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: school_stats_by_years
+      name: index_school_stats_by_years_on_school_id
+      unique: false
+      columns:
+        - school_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   schools:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: schools
-    name: index_schools_on_id
-    unique: true
-    columns:
-    - id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: schools
-    name: index_schools_on_last_known_school_year_open
-    unique: false
-    columns:
-    - last_known_school_year_open
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: schools
-    name: index_schools_on_school_district_id
-    unique: false
-    columns:
-    - school_district_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: schools
-    name: index_schools_on_zip
-    unique: false
-    columns:
-    - zip
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: schools
-    name: index_schools_on_name_and_city
-    unique: false
-    columns:
-    - name
-    - city
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type: :fulltext
-    using:
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: schools
+      name: index_schools_on_id
+      unique: true
+      columns:
+        - id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: schools
+      name: index_schools_on_school_district_id
+      unique: false
+      columns:
+        - school_district_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: schools
+      name: index_schools_on_zip
+      unique: false
+      columns:
+        - zip
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: schools
+      name: index_schools_on_last_known_school_year_open
+      unique: false
+      columns:
+        - last_known_school_year_open
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: schools
+      name: index_schools_on_name_and_city
+      unique: false
+      columns:
+        - name
+        - city
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type: :fulltext
+      using:
+      comment:
   script_levels:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: script_levels
-    name: index_script_levels_on_seed_key
-    unique: true
-    columns:
-    - seed_key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: script_levels
-    name: index_script_levels_on_activity_section_id
-    unique: false
-    columns:
-    - activity_section_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: script_levels
-    name: index_script_levels_on_script_id
-    unique: false
-    columns:
-    - script_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: script_levels
-    name: index_script_levels_on_stage_id
-    unique: false
-    columns:
-    - stage_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: script_levels
+      name: index_script_levels_on_seed_key
+      unique: true
+      columns:
+        - seed_key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: script_levels
+      name: index_script_levels_on_activity_section_id
+      unique: false
+      columns:
+        - activity_section_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: script_levels
+      name: index_script_levels_on_script_id
+      unique: false
+      columns:
+        - script_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: script_levels
+      name: index_script_levels_on_stage_id
+      unique: false
+      columns:
+        - stage_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   scripts:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
-    name: index_scripts_on_name
-    unique: true
-    columns:
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
-    name: index_scripts_on_new_name
-    unique: true
-    columns:
-    - new_name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
-    name: index_scripts_on_family_name
-    unique: false
-    columns:
-    - family_name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
-    name: index_scripts_on_instruction_type
-    unique: false
-    columns:
-    - instruction_type
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
-    name: index_scripts_on_instructor_audience
-    unique: false
-    columns:
-    - instructor_audience
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
-    name: index_scripts_on_participant_audience
-    unique: false
-    columns:
-    - participant_audience
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
-    name: index_scripts_on_published_state
-    unique: false
-    columns:
-    - published_state
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
-    name: index_scripts_on_wrapup_video_id
-    unique: false
-    columns:
-    - wrapup_video_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: scripts
+      name: index_scripts_on_name
+      unique: true
+      columns:
+        - name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: scripts
+      name: index_scripts_on_new_name
+      unique: true
+      columns:
+        - new_name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: scripts
+      name: index_scripts_on_family_name
+      unique: false
+      columns:
+        - family_name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: scripts
+      name: index_scripts_on_wrapup_video_id
+      unique: false
+      columns:
+        - wrapup_video_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: scripts
+      name: index_scripts_on_published_state
+      unique: false
+      columns:
+        - published_state
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: scripts
+      name: index_scripts_on_instruction_type
+      unique: false
+      columns:
+        - instruction_type
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: scripts
+      name: index_scripts_on_instructor_audience
+      unique: false
+      columns:
+        - instructor_audience
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: scripts
+      name: index_scripts_on_participant_audience
+      unique: false
+      columns:
+        - participant_audience
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   scripts_resources:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts_resources
-    name: index_scripts_resources_on_script_id_and_resource_id
-    unique: true
-    columns:
-    - script_id
-    - resource_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts_resources
-    name: index_scripts_resources_on_resource_id_and_script_id
-    unique: false
-    columns:
-    - resource_id
-    - script_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: scripts_resources
+      name: index_scripts_resources_on_script_id_and_resource_id
+      unique: true
+      columns:
+        - script_id
+        - resource_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: scripts_resources
+      name: index_scripts_resources_on_resource_id_and_script_id
+      unique: false
+      columns:
+        - resource_id
+        - script_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   scripts_student_resources:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts_student_resources
-    name: index_scripts_student_resources_on_script_id_and_resource_id
-    unique: true
-    columns:
-    - script_id
-    - resource_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts_student_resources
-    name: index_scripts_student_resources_on_resource_id_and_script_id
-    unique: false
-    columns:
-    - resource_id
-    - script_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: scripts_student_resources
+      name: index_scripts_student_resources_on_script_id_and_resource_id
+      unique: true
+      columns:
+        - script_id
+        - resource_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: scripts_student_resources
+      name: index_scripts_student_resources_on_resource_id_and_script_id
+      unique: false
+      columns:
+        - resource_id
+        - script_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   secret_pictures:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: secret_pictures
-    name: index_secret_pictures_on_name
-    unique: true
-    columns:
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: secret_pictures
-    name: index_secret_pictures_on_path
-    unique: true
-    columns:
-    - path
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: secret_pictures
+      name: index_secret_pictures_on_name
+      unique: true
+      columns:
+        - name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: secret_pictures
+      name: index_secret_pictures_on_path
+      unique: true
+      columns:
+        - path
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   secret_words:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: secret_words
-    name: index_secret_words_on_word
-    unique: true
-    columns:
-    - word
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: secret_words
+      name: index_secret_words_on_word
+      unique: true
+      columns:
+        - word
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   section_hidden_scripts:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: section_hidden_scripts
-    name: index_section_hidden_scripts_on_script_id
-    unique: false
-    columns:
-    - script_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: section_hidden_scripts
-    name: index_section_hidden_scripts_on_section_id
-    unique: false
-    columns:
-    - section_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: section_hidden_scripts
+      name: index_section_hidden_scripts_on_script_id
+      unique: false
+      columns:
+        - script_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: section_hidden_scripts
+      name: index_section_hidden_scripts_on_section_id
+      unique: false
+      columns:
+        - section_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   section_hidden_stages:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: section_hidden_stages
-    name: index_section_hidden_stages_on_section_id
-    unique: false
-    columns:
-    - section_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: section_hidden_stages
-    name: index_section_hidden_stages_on_stage_id
-    unique: false
-    columns:
-    - stage_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: section_hidden_stages
+      name: index_section_hidden_stages_on_section_id
+      unique: false
+      columns:
+        - section_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: section_hidden_stages
+      name: index_section_hidden_stages_on_stage_id
+      unique: false
+      columns:
+        - stage_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   section_instructors:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: section_instructors
-    name: index_section_instructors_on_instructor_id_and_section_id
-    unique: true
-    columns:
-    - instructor_id
-    - section_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: section_instructors
-    name: index_section_instructors_on_deleted_at
-    unique: false
-    columns:
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: section_instructors
-    name: index_section_instructors_on_instructor_id
-    unique: false
-    columns:
-    - instructor_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: section_instructors
-    name: index_section_instructors_on_invited_by_id
-    unique: false
-    columns:
-    - invited_by_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: section_instructors
-    name: index_section_instructors_on_section_id
-    unique: false
-    columns:
-    - section_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: section_instructors
+      name: index_section_instructors_on_instructor_id_and_section_id
+      unique: true
+      columns:
+        - instructor_id
+        - section_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: section_instructors
+      name: index_section_instructors_on_instructor_id
+      unique: false
+      columns:
+        - instructor_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: section_instructors
+      name: index_section_instructors_on_section_id
+      unique: false
+      columns:
+        - section_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: section_instructors
+      name: index_section_instructors_on_invited_by_id
+      unique: false
+      columns:
+        - invited_by_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: section_instructors
+      name: index_section_instructors_on_deleted_at
+      unique: false
+      columns:
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   sections:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: sections
-    name: index_sections_on_code
-    unique: true
-    columns:
-    - code
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: sections
-    name: fk_rails_20b1e5de46
-    unique: false
-    columns:
-    - course_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: sections
-    name: index_sections_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: sections
-    name: fk_rails_f0d4df9901
-    unique: false
-    columns:
-    - lti_integration_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: sections
+      name: index_sections_on_code
+      unique: true
+      columns:
+        - code
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: sections
+      name: fk_rails_20b1e5de46
+      unique: false
+      columns:
+        - course_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: sections
+      name: index_sections_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: sections
+      name: fk_rails_f0d4df9901
+      unique: false
+      columns:
+        - lti_integration_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   seed_info:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: seed_info
-    name: index_seed_info_on_table
-    unique: false
-    columns:
-    - table
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: seed_info
+      name: index_seed_info_on_table
+      unique: false
+      columns:
+        - table
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   seeded_s3_objects:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: seeded_s3_objects
-    name: index_seeded_s3_objects_on_bucket_and_key_and_etag
-    unique: false
-    columns:
-    - bucket
-    - key
-    - etag
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: seeded_s3_objects
+      name: index_seeded_s3_objects_on_bucket_and_key_and_etag
+      unique: false
+      columns:
+        - bucket
+        - key
+        - etag
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   shared_blockly_functions: []
   sign_ins:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: sign_ins
-    name: index_sign_ins_on_sign_in_at
-    unique: false
-    columns:
-    - sign_in_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: sign_ins
-    name: index_sign_ins_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: sign_ins
+      name: index_sign_ins_on_sign_in_at
+      unique: false
+      columns:
+        - sign_in_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: sign_ins
+      name: index_sign_ins_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   stages:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: stages
-    name: index_stages_on_script_id_and_key
-    unique: true
-    columns:
-    - script_id
-    - key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: stages
-    name: index_stages_on_lesson_group_id_and_key
-    unique: true
-    columns:
-    - lesson_group_id
-    - key
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: stages
+      name: index_stages_on_script_id_and_key
+      unique: true
+      columns:
+        - script_id
+        - key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: stages
+      name: index_stages_on_lesson_group_id_and_key
+      unique: true
+      columns:
+        - lesson_group_id
+        - key
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   stages_standards:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: stages_standards
-    name: index_stages_standards_on_stage_id
-    unique: false
-    columns:
-    - stage_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: stages_standards
-    name: index_stages_standards_on_standard_id
-    unique: false
-    columns:
-    - standard_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: stages_standards
+      name: index_stages_standards_on_stage_id
+      unique: false
+      columns:
+        - stage_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: stages_standards
+      name: index_stages_standards_on_standard_id
+      unique: false
+      columns:
+        - standard_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   standard_categories:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: standard_categories
-    name: index_standard_categories_on_framework_id_and_shortcode
-    unique: true
-    columns:
-    - framework_id
-    - shortcode
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: standard_categories
-    name: index_standard_categories_on_parent_category_id
-    unique: false
-    columns:
-    - parent_category_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: standard_categories
+      name: index_standard_categories_on_framework_id_and_shortcode
+      unique: true
+      columns:
+        - framework_id
+        - shortcode
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: standard_categories
+      name: index_standard_categories_on_parent_category_id
+      unique: false
+      columns:
+        - parent_category_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   standards:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: standards
-    name: index_standards_on_category_id
-    unique: false
-    columns:
-    - category_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: standards
-    name: index_standards_on_framework_id_and_shortcode
-    unique: false
-    columns:
-    - framework_id
-    - shortcode
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: standards
-    name: index_standards_on_description
-    unique: false
-    columns:
-    - description
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type: :fulltext
-    using:
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: standards
+      name: index_standards_on_category_id
+      unique: false
+      columns:
+        - category_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: standards
+      name: index_standards_on_framework_id_and_shortcode
+      unique: false
+      columns:
+        - framework_id
+        - shortcode
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: standards
+      name: index_standards_on_description
+      unique: false
+      columns:
+        - description
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type: :fulltext
+      using:
+      comment:
   studio_people: []
   survey_results:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: survey_results
-    name: index_survey_results_on_kind
-    unique: false
-    columns:
-    - kind
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: survey_results
-    name: index_survey_results_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: survey_results
+      name: index_survey_results_on_kind
+      unique: false
+      columns:
+        - kind
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: survey_results
+      name: index_survey_results_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   teacher_feedbacks:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: teacher_feedbacks
-    name: index_feedback_on_student_and_level_and_teacher_id
-    unique: false
-    columns:
-    - student_id
-    - level_id
-    - teacher_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: teacher_feedbacks
-    name: index_teacher_feedbacks_on_teacher_id
-    unique: false
-    columns:
-    - teacher_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: teacher_feedbacks
+      name: index_feedback_on_student_and_level_and_teacher_id
+      unique: false
+      columns:
+        - student_id
+        - level_id
+        - teacher_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: teacher_feedbacks
+      name: index_teacher_feedbacks_on_teacher_id
+      unique: false
+      columns:
+        - teacher_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   teacher_profiles:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: teacher_profiles
-    name: index_teacher_profiles_on_studio_person_id
-    unique: false
-    columns:
-    - studio_person_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: teacher_profiles
+      name: index_teacher_profiles_on_studio_person_id
+      unique: false
+      columns:
+        - studio_person_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   teacher_scores:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: teacher_scores
-    name: index_teacher_scores_on_user_level_id
-    unique: false
-    columns:
-    - user_level_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: teacher_scores
+      name: index_teacher_scores_on_user_level_id
+      unique: false
+      columns:
+        - user_level_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   unit_groups:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups
-    name: index_unit_groups_on_instruction_type
-    unique: false
-    columns:
-    - instruction_type
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups
-    name: index_unit_groups_on_instructor_audience
-    unique: false
-    columns:
-    - instructor_audience
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups
-    name: index_unit_groups_on_name
-    unique: false
-    columns:
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups
-    name: index_unit_groups_on_participant_audience
-    unique: false
-    columns:
-    - participant_audience
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups
-    name: index_unit_groups_on_published_state
-    unique: false
-    columns:
-    - published_state
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: unit_groups
+      name: index_unit_groups_on_name
+      unique: false
+      columns:
+        - name
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: unit_groups
+      name: index_unit_groups_on_published_state
+      unique: false
+      columns:
+        - published_state
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: unit_groups
+      name: index_unit_groups_on_instruction_type
+      unique: false
+      columns:
+        - instruction_type
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: unit_groups
+      name: index_unit_groups_on_instructor_audience
+      unique: false
+      columns:
+        - instructor_audience
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: unit_groups
+      name: index_unit_groups_on_participant_audience
+      unique: false
+      columns:
+        - participant_audience
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   unit_groups_resources:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups_resources
-    name: index_unit_groups_resources_on_unit_group_id_and_resource_id
-    unique: true
-    columns:
-    - unit_group_id
-    - resource_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups_resources
-    name: index_unit_groups_resources_on_resource_id_and_unit_group_id
-    unique: false
-    columns:
-    - resource_id
-    - unit_group_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: unit_groups_resources
+      name: index_unit_groups_resources_on_unit_group_id_and_resource_id
+      unique: true
+      columns:
+        - unit_group_id
+        - resource_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: unit_groups_resources
+      name: index_unit_groups_resources_on_resource_id_and_unit_group_id
+      unique: false
+      columns:
+        - resource_id
+        - unit_group_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   unit_groups_student_resources:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups_student_resources
-    name: index_ug_student_resources_on_unit_group_id_and_resource_id
-    unique: true
-    columns:
-    - unit_group_id
-    - resource_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups_student_resources
-    name: index_ug_student_resources_on_resource_id_and_unit_group_id
-    unique: false
-    columns:
-    - resource_id
-    - unit_group_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: unit_groups_student_resources
+      name: index_ug_student_resources_on_unit_group_id_and_resource_id
+      unique: true
+      columns:
+        - unit_group_id
+        - resource_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: unit_groups_student_resources
+      name: index_ug_student_resources_on_resource_id_and_unit_group_id
+      unique: false
+      columns:
+        - resource_id
+        - unit_group_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   user_geos:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_geos
-    name: index_user_geos_on_indexed_at
-    unique: false
-    columns:
-    - indexed_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_geos
-    name: index_user_geos_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_geos
+      name: index_user_geos_on_indexed_at
+      unique: false
+      columns:
+        - indexed_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_geos
+      name: index_user_geos_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   user_levels:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_levels
-    name: index_user_levels_unique
-    unique: true
-    columns:
-    - user_id
-    - script_id
-    - level_id
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_levels
+      name: index_user_levels_unique
+      unique: true
+      columns:
+        - user_id
+        - script_id
+        - level_id
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   user_ml_models:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_ml_models
-    name: index_user_ml_models_on_model_id
-    unique: false
-    columns:
-    - model_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_ml_models
-    name: index_user_ml_models_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_ml_models
+      name: index_user_ml_models_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_ml_models
+      name: index_user_ml_models_on_model_id
+      unique: false
+      columns:
+        - model_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   user_module_task_assignments:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_module_task_assignments
-    name: task_assignment_to_task_index
-    unique: false
-    columns:
-    - professional_learning_task_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_module_task_assignments
-    name: task_assignment_to_module_assignment_index
-    unique: false
-    columns:
-    - user_enrollment_module_assignment_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_module_task_assignments
+      name: task_assignment_to_task_index
+      unique: false
+      columns:
+        - professional_learning_task_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_module_task_assignments
+      name: task_assignment_to_module_assignment_index
+      unique: false
+      columns:
+        - user_enrollment_module_assignment_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   user_permissions:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_permissions
-    name: index_user_permissions_on_user_id_and_permission
-    unique: true
-    columns:
-    - user_id
-    - permission
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_permissions
+      name: index_user_permissions_on_user_id_and_permission
+      unique: true
+      columns:
+        - user_id
+        - permission
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   user_proficiencies:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_proficiencies
-    name: index_user_proficiencies_on_user_id
-    unique: true
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_proficiencies
+      name: index_user_proficiencies_on_user_id
+      unique: true
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   user_project_storage_ids:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_project_storage_ids
-    name: user_id
-    unique: true
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_project_storage_ids
-    name: user_storage_ids_user_id_index
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_project_storage_ids
+      name: user_id
+      unique: true
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_project_storage_ids
+      name: user_storage_ids_user_id_index
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   user_school_infos:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_school_infos
-    name: index_user_school_infos_on_user_id
-    unique: false
-    columns:
-    - user_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_school_infos
+      name: index_user_school_infos_on_user_id
+      unique: false
+      columns:
+        - user_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   user_scripts:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_scripts
-    name: index_user_scripts_on_user_id_and_script_id_and_deleted_at
-    unique: true
-    columns:
-    - user_id
-    - script_id
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: user_scripts
-    name: index_user_scripts_on_script_id
-    unique: false
-    columns:
-    - script_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_scripts
+      name: index_user_scripts_on_user_id_and_script_id_and_deleted_at
+      unique: true
+      columns:
+        - user_id
+        - script_id
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: user_scripts
+      name: index_user_scripts_on_script_id
+      unique: false
+      columns:
+        - script_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   users:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_invitation_token
-    unique: true
-    columns:
-    - invitation_token
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_provider_and_uid_and_deleted_at
-    unique: true
-    columns:
-    - provider
-    - uid
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_reset_password_token_and_deleted_at
-    unique: true
-    columns:
-    - reset_password_token
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_username_and_deleted_at
-    unique: true
-    columns:
-    - username
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_birthday
-    unique: false
-    columns:
-    - birthday
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_current_sign_in_at
-    unique: false
-    columns:
-    - current_sign_in_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_deleted_at
-    unique: false
-    columns:
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_email_and_deleted_at
-    unique: false
-    columns:
-    - email
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_hashed_email_and_deleted_at
-    unique: false
-    columns:
-    - hashed_email
-    - deleted_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_invitations_count
-    unique: false
-    columns:
-    - invitations_count
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_invited_by_id
-    unique: false
-    columns:
-    - invited_by_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_parent_email
-    unique: false
-    columns:
-    - parent_email
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_purged_at
-    unique: false
-    columns:
-    - purged_at
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_school_info_id
-    unique: false
-    columns:
-    - school_info_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: users
-    name: index_users_on_studio_person_id
-    unique: false
-    columns:
-    - studio_person_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_invitation_token
+      unique: true
+      columns:
+        - invitation_token
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_provider_and_uid_and_deleted_at
+      unique: true
+      columns:
+        - provider
+        - uid
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_reset_password_token_and_deleted_at
+      unique: true
+      columns:
+        - reset_password_token
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_username_and_deleted_at
+      unique: true
+      columns:
+        - username
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_birthday
+      unique: false
+      columns:
+        - birthday
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_current_sign_in_at
+      unique: false
+      columns:
+        - current_sign_in_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_deleted_at
+      unique: false
+      columns:
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_email_and_deleted_at
+      unique: false
+      columns:
+        - email
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_hashed_email_and_deleted_at
+      unique: false
+      columns:
+        - hashed_email
+        - deleted_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_invitations_count
+      unique: false
+      columns:
+        - invitations_count
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_invited_by_id
+      unique: false
+      columns:
+        - invited_by_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_parent_email
+      unique: false
+      columns:
+        - parent_email
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_purged_at
+      unique: false
+      columns:
+        - purged_at
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_school_info_id
+      unique: false
+      columns:
+        - school_info_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: users
+      name: index_users_on_studio_person_id
+      unique: false
+      columns:
+        - studio_person_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   users_view: []
   videos:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: videos
-    name: index_videos_on_key_and_locale
-    unique: true
-    columns:
-    - key
-    - locale
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: videos
+      name: index_videos_on_key_and_locale
+      unique: true
+      columns:
+        - key
+        - locale
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
   vocabularies:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: vocabularies
-    name: index_vocabularies_on_key_and_course_version_id
-    unique: true
-    columns:
-    - key
-    - course_version_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type:
-    using: :btree
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: vocabularies
-    name: index_vocabularies_on_word_and_definition
-    unique: false
-    columns:
-    - word
-    - definition
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where:
-    type: :fulltext
-    using:
-    comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: vocabularies
+      name: index_vocabularies_on_key_and_course_version_id
+      unique: true
+      columns:
+        - key
+        - course_version_id
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type:
+      using: :btree
+      comment:
+    - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+      table: vocabularies
+      name: index_vocabularies_on_word_and_definition
+      unique: false
+      columns:
+        - word
+        - definition
+      lengths: {}
+      orders: {}
+      opclasses: {}
+      where:
+      type: :fulltext
+      using:
+      comment:
 version: 20231107182805
-database_version: !ruby/object:ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
+database_version:
+  !ruby/object:ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
   version:
-  - 5
-  - 7
-  - 42
-  full_version_string: 5.7.42
+    - 5
+    - 7
+    - 12
+  full_version_string: 5.7.12-log


### PR DESCRIPTION
This PR adds a new column, `deleted_at` to the LtiUserIdentity model. This allows us to use the `acts_as_paranoid` module, which does soft deletes. This mimics the same behavior as the User model, which is the parent of this model (via associations).

The followup PR that implements these changes is here: https://github.com/code-dot-org/code-dot-org/pull/54188

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
