### PR TITLE
Adding Korean HoC certificate links

### DIFF
--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -5,6 +5,7 @@ import StudentsBeyondHoc from './StudentsBeyondHoc';
 import TeachersBeyondHoc from './TeachersBeyondHoc';
 import PetitionCallToAction from '@cdo/apps/templates/certificates/petition/PetitionCallToAction';
 import styleConstants from '../../styleConstants';
+import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import color from '../../util/color';
 import GraduateToNextLevel from '@cdo/apps/templates/certificates/GraduateToNextLevel';
 
@@ -32,6 +33,23 @@ export default function Congrats(props) {
    */
   const renderExtraCertificateLinks = (language, tutorial) => {
     let extraLinkUrl, extraLinkText;
+    // In order to remove the certificate links remove or comment the following section -------------------------------
+    if (language === 'ko') {
+      extraLinkText =
+        '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
+      if (/oceans/.test(tutorial)) {
+        extraLinkUrl = pegasus('/files/online-coding-party-2023-2-oceans.png');
+      } else if (/dance/.test(tutorial)) {
+        extraLinkUrl = pegasus('/files/online-coding-party-2023-2-dance.png');
+      } else if (/frozen/.test(tutorial)) {
+        extraLinkUrl = pegasus('/files/online-coding-party-2023-2-frozen.png');
+      } else if (/hero/.test(tutorial)) {
+        extraLinkUrl = pegasus('/files/online-coding-party-2023-2-hero.png');
+      } else {
+        extraLinkText = null;
+      }
+    }
+    // End of section to be removed or commented ----------------------------------------------------------------------
     // If Adding extra links see this PR: https://github.com/code-dot-org/code-dot-org/pull/48515
     if (!extraLinkUrl || !extraLinkText) {
       // There are no extra links to render.


### PR DESCRIPTION
Our Korean partners would like us to show a custom certificate for Korean students. This PR adds a link to a certificate provided by our partner when the language is in Korean. The links will be removed once their HoC promotion is over.

## Screenshots
AI for Oceans
![Screenshot 2023-10-16 at 3 44 24 PM](https://github.com/code-dot-org/code-dot-org/assets/1372238/b003579e-7240-4fde-80a1-1a91faf81020)

When you click the link...
![image](https://github.com/code-dot-org/code-dot-org/assets/1372238/dffa9b4e-a18a-4ec5-ba1c-aaa8e14de7ba)


## Links
* [JIRA](https://codedotorg.atlassian.net/browse/P20-427)

## Testing story
Before all the tests, open the following link in a new incognito window:
* [Setup code.org to be in Korean](http://localhost-studio.code.org:3000/lang/ko-kr)

Click the follow links to the end of a HoC tutorial and observe the special link under the image of the HoC certificate
* [Finish AI for Oceans](http://localhost.code.org:3000/api/hour/finish/oceans)
* [Finish Minecraft Heroe's Journey](http://localhost.code.org:3000/api/hour/finish/hero)
* [Finish Frozen](http://localhost.code.org:3000/api/hour/finish/frozen)
* [Finish Dance Party](http://localhost.code.org:3000/api/hour/finish/dance-2019)

Click the following link and observer there is NO certificate link under the image of the HoC certificate
* [Finish Minecraft Squatic](http://localhost.code.org:3000/api/hour/finish/aquatic)

## Follow-up work
* Revert this PR when the campaign is over in November
