### PR TITLE
Update census_summary.rb to remove transaction block

### DIFF
--- a/dashboard/app/models/census/census_summary.rb
+++ b/dashboard/app/models/census/census_summary.rb
@@ -54,40 +54,36 @@ class Census::CensusSummary < ApplicationRecord
   end
 
   # Loads/merges the data from a CSV into the table.
-  # Requires a block to parse the row.
   # @param filename [String] The CSV file name.
   # @param options [Hash] The CSV file parsing options.
   # @param is_dry_run [Boolean] Allows testing of importing a CSV by rolling back any changes.
   def self.merge_from_csv(filename, options = CSV_IMPORT_OPTIONS, is_dry_run: false)
-    census_summaries = nil
     entries_skipped = 0
 
-    ActiveRecord::Base.transaction do
-      census_summaries = CSV.read(filename, **options).each do |row|
-        parsed = row.to_hash.symbolize_keys
+    census_summaries = CSV.read(filename, **options).each do |row|
+      parsed = row.to_hash.symbolize_keys
 
-        # (As of Sept. 2023) Skip entries with school_id that doesn't match school in our database.
-        # This is likely due to not receiving NCES private school data yet (will be ready in November).
-        if School.find_by_id(parsed[:school_id]).nil?
-          entries_skipped += 1
-          next
-        end
-
-        parsed[:teaches_cs] = parsed[:teaches_cs] == 'unknown' ? 'U' : parsed[:teaches_cs]
-        db_entry = find_by(school_id: parsed[:school_id])
-        if db_entry.nil?
-          Census::CensusSummary.new(parsed).save!
-        else
-          db_entry.update!(parsed)
-        end
+      # (As of Sept. 2023) Skip entries with school_id that doesn't match school in our database.
+      # This is likely due to not receiving NCES private school data yet (will be ready in November).
+      if School.find_by_id(parsed[:school_id]).nil?
+        entries_skipped += 1
+        next
       end
 
-      # Raise an error so that the db transaction rolls back
-      raise "This was a dry run. No rows were modified or added. Set dry_run: false to modify db" if is_dry_run
-    ensure
-      CDO.log.info "#{entries_skipped} census summaries skipped due to no school_id match in database."
-      CDO.log.info "Census summaries seeding: done processing #{filename}.\n"
+      parsed[:teaches_cs] = parsed[:teaches_cs] == 'unknown' ? 'U' : parsed[:teaches_cs]
+      db_entry = find_by(school_id: parsed[:school_id])
+      if db_entry.nil?
+        Census::CensusSummary.new(parsed).save!
+      else
+        db_entry.update!(parsed)
+      end
     end
+
+    # Raise an error so that the db transaction rolls back
+    raise "This was a dry run. No rows were modified or added. Set dry_run: false to modify db" if is_dry_run
+
+    CDO.log.info "#{entries_skipped} census summaries skipped due to no school_id match in database."
+    CDO.log.info "Census summaries seeding: done processing #{filename}.\n"
 
     census_summaries
   end

--- a/dashboard/app/models/census/census_summary.rb
+++ b/dashboard/app/models/census/census_summary.rb
@@ -56,8 +56,7 @@ class Census::CensusSummary < ApplicationRecord
   # Loads/merges the data from a CSV into the table.
   # @param filename [String] The CSV file name.
   # @param options [Hash] The CSV file parsing options.
-  # @param is_dry_run [Boolean] Allows testing of importing a CSV by rolling back any changes.
-  def self.merge_from_csv(filename, options = CSV_IMPORT_OPTIONS, is_dry_run: false)
+  def self.merge_from_csv(filename, options = CSV_IMPORT_OPTIONS)
     entries_skipped = 0
 
     census_summaries = CSV.read(filename, **options).each do |row|
@@ -78,9 +77,6 @@ class Census::CensusSummary < ApplicationRecord
         db_entry.update!(parsed)
       end
     end
-
-    # Raise an error so that the db transaction rolls back
-    raise "This was a dry run. No rows were modified or added. Set dry_run: false to modify db" if is_dry_run
 
     CDO.log.info "#{entries_skipped} census summaries skipped due to no school_id match in database."
     CDO.log.info "Census summaries seeding: done processing #{filename}.\n"


### PR DESCRIPTION
Makes the changes to `census_summary.rb` made in [this PR](https://github.com/code-dot-org/code-dot-org/pull/53972) to remove the `transaction` block since it can be [costly for database performance](https://github.com/code-dot-org/code-dot-org/pull/53972#issuecomment-1747344316) and is not really necessary given its use case. Since the data is updated so infrequently (about once a year) and it is manually verified before showing the new data, it's a relatively low risk change (reading Dave's insight [here](https://github.com/code-dot-org/code-dot-org/pull/53972#issuecomment-1747455187)).

## Links
PR comment about splitting it up: [here](https://github.com/code-dot-org/code-dot-org/pull/53972/files#r1361303103)

## Testing story
Locally ran `rake seed:census_summaries` without errors and checked that database was populated with seeded data.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
