### PR TITLE
Update to Ubuntu 20 in Production: Part 1 of 3 (`production-console`)

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -584,7 +584,9 @@ Resources:
     DeletionPolicy: Retain
     CreationPolicy: {ResourceSignal: {Timeout: PT2H}}
     Properties:
-      ImageId: <%=IMAGE_ID%>
+      # Temporarily hardcode the Ubuntu 20 image just for this server, so we can gradually roll out the update.
+      # TODO (infra): finish updating all environments, and restore this line to again reference IMAGE_ID
+      ImageId: 'ami-0261755bbcb8c4a84'
       InstanceType: !Ref ConsoleInstanceType
       IamInstanceProfile: !Ref FrontendInstanceProfile
       KeyName: <%=SSH_KEY_NAME%>
@@ -593,7 +595,7 @@ Resources:
         - {Key: Name, Value: <%=environment%>-console}
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
-          Ebs: {VolumeSize: 64, VolumeType: gp2}
+          Ebs: {VolumeSize: 256, VolumeType: gp2}
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -x


### PR DESCRIPTION
The high-level plan:

1. `production-console` (this PR)
   - Override the cloudformation template to hardcode the ami, rather than using IMAGE_ID
   - Also make volume size match reality, to avoid accidentally shrinking it
2. `production-daemon` (https://github.com/code-dot-org/code-dot-org/pull/54271)
   - Hardcode the ami instead of using IMAGE_ID
   - Also disable all cron jobs except ci_build
   - Also make volume size match reality, to avoid accidentally shrinking
3. `ami-builder` (https://github.com/code-dot-org/code-dot-org/pull/54272)
   - Hardcode the ami, or just update IMAGE_ID since this is the last server
   - Keep volume size at 64GB, as this matches reality

## Links

See doc at https://docs.google.com/document/d/1icoCcfsajs1eqP1w7cymXjsrbC9DIW-1Im6p4EE3OJ8/edit#heading=h.r0g6m46ca94w for more of the rollout plan.

## Deployment strategy

Before merging, we plan to take a snapshot of the existing `production-console` instance.