### PR TITLE
Update to Ubuntu 20 in Production: Part 2 of 3 (`production-daemon`)

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -510,7 +510,9 @@ Resources:
       ResourceSignal:
         Timeout: PT4H
     Properties:
-      ImageId: <%=IMAGE_ID%>
+      # Temporarily hardcode the Ubuntu 20 image just for production-daemon, so we can gradually roll out the update.
+      # TODO (infra): finish updating all environments, and restore this line to always just use IMAGE_ID
+      ImageId: <%=rack_env?(:production) ? IMAGE_ID : 'ami-0261755bbcb8c4a84'%>
       InstanceType: !Ref <%=frontends ? 'DaemonInstanceType' : 'InstanceType' %>
       IamInstanceProfile: !Ref DaemonInstanceProfile
       KeyName: <%=SSH_KEY_NAME%>
@@ -528,7 +530,7 @@ Resources:
           # upgrading everything to 256.
           default_volume_size = 64
           volume_size_overrides = {
-            production: 128,
+            production: 256,
             staging: 256,
             test: 256
           }

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -584,7 +584,9 @@ Resources:
     DeletionPolicy: Retain
     CreationPolicy: {ResourceSignal: {Timeout: PT2H}}
     Properties:
-      ImageId: <%=IMAGE_ID%>
+      # Temporarily hardcode the Ubuntu 20 image just for this server, so we can gradually roll out the update.
+      # TODO (infra): finish updating all environments, and restore this line to again reference IMAGE_ID
+      ImageId: 'ami-0261755bbcb8c4a84'
       InstanceType: !Ref ConsoleInstanceType
       IamInstanceProfile: !Ref FrontendInstanceProfile
       KeyName: <%=SSH_KEY_NAME%>
@@ -593,7 +595,7 @@ Resources:
         - {Key: Name, Value: <%=environment%>-console}
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
-          Ebs: {VolumeSize: 64, VolumeType: gp2}
+          Ebs: {VolumeSize: 256, VolumeType: gp2}
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -x

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -41,8 +41,11 @@
 
     notify = params[:notify].to_s
     action = "BUNDLE_GEMFILE=#{deploy_dir('Gemfile')} bundle exec #{bin_dir('cronjob')} #{action.shellescape} #{notify}".strip
+    job = "#{time} #{action}"
 
-    $crontab << "#{time} #{action}"
+    job = "##{job}" if params[:disabled]
+
+    $crontab << job
   end
 
   def crontab()
@@ -94,34 +97,41 @@
     end
 
 
+    # To facilitate the Ubuntu 20 upgrade, temporarily disable all cronjobs on
+    # the production daemon but still write them to the crontab. We can then
+    # easily reenable them on just the old server, so that we still have jobs
+    # running while the new server is under construction.
+    #
+    # TODO (infra): reenable all of these (and probably remove the 'disabled'
+    # param from the cronjob method) once the new server is up and running.
     if node.chef_environment == 'production' # production daemon
-      cronjob at:'30 14 * * *', do:dashboard_dir('bin','scheduled_pd_workshop_emails')
-      cronjob at:'0 16 * * *', do:dashboard_dir('bin','scheduled_pd_application_emails')
-      cronjob at:'*/4 * * * *', do:dashboard_dir('bin', 'process_pd_workshop_ends')
-      cronjob at:'*/5 * * * *', do:dashboard_dir('bin', 'fill_jotform_placeholders')
-      cronjob at:'*/30 * * * *', do:dashboard_dir('bin', 'sync_jotforms')
-      cronjob at:'0 6 * * *', do:deploy_dir('bin', 'cron', 'process_foorm_data')
-      cronjob at:'25 7 * * *', do:deploy_dir('bin', 'cron', 'update_hoc_map')
-      cronjob at:'*/10 * * * *', do:deploy_dir('bin', 'cron', 'delete_twilio_data')
-      cronjob at:'* * * * *', do:deploy_dir('bin', 'cron', 'confirm_usage')
-      cronjob at:'0 */2 * * *', do:deploy_dir('bin', 'cron', 'teacher_applications_to_gdrive')
-      cronjob at:'30 */2 * * *', do:deploy_dir('bin', 'cron', 'summer_workshops_to_gdrive')
-      cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'csf_workshop_attendance_to_gdrive')
-      cronjob at:'0 13 * * *', do:deploy_dir('bin', 'cron', 'eir_teachers_to_gdrive')
-      cronjob at:'0 7 * * 6', do:deploy_dir('bin', 'cron', 'stop_inactive_adhoc_instances')
-      cronjob at:'0 10 * * *', do:deploy_dir('bin', 'cron', 'redshift_rollups')
-      cronjob at:'1 7 * * 6', do:deploy_dir('bin', 'cron', 'cleanup_workshop_attendance_codes')
-      cronjob at:'31 16 * * 1-5', do:deploy_dir('bin', 'cron', 'zendesk_slack_report')
-      cronjob at:'5 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'daily_weather')
-      cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'spotify')
-      cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'covid19')
-      cronjob at:'00 02 * * *', do:deploy_dir('bin', 'cron', 'export_mysql_database_to_redshift')
-      cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'build_contact_rollups_v2')
-      cronjob at:'0 2 * * *', do:deploy_dir('bin', 'cron', 'hoc_student_name_cleanup')
-      cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'send_permission_email_reminders')
+      cronjob disabled: true, at:'30 14 * * *', do:dashboard_dir('bin','scheduled_pd_workshop_emails')
+      cronjob disabled: true, at:'0 16 * * *', do:dashboard_dir('bin','scheduled_pd_application_emails')
+      cronjob disabled: true, at:'*/4 * * * *', do:dashboard_dir('bin', 'process_pd_workshop_ends')
+      cronjob disabled: true, at:'*/5 * * * *', do:dashboard_dir('bin', 'fill_jotform_placeholders')
+      cronjob disabled: true, at:'*/30 * * * *', do:dashboard_dir('bin', 'sync_jotforms')
+      cronjob disabled: true, at:'0 6 * * *', do:deploy_dir('bin', 'cron', 'process_foorm_data')
+      cronjob disabled: true, at:'25 7 * * *', do:deploy_dir('bin', 'cron', 'update_hoc_map')
+      cronjob disabled: true, at:'*/10 * * * *', do:deploy_dir('bin', 'cron', 'delete_twilio_data')
+      cronjob disabled: true, at:'* * * * *', do:deploy_dir('bin', 'cron', 'confirm_usage')
+      cronjob disabled: true, at:'0 */2 * * *', do:deploy_dir('bin', 'cron', 'teacher_applications_to_gdrive')
+      cronjob disabled: true, at:'30 */2 * * *', do:deploy_dir('bin', 'cron', 'summer_workshops_to_gdrive')
+      cronjob disabled: true, at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'csf_workshop_attendance_to_gdrive')
+      cronjob disabled: true, at:'0 13 * * *', do:deploy_dir('bin', 'cron', 'eir_teachers_to_gdrive')
+      cronjob disabled: true, at:'0 7 * * 6', do:deploy_dir('bin', 'cron', 'stop_inactive_adhoc_instances')
+      cronjob disabled: true, at:'0 10 * * *', do:deploy_dir('bin', 'cron', 'redshift_rollups')
+      cronjob disabled: true, at:'1 7 * * 6', do:deploy_dir('bin', 'cron', 'cleanup_workshop_attendance_codes')
+      cronjob disabled: true, at:'31 16 * * 1-5', do:deploy_dir('bin', 'cron', 'zendesk_slack_report')
+      cronjob disabled: true, at:'5 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'daily_weather')
+      cronjob disabled: true, at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'spotify')
+      cronjob disabled: true, at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'covid19')
+      cronjob disabled: true, at:'00 02 * * *', do:deploy_dir('bin', 'cron', 'export_mysql_database_to_redshift')
+      cronjob disabled: true, at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'build_contact_rollups_v2')
+      cronjob disabled: true, at:'0 2 * * *', do:deploy_dir('bin', 'cron', 'hoc_student_name_cleanup')
+      cronjob disabled: true, at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'send_permission_email_reminders')
 
       # RDS backup window is 05:17-05:47 UTC, so by 11:50 backups should definitely be ready
-      cronjob at:'50 11 * * *', do:deploy_dir('bin', 'cron', 'push_latest_aurora_backup_to_secondary_account')
+      cronjob disabled:true, at:'50 11 * * *', do:deploy_dir('bin', 'cron', 'push_latest_aurora_backup_to_secondary_account')
     end
 
     # 'daemons' in all environments.


### PR DESCRIPTION
The high-level plan:

1. `production-console` (https://github.com/code-dot-org/code-dot-org/pull/54269)
   - Override the cloudformation template to hardcode the ami, rather than using IMAGE_ID
   - Also make volume size match reality, to avoid accidentally shrinking it
2. `production-daemon` (this PR)
   - Hardcode the ami instead of using IMAGE_ID
   - Also disable all cron jobs except ci_build
   - Also make volume size match reality, to avoid accidentally shrinking
3. `ami-builder` (https://github.com/code-dot-org/code-dot-org/pull/54272)
   - Hardcode the ami, or just update IMAGE_ID since this is the last server
   - Keep volume size at 64GB, as this matches reality

## Links

See doc at https://docs.google.com/document/d/1icoCcfsajs1eqP1w7cymXjsrbC9DIW-1Im6p4EE3OJ8/edit#heading=h.r0g6m46ca94w for more of the rollout plan.

## Testing Story

I verified the new logic for creating commented-out crontab entries on an adhoc of [a testing branch](https://github.com/code-dot-org/code-dot-org/pull/54262/files)

## Deployment strategy

Before merging, we plan to take a snapshot of the existing `production-daemon` instance.

After the old production-daemon instance picks up the crontab updates included in this PR, we plan to manually reenable the commented-out cronjobs and disable the `ci_build` cronjob, so the old server can continue to send emails and perform other necessary tasks while the new server is being created.

Once the new server is up and running, we will manually cut the cronjobs over from old server to new.

## Follow-up work

Once our servers have been successfully updated and the cronjobs have successfully executed on the new server, we can reenable the disabled cronjobs and remove the new disabling functionality.