### PR TITLE
[Google Blockly] Merge level toolbox xml blocks into auto-populated variables category

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -613,6 +613,7 @@
   "createAccountToShareDescription": "You must create a Code.org account before you can share and publish your project. Creating an account will also let you save your progress and continue to work on your project later.",
   "createBlocklyBehavior": "Create a Behavior",
   "createBlocklyFunction": "Create a Function",
+  "createBlocklyVariable": "Create a Variable",
   "createClassSections": "Create class sections",
   "createClassSectionsToAssign": "Create class section to assign a curriculum",
   "createClassSectionToAssignButton": "Create Section",

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -356,3 +356,32 @@ export function partitionBlocksByType(
 
   return [...prioritizedBlocks, ...remainingBlocks];
 }
+
+/**
+ * Retrieves custom category blocks from the Blockly toolbox XML for display in a flyout.
+ *
+ * @param {string} category - The name of the custom category to retrieve blocks from.
+ * @returns {HTMLCollection} - a collection of XML blocks for flyout, or an empty array
+ */
+export function getCustomCategoryBlocksForFlyout(category) {
+  const parser = new DOMParser();
+  // TODO: Update this to use JSON once https://codedotorg.atlassian.net/browse/CT-8 is merged
+  const xmlDoc = parser.parseFromString(Blockly.toolboxBlocks, 'text/xml');
+
+  const categoryNodes = xmlDoc.getElementsByTagName('category');
+  for (const categoryNode of categoryNodes) {
+    const categoryCustom = categoryNode.getAttribute('custom');
+
+    if (categoryCustom === category) {
+      const xmlList = document.createDocumentFragment();
+      const blockNodes = categoryNode.getElementsByTagName('block');
+      for (const blockNode of blockNodes) {
+        if (blockNode.parentElement === categoryNode) {
+          xmlList.appendChild(blockNode.cloneNode(true));
+        }
+      }
+      return xmlList.children;
+    }
+  }
+  return [];
+}

--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
@@ -179,9 +179,15 @@ export function flyoutCategory(workspace, functionEditorOpen = false) {
 
   // Blockly supports XML or JSON, but not a combination of both.
   // We convert to JSON here because the behavior_get blocks are JSON.
-  const blocksJson = convertToolboxXmlToJson(
-    Blockly.cdoUtils.getCustomCategoryBlocksForFlyout('Behavior')
+  const levelToolboxBlocks = Blockly.cdoUtils.getLevelToolboxBlocks('Behavior');
+  if (!levelToolboxBlocks) {
+    return;
+  }
+  const blocksConvertedJson = convertXmlToJson(
+    levelToolboxBlocks.documentElement
   );
+  const blocksJson =
+    Blockly.cdoUtils.getSimplifiedStateForFlyout(blocksConvertedJson);
   blockList.push(...blocksJson);
 
   // Workspaces to populate behaviors flyout category from
@@ -218,44 +224,6 @@ export function flyoutCategory(workspace, functionEditorOpen = false) {
   });
 
   return blockList;
-}
-
-// Gets an array of simplified JSON blocks for flyout
-function convertToolboxXmlToJson(xmlList) {
-  const parser = new DOMParser();
-  const xmlRootElement = parser.parseFromString(
-    '<xml></xml>',
-    'application/xml'
-  );
-
-  // Iterate through each block element in xmlList
-  for (const blockElement of xmlList) {
-    // Append the block element to the xmlRootElement
-    xmlRootElement.documentElement.appendChild(blockElement);
-  }
-
-  const jsonBlocks = convertXmlToJson(xmlRootElement.documentElement);
-  const flyoutBlocks = jsonBlocks.blocks?.blocks?.map(
-    simplifyBlockStateForFlyout
-  );
-
-  return flyoutBlocks;
-}
-
-// Used to simplify block state for inclusion in the Behaviors category flyout
-function simplifyBlockStateForFlyout(block) {
-  // Clone the original block object to avoid modifying it directly
-  const modifiedBlock = {...block};
-
-  // Remove id, x, and y properties
-  delete modifiedBlock.id;
-  delete modifiedBlock.x;
-  delete modifiedBlock.y;
-
-  // Add kind property with value 'block'
-  modifiedBlock.kind = 'block';
-
-  return modifiedBlock;
 }
 
 const getNewBehaviorButtonWithCallback = (

--- a/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.js
@@ -1,92 +1,164 @@
+import {convertXmlToJson} from '../../addons/cdoSerializationHelpers';
+import msg from '@cdo/locale';
+
 /**
  * Constructs the blocks required by the flyout for the variables category.
- * @param {WorkspaceSvg} workspace The workspace containing variables.
- * @returns an array of XML block elements
+ * @param {WorkspaceSvg} workspace The workspace containing procedures.
+ * @returns {Array<Object>} An array of JSON block elements.
  */
 export function flyoutCategory(workspace) {
-  const button = document.createElement('button');
-  button.setAttribute('text', '%{BKY_NEW_VARIABLE}');
-  button.setAttribute('callbackKey', 'CREATE_VARIABLE');
+  const blockList = [];
+  const newVariableButton = getNewVariableButtonWithCallback(workspace);
+  blockList.push(newVariableButton);
 
-  workspace.registerButtonCallback('CREATE_VARIABLE', function (button) {
-    Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace());
-  });
-
-  const levelConfigBlocks = Array.from(
-    Blockly.cdoUtils.getCustomCategoryBlocksForFlyout('VARIABLE')
+  const categoryBlocks = flyoutCategoryBlocks(workspace);
+  blockList.push(...categoryBlocks);
+  const levelToolboxBlocks = Blockly.cdoUtils.getLevelToolboxBlocks('VARIABLE');
+  if (!levelToolboxBlocks) {
+    return;
+  }
+  const blocksConvertedJson = convertXmlToJson(
+    levelToolboxBlocks.documentElement
   );
+  const flyoutJson =
+    Blockly.cdoUtils.getSimplifiedStateForFlyout(blocksConvertedJson);
 
-  let mathChangeBlock = null;
+  blockList.push(...flyoutJson);
 
-  // Find and get the "math_change" block if it exists, and remove it from levelConfigBlocks
-  const updatedLevelConfigBlocks = levelConfigBlocks.filter(block => {
-    if (block.getAttribute('type') === 'math_change') {
-      mathChangeBlock = block;
-      return false; // Exclude the math_change block
+  // Count the 'math_change' blocks in blockList.
+  const mathChangeBlocksCount = blockList.filter(
+    block => block.type === 'math_change'
+  ).length;
+
+  // If there is more than one, remove the first occurrence which was auto-generated.
+  if (mathChangeBlocksCount > 1) {
+    const firstMathChangeIndex = blockList.findIndex(
+      block => block.type === 'math_change'
+    );
+    if (firstMathChangeIndex !== -1) {
+      blockList.splice(firstMathChangeIndex, 1);
     }
-    return true; // Include other blocks
+  }
+
+  return blockList;
+}
+
+const getNewVariableButtonWithCallback = workspace => {
+  const callbackKey = 'newVariableCallback';
+  workspace.registerButtonCallback(callbackKey, () => {
+    Blockly.FieldVariable.modalPromptName(
+      msg.renameThisPromptTitle(),
+      msg.create(),
+      '',
+      newName => {
+        workspace.createVariable(newName);
+      }
+    );
   });
 
-  // Call flyoutCategoryBlocks with the mathChangeBlock if found
-  const categoryBlocks = flyoutCategoryBlocks(workspace, mathChangeBlock);
-
-  return [button, ...categoryBlocks, ...updatedLevelConfigBlocks];
-}
+  return {
+    kind: 'button',
+    text: msg.createBlocklyVariable(),
+    callbackKey,
+  };
+};
 
 /**
  * Construct the blocks required by the flyout for the variable category.
- * Modifed version of Blockly.Variables.flyoutCategoryBlocks that skips 'math_change' blocks.
+ *
  * @param workspace The workspace containing variables.
- * @returns Array of XML block elements.
+ * @returns {Array<Object>} An array of JSON block objects for a flyout.
  */
-function flyoutCategoryBlocks(workspace, mathChangeBlock) {
+export function flyoutCategoryBlocks(workspace) {
   const variableModelList = workspace.getVariablesOfType('');
 
-  const xmlList = [];
+  const blockList = [];
   if (variableModelList.length > 0) {
-    // New variables are added to the end of the variableModelList.
-    const mostRecentVariable = variableModelList[variableModelList.length - 1];
-
     if (Blockly.Blocks['variables_get']) {
       variableModelList.sort(Blockly.VariableModel.compareByName);
       for (let i = 0, variable; (variable = variableModelList[i]); i++) {
-        const block = Blockly.utils.xml.createElement('block');
-        block.setAttribute('type', 'variables_get');
-        block.setAttribute('gap', '8');
-        block.appendChild(Blockly.Variables.generateVariableFieldDom(variable));
-        xmlList.push(block);
+        const block = {
+          kind: 'block',
+          type: 'variables_get',
+          fields: {
+            VAR: {
+              name: variable.name,
+              type: variable.type,
+            },
+          },
+        };
+        blockList.push(block);
       }
     }
+    // New variables are added to the end of the variableModelList.
+    const mostRecentVariable = variableModelList[variableModelList.length - 1];
     if (Blockly.Blocks['variables_set']) {
-      const block = Blockly.utils.xml.createElement('block');
-      block.setAttribute('type', 'variables_set');
-      block.setAttribute('gap', '8');
-      block.appendChild(
-        Blockly.Variables.generateVariableFieldDom(mostRecentVariable)
-      );
-      xmlList.push(block);
+      const block = {
+        kind: 'block',
+        type: 'variables_set',
+        fields: {
+          VAR: {name: mostRecentVariable.name, type: mostRecentVariable.type},
+        },
+      };
+      blockList.push(block);
     }
-    if (Blockly.Blocks['math_change'] && !mathChangeBlock) {
-      const block = Blockly.utils.xml.createElement('block');
-      block.setAttribute('type', 'math_change');
-      block.setAttribute('gap', Blockly.Blocks['variables_get'] ? '20' : '8');
-      block.appendChild(
-        Blockly.Variables.generateVariableFieldDom(mostRecentVariable)
-      );
-      const value = Blockly.utils.xml.textToDom(
-        '<value name="DELTA">' +
-          '<shadow type="math_number">' +
-          '<field name="NUM">1</field>' +
-          '</shadow>' +
-          '</value>'
-      );
-      block.appendChild(value);
-      xmlList.push(block);
+    if (Blockly.Blocks['math_change']) {
+      const block = {
+        kind: 'block',
+        type: 'math_change',
+        fields: {
+          VAR: mostRecentVariable,
+        },
+        inputs: {
+          DELTA: {
+            shadow: {
+              type: 'math_number',
+              fields: {
+                NUM: 1,
+              },
+            },
+          },
+        },
+      };
+      blockList.push(block);
     }
   }
-  if (mathChangeBlock) {
-    // Use the provided math_change block
-    xmlList.push(mathChangeBlock);
-  }
-  return xmlList;
+  return blockList;
 }
+[
+  {
+    type: 'variables_set',
+    fields: {
+      VAR: {
+        id: '{i~K0[38l!xMM+u/O#.-',
+      },
+    },
+  },
+  {
+    type: 'variables_get',
+    fields: {
+      VAR: {
+        id: '{i~K0[38l!xMM+u/O#.-',
+      },
+    },
+  },
+  {
+    type: 'math_change',
+    fields: {
+      VAR: {
+        id: '{i~K0[38l!xMM+u/O#.-',
+      },
+    },
+    inputs: {
+      DELTA: {
+        shadow: {
+          type: 'math_number',
+          id: '~9T;lR*2}(m~=ETx!$pG',
+          fields: {
+            NUM: 1,
+          },
+        },
+      },
+    },
+  },
+];

--- a/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.js
@@ -1,0 +1,62 @@
+/**
+ * Constructs the blocks required by the flyout for the variables category.
+ * @param {WorkspaceSvg} workspace The workspace containing variables.
+ * @returns an array of XML block elements
+ */
+export function flyoutCategory(workspace) {
+  const button = document.createElement('button');
+  button.setAttribute('text', '%{BKY_NEW_VARIABLE}');
+  button.setAttribute('callbackKey', 'CREATE_VARIABLE');
+
+  workspace.registerButtonCallback('CREATE_VARIABLE', function (button) {
+    Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace());
+  });
+
+  let blockList = [button];
+
+  blockList.push(
+    ...Blockly.cdoUtils.getCustomCategoryBlocksForFlyout('VARIABLE')
+  );
+
+  const xmlBlockList = flyoutCategoryBlocks(workspace);
+  blockList = blockList.concat(xmlBlockList);
+
+  return blockList;
+}
+
+/**
+ * Construct the blocks required by the flyout for the variable category.
+ * Modifed version of Blockly.Variables.flyoutCategoryBlocks that skips 'math_change' blocks.
+ * @param workspace The workspace containing variables.
+ * @returns Array of XML block elements.
+ */
+function flyoutCategoryBlocks(workspace) {
+  const variableModelList = workspace.getVariablesOfType('');
+
+  const xmlList = [];
+  if (variableModelList.length > 0) {
+    // New variables are added to the end of the variableModelList.
+    const mostRecentVariable = variableModelList[variableModelList.length - 1];
+    if (Blockly.Blocks['variables_set']) {
+      const block = Blockly.utils.xml.createElement('block');
+      block.setAttribute('type', 'variables_set');
+      block.setAttribute('gap', '8');
+      block.appendChild(
+        Blockly.Variables.generateVariableFieldDom(mostRecentVariable)
+      );
+      xmlList.push(block);
+    }
+
+    if (Blockly.Blocks['variables_get']) {
+      variableModelList.sort(Blockly.VariableModel.compareByName);
+      for (let i = 0, variable; (variable = variableModelList[i]); i++) {
+        const block = Blockly.utils.xml.createElement('block');
+        block.setAttribute('type', 'variables_get');
+        block.setAttribute('gap', '8');
+        block.appendChild(Blockly.Variables.generateVariableFieldDom(variable));
+        xmlList.push(block);
+      }
+    }
+  }
+  return xmlList;
+}

--- a/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.js
@@ -77,7 +77,7 @@ export function flyoutCategoryBlocks(workspace) {
   if (variableModelList.length > 0) {
     if (Blockly.Blocks['variables_get']) {
       variableModelList.sort(Blockly.VariableModel.compareByName);
-      for (let i = 0, variable; (variable = variableModelList[i]); i++) {
+      variableModelList.forEach(variable => {
         const block = {
           kind: 'block',
           type: 'variables_get',
@@ -89,7 +89,7 @@ export function flyoutCategoryBlocks(workspace) {
           },
         };
         blockList.push(block);
-      }
+      });
     }
     // New variables are added to the end of the variableModelList.
     const mostRecentVariable = variableModelList[variableModelList.length - 1];
@@ -126,40 +126,3 @@ export function flyoutCategoryBlocks(workspace) {
   }
   return blockList;
 }
-[
-  {
-    type: 'variables_set',
-    fields: {
-      VAR: {
-        id: '{i~K0[38l!xMM+u/O#.-',
-      },
-    },
-  },
-  {
-    type: 'variables_get',
-    fields: {
-      VAR: {
-        id: '{i~K0[38l!xMM+u/O#.-',
-      },
-    },
-  },
-  {
-    type: 'math_change',
-    fields: {
-      VAR: {
-        id: '{i~K0[38l!xMM+u/O#.-',
-      },
-    },
-    inputs: {
-      DELTA: {
-        shadow: {
-          type: 'math_number',
-          id: '~9T;lR*2}(m~=ETx!$pG',
-          fields: {
-            NUM: 1,
-          },
-        },
-      },
-    },
-  },
-];

--- a/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.js
@@ -25,11 +25,12 @@ export function flyoutCategory(workspace) {
 
   blockList.push(...flyoutJson);
 
+  // The may include "change [var] by" blocks with custom default values.
+  // If any of these blocks are found, we can remove the auto-generated block.
   // Count the 'math_change' blocks in blockList.
   const mathChangeBlocksCount = blockList.filter(
     block => block.type === 'math_change'
   ).length;
-
   // If there is more than one, remove the first occurrence which was auto-generated.
   if (mathChangeBlocksCount > 1) {
     const firstMathChangeIndex = blockList.findIndex(

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -52,6 +52,7 @@ import {registerAllContextMenuItems} from './addons/contextMenu';
 import BlockSvgUnused, {onBlockClickDragDelete} from './addons/blockSvgUnused';
 import {ToolboxType, Themes, Renderers} from './constants';
 import {flyoutCategory as functionsFlyoutCategory} from './customBlocks/googleBlockly/proceduresBlocks';
+import {flyoutCategory as variablesFlyoutCategory} from './customBlocks/googleBlockly/variableBlocks';
 import {flyoutCategory as behaviorsFlyoutCategory} from './customBlocks/googleBlockly/behaviorBlocks';
 import CdoBlockSerializer from './addons/cdoBlockSerializer.js';
 import customBlocks from './customBlocks/googleBlockly/index.js';
@@ -689,6 +690,11 @@ function initializeBlocklyWrapper(blocklyInstance) {
       'PROCEDURE',
       functionsFlyoutCategory
     );
+    workspace.registerToolboxCategoryCallback(
+      'VARIABLE',
+      variablesFlyoutCategory
+    );
+
     workspace.registerToolboxCategoryCallback(
       'Behavior',
       behaviorsFlyoutCategory


### PR DESCRIPTION
This makes some changes to the auto-populated variable flyout so that the blocks specified in the level XML are also included. We had to do a similar patch for the behaviors category, so I reused some logic to accomplish this.

For comparison purposes, I'm including videos where I will perform the same basic operations, comparing the toolbox contents as I go:
1. Open "Variables" category in brand new project
2. Create a variable called "test"
3. Create another variable called "test2"
4. Compare the flyout contents

CDO Blockly does not support the "Create a variable button...", but the curriculum team has expressed interest in using this feature as it feels more modern and better aligns to tools like scratch.

### CDO Blockly (baseline)
_In order to create a new variable, one must drag out a block with a variable picker input, choose "**Rename this variable**", then enter a new name. The block used for this operation is updated and the toolbox is updated behind the scenes._
* `change counter by 1` and `???` are both provided by the level's toolbox XML
* a pair of `set var to` and `var` (getter) blocks are added to the toolbox for each variable present in the main workspace

https://github.com/code-dot-org/code-dot-org/assets/43474485/8503d793-830d-40f1-89a8-ef3e83bcd50e

### Google Blockly (staging)
_In order to create a new variable, you either do use the method above (not shown here), or press the "**Create variable...**" button which creates a modal. The flyout stays open and is immediately updated.
* The `change counter by 1` and `???` blocks specified in the level's toolbox XML are not shown.
* If variables are present, `set var to` and `change var by 1` blocks are created, along with a `var` (getter) block for each block. Note that the `change test2 by 1` block in the video below comes from a different place than the `change counter by 1` block in the video above.

https://github.com/code-dot-org/code-dot-org/assets/43474485/d6ea4cd6-8181-488f-8949-b711723a4688

### Google Blockly (feature branch)
_Variables can be created using either method, as above._
* `change counter by 1` and `???` are both provided by the level's toolbox XML
* If variables are present, a single `set var to` block is created, along with a `var` (getter) block for each block. Because levels commonly include the `change var by` block (since CDO Blockly didn't provide it), we prevent Blockly from creating extra copies of the block when a variable is created. If no `change by` block is listed in the toolbox XML, we will now create one. This means the curriculum team won't have to manually include this block any more, but still can if they want to customize its default values.


https://github.com/code-dot-org/code-dot-org/assets/43474485/f7b08dba-af18-407c-ab2e-5293d47250b5

(Note: the above video was captured using the dark theme, but that has no relation to the PR.)

This PR also updates the modal used when the "Create a Variable" button is clicked:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/281da744-c95f-4fdf-9434-be0613b20571)![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/3c3dba87-dc3b-48bf-af26-a67a602ff490)


## Links

[CT-128: Merge level toolbox xml blocks into auto-populated variables category](https://codedotorg.atlassian.net/browse/CT-128)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work



## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
