### PR TITLE
Fix SQLUser Lambda Name

### DIFF
--- a/aws/cloudformation/lambda.yml.erb
+++ b/aws/cloudformation/lambda.yml.erb
@@ -278,7 +278,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Description: 'Custom CloudFormation Resource: Create/Update/Delete a SQL User and its permissions in a MySQL database.'
-      FunctionName: !Sub "SQLUser-CloudFormation-Custom-Resource-${AWS::StackName}"
+      FunctionName: SQLUser
       Code: <%=package_node_lambda 'sql-user' %>
       Handler: index.handler
       Runtime: nodejs18.x


### PR DESCRIPTION
Make it easier for our main CloudFormation template to invoke this lambda to back a custom CloudFormation Resource with:

``` erb
<%= lambda_fn 'SQLUser'
```

## Testing story

``` bash
 % bundle exec rake stack:lambda:validate
Finished stack:lambda:environment (less than a minute)
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn  --production
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig npm install  ci --only=prod
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn
Pending update for stack `lambda`:
Modify SQLUserLambda [AWS::Lambda::Function] Properties Replacement: True (FunctionName)
Finished stack:lambda:validate (less than a minute)
```


## Deployment strategy

`$ bundle exec rake stack:lambda:start`

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
