### PR TITLE
Install `sql_runner` from GitHub Rather than Bintray

### DIFF
--- a/cookbooks/cdo-analytics/recipes/default.rb
+++ b/cookbooks/cdo-analytics/recipes/default.rb
@@ -5,7 +5,7 @@ include_recipe 'ark'
 ark 'sql-runner' do
   version = node['cdo-analytics']['sql_runner']['version']
   version version
-  url "https://dl.bintray.com/snowplow/snowplow-generic/sql_runner_#{version}_linux_amd64.zip"
+  url "https://github.com/snowplow/sql-runner/releases/download/#{version}/sql_runner_#{version}_linux_amd64.zip"
   checksum node['cdo-analytics']['sql_runner']['checksum']
   strip_components 0
   has_binaries ['sql-runner']


### PR DESCRIPTION
The URL from which we were formerly downloading the `sql_runner` installer now 404s, and the domain redirects to https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

Instead, we start targeting the URL which [the README for the `sql_runner` repository](https://github.com/snowplow/sql-runner) recommends we use: [the GitHub release](https://github.com/snowplow/sql-runner/releases/tag/0.6.0)

## Testing story

Verified locally that the file at https://github.com/snowplow/sql-runner/releases/download/0.6.0/sql_runner_0.6.0_linux_amd64.zip has the exact same checksum as what we were previously downloading:

```
$ shasum -a256 sql_runner_0.6.0_linux_amd64.zip
4a7521e8e50ac87a4c00a0e1fa9269e383108aa09cc9e7699c0666c70925806e  sql_runner_0.6.0_linux_amd64.zip
```

https://github.com/code-dot-org/code-dot-org/blob/32c7321546f10a5d4241571b96545ae3683071c9/cookbooks/cdo-analytics/attributes/default.rb#L4