### PR TITLE
Add editor for tips

### DIFF
--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -80,6 +80,22 @@ export default function LearningGoalItem({
           learningGoalData={exisitingLearningGoalData}
           updateLearningGoal={updateLearningGoal}
         />
+        <label
+          style={{...styles.labelAndInput, ...styles.textboxLabelAndInput}}
+        >
+          Tips
+          <textarea
+            value={exisitingLearningGoalData.tips || ''}
+            onChange={event =>
+              updateLearningGoal(
+                exisitingLearningGoalData.id,
+                'tips',
+                event.target.value
+              )
+            }
+            style={{width: '100%', height: 100}}
+          />
+        </label>
         <Button
           text="Delete key concept"
           color={Button.ButtonColor.red}
@@ -168,5 +184,11 @@ const styles = {
     justifyContent: 'flex-start',
     flexWrap: 'wrap',
     flex: '1 1',
+  },
+  textboxLabelAndInput: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    marginLeft: 0,
+    marginRight: 25,
   },
 };

--- a/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/RubricsContainer.jsx
@@ -50,6 +50,7 @@ export default function RubricsContainer({
       learningGoal: '',
       aiEnabled: false,
       position: nextPosition,
+      tips: null,
       learningGoalEvidenceLevelsAttributes: [
         {
           teacherDescription: '',

--- a/apps/test/unit/lib/levelbuilder/rubrics/LearningGoalItemTest.js
+++ b/apps/test/unit/lib/levelbuilder/rubrics/LearningGoalItemTest.js
@@ -31,6 +31,7 @@ describe('LearningGoalItem', () => {
     expect(wrapper.find('input[type="checkbox"]').length).to.equal(1);
     expect(wrapper.find('Button').length).to.equal(1);
     expect(wrapper.find('EvidenceDescriptions').length).to.equal(1);
+    expect(wrapper.find('textarea').length).to.equal(1);
   });
 
   it('disables editing of AI textboxes when unchecked', () => {
@@ -66,5 +67,25 @@ describe('LearningGoalItem', () => {
     const wrapper = shallow(<LearningGoalItem {...defaultProps} />);
     wrapper.find('Button').simulate('click');
     expect(deleteLearningGoalSpy.calledOnce).to.be.true;
+  });
+
+  it('calls updateLearningGoal when tips text is changed', () => {
+    const updateLearningGoalSpy = sinon.spy();
+    const wrapper = shallow(
+      <LearningGoalItem
+        {...defaultProps}
+        updateLearningGoal={updateLearningGoalSpy}
+      />
+    );
+    wrapper
+      .find('textarea')
+      .simulate('change', {target: {value: 'Learning Goal Tip'}});
+    expect(
+      updateLearningGoalSpy.withArgs(
+        exisitingLearningGoalData.id,
+        'tips',
+        'Learning Goal Tip'
+      ).calledOnce
+    ).to.be.true;
   });
 });

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -111,6 +111,7 @@ class RubricsController < ApplicationController
         :id,
         :learning_goal,
         :ai_enabled,
+        :tips,
         :position,
         :_destroy,
         {

--- a/dashboard/app/models/learning_goal.rb
+++ b/dashboard/app/models/learning_goal.rb
@@ -56,6 +56,7 @@ class LearningGoal < ApplicationRecord
       position: position,
       learningGoal: learning_goal,
       aiEnabled: ai_enabled,
+      tips: tips,
       learningGoalEvidenceLevelsAttributes: learning_goal_evidence_levels.map(&:summarize_for_rubric_edit)
     }
   end


### PR DESCRIPTION
Adds an editor for tips! I've been using this to add tips to the learning goals, but spent a little bit of time this morning adding tests.

![Screenshot 2023-10-18 at 7 29 01 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/d2858c39-f91d-4205-aabd-be25c4b4f96d)
