### PR TITLE
Fix evidence level description text and move tips on CSD3 L18

### DIFF
--- a/dashboard/config/scripts_json/csd3-2023.script_json
+++ b/dashboard/config/scripts_json/csd3-2023.script_json
@@ -17,7 +17,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2023-10-18 00:03:42 UTC",
+    "serialized_at": "2023-10-18 11:28:52 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -20519,7 +20519,7 @@
       "position": 1,
       "learning_goal": "Program Development - Peer Feedback",
       "ai_enabled": false,
-      "tips": "(1) **Sequenced the program well**\n- If the program code is not sequenced correctly, some elements, such as shapes, sprites, and text, may be unintentionally hidden behind others. \n- In the specific case of sprites, if the `drawSprites()` code is not sequenced correctly, some or all sprites may not appear on the screen.\n\n(2) **Code in and out of the draw loop**\n- Code outside the draw loop is used to set up the program and its starting elements (creating sprites, setting sprite properties that won’t change, etc). \n- Code inside the draw loop is for things that are changing as the program is running. This includes updating properties or non-sprite variables as well as any shapes for the background, text, and the `drawSprites()` block.",
+      "tips": "",
       "seeding_key": {
         "learning_goal.key": "3a264bf8-ae90-4eba-8442-0adee5613bd1",
         "lesson.key": "Project - Interactive Card",
@@ -20857,7 +20857,7 @@
       "position": 2,
       "learning_goal": "Program Development - Program Sequence",
       "ai_enabled": false,
-      "tips": null,
+      "tips": "(1) **Sequenced the program well**\n- If the program code is not sequenced correctly, some elements, such as shapes, sprites, and text, may be unintentionally hidden behind others. \n- In the specific case of sprites, if the `drawSprites()` code is not sequenced correctly, some or all sprites may not appear on the screen.\n\n(2) **Code in and out of the draw loop**\n- Code outside the draw loop is used to set up the program and its starting elements (creating sprites, setting sprite properties that won’t change, etc). \n- Code inside the draw loop is for things that are changing as the program is running. This includes updating properties or non-sprite variables as well as any shapes for the background, text, and the `drawSprites()` block.",
       "seeding_key": {
         "learning_goal.key": "f7799b1e-f81e-46a3-a206-8b2ec055555e",
         "lesson.key": "Project - Interactive Card",
@@ -21363,7 +21363,7 @@
     },
     {
       "understanding": 3,
-      "teacher_description": "You gave thoughtful feedback to peers and you responded to peer feedback by making appropriate changes to program.You sequenced the program well1  and properly separated code in and out of the draw loop (2).\nYou property separated code in and out of the draw loop, however they have a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.\nYou have several sequencing errors, resulting in many elements unintentionally hidden or overlapping others. Some code is improperly placed in or out of the loop.\nErrors in program sequencing are significant enough to keep the output from resembling the intended scene or the Draw loop is not used to create animation\n\n",
+      "teacher_description": "You gave thoughtful feedback to peers and you responded to peer feedback by making appropriate changes to program.",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 3,
@@ -22611,7 +22611,7 @@
     },
     {
       "understanding": 3,
-      "teacher_description": "You sequenced the program well1  and properly separated code in and out of the draw loop (2).",
+      "teacher_description": "You sequenced the program well (1)  and properly separated code in and out of the draw loop (2).",
       "ai_prompt": "",
       "seeding_key": {
         "understanding": 3,


### PR DESCRIPTION
This was caught in the bug bash. The extensive evidence level description for "Program Development - Peer Feedback" included the description for the extensive evidence level for "Program Development - Program Sequence". I didn't notice when I added tips, so I also put them in the wrong place. This PR fixes the evidence level description for "Program Development - Peer Feedback" and moves the tips down.