### PR TITLE
Send Amplitude event when rubric is submitted

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -84,6 +84,7 @@ const EVENTS = {
   TA_RUBRIC_LEARNING_GOAL_COLLAPSED_EVENT: 'TA Rubric Learning Goal Collapsed',
   TA_RUBRIC_ON_STUDENT_WORK_LOADED: 'TA Rubric On Student Work Loaded',
   TA_RUBRIC_ON_STUDENT_WORK_UNLOADED: 'TA Rubric On Student Work Unloaded',
+  TA_RUBRIC_SUBMITTED: 'TA Rubric Submitted',
 
   AGE_21_SELECTED_EVENT: 'Age 21+ Selected',
 };

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -51,7 +51,10 @@ export default function RubricContent({
   const [errorSubmitting, setErrorSubmitting] = useState(false);
   const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
   const submitFeedbackToStudent = () => {
-    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_SUBMITTED, reportingData);
+    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_SUBMITTED, {
+      ...reportingData,
+      studentId: studentLevelInfo.user_id,
+    });
     setIsSubmittingToStudent(true);
     setErrorSubmitting(false);
     const body = JSON.stringify({

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -17,6 +17,8 @@ import LearningGoal from './LearningGoal';
 import Button from '@cdo/apps/templates/Button';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import classnames from 'classnames';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 const formatTimeSpent = timeSpent => {
   const minutes = Math.floor(timeSpent / 60);
@@ -49,6 +51,7 @@ export default function RubricContent({
   const [errorSubmitting, setErrorSubmitting] = useState(false);
   const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
   const submitFeedbackToStudent = () => {
+    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_SUBMITTED, reportingData);
     setIsSubmittingToStudent(true);
     setErrorSubmitting(false);
     const body = JSON.stringify({


### PR DESCRIPTION
Sends an event when the rubric feedback is submitted.

Example event output:
```
[AMPLITUDE ANALYTICS EVENT]: TA Rubric Submitted. Payload: {"payload":{"unitName":"csd3-2023","courseName":"csd-2023","levelName":"CSD U3 Interactive Card Final_2023","studentId":947}}
```