### PR TITLE
AITT-269 - Understanding level is not saved correctly

### DIFF
--- a/apps/src/templates/rubrics/LearningGoal.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.jsx
@@ -45,6 +45,7 @@ export default function LearningGoal({
   const [displayUnderstanding, setDisplayUnderstanding] =
     useState(invalidUnderstanding);
   const teacherFeedback = useRef('');
+  const understandingLevel = useRef(invalidUnderstanding);
 
   const aiEnabled = learningGoal.aiEnabled && teacherHasEnabledAi;
   const base_teacher_evaluation_endpoint = '/learning_goal_teacher_evaluations';
@@ -86,7 +87,7 @@ export default function LearningGoal({
       studentId: studentLevelInfo.user_id,
       learningGoalId: learningGoal.id,
       feedback: teacherFeedback.current,
-      understanding: displayUnderstanding,
+      understanding: understandingLevel.current,
     });
     HttpClient.put(
       `${base_teacher_evaluation_endpoint}/${learningGoalEval.id}`,
@@ -131,8 +132,7 @@ export default function LearningGoal({
           }
           if (json.understanding >= 0 && json.understanding !== null) {
             setDisplayUnderstanding(json.understanding);
-          } else {
-            setDisplayUnderstanding(invalidUnderstanding);
+            understandingLevel.current = json.understanding;
           }
         })
         .catch(error => console.log(error));
@@ -142,6 +142,7 @@ export default function LearningGoal({
   // Callback to retrieve understanding data from EvidenceLevels
   const radioButtonCallback = radioButtonData => {
     setDisplayUnderstanding(radioButtonData);
+    understandingLevel.current = radioButtonData;
     if (!isAutosaving) {
       autosave();
     }


### PR DESCRIPTION
Updated LearningGoal to use useRef to store understanding data to send to backend. This solves the issue of stale data being sent to the backend when using useState to pass data to rails.

https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?assignee=712020%3A250d7a97-0218-4596-992c-547f32c30439&selectedIssue=AITT-269