### PR TITLE
[JIMT]all-songs-available

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_default_song.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_default_song.html.haml
@@ -22,4 +22,4 @@
 
 %p Previously chosen default song (may not match actual default if song selection was limited):
 
-= (songMap[@level.default_song]||[])[0]
+= songMap[@level.default_song]&.[](0) || "No song chosen"

--- a/dashboard/app/views/levels/editors/fields/_default_song.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_default_song.html.haml
@@ -22,4 +22,4 @@
 
 %p Previously chosen default song (may not match actual default if song selection was limited):
 
-= songMap[@level.default_song][0]
+= (songMap[@level.default_song]||[])[0]

--- a/dashboard/app/views/levels/editors/fields/_song_selection.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_song_selection.html.haml
@@ -11,4 +11,4 @@
   = f.select :song_selection, ((@level.song_selection || []).map {|s| songMap[s] } + @level.class.hoc_songs).uniq, {}, {size: 12, multiple: true}
   %p Songs currently selected (does not update until level is saved):
 
-  = (@level.song_selection || []).map {|s| songMap[s][0] }
+  = @level.song_selection ? @level.song_selection.map {|s| songMap[s][0] } : "All songs are available"


### PR DESCRIPTION
This is an updated to #54208 

Three small things -
• When no songs are selected, then all songs are available. Change the output on the "Songs currently" selected paragraph to say "All songs are available" instead of `[]`
• If no default song was selected, then it says "No song chosen"  
• There was a bug creating a new level because it was assuming a default song was already populated (testing miss). So just shoves in a default value.

<img width="752" alt="Screenshot 2023-10-18 at 2 12 16 PM" src="https://github.com/code-dot-org/code-dot-org/assets/1466175/6dba9abe-50b0-4312-88f7-714feee38842">
