### PR TITLE
[JIMT][LABS-63] cachebuster sign cookies

### DIFF
--- a/apps/src/dance/danceRedux.ts
+++ b/apps/src/dance/danceRedux.ts
@@ -122,7 +122,7 @@ export const setSong = createAsyncThunk(
     loadSong(songId, songData, async (status: number) => {
       if (status === 403) {
         // The cloudfront signed cookies may have expired.
-        await fetchSignedCookies();
+        await fetchSignedCookies(true);
         loadSong(songId, songData, (status: number) => {
           if (status === 403) {
             // Something is wrong, because we just re-fetched cloudfront credentials.

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -955,6 +955,11 @@ export function isProductionEnvironment() {
  * Fetch cookies signed by cloudfront which grant access to restricted content.
  * @returns {Promise<Response>}
  */
-export function fetchSignedCookies() {
-  return fetch('/dashboardapi/sign_cookies', {credentials: 'same-origin'});
+export function fetchSignedCookies(buster = false) {
+  return fetch(
+    `/dashboardapi/sign_cookies${buster ? `?bust=${Date.now()}` : ''}`,
+    {
+      credentials: 'same-origin',
+    }
+  );
 }


### PR DESCRIPTION
YA attempt to solve this. Deprecates the old PR @ #53981 .

This gives the `fetchCookies` function a buster parameter. If it's true, then we tack on a query string value with the current time in ms, so as to hopefully bust the cache, re-query the endpoint, and re-create the cookie. If it's false (the default), then it's loaded w/o the buster param.

Then the `danceRedux` file catches the `403` and calls signCookies and hands it a true buster param, to generate w/the query string and hopefully fix everything. 🤞 

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
