### PR TITLE
Add regenerate option to Dance AI modal

### DIFF
--- a/apps/src/dance/ai/DanceAiModal.tsx
+++ b/apps/src/dance/ai/DanceAiModal.tsx
@@ -127,6 +127,18 @@ const DanceAiModal: React.FunctionComponent<DanceAiProps> = ({onClose}) => {
     setMode(Mode.GENERATING);
   };
 
+  const handleRegenerateClick = () => {
+    // Reset state
+    setTypingDone(false);
+    setResultJson('');
+    setShowPreview(false);
+    setProcessingDone(false);
+    setGeneratingNodesDone(false);
+    setGeneratingDone(false);
+
+    handleGenerateClick();
+  };
+
   const handleProcessClick = () => {
     startAi();
     setMode(Mode.PROCESSING);
@@ -302,12 +314,10 @@ const DanceAiModal: React.FunctionComponent<DanceAiProps> = ({onClose}) => {
           {mode === Mode.SELECT_INPUTS && currentInputSlot < SLOT_COUNT && (
             <div className={moduleStyles.itemContainer}>
               {getAllItems(currentInputSlot).map(
-                (item: AiModalReturnedItem, index: number) => {
+                (item: AiModalReturnedItem) => {
                   return (
-                    <div
-                      tabIndex={
-                        index === 0 && currentInputSlot === 0 ? 0 : undefined
-                      }
+                    <button
+                      type={'button'}
                       key={item.id}
                       onClick={() => item.available && handleItemClick(item.id)}
                       style={{
@@ -460,16 +470,25 @@ const DanceAiModal: React.FunctionComponent<DanceAiProps> = ({onClose}) => {
 
         <div id="buttons-area" className={moduleStyles.buttonsArea}>
           {mode === Mode.RESULTS_FINAL && (
-            <Button
-              id="start-over"
-              text={'Start over'}
-              onClick={handleStartOverClick}
-              color={Button.ButtonColor.brandSecondaryDefault}
-              className={classNames(
-                moduleStyles.button,
-                moduleStyles.buttonLeft
-              )}
-            />
+            <div
+              id="buttons-area-left"
+              className={moduleStyles.buttonsAreaLeft}
+            >
+              <Button
+                id="start-over"
+                text={'Start over'}
+                onClick={handleStartOverClick}
+                color={Button.ButtonColor.brandSecondaryDefault}
+                className={classNames(moduleStyles.button)}
+              />
+              <Button
+                id="regenerate"
+                text={'Regenerate'}
+                onClick={handleRegenerateClick}
+                color={Button.ButtonColor.brandSecondaryDefault}
+                className={classNames(moduleStyles.button)}
+              />
+            </div>
           )}
 
           {mode === Mode.SELECT_INPUTS && currentInputSlot >= SLOT_COUNT && (

--- a/apps/src/dance/ai/dance-ai-modal.module.scss
+++ b/apps/src/dance/ai/dance-ai-modal.module.scss
@@ -1,4 +1,5 @@
 @import 'color.scss';
+@import '../../mixins.scss';
 
 @keyframes appear {
   0% {
@@ -11,7 +12,8 @@
 
 // Fade in for 1 seconds after a 1 second delay.
 @keyframes appear1 {
-  0%, 50% {
+  0%,
+  50% {
     opacity: 0;
   }
   100% {
@@ -30,7 +32,8 @@
 
 // 0.5 second pause, then scan over 2.5 seconds
 @keyframes scan-left-to-right {
-  0%, 16.6% {
+  0%,
+  16.6% {
     left: calc(50% - 65px);
   }
   100% {
@@ -49,7 +52,7 @@
 
 @keyframes right-to-center {
   0% {
-    left: 83%
+    left: 83%;
   }
   100% {
     left: 45%;
@@ -92,6 +95,7 @@
         animation: appear1 2s;
 
         .item {
+          @include remove-button-styles;
           background-size: contain;
           background-repeat: no-repeat;
           background-position: center;
@@ -277,12 +281,12 @@
       left: 0;
       width: 100%;
 
+      &Left {
+        margin-right: auto;
+      }
+
       .button {
         font-size: 16px;
-
-        &Left {
-          margin-right: auto;
-        }
       }
     }
   }


### PR DESCRIPTION
Adds a Renegerate option to the Dance AI modal which returns to the generate screen. For now, this will just regenerate the same output, but once [Tyrone's change](https://github.com/code-dot-org/code-dot-org/pull/54299) is implemented, we should get a random selection from the set of top options every time.

https://github.com/code-dot-org/code-dot-org/assets/85528507/31fbe234-0cc6-4f34-ac01-a75060a8974a


## Links

https://trello.com/c/asblrNte

## Testing story

Tested locally.

## Follow-up work

The transition animation could be cleaned up a bit but since the UI is still in a bit of flux I opted to leave that out until other elements are finalized. There's also potential to refactor the state in DanceAiModal a bit which I may look into as a fast follow.