### PR TITLE
refactored evidence levels for teachers and students

### DIFF
--- a/apps/src/templates/rubrics/EvidenceLevels.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevels.jsx
@@ -11,24 +11,27 @@ export default function EvidenceLevels({
   understanding,
   radioButtonCallback,
   submittedEvaluation,
+  isStudent,
 }) {
   const sortedEvidenceLevels = () => {
     const newArray = [...evidenceLevels];
     return newArray.sort((a, b) => b.understanding - a.understanding);
   };
-  if (canProvideFeedback) {
+  if (isStudent) {
+    return (
+      <EvidenceLevelsForStudents
+        evidenceLevels={sortedEvidenceLevels()}
+        submittedEvaluation={submittedEvaluation}
+      />
+    );
+  } else {
     return (
       <EvidenceLevelsForTeachers
         learningGoalKey={learningGoalKey}
         evidenceLevels={sortedEvidenceLevels()}
         understanding={understanding}
         radioButtonCallback={radioButtonCallback}
-      />
-    );
-  } else {
-    return (
-      <EvidenceLevelsForStudents
-        evidenceLevels={sortedEvidenceLevels()}
+        canProvideFeedback={canProvideFeedback}
         submittedEvaluation={submittedEvaluation}
       />
     );
@@ -42,4 +45,5 @@ EvidenceLevels.propTypes = {
   understanding: PropTypes.number,
   radioButtonCallback: PropTypes.func,
   submittedEvaluation: submittedEvaluationShape,
+  isStudent: PropTypes.bool,
 };

--- a/apps/src/templates/rubrics/EvidenceLevels.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevels.jsx
@@ -1,16 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import i18n from '@cdo/locale';
-import style from './rubrics.module.scss';
 import {evidenceLevelShape, submittedEvaluationShape} from './rubricShapes';
-import RadioButton from '@cdo/apps/componentLibrary/radioButton/RadioButton';
-import {
-  BodyThreeText,
-  Heading6,
-  StrongText,
-} from '@cdo/apps/componentLibrary/typography';
-import {UNDERSTANDING_LEVEL_STRINGS} from './rubricHelpers';
+import EvidenceLevelsForStudents from './EvidenceLevelsForStudents';
+import EvidenceLevelsForTeachers from './EvidenceLevelsForTeachers';
 
 export default function EvidenceLevels({
   evidenceLevels,
@@ -25,61 +17,20 @@ export default function EvidenceLevels({
     return newArray.sort((a, b) => b.understanding - a.understanding);
   };
   if (canProvideFeedback) {
-    const radioGroupName = `evidence-levels-${learningGoalKey}`;
     return (
-      <div className={style.evidenceLevelSet}>
-        <Heading6>{i18n.assignARubricScore()}</Heading6>
-        {sortedEvidenceLevels().map(evidenceLevel => (
-          <div
-            key={evidenceLevel.id}
-            className={classNames(
-              style.evidenceLevelOption,
-              style.evidenceLevelLabel
-            )}
-          >
-            {' '}
-            <RadioButton
-              label={UNDERSTANDING_LEVEL_STRINGS[evidenceLevel.understanding]}
-              name={radioGroupName}
-              value={evidenceLevel.id}
-              size="s"
-              onChange={() => {
-                radioButtonCallback(evidenceLevel.understanding);
-              }}
-              checked={understanding === evidenceLevel.understanding}
-            />
-            <BodyThreeText
-              className={classNames(style.evidenceLevelDescriptionIndented)}
-            >
-              {evidenceLevel.teacherDescription}
-            </BodyThreeText>
-          </div>
-        ))}
-      </div>
+      <EvidenceLevelsForTeachers
+        learningGoalKey={learningGoalKey}
+        evidenceLevels={sortedEvidenceLevels()}
+        understanding={understanding}
+        radioButtonCallback={radioButtonCallback}
+      />
     );
   } else {
     return (
-      <div className={style.evidenceLevelSet}>
-        <Heading6>{i18n.rubricScores()}</Heading6>
-        {sortedEvidenceLevels().map(evidenceLevel => (
-          <div
-            key={evidenceLevel.id}
-            className={classNames(style.evidenceLevelOption, {
-              [style.submittedEvaluationEvidenceLevel]:
-                submittedEvaluation?.understanding ===
-                evidenceLevel.understanding,
-            })}
-          >
-            {/*TODO: [DES-321] Label-two styles here*/}
-            <BodyThreeText>
-              <StrongText>
-                {UNDERSTANDING_LEVEL_STRINGS[evidenceLevel.understanding]}
-              </StrongText>
-            </BodyThreeText>
-            <BodyThreeText>{evidenceLevel.teacherDescription}</BodyThreeText>
-          </div>
-        ))}
-      </div>
+      <EvidenceLevelsForStudents
+        evidenceLevels={sortedEvidenceLevels()}
+        submittedEvaluation={submittedEvaluation}
+      />
     );
   }
 }

--- a/apps/src/templates/rubrics/EvidenceLevels.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevels.jsx
@@ -32,7 +32,6 @@ export default function EvidenceLevels({
         understanding={understanding}
         radioButtonCallback={radioButtonCallback}
         canProvideFeedback={canProvideFeedback}
-        submittedEvaluation={submittedEvaluation}
       />
     );
   }

--- a/apps/src/templates/rubrics/EvidenceLevelsForStudents.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForStudents.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import i18n from '@cdo/locale';
+import style from './rubrics.module.scss';
+import {evidenceLevelShape, submittedEvaluationShape} from './rubricShapes';
+import {
+  BodyThreeText,
+  Heading6,
+  StrongText,
+} from '@cdo/apps/componentLibrary/typography';
+import {UNDERSTANDING_LEVEL_STRINGS} from './rubricHelpers';
+
+export default function EvidenceLevelsForStudents({
+  evidenceLevels,
+  submittedEvaluation,
+}) {
+  return (
+    <div className={style.evidenceLevelSet}>
+      <Heading6>{i18n.rubricScores()}</Heading6>
+      <div className={style.evidenceLevelSetHorizontal}>
+        {evidenceLevels.map((evidenceLevel, index) => (
+          <div
+            key={evidenceLevel.id}
+            className={classNames(style.evidenceLevelOption, {
+              [style.submittedEvaluationEvidenceLevel]:
+                submittedEvaluation?.understanding ===
+                evidenceLevel.understanding,
+              [style.borderedBoxRight]: index < 3,
+            })}
+          >
+            {/*TODO: [DES-321] Label-two styles here*/}
+            <BodyThreeText>
+              <StrongText>
+                {UNDERSTANDING_LEVEL_STRINGS[evidenceLevel.understanding]}
+              </StrongText>
+            </BodyThreeText>
+            <BodyThreeText>{evidenceLevel.teacherDescription}</BodyThreeText>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+EvidenceLevelsForStudents.propTypes = {
+  evidenceLevels: PropTypes.arrayOf(evidenceLevelShape).isRequired,
+  submittedEvaluation: submittedEvaluationShape,
+};

--- a/apps/src/templates/rubrics/EvidenceLevelsForStudents.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForStudents.jsx
@@ -20,22 +20,23 @@ export default function EvidenceLevelsForStudents({
       <Heading6>{i18n.rubricScores()}</Heading6>
       <div className={style.evidenceLevelSetHorizontal}>
         {evidenceLevels.map((evidenceLevel, index) => (
-          <div
-            key={evidenceLevel.id}
-            className={classNames(style.evidenceLevelOption, {
-              [style.submittedEvaluationEvidenceLevel]:
-                submittedEvaluation?.understanding ===
-                evidenceLevel.understanding,
-              [style.borderedBoxRight]: index < 3,
-            })}
-          >
-            {/*TODO: [DES-321] Label-two styles here*/}
-            <BodyThreeText>
-              <StrongText>
-                {UNDERSTANDING_LEVEL_STRINGS[evidenceLevel.understanding]}
-              </StrongText>
-            </BodyThreeText>
-            <BodyThreeText>{evidenceLevel.teacherDescription}</BodyThreeText>
+          <div className={style.evidenceLevelInnerDiv}>
+            <div
+              key={evidenceLevel.id}
+              className={classNames(style.evidenceLevelOption, {
+                [style.submittedEvaluationEvidenceLevel]:
+                  submittedEvaluation?.understanding ===
+                  evidenceLevel.understanding,
+              })}
+            >
+              {/*TODO: [DES-321] Label-two styles here*/}
+              <BodyThreeText>
+                <StrongText>
+                  {UNDERSTANDING_LEVEL_STRINGS[evidenceLevel.understanding]}
+                </StrongText>
+              </BodyThreeText>
+              <BodyThreeText>{evidenceLevel.teacherDescription}</BodyThreeText>
+            </div>
           </div>
         ))}
       </div>

--- a/apps/src/templates/rubrics/EvidenceLevelsForStudents.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForStudents.jsx
@@ -20,9 +20,8 @@ export default function EvidenceLevelsForStudents({
       <Heading6>{i18n.rubricScores()}</Heading6>
       <div className={style.evidenceLevelSetHorizontal}>
         {evidenceLevels.map((evidenceLevel, index) => (
-          <div className={style.evidenceLevelInnerDiv}>
+          <div key={evidenceLevel.id} className={style.evidenceLevelInnerDiv}>
             <div
-              key={evidenceLevel.id}
               className={classNames(style.evidenceLevelOption, {
                 [style.submittedEvaluationEvidenceLevel]:
                   submittedEvaluation?.understanding ===

--- a/apps/src/templates/rubrics/EvidenceLevelsForTeachers.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForTeachers.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import i18n from '@cdo/locale';
 import style from './rubrics.module.scss';
-import {evidenceLevelShape, submittedEvaluationShape} from './rubricShapes';
+import {evidenceLevelShape} from './rubricShapes';
 import RadioButton from '@cdo/apps/componentLibrary/radioButton/RadioButton';
 import {
   BodyThreeText,
@@ -18,7 +18,6 @@ export default function EvidenceLevelsForTeachers({
   understanding,
   radioButtonCallback,
   canProvideFeedback,
-  submittedEvaluation,
 }) {
   const radioGroupName = `evidence-levels-${learningGoalKey}`;
   if (canProvideFeedback) {
@@ -58,14 +57,7 @@ export default function EvidenceLevelsForTeachers({
       <div className={style.evidenceLevelSet}>
         <Heading6>{i18n.rubricScores()}</Heading6>
         {evidenceLevels.map(evidenceLevel => (
-          <div
-            key={evidenceLevel.id}
-            className={classNames(style.evidenceLevelOption, {
-              [style.submittedEvaluationEvidenceLevel]:
-                submittedEvaluation?.understanding ===
-                evidenceLevel.understanding,
-            })}
-          >
+          <div key={evidenceLevel.id} className={style.evidenceLevelOption}>
             {/*TODO: [DES-321] Label-two styles here*/}
             <BodyThreeText>
               <StrongText>
@@ -86,5 +78,4 @@ EvidenceLevelsForTeachers.propTypes = {
   understanding: PropTypes.number,
   radioButtonCallback: PropTypes.func,
   canProvideFeedback: PropTypes.bool,
-  submittedEvaluation: submittedEvaluationShape,
 };

--- a/apps/src/templates/rubrics/EvidenceLevelsForTeachers.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForTeachers.jsx
@@ -3,9 +3,13 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import i18n from '@cdo/locale';
 import style from './rubrics.module.scss';
-import {evidenceLevelShape} from './rubricShapes';
+import {evidenceLevelShape, submittedEvaluationShape} from './rubricShapes';
 import RadioButton from '@cdo/apps/componentLibrary/radioButton/RadioButton';
-import {BodyThreeText, Heading6} from '@cdo/apps/componentLibrary/typography';
+import {
+  BodyThreeText,
+  StrongText,
+  Heading6,
+} from '@cdo/apps/componentLibrary/typography';
 import {UNDERSTANDING_LEVEL_STRINGS} from './rubricHelpers';
 
 export default function EvidenceLevelsForTeachers({
@@ -13,39 +17,67 @@ export default function EvidenceLevelsForTeachers({
   learningGoalKey,
   understanding,
   radioButtonCallback,
+  canProvideFeedback,
+  submittedEvaluation,
 }) {
   const radioGroupName = `evidence-levels-${learningGoalKey}`;
-  return (
-    <div className={style.evidenceLevelSet}>
-      <Heading6>{i18n.assignARubricScore()}</Heading6>
-      {evidenceLevels.map(evidenceLevel => (
-        <div
-          key={evidenceLevel.id}
-          className={classNames(
-            style.evidenceLevelOption,
-            style.evidenceLevelLabel
-          )}
-        >
-          {' '}
-          <RadioButton
-            label={UNDERSTANDING_LEVEL_STRINGS[evidenceLevel.understanding]}
-            name={radioGroupName}
-            value={evidenceLevel.id}
-            size="s"
-            onChange={() => {
-              radioButtonCallback(evidenceLevel.understanding);
-            }}
-            checked={understanding === evidenceLevel.understanding}
-          />
-          <BodyThreeText
-            className={classNames(style.evidenceLevelDescriptionIndented)}
+  if (canProvideFeedback) {
+    return (
+      <div className={style.evidenceLevelSet}>
+        <Heading6>{i18n.assignARubricScore()}</Heading6>
+        {evidenceLevels.map(evidenceLevel => (
+          <div
+            key={evidenceLevel.id}
+            className={classNames(
+              style.evidenceLevelOption,
+              style.evidenceLevelLabel
+            )}
           >
-            {evidenceLevel.teacherDescription}
-          </BodyThreeText>
-        </div>
-      ))}
-    </div>
-  );
+            {' '}
+            <RadioButton
+              label={UNDERSTANDING_LEVEL_STRINGS[evidenceLevel.understanding]}
+              name={radioGroupName}
+              value={evidenceLevel.id}
+              size="s"
+              onChange={() => {
+                radioButtonCallback(evidenceLevel.understanding);
+              }}
+              checked={understanding === evidenceLevel.understanding}
+            />
+            <BodyThreeText
+              className={classNames(style.evidenceLevelDescriptionIndented)}
+            >
+              {evidenceLevel.teacherDescription}
+            </BodyThreeText>
+          </div>
+        ))}
+      </div>
+    );
+  } else {
+    return (
+      <div className={style.evidenceLevelSet}>
+        <Heading6>{i18n.rubricScores()}</Heading6>
+        {evidenceLevels.map(evidenceLevel => (
+          <div
+            key={evidenceLevel.id}
+            className={classNames(style.evidenceLevelOption, {
+              [style.submittedEvaluationEvidenceLevel]:
+                submittedEvaluation?.understanding ===
+                evidenceLevel.understanding,
+            })}
+          >
+            {/*TODO: [DES-321] Label-two styles here*/}
+            <BodyThreeText>
+              <StrongText>
+                {UNDERSTANDING_LEVEL_STRINGS[evidenceLevel.understanding]}
+              </StrongText>
+            </BodyThreeText>
+            <BodyThreeText>{evidenceLevel.teacherDescription}</BodyThreeText>
+          </div>
+        ))}
+      </div>
+    );
+  }
 }
 
 EvidenceLevelsForTeachers.propTypes = {
@@ -53,4 +85,6 @@ EvidenceLevelsForTeachers.propTypes = {
   learningGoalKey: PropTypes.string,
   understanding: PropTypes.number,
   radioButtonCallback: PropTypes.func,
+  canProvideFeedback: PropTypes.bool,
+  submittedEvaluation: submittedEvaluationShape,
 };

--- a/apps/src/templates/rubrics/EvidenceLevelsForTeachers.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForTeachers.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import i18n from '@cdo/locale';
+import style from './rubrics.module.scss';
+import {evidenceLevelShape} from './rubricShapes';
+import RadioButton from '@cdo/apps/componentLibrary/radioButton/RadioButton';
+import {BodyThreeText, Heading6} from '@cdo/apps/componentLibrary/typography';
+import {UNDERSTANDING_LEVEL_STRINGS} from './rubricHelpers';
+
+export default function EvidenceLevelsForTeachers({
+  evidenceLevels,
+  learningGoalKey,
+  understanding,
+  radioButtonCallback,
+}) {
+  const radioGroupName = `evidence-levels-${learningGoalKey}`;
+  return (
+    <div className={style.evidenceLevelSet}>
+      <Heading6>{i18n.assignARubricScore()}</Heading6>
+      {evidenceLevels.map(evidenceLevel => (
+        <div
+          key={evidenceLevel.id}
+          className={classNames(
+            style.evidenceLevelOption,
+            style.evidenceLevelLabel
+          )}
+        >
+          {' '}
+          <RadioButton
+            label={UNDERSTANDING_LEVEL_STRINGS[evidenceLevel.understanding]}
+            name={radioGroupName}
+            value={evidenceLevel.id}
+            size="s"
+            onChange={() => {
+              radioButtonCallback(evidenceLevel.understanding);
+            }}
+            checked={understanding === evidenceLevel.understanding}
+          />
+          <BodyThreeText
+            className={classNames(style.evidenceLevelDescriptionIndented)}
+          >
+            {evidenceLevel.teacherDescription}
+          </BodyThreeText>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+EvidenceLevelsForTeachers.propTypes = {
+  evidenceLevels: PropTypes.arrayOf(evidenceLevelShape).isRequired,
+  learningGoalKey: PropTypes.string,
+  understanding: PropTypes.number,
+  radioButtonCallback: PropTypes.func,
+};

--- a/apps/src/templates/rubrics/LearningGoal.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.jsx
@@ -35,6 +35,7 @@ export default function LearningGoal({
   aiUnderstanding,
   aiConfidence,
   submittedEvaluation,
+  isStudent,
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [isAutosaving, setIsAutosaving] = useState(false);
@@ -281,6 +282,7 @@ export default function LearningGoal({
             understanding={displayUnderstanding}
             radioButtonCallback={radioButtonCallback}
             submittedEvaluation={submittedEvaluation}
+            isStudent={isStudent}
           />
           {learningGoal.tips && (
             <div>
@@ -306,6 +308,7 @@ LearningGoal.propTypes = {
   aiUnderstanding: PropTypes.number,
   aiConfidence: PropTypes.number,
   submittedEvaluation: submittedEvaluationShape,
+  isStudent: PropTypes.bool,
 };
 
 const AiToken = () => {

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -186,6 +186,7 @@ export default function RubricContent({
             studentLevelInfo={studentLevelInfo}
             aiUnderstanding={getAiUnderstanding(lg.id)}
             aiConfidence={getAiConfidence(lg.id)}
+            isStudent={false}
           />
         ))}
       </div>

--- a/apps/src/templates/rubrics/StudentRubricView.jsx
+++ b/apps/src/templates/rubrics/StudentRubricView.jsx
@@ -41,6 +41,7 @@ export default function StudentRubricView({rubric}) {
           }
           /* TODO: [AITT-161] add reporting data for the student case */
           reportingData={{}}
+          isStudent={true}
         />
       ))}
     </div>

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -351,6 +351,19 @@ h2.studentName {
   }
 }
 
+.evidenceLevelSetHorizontal {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  width: 100%;
+
+  > div {
+    width: 100%;
+    padding: 0.25rem;
+    border-right: 1px solid $neutral_dark40;
+  }
+}
+
 .evidenceLevelSet {
   display: flex;
   align-items: flex-start;
@@ -395,7 +408,6 @@ h2.studentName {
 
 .submittedEvaluationEvidenceLevel {
   border-radius: 4px;
-  border-width: 0;
   background: $light_primary_100;
 }
 

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -360,7 +360,7 @@ h2.studentName {
 .evidenceLevelInnerDiv:first-child {
   padding: 1em;
   width: 100%;
-  border-left: 0px;
+  border-left: 0;
 }
 
 .evidenceLevelInnerDiv {

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -354,14 +354,19 @@ h2.studentName {
 .evidenceLevelSetHorizontal {
   display: flex;
   flex-direction: row;
-  gap: 0.5rem;
   width: 100%;
+}
 
-  > div {
-    width: 100%;
-    padding: 0.25rem;
-    border-right: 1px solid $neutral_dark40;
-  }
+.evidenceLevelInnerDiv:first-child {
+  padding: 1em;
+  width: 100%;
+  border-left: 0px;
+}
+
+.evidenceLevelInnerDiv {
+  padding: 1em;
+  border-left: 1px solid #a9acaf;
+  width: 100%
 }
 
 .evidenceLevelSet {
@@ -409,6 +414,7 @@ h2.studentName {
 .submittedEvaluationEvidenceLevel {
   border-radius: 4px;
   background: $light_primary_100;
+  height: 100%;
 }
 
 .studentLearningGoalContainer {

--- a/apps/test/unit/templates/rubrics/EvidenceLevelsForStudentsTest.jsx
+++ b/apps/test/unit/templates/rubrics/EvidenceLevelsForStudentsTest.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {expect} from '../../../util/reconfiguredChai';
+import {shallow} from 'enzyme';
+import EvidenceLevelsForStudents from '@cdo/apps/templates/rubrics/EvidenceLevelsForStudents';
+import {UNDERSTANDING_LEVEL_STRINGS} from '@cdo/apps/templates/rubrics/rubricHelpers';
+
+const DEFAULT_PROPS = {
+  evidenceLevels: [
+    {id: 1, understanding: 0, teacherDescription: 'test1'},
+    {id: 2, understanding: 1, teacherDescription: 'test2'},
+  ],
+};
+
+describe('EvidenceLevelsForStudents', () => {
+  it('renders evidence levels', () => {
+    const wrapper = shallow(<EvidenceLevelsForStudents {...DEFAULT_PROPS} />);
+    expect(wrapper.find('Heading6').length).to.equal(1);
+    expect(wrapper.find('Heading6').props().children).to.equal('Rubric Scores');
+    expect(wrapper.find('Memo(RadioButton)').length).to.equal(0);
+    // Two BodyThreeText per evidence level
+    expect(wrapper.find('BodyThreeText').length).to.equal(
+      DEFAULT_PROPS.evidenceLevels.length * 2
+    );
+    const firstEvidenceLevel = DEFAULT_PROPS.evidenceLevels[0];
+    expect(wrapper.find('StrongText').at(0).props().children).to.equal(
+      UNDERSTANDING_LEVEL_STRINGS[firstEvidenceLevel.understanding]
+    );
+    expect(wrapper.find('BodyThreeText').at(1).props().children).to.equal(
+      firstEvidenceLevel.teacherDescription
+    );
+  });
+});

--- a/apps/test/unit/templates/rubrics/EvidenceLevelsForTeachersTest.jsx
+++ b/apps/test/unit/templates/rubrics/EvidenceLevelsForTeachersTest.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {expect} from '../../../util/reconfiguredChai';
+import {shallow, mount} from 'enzyme';
+import sinon from 'sinon';
+import EvidenceLevelsForTeachers from '@cdo/apps/templates/rubrics/EvidenceLevelsForTeachers';
+import {UNDERSTANDING_LEVEL_STRINGS} from '@cdo/apps/templates/rubrics/rubricHelpers';
+
+const DEFAULT_PROPS = {
+  evidenceLevels: [
+    {id: 1, understanding: 0, teacherDescription: 'test1'},
+    {id: 2, understanding: 1, teacherDescription: 'test2'},
+  ],
+  learningGoalKey: 'key-1',
+};
+
+describe('EvidenceLevels', () => {
+  it('renders evidence levels', () => {
+    const wrapper = shallow(<EvidenceLevelsForTeachers {...DEFAULT_PROPS} />);
+    expect(wrapper.find('Heading6').length).to.equal(1);
+    expect(wrapper.find('Heading6').props().children).to.equal(
+      'Assign a Rubric Score'
+    );
+    expect(wrapper.find('Memo(RadioButton)').length).to.equal(
+      DEFAULT_PROPS.evidenceLevels.length
+    );
+    expect(wrapper.find('BodyThreeText').length).to.equal(
+      DEFAULT_PROPS.evidenceLevels.length
+    );
+    const firstEvidenceLevel = DEFAULT_PROPS.evidenceLevels[0];
+    expect(wrapper.find('BodyThreeText').at(0).props().children).to.equal(
+      firstEvidenceLevel.teacherDescription
+    );
+    expect(wrapper.find('Memo(RadioButton)').at(0).prop('label')).to.equal(
+      UNDERSTANDING_LEVEL_STRINGS[firstEvidenceLevel.understanding]
+    );
+  });
+
+  it('calls radioButtonCallback when understanding is selected', () => {
+    const callback = sinon.stub();
+    const wrapper = mount(
+      <EvidenceLevelsForTeachers
+        {...DEFAULT_PROPS}
+        radioButtonCallback={callback}
+      />
+    );
+    wrapper.find('input').first().simulate('change');
+    sinon.assert.calledOnce(callback);
+    wrapper.unmount();
+  });
+});

--- a/apps/test/unit/templates/rubrics/EvidenceLevelsForTeachersTest.jsx
+++ b/apps/test/unit/templates/rubrics/EvidenceLevelsForTeachersTest.jsx
@@ -13,7 +13,7 @@ const DEFAULT_PROPS = {
   learningGoalKey: 'key-1',
 };
 
-describe('EvidenceLevels', () => {
+describe('EvidenceLevelsForTeachers', () => {
   it('renders evidence levels', () => {
     const wrapper = shallow(
       <EvidenceLevelsForTeachers {...DEFAULT_PROPS} canProvideFeedback={true} />

--- a/apps/test/unit/templates/rubrics/EvidenceLevelsForTeachersTest.jsx
+++ b/apps/test/unit/templates/rubrics/EvidenceLevelsForTeachersTest.jsx
@@ -15,7 +15,9 @@ const DEFAULT_PROPS = {
 
 describe('EvidenceLevels', () => {
   it('renders evidence levels', () => {
-    const wrapper = shallow(<EvidenceLevelsForTeachers {...DEFAULT_PROPS} />);
+    const wrapper = shallow(
+      <EvidenceLevelsForTeachers {...DEFAULT_PROPS} canProvideFeedback={true} />
+    );
     expect(wrapper.find('Heading6').length).to.equal(1);
     expect(wrapper.find('Heading6').props().children).to.equal(
       'Assign a Rubric Score'
@@ -41,10 +43,29 @@ describe('EvidenceLevels', () => {
       <EvidenceLevelsForTeachers
         {...DEFAULT_PROPS}
         radioButtonCallback={callback}
+        canProvideFeedback={true}
       />
     );
     wrapper.find('input').first().simulate('change');
     sinon.assert.calledOnce(callback);
     wrapper.unmount();
+  });
+
+  it('renders evidence levels without RadioButtons when the teacher cannot provide feedback', () => {
+    const wrapper = shallow(<EvidenceLevelsForTeachers {...DEFAULT_PROPS} />);
+    expect(wrapper.find('Heading6').length).to.equal(1);
+    expect(wrapper.find('Heading6').props().children).to.equal('Rubric Scores');
+    expect(wrapper.find('Memo(RadioButton)').length).to.equal(0);
+    // Two BodyThreeText per evidence level
+    expect(wrapper.find('BodyThreeText').length).to.equal(
+      DEFAULT_PROPS.evidenceLevels.length * 2
+    );
+    const firstEvidenceLevel = DEFAULT_PROPS.evidenceLevels[0];
+    expect(wrapper.find('StrongText').at(0).props().children).to.equal(
+      UNDERSTANDING_LEVEL_STRINGS[firstEvidenceLevel.understanding]
+    );
+    expect(wrapper.find('BodyThreeText').at(1).props().children).to.equal(
+      firstEvidenceLevel.teacherDescription
+    );
   });
 });

--- a/apps/test/unit/templates/rubrics/EvidenceLevelsTest.jsx
+++ b/apps/test/unit/templates/rubrics/EvidenceLevelsTest.jsx
@@ -13,15 +13,26 @@ const DEFAULT_PROPS = {
 
 describe('EvidenceLevels', () => {
   it('renders teachers view of evidence levels when the user can provide feedback', () => {
-    const wrapper = shallow(
-      <EvidenceLevels {...DEFAULT_PROPS} canProvideFeedback />
-    );
+    const wrapper = shallow(<EvidenceLevels {...DEFAULT_PROPS} />);
     expect(wrapper.find('EvidenceLevelsForTeachers').length).to.equal(1);
+    expect(
+      wrapper.find('EvidenceLevelsForTeachers').props().canProvideFeedback
+    ).to.equal(undefined);
   });
 
-  it('renders student view of evidence levels when feedback not available', () => {
+  it('renders teachers view of evidence levels when the user can provide feedback', () => {
     const wrapper = shallow(
-      <EvidenceLevels {...DEFAULT_PROPS} canProvideFeedback={false} />
+      <EvidenceLevels {...DEFAULT_PROPS} canProvideFeedback={true} />
+    );
+    expect(wrapper.find('EvidenceLevelsForTeachers').length).to.equal(1);
+    expect(
+      wrapper.find('EvidenceLevelsForTeachers').props().canProvideFeedback
+    ).to.equal(true);
+  });
+
+  it('renders student view of evidence levels when student is viewing the rubric', () => {
+    const wrapper = shallow(
+      <EvidenceLevels {...DEFAULT_PROPS} isStudent={true} />
     );
     expect(wrapper.find('EvidenceLevelsForStudents').length).to.equal(1);
   });

--- a/apps/test/unit/templates/rubrics/EvidenceLevelsTest.jsx
+++ b/apps/test/unit/templates/rubrics/EvidenceLevelsTest.jsx
@@ -12,7 +12,7 @@ const DEFAULT_PROPS = {
 };
 
 describe('EvidenceLevels', () => {
-  it('renders teachers view of evidence levels when the user can provide feedback', () => {
+  it('renders teachers view of evidence levels when the user can not provide feedback', () => {
     const wrapper = shallow(<EvidenceLevels {...DEFAULT_PROPS} />);
     expect(wrapper.find('EvidenceLevelsForTeachers').length).to.equal(1);
     expect(

--- a/apps/test/unit/templates/rubrics/EvidenceLevelsTest.jsx
+++ b/apps/test/unit/templates/rubrics/EvidenceLevelsTest.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import {expect} from '../../../util/reconfiguredChai';
-import {shallow, mount} from 'enzyme';
-import sinon from 'sinon';
+import {shallow} from 'enzyme';
 import EvidenceLevels from '@cdo/apps/templates/rubrics/EvidenceLevels';
-import {UNDERSTANDING_LEVEL_STRINGS} from '@cdo/apps/templates/rubrics/rubricHelpers';
 
 const DEFAULT_PROPS = {
   evidenceLevels: [
@@ -14,62 +12,17 @@ const DEFAULT_PROPS = {
 };
 
 describe('EvidenceLevels', () => {
-  it('renders evidence levels when feedback available', () => {
+  it('renders teachers view of evidence levels when the user can provide feedback', () => {
     const wrapper = shallow(
       <EvidenceLevels {...DEFAULT_PROPS} canProvideFeedback />
     );
-    expect(wrapper.find('Heading6').length).to.equal(1);
-    expect(wrapper.find('Heading6').props().children).to.equal(
-      'Assign a Rubric Score'
-    );
-    expect(wrapper.find('Memo(RadioButton)').length).to.equal(
-      DEFAULT_PROPS.evidenceLevels.length
-    );
-    expect(wrapper.find('BodyThreeText').length).to.equal(
-      DEFAULT_PROPS.evidenceLevels.length
-    );
-    const lastEvidenceLevel =
-      DEFAULT_PROPS.evidenceLevels[DEFAULT_PROPS.evidenceLevels.length - 1];
-    expect(wrapper.find('BodyThreeText').at(0).props().children).to.equal(
-      lastEvidenceLevel.teacherDescription
-    );
-    expect(wrapper.find('Memo(RadioButton)').at(0).prop('label')).to.equal(
-      UNDERSTANDING_LEVEL_STRINGS[lastEvidenceLevel.understanding]
-    );
+    expect(wrapper.find('EvidenceLevelsForTeachers').length).to.equal(1);
   });
 
-  it('renders evidence levels when feedback not available', () => {
+  it('renders student view of evidence levels when feedback not available', () => {
     const wrapper = shallow(
       <EvidenceLevels {...DEFAULT_PROPS} canProvideFeedback={false} />
     );
-    expect(wrapper.find('Heading6').length).to.equal(1);
-    expect(wrapper.find('Heading6').props().children).to.equal('Rubric Scores');
-    expect(wrapper.find('Memo(RadioButton)').length).to.equal(0);
-    // Two BodyThreeText per evidence level
-    expect(wrapper.find('BodyThreeText').length).to.equal(
-      DEFAULT_PROPS.evidenceLevels.length * 2
-    );
-    const lastEvidenceLevel =
-      DEFAULT_PROPS.evidenceLevels[DEFAULT_PROPS.evidenceLevels.length - 1];
-    expect(wrapper.find('StrongText').at(0).props().children).to.equal(
-      UNDERSTANDING_LEVEL_STRINGS[lastEvidenceLevel.understanding]
-    );
-    expect(wrapper.find('BodyThreeText').at(1).props().children).to.equal(
-      lastEvidenceLevel.teacherDescription
-    );
-  });
-
-  it('calls radioButtonCallback when understanding is selected', () => {
-    const callback = sinon.stub();
-    const wrapper = mount(
-      <EvidenceLevels
-        {...DEFAULT_PROPS}
-        canProvideFeedback
-        radioButtonCallback={callback}
-      />
-    );
-    wrapper.find('input').first().simulate('change');
-    sinon.assert.calledOnce(callback);
-    wrapper.unmount();
+    expect(wrapper.find('EvidenceLevelsForStudents').length).to.equal(1);
   });
 });

--- a/apps/test/unit/templates/rubrics/LearningGoalTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalTest.jsx
@@ -272,4 +272,27 @@ describe('LearningGoal', () => {
       'Limited Evidence'
     );
   });
+
+  it('passes isStudent down to EvidenceLevels', () => {
+    const props = {
+      learningGoal: {
+        learningGoal: 'Testing',
+        evidenceLevels: [{understanding: 1, teacherDescription: 'test'}],
+      },
+      submittedEvaluation: {
+        feedback: 'test feedback',
+        understanding: RubricUnderstandingLevels.LIMITED,
+      },
+      canProvideFeedback: false,
+      isStudent: true,
+    };
+    const wrapper = shallow(<LearningGoal {...props} />);
+    expect(wrapper.find('EvidenceLevels').props().isStudent).to.equal(true);
+    expect(wrapper.find('EvidenceLevels').props().submittedEvaluation).to.equal(
+      props.submittedEvaluation
+    );
+    expect(wrapper.find('EvidenceLevels').props().evidenceLevels).to.equal(
+      props.learningGoal.evidenceLevels
+    );
+  });
 });

--- a/apps/test/unit/templates/rubrics/StudentRubricViewTest.jsx
+++ b/apps/test/unit/templates/rubrics/StudentRubricViewTest.jsx
@@ -45,6 +45,7 @@ describe('StudentRubricView', () => {
       renderedLearningGoals.at(1).props().learningGoal.learningGoal
     ).to.equal('goal 2');
     expect(renderedLearningGoals.at(1).props().canProvideFeedback).to.be.false;
+    expect(renderedLearningGoals.at(1).props().isStudent).to.be.true;
   });
 
   it('fetches evaluation and passes props down', async () => {


### PR DESCRIPTION
This refactors the `EvidenceLevels` component by creating two different components - one for teacher view and another for  student view.  For the student view, the students will see a horizontal view of the evidence levels. 

The new student view also works for when text is really long and is responsive to screen resizing:
<img width="1125" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/bb91a14e-03c3-45a8-a359-523f6829d020">

Here's what the teacher side looks like for the various states:
<img width="1147" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/42798a5f-c098-459f-b73f-2147574cc244">


## Links

[AITT-219](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?selectedIssue=AITT-219)

## Testing story

Modified one testing file and added two testing files.