### PR TITLE
pass openai api key when calling python service

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -595,7 +595,7 @@ ec2_instance_id_endpoint: 'http://169.254.169.254/latest/meta-data/instance-id'
 # Credentials for OpenAI API
 openai_chat_completion_api_key: !Secret
 openai_chat_completion_org_id: !Secret
-openai_evaluate_rubric_api_key:
+openai_evaluate_rubric_api_key: !Secret
 openai_evaluate_rubric_org_id:
 
 ai_proxy_origin:

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -69,6 +69,7 @@ jwks_data:
 jwk_private_key_data:
 
 openai_chat_completion_api_key: ''
+openai_evaluate_rubric_api_key:
 
 ai_proxy_origin: 'http://localhost:5000'
 

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -35,6 +35,7 @@ class EvaluateRubricJob < ApplicationJob
     script_level = ScriptLevel.find(script_level_id)
     lesson_s3_name = EvaluateRubricJob.get_lesson_s3_name(script_level)
 
+    raise 'CDO.openai_evaluate_rubric_api_key not set' unless CDO.openai_evaluate_rubric_api_key
     raise "lesson_s3_name not found for script_level_id: #{script_level.id}" if lesson_s3_name.blank?
 
     rubric = Rubric.find_by!(lesson_id: script_level.lesson.id, level_id: script_level.level.id)
@@ -117,10 +118,11 @@ class EvaluateRubricJob < ApplicationJob
     rubric = read_file_from_s3(lesson_s3_name, 'standard_rubric.csv')
     examples = read_examples(lesson_s3_name)
     params.merge(
-      "code" => code,
-      "prompt" => prompt,
-      "rubric" => rubric,
-      "examples" => examples.to_json,
+      'code' => code,
+      'prompt' => prompt,
+      'rubric' => rubric,
+      'examples' => examples.to_json,
+      'api-key' => CDO.openai_evaluate_rubric_api_key,
     )
   end
 

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -16,6 +16,8 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
 
     # Don't actually talk to S3 when running SourceBucket.new
     AWS::S3.stubs :create_client
+
+    CDO.stubs(:openai_evaluate_rubric_api_key).returns('fake-api-key')
   end
 
   test "job succeeds on ai-enabled level" do
@@ -159,6 +161,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       "prompt" => 'fake-system-prompt',
       "rubric" => 'fake-standard-rubric',
       "examples" => expected_examples.to_json,
+      'api-key' => 'fake-api-key',
     }
     fake_ai_evaluations = [
       {


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-271 . Note that values for `CDO.openai_evaluate_rubric_api_key` have been uploaded to AWS secrets manager for production, staging, test, levelbuilder and adhoc environments.

## Testing story

- updated existing unit tests
- verified locally I can evaluate student work end-to-end after removing the api key from the aiproxy config