### PR TITLE
[Google Blockly] Clean up modal function editor styling

### DIFF
--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -10,6 +10,7 @@ import {
   MODAL_EDITOR_DELETE_ID,
 } from './functionEditorConstants';
 import {disableOrphans} from '@cdo/apps/blockly/eventHandlers';
+import CdoMetricsManager from './cdoMetricsManager';
 
 // This class creates the modal function editor, which is used by Sprite Lab and Artist.
 export default class FunctionEditor {
@@ -50,6 +51,9 @@ export default class FunctionEditor {
           vertical: true,
         },
         wheel: true,
+      },
+      plugins: {
+        metricsManager: CdoMetricsManager,
       },
       renderer: options.renderer,
       theme: Blockly.cdoUtils.getUserTheme(options.theme),

--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -312,8 +312,8 @@ export default class FunctionEditor {
   addEditorWorkspaceBlockConfig(blockConfig) {
     const returnValue = {
       ...blockConfig,
-      x: 50,
-      y: 50,
+      x: 20,
+      y: 20,
     };
     return returnValue;
   }

--- a/apps/src/blockly/components/ModalFunctionEditor.jsx
+++ b/apps/src/blockly/components/ModalFunctionEditor.jsx
@@ -6,8 +6,25 @@ import {
 } from '@cdo/apps/blockly/addons/functionEditorConstants';
 import moduleStyles from './modal-function-editor.module.scss';
 import classNames from 'classnames';
+import Button from '@cdo/apps/templates/Button';
+import msg from '@cdo/locale';
 
 export default function ModalFunctionEditor() {
+  function renderButton(id, text, color) {
+    /** functionEditor.js handles setting the click handlers on these buttons. */
+    return (
+      <Button
+        type="button"
+        id={id}
+        onClick={() => {}}
+        color={color}
+        size={Button.ButtonSize.narrow}
+      >
+        {text}
+      </Button>
+    );
+  }
+
   return (
     <div
       id={MODAL_EDITOR_ID}
@@ -18,12 +35,16 @@ export default function ModalFunctionEditor() {
     >
       <div className={classNames('toolbar', moduleStyles.toolbar)}>
         <div className={moduleStyles.buttons}>
-          <button type="button" id={MODAL_EDITOR_DELETE_ID}>
-            delete
-          </button>
-          <button type="button" id={MODAL_EDITOR_CLOSE_ID}>
-            close
-          </button>
+          {renderButton(
+            MODAL_EDITOR_DELETE_ID,
+            msg.delete(),
+            Button.ButtonColor.neutralDark
+          )}
+          {renderButton(
+            MODAL_EDITOR_CLOSE_ID,
+            msg.closeDialog(),
+            Button.ButtonColor.brandSecondaryDefault
+          )}
         </div>
       </div>
     </div>

--- a/apps/src/blockly/components/ModalFunctionEditor.jsx
+++ b/apps/src/blockly/components/ModalFunctionEditor.jsx
@@ -10,20 +10,9 @@ import Button from '@cdo/apps/templates/Button';
 import msg from '@cdo/locale';
 
 export default function ModalFunctionEditor() {
-  function renderButton(id, text, color) {
-    /** functionEditor.js handles setting the click handlers on these buttons. */
-    return (
-      <Button
-        type="button"
-        id={id}
-        onClick={() => {}}
-        color={color}
-        size={Button.ButtonSize.narrow}
-      >
-        {text}
-      </Button>
-    );
-  }
+  const buttonSize = Button.ButtonSize.narrow;
+  // functionEditor.js handles setting the click handlers on these buttons.
+  const emptyOnClick = () => {};
 
   return (
     <div
@@ -35,16 +24,24 @@ export default function ModalFunctionEditor() {
     >
       <div className={classNames('toolbar', moduleStyles.toolbar)}>
         <div className={moduleStyles.buttons}>
-          {renderButton(
-            MODAL_EDITOR_DELETE_ID,
-            msg.delete(),
-            Button.ButtonColor.neutralDark
-          )}
-          {renderButton(
-            MODAL_EDITOR_CLOSE_ID,
-            msg.closeDialog(),
-            Button.ButtonColor.brandSecondaryDefault
-          )}
+          <Button
+            type="button"
+            id={MODAL_EDITOR_DELETE_ID}
+            onClick={emptyOnClick}
+            color={Button.ButtonColor.neutralDark}
+            size={buttonSize}
+          >
+            {msg.delete()}
+          </Button>
+          <Button
+            type="button"
+            id={MODAL_EDITOR_CLOSE_ID}
+            onClick={emptyOnClick}
+            color={Button.ButtonColor.brandSecondaryDefault}
+            size={buttonSize}
+          >
+            {msg.closeDialog()}
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/src/blockly/components/modal-function-editor.module.scss
+++ b/apps/src/blockly/components/modal-function-editor.module.scss
@@ -12,7 +12,8 @@
 .toolbar {
   position: absolute;
   width: 100%;
-  top: 5px;
+  top: 10px;
+  right: 10px;
   z-index: 1;
 }
 

--- a/apps/src/blockly/components/modal-function-editor.module.scss
+++ b/apps/src/blockly/components/modal-function-editor.module.scss
@@ -5,34 +5,23 @@
   position: absolute;
   // TODO: Calculate these values based on the size of the workspace
   top: 30px;
+  left: 0;
   z-index: 1000;
   width: 100%;
   height: 100%;
-  bottom: 0;
-  background: $white;
+  // bottom: 0;
+  // background: $white;
 }
 
 .toolbar {
-  position: absolute;
-  left: 142px;
-  top: 10px;
-  width: 800px;
-  pointer-events: auto;
+  // position: absolute;
+  // left: 142px;
+  // top: 10px;
+  // width: 800px;
+  // z-index: 1;
+  //pointer-events: auto;
 }
 
 .buttons {
   float: right;
-}
-
-.inputs {
-  z-index: 0;
-}
-
-.inputTitleContainer {
-  padding: 10px;
-  width: 100%;
-}
-
-.wideInput {
-  width: 100%;
 }

--- a/apps/src/blockly/components/modal-function-editor.module.scss
+++ b/apps/src/blockly/components/modal-function-editor.module.scss
@@ -2,24 +2,18 @@
 
 .container {
   display: none;
-  position: absolute;
-  // TODO: Calculate these values based on the size of the workspace
-  top: 30px;
-  left: 0;
+  position: relative;
   z-index: 1000;
   width: 100%;
   height: 100%;
-  // bottom: 0;
-  // background: $white;
+  bottom: 0;
 }
 
 .toolbar {
-  // position: absolute;
-  // left: 142px;
-  // top: 10px;
-  // width: 800px;
-  // z-index: 1;
-  //pointer-events: auto;
+  position: absolute;
+  width: 100%;
+  top: 5px;
+  z-index: 1;
 }
 
 .buttons {

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1835,27 +1835,3 @@ div.WireframeButtons_active {
   width: 800px;
   margin-left: -400px;
 }
-
-// Modal Function Editor Styles. These are needed in order to make it so the blocks
-// show over the name and description inputs, but the name and description inputs
-// are still usable.
-
-.modalFunctionEditorContainer svg {
-  position: absolute;
-  top: 50;
-  left: 0;
-  // We use important here to override the background set by the theme.
-  // The modal function editor background must be transparent.
-  background: transparent !important;
-  pointer-events: none;
-}
-
-.modalFunctionEditorContainer svg .blocklyBlockCanvas,
-.modalFunctionEditorContainer .blocklyScrollbarVertical,
-.blocklyToolboxDiv {
-  pointer-events: visiblePainted;
-}
-
-.modalFunctionEditorContainer .injectionDiv {
-  pointer-events: none;
-}


### PR DESCRIPTION
A few style clean ups and updates to the modal function editor now that we no longer have a name and description input:
- Remove the styles that made the name/description inputs work. This makes it so the workspace now is clickable everywhere, and themes work.
- Update the delete and close buttons to use the design system buttons. In addition, make them placed responsively, rather than possibly being off the screen.
- Use `CdoMetricsManager` for `editorWorkspace` so a scroll bar does not show up until there is content to scroll.
- Move the definition block up in the editor workspace since we don't need to leave room for the name and description inputs anymore.

### Before
![Screenshot 2023-10-18 at 3 34 47 PM](https://github.com/code-dot-org/code-dot-org/assets/33666587/c91e5af5-d174-43eb-80eb-ad16c39b93a4)


### After
![Screenshot 2023-10-18 at 3 37 56 PM](https://github.com/code-dot-org/code-dot-org/assets/33666587/efcb7496-9136-4d54-a7f6-603b183973d1)


## Links

- jira tickets: [CT-16](https://codedotorg.atlassian.net/browse/CT-16), [CT-17](https://codedotorg.atlassian.net/browse/CT-17)

## Testing story
Tested locally

## Follow up work
We are still discussing if we want a border or banner around the workspace to make it clearer that you are editing a function/behavior.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
