### PR TITLE
Fix Backwards Ternary Logic in Cloudformation Template

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -512,7 +512,7 @@ Resources:
     Properties:
       # Temporarily hardcode the Ubuntu 20 image just for production-daemon, so we can gradually roll out the update.
       # TODO (infra): finish updating all environments, and restore this line to always just use IMAGE_ID
-      ImageId: <%=rack_env?(:production) ? 'ami-0261755bbcb8c4a84': IMAGE_ID%>
+      ImageId: <%=rack_env?(:production) ? 'ami-0261755bbcb8c4a84' : IMAGE_ID%>
       InstanceType: !Ref <%=frontends ? 'DaemonInstanceType' : 'InstanceType' %>
       IamInstanceProfile: !Ref DaemonInstanceProfile
       KeyName: <%=SSH_KEY_NAME%>

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -512,7 +512,7 @@ Resources:
     Properties:
       # Temporarily hardcode the Ubuntu 20 image just for production-daemon, so we can gradually roll out the update.
       # TODO (infra): finish updating all environments, and restore this line to always just use IMAGE_ID
-      ImageId: <%=rack_env?(:production) ? IMAGE_ID : 'ami-0261755bbcb8c4a84'%>
+      ImageId: <%=rack_env?(:production) ? 'ami-0261755bbcb8c4a84': IMAGE_ID%>
       InstanceType: !Ref <%=frontends ? 'DaemonInstanceType' : 'InstanceType' %>
       IamInstanceProfile: !Ref DaemonInstanceProfile
       KeyName: <%=SSH_KEY_NAME%>


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/54271/files#diff-05f735a77c1690d408705af877d23378558782cabe19b703c77beefd32c960f8R515, which attempted to hardcode the Ubuntu 20 AMI for the production daemon, but actually hardcoded it for all our *other* daemons.