### PR TITLE
set node name correctly for all daemon servers

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -544,7 +544,7 @@ Resources:
           #!/bin/bash -x
           <%=indent(erb_file(BOOTSTRAP_CHEF,
             resource_id: daemon,
-            node_name: '$STACK',
+            node_name: frontends ? '$ENVIRONMENT-daemon' : '$STACK',
             run_list: CDO.chef_local_mode ? ['recipe[cdo-apps]', 'recipe[cdo-home-ubuntu]'] : ['role[daemon]'],
             commit: nil, # track branch
             daemon: true


### PR DESCRIPTION
The existing logic results in `production-daemon` being given a node_name of `autoscale-prod`. This ensure that any environment where separate frontend instances are being created (therefore reducing the responsibility of this server to the pure daemon role) will have the daemon server named per our convention.

For reference, see our UserData script for the Console server:

```
      UserData:
        Fn::Base64: !Sub |
          #!/bin/bash -x
          <%=indent(erb_file(BOOTSTRAP_CHEF,
            resource_id: 'Console',
            node_name: '$ENVIRONMENT-console',
            run_list: CDO.chef_local_mode ? ['recipe[cdo-apps]', 'recipe[cdo-home-ubuntu]'] : ['role[console]'],
            commit: nil, # track branch
            daemon: false
          ), 10)%>
```

As of now, this would only affect production, because that's the only environment where `frontends` is truthy. A more focused alternative would be:

`rack_env?(:production) ? '$ENVIRONMENT-daemon' : '$STACK'`
