### PR TITLE
Default to Rubric tab when feedback is available

### DIFF
--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -230,6 +230,26 @@ class TopInstructions extends Component {
     }
 
     if (
+      !this.state.teacherViewingStudentWork &&
+      user &&
+      this.isViewingAsStudent &&
+      taRubric
+    ) {
+      promises.push(
+        topInstructionsDataApi
+          .getTaRubricFeedbackForStudent(taRubric.id)
+          .then(data => {
+            if (data.value?.length > 0) {
+              this.setState({
+                taRubricEvaluation: data.value,
+                tabSelected: TabType.TA_RUBRIC,
+              });
+            }
+          })
+      );
+    }
+
+    if (
       this.state.teacherViewingStudentWork &&
       user &&
       serverLevelId &&
@@ -781,7 +801,10 @@ class TopInstructions extends Component {
                 </div>
               )}
             {tabSelected === TabType.TA_RUBRIC && (
-              <StudentRubricView rubric={this.props.taRubric} />
+              <StudentRubricView
+                rubric={this.props.taRubric}
+                submittedEvaluation={this.state.taRubricEvaluation}
+              />
             )}
             {(this.isViewingAsTeacher || isViewingAsInstructorInTraining) &&
               (hasContainedLevels || teacherMarkdown) && (

--- a/apps/src/templates/instructions/topInstructionsDataApi.js
+++ b/apps/src/templates/instructions/topInstructionsDataApi.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import HttpClient from '@cdo/apps/util/HttpClient';
 
 export function getTeacherFeedbackForStudent(studentId, levelId, scriptId) {
   return $.ajax({
@@ -36,4 +37,8 @@ export function incrementVisitCount(latestFeedbackId, token) {
     contentType: 'application/json;charset=UTF-8',
     headers: {'X-CSRF-Token': token},
   });
+}
+
+export function getTaRubricFeedbackForStudent(rubricId) {
+  return HttpClient.fetchJson(`/rubrics/${rubricId}/get_teacher_evaluations`);
 }

--- a/apps/src/templates/rubrics/StudentRubricView.jsx
+++ b/apps/src/templates/rubrics/StudentRubricView.jsx
@@ -1,28 +1,18 @@
-import React, {useEffect, useState} from 'react';
+import React, {useMemo} from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import HttpClient from '@cdo/apps/util/HttpClient';
 import style from './rubrics.module.scss';
-import {rubricShape} from './rubricShapes';
+import {rubricShape, submittedEvaluationShape} from './rubricShapes';
 import LearningGoal from './LearningGoal';
 
-export default function StudentRubricView({rubric}) {
-  const [evaluationsByLearningGoal, setEvaluationsByLearningGoal] =
-    useState(null);
-
-  useEffect(() => {
-    HttpClient.fetchJson(`/rubrics/${rubric.id}/get_teacher_evaluations`)
-      .then(response => {
-        const data = response.value;
-        const evaluationMap = {};
-        data.forEach(evaluation => {
-          evaluationMap[evaluation.learning_goal_id] = evaluation;
-        });
-        setEvaluationsByLearningGoal(evaluationMap);
-      })
-      .catch(error => {
-        console.error(error);
-      });
-  }, [rubric.id]);
+export default function StudentRubricView({rubric, submittedEvaluation}) {
+  const evaluationsByLearningGoal = useMemo(() => {
+    const evaluationMap = {};
+    submittedEvaluation?.forEach(evaluation => {
+      evaluationMap[evaluation.learning_goal_id] = evaluation;
+    });
+    return evaluationMap;
+  }, [submittedEvaluation]);
 
   return (
     <div
@@ -49,4 +39,5 @@ export default function StudentRubricView({rubric}) {
 
 StudentRubricView.propTypes = {
   rubric: rubricShape.isRequired,
+  submittedEvaluation: PropTypes.arrayOf(submittedEvaluationShape),
 };

--- a/apps/test/unit/templates/rubrics/StudentRubricViewTest.jsx
+++ b/apps/test/unit/templates/rubrics/StudentRubricViewTest.jsx
@@ -65,8 +65,6 @@ describe('StudentRubricView', () => {
         ]}
       />
     );
-    //await new Promise(resolve => setTimeout(resolve, 0));
-    //wrapper.update();
 
     const renderedLearningGoals = wrapper.find('LearningGoal');
     expect(renderedLearningGoals).to.have.lengthOf(2);

--- a/apps/test/unit/templates/rubrics/StudentRubricViewTest.jsx
+++ b/apps/test/unit/templates/rubrics/StudentRubricViewTest.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import {expect} from '../../../util/reconfiguredChai';
-import {mount, shallow} from 'enzyme';
-import sinon from 'sinon';
-import HttpClient from '@cdo/apps/util/HttpClient';
+import {shallow} from 'enzyme';
 import StudentRubricView from '@cdo/apps/templates/rubrics/StudentRubricView';
 
 describe('StudentRubricView', () => {
@@ -47,11 +45,11 @@ describe('StudentRubricView', () => {
     expect(renderedLearningGoals.at(1).props().canProvideFeedback).to.be.false;
   });
 
-  it('fetches evaluation and passes props down', async () => {
-    const fetchStub = sinon.stub(HttpClient, 'fetchJson');
-    fetchStub.returns(
-      Promise.resolve({
-        value: [
+  it('passes evaluation down to learning goals', async () => {
+    const wrapper = shallow(
+      <StudentRubricView
+        rubric={defaultRubric}
+        submittedEvaluation={[
           {
             id: 1,
             learning_goal_id: 1,
@@ -64,13 +62,11 @@ describe('StudentRubricView', () => {
             understanding: 3,
             feedback: 'feedback for learning goal 2',
           },
-        ],
-      })
+        ]}
+      />
     );
-
-    const wrapper = mount(<StudentRubricView rubric={defaultRubric} />);
-    await new Promise(resolve => setTimeout(resolve, 0));
-    wrapper.update();
+    //await new Promise(resolve => setTimeout(resolve, 0));
+    //wrapper.update();
 
     const renderedLearningGoals = wrapper.find('LearningGoal');
     expect(renderedLearningGoals).to.have.lengthOf(2);


### PR DESCRIPTION
Defaults to the rubric view when teacher evaluations are available.

I followed the pattern we use for the Feedback tab and moved the call to fetch the teacher evaluations up to `TopInstructions` so that they would be fetched on page load. Unlike the Feedback tab, the Rubrics tab is shown whether or not there is feedback but, like the Feedback tab, is switched to automatically if there is feedback.