### PR TITLE
Amplitude logging for visiting certificates batch page

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -87,6 +87,8 @@ const EVENTS = {
   TA_RUBRIC_SUBMITTED: 'TA Rubric Submitted',
 
   AGE_21_SELECTED_EVENT: 'Age 21+ Selected',
+
+  BATCH_CERTIFICATES_PAGE_VIEWED: 'Bacth Certificates Page Viewed',
 };
 
 export {EVENTS};

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -88,7 +88,7 @@ const EVENTS = {
 
   AGE_21_SELECTED_EVENT: 'Age 21+ Selected',
 
-  BATCH_CERTIFICATES_PAGE_VIEWED: 'Bacth Certificates Page Viewed',
+  BATCH_CERTIFICATES_PAGE_VIEWED: 'Batch Certificates Page Viewed',
 };
 
 export {EVENTS};

--- a/apps/src/sites/studio/pages/certificates/batch.js
+++ b/apps/src/sites/studio/pages/certificates/batch.js
@@ -2,10 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import getScriptData from '@cdo/apps/util/getScriptData';
 import CertificateBatch from '@cdo/apps/templates/certificates/CertificateBatch';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 $(document).ready(function () {
   const certificateData = getScriptData('certificate');
   const {courseName, courseTitle, studentNames, imageUrl} = certificateData;
+  analyticsReporter.sendEvent(EVENTS.BATCH_CERTIFICATES_PAGE_VIEWED);
   ReactDOM.render(
     <CertificateBatch
       courseName={courseName}


### PR DESCRIPTION
Adds amplitude logging for visiting the certificates batch page.
`certificates/batch`

### Log statement after loading the certificates batch page

<img width="506" alt="Screenshot 2023-10-19 at 10 53 34 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/d500e7a2-3204-459e-84c1-78f21cbb092c">


## Links


- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?selectedIssue=ACQ-1069)


## Testing story
Local







## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
