### PR TITLE
Adds migration for adding rubric_ai_evaluations table.

### DIFF
--- a/dashboard/db/migrate/20231020022038_create_rubric_ai_evaluations.rb
+++ b/dashboard/db/migrate/20231020022038_create_rubric_ai_evaluations.rb
@@ -3,6 +3,7 @@ class CreateRubricAiEvaluations < ActiveRecord::Migration[6.1]
     create_table :rubric_ai_evaluations do |t|
       t.references :user, index: true, foreign_key: true, null: false, type: :integer
       t.references :requester, index: {name: 'rubric_ai_evaluation_requester_index'}, foreign_key: {to_table: :users}, null: false, type: :integer
+      t.references :rubric, index: {name: 'rubric_ai_evaluation_rubric_index'}, foreign_key: true, null: false, type: :bigint
       t.integer :project_id, null: false
       t.string :project_version, limit: 255
       t.integer :status

--- a/dashboard/db/migrate/20231020022038_create_rubric_ai_evaluations.rb
+++ b/dashboard/db/migrate/20231020022038_create_rubric_ai_evaluations.rb
@@ -1,0 +1,13 @@
+class CreateRubricAiEvaluations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :rubric_ai_evaluations do |t|
+      t.references :user, index: true, foreign_key: true, null: false, type: :integer
+      t.references :requester, index: {name: 'rubric_ai_evaluation_requester_index'}, foreign_key: {to_table: :users}, null: false, type: :integer
+      t.integer :project_id, null: false
+      t.string :project_version, limit: 255
+      t.integer :status
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1653,12 +1653,14 @@ ActiveRecord::Schema.define(version: 2023_10_26_194936) do
   create_table "rubric_ai_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "requester_id", null: false
+    t.bigint "rubric_id", null: false
     t.integer "project_id", null: false
     t.string "project_version"
     t.integer "status"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["requester_id"], name: "rubric_ai_evaluation_requester_index"
+    t.index ["rubric_id"], name: "rubric_ai_evaluation_rubric_index"
     t.index ["user_id"], name: "index_rubric_ai_evaluations_on_user_id"
   end
 
@@ -2331,6 +2333,7 @@ ActiveRecord::Schema.define(version: 2023_10_26_194936) do
   add_foreign_key "plc_course_units", "scripts"
   add_foreign_key "plc_learning_modules", "stages"
   add_foreign_key "queued_account_purges", "users"
+  add_foreign_key "rubric_ai_evaluations", "rubrics"
   add_foreign_key "rubric_ai_evaluations", "users"
   add_foreign_key "rubric_ai_evaluations", "users", column: "requester_id"
   add_foreign_key "school_infos", "school_districts"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1650,6 +1650,18 @@ ActiveRecord::Schema.define(version: 2023_10_26_194936) do
     t.index ["name", "url"], name: "index_resources_on_name_and_url", type: :fulltext
   end
 
+  create_table "rubric_ai_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "requester_id", null: false
+    t.integer "project_id", null: false
+    t.string "project_version"
+    t.integer "status"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["requester_id"], name: "rubric_ai_evaluation_requester_index"
+    t.index ["user_id"], name: "index_rubric_ai_evaluations_on_user_id"
+  end
+
   create_table "rubrics", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.integer "level_id", null: false
@@ -2319,6 +2331,8 @@ ActiveRecord::Schema.define(version: 2023_10_26_194936) do
   add_foreign_key "plc_course_units", "scripts"
   add_foreign_key "plc_learning_modules", "stages"
   add_foreign_key "queued_account_purges", "users"
+  add_foreign_key "rubric_ai_evaluations", "users"
+  add_foreign_key "rubric_ai_evaluations", "users", column: "requester_id"
   add_foreign_key "school_infos", "school_districts"
   add_foreign_key "school_infos", "schools"
   add_foreign_key "school_stats_by_years", "schools"


### PR DESCRIPTION
This adds a migration to create the `rubric_ai_evaluations` table. This table will be the general record for an AI evaluation. `LearningGoalAiEvaluation` records will be relegated to children of this one.

This migration and table are straightforward.

A `RubricAiEvaluation` table:
- belongs to a User (who is being assessed)
- belongs to a User via `requester_id` (who requested it)
- belongs to a Project (what is being assessed)
- has a `project_version` (what version of the project is being assessed)
- has a `status` integer that can attach an enumerated value for queued/success/failure/etc (what happened)

These columns are all redundantly found in the learning_goal_ai_evaluations table. They have to be copied over in a future commit.

## Links

- jira ticket: [AITT-272](https://codedotorg.atlassian.net/browse/AITT-272)

## Follow-up work

Task list for adding the `RubricAiEvaluation` model:

- [x] Add the migration (**THIS PR**)
- [ ] Add the model and start writing to the new table and the old (https://github.com/code-dot-org/code-dot-org/pull/54379)
- [ ] Forge new `LearningGoalAiEvaluation` record (and move old one to new name) with a foreign key to point to `RubricAiEvaluation` (https://github.com/code-dot-org/code-dot-org/pull/54386)
- [ ] Add a data migration to move the old data from `LearningGoalAiEvaluation` records to this one (https://github.com/code-dot-org/code-dot-org/pull/54413)
- [ ] Drop old LearningGoalAiEvaluation table and properly add in logic to write/query RubricAiEvaluation (https://github.com/code-dot-org/code-dot-org/pull/54435)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
