### PR TITLE
Remove Deprecated Method for Collecting CloudWatch Metrics

### DIFF
--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -26,8 +26,8 @@
       Dimensions:
         - {Name: InstanceId, Value: !Ref <%=daemon%>}
       EvaluationPeriods: 7
-      MetricName: MemoryUtilization
-      Namespace: 'System/Linux'
+      MetricName: mem_used_percent
+      Namespace: CWAgent
       Period: 60
       Statistic: Maximum
       Threshold: 87

--- a/bin/cron/restart_high_memory_frontend_services
+++ b/bin/cron/restart_high_memory_frontend_services
@@ -42,7 +42,7 @@ def main
     )
     ChatClient.message 'infra-production', "Found #{production_frontends.count} production front end webservers"
     production_frontends.each do |instance|
-      memory_utilization = cloudwatch_resource.metric('System/Linux', 'MemoryUtilization').get_statistics(
+      memory_utilization = cloudwatch_resource.metric('CWAgent', 'mem_used_percent').get_statistics(
         {
           dimensions: [
             {

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -155,11 +155,6 @@
   # cronjobs that run on all instances in all environments go here:
 
   cronjob at:"#{rand(60)} * * * *", do:"#{deploy_dir('bin','upload-logs-to-s3')} dashboard pegasus"
-
-  # report memory and disk space utilization to CloudWatch every minute
-  # we do not use the cronjob helper method because this should not execute with
-  # bundle.
-  $crontab << "*/1 * * * * /usr/local/aws-scripts-mon/mon-put-instance-data.pl --mem-util --disk-space-util --disk-path=/ --from-cron#{node['cdo-apps']['daemon'] ? '' : ' --auto-scaling'}"
 %>
 #
 # node: <%= node.name %>


### PR DESCRIPTION
The CloudWatch monitoring scripts are deprecated in favor of the CloudWatch agent, which we started using with https://github.com/code-dot-org/code-dot-org/pull/32110

## Links

- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-scripts-intro.html

## Follow-up work

We may still have dashboards that are referencing the old `System/Linux/MemoryUtilization` metrics; those should be updated to use `CWAgent/mem_used_percent`