### PR TITLE
Remove manual block translation

### DIFF
--- a/dashboard/config/locales/blocks.en.yml
+++ b/dashboard/config/locales/blocks.en.yml
@@ -652,65 +652,6 @@ en:
             '"tropical"': Tropical
             '"vintage"': Vintage
             '"warm"': Warm
-      Dancelab_setBackgroundEffectWithPaletteAI:
-        text: |-
-          set background effect
-          {PALETTE} {EFFECT}
-        options:
-          EFFECT:
-            '"none"': None
-            '"rand"': "(Random)"
-            '"blooming_petals"': Blooming Petals
-            '"circles"': Circles
-            '"clouds"': Clouds
-            '"frosted_grid"': Frosted Grid
-            '"quads"': Angles
-            '"color_cycle"': Colors
-            '"diamonds"': Diamonds
-            '"disco_ball"': Disco Ball
-            '"fireworks"': Fireworks
-            '"flowers"': Flowers
-            '"growing_stars"': Growing Stars
-            '"higher_power"': Higher Power
-            '"swirl"': Hypno
-            '"kaleidoscope"': Kaleidoscope
-            '"lasers"': Laser Dance Floor
-            '"splatter"': Paint Splatter
-            '"rainbow"': Rainbow
-            '"ripples_random"': Random Ripples
-            '"ripples"': Ripples
-            '"snowflakes"': Snow
-            '"text"': Song Names
-            '"squiggles"': Squiggles
-            '"galaxy"': Space
-            '"sparkles"': Sparkles
-            '"spiral"': Spiral
-            '"disco"': Squares
-            '"stars"': Stars
-            '"starburst"': Starburst
-            '"music_wave"': Waves
-          PALETTE:
-            '"rave"': Black and White
-            '"cool"': Cool
-            '"electronic"': Electronic
-            '"iceCream"': Ice Cream
-            '"default"': Light
-            '"neon"': Neon
-            '"tropical"': Tropical
-            '"vintage"': Vintage
-            '"warm"': Warm
-            '"grayscale"': Grayscale
-            '"sky"': Sky
-            '"ocean"': Ocean
-            '"sunrise"': Sunrise
-            '"sunset"': Sunset
-            '"spring"': Spring
-            '"summer"': Summer
-            '"autumn"': Autumn
-            '"winter"': Winter
-            '"twinkling"': Twinkling
-            '"rainbow"': Rainbow
-            '"roses"': Roses
       Dancelab_setDanceSpeed:
         text: set {SPRITE} dance speed to {SPEED}
         options:


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR removes the manual translation of a new Blockly block added by https://github.com/code-dot-org/code-dot-org/pull/54218. Even though this is not necessary - posting the PR as a lesson learned!

[Slack thread](https://codedotorg.slack.com/archives/CFTFD6BPV/p1697760109555259)
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
