### PR TITLE
Set project and version ids on teacher evaluations

### DIFF
--- a/dashboard/app/controllers/learning_goal_teacher_evaluations_controller.rb
+++ b/dashboard/app/controllers/learning_goal_teacher_evaluations_controller.rb
@@ -26,10 +26,29 @@ class LearningGoalTeacherEvaluationsController < ApplicationController
   end
 
   def get_or_create_evaluation
+    learning_goal = LearningGoal.find(learning_goal_teacher_evaluation_params[:learning_goal_id])
+    @rubric = Rubric.find(learning_goal.rubric_id)
+
+    user_storage_id = storage_id_for_user_id(learning_goal_teacher_evaluation_params[:user_id])
+    script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
+    channel_token = ChannelToken.find_channel_token(
+      script_level.level,
+      user_storage_id,
+      script_level.script_id
+    )
+    raise "channel token not found for user id #{learning_goal_teacher_evaluation_params[:user_id]} and script level id #{script_level.id}" unless channel_token
+    _owner_id, project_id = storage_decrypt_channel_id(channel_token.channel)
+    source_data = SourceBucket.new.get(channel_token.channel, "main.json")
+    puts source_data.inspect
+    raise "main.json not found for channel id #{channel_id}" unless source_data[:status] == 'FOUND'
+    version_id = source_data[:version_id]
+
     learning_goal_teacher_evaluation = LearningGoalTeacherEvaluation.find_or_create_by!(
       user_id: learning_goal_teacher_evaluation_params[:user_id],
       teacher_id: current_user.id,
       learning_goal_id: learning_goal_teacher_evaluation_params[:learning_goal_id],
+      project_id: project_id,
+      project_version: version_id,
     )
     render json: learning_goal_teacher_evaluation
   end

--- a/dashboard/app/controllers/learning_goal_teacher_evaluations_controller.rb
+++ b/dashboard/app/controllers/learning_goal_teacher_evaluations_controller.rb
@@ -27,7 +27,7 @@ class LearningGoalTeacherEvaluationsController < ApplicationController
 
   def get_or_create_evaluation
     learning_goal = LearningGoal.find(learning_goal_teacher_evaluation_params[:learning_goal_id])
-    @rubric = Rubric.find(learning_goal.rubric_id)
+    @rubric = learning_goal.rubric
 
     user_storage_id = storage_id_for_user_id(learning_goal_teacher_evaluation_params[:user_id])
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}

--- a/dashboard/app/controllers/learning_goal_teacher_evaluations_controller.rb
+++ b/dashboard/app/controllers/learning_goal_teacher_evaluations_controller.rb
@@ -39,7 +39,6 @@ class LearningGoalTeacherEvaluationsController < ApplicationController
     raise "channel token not found for user id #{learning_goal_teacher_evaluation_params[:user_id]} and script level id #{script_level.id}" unless channel_token
     _owner_id, project_id = storage_decrypt_channel_id(channel_token.channel)
     source_data = SourceBucket.new.get(channel_token.channel, "main.json")
-    puts source_data.inspect
     raise "main.json not found for channel id #{channel_id}" unless source_data[:status] == 'FOUND'
     version_id = source_data[:version_id]
 

--- a/dashboard/test/controllers/learning_goal_teacher_evaluations_controller_test.rb
+++ b/dashboard/test/controllers/learning_goal_teacher_evaluations_controller_test.rb
@@ -5,14 +5,31 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
     @teacher = create :teacher
     @student = create :student
     sign_in @teacher
-    @learning_goal = create :learning_goal
-    @learning_goal_teacher_evaluation = create :learning_goal_teacher_evaluation, teacher_id: @teacher.id, user_id: @student.id, learning_goal_id: @learning_goal.id
+
+    @script_level = create :script_level
+    assert_equal @script_level.script, @script_level.lesson.script
+
+    @fake_ip = '127.0.0.1'
+    @storage_id = create_storage_id_for_user(@student.id)
+
+    @rubric = create :rubric, level: @script_level.level, lesson: @script_level.lesson
+    @learning_goal_1 = create :learning_goal, rubric: @rubric, learning_goal: 'learning-goal-1'
+    @learning_goal_2 = create :learning_goal, rubric: @rubric, learning_goal: 'learning-goal-2'
+    assert_equal 2, @rubric.learning_goals.count
+
+    channel_token = ChannelToken.find_or_create_channel_token(@script_level.level, @fake_ip, @storage_id, @script_level.script_id)
+    @channel_id = channel_token.channel
+
+    @learning_goal_teacher_evaluation = create :learning_goal_teacher_evaluation, teacher_id: @teacher.id, user_id: @student.id, learning_goal_id: @learning_goal_1.id
+
+    # Don't actually talk to S3 when running SourceBucket.new
+    AWS::S3.stubs :create_client
   end
 
   test 'create learning goal evaluation' do
     user_id = @student.id
     teacher_id = @teacher.id
-    learning_goal_id = @learning_goal.id
+    learning_goal_id = @learning_goal_1.id
     understanding = 5
     feedback = 'abc'
 
@@ -38,7 +55,7 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
     id = @learning_goal_teacher_evaluation.id
     user_id = @student.id
     teacher_id = @teacher.id
-    learning_goal_id = @learning_goal.id
+    learning_goal_id = @learning_goal_1.id
     understanding = 6
     feedback = 'ghi'
 
@@ -73,7 +90,8 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
     assert_equal response_json['id'], @learning_goal_teacher_evaluation.id
   end
 
-  test 'get_or_create_evaluation method' do
+  test 'get_or_create_evaluation method get' do
+    stub_project_source_data(@channel_id)
     post :get_or_create_evaluation, params: {
       userId: @learning_goal_teacher_evaluation.user_id,
       learningGoalId: @learning_goal_teacher_evaluation.learning_goal_id
@@ -82,11 +100,19 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
 
     response_json = JSON.parse(response.body)
     assert_equal response_json['id'], @learning_goal_teacher_evaluation.id
+  end
 
+  test 'get_or_create_evaluation method create' do
     new_student = create :student
+    new_storage_id = create_storage_id_for_user(new_student.id)
+
+    new_channel_token = ChannelToken.find_or_create_channel_token(@script_level.level, @fake_ip, new_storage_id, @script_level.script_id)
+    new_channel_id = new_channel_token.channel
 
     user_id = new_student.id
-    learning_goal_id = @learning_goal.id
+    learning_goal_id = @learning_goal_1.id
+
+    stub_project_source_data(new_channel_id)
 
     post :get_or_create_evaluation, params: {
       userId: user_id,
@@ -101,9 +127,9 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
   end
 
   # Test create responses
-  test_user_gets_response_for :create, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
-  test_user_gets_response_for :create, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: :student, response: :forbidden
-  test_user_gets_response_for :create, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: :teacher, response: :success
+  test_user_gets_response_for :create, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+  test_user_gets_response_for :create, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: :student, response: :forbidden
+  test_user_gets_response_for :create, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: :teacher, response: :success
 
   # Test update responses
   test_user_gets_response_for :update, params: -> {{id: @learning_goal_teacher_evaluation.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
@@ -113,14 +139,24 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
   test_user_gets_response_for :update, params: -> {{id: @learning_goal_teacher_evaluation.id}}, user: :teacher, response: :forbidden
 
   # Test get_evaluation responses
-  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
-  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: :student, response: :forbidden
-  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: -> {@teacher}, response: :success
+  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: :student, response: :forbidden
+  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: -> {@teacher}, response: :success
   # Test returns not found for a different teacher
-  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: :teacher, response: :not_found
+  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: :teacher, response: :not_found
 
   # Test get_or_create responses
-  test_user_gets_response_for :get_or_create_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
-  test_user_gets_response_for :get_or_create_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: :student, response: :forbidden
-  test_user_gets_response_for :get_or_create_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: :teacher, response: :success
+  test_user_gets_response_for :get_or_create_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+  test_user_gets_response_for :get_or_create_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: :student, response: :forbidden
+  test_user_gets_response_for :get_or_create_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: :teacher, response: :success
+
+  private def stub_project_source_data(channel_id, code: 'fake-code', version_id: 'fake-version-id')
+    fake_main_json = {source: code}.to_json
+    fake_source_data = {
+      status: 'FOUND',
+      body: StringIO.new(fake_main_json),
+      version_id: version_id
+    }
+    SourceBucket.any_instance.stubs(:get).with(channel_id, "main.json").returns(fake_source_data)
+  end
 end

--- a/dashboard/test/controllers/learning_goal_teacher_evaluations_controller_test.rb
+++ b/dashboard/test/controllers/learning_goal_teacher_evaluations_controller_test.rb
@@ -91,7 +91,7 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
     assert_equal response_json['id'], @learning_goal_teacher_evaluation.id
   end
 
-  test 'get_or_create_evaluation method get' do
+  test 'get_or_create_evaluation method gets existing evaluation' do
     post :get_or_create_evaluation, params: {
       userId: @learning_goal_teacher_evaluation.user_id,
       learningGoalId: @learning_goal_teacher_evaluation.learning_goal_id
@@ -102,7 +102,7 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
     assert_equal response_json['id'], @learning_goal_teacher_evaluation.id
   end
 
-  test 'get_or_create_evaluation method create' do
+  test 'get_or_create_evaluation method creates evaluation if one does not exist' do
     new_student = create :student
     new_storage_id = create_storage_id_for_user(new_student.id)
 


### PR DESCRIPTION
Added code to retrieve project_id from database and version_id from S3 in learning_goal_teacher_evaluations. No frontend work for this yet.