### PR TITLE
Hide tips for students, only send events for teachers, and remove placeholder text

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -74,6 +74,7 @@
   "aiBot": "AI Bot",
   "aiCannotAssess": "This learning goal is too subjective for AI to evaluate.",
   "aiConfidence": "AI has {aiConfidence} confidence in this assessment",
+  "aiConfidenceTooltip": "The confidence score is calculated from how well the AI assessment worked for this learning goal on our training set of student projects. Pay extra attention to projects with medium or low confidence.",
   "aiStudentAssessment": "{studentName} has achieved {understandingLevel} for this learning goal.",
   "aiTrainedModels": "AI Trained Models",
   "aiTrainedModelsNoModels": "You have not trained any AI models yet.",

--- a/apps/src/templates/rubrics/AiAssessmentBox.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentBox.jsx
@@ -58,23 +58,15 @@ export default function AiAssessmentBox({
                 <FontAwesome icon="info-circle" className={style.infoTipIcon} />
               </span>
               <ReactTooltip id="info-tip" effect="solid">
-                PLACEHOLDER TEXT FOR INFO TIP
+                <div className={style.infoTipText}>
+                  {i18n.aiConfidenceTooltip()}
+                </div>
               </ReactTooltip>
             </div>
           )}
         </div>
       )}
-      {!isAiAssessed && (
-        <div>
-          <EmText>{i18n.aiCannotAssess()}</EmText>
-          <span data-tip data-for="info-tip">
-            <FontAwesome icon="info-circle" className={style.infoTipIcon} />
-          </span>
-          <ReactTooltip id="info-tip" effect="solid">
-            PLACEHOLDER TEXT FOR INFO TIP
-          </ReactTooltip>
-        </div>
-      )}
+      {!isAiAssessed && <EmText>{i18n.aiCannotAssess()}</EmText>}
     </div>
   );
 }

--- a/apps/src/templates/rubrics/AiAssessmentBox.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentBox.jsx
@@ -7,8 +7,6 @@ import {
   StrongText,
   BodyThreeText,
 } from '@cdo/apps/componentLibrary/typography';
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
-import ReactTooltip from 'react-tooltip';
 import {RubricUnderstandingLevels} from '@cdo/apps/util/sharedConstants';
 
 export default function AiAssessmentBox({
@@ -51,30 +49,10 @@ export default function AiAssessmentBox({
           <BodyThreeText>
             <StrongText>{studentAchievment()}</StrongText>
           </BodyThreeText>
-          {aiConfidence && (
-            <div>
-              <EmText>{aiConfidenceText()}</EmText>
-              <span data-tip data-for="info-tip">
-                <FontAwesome icon="info-circle" className={style.infoTipIcon} />
-              </span>
-              <ReactTooltip id="info-tip" effect="solid">
-                PLACEHOLDER TEXT FOR INFO TIP
-              </ReactTooltip>
-            </div>
-          )}
+          {aiConfidence && <EmText>{aiConfidenceText()}</EmText>}
         </div>
       )}
-      {!isAiAssessed && (
-        <div>
-          <EmText>{i18n.aiCannotAssess()}</EmText>
-          <span data-tip data-for="info-tip">
-            <FontAwesome icon="info-circle" className={style.infoTipIcon} />
-          </span>
-          <ReactTooltip id="info-tip" effect="solid">
-            PLACEHOLDER TEXT FOR INFO TIP
-          </ReactTooltip>
-        </div>
-      )}
+      {!isAiAssessed && <EmText>{i18n.aiCannotAssess()}</EmText>}
     </div>
   );
 }

--- a/apps/src/templates/rubrics/AiAssessmentBox.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentBox.jsx
@@ -7,6 +7,8 @@ import {
   StrongText,
   BodyThreeText,
 } from '@cdo/apps/componentLibrary/typography';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import ReactTooltip from 'react-tooltip';
 import {RubricUnderstandingLevels} from '@cdo/apps/util/sharedConstants';
 
 export default function AiAssessmentBox({
@@ -49,10 +51,30 @@ export default function AiAssessmentBox({
           <BodyThreeText>
             <StrongText>{studentAchievment()}</StrongText>
           </BodyThreeText>
-          {aiConfidence && <EmText>{aiConfidenceText()}</EmText>}
+          {aiConfidence && (
+            <div>
+              <EmText>{aiConfidenceText()}</EmText>
+              <span data-tip data-for="info-tip">
+                <FontAwesome icon="info-circle" className={style.infoTipIcon} />
+              </span>
+              <ReactTooltip id="info-tip" effect="solid">
+                PLACEHOLDER TEXT FOR INFO TIP
+              </ReactTooltip>
+            </div>
+          )}
         </div>
       )}
-      {!isAiAssessed && <EmText>{i18n.aiCannotAssess()}</EmText>}
+      {!isAiAssessed && (
+        <div>
+          <EmText>{i18n.aiCannotAssess()}</EmText>
+          <span data-tip data-for="info-tip">
+            <FontAwesome icon="info-circle" className={style.infoTipIcon} />
+          </span>
+          <ReactTooltip id="info-tip" effect="solid">
+            PLACEHOLDER TEXT FOR INFO TIP
+          </ReactTooltip>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/src/templates/rubrics/LearningGoal.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.jsx
@@ -56,14 +56,16 @@ export default function LearningGoal({
   const saveAfter = 2000;
 
   const handleClick = () => {
-    const eventName = isOpen
-      ? EVENTS.TA_RUBRIC_LEARNING_GOAL_COLLAPSED_EVENT
-      : EVENTS.TA_RUBRIC_LEARNING_GOAL_EXPANDED_EVENT;
-    analyticsReporter.sendEvent(eventName, {
-      ...(reportingData || {}),
-      learningGoalKey: learningGoal.key,
-      learningGoal: learningGoal.learningGoal,
-    });
+    if (!isStudent) {
+      const eventName = isOpen
+        ? EVENTS.TA_RUBRIC_LEARNING_GOAL_COLLAPSED_EVENT
+        : EVENTS.TA_RUBRIC_LEARNING_GOAL_EXPANDED_EVENT;
+      analyticsReporter.sendEvent(eventName, {
+        ...(reportingData || {}),
+        learningGoalKey: learningGoal.key,
+        learningGoal: learningGoal.learningGoal,
+      });
+    }
     setIsOpen(!isOpen);
   };
 
@@ -285,7 +287,7 @@ export default function LearningGoal({
             submittedEvaluation={submittedEvaluation}
             isStudent={isStudent}
           />
-          {learningGoal.tips && (
+          {learningGoal.tips && !isStudent && (
             <div>
               <Heading6>{i18n.tipsForEvaluation()}</Heading6>
               <div className={style.learningGoalTips}>

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -435,6 +435,10 @@ p.errorMessage {
   color: gray;
 }
 
+.infoTipText {
+  max-width: 500px;
+}
+
 .openedAiAssessment {
   padding: 1rem 1rem 0 1rem;
 }

--- a/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
+++ b/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
@@ -71,7 +71,6 @@ describe('AiAssessmentBox', () => {
     expect(wrapper.find('BodyThreeText')).to.have.lengthOf(0);
     expect(wrapper.find('EmText')).to.have.lengthOf(1);
     expect(wrapper.html().includes(i18n.aiCannotAssess())).to.be.true;
-    expect(wrapper.find('ReactTooltip')).to.have.lengthOf(1);
     expect(wrapper.find('div').first().hasClass(style.noAiAssessment)).to.be
       .true;
   });

--- a/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
+++ b/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
@@ -18,6 +18,7 @@ describe('AiAssessmentBox', () => {
     const wrapper = shallow(<AiAssessmentBox {...props} />);
     expect(wrapper.find('EmText')).to.have.lengthOf(1);
     expect(wrapper.find('BodyThreeText')).to.have.lengthOf(1);
+    expect(wrapper.find('ReactTooltip')).to.have.lengthOf(1);
   });
 
   it('renders AiAssessmentBox without AI confidence when unavailable', () => {
@@ -70,6 +71,7 @@ describe('AiAssessmentBox', () => {
     expect(wrapper.find('BodyThreeText')).to.have.lengthOf(0);
     expect(wrapper.find('EmText')).to.have.lengthOf(1);
     expect(wrapper.html().includes(i18n.aiCannotAssess())).to.be.true;
+    expect(wrapper.find('ReactTooltip')).to.have.lengthOf(1);
     expect(wrapper.find('div').first().hasClass(style.noAiAssessment)).to.be
       .true;
   });

--- a/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
+++ b/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
@@ -18,7 +18,6 @@ describe('AiAssessmentBox', () => {
     const wrapper = shallow(<AiAssessmentBox {...props} />);
     expect(wrapper.find('EmText')).to.have.lengthOf(1);
     expect(wrapper.find('BodyThreeText')).to.have.lengthOf(1);
-    expect(wrapper.find('ReactTooltip')).to.have.lengthOf(1);
   });
 
   it('renders AiAssessmentBox without AI confidence when unavailable', () => {
@@ -71,7 +70,6 @@ describe('AiAssessmentBox', () => {
     expect(wrapper.find('BodyThreeText')).to.have.lengthOf(0);
     expect(wrapper.find('EmText')).to.have.lengthOf(1);
     expect(wrapper.html().includes(i18n.aiCannotAssess())).to.be.true;
-    expect(wrapper.find('ReactTooltip')).to.have.lengthOf(1);
     expect(wrapper.find('div').first().hasClass(style.noAiAssessment)).to.be
       .true;
   });

--- a/apps/test/unit/templates/rubrics/LearningGoalTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalTest.jsx
@@ -68,7 +68,7 @@ describe('LearningGoal', () => {
     expect(wrapper.find('AiAssessment')).to.have.lengthOf(0);
   });
 
-  it('renders tips', () => {
+  it('renders tips for teachers', () => {
     const wrapper = shallow(
       <LearningGoal
         learningGoal={{
@@ -78,11 +78,28 @@ describe('LearningGoal', () => {
           tips: 'Tips',
         }}
         teacherHasEnabledAi
+        isStudent={false}
       />
     );
     expect(wrapper.find('Heading6')).to.have.lengthOf(1);
     expect(wrapper.find('SafeMarkdown')).to.have.lengthOf(1);
     expect(wrapper.find('SafeMarkdown').props().markdown).to.equal('Tips');
+  });
+
+  it('does not render tips for students', () => {
+    const wrapper = shallow(
+      <LearningGoal
+        learningGoal={{
+          learningGoal: 'Testing',
+          aiEnabled: true,
+          evidenceLevels: [],
+          tips: 'Tips',
+        }}
+        isStudent={true}
+      />
+    );
+    expect(wrapper.find('Heading6')).to.have.lengthOf(0);
+    expect(wrapper.find('SafeMarkdown')).to.have.lengthOf(0);
   });
 
   it('shows AI token when AI is enabled', () => {


### PR DESCRIPTION
This PR groups a few small fixes:
- hides tips for students (https://codedotorg.atlassian.net/browse/AITT-264)
- removes placeholder tooltips (https://codedotorg.atlassian.net/browse/AITT-261)
- stops sending an event for students (no Jira task)

Screenshot of the AiAssessment component without tooltip:
![Screenshot 2023-10-20 at 3 41 21 PM](https://github.com/code-dot-org/code-dot-org/assets/46464143/7c2f0699-dcf9-42b9-86a3-43a11772ca39)
