### PR TITLE
Extend Startup Timeout for new Web Services

### DIFF
--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -30,7 +30,7 @@ ssh_key_name ||= {Ref: 'SSHKeyName'}.to_json
 instance_type ||= {Ref: 'InstanceType'}.to_json
 
 ami_timeout ||= 'PT10M'
-frontend_timeout ||= 'PT10M'
+frontend_timeout ||= 'PT20M'
 lifecycle_timeout ||= 1200 # seconds = 20 minutes
 frontend_volume_size ||= 16
 frontend_device_name ||= '/dev/sda1'

--- a/cookbooks/cdo-apps/templates/default/puma.service.erb
+++ b/cookbooks/cdo-apps/templates/default/puma.service.erb
@@ -10,9 +10,9 @@ After=network.target
 Type=notify
 WatchdogSec=10
 
-# Our servers can take a while to start up; wait five full minutes for them to
+# Our servers can take a while to start up; wait ten full minutes for them to
 # do so before giving up.
-TimeoutStartSec=300
+TimeoutStartSec=600
 
 User=<%= @user %>
 WorkingDirectory=<%= @app_root %>


### PR DESCRIPTION
On the first build following the Ubuntu 20 upgrade, our newly-created web servers are taking a very long time to start up dashboard and pegasus the first time. Speculatively double the timeouts for the individual services from 5 minutes to 10 minutes, and also double the timeout for the frontend as a whole from 10 minutes to 20 minutes.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
