### PR TITLE
Flakey test fix attempt

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/tutorial_landing_pages.feature
+++ b/dashboard/test/ui/features/hour_of_code/tutorial_landing_pages.feature
@@ -6,7 +6,7 @@ Scenario Outline: Simple page view
   When I open my eyes to test "<test_name>"
   And I am on "<url>"
   And I dismiss the language selector
-  And I wait for the page to fully load
+  And I wait for two seconds
   Then I see no difference for "initial load"
   And I close my eyes
   And I sign out

--- a/dashboard/test/ui/features/hour_of_code/tutorial_landing_pages.feature
+++ b/dashboard/test/ui/features/hour_of_code/tutorial_landing_pages.feature
@@ -6,6 +6,7 @@ Scenario Outline: Simple page view
   When I open my eyes to test "<test_name>"
   And I am on "<url>"
   And I dismiss the language selector
+  And I wait for the page to fully load
   Then I see no difference for "initial load"
   And I close my eyes
   And I sign out

--- a/dashboard/test/ui/features/hour_of_code/tutorial_landing_pages.feature
+++ b/dashboard/test/ui/features/hour_of_code/tutorial_landing_pages.feature
@@ -6,7 +6,7 @@ Scenario Outline: Simple page view
   When I open my eyes to test "<test_name>"
   And I am on "<url>"
   And I dismiss the language selector
-  And I wait for two seconds
+  And I wait for 2 seconds
   Then I see no difference for "initial load"
   And I close my eyes
   And I sign out


### PR DESCRIPTION
Following a callout on two eyes tests from this feature file, it appears we are getting eyes diffs when the comparison happens before the page has fully loaded its assets. This is a hopeful fix: instructing the test to wait two seconds (for hopefully the assets to load) to take a comparison screenshot. 

Callout here: https://codedotorg.slack.com/archives/C03CM903Y/p1697831676788779?thread_ts=1697819065.888319&cid=C03CM903Y
Applitools link here: https://eyes.applitools.com/app/test-results/00000251704482397036/?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1101

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
