### PR TITLE
Require location field for non-home Hour of Code events

### DIFF
--- a/apps/src/sites/hourofcode.com/pages/public/events/index.js
+++ b/apps/src/sites/hourofcode.com/pages/public/events/index.js
@@ -257,8 +257,14 @@ function validateFields() {
     } else {
       $('#school-name-error').hide();
     }
+  }
 
-    if ($('#hoc-event-location').val() === '') {
+  if (
+    ['out_of_school', 'after_school'].includes($('#hoc-event-type').val()) ||
+    ($('#hoc-event-type').val() === 'in_school' &&
+      ($('#country').val() !== 'US' || schoolData.nces === SCHOOL_NOT_FOUND))
+  ) {
+    if ($('.mapboxgl-ctrl-geocoder--input').val() === '') {
       $('#event-location-error').show();
       return false;
     } else {

--- a/apps/src/sites/hourofcode.com/pages/public/events/index.js
+++ b/apps/src/sites/hourofcode.com/pages/public/events/index.js
@@ -238,15 +238,6 @@ function validateFields() {
     $('#event-type-error').hide();
   }
 
-  if (['out_of_school', 'after_school'].includes($('#hoc-event-type').val())) {
-    if ($('#organization-name').val() === '') {
-      $('#organization-name-error').show();
-      return false;
-    } else {
-      $('#organization-name-error').hide();
-    }
-  }
-
   if (
     $('#hoc-event-type').val() === 'in_school' &&
     ($('#country').val() !== 'US' || schoolData.nces === SCHOOL_NOT_FOUND)
@@ -259,8 +250,21 @@ function validateFields() {
     }
   }
 
+  const inOrAfterSchool = ['out_of_school', 'after_school'].includes(
+    $('#hoc-event-type').val()
+  );
+
+  if (inOrAfterSchool) {
+    if ($('#organization-name').val() === '') {
+      $('#organization-name-error').show();
+      return false;
+    } else {
+      $('#organization-name-error').hide();
+    }
+  }
+
   if (
-    ['out_of_school', 'after_school'].includes($('#hoc-event-type').val()) ||
+    inOrAfterSchool ||
     ($('#hoc-event-type').val() === 'in_school' &&
       ($('#country').val() !== 'US' || schoolData.nces === SCHOOL_NOT_FOUND))
   ) {


### PR DESCRIPTION
As laid out in [this Slack thread](https://codedotorg.slack.com/archives/C5V9YCXTR/p1697663563222279), we discovered that some submitted Hour of Code events weren't showing up on the map due to no location being provided. The location field appears if the user has set the event type to either 'School', 'After school program', or 'Organization/Company' (i.e. any type other than 'Home'). However, the location is currenlty only required if the event is both of type 'School' and is either outside of the U.S. or at a school missing in our school search dropdown. This means that users can create events without a location, meaning they will not appear on the [events map](https://hourofcode.com/us).

This PR makes the location field required both for the same case as before and for event types of 'After school program' or 'Organization/Company' (i.e. any time the location field appears). This will ensure that any future event entries will have a location so they will both appear on the [map](https://hourofcode.com/us) and on the event [lists](https://hourofcode.com/us/events/all).

## Demos
### 'School' event type with U.S. school not found in our dropdown still shows error when location field is blank
![School_us_no_school_error](https://github.com/code-dot-org/code-dot-org/assets/56283563/42d895cc-7402-4b1a-af4e-163e2099226e)

### 'School' event type with non-U.S. school still shows error when location field is blank
![School_non_us_error](https://github.com/code-dot-org/code-dot-org/assets/56283563/0c313412-fb25-462d-ba58-ab6c3345c262)

### 'After school program' event type now shows error when location field is blank
![After_school_error](https://github.com/code-dot-org/code-dot-org/assets/56283563/848cdd27-1bea-4f19-8219-11556923674a)

### 'Organization/Company' event type now shows error when location field is blank
![Organization_error](https://github.com/code-dot-org/code-dot-org/assets/56283563/d4f02e8e-317a-4e58-a520-851f8945a38a)

### Once location field is filled in, error goes away as expected
![Entering_location_removes_error](https://github.com/code-dot-org/code-dot-org/assets/56283563/6575dd97-c7eb-4b66-b3af-7a0e2134f04b)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1087)
Slack thread discussion: [here](https://codedotorg.slack.com/archives/C5V9YCXTR/p1697654397552349)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
