### PR TITLE
fix positions of learning goals when new ones are added or deleted

### DIFF
--- a/apps/src/lib/levelbuilder/rubrics/rubricHelper.js
+++ b/apps/src/lib/levelbuilder/rubrics/rubricHelper.js
@@ -110,7 +110,7 @@ function removeNewIds(keyConceptList) {
 function resetPositionsOfLearningGoals(keyConceptList) {
   let position = 1;
   keyConceptList.forEach(keyConcept => {
-    if (keyConceptList._delete) {
+    if (keyConcept._destroy) {
       keyConcept.position = -1;
     } else {
       keyConcept.position = position;


### PR DESCRIPTION
When curriculum writers are editing a rubric, the `position` of a learning goal may change as they add or delete learning goals for a rubric.  In the past, the positions were always increasing but not necessarily sequential (ex. they would have positions of 1, 4, 6, 7, BUT ideally those positions should be 1, 2, 3, 4. 

Note that currently Curriculum Writers cannot reorder learning goals in the UI themselves, but this work would also set-up this feature in the future.

PR fixes this ordering issue in the back end.


## Testing story

I did not modify any tests for this since this function is only called when saving to the back end.  If we think a test needs to be added, i'd love to see how this is done in similar helper files.  I searched our codebase and couldn't find a good similar example...
