### PR TITLE
Move project and version id logic to submit evaluation method

### DIFF
--- a/dashboard/app/controllers/learning_goal_teacher_evaluations_controller.rb
+++ b/dashboard/app/controllers/learning_goal_teacher_evaluations_controller.rb
@@ -26,28 +26,10 @@ class LearningGoalTeacherEvaluationsController < ApplicationController
   end
 
   def get_or_create_evaluation
-    learning_goal = LearningGoal.find(learning_goal_teacher_evaluation_params[:learning_goal_id])
-    @rubric = learning_goal.rubric
-
-    user_storage_id = storage_id_for_user_id(learning_goal_teacher_evaluation_params[:user_id])
-    script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
-    channel_token = ChannelToken.find_channel_token(
-      script_level.level,
-      user_storage_id,
-      script_level.script_id
-    )
-    raise "channel token not found for user id #{learning_goal_teacher_evaluation_params[:user_id]} and script level id #{script_level.id}" unless channel_token
-    _owner_id, project_id = storage_decrypt_channel_id(channel_token.channel)
-    source_data = SourceBucket.new.get(channel_token.channel, "main.json")
-    raise "main.json not found for channel id #{channel_id}" unless source_data[:status] == 'FOUND'
-    version_id = source_data[:version_id]
-
     learning_goal_teacher_evaluation = LearningGoalTeacherEvaluation.find_or_create_by!(
       user_id: learning_goal_teacher_evaluation_params[:user_id],
       teacher_id: current_user.id,
       learning_goal_id: learning_goal_teacher_evaluation_params[:learning_goal_id],
-      project_id: project_id,
-      project_version: version_id,
     )
     render json: learning_goal_teacher_evaluation
   end

--- a/dashboard/test/controllers/learning_goal_teacher_evaluations_controller_test.rb
+++ b/dashboard/test/controllers/learning_goal_teacher_evaluations_controller_test.rb
@@ -83,7 +83,6 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
 
   test 'get_or_create_evaluation method creates evaluation if one does not exist' do
     new_student = create :student
-    
     user_id = new_student.id
     learning_goal_id = @learning_goal.id
 

--- a/dashboard/test/controllers/learning_goal_teacher_evaluations_controller_test.rb
+++ b/dashboard/test/controllers/learning_goal_teacher_evaluations_controller_test.rb
@@ -4,36 +4,15 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
   setup do
     @teacher = create :teacher
     sign_in @teacher
-
     @student = create :student
-
-    @script_level = create :script_level
-    assert_equal @script_level.script, @script_level.lesson.script
-
-    @fake_ip = '127.0.0.1'
-    @storage_id = create_storage_id_for_user(@student.id)
-
-    @rubric = create :rubric, level: @script_level.level, lesson: @script_level.lesson
-    @learning_goal_1 = create :learning_goal, rubric: @rubric, learning_goal: 'learning-goal-1'
-    @learning_goal_2 = create :learning_goal, rubric: @rubric, learning_goal: 'learning-goal-2'
-    assert_equal 2, @rubric.learning_goals.count
-
-    channel_token = ChannelToken.find_or_create_channel_token(@script_level.level, @fake_ip, @storage_id, @script_level.script_id)
-    @channel_id = channel_token.channel
-
-    # Don't actually talk to S3 when running SourceBucket.new
-    AWS::S3.stubs :create_client
-    stub_project_source_data(@channel_id)
-    _, @project_id = storage_decrypt_channel_id(@channel_id)
-    @version_id = "fake-version-id"
-
-    @learning_goal_teacher_evaluation = create :learning_goal_teacher_evaluation, teacher_id: @teacher.id, user_id: @student.id, learning_goal_id: @learning_goal_1.id, project_id: @project_id, project_version: @version_id
+    @learning_goal = create :learning_goal
+    @learning_goal_teacher_evaluation = create :learning_goal_teacher_evaluation, teacher_id: @teacher.id, user_id: @student.id, learning_goal_id: @learning_goal.id
   end
 
   test 'create learning goal teacher evaluation' do
     user_id = @student.id
     teacher_id = @teacher.id
-    learning_goal_id = @learning_goal_2.id
+    learning_goal_id = @learning_goal.id
     understanding = 1
     feedback = 'feedback'
 
@@ -59,7 +38,7 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
     id = @learning_goal_teacher_evaluation.id
     user_id = @student.id
     teacher_id = @teacher.id
-    learning_goal_id = @learning_goal_1.id
+    learning_goal_id = @learning_goal.id
     understanding = 2
     feedback = 'kcabdeef'
 
@@ -104,15 +83,9 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
 
   test 'get_or_create_evaluation method creates evaluation if one does not exist' do
     new_student = create :student
-    new_storage_id = create_storage_id_for_user(new_student.id)
-
-    new_channel_token = ChannelToken.find_or_create_channel_token(@script_level.level, @fake_ip, new_storage_id, @script_level.script_id)
-    new_channel_id = new_channel_token.channel
-
+    
     user_id = new_student.id
-    learning_goal_id = @learning_goal_1.id
-
-    stub_project_source_data(new_channel_id)
+    learning_goal_id = @learning_goal.id
 
     post :get_or_create_evaluation, params: {
       userId: user_id,
@@ -127,9 +100,9 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
   end
 
   # Test create responses
-  test_user_gets_response_for :create, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
-  test_user_gets_response_for :create, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: :student, response: :forbidden
-  test_user_gets_response_for :create, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: :teacher, response: :success
+  test_user_gets_response_for :create, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+  test_user_gets_response_for :create, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: :student, response: :forbidden
+  test_user_gets_response_for :create, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: :teacher, response: :success
 
   # Test update responses
   test_user_gets_response_for :update, params: -> {{id: @learning_goal_teacher_evaluation.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
@@ -139,24 +112,14 @@ class LearningGoalTeacherEvaluationsControllerTest < ActionController::TestCase
   test_user_gets_response_for :update, params: -> {{id: @learning_goal_teacher_evaluation.id}}, user: :teacher, response: :forbidden
 
   # Test get_evaluation responses
-  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
-  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: :student, response: :forbidden
-  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: -> {@teacher}, response: :success
+  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: :student, response: :forbidden
+  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: -> {@teacher}, response: :success
   # Test returns not found for a different teacher
-  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: :teacher, response: :not_found
+  test_user_gets_response_for :get_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: :teacher, response: :not_found
 
   # Test get_or_create responses
-  test_user_gets_response_for :get_or_create_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
-  test_user_gets_response_for :get_or_create_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: :student, response: :forbidden
-  test_user_gets_response_for :get_or_create_evaluation, params: -> {{learningGoalId: @learning_goal_1.id, userId: @student.id}}, user: :teacher, response: :success
-
-  private def stub_project_source_data(channel_id, code: 'fake-code', version_id: 'fake-version-id')
-    fake_main_json = {source: code}.to_json
-    fake_source_data = {
-      status: 'FOUND',
-      body: StringIO.new(fake_main_json),
-      version_id: version_id
-    }
-    SourceBucket.any_instance.stubs(:get).with(channel_id, "main.json").returns(fake_source_data)
-  end
+  test_user_gets_response_for :get_or_create_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+  test_user_gets_response_for :get_or_create_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: :student, response: :forbidden
+  test_user_gets_response_for :get_or_create_evaluation, params: -> {{learningGoalId: @learning_goal.id, userId: @student.id}}, user: :teacher, response: :success
 end

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -8,6 +8,21 @@ class RubricsControllerTest < ActionController::TestCase
     @lesson = create(:lesson, :with_lesson_group)
     @level = create(:level)
     @script_level = create :script_level, script: @lesson.script, lesson: @lesson, levels: [@level]
+
+    @teacher = create :teacher
+    @student = create :student
+
+    @fake_ip = '127.0.0.1'
+    @storage_id = create_storage_id_for_user(@student.id)
+
+    channel_token = ChannelToken.find_or_create_channel_token(@script_level.level, @fake_ip, @storage_id, @script_level.script_id)
+    @channel_id = channel_token.channel
+
+    # Don't actually talk to S3 when running SourceBucket.new
+    AWS::S3.stubs :create_client
+    stub_project_source_data(@channel_id)
+    _, @project_id = storage_decrypt_channel_id(@channel_id)
+    @version_id = "fake-version-id"
   end
 
   # new page is levelbuilder only
@@ -70,43 +85,38 @@ class RubricsControllerTest < ActionController::TestCase
   end
 
   test 'submits rubric evaluations of a student' do
-    student = create :student
-    teacher = create :teacher
-    rubric = create :rubric, :with_teacher_evaluations, lesson: @lesson, level: @level, num_evaluations_per_goal: 2, teacher: teacher, student: student
+    rubric = create :rubric, :with_teacher_evaluations, lesson: @lesson, level: @level, num_evaluations_per_goal: 2, teacher: @teacher, student: @student
 
-    sign_in teacher
-    post :submit_evaluations, params: {id: rubric.id, student_id: student.id}
+    sign_in @teacher
+    post :submit_evaluations, params: {id: rubric.id, student_id: @student.id}
     assert_response :success
-    assert_equal 2, LearningGoalTeacherEvaluation.where(user: student, teacher: teacher).where.not(submitted_at: nil).count
+    assert_equal 2, LearningGoalTeacherEvaluation.where(user: @student, teacher: @teacher).where.not(submitted_at: nil).count
   end
 
   test 'can only submit evaluations with same teacher_id as current_user' do
     rubric = create :rubric, lesson: @lesson, level: @level
-    student = create :student
-    teacher = create :teacher
     another_teacher = create :teacher
-    create :learning_goal, :with_teacher_evaluations, rubric: rubric, teacher: teacher, student: student
-    create :learning_goal, :with_teacher_evaluations, rubric: rubric, teacher: another_teacher, student: student
+    create :learning_goal, :with_teacher_evaluations, rubric: rubric, teacher: @teacher, student: @student
+    create :learning_goal, :with_teacher_evaluations, rubric: rubric, teacher: another_teacher, student: @student
 
-    sign_in teacher
-    post :submit_evaluations, params: {id: rubric.id, student_id: student.id}
+    sign_in @teacher
+    post :submit_evaluations, params: {id: rubric.id, student_id: @student.id}
 
     assert_response :success
-    refute_nil LearningGoalTeacherEvaluation.find_by(user: student, teacher: teacher).submitted_at
-    assert_nil LearningGoalTeacherEvaluation.find_by(user: student, teacher: another_teacher).submitted_at
+    refute_nil LearningGoalTeacherEvaluation.find_by(user: @student, teacher: @teacher).submitted_at
+    assert_nil LearningGoalTeacherEvaluation.find_by(user: @student, teacher: another_teacher).submitted_at
   end
 
   test "gets ai evaluations for student and learning goal" do
     student = create :student
-    teacher = create :teacher
-    create :follower, student_user: student, user: teacher
-    sign_in teacher
+    create :follower, student_user: student, user: @teacher
+    sign_in @teacher
 
     rubric = create :rubric
     learning_goal1 = create :learning_goal, rubric: rubric
     learning_goal2 = create :learning_goal, rubric: rubric
-    ai_evaluation1 = create :learning_goal_ai_evaluation, learning_goal: learning_goal1, user: student, requester: teacher, understanding: 1
-    ai_evaluation2 = create :learning_goal_ai_evaluation, learning_goal: learning_goal2, user: student, requester: teacher,  understanding: 2
+    ai_evaluation1 = create :learning_goal_ai_evaluation, learning_goal: learning_goal1, user: student, requester: @teacher, understanding: 1
+    ai_evaluation2 = create :learning_goal_ai_evaluation, learning_goal: learning_goal2, user: student, requester: @teacher,  understanding: 2
 
     get :get_ai_evaluations, params: {
       id: rubric.id,
@@ -121,11 +131,10 @@ class RubricsControllerTest < ActionController::TestCase
 
   test "cannot get ai evaluations for student if not teacher of student" do
     student = create :student
-    teacher = create :teacher
-    sign_in teacher
+    sign_in @teacher
 
     learning_goal = create :learning_goal
-    create :learning_goal_ai_evaluation, learning_goal: learning_goal, user: student, requester: teacher
+    create :learning_goal_ai_evaluation, learning_goal: learning_goal, user: student, requester: @teacher
 
     get :get_ai_evaluations, params: {
       id: learning_goal.rubric.id,
@@ -137,14 +146,13 @@ class RubricsControllerTest < ActionController::TestCase
 
   test "only returns the most recent ai evaluation for student" do
     student = create :student
-    teacher = create :teacher
-    create :follower, student_user: student, user: teacher
-    sign_in teacher
+    create :follower, student_user: student, user: @teacher
+    sign_in @teacher
 
     learning_goal = create :learning_goal
-    create :learning_goal_ai_evaluation, learning_goal: learning_goal, user: student, requester: teacher, understanding: 1
+    create :learning_goal_ai_evaluation, learning_goal: learning_goal, user: student, requester: @teacher, understanding: 1
     travel 1.minute do
-      create :learning_goal_ai_evaluation, learning_goal: learning_goal, user: student, requester: teacher, understanding: 2
+      create :learning_goal_ai_evaluation, learning_goal: learning_goal, user: student, requester: @teacher, understanding: 2
     end
 
     get :get_ai_evaluations, params: {
@@ -199,11 +207,10 @@ class RubricsControllerTest < ActionController::TestCase
   test "run ai evaluations for user calls EvaluateRubricJob" do
     rubric = create :rubric, lesson: @lesson, level: @level
     student = create :student
-    teacher = create :teacher
-    create :follower, student_user: student, user: teacher
-    sign_in teacher
+    create :follower, student_user: student, user: @teacher
+    sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: teacher, experiment_name: 'ai-rubrics').returns(true)
+    Experiment.stubs(:enabled?).with(user: @teacher, experiment_name: 'ai-rubrics').returns(true)
     EvaluateRubricJob.stubs(:ai_enabled?).returns(true)
     EvaluateRubricJob.expects(:perform_later).with(user_id: student.id, script_level_id: @script_level.id).once
 
@@ -217,11 +224,10 @@ class RubricsControllerTest < ActionController::TestCase
   test "run ai evaluations for user does not call EvaluateRubricJob if ai experiment is disabled" do
     rubric = create :rubric, lesson: @lesson, level: @level
     student = create :student
-    teacher = create :teacher
-    create :follower, student_user: student, user: teacher
-    sign_in teacher
+    create :follower, student_user: student, user: @teacher
+    sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: teacher, experiment_name: 'ai-rubrics').returns(false)
+    Experiment.stubs(:enabled?).with(user: @teacher, experiment_name: 'ai-rubrics').returns(false)
     EvaluateRubricJob.expects(:perform_later).never
 
     post :run_ai_evaluations_for_user, params: {
@@ -233,8 +239,7 @@ class RubricsControllerTest < ActionController::TestCase
 
   test "cannot run ai evaluations for user if not teacher of student" do
     student = create :student
-    teacher = create :teacher
-    sign_in teacher
+    sign_in @teacher
 
     rubric = create :rubric, lesson: @lesson, level: @level
 
@@ -243,5 +248,15 @@ class RubricsControllerTest < ActionController::TestCase
       userId: student.id,
     }
     assert_response :forbidden
+  end
+
+  private def stub_project_source_data(channel_id, code: 'fake-code', version_id: 'fake-version-id')
+    fake_main_json = {source: code}.to_json
+    fake_source_data = {
+      status: 'FOUND',
+      body: StringIO.new(fake_main_json),
+      version_id: version_id
+    }
+    SourceBucket.any_instance.stubs(:get).with(channel_id, "main.json").returns(fake_source_data)
   end
 end


### PR DESCRIPTION
Moved code to retrieve project id and version id for student code from get_or_create_evaluation method in learning_goal_teacher_evaluations_controller to submit_evaluations method in rubrics_controller. This should prevent the issue causing teachers to see blank evals if student code version changed. Also improves efficiency since S3 only needs to be hit once per rubric instead of once per learning goal.