### PR TITLE
Deflake expanded card UI test

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -167,6 +167,7 @@ Feature: Curriculum Catalog Page
     And I click selector "[aria-label='View details about CS Fundamentals: Course A']"
     Then I wait until element "a:contains(Facilitator led workshops)" is visible
     And I click selector "a:contains(Facilitator led workshops)"
+    Then I wait for jquery to load
     Then I wait until element "h1:contains(Professional development for elementary teachers)" is visible
     
 


### PR DESCRIPTION
Attempt to de-flake expanded card UI test ` Scenario: Signed-out user can navigate to facilitator led workshop through expanded card` within `curriculum_catalog.feature`.
The test appeared to time out before `Then I wait until element "h1:contains(Professional development for elementary teachers)" is visible` was run due to a jquery load error. 
Added  `Then I wait for jquery to load` in order to allow for some time for jquery to load before timing out.

## Links

- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?selectedIssue=ACQ-1057)


## Testing story
Tested through SauceLabs



## Follow-up work
I will work on figuring out how we could stay within the test environment when clicking on the links within the test.





## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
