### PR TITLE
small change to refresh eval on open/close

### DIFF
--- a/apps/src/templates/rubrics/LearningGoal.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.jsx
@@ -138,7 +138,7 @@ export default function LearningGoal({
         })
         .catch(error => console.log(error));
     }
-  }, [studentLevelInfo, learningGoal]);
+  }, [studentLevelInfo, learningGoal, isOpen]);
 
   // Callback to retrieve understanding data from EvidenceLevels
   const radioButtonCallback = radioButtonData => {


### PR DESCRIPTION
Have not been able to reproduce the bug from [AITT-235](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?assignee=712020%3A250d7a97-0218-4596-992c-547f32c30439&selectedIssue=AITT-235). 

This update adds the isOpen state to the useEffect argument list so that the teacher eval is refreshed any time the rubric / learning goal is opened or closed. This should prevent the bug from appearing in the future, assuming it happened under some special circumstances.