### PR TITLE
Re-enable yourschool.feature test

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/yourschool.feature
+++ b/dashboard/test/ui/features/acquisition_products/yourschool.feature
@@ -29,9 +29,6 @@ Feature: Using the YourSchool census page
     Then I press "#submit-button" using jQuery
     Then I wait until I am on "http://code.org/yourschool/thankyou"
 
-  # The google map on /yourschool is broken in production. We should stop skipping
-  # this test as soon as that page is fixed.
-  @skip
   @no_circle
   Scenario: Use census map to select school
     Given I am on "http://code.org/yourschool"


### PR DESCRIPTION
While working on the /yourschool map, I saw that one of the UI tests was skipped for back when the map was broken on production. It's been a while since then and the map is working again so this PR undoes the skipping.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1028)

## Testing story
Passing drone.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
