### PR TITLE
Remove Temporary `init.d` Cleanup Logic

### DIFF
--- a/cookbooks/cdo-apps/libraries/cdo_apps.rb
+++ b/cookbooks/cdo-apps/libraries/cdo_apps.rb
@@ -54,14 +54,6 @@ module CdoApps
       notifies :run, "execute[restart #{app_name} service]", :delayed
     end
 
-    # TODO: remove this once all persistent managed servers have been cleaned up
-    old_init_script = "/etc/init.d/#{app_name}"
-    execute "remove old SysV #{app_name} implementation" do
-      command "#{old_init_script} stop && mv #{old_init_script} /tmp/old-init-d-#{app_name}"
-      only_if {::File.exist?(old_init_script)}
-      notifies :run, "execute[restart #{app_name} service]", :delayed
-    end
-
     # Define an execute resource for restarting (or starting) the entire
     # SystemD service, which can be invoked by other Chef resources
     execute "restart #{app_name} service" do


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/52368

Now that all persistent managed servers have been cleaned up (slash recreated from scratch), we can remove the logic we temporarily added to perform that cleanup.