### PR TITLE
configure EvaluateRubricJob to use containerized aiproxy

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -598,4 +598,5 @@ openai_chat_completion_org_id: !Secret
 openai_evaluate_rubric_api_key: !Secret
 openai_evaluate_rubric_org_id:
 
-ai_proxy_origin:
+# AI Proxy for OpenAI API
+ai_proxy_origin: https://aiproxy-test.code.org

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -71,7 +71,5 @@ jwk_private_key_data:
 openai_chat_completion_api_key: ''
 openai_evaluate_rubric_api_key:
 
-ai_proxy_origin: 'http://localhost:5000'
-
 # Mapbox
 mapbox_upload_tileset:    'censustiles-dev'

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -39,6 +39,9 @@ imm_reader_subdomain:     'cdo-immersive-reader-prod'
 # General CDO Amplitude key
 cdo_amplitude_api_key: !Secret
 
+# AI Proxy for OpenAI API
+ai_proxy_origin: https://aiproxy.code.org
+
 # Mapbox
 mapbox_upload_tileset:    'censustiles'
 mapbox_upload_token:      !Secret


### PR DESCRIPTION
now that our python service is up and running in AWS containers:
* https://aiproxy.code.org/test
* https://aiproxy-test.code.org/test

We want to update our rails config to point to these containers, so that the service will start working in production and so that we do not have to run the container locally in development and adhoc environments.

## Testing story

* we have verified that setting `ai_proxy_origin: https://aiproxy-test.code.org` in locals.yml works on an adhoc over the past few days. 
* aiproxy.code.org has not been tested on adhoc, but `https://aiproxy.code.org/test` and `https://aiproxy.code.org/test/openai?api-key=sk-rest-of-openai-api-key` return expected results, the latter of which indicates successfully connecting to openai.