### PR TITLE
Revert "Simplify DCDO Cache Expiration Logic"

### DIFF
--- a/lib/dynamic_config/datastore_cache.rb
+++ b/lib/dynamic_config/datastore_cache.rb
@@ -8,14 +8,16 @@ class DatastoreCache
   # @param cache_expiration [int] seconds after which a cached entry expires
   def initialize(datastore, cache_expiration: 30)
     @cache = {}
-    @expirations = {}
     @datastore = datastore
     @cache_expiration = cache_expiration
 
     # A list of change listeners.
     @listeners = []
 
+    # Note we intentionally do this before spawning the background thread
+    # to make sure the cache is seeded successfully on init
     update_cache
+    @update_thread = spawn_update_thread
   end
 
   # Adds a listener that will be invoked whenever the store changes.
@@ -36,26 +38,15 @@ class DatastoreCache
     end
   end
 
-  # Gets the data associated with a given key.
-  #
-  # Will return the cached data if it hasn't yet expired; if it has, this
-  # method will fetch a fresh value, update the cache, and then return.
-  # Notably, this means this method has inconsistent response time; it's
-  # usually quick, but sometimes has to fetch data from a remote store.
-  #
+  # Gets the data associated with a given key
   # @param key [String]
   # @returns stored value
   def get(key)
     raise ArgumentError unless key.is_a? String
-    old_value = @cache[key]
-    return old_value if @expirations.key?(key) && @expirations[key] > Time.now
-    new_value = @datastore.get(key)
-    set(key, new_value)
-    return new_value
+    return @cache[key]
   end
 
   # Sets the given value for the key in both the local cache and datastore
-  #
   # @param key [String]
   # @param value [JSONable]
   def set(key, value)
@@ -78,6 +69,12 @@ class DatastoreCache
     notify_change_listeners
   end
 
+  # When unicorn preload the app and then forks worker processes the update_thread
+  # doesn't make it to the other processes.  Restart it here
+  def after_fork
+    @update_thread = spawn_update_thread unless @update_thread&.alive?
+  end
+
   # Pulls all values from the datastore and populates the local cache
   def update_cache
     tries ||= 3
@@ -95,12 +92,21 @@ class DatastoreCache
     end
   end
 
-  # Sets the given value for the key in the local cache, with an expiration.
-  #
+  # Sets the given value for the key in the local cache
   # @param key [String]
   # @param value [String]
   private def set_local(key, value)
     @cache[key] = value
-    @expirations[key] = Time.new + @cache_expiration
+  end
+
+  # Spawns a background thread that periodically updates the cached
+  # values from the persistent datastore
+  private def spawn_update_thread
+    Thread.new do
+      loop do
+        sleep @cache_expiration
+        update_cache
+      end
+    end
   end
 end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#53833; this caused a bunch of `TypeError: Nil is not a valid JSON source.` errors on staging: https://app.honeybadger.io/projects/3240/faults/101613548