### PR TITLE
Revert "Revert "Simplify DCDO Cache Expiration Logic""

### DIFF
--- a/lib/dynamic_config/adapters/json_file_adapter.rb
+++ b/lib/dynamic_config/adapters/json_file_adapter.rb
@@ -22,6 +22,7 @@ class JSONFileDatastoreAdapter
   # @returns [JSONable Object] or nil if key doesn't exist
   def get(key)
     load_from_file
+    return nil unless @hash.key?(key)
     begin
       return Oj.load(@hash[key])
     rescue => exception

--- a/lib/dynamic_config/adapters/memory_adapter.rb
+++ b/lib/dynamic_config/adapters/memory_adapter.rb
@@ -13,6 +13,7 @@ class MemoryAdapter
   end
 
   def get(key)
+    return nil unless @hash.key?(key)
     Oj.load(@hash[key])
   rescue => exception
     Honeybadger.notify(exception)


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#54445, restoring https://github.com/code-dot-org/code-dot-org/pull/53833

In our previous implementation, we'd never attempt to invoke `.get` directly on the datastore for keys that hadn't ever been set; we just used `.all` to collect everything that was set and put in all in the cache, then tried to get values off the cache.

With the new implementation, we will actually check the datastore for values. This means that any key that hasn't had an explicit value set will attempt to load a `nil` value from the datastore, which right now for the JSON-backed and in-memory datastores will also log an error in Honeybadger.

Instead, we simply check for the existence of the key in the datastore before trying to parse it as JSON. Note that this is already how it works for the DynamoDB-backed datastore used in production; see [this comparable line](https://github.com/code-dot-org/code-dot-org/blob/02f7d6ea7a50454b7304ff81024ff211b81bd13d/lib/dynamic_config/adapters/dynamodb_adapter.rb#L22) in that version of the adapter.