### PR TITLE
[Google Blockly] Modal Function Editor UI Fixes

### DIFF
--- a/apps/src/blockly/components/ModalFunctionEditor.jsx
+++ b/apps/src/blockly/components/ModalFunctionEditor.jsx
@@ -28,7 +28,7 @@ export default function ModalFunctionEditor() {
             type="button"
             id={MODAL_EDITOR_DELETE_ID}
             onClick={emptyOnClick}
-            color={Button.ButtonColor.neutralDark}
+            color={Button.ButtonColor.brandSecondaryDefault}
             size={buttonSize}
           >
             {msg.delete()}

--- a/apps/src/blockly/components/modal-function-editor.module.scss
+++ b/apps/src/blockly/components/modal-function-editor.module.scss
@@ -11,7 +11,6 @@
 
 .toolbar {
   position: absolute;
-  width: 100%;
   top: 10px;
   right: 10px;
   z-index: 1;


### PR DESCRIPTION
2 small fixes to the modal function editor:
- remove `width: 100%` on the toolbar (delete/close buttons) as this was preventing click on part of the definition block.
- Change the delete button to be purple rather than white. We are adding a modal soon to confirm delete, and these colors are in line with the existing CDO Blockly colors

### New Button Color
![Screenshot 2023-10-24 at 12 52 36 PM](https://github.com/code-dot-org/code-dot-org/assets/33666587/472b6510-f593-4492-9cd2-d86f251c7304)


## Links

- jira ticket: [CT-141](https://codedotorg.atlassian.net/browse/CT-141)

## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
