### PR TITLE
Improve SQL User Lambda Delete operation

### DIFF
--- a/aws/cloudformation/lambdas/sql-user/index.js
+++ b/aws/cloudformation/lambdas/sql-user/index.js
@@ -58,17 +58,14 @@ exports.handler = async (event, context) => {
           password: dbCredentialSQLUser.password,
           privileges: props.Privileges,
         });
-        // Results from the CREATE USER query.
         console.log(
           "CREATE USER SQL Statement Execution Results:\n",
           results.createUser
         );
-        // Results from the UPDATE USER query.
         console.log(
           "UPDATE USER SQL Statement Execution Results:\n",
           results.updateUser
         );
-        // Array of results from each GRANT operation.
         console.log(
           "GRANT USER SQL Statement Execution Results:\n",
           results.grantResults
@@ -153,7 +150,7 @@ const deleteSQLUser = async (connection, { name, clientHost }) => {
   const dropUser = `DROP USER IF EXISTS '${name}'@'${clientHost}';`;
   return await queryPromise(connection, dropUser).catch((error) => {
     if (error.code === "ENOTFOUND") {
-      let databaseDeletedAlreadyMessage = `
+      const databaseDeletedAlreadyMessage = `
         Cannot connect to database to delete SQL user because the server name lookup failed. Assuming the database was
         already deleted by CloudFormation, so there's no need to delete the user. ${error}
        `;

--- a/aws/cloudformation/lambdas/sql-user/index.js
+++ b/aws/cloudformation/lambdas/sql-user/index.js
@@ -154,7 +154,7 @@ const deleteSQLUser = async (connection, { name, clientHost }) => {
   return await queryPromise(connection, dropUser).catch((error) => {
     if (error.code === "ENOTFOUND") {
       let databaseDeletedAlreadyMessage = `
-        Cannot connect to database to delete SQL user because the server name lookup failed. Assume the database was
+        Cannot connect to database to delete SQL user because the server name lookup failed. Assuming the database was
         already deleted by CloudFormation, so there's no need to delete the user. ${error}
        `;
       console.log(databaseDeletedAlreadyMessage);


### PR DESCRIPTION
During end-to-end testing of the SQL User lambda in #52796 we found that when a CloudFormation template incorrectly allows for a database resource to be deleted before a SQLUser resource, the delete operation fails on the SQLUser resource even though deleting the database effectively deletes the user.



## Testing story

JS tests
```
sql-user % npm test

> sql-user@1.0.0 test
> mocha *.test.js



  SQL User Custom Resource
REQUEST RECEIVED:
 {"RequestType":"Create","ResourceProperties":{"Privileges":["ALL PRIVILEGES"]},"PhysicalResourceId":"someId"}
CREATE USER SQL Statement Execution Results:
 {}
UPDATE USER SQL Statement Execution Results:
 {}
GRANT USER SQL Statement Execution Results:
 [ {}, {} ]
    ✔ should handle Create event successfully
REQUEST RECEIVED:
 {"RequestType":"Delete","ResourceProperties":{},"PhysicalResourceId":"someId"}
DELETE USER SQL Statement Execution Results:
 {}
    ✔ should handle Delete event successfully


  2 passing (23ms)
```

CloudFormation validate
```
% bundle exec rake stack:lambda:validate
Finished stack:lambda:environment (less than a minute)
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn  --production
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig npm install  ci --only=prod
Uploading Lambda zip package to S3 (14455998 bytes)...
PKG_CONFIG_PATH=/usr/X11/lib/pkgconfig yarn
Pending update for stack `lambda`:
Modify SQLUserLambda [AWS::Lambda::Function] Properties (Code)
Finished stack:lambda:validate (1 minute)
```

## Deployment strategy

`$ bundle exec rake stack:lambda:start`

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
