### PR TITLE
Small Refactor and Adds Amplitude Event to Email Send Button

### DIFF
--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -104,7 +104,7 @@ class DanceVisualizationColumn extends React.Component {
         {!this.props.isShareView && (
           <AgeDialog turnOffFilter={this.turnFilterOff} />
         )}
-        {this.props.over21 && (
+        {this.props.over21 && !isSignedIn && (
           <HourOfCodeGuideEmailDialog isSignedIn={isSignedIn} />
         )}
         <div style={{maxWidth: MAX_GAME_WIDTH}}>

--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -96,12 +96,17 @@ class DanceVisualizationColumn extends React.Component {
     const enableSongSelection =
       !this.props.levelIsRunning && !this.props.levelRunIsStarting;
 
+    const isSignedIn =
+      this.props.userType === 'teacher' || this.props.userType === 'student';
+
     return (
       <div>
         {!this.props.isShareView && (
           <AgeDialog turnOffFilter={this.turnFilterOff} />
         )}
-        {this.props.over21 && <HourOfCodeGuideEmailDialog />}
+        {this.props.over21 && (
+          <HourOfCodeGuideEmailDialog isSignedIn={isSignedIn} />
+        )}
         <div style={{maxWidth: MAX_GAME_WIDTH}}>
           {!this.props.isShareView && (
             <SongSelector

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -86,7 +86,9 @@ const EVENTS = {
   TA_RUBRIC_ON_STUDENT_WORK_UNLOADED: 'TA Rubric On Student Work Unloaded',
   TA_RUBRIC_SUBMITTED: 'TA Rubric Submitted',
 
+  // Hour of Code
   AGE_21_SELECTED_EVENT: 'Age 21+ Selected',
+  GUIDE_SENT_EVENT: 'Guide Sent',
 
   BATCH_CERTIFICATES_PAGE_VIEWED: 'Batch Certificates Page Viewed',
   TEACHER_HOC_CONGRATS_PAGE_VISITED:

--- a/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
+++ b/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
@@ -1,29 +1,43 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
-import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import Button from '@cdo/apps/templates/Button';
 import AccessibleDialog from '@cdo/apps/templates/AccessibleDialog';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {Heading1, Heading3} from '@cdo/apps/componentLibrary/typography';
 import experiments from '@cdo/apps/util/experiments';
 import style from './accessible-dialogue.module.scss';
 
-function HourOfCodeGuideEmailDialog(signedIn) {
+function HourOfCodeGuideEmailDialog({isSignedIn}) {
   const [isOpen, setIsOpen] = useState(true);
 
   const onClose = () => {
     setIsOpen(false);
   };
 
-  const bodyText = () =>
-    signedIn === true ? i18n.weHaveEverything() : i18n.signUpToReceiveGuide();
+  const sendEmail = () => {
+    analyticsReporter.sendEvent(EVENTS.GUIDE_SENT_EVENT, {
+      isSignedIn: isSignedIn,
+    });
+    // TODO: send email to stored address here
+  };
 
-  const emailGuideButtonText = () =>
-    signedIn === true ? i18n.emailMeAGuide() : i18n.getGuideContinue();
+  const saveInputs = () => {
+    // TODO: store name and email here
+  };
 
-  const continueWithoutEmailButtonText = () =>
-    signedIn === true ? i18n.continueToActivity() : i18n.continueWithoutGuide();
+  const bodyText = isSignedIn
+    ? i18n.weHaveEverything()
+    : i18n.signUpToReceiveGuide();
+
+  const emailGuideButtonText = isSignedIn
+    ? i18n.emailMeAGuide()
+    : i18n.getGuideContinue();
+
+  const continueWithoutEmailButtonText = isSignedIn
+    ? i18n.continueToActivity()
+    : i18n.continueWithoutGuide();
 
   return (
     <div>
@@ -34,12 +48,12 @@ function HourOfCodeGuideEmailDialog(signedIn) {
           </div>
           <div className={style.middle}>
             <Heading3>{i18n.learnHowToHost()}</Heading3>
-            {bodyText()}
+            {bodyText}
           </div>
           <div className={style.buttonsBottom}>
             <Button
               id="uitest-no-email-guide"
-              text={continueWithoutEmailButtonText()}
+              text={continueWithoutEmailButtonText}
               onClick={() => {
                 onClose();
               }}
@@ -47,8 +61,10 @@ function HourOfCodeGuideEmailDialog(signedIn) {
             />
             <Button
               id="uitest-email-guide"
-              text={emailGuideButtonText()}
+              text={emailGuideButtonText}
               onClick={() => {
+                saveInputs();
+                sendEmail();
                 onClose();
               }}
               color={Button.ButtonColor.brandSecondaryDefault}
@@ -61,12 +77,9 @@ function HourOfCodeGuideEmailDialog(signedIn) {
 }
 
 HourOfCodeGuideEmailDialog.propTypes = {
-  // Provided by redux
-  signedIn: PropTypes.bool,
+  isSignedIn: PropTypes.bool.isRequired,
 };
 
 export const UnconnectedHourOfCodeGuideEmailDialog = HourOfCodeGuideEmailDialog;
 
-export default connect(state => ({
-  signedIn: state.currentUser.signInState === SignInState.SignedIn,
-}))(HourOfCodeGuideEmailDialog);
+export default HourOfCodeGuideEmailDialog;

--- a/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
+++ b/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
@@ -1,12 +1,9 @@
 import {assert, expect} from 'chai';
 import React from 'react';
-import sinon from 'sinon';
 import {UnconnectedHourOfCodeGuideEmailDialog as HourOfCodeGuideEmailDialog} from '@cdo/apps/templates/HourOfCodeGuideEmailDialog';
-import {shallow, mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import i18n from '@cdo/locale';
 import experiments from '@cdo/apps/util/experiments';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 describe('HourOfCodeGuideEmailDialog', () => {
   const defaultProps = {
@@ -31,15 +28,5 @@ describe('HourOfCodeGuideEmailDialog', () => {
     experiments.setEnabled(experiments.HOC_TUTORIAL_DIALOG, false);
     const wrapper = shallow(<HourOfCodeGuideEmailDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);
-  });
-
-  it('sends Amplitude event', () => {
-    const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
-    const wrapper = mount(<HourOfCodeGuideEmailDialog {...defaultProps} />);
-    wrapper.find('button#uitest-email-guide').simulate('click');
-
-    expect(analyticsSpy).to.have.been.calledOnce;
-    expect(analyticsSpy.firstCall.args).to.deep.eq([EVENTS.GUIDE_SENT_EVENT]);
-    analyticsSpy.restore();
   });
 });

--- a/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
+++ b/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
@@ -1,13 +1,16 @@
 import {assert, expect} from 'chai';
 import React from 'react';
+import sinon from 'sinon';
 import {UnconnectedHourOfCodeGuideEmailDialog as HourOfCodeGuideEmailDialog} from '@cdo/apps/templates/HourOfCodeGuideEmailDialog';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import i18n from '@cdo/locale';
 import experiments from '@cdo/apps/util/experiments';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 describe('HourOfCodeGuideEmailDialog', () => {
   const defaultProps = {
-    signedIn: true,
+    isSignedIn: true,
   };
 
   it('renders signed out text in Dialog', () => {
@@ -19,7 +22,7 @@ describe('HourOfCodeGuideEmailDialog', () => {
   it('renders correct translations if user is not signed in', () => {
     experiments.setEnabled(experiments.HOC_TUTORIAL_DIALOG, true);
     const wrapper = shallow(
-      <HourOfCodeGuideEmailDialog {...defaultProps} signedIn={false} />
+      <HourOfCodeGuideEmailDialog {...defaultProps} isSignedIn={false} />
     );
     expect(wrapper.contains(i18n.getGuideContinue()));
   });
@@ -28,5 +31,15 @@ describe('HourOfCodeGuideEmailDialog', () => {
     experiments.setEnabled(experiments.HOC_TUTORIAL_DIALOG, false);
     const wrapper = shallow(<HourOfCodeGuideEmailDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);
+  });
+
+  it('sends Amplitude event', () => {
+    const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
+    const wrapper = mount(<HourOfCodeGuideEmailDialog {...defaultProps} />);
+    wrapper.find('button#uitest-email-guide').simulate('click');
+
+    expect(analyticsSpy).to.have.been.calledOnce;
+    expect(analyticsSpy.firstCall.args).to.deep.eq([EVENTS.GUIDE_SENT_EVENT]);
+    analyticsSpy.restore();
   });
 });


### PR DESCRIPTION
This PR handles a small refactor (namely, uses a passed through variable for isSignedIn instead of hooking up to current user redux). The translation/text constants are updated accordingly. 

Then, it sets up some scaffolding for the send email button, splitting into a function for saving the inputs and sending the email. The email send function will also send the amplitude event, which is now set up!

<img width="525" alt="Screenshot 2023-10-24 at 4 07 01 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/cac9a2f9-0dd3-4cf5-adad-7676a0389491">


## Links

- spec: https://docs.google.com/document/d/1jSmRkX8O-PMDj9y-hvMubOMl1hkcRz8o9_nUO1s7gls/edit?pli=1
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1078

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
