### PR TITLE
Fixed not populating invited_by field for coteacher invitations

### DIFF
--- a/dashboard/app/controllers/api/v1/section_instructors_controller.rb
+++ b/dashboard/app/controllers/api/v1/section_instructors_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::SectionInstructorsController < Api::V1::JSONApiController
     authorize! :manage, section
 
     begin
-      si = section.add_instructor(params.require(:email))
+      si = section.add_instructor(params.require(:email), current_user)
       render json: si, serializer: Api::V1::SectionInstructorSerializer
     rescue ArgumentError => exception
       render json: {error: exception.message}, status: :bad_request

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -70,7 +70,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
     return head :bad_request unless section.persisted?
 
     # Add all coteachers specified in params
-    params[:instructor_emails]&.each {|instructor_email| section.add_instructor(instructor_email)}
+    params[:instructor_emails]&.each {|instructor_email| section.add_instructor(instructor_email, current_user)}
 
     # TODO: Move to an after_create step on Section model when old API is fully deprecated
     current_user.assign_script @unit if @unit
@@ -114,7 +114,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
     end
 
     # Add all coteachers specified in params
-    params[:instructor_emails]&.each {|instructor_email| section.add_instructor(instructor_email)}
+    params[:instructor_emails]&.each {|instructor_email| section.add_instructor(instructor_email, current_user)}
 
     render json: section.summarize
   end

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -584,7 +584,7 @@ class Section < ApplicationRecord
   end
   before_validation :strip_emoji_from_name
 
-  public def add_instructor(email)
+  public def add_instructor(email, current_user)
     instructor = User.find_by!(email: email, user_type: :teacher)
 
     deleted_section_instructor = validate_instructor(instructor)

--- a/dashboard/test/controllers/api/v1/section_instructors_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/section_instructors_controller_test.rb
@@ -62,6 +62,7 @@ class Api::V1::SectionInstructorsControllerTest < ActionController::TestCase
     assert_equal @teacher3.id, si.instructor_id
     assert_equal @section.id, si.section_id
     assert_equal :invited, si.status.to_sym
+    assert_equal @teacher, si.invited_by
   end
 
   test 'instructor can add a former instructor to instruct a section' do

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -539,7 +539,7 @@ class SectionTest < ActiveSupport::TestCase
     Timecop.freeze(Time.zone.now) do
       section = create :section
       coteacher_user = create :teacher
-      section.add_instructor(coteacher_user.email)
+      section.add_instructor(coteacher_user.email, current_user)
       section.reload
 
       expected = {


### PR DESCRIPTION
The `invited_by` field in `SectionInstructor` was not being populated correctly because the `add_instructor` method in `sections.rb` was not able to correctly identify the current_user [here](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/sections/section.rb#L597). FLUP to [this PR](https://github.com/code-dot-org/code-dot-org/pull/54392)

This PR fixes the bug and adds a test that `invited_by` is correctly filled out.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
