### PR TITLE
Remove pointers to local schools page

### DIFF
--- a/apps/src/templates/certificates/StudentsBeyondHoc.jsx
+++ b/apps/src/templates/certificates/StudentsBeyondHoc.jsx
@@ -3,7 +3,6 @@ import React, {Component} from 'react';
 import i18n from '@cdo/locale';
 import {connect} from 'react-redux';
 import VerticalImageResourceCardRow from '../VerticalImageResourceCardRow';
-import {LocalClassActionBlock} from '../studioHomepages/TwoColumnActionBlock';
 import {tutorialTypes} from '../tutorialTypes.js';
 import {cardSets} from './congratsBeyondHocActivityCards';
 import {ResponsiveSize} from '@cdo/apps/code-studio/responsiveRedux';
@@ -159,7 +158,6 @@ class StudentsBeyondHoc extends Component {
           />
         )}
         <div style={styles.spacer} />
-        <LocalClassActionBlock showHeading={false} />
       </div>
     );
   }

--- a/apps/src/templates/studioHomepages/CoursesStudentEnglish.jsx
+++ b/apps/src/templates/studioHomepages/CoursesStudentEnglish.jsx
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import {LocalClassActionBlock} from './TwoColumnActionBlock';
 import {CourseBlocksHoc} from './CourseBlocks';
 import CourseBlocksWrapper from '@cdo/apps/templates/studioHomepages/CourseBlocksWrapper';
 import {StudentGradeBandCards} from '@cdo/apps/util/courseBlockCardsConstants';
@@ -23,8 +22,6 @@ class CoursesStudentEnglish extends Component {
         />
 
         <CourseBlocksHoc />
-
-        <LocalClassActionBlock showHeading={true} />
       </div>
     );
   }

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -111,34 +111,6 @@ export const TwoColumnActionBlock = connect(state => ({
   isRtl: state.isRtl,
 }))(UnconnectedTwoColumnActionBlock);
 
-export class LocalClassActionBlock extends Component {
-  static propTypes = {
-    showHeading: PropTypes.bool.isRequired,
-  };
-
-  render() {
-    const {showHeading} = this.props;
-    const heading = showHeading ? i18n.findLocalClassHeading() : '';
-
-    return (
-      <TwoColumnActionBlock
-        imageUrl={pegasus(
-          '/shared/images/fill-540x300/misc/beyond-local-map.png'
-        )}
-        heading={heading}
-        subHeading={i18n.findLocalClassSubheading()}
-        description={i18n.findLocalClassDescription()}
-        buttons={[
-          {
-            url: pegasus('/learn/local'),
-            text: i18n.findLocalClassButton(),
-          },
-        ]}
-      />
-    );
-  }
-}
-
 export class AdministratorResourcesActionBlock extends Component {
   render() {
     return (

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.story.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.story.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  LocalClassActionBlock,
   AdministratorResourcesActionBlock,
   TwoColumnActionBlock,
 } from './TwoColumnActionBlock';
@@ -12,14 +11,6 @@ export default {
   component: TwoColumnActionBlock,
 };
 
-const LocalClassActionBlockTemplate = args => {
-  return (
-    <Provider store={reduxStore()}>
-      <LocalClassActionBlock showHeading={true} />
-    </Provider>
-  );
-};
-
 const AdministratorResourcesActionBlockTemplate = args => {
   return (
     <Provider store={reduxStore()}>
@@ -27,10 +18,6 @@ const AdministratorResourcesActionBlockTemplate = args => {
     </Provider>
   );
 };
-
-export const LocalClassActionBlockExamples = LocalClassActionBlockTemplate.bind(
-  {}
-);
 
 export const AdministratorResourcesActionBlockExamples =
   AdministratorResourcesActionBlockTemplate.bind({});

--- a/apps/test/unit/templates/certificates/StudentsBeyondHocTest.js
+++ b/apps/test/unit/templates/certificates/StudentsBeyondHocTest.js
@@ -37,16 +37,4 @@ describe('StudentsBeyondHoc', () => {
     );
     expect(wrapper.find('CourseBlocksStudentGradeBands').exists());
   });
-
-  it('renders a LocalClassActionBlock component', () => {
-    const wrapper = wrapped(
-      <StudentsBeyondHoc
-        completedTutorialType="other"
-        MCShareLink="code.org/minecraft/sharelink"
-        userType="signedOut"
-        isEnglish={true}
-      />
-    );
-    expect(wrapper.find('LocalClassActionBlock').exists());
-  });
 });

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -35,7 +35,6 @@ describe('Courses', () => {
         'SpecialAnnouncement',
         'CourseBlocksWrapper',
         'CourseBlocksHoc',
-        'LocalClassActionBlock',
       ]);
     });
 

--- a/pegasus/emails/petition_receipt.md
+++ b/pegasus/emails/petition_receipt.md
@@ -12,7 +12,7 @@ subject: 'Thanks!'
 
 ## 1) Learn yourself (or have your child learn)
 
-[Learn online](https://code.org/learn) or [find local schools, camps, or workshops](https://code.org/learn/local) that teach coding.
+[Learn online](https://code.org/learn).
 
 <% if defined?(role_s) && ['educator'].include?(role_s) %>
 
@@ -38,7 +38,7 @@ You can teach these self-serve [intro courses](https://studio.code.org), with pr
 
 ## 3) Ask your local school to [teach computer science](https://code.org/educate)
 
-Here's a [sample letter](https://code.org/promote/letter) to send to your school! Your local school can teach these [intro courses](https://studio.code.org), partner with us to bring computer science [to your entire district or region](https://code.org/educate/partner), and inspire students with [these videos](https://code.org/educate/inspire). Check [our map](https://code.org/learn/local) to see if your school teaches computer science. If not, ask them to.
+Here's a [sample letter](https://code.org/promote/letter) to send to your school! Your local school can teach these [intro courses](https://studio.code.org), partner with us to bring computer science [to your entire district or region](https://code.org/educate/partner), and inspire students with [these videos](https://code.org/educate/inspire). Check [our map](https://code.org/yourschool) to see if your school teaches computer science. If not, ask them to.
 
 <% end %>
 

--- a/pegasus/sites.v3/hourofcode.com/public/beyond.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/beyond.haml
@@ -18,15 +18,6 @@ layout: wide
 .clear
 
 %h1#student-section For students
-%h2 Find a local class
-.full-resource-block{style: "margin-top: 20px;"}
-  %img.side-image.left{src: "/images/beyond-local-map.png"}
-  .side-description-area.right
-    .description
-      %h2.resource-title{style: "padding-bottom: 10px;"} Local classes
-      Find a local workshop, school, or summer camp to learn in a classroom.
-    %a{href: "https://code.org/learn/local"}
-      %button.gray-button Find a class
 
 .clear
 

--- a/pegasus/test/fixtures/deliverer/expected/petition_receipt/body.html
+++ b/pegasus/test/fixtures/deliverer/expected/petition_receipt/body.html
@@ -8,7 +8,7 @@
 
 <h2>1) Learn yourself (or have your child learn)</h2>
 
-<p><a href="https://code.org/learn">Learn online</a> or <a href="https://code.org/learn/local">find local schools, camps, or workshops</a> that teach coding.</p>
+<p><a href="https://code.org/learn">Learn online</a>.</p>
 
 <h2>2) <a href="https://hourofcode.com">Host an Hour of Code</a> at work, in your community, or local school</h2>
 
@@ -17,7 +17,7 @@
 <h2>3) Ask your local school to <a href="https://code.org/educate">teach computer science</a>
 </h2>
 
-<p>Here's a <a href="https://code.org/promote/letter">sample letter</a> to send to your school! Your local school can teach these <a href="https://studio.code.org">intro courses</a>, partner with us to bring computer science <a href="https://code.org/educate/partner">to your entire district or region</a>, and inspire students with <a href="https://code.org/educate/inspire">these videos</a>. Check <a href="https://code.org/learn/local">our map</a> to see if your school teaches computer science. If not, ask them to.</p>
+<p>Here's a <a href="https://code.org/promote/letter">sample letter</a> to send to your school! Your local school can teach these <a href="https://studio.code.org">intro courses</a>, partner with us to bring computer science <a href="https://code.org/educate/partner">to your entire district or region</a>, and inspire students with <a href="https://code.org/educate/inspire">these videos</a>. Check <a href="https://code.org/yourschool">our map</a> to see if your school teaches computer science. If not, ask them to.</p>
 
 <h2>4) Support our work</h2>
 


### PR DESCRIPTION
Removes links to code.org/learn/local from Congrats Page, Student Courses Page, Hour of Code Beyond page, and Petition text. Sending people to this page is not leading them down the funnels we are hoping for them to accomplish at those times.