### PR TITLE
Fix squished text in the LearningGoal component

### DIFF
--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -295,7 +295,6 @@ button.rubricHeaderTab {
   display: flex;
   align-items: center;
   gap: 16px;
-  width: 100%;
   font-size: 14px;
   padding-left: 10px;
 }


### PR DESCRIPTION
Before:

<img width="759" alt="Screenshot 2023-10-25 at 11 40 02 AM" src="https://github.com/code-dot-org/code-dot-org/assets/46464143/04c83e3b-bdbe-4c24-b8c6-46d11673748b">

After:

<img width="759" alt="Screenshot 2023-10-25 at 11 41 56 AM" src="https://github.com/code-dot-org/code-dot-org/assets/46464143/3f42d8be-c382-4ca1-87cb-87eeabe59fed">

I checked this in Chrome, Firefox, and Safari and it looks good to me.