### PR TITLE
Show string when understanding is No Evidence for student

### DIFF
--- a/apps/src/templates/rubrics/LearningGoal.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.jsx
@@ -228,7 +228,7 @@ export default function LearningGoal({
           )}
           {submittedEvaluation && (
             <div className={style.submittedEvaluation}>
-              {submittedEvaluation.understanding && (
+              {submittedEvaluation.understanding !== null && (
                 <BodyThreeText>
                   {
                     UNDERSTANDING_LEVEL_STRINGS[

--- a/apps/test/unit/templates/rubrics/LearningGoalTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalTest.jsx
@@ -279,6 +279,24 @@ describe('LearningGoal', () => {
     );
   });
 
+  it('shows No Evidence understanding in header if submittedEvaluation contains understand', () => {
+    const wrapper = shallow(
+      <LearningGoal
+        learningGoal={{
+          learningGoal: 'Testing',
+          evidenceLevels: [],
+        }}
+        submittedEvaluation={{
+          feedback: 'test feedback',
+          understanding: RubricUnderstandingLevels.NONE,
+        }}
+      />
+    );
+    expect(wrapper.find('BodyThreeText').props().children).to.equal(
+      'No Evidence'
+    );
+  });
+
   it('passes isStudent down to EvidenceLevels', () => {
     const props = {
       learningGoal: {


### PR DESCRIPTION
This one was a little bit of a journey -- took me quite a while to realize that `0 && true` returns `0` in JS and that's why the zero was appearing 🙃 checking that it's not null is working as expected

before:
<img width="1113" alt="Screenshot 2023-10-25 at 12 43 27 PM" src="https://github.com/code-dot-org/code-dot-org/assets/46464143/bf5251c7-06b8-4e8e-bb66-cbe084ab29d1">

after:
<img width="1116" alt="Screenshot 2023-10-25 at 12 41 23 PM" src="https://github.com/code-dot-org/code-dot-org/assets/46464143/7ce6e50f-c1b2-46e6-94db-378c3900523a">

The teacher view has been working as expected so no updates were needed there.
