### PR TITLE
Alarm on Missing Memory Utilization Data

### DIFF
--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -31,7 +31,7 @@
       Period: 60
       Statistic: Maximum
       Threshold: 87
-      TreatMissingData: missing
+      TreatMissingData: breaching
 <% if environment == :production -%>
   # Detect problems with the bin/cron/deliver_poste_messages scheduled job by monitoring outbound emails sent by AWS SES.
   OutboundEmailAlarm:


### PR DESCRIPTION
Treat missing data in the metric for memory utilization on our frontend servers as an error, rather than just accepting it. We want to know if our memory usage metrics stop working for any reason.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/54367