### PR TITLE
P20-398: Fix the Dashboard Curriculum content i18n sync-out

### DIFF
--- a/bin/i18n/resources/dashboard/curriculum_content/sync_out.rb
+++ b/bin/i18n/resources/dashboard/curriculum_content/sync_out.rb
@@ -268,6 +268,12 @@ module I18n
             # Finally, write each resulting collection of strings out to a rails i18n config file.
             types_i18n_data.each do |type, type_i18n_data|
               target_i18n_file_path = File.join(ORIGIN_I18N_DIR_PATH, "#{type}.#{language[:locale_s]}.json")
+
+              if File.exist?(target_i18n_file_path)
+                existing_type_i18n_data = JSON.load_file(target_i18n_file_path).dig(language[:locale_s], 'data', type)
+                type_i18n_data = existing_type_i18n_data.deep_merge(type_i18n_data)
+              end
+
               i18n_data = I18nScriptUtils.to_dashboard_i18n_data(language[:locale_s], type, type_i18n_data)
 
               I18nScriptUtils.write_json_file(target_i18n_file_path, i18n_data)


### PR DESCRIPTION
Fixed removing existing Curriculum content localizations from the Dashboard locale files during i18n sync-out:
https://github.com/code-dot-org/code-dot-org/pull/54459/commits/4e57ce393de97ea0ed9fc9b7abda26f408b0cbbd#diff-284bfa7cb8fe9507ec765d426b9b02ba7d3beabd64f935335895f89b20efad98

## Links
- jira ticket: [P20-398](https://codedotorg.atlassian.net/browse/P20-398)