### PR TITLE
Restore and de-flake /yourschool UI test

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/yourschool.feature
+++ b/dashboard/test/ui/features/acquisition_products/yourschool.feature
@@ -29,9 +29,6 @@ Feature: Using the YourSchool census page
     Then I press "#submit-button" using jQuery
     Then I wait until I am on "http://code.org/yourschool/thankyou"
 
-  # The google map on /yourschool is broken in production. We should stop skipping
-  # this test as soon as that page is fixed.
-  @skip
   @no_circle
   Scenario: Use census map to select school
     Given I am on "http://code.org/yourschool"
@@ -46,10 +43,6 @@ Feature: Using the YourSchool census page
     Then I press keys "ALBERT EINSTEIN ACADEMY ELEMENTARY" for element "#map input"
     Then I wait until element ".VirtualizedSelectOption:contains('Albert Einstein Academy Elementary - Santa Clarita, CA 91355')" is visible
     Then I press ".VirtualizedSelectOption:contains('Albert Einstein Academy Elementary - Santa Clarita, CA 91355')" using jQuery
-
-    # Click the "Take the survey for this school" button
-    Then I wait until element "#census-info-window" is visible
-    And I press the first "#census-info-window div.button-text" element
 
     # Verify that the correct school id is set in the census form
     Then element "#form input[name='nces_school_s']" has value "60000113717"


### PR DESCRIPTION
[This PR](https://github.com/code-dot-org/code-dot-org/pull/54429) was supposed to restore the /yourschool test we had been skipping for a while back when the mapbox was broken on production. However, it was super flaky due to [this line](https://github.com/code-dot-org/code-dot-org/pull/54429/files#diff-237daa47d5d4ea641c085b8e74468c883c0ddc8b01d482284e6e41bf8c34d6ebL51) where it would zoom in on where the school was but not always open up the dialog associated with that school (so, it would never see "#census-info-window" and it would fail). That PR was then [reverted](https://github.com/code-dot-org/code-dot-org/pull/54455).

This PR takes another stab at restoring the test by removing the section where it views the dialog within the map and just checks that the correct school was found when searching for it in the dropdown. While this removes any explicit testing of the mapbox, I think this might be for the best due to how finicky mapbox is (especially in non-production contexts). We were already skipping this test anyways, so adding this can only give us more confidence the page working properly.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1028)

## Testing story
Ran this locally and it succeeded every time. For comparison, when I ran the [original test restoration PR](https://github.com/code-dot-org/code-dot-org/pull/54429) it failed half the time locally, so this seems promising.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
