### PR TITLE
Makes AccessibleDialog functional and flexible, makes HOC Guide show up for signed in

### DIFF
--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -104,7 +104,7 @@ class DanceVisualizationColumn extends React.Component {
         {!this.props.isShareView && (
           <AgeDialog turnOffFilter={this.turnFilterOff} />
         )}
-        {this.props.over21 && !isSignedIn && (
+        {(this.props.over21 || this.props.userType === 'teacher') && (
           <HourOfCodeGuideEmailDialog isSignedIn={isSignedIn} />
         )}
         <div style={{maxWidth: MAX_GAME_WIDTH}}>

--- a/apps/src/templates/AccessibleDialog.jsx
+++ b/apps/src/templates/AccessibleDialog.jsx
@@ -2,32 +2,40 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import FocusTrap from 'focus-trap-react';
 import CloseOnEscape from '@cdo/apps/templates/CloseOnEscape';
-import style from './accessible-dialogue.module.scss';
+import defaultStyle from './accessible-dialogue.module.scss';
 import classnames from 'classnames';
 
-const AccessibleDialog = ({
+function AccessibleDialog({
+  styles,
   onClose,
   children,
   className,
   initialFocus = true,
-}) => (
-  <>
-    <div className={style.modalBackdrop} />
-    <CloseOnEscape handleClose={onClose}>
-      <FocusTrap focusTrapOptions={{initialFocus: initialFocus}}>
-        <div
-          aria-modal
-          className={classnames(style.modal, className)}
-          role="dialog"
-        >
-          {children}
-        </div>
-      </FocusTrap>
-    </CloseOnEscape>
-  </>
-);
+}) {
+  // If these styles are provided by the given stylesheet, use them
+  const modalStyle = styles?.modal || defaultStyle.modal;
+  const backdropStyle = styles?.modalBackdrop || defaultStyle.modalBackdrop;
+
+  return (
+    <div>
+      <div className={backdropStyle} />
+      <CloseOnEscape handleClose={onClose}>
+        <FocusTrap focusTrapOptions={{initialFocus: initialFocus}}>
+          <div
+            aria-modal
+            className={classnames(modalStyle, className)}
+            role="dialog"
+          >
+            {children}
+          </div>
+        </FocusTrap>
+      </CloseOnEscape>
+    </div>
+  );
+}
 
 AccessibleDialog.propTypes = {
+  styles: PropTypes.object,
   onClose: PropTypes.func.isRequired,
   children: PropTypes.node,
   className: PropTypes.string,

--- a/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
+++ b/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
@@ -7,7 +7,7 @@ import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {Heading1, Heading3} from '@cdo/apps/componentLibrary/typography';
 import experiments from '@cdo/apps/util/experiments';
-import style from './accessible-dialogue.module.scss';
+import style from './hoc-guide-dialogue.module.scss';
 
 function HourOfCodeGuideEmailDialog({isSignedIn}) {
   const [isOpen, setIsOpen] = useState(true);
@@ -42,7 +42,7 @@ function HourOfCodeGuideEmailDialog({isSignedIn}) {
   return (
     <div>
       {isOpen && experiments.isEnabled(experiments.HOC_TUTORIAL_DIALOG) && (
-        <AccessibleDialog onClose={onClose}>
+        <AccessibleDialog styles={style} onClose={onClose}>
           <div tabIndex="0">
             <Heading1>{i18n.welcomeToDanceParty()}</Heading1>
           </div>

--- a/apps/src/templates/hoc-guide-dialogue.module.scss
+++ b/apps/src/templates/hoc-guide-dialogue.module.scss
@@ -8,7 +8,7 @@
   left: 0;
   background-color: #000;
   opacity: 0.6;
-  z-index: 1250;
+  z-index: 10500;
 };
 
 .modal {
@@ -16,11 +16,28 @@
   top: 10%;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 1350;
+  z-index: 11000;
   width: 70%;
   max-width: 600px;
   background-color: #fff;
   border-radius: 4px;
   padding: 1rem;
   overflow: auto;
+};
+
+.middle {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  padding-bottom: 20px;
+  padding-top: 20px;
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+  border-right-width: 0;
+  border-left-width: 0;
+  border-style: solid;
+  border-color: $lighter_gray;
+};
+
+.buttonsBottom {
+  float: right;
 };


### PR DESCRIPTION
This PR does a few things. 

1. Adds the HOC guide component for signed in users (still behind experiment flag), displaying the email option in front of any videos that exist on the relevant levels (this is what the jira ticket below refers to)
2. Refactors the AccessibleDialog component to allow style inputs (this allows the overlays to be altered so they display at a higher z index than the videos)
3. Turns the AccessibleDialog into a functional component
4. Moves the styling for the HOC Guide component into its own stylesheet, removes the former additions to the accessible dialog stylesheet from [PR earlier in this project](https://github.com/code-dot-org/code-dot-org/pull/54338/files)

How the dialog now looks for signed in users:
<img width="1167" alt="Screenshot 2023-10-25 at 3 58 04 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/deaa8235-880f-4da6-b5fa-1c5114654432">


## Links

- spec: https://docs.google.com/document/d/1jSmRkX8O-PMDj9y-hvMubOMl1hkcRz8o9_nUO1s7gls/edit?pli=1
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1081

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
