### PR TITLE
P20-398: Fix the Dashboard Curriculum content i18n sync-out

### DIFF
--- a/bin/i18n/resources/dashboard/curriculum_content/sync_out.rb
+++ b/bin/i18n/resources/dashboard/curriculum_content/sync_out.rb
@@ -238,7 +238,7 @@ module I18n
             types_i18n_data = {}
 
             crowdin_file_paths = Dir.glob(File.join(crowdin_locale_dir_of(language), '**/*.json'))
-            progress_bar.total += crowdin_file_paths.size
+            mutex.synchronize {progress_bar.total += crowdin_file_paths.size}
 
             # First we gather together all our script objects into a single hash
             crowdin_file_paths.each do |crowdin_file_path|
@@ -247,7 +247,7 @@ module I18n
 
               types_i18n_data[type] = type_i18n_data if type_i18n_data.present?
             ensure
-              progress_bar.increment
+              mutex.synchronize {progress_bar.increment}
             end
 
             # Then we recursively flatten all of our hashes of objects, to group them by type rather than by script
@@ -258,7 +258,7 @@ module I18n
             types_i18n_data = restore_reference_guide_i18n_keys(types_i18n_data)
             types_i18n_data = fix_resource_urls(types_i18n_data)
 
-            types_i18n_data
+            types_i18n_data.stringify_keys
           end
 
           def distribute_localization(language)

--- a/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_out.rb
+++ b/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_out.rb
@@ -157,8 +157,7 @@ describe I18n::Resources::Dashboard::CurriculumContent::SyncOut do
     let(:flatten_types_i18n_data) {'flatten_types_i18n_data'}
     let(:restored_lesson_keys_i18n_data) {'restored_lesson_keys_i18n_data'}
     let(:restored_reference_guide_keys_i18n_data) {'restored_reference_guide_keys_i18n_data'}
-    let(:fixed_resource_urls_i18n_data) {'restore_resource_keys_i18n_data'}
-    let(:expected_types_i18n_data) {fixed_resource_urls_i18n_data}
+    let(:fixed_resource_urls_i18n_data) {{fixed_resource_urls: 'i18n_data'}}
 
     before do
       FileUtils.mkdir_p File.dirname(crowdin_file_path)
@@ -174,7 +173,7 @@ describe I18n::Resources::Dashboard::CurriculumContent::SyncOut do
       described_instance.expects(:restore_reference_guide_i18n_keys).with(restored_lesson_keys_i18n_data).in_sequence(execution_sequence).returns(restored_reference_guide_keys_i18n_data)
       described_instance.expects(:fix_resource_urls).with(restored_reference_guide_keys_i18n_data).in_sequence(execution_sequence).returns(fixed_resource_urls_i18n_data)
 
-      assert_equal expected_types_i18n_data, types_i18n_data
+      assert_equal({'fixed_resource_urls' => 'i18n_data'}, types_i18n_data)
     end
   end
 


### PR DESCRIPTION
## Issue
1. bundler: failed to load command: `./bin/i18n/sync-all.rb (./bin/i18n/sync-all.rb)`
2. `./bin/i18n/resources/dashboard/curriculum_content/sync_out.rb:274`:in block in `distribute_localization`: `undefined method "deep_merge" for nil:NilClass (NoMethodError)`

## Links
- jira ticket: [P20-398](https://codedotorg.atlassian.net/browse/P20-398)