### PR TITLE
[Google Blockly] Workaround for procedure rename bug

### DIFF
--- a/apps/src/blockly/eventHandlers.js
+++ b/apps/src/blockly/eventHandlers.js
@@ -17,13 +17,18 @@
 // This bug is tracked by the Blockly team:
 // https://github.com/google/blockly-samples/issues/2035
 export function disableOrphans(blockEvent) {
+  // This check is for when a block goes from disabled to enabled (value false is enabled).
+  // We need to run the check on this event due to the Blockly bug described above.
+  const isEnabledEvent =
+    blockEvent.type === Blockly.Events.BLOCK_CHANGE &&
+    blockEvent.element === 'disabled' &&
+    !blockEvent.newValue &&
+    blockEvent.oldValue;
+
   if (
     blockEvent.type === Blockly.Events.BLOCK_MOVE ||
     blockEvent.type === Blockly.Events.BLOCK_CREATE ||
-    (blockEvent.type === Blockly.Events.BLOCK_CHANGE &&
-      blockEvent.element === 'disabled' &&
-      !blockEvent.newValue &&
-      blockEvent.oldValue)
+    isEnabledEvent
   ) {
     if (!blockEvent.workspaceId) {
       return;

--- a/apps/src/blockly/eventHandlers.js
+++ b/apps/src/blockly/eventHandlers.js
@@ -1,14 +1,27 @@
-// A custom version of Blockly's Events.disableOrphans that will disable orphans
-// even if the workspace is dragging. This enables the preview to update as soon as
+// A custom version of Blockly's Events.disableOrphans. This makes a couple
+// changes to the original function.
+
+// First, it will disable orphans even if the workspace is dragging.
+// This enables the preview to update as soon as
 // a block is dragged away from "when run", and for a new block to be
 // immediately disabled until it is attached to the main block.
-// Copied and modified from Blockly/core/events/utils:disableOrphans. The only change from
+// Copied and modified from Blockly/core/events/utils:disableOrphans. The change from
 // the original function was to remove a check on eventWorkspace.isDragging():
 // https://github.com/google/blockly/blob/1e3b5b4c76f24d2274ef4947c1fcf657f0058f11/core/events/utils.ts#L549
+
+// Second, we also run this event if a block change event fired for a field. This is
+// because of procedures. When we rename a procedure it triggers a field change
+// on the main workspace caller block. If that block was an orphan, it becomes enabled
+// because it gets an update from the other workspace which did not know it was previously
+// disabled, and therefore wipes the disabled status. We therefore need to check again
+// if it should be disabled.
 export function disableOrphans(blockEvent) {
+  console.log({blockEvent});
   if (
     blockEvent.type === Blockly.Events.BLOCK_MOVE ||
-    blockEvent.type === Blockly.Events.BLOCK_CREATE
+    blockEvent.type === Blockly.Events.BLOCK_CREATE ||
+    (blockEvent.type === Blockly.Events.BLOCK_CHANGE &&
+      blockEvent.element === 'field')
   ) {
     if (!blockEvent.workspaceId) {
       return;


### PR DESCRIPTION
There is an [issue](https://github.com/google/blockly-samples/issues/2035) in the Google Blockly shareable procedures code where if you edit the name of a block that is in the workspace but not attached to “when run”, it will become enabled when you close the function editor. In addition, every other disabled function block will also become enabled.

While we wait for a fix (which will also require us to upgrade to v10), we can work around this issue with our custom `disableOrphans` event handler. We now run this event when we see a block go from disabled to enabled, so we can re-disable the block if needed.

## Links

- jira ticket: [CT-116](https://codedotorg.atlassian.net/browse/CT-116)


## Testing story
Tested locally that renaming a block does not change the enabled/disabled state of that block.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
