### PR TITLE
DOTD: update end of shift DOTD msg in script to match current team norms

### DIFF
--- a/bin/dotd
+++ b/bin/dotd
@@ -341,7 +341,7 @@ end
 def puts_script_conclusion
   puts <<-EOS.unindent
 
-   #{bold "Send your DOTD Report to dev@code.org. You can find a log of your day at #{LOG_FILE}"}
+   #{bold "Post a summary of your DOTD shift in the #developers Slack channel. You can find a log of your day at #{LOG_FILE}"}
 
   #{bold "You're done!"}
   EOS


### PR DESCRIPTION
Tiny update to the DOTD script to better reflect how the DOTD now keeps the team informed about the their shift. 
