### PR TITLE
Export census_summaries to Redshift

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -73,6 +73,7 @@ cron:
     - tell_us_more
     - inaccuracy_comment
 - dashboard.census_submissions_school_infos
+- dashboard.census_summaries
 - dashboard.standards
 - dashboard.stages_standards
 - dashboard.standard_categories


### PR DESCRIPTION
Added dashboard.census_summaries to redshift export cron.


## Testing story

```
code-dot-org % export AWS_PROFILE=codeorg-admin
code-dot-org % bundle exec rake stack:data:validate RAILS_ENV=production
Finished stack:data:environment (less than a minute)
Pending update for stack `DATA-production`:
Modify DMSCron [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
Finished stack:data:validate (1 minute)
```

## Follow-up work

This table gets updated once a year, and needs to be pulled into redshift at that time.  I'm not sure that adding it to the daily replication process is the most efficient (unless there is some mechanism for DMS to know that nothing has changed and it ignores it.  In which case, fine.


## Privacy

This table has no PII.


## PR Checklist:


- [ ] Tests provide adequate coverage
- [X ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [X ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
