### PR TITLE
Add emojis map in prep for emoji name experiment

### DIFF
--- a/apps/script/HoC2023AiGenerateWeights.py
+++ b/apps/script/HoC2023AiGenerateWeights.py
@@ -8,10 +8,14 @@ import json
 nlp = spacy.load("en_core_web_lg")
 
 ai_inputs_file = open('apps/static/dance/ai/ai-inputs.json')
-data = json.load(ai_inputs_file)
-emoji_ids = []
-for emoji in data['items']:
-    emoji_ids.append(emoji['name'])
+emojis_data = json.load(ai_inputs_file)
+emojis_map = {}
+emojis_list = []
+for emoji in emojis_data['items']:
+    name = emoji['name']
+    id = emoji['id']
+    emojis_map[name] = id
+    emojis_list.append(name)
 
 # We rename foreground/background effects and palettes as their python_name
 # to better reflect the actual output of the effect or color.
@@ -108,36 +112,33 @@ foreground_dict = {}
 color_palettes = list(color_palettes_map.keys())
 background_effects = list(background_effects_map.keys())
 foreground_effects = list(foreground_effects_map.keys())
-print(color_palettes)
-print(background_effects)
-print(foreground_effects)
 
 # Calculate and print similarity scores
-for id_word in emoji_ids:
+for emoji_name in emojis_list:
     palette_scores = []
     for palette_word in color_palettes:
-        id_token = nlp(id_word)
+        id_token = nlp(emoji_name)
         palette_token = nlp(palette_word)
         similarity_score = id_token.similarity(palette_token)
         palette_scores.append(round(similarity_score, 2))
     
     background_scores = []
-    for bg_word in background_effects:
-        id_token = nlp(id_word)
-        bg_token = nlp(bg_word)
-        similarity_score = id_token.similarity(bg_token)
+    for background_word in background_effects:
+        id_token = nlp(emoji_name)
+        background_token = nlp(background_word)
+        similarity_score = id_token.similarity(background_token)
         background_scores.append(round(similarity_score, 2))
         
     foreground_scores = []
-    for fg_word in foreground_effects:
-        id_token = nlp(id_word)
-        fg_token = nlp(fg_word)
-        similarity_score = id_token.similarity(fg_token)
+    for foreground_word in foreground_effects:
+        id_token = nlp(emoji_name)
+        foreground_token = nlp(foreground_word)
+        similarity_score = id_token.similarity(foreground_token)
         foreground_scores.append(round(similarity_score, 2))
-        
-    palette_dict[id_word] = palette_scores
-    background_dict[id_word] = background_scores
-    foreground_dict[id_word] = foreground_scores
+    emoji_id = emojis_map[emoji_name]
+    palette_dict[emoji_id] = palette_scores
+    background_dict[emoji_id] = background_scores
+    foreground_dict[emoji_id] = foreground_scores
 
 palette_output = {'emojiAssociations': palette_dict, 'output': color_palettes}
 background_output = {'emojiAssociations': background_dict, 'output': background_effects}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
@samantha-code would like to experiment with using different descriptions for the emojis used in the AI modal. In prep for this, this PR adds an emojis map to `HoC2023AiGenerateWeights.py` so that we can experiement with different names in the `ai-inputs.json` file. The emoji id must remain the same, but the emoji name can be updated. 

This is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/54499.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
