### PR TITLE
Adding runtime metrics to sync base scripts

### DIFF
--- a/bin/i18n/utils/sync_in_base.rb
+++ b/bin/i18n/utils/sync_in_base.rb
@@ -5,9 +5,9 @@ module I18n
   module Utils
     class SyncInBase
       def self.perform
-        resource_class = name.match(/.*::(?<component>\w+)::SyncIn/)
+        resource_class = name[/^.*::(\w+::\w+)::SyncIn/, 1] || name
 
-        I18n::Metrics.report_runtime(resource_class[:component], 'sync-in') do
+        I18n::Metrics.report_runtime(resource_class, 'sync-in') do
           new.send(:perform)
         end
       end

--- a/bin/i18n/utils/sync_in_base.rb
+++ b/bin/i18n/utils/sync_in_base.rb
@@ -1,10 +1,15 @@
 require_relative '../i18n_script_utils'
+require_relative '../metrics'
 
 module I18n
   module Utils
     class SyncInBase
       def self.perform
-        new.send(:perform)
+        resource_class = name.match(/.*::(?<component>\w+)::SyncIn/)
+
+        I18n::Metrics.report_runtime(resource_class[:component], 'sync-in') do
+          new.send(:perform)
+        end
       end
 
       protected

--- a/bin/i18n/utils/sync_out_base.rb
+++ b/bin/i18n/utils/sync_out_base.rb
@@ -5,7 +5,7 @@ module I18n
   module Utils
     class SyncOutBase
       def self.perform
-        resource_class = name.match(/.*::(?<component>\w+)::SyncOut/)
+        resource_class = name[/^.*::(\w+::\w+)::SyncOut/, 1] || name
 
         I18n::Metrics.report_runtime(resource_class, 'sync-out') do
           new.send(:perform)

--- a/bin/i18n/utils/sync_out_base.rb
+++ b/bin/i18n/utils/sync_out_base.rb
@@ -1,10 +1,15 @@
 require_relative '../i18n_script_utils'
+require_relative '../metrics'
 
 module I18n
   module Utils
     class SyncOutBase
       def self.perform
-        new.send(:perform)
+        resource_class = name.match(/.*::(?<component>\w+)::SyncOut/)
+
+        I18n::Metrics.report_runtime(resource_class, 'sync-out') do
+          new.send(:perform)
+        end
       end
 
       protected

--- a/bin/test/i18n/utils/test_sync_in_base.rb
+++ b/bin/test/i18n/utils/test_sync_in_base.rb
@@ -10,6 +10,11 @@ describe I18n::Utils::SyncInBase do
       described_class.any_instance.expects(:process).once
       described_class.perform
     end
+
+    it 'calls report_runtime metrics with class name' do
+      I18n::Metrics.expects(:report_runtime).with(described_class.name, 'sync-in').once
+      described_class.perform
+    end
   end
 
   describe '#process' do

--- a/bin/test/i18n/utils/test_sync_in_base.rb
+++ b/bin/test/i18n/utils/test_sync_in_base.rb
@@ -15,6 +15,23 @@ describe I18n::Utils::SyncInBase do
       I18n::Metrics.expects(:report_runtime).with(described_class.name, 'sync-in').once
       described_class.perform
     end
+
+    it 'reports the runtime metric with ResourceParent::ResourceChild' do
+      module I18n
+        module Resources
+          module ResourceParent
+            module ResourceChild
+              class SyncIn < I18n::Utils::SyncInBase
+              end
+            end
+          end
+        end
+      end
+
+      I18n::Metrics.expects(:report_runtime).with('ResourceParent::ResourceChild', 'sync-in').once
+
+      I18n::Resources::ResourceParent::ResourceChild::SyncIn.perform
+    end
   end
 
   describe '#process' do

--- a/bin/test/i18n/utils/test_sync_out_base.rb
+++ b/bin/test/i18n/utils/test_sync_out_base.rb
@@ -25,6 +25,23 @@ describe I18n::Utils::SyncOutBase do
       I18n::Metrics.expects(:report_runtime).with(described_class.name, 'sync-out').once
       described_class.perform
     end
+
+    it 'reports the runtime metric with ResourceParent::ResourceChild' do
+      module I18n
+        module Resources
+          module ResourceParent
+            module ResourceChild
+              class SyncOut < I18n::Utils::SyncOutBase
+              end
+            end
+          end
+        end
+      end
+
+      I18n::Metrics.expects(:report_runtime).with('ResourceParent::ResourceChild', 'sync-out').once
+
+      I18n::Resources::ResourceParent::ResourceChild::SyncOut.perform
+    end
   end
 
   describe '#process' do

--- a/bin/test/i18n/utils/test_sync_out_base.rb
+++ b/bin/test/i18n/utils/test_sync_out_base.rb
@@ -20,6 +20,11 @@ describe I18n::Utils::SyncOutBase do
       described_class.any_instance.expects(:process).once
       described_class.perform
     end
+
+    it 'calls report_runtime metrics with class name' do
+      I18n::Metrics.expects(:report_runtime).with(described_class.name, 'sync-out').once
+      described_class.perform
+    end
   end
 
   describe '#process' do


### PR DESCRIPTION
This PR adds runtime logging to the sync base scripts.
With this addition, any new sync-in or sync-out module that inherits the base sync classes will automatically log runtime metrics to CloundWatch.

## Links

Jira tickets: 
- [P20-440](https://codedotorg.atlassian.net/browse/P20-440)
- [P20-441](https://codedotorg.atlassian.net/browse/P20-441)

## Testing story

Ran a couple times the sync-in to verify different components where logging runtimes:
<img width="1425" alt="Screenshot 2023-10-26 at 13 54 36" src="https://github.com/code-dot-org/code-dot-org/assets/66776217/c7918d0b-f5fd-426f-8119-20c937135878">

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
