### PR TITLE
Kaitie - Amplitude Event for changing rubric evaluation

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -85,6 +85,7 @@ const EVENTS = {
   TA_RUBRIC_ON_STUDENT_WORK_LOADED: 'TA Rubric On Student Work Loaded',
   TA_RUBRIC_ON_STUDENT_WORK_UNLOADED: 'TA Rubric On Student Work Unloaded',
   TA_RUBRIC_SUBMITTED: 'TA Rubric Submitted',
+  TA_RUBRIC_EVIDENCE_LEVEL_SELECTED: 'TA Rubric Evidence Level Selected',
 
   // Hour of Code
   AGE_21_SELECTED_EVENT: 'Age 21+ Selected',

--- a/apps/src/templates/rubrics/LearningGoal.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.jsx
@@ -145,6 +145,13 @@ export default function LearningGoal({
 
   // Callback to retrieve understanding data from EvidenceLevels
   const radioButtonCallback = radioButtonData => {
+    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_EVIDENCE_LEVEL_SELECTED, {
+      ...(reportingData || {}),
+      learningGoalId: learningGoal.id,
+      learningGoal: learningGoal.learningGoal,
+      newlySelectedEvidenceLevel: radioButtonData,
+      previouslySelectedEvidenceLevel: understandingLevel.current,
+    });
     setDisplayUnderstanding(radioButtonData);
     understandingLevel.current = radioButtonData;
     if (!isAutosaving) {

--- a/apps/test/unit/templates/rubrics/EvidenceLevelsForTeachersTest.jsx
+++ b/apps/test/unit/templates/rubrics/EvidenceLevelsForTeachersTest.jsx
@@ -38,7 +38,7 @@ describe('EvidenceLevelsForTeachers', () => {
   });
 
   it('calls radioButtonCallback when understanding is selected', () => {
-    const callback = sinon.stub();
+    const callback = sinon.spy();
     const wrapper = mount(
       <EvidenceLevelsForTeachers
         {...DEFAULT_PROPS}
@@ -48,6 +48,8 @@ describe('EvidenceLevelsForTeachers', () => {
     );
     wrapper.find('input').first().simulate('change');
     sinon.assert.calledOnce(callback);
+    const firstEvidenceLevel = DEFAULT_PROPS.evidenceLevels[0];
+    expect(callback).to.have.been.calledWith(firstEvidenceLevel.understanding);
     wrapper.unmount();
   });
 


### PR DESCRIPTION
This event tracks every time a teach changes the evaluation for a Evidence Level Selected by a teacher evaluating student work.

This is my first time setting up an amplitude event which is why I am seeking out feedback for this TINY PR - looking to make sure it all looks good before doing the rest of the events. 

Here's what it looks like in the console:

<img width="1258" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/362e0ca8-94ff-4bf6-af12-3af3a2f6cafb">


## Links

[Jira Ticket](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70/backlog?selectedIssue=AITT-195)

## Testing story

I modified the test for EvidenceLevels as this is where the call to the function that triggers the event takes place. 

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
