### PR TITLE
[Google Blockly] Fix for procedure load order bug

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -469,9 +469,9 @@ StudioApp.prototype.init = function (config) {
   // shared apps that are embedded in an iframe handle warnings in
   // startIFrameEmbeddedApp since they don't become "active" until the user
   // clicks on them.
-  if (config.shareWarningInfo && !config.level.iframeEmbed) {
-    showWarnings(config);
-  }
+  // if (config.shareWarningInfo && !config.level.iframeEmbed) {
+  //   showWarnings(config);
+  // }
 
   this.initProjectTemplateWorkspaceIconCallout();
 

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -469,9 +469,9 @@ StudioApp.prototype.init = function (config) {
   // shared apps that are embedded in an iframe handle warnings in
   // startIFrameEmbeddedApp since they don't become "active" until the user
   // clicks on them.
-  // if (config.shareWarningInfo && !config.level.iframeEmbed) {
-  //   showWarnings(config);
-  // }
+  if (config.shareWarningInfo && !config.level.iframeEmbed) {
+    showWarnings(config);
+  }
 
   this.initProjectTemplateWorkspaceIconCallout();
 

--- a/apps/src/blockly/addons/cdoSerializationHelpers.js
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.js
@@ -23,6 +23,7 @@ export function convertXmlToJson(xml) {
   //   x: the x attribute found in <block/> element
   //   y: the y attribute found in <block/> element
   const xmlBlocks = Blockly.Xml.domToBlockSpace(tempWorkspace, xml);
+
   const stateToLoad = Blockly.serialization.workspaces.save(tempWorkspace);
 
   if (xmlBlocks.length && stateToLoad.blocks) {

--- a/apps/src/blockly/addons/cdoSerializationHelpers.js
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.js
@@ -23,36 +23,7 @@ export function convertXmlToJson(xml) {
   //   x: the x attribute found in <block/> element
   //   y: the y attribute found in <block/> element
   const xmlBlocks = Blockly.Xml.domToBlockSpace(tempWorkspace, xml);
-  // const date = Date.now();
-  // let currentDate = null;
-  // do {
-  //   currentDate = Date.now();
-  // } while (currentDate - date < 1000);
-
-  // const timeout = () =>
-  //   new Promise(() =>
-  //     setTimeout(() => {
-  //       const stateToLoad =
-  //         Blockly.serialization.workspaces.save(tempWorkspace);
-  //       console.log({stateToLoad});
-
-  //       if (xmlBlocks.length && stateToLoad.blocks) {
-  //         // Create a map of ids (key) and block serializations (value).
-  //         const blockIdMap = stateToLoad.blocks.blocks.reduce(
-  //           (map, blockJson) => map.set(blockJson.id, blockJson),
-  //           new Map()
-  //         );
-
-  //         addPositionsToState(xmlBlocks, blockIdMap);
-  //       }
-  //       tempWorkspace.dispose();
-  //       return stateToLoad;
-  //     }, 100)
-  //   );
-  // await timeout();
-
   const stateToLoad = Blockly.serialization.workspaces.save(tempWorkspace);
-  console.log(JSON.stringify(stateToLoad));
 
   if (xmlBlocks.length && stateToLoad.blocks) {
     // Create a map of ids (key) and block serializations (value).

--- a/apps/src/blockly/addons/cdoSerializationHelpers.js
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.js
@@ -23,8 +23,36 @@ export function convertXmlToJson(xml) {
   //   x: the x attribute found in <block/> element
   //   y: the y attribute found in <block/> element
   const xmlBlocks = Blockly.Xml.domToBlockSpace(tempWorkspace, xml);
+  // const date = Date.now();
+  // let currentDate = null;
+  // do {
+  //   currentDate = Date.now();
+  // } while (currentDate - date < 1000);
+
+  // const timeout = () =>
+  //   new Promise(() =>
+  //     setTimeout(() => {
+  //       const stateToLoad =
+  //         Blockly.serialization.workspaces.save(tempWorkspace);
+  //       console.log({stateToLoad});
+
+  //       if (xmlBlocks.length && stateToLoad.blocks) {
+  //         // Create a map of ids (key) and block serializations (value).
+  //         const blockIdMap = stateToLoad.blocks.blocks.reduce(
+  //           (map, blockJson) => map.set(blockJson.id, blockJson),
+  //           new Map()
+  //         );
+
+  //         addPositionsToState(xmlBlocks, blockIdMap);
+  //       }
+  //       tempWorkspace.dispose();
+  //       return stateToLoad;
+  //     }, 100)
+  //   );
+  // await timeout();
 
   const stateToLoad = Blockly.serialization.workspaces.save(tempWorkspace);
+  console.log(JSON.stringify(stateToLoad));
 
   if (xmlBlocks.length && stateToLoad.blocks) {
     // Create a map of ids (key) and block serializations (value).

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -26,11 +26,13 @@ import {parseElement as parseXmlElement} from '../../xml';
  * @param {[string]} hiddenDefinitions - hidden definitions serialization, in JSON. Only used in Google Blockly labs.
  */
 export function loadBlocksToWorkspace(workspace, source, hiddenDefinitions) {
+  console.log('beginning of loadBlocksToWorkspace');
   const {parsedSource, parsedHiddenDefinitions, blockOrderMap} =
     prepareSourcesForWorkspaces(source, hiddenDefinitions);
   Blockly.serialization.workspaces.load(parsedSource, workspace);
   positionBlocksOnWorkspace(workspace, blockOrderMap);
   loadHiddenDefinitionBlocksToWorkspace(parsedHiddenDefinitions);
+  console.log('end of loadBlocksToWorkspace');
 }
 
 /**
@@ -41,6 +43,7 @@ function loadHiddenDefinitionBlocksToWorkspace(hiddenDefinitionSource) {
   if (!Blockly.getHiddenDefinitionWorkspace() || !hiddenDefinitionSource) {
     return;
   }
+  console.log({hiddenDefinitionSource});
   Blockly.serialization.workspaces.load(
     hiddenDefinitionSource,
     Blockly.getHiddenDefinitionWorkspace()

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -26,13 +26,11 @@ import {parseElement as parseXmlElement} from '../../xml';
  * @param {[string]} hiddenDefinitions - hidden definitions serialization, in JSON. Only used in Google Blockly labs.
  */
 export function loadBlocksToWorkspace(workspace, source, hiddenDefinitions) {
-  console.log('beginning of loadBlocksToWorkspace');
   const {parsedSource, parsedHiddenDefinitions, blockOrderMap} =
     prepareSourcesForWorkspaces(source, hiddenDefinitions);
   Blockly.serialization.workspaces.load(parsedSource, workspace);
   positionBlocksOnWorkspace(workspace, blockOrderMap);
   loadHiddenDefinitionBlocksToWorkspace(parsedHiddenDefinitions);
-  console.log('end of loadBlocksToWorkspace');
 }
 
 /**
@@ -43,7 +41,6 @@ function loadHiddenDefinitionBlocksToWorkspace(hiddenDefinitionSource) {
   if (!Blockly.getHiddenDefinitionWorkspace() || !hiddenDefinitionSource) {
     return;
   }
-  console.log({hiddenDefinitionSource});
   Blockly.serialization.workspaces.load(
     hiddenDefinitionSource,
     Blockly.getHiddenDefinitionWorkspace()

--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
@@ -91,7 +91,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedure_caller_var_mixin',
       'procedure_caller_update_shape_mixin',
       'procedure_caller_context_menu_mixin',
-      'procedure_caller_on_change_mixin',
+      'procedure_caller_onchange_mixin',
       'procedure_callernoreturn_get_def_block_mixin',
       'modal_procedures_no_destroy',
     ],

--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
@@ -91,7 +91,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedure_caller_var_mixin',
       'procedure_caller_update_shape_mixin',
       'procedure_caller_context_menu_mixin',
-      'custom_procedure_caller_on_change_mixin',
+      'procedure_caller_on_change_mixin',
       'procedure_callernoreturn_get_def_block_mixin',
       'modal_procedures_no_destroy',
     ],

--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
@@ -91,7 +91,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedure_caller_var_mixin',
       'procedure_caller_update_shape_mixin',
       'procedure_caller_context_menu_mixin',
-      'procedure_caller_onchange_mixin',
+      'custom_procedure_caller_on_change_mixin',
       'procedure_callernoreturn_get_def_block_mixin',
       'modal_procedures_no_destroy',
     ],

--- a/apps/src/blockly/customBlocks/googleBlockly/mixins/procedureCallerOnChangeMixin.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mixins/procedureCallerOnChangeMixin.js
@@ -1,3 +1,7 @@
+// This is copied from
+// https://github.com/google/blockly-samples/blob/82f1c35be007a99b7446e199448d083ac68a9f84/plugins/block-shareable-procedures/src/blocks.ts#L1184-L1285
+// Once we upgrade to Blockly v10 we can go back to using the original mixin.
+// We needed a bug fix not present in our current version of the plugin.
 const procedureCallerOnChangeMixin = {
   /**
    * Procedure calls cannot exist without the corresponding procedure

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorGetMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorGetMutator.js
@@ -5,16 +5,18 @@ export const behaviorGetMutator = {
 
   domToMutation: function (element) {
     const name = element.nextElementSibling.textContent;
+    console.log({name: element.getAttribute('name'), actualName: name});
     this.behaviorId = element.nextElementSibling.getAttribute('id');
-    const model = this.findProcedureModel_(name);
-    if (model) {
-      this.model_ = model;
-      if (this.getProcedureModel()) {
-        this.initBlockWithProcedureModel_();
-      }
-    } else {
-      throw new Error(`Procedure model not found for behavior: ${name}`);
-    }
+    this.deserialize_(name, []);
+    // const model = this.findProcedureModel_(name);
+    // if (model) {
+    //   this.model_ = model;
+    //   if (this.getProcedureModel()) {
+    //     this.initBlockWithProcedureModel_();
+    //   }
+    // } else {
+    //   throw new Error(`Procedure model not found for behavior: ${name}`);
+    // }
   },
 
   // Only used to save in XML, but still required to exist by Blockly.
@@ -27,6 +29,9 @@ export const behaviorGetMutator = {
   saveExtraState: function () {
     const state = Object.create(null);
     const model = this.getProcedureModel();
+    if (!model) {
+      state['name'] = this.getFieldValue('NAME');
+    }
     if (!model) return state;
     state['name'] = model.getName();
     if (model.getParameters().length) {

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorGetMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorGetMutator.js
@@ -15,46 +15,4 @@ export const behaviorGetMutator = {
   mutationToDom: function () {},
 
   ...commonFunctions,
-  // /**
-  //  * Returns the state of this block as a JSON serializable object.
-  //  * @returns The state of
-  //  *     this block, ie the params and procedure name.
-  //  */
-  // saveExtraState: function () {
-  //   const state = Object.create(null);
-  //   const model = this.getProcedureModel();
-  //   if (!model) {
-  //     state['name'] = this.getFieldValue('NAME');
-  //     return state;
-  //   }
-  //   state['name'] = model.getName();
-  //   if (model.getParameters().length) {
-  //     state['params'] = model.getParameters().map(p => p.getName());
-  //   }
-  //   return state;
-  // },
-  // /**
-  //  * Applies the given state to this block.
-  //  * @param state The state to apply to this block, ie the params and
-  //  *     procedure name.
-  //  */
-  // loadExtraState: function (state) {
-  //   this.deserialize_(state['name'], state['params'] || []);
-  // },
-  // /**
-  //  * Applies the given name and params from the serialized state to the block.
-  //  * @param name The name to apply to the block.
-  //  * @param params The parameters to apply to the block.
-  //  */
-  // deserialize_: function (name, params) {
-  //   this.setFieldValue(name, 'NAME');
-  //   if (!this.model_) this.model_ = this.findProcedureModel_(name, params);
-  //   if (this.getProcedureModel()) {
-  //     this.initBlockWithProcedureModel_();
-  //   } else {
-  //     // Create inputs based on the mutation so that children can be connected.
-  //     this.createArgInputs_(params);
-  //   }
-  //   this.paramsFromSerializedState_ = params;
-  // },
 };

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorGetMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorGetMutator.js
@@ -1,3 +1,5 @@
+import {commonFunctions} from './commonProcedureCallerMutator';
+
 export const behaviorGetMutator = {
   previousEnabledState_: true,
 
@@ -11,46 +13,48 @@ export const behaviorGetMutator = {
 
   // Only used to save in XML, but still required to exist by Blockly.
   mutationToDom: function () {},
-  /**
-   * Returns the state of this block as a JSON serializable object.
-   * @returns The state of
-   *     this block, ie the params and procedure name.
-   */
-  saveExtraState: function () {
-    const state = Object.create(null);
-    const model = this.getProcedureModel();
-    if (!model) {
-      state['name'] = this.getFieldValue('NAME');
-      return state;
-    }
-    state['name'] = model.getName();
-    if (model.getParameters().length) {
-      state['params'] = model.getParameters().map(p => p.getName());
-    }
-    return state;
-  },
-  /**
-   * Applies the given state to this block.
-   * @param state The state to apply to this block, ie the params and
-   *     procedure name.
-   */
-  loadExtraState: function (state) {
-    this.deserialize_(state['name'], state['params'] || []);
-  },
-  /**
-   * Applies the given name and params from the serialized state to the block.
-   * @param name The name to apply to the block.
-   * @param params The parameters to apply to the block.
-   */
-  deserialize_: function (name, params) {
-    this.setFieldValue(name, 'NAME');
-    if (!this.model_) this.model_ = this.findProcedureModel_(name, params);
-    if (this.getProcedureModel()) {
-      this.initBlockWithProcedureModel_();
-    } else {
-      // Create inputs based on the mutation so that children can be connected.
-      this.createArgInputs_(params);
-    }
-    this.paramsFromSerializedState_ = params;
-  },
+
+  ...commonFunctions,
+  // /**
+  //  * Returns the state of this block as a JSON serializable object.
+  //  * @returns The state of
+  //  *     this block, ie the params and procedure name.
+  //  */
+  // saveExtraState: function () {
+  //   const state = Object.create(null);
+  //   const model = this.getProcedureModel();
+  //   if (!model) {
+  //     state['name'] = this.getFieldValue('NAME');
+  //     return state;
+  //   }
+  //   state['name'] = model.getName();
+  //   if (model.getParameters().length) {
+  //     state['params'] = model.getParameters().map(p => p.getName());
+  //   }
+  //   return state;
+  // },
+  // /**
+  //  * Applies the given state to this block.
+  //  * @param state The state to apply to this block, ie the params and
+  //  *     procedure name.
+  //  */
+  // loadExtraState: function (state) {
+  //   this.deserialize_(state['name'], state['params'] || []);
+  // },
+  // /**
+  //  * Applies the given name and params from the serialized state to the block.
+  //  * @param name The name to apply to the block.
+  //  * @param params The parameters to apply to the block.
+  //  */
+  // deserialize_: function (name, params) {
+  //   this.setFieldValue(name, 'NAME');
+  //   if (!this.model_) this.model_ = this.findProcedureModel_(name, params);
+  //   if (this.getProcedureModel()) {
+  //     this.initBlockWithProcedureModel_();
+  //   } else {
+  //     // Create inputs based on the mutation so that children can be connected.
+  //     this.createArgInputs_(params);
+  //   }
+  //   this.paramsFromSerializedState_ = params;
+  // },
 };

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/commonProcedureCallerMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/commonProcedureCallerMutator.js
@@ -1,0 +1,44 @@
+export const commonFunctions = {
+  /**
+   * Returns the state of this block as a JSON serializable object.
+   * @returns The state of
+   *     this block, ie the params and procedure name.
+   */
+  saveExtraState: function () {
+    const state = Object.create(null);
+    const model = this.getProcedureModel();
+    if (!model) {
+      state['name'] = this.getFieldValue('NAME');
+      return state;
+    }
+    state['name'] = model.getName();
+    if (model.getParameters().length) {
+      state['params'] = model.getParameters().map(p => p.getName());
+    }
+    return state;
+  },
+  /**
+   * Applies the given state to this block.
+   * @param state The state to apply to this block, ie the params and
+   *     procedure name.
+   */
+  loadExtraState: function (state) {
+    this.deserialize_(state['name'], state['params'] || []);
+  },
+  /**
+   * Applies the given name and params from the serialized state to the block.
+   * @param name The name to apply to the block.
+   * @param params The parameters to apply to the block.
+   */
+  deserialize_: function (name, params) {
+    this.setFieldValue(name, 'NAME');
+    if (!this.model_) this.model_ = this.findProcedureModel_(name, params);
+    if (this.getProcedureModel()) {
+      this.initBlockWithProcedureModel_();
+    } else {
+      // Create inputs based on the mutation so that children can be connected.
+      this.createArgInputs_(params);
+    }
+    this.paramsFromSerializedState_ = params;
+  },
+};

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/commonProcedureCallerMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/commonProcedureCallerMutator.js
@@ -17,6 +17,7 @@ export const commonFunctions = {
     }
     return state;
   },
+
   /**
    * Applies the given state to this block.
    * @param state The state to apply to this block, ie the params and
@@ -25,6 +26,7 @@ export const commonFunctions = {
   loadExtraState: function (state) {
     this.deserialize_(state['name'], state['params'] || []);
   },
+
   /**
    * Applies the given name and params from the serialized state to the block.
    * @param name The name to apply to the block.

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureCallerMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureCallerMutator.js
@@ -1,3 +1,10 @@
+// This is a copied version of blockly's procedureCallerMutator.
+// The only change is in saveExtraState (imported from commonFunctions).
+// This change loads the name from the field value if the procedure model
+// is not found.
+
+// Blockly is fixing this issue, so we should be able to remove this file
+// once we upgrade to Blockly v10.
 import {commonFunctions} from './commonProcedureCallerMutator';
 
 export const procedureCallerMutator = {
@@ -43,49 +50,4 @@ export const procedureCallerMutator = {
   },
 
   ...commonFunctions,
-
-  /**
-   * Returns the state of this block as a JSON serializable object.
-   * @returns The state of
-   *     this block, ie the params and procedure name.
-   */
-  // saveExtraState: function () {
-  //   const state = Object.create(null);
-  //   const model = this.getProcedureModel();
-  //   if (!model) {
-  //     state['name'] = this.getFieldValue('NAME');
-  //     return state;
-  //   }
-  //   state['name'] = model.getName();
-  //   if (model.getParameters().length) {
-  //     state['params'] = model.getParameters().map(p => p.getName());
-  //   }
-  //   return state;
-  // },
-
-  // /**
-  //  * Applies the given state to this block.
-  //  * @param state The state to apply to this block, ie the params and
-  //  *     procedure name.
-  //  */
-  // loadExtraState: function (state) {
-  //   this.deserialize_(state['name'], state['params'] || []);
-  // },
-
-  // /**
-  //  * Applies the given name and params from the serialized state to the block.
-  //  * @param name The name to apply to the block.
-  //  * @param params The parameters to apply to the block.
-  //  */
-  // deserialize_: function (name, params) {
-  //   this.setFieldValue(name, 'NAME');
-  //   if (!this.model_) this.model_ = this.findProcedureModel_(name, params);
-  //   if (this.getProcedureModel()) {
-  //     this.initBlockWithProcedureModel_();
-  //   } else {
-  //     // Create inputs based on the mutation so that children can be connected.
-  //     this.createArgInputs_(params);
-  //   }
-  //   this.paramsFromSerializedState_ = params;
-  // },
 };

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureCallerMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureCallerMutator.js
@@ -7,7 +7,7 @@
 // once we upgrade to Blockly v10.
 import {commonFunctions} from './commonProcedureCallerMutator';
 
-export const procedureCallerMutator = {
+const procedureCallerMutator = {
   previousEnabledState_: true,
 
   paramsFromSerializedState_: [],
@@ -51,3 +51,5 @@ export const procedureCallerMutator = {
 
   ...commonFunctions,
 };
+
+export default procedureCallerMutator;

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureCallerMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureCallerMutator.js
@@ -1,3 +1,5 @@
+import {commonFunctions} from './commonProcedureCallerMutator';
+
 export const procedureCallerMutator = {
   previousEnabledState_: true,
 
@@ -40,48 +42,50 @@ export const procedureCallerMutator = {
     this.deserialize_(name, params);
   },
 
+  ...commonFunctions,
+
   /**
    * Returns the state of this block as a JSON serializable object.
    * @returns The state of
    *     this block, ie the params and procedure name.
    */
-  saveExtraState: function () {
-    const state = Object.create(null);
-    const model = this.getProcedureModel();
-    if (!model) {
-      state['name'] = this.getFieldValue('NAME');
-      return state;
-    }
-    state['name'] = model.getName();
-    if (model.getParameters().length) {
-      state['params'] = model.getParameters().map(p => p.getName());
-    }
-    return state;
-  },
+  // saveExtraState: function () {
+  //   const state = Object.create(null);
+  //   const model = this.getProcedureModel();
+  //   if (!model) {
+  //     state['name'] = this.getFieldValue('NAME');
+  //     return state;
+  //   }
+  //   state['name'] = model.getName();
+  //   if (model.getParameters().length) {
+  //     state['params'] = model.getParameters().map(p => p.getName());
+  //   }
+  //   return state;
+  // },
 
-  /**
-   * Applies the given state to this block.
-   * @param state The state to apply to this block, ie the params and
-   *     procedure name.
-   */
-  loadExtraState: function (state) {
-    this.deserialize_(state['name'], state['params'] || []);
-  },
+  // /**
+  //  * Applies the given state to this block.
+  //  * @param state The state to apply to this block, ie the params and
+  //  *     procedure name.
+  //  */
+  // loadExtraState: function (state) {
+  //   this.deserialize_(state['name'], state['params'] || []);
+  // },
 
-  /**
-   * Applies the given name and params from the serialized state to the block.
-   * @param name The name to apply to the block.
-   * @param params The parameters to apply to the block.
-   */
-  deserialize_: function (name, params) {
-    this.setFieldValue(name, 'NAME');
-    if (!this.model_) this.model_ = this.findProcedureModel_(name, params);
-    if (this.getProcedureModel()) {
-      this.initBlockWithProcedureModel_();
-    } else {
-      // Create inputs based on the mutation so that children can be connected.
-      this.createArgInputs_(params);
-    }
-    this.paramsFromSerializedState_ = params;
-  },
+  // /**
+  //  * Applies the given name and params from the serialized state to the block.
+  //  * @param name The name to apply to the block.
+  //  * @param params The parameters to apply to the block.
+  //  */
+  // deserialize_: function (name, params) {
+  //   this.setFieldValue(name, 'NAME');
+  //   if (!this.model_) this.model_ = this.findProcedureModel_(name, params);
+  //   if (this.getProcedureModel()) {
+  //     this.initBlockWithProcedureModel_();
+  //   } else {
+  //     // Create inputs based on the mutation so that children can be connected.
+  //     this.createArgInputs_(params);
+  //   }
+  //   this.paramsFromSerializedState_ = params;
+  // },
 };

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureCallerOnChangeMixin.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureCallerOnChangeMixin.js
@@ -6,7 +6,13 @@ const procedureCallerOnChangeMixin = {
    * @this {Blockly.Block}
    */
   onchange: function (event) {
-    console.log({event});
+    //console.log(event.type);
+    if (event.type === Blockly.Events.BLOCK_CREATE) {
+      console.log({event, block: this});
+    }
+    if (event.type === Blockly.Events.FINISHED_LOADING) {
+      console.log({event});
+    }
     if (this.disposed || this.workspace.isFlyout) return;
     if (event.type === Blockly.Events.BLOCK_MOVE) this.updateArgsMap_(true);
     if (
@@ -21,10 +27,12 @@ const procedureCallerOnChangeMixin = {
     // Look for the case where a procedure call was created (usually through
     // paste) and there is no matching definition.  In this case, create
     // an empty definition block with the correct signature.
-    console.log('looking for def in onchange');
+    if (event.type === Blockly.Events.FINISHED_LOADING) {
+      console.log('looking for def in onchange');
+    }
     const name = this.getFieldValue('NAME');
     let def = Blockly.Procedures.getDefinition(name, this.workspace);
-    console.log({name, def});
+    console.log({name, def, block: this});
     if (!this.defMatches_(def)) def = null;
     if (!def) {
       // We have no def nor procedure model.

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureCallerOnChangeMixin.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureCallerOnChangeMixin.js
@@ -1,0 +1,107 @@
+const procedureCallerOnChangeMixin = {
+  /**
+   * Procedure calls cannot exist without the corresponding procedure
+   * definition.  Enforce this link whenever an event is fired.
+   * @param event Change event.
+   * @this {Blockly.Block}
+   */
+  onchange: function (event) {
+    console.log({event});
+    if (this.disposed || this.workspace.isFlyout) return;
+    if (event.type === Blockly.Events.BLOCK_MOVE) this.updateArgsMap_(true);
+    if (
+      event.type !== Blockly.Events.FINISHED_LOADING &&
+      !this.eventIsCreatingThisBlockDuringPaste_(event)
+    )
+      return;
+
+    // We already found our model, which means we don't need to create a block.
+    if (this.getProcedureModel()) return;
+
+    // Look for the case where a procedure call was created (usually through
+    // paste) and there is no matching definition.  In this case, create
+    // an empty definition block with the correct signature.
+    console.log('looking for def in onchange');
+    const name = this.getFieldValue('NAME');
+    let def = Blockly.Procedures.getDefinition(name, this.workspace);
+    console.log({name, def});
+    if (!this.defMatches_(def)) def = null;
+    if (!def) {
+      // We have no def nor procedure model.
+      Blockly.Events.setGroup(event.group);
+      this.model_ = this.createDef_(
+        this.getFieldValue('NAME'),
+        this.paramsFromSerializedState_
+      );
+      Blockly.Events.setGroup(false);
+    }
+    if (!this.getProcedureModel()) {
+      // We have a def, but no reference to its model.
+      this.model_ = this.findProcedureModel_(
+        this.getFieldValue('NAME'),
+        this.paramsFromSerializedState_
+      );
+    }
+    this.initBlockWithProcedureModel_();
+  },
+
+  /**
+   * @param event The event to check.
+   * @returns True if the given event is a paste event for this block.
+   */
+  eventIsCreatingThisBlockDuringPaste_(event) {
+    return (
+      event.type === Blockly.Events.BLOCK_CREATE &&
+      (event.blockId === this.id || event.ids.indexOf(this.id) !== -1) &&
+      // Record undo makes sure this is during paste.
+      event.recordUndo
+    );
+  },
+
+  /**
+   * Returns true if the given def block matches the definition of this caller
+   * block.
+   * @param defBlock The definition block to check against.
+   * @returns Whether the def block matches or not.
+   */
+  defMatches_(defBlock) {
+    return (
+      defBlock &&
+      defBlock.type === this.defType_ &&
+      JSON.stringify(defBlock.getVars()) ===
+        JSON.stringify(this.paramsFromSerializedState_)
+    );
+  },
+
+  /**
+   * Creates a procedure definition block with the given name and params,
+   * and returns the procedure model associated with it.
+   * @param name The name of the procedure to create.
+   * @param params The names of the parameters to create.
+   * @returns The procedure model associated with the new
+   *     procedure definition block.
+   */
+  createDef_(name, params = []) {
+    const xy = this.getRelativeToSurfaceXY();
+    const newName = Blockly.Procedures.findLegalName(name, this);
+    this.renameProcedure(name, newName);
+
+    const blockDef = {
+      type: this.defType_,
+      x: xy.x + Blockly.config.snapRadius * (this.RTL ? -1 : 1),
+      y: xy.y + Blockly.config.snapRadius * 2,
+      extraState: {
+        params: params.map(p => ({name: p})),
+      },
+      fields: {NAME: newName},
+    };
+    const block = Blockly.serialization.blocks.append(
+      blockDef,
+      this.getTargetWorkspace_(),
+      {recordUndo: true}
+    );
+    return block.getProcedureModel();
+  },
+};
+
+export default procedureCallerOnChangeMixin;

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureCallerOnChangeMixin.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureCallerOnChangeMixin.js
@@ -6,13 +6,6 @@ const procedureCallerOnChangeMixin = {
    * @this {Blockly.Block}
    */
   onchange: function (event) {
-    //console.log(event.type);
-    if (event.type === Blockly.Events.BLOCK_CREATE) {
-      console.log({event, block: this});
-    }
-    if (event.type === Blockly.Events.FINISHED_LOADING) {
-      console.log({event});
-    }
     if (this.disposed || this.workspace.isFlyout) return;
     if (event.type === Blockly.Events.BLOCK_MOVE) this.updateArgsMap_(true);
     if (
@@ -27,12 +20,8 @@ const procedureCallerOnChangeMixin = {
     // Look for the case where a procedure call was created (usually through
     // paste) and there is no matching definition.  In this case, create
     // an empty definition block with the correct signature.
-    if (event.type === Blockly.Events.FINISHED_LOADING) {
-      console.log('looking for def in onchange');
-    }
     const name = this.getFieldValue('NAME');
     let def = Blockly.Procedures.getDefinition(name, this.workspace);
-    console.log({name, def, block: this});
     if (!this.defMatches_(def)) def = null;
     if (!def) {
       // We have no def nor procedure model.

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -5,6 +5,7 @@ import BlockSvgFrame from '@cdo/apps/blockly/addons/blockSvgFrame';
 import {procedureDefMutator} from './mutators/procedureDefMutator';
 import {BLOCK_TYPES} from '@cdo/apps/blockly/constants';
 import procedureCallerOnChangeMixin from './mutators/procedureCallerOnChangeMixin';
+import {procedureCallerMutator} from './mutators/procedureCallerMutator';
 // In Lab2, the level properties are in Redux, not appOptions. To make this work in Lab2,
 // we would need to send that property from the backend and save it in lab2Redux.
 const useModalFunctionEditor = window.appOptions?.level?.useModalFunctionEditor;
@@ -91,7 +92,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedure_callernoreturn_get_def_block_mixin',
       'modal_procedures_no_destroy',
     ],
-    mutator: 'procedure_caller_mutator',
+    mutator: 'custom_procedure_caller_mutator',
   },
 ]);
 
@@ -189,6 +190,11 @@ GoogleBlockly.Extensions.unregister('procedure_def_mutator');
 GoogleBlockly.Extensions.registerMutator(
   'procedure_def_mutator',
   procedureDefMutator
+);
+
+GoogleBlockly.Extensions.registerMutator(
+  'custom_procedure_caller_mutator',
+  procedureCallerMutator
 );
 
 GoogleBlockly.Extensions.registerMixin(

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -5,7 +5,7 @@ import BlockSvgFrame from '@cdo/apps/blockly/addons/blockSvgFrame';
 import {procedureDefMutator} from './mutators/procedureDefMutator';
 import {BLOCK_TYPES} from '@cdo/apps/blockly/constants';
 import procedureCallerOnChangeMixin from './mixins/procedureCallerOnChangeMixin';
-import {procedureCallerMutator} from './mutators/procedureCallerMutator';
+import procedureCallerMutator from './mutators/procedureCallerMutator';
 // In Lab2, the level properties are in Redux, not appOptions. To make this work in Lab2,
 // we would need to send that property from the backend and save it in lab2Redux.
 const useModalFunctionEditor = window.appOptions?.level?.useModalFunctionEditor;
@@ -194,6 +194,7 @@ GoogleBlockly.Extensions.registerMutator(
 
 // TODO: After updating to Blockly v10, use the original
 // procedure_caller_mutator and procedure_caller_on_change_mixin.
+// https://codedotorg.atlassian.net/browse/CT-148
 GoogleBlockly.Extensions.unregister('procedure_caller_mutator');
 GoogleBlockly.Extensions.registerMutator(
   'procedure_caller_mutator',

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -4,6 +4,7 @@ import {nameComparator} from '@cdo/apps/util/sort';
 import BlockSvgFrame from '@cdo/apps/blockly/addons/blockSvgFrame';
 import {procedureDefMutator} from './mutators/procedureDefMutator';
 import {BLOCK_TYPES} from '@cdo/apps/blockly/constants';
+import procedureCallerOnChangeMixin from './mutators/procedureCallerOnChangeMixin';
 // In Lab2, the level properties are in Redux, not appOptions. To make this work in Lab2,
 // we would need to send that property from the backend and save it in lab2Redux.
 const useModalFunctionEditor = window.appOptions?.level?.useModalFunctionEditor;
@@ -86,7 +87,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedure_caller_var_mixin',
       'procedure_caller_update_shape_mixin',
       'procedure_caller_context_menu_mixin',
-      'procedure_caller_onchange_mixin',
+      'custom_procedure_caller_on_change_mixin',
       'procedure_callernoreturn_get_def_block_mixin',
       'modal_procedures_no_destroy',
     ],
@@ -188,6 +189,11 @@ GoogleBlockly.Extensions.unregister('procedure_def_mutator');
 GoogleBlockly.Extensions.registerMutator(
   'procedure_def_mutator',
   procedureDefMutator
+);
+
+GoogleBlockly.Extensions.registerMixin(
+  'custom_procedure_caller_on_change_mixin',
+  procedureCallerOnChangeMixin
 );
 
 /**

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -88,7 +88,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedure_caller_var_mixin',
       'procedure_caller_update_shape_mixin',
       'procedure_caller_context_menu_mixin',
-      'procedure_caller_on_change_mixin',
+      'procedure_caller_onchange_mixin',
       'procedure_callernoreturn_get_def_block_mixin',
       'modal_procedures_no_destroy',
     ],
@@ -200,9 +200,9 @@ GoogleBlockly.Extensions.registerMutator(
   procedureCallerMutator
 );
 
-GoogleBlockly.Extensions.unregister('procedure_caller_on_change_mixin');
+GoogleBlockly.Extensions.unregister('procedure_caller_onchange_mixin');
 GoogleBlockly.Extensions.registerMixin(
-  'procedure_caller_on_change_mixin',
+  'procedure_caller_onchange_mixin',
   procedureCallerOnChangeMixin
 );
 

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -4,7 +4,7 @@ import {nameComparator} from '@cdo/apps/util/sort';
 import BlockSvgFrame from '@cdo/apps/blockly/addons/blockSvgFrame';
 import {procedureDefMutator} from './mutators/procedureDefMutator';
 import {BLOCK_TYPES} from '@cdo/apps/blockly/constants';
-import procedureCallerOnChangeMixin from './mutators/procedureCallerOnChangeMixin';
+import procedureCallerOnChangeMixin from './mixins/procedureCallerOnChangeMixin';
 import {procedureCallerMutator} from './mutators/procedureCallerMutator';
 // In Lab2, the level properties are in Redux, not appOptions. To make this work in Lab2,
 // we would need to send that property from the backend and save it in lab2Redux.
@@ -88,11 +88,11 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedure_caller_var_mixin',
       'procedure_caller_update_shape_mixin',
       'procedure_caller_context_menu_mixin',
-      'custom_procedure_caller_on_change_mixin',
+      'procedure_caller_on_change_mixin',
       'procedure_callernoreturn_get_def_block_mixin',
       'modal_procedures_no_destroy',
     ],
-    mutator: 'custom_procedure_caller_mutator',
+    mutator: 'procedure_caller_mutator',
   },
 ]);
 
@@ -192,13 +192,17 @@ GoogleBlockly.Extensions.registerMutator(
   procedureDefMutator
 );
 
+// TODO: After updating to Blockly v10, use the original
+// procedure_caller_mutator and procedure_caller_on_change_mixin.
+GoogleBlockly.Extensions.unregister('procedure_caller_mutator');
 GoogleBlockly.Extensions.registerMutator(
-  'custom_procedure_caller_mutator',
+  'procedure_caller_mutator',
   procedureCallerMutator
 );
 
+GoogleBlockly.Extensions.unregister('procedure_caller_on_change_mixin');
 GoogleBlockly.Extensions.registerMixin(
-  'custom_procedure_caller_on_change_mixin',
+  'procedure_caller_on_change_mixin',
   procedureCallerOnChangeMixin
 );
 

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -155,18 +155,13 @@ function initializeBlocklyWrapper(blocklyInstance) {
 
   blocklyWrapper.loopHighlight = function () {}; // TODO
   blocklyWrapper.getWorkspaceCode = function () {
-    let workspaceCode = '';
-    try {
-      workspaceCode = Blockly.JavaScript.workspaceToCode(
-        Blockly.mainBlockSpace
+    let workspaceCode = Blockly.JavaScript.workspaceToCode(
+      Blockly.mainBlockSpace
+    );
+    if (this.getHiddenDefinitionWorkspace()) {
+      workspaceCode += Blockly.JavaScript.workspaceToCode(
+        this.getHiddenDefinitionWorkspace()
       );
-      if (this.getHiddenDefinitionWorkspace()) {
-        workspaceCode += Blockly.JavaScript.workspaceToCode(
-          this.getHiddenDefinitionWorkspace()
-        );
-      }
-    } catch (e) {
-      console.warn('Error generating workspace code', e);
     }
     return workspaceCode;
   };

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -185,7 +185,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('common');
   blocklyWrapper.wrapReadOnlyProperty('common_locale');
   blocklyWrapper.wrapReadOnlyProperty('ComponentManager');
-  blocklyWrapper.wrapReadOnlyProperty('config');
   blocklyWrapper.wrapReadOnlyProperty('Connection');
   blocklyWrapper.wrapReadOnlyProperty('ConnectionType');
   blocklyWrapper.wrapReadOnlyProperty('ContextMenu');

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -155,8 +155,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
 
   blocklyWrapper.loopHighlight = function () {}; // TODO
   blocklyWrapper.getWorkspaceCode = function () {
-    setTimeout(() => {
-      let workspaceCode = Blockly.JavaScript.workspaceToCode(
+    let workspaceCode = '';
+    try {
+      workspaceCode = Blockly.JavaScript.workspaceToCode(
         Blockly.mainBlockSpace
       );
       if (this.getHiddenDefinitionWorkspace()) {
@@ -164,8 +165,10 @@ function initializeBlocklyWrapper(blocklyInstance) {
           this.getHiddenDefinitionWorkspace()
         );
       }
-      return workspaceCode;
-    }, 100);
+    } catch (e) {
+      console.warn('Error generating workspace code', e);
+    }
+    return workspaceCode;
   };
 
   blocklyWrapper.wrapReadOnlyProperty('ALIGN_CENTRE');
@@ -182,6 +185,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('common');
   blocklyWrapper.wrapReadOnlyProperty('common_locale');
   blocklyWrapper.wrapReadOnlyProperty('ComponentManager');
+  blocklyWrapper.wrapReadOnlyProperty('config');
   blocklyWrapper.wrapReadOnlyProperty('Connection');
   blocklyWrapper.wrapReadOnlyProperty('ConnectionType');
   blocklyWrapper.wrapReadOnlyProperty('ContextMenu');

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -155,15 +155,17 @@ function initializeBlocklyWrapper(blocklyInstance) {
 
   blocklyWrapper.loopHighlight = function () {}; // TODO
   blocklyWrapper.getWorkspaceCode = function () {
-    let workspaceCode = Blockly.JavaScript.workspaceToCode(
-      Blockly.mainBlockSpace
-    );
-    if (this.getHiddenDefinitionWorkspace()) {
-      workspaceCode += Blockly.JavaScript.workspaceToCode(
-        this.getHiddenDefinitionWorkspace()
+    setTimeout(() => {
+      let workspaceCode = Blockly.JavaScript.workspaceToCode(
+        Blockly.mainBlockSpace
       );
-    }
-    return workspaceCode;
+      if (this.getHiddenDefinitionWorkspace()) {
+        workspaceCode += Blockly.JavaScript.workspaceToCode(
+          this.getHiddenDefinitionWorkspace()
+        );
+      }
+      return workspaceCode;
+    }, 100);
   };
 
   blocklyWrapper.wrapReadOnlyProperty('ALIGN_CENTRE');


### PR DESCRIPTION
We found a bug where if a function definition had a behavior call block in it, it could not be converted from xml to json. Additionally, functions with circular references could not be converted from xml to json. This is because in our legacy xml we have no concept of a procedure model, and in order to save a call block you need the procedure model to exist for that call block. Blockly handles a call block being loaded before its definition block in event handlers, which don't run instantly on load. We do our xml conversion by loading xml into a workspace, then immediately saving the converted json. The event handler did not have time to run, and we lost the procedure name for a call block that was loaded out of order.

There were 3 changes required to fix this issue. 2 are covered by Blockly fixes, and one was an issue with our deserialization of behavior callers.
- (Our bug) In `domToMutation` we were throwing an error if a behavior caller did not find a procedure model. We could instead do Blockly's method here (which we already used for procedure callers), and just call `deserialize_` ([Blockly code](https://github.com/google/blockly-samples/blob/82f1c35be007a99b7446e199448d083ac68a9f84/plugins/block-shareable-procedures/src/blocks.ts#L959C14-L959C14).
- (Blockly issue, already fixed) The event handler for assigning a model to a caller if things run out of order needed to run on the `FINISHED_LOADING` event. This change has already been made [here](https://github.com/google/blockly-samples/pull/2037). We are copying this change over until we can upgrade to Blockly v10.
- (Blockly issue, already fixed) When saving json of a caller, if there is no procedure model found, still save the procedure name as extra state. In order to apply this change I updated `behaviorGetMutator` and made our own copied version of `procedureCallerMutator`. Once we upgrade to v10 and this issue is fixed we can get rid of our version of `procedureCallerMutator`.

Since I needed to make `procedureCallerMutator` which has a lot of shared code with `behaviorGetMutator`, I made a helper object with those shared functions as well.

## Links
- jira ticket: [CT-135](https://codedotorg.atlassian.net/browse/CT-135)


## Testing story
Tested that we can load from xml->json for projects with circular function references or with functions that contain behaviors. We can also still edit, load and save functions and behaviors as before.


## Follow-up work
We should be able to get rid of the block ordering logic for loading procedure/behavior definitions before all other blocks now. [Task](https://codedotorg.atlassian.net/browse/CT-137).

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
