### PR TITLE
Create and use new step that waits for video thumbnails to load

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/tutorial_landing_pages.feature
+++ b/dashboard/test/ui/features/hour_of_code/tutorial_landing_pages.feature
@@ -6,7 +6,7 @@ Scenario Outline: Simple page view
   When I open my eyes to test "<test_name>"
   And I am on "<url>"
   And I dismiss the language selector
-  And I wait for 2 seconds
+  And I wait for the video thumbnails to load
   Then I see no difference for "initial load"
   And I close my eyes
   And I sign out

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -319,6 +319,10 @@ When /^I wait for (\d+(?:\.\d*)?) seconds?$/ do |seconds|
   sleep seconds.to_f
 end
 
+When /^I wait for the video thumbnails to load$/ do
+  wait_until {@browser.execute_script('return $(".video-thumbnail-loaded").length == $(".video-thumbnail-wrapper").length')}
+end
+
 When /^I rotate to (landscape|portrait)$/ do |orientation|
   if ENV['BS_ROTATABLE'] == "true"
     $http_client.call(

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -320,7 +320,7 @@ When /^I wait for (\d+(?:\.\d*)?) seconds?$/ do |seconds|
 end
 
 When /^I wait for the video thumbnails to load$/ do
-  wait_until {@browser.execute_script('return $(".video-thumbnail-loaded").length == $(".video-thumbnail-wrapper").length')}
+  wait_until {@browser.execute_script("return $('.video-thumbnail-loaded').length == $('.video-thumbnail-wrapper').length")}
 end
 
 When /^I rotate to (landscape|portrait)$/ do |orientation|

--- a/pegasus/sites.v3/code.org/public/athletes.haml
+++ b/pegasus/sites.v3/code.org/public/athletes.haml
@@ -66,7 +66,7 @@ video_player: true
     %h2.header= I18n.t(:watch_inspirational_videos)
     - videos = []
     - videos << { id: 'steph_curry',  code: 'NYzN0a1U8mI', text: I18n.t(:video_title_steph_curry),  duration: I18n.t(:video_2min), download: "//videos.code.org/social/athlete-steph-curry.mp4"}
-    - videos << { id: 'draymond_green',  code: 'uJZyqeiAtlA', text: I18n.t(:video_title_draymond_green),  duration: I18n.t(:video_1min), download: "//videos.code.org/social/athlete-draymond-green.mp4"}
+    - videos << { id: 'draymond_green_fail',  code: 'uJZyqeiAtlA', text: I18n.t(:video_title_draymond_green),  duration: I18n.t(:video_1min), download: "//videos.code.org/social/athlete-draymond-green.mp4"}
     - videos << { id: 'russell_okung',   code: '-aGEKVvoyLI', text: I18n.t(:video_title_russell_okung),   duration: I18n.t(:video_2min), download: "//videos.code.org/social/athlete-russell-okung.mp4"}
     - videos << { id: 'marco_belinelli', code: 'Zh6E99aySI4', text: I18n.t(:video_title_marco_belinelli), duration: I18n.t(:video_2min)}
     - videos << { id: 'chris_bosh',      code: 'kx3DxBbweGY', text: I18n.t(:video_title_chris_bosh),      duration: I18n.t(:video_1min), download: "//videos.code.org/social/athlete-chris-bosh.mp4"}

--- a/pegasus/sites.v3/code.org/public/athletes.haml
+++ b/pegasus/sites.v3/code.org/public/athletes.haml
@@ -66,7 +66,7 @@ video_player: true
     %h2.header= I18n.t(:watch_inspirational_videos)
     - videos = []
     - videos << { id: 'steph_curry',  code: 'NYzN0a1U8mI', text: I18n.t(:video_title_steph_curry),  duration: I18n.t(:video_2min), download: "//videos.code.org/social/athlete-steph-curry.mp4"}
-    - videos << { id: 'draymond_green_fail',  code: 'uJZyqeiAtlA', text: I18n.t(:video_title_draymond_green),  duration: I18n.t(:video_1min), download: "//videos.code.org/social/athlete-draymond-green.mp4"}
+    - videos << { id: 'draymond_green',  code: 'uJZyqeiAtlA', text: I18n.t(:video_title_draymond_green),  duration: I18n.t(:video_1min), download: "//videos.code.org/social/athlete-draymond-green.mp4"}
     - videos << { id: 'russell_okung',   code: '-aGEKVvoyLI', text: I18n.t(:video_title_russell_okung),   duration: I18n.t(:video_2min), download: "//videos.code.org/social/athlete-russell-okung.mp4"}
     - videos << { id: 'marco_belinelli', code: 'Zh6E99aySI4', text: I18n.t(:video_title_marco_belinelli), duration: I18n.t(:video_2min)}
     - videos << { id: 'chris_bosh',      code: 'kx3DxBbweGY', text: I18n.t(:video_title_chris_bosh),      duration: I18n.t(:video_1min), download: "//videos.code.org/social/athlete-chris-bosh.mp4"}

--- a/pegasus/sites.v3/code.org/views/ai_videos.haml
+++ b/pegasus/sites.v3/code.org/views/ai_videos.haml
@@ -2,7 +2,7 @@
   videos = [
     {
       id: 'seeing_ai',
-      code: 'DybczED-GKE-incorrect',
+      code: 'DybczED-GKE',
       text: hoc_s(:ai_video_title_seeing_ai)
     },
     {

--- a/pegasus/sites.v3/code.org/views/ai_videos.haml
+++ b/pegasus/sites.v3/code.org/views/ai_videos.haml
@@ -2,7 +2,7 @@
   videos = [
     {
       id: 'seeing_ai',
-      code: 'DybczED-GKE',
+      code: 'DybczED-GKE-incorrect',
       text: hoc_s(:ai_video_title_seeing_ai)
     },
     {

--- a/pegasus/sites.v3/code.org/views/display_video_thumbnail.haml
+++ b/pegasus/sites.v3/code.org/views/display_video_thumbnail.haml
@@ -109,10 +109,17 @@
 .videothumbnail{:onclick => "return showVideo_#{id}()", class: "play-button-#{play_button}"}
   %div.thumbnail-wrapper
     %div.video-thumbnail-wrapper
-      %img.thumbnail-image{:src => image, :alt => "Video thumbnail"}
+      %img.thumbnail-image{:alt => "Video thumbnail", :id => "video-thumbnail-#{id}"}
       %button.play-button-wrapper
         %img.play{:src => "/shared/images/play-button.png", :alt => "Play video #{caption}"}
     .video_caption_link= caption
 
 - unless thumbnail_only
   = view :display_video_lightbox, id: id, video_code: video_code, facebook: facebook, twitter: twitter, download_filename: download_filename, download_path: download_path
+
+:javascript
+  var img_#{id} = document.getElementById("video-thumbnail-#{id}");
+  img_#{id}.onload = function() {
+    $(img_#{id}).addClass('video-thumbnail-loaded')
+  }
+  img_#{id}.src = "#{image}"


### PR DESCRIPTION
This feature file has been particularly flakey, and it appears the video thumbnails are not loading before the eyes screenshots.

This PR injects some javascript into the video image loader haml file, which is then used in a new steps function that checks all the video thumbnail images we're looking for have been successfully loaded. 

## Links


- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1122

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
