### PR TITLE
P20-398: Fix Curriculum content i18n keys duplication

### DIFF
--- a/bin/i18n/resources/dashboard/curriculum_content/sync_out.rb
+++ b/bin/i18n/resources/dashboard/curriculum_content/sync_out.rb
@@ -258,7 +258,7 @@ module I18n
             types_i18n_data = restore_reference_guide_i18n_keys(types_i18n_data)
             types_i18n_data = fix_resource_urls(types_i18n_data)
 
-            types_i18n_data.stringify_keys
+            types_i18n_data.deep_stringify_keys
           end
 
           def distribute_localization(language)

--- a/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_out.rb
+++ b/bin/test/i18n/resources/dashboard/curriculum_content/test_sync_out.rb
@@ -157,7 +157,7 @@ describe I18n::Resources::Dashboard::CurriculumContent::SyncOut do
     let(:flatten_types_i18n_data) {'flatten_types_i18n_data'}
     let(:restored_lesson_keys_i18n_data) {'restored_lesson_keys_i18n_data'}
     let(:restored_reference_guide_keys_i18n_data) {'restored_reference_guide_keys_i18n_data'}
-    let(:fixed_resource_urls_i18n_data) {{fixed_resource_urls: 'i18n_data'}}
+    let(:fixed_resource_urls_i18n_data) {{fixed_resource_urls: {i18n_key: 'i18n_data'}}}
 
     before do
       FileUtils.mkdir_p File.dirname(crowdin_file_path)
@@ -173,7 +173,7 @@ describe I18n::Resources::Dashboard::CurriculumContent::SyncOut do
       described_instance.expects(:restore_reference_guide_i18n_keys).with(restored_lesson_keys_i18n_data).in_sequence(execution_sequence).returns(restored_reference_guide_keys_i18n_data)
       described_instance.expects(:fix_resource_urls).with(restored_reference_guide_keys_i18n_data).in_sequence(execution_sequence).returns(fixed_resource_urls_i18n_data)
 
-      assert_equal({'fixed_resource_urls' => 'i18n_data'}, types_i18n_data)
+      assert_equal({'fixed_resource_urls' => {'i18n_key' => 'i18n_data'}}, types_i18n_data)
     end
   end
 


### PR DESCRIPTION
## Issue
https://github.com/code-dot-org/code-dot-org/blob/fc6367b996aefa67a650b29c89c7e6d4d453f255/dashboard/config/locales/announcements.es-ES.json#L42-L45

## Links
- jira ticket: [P20-398](https://codedotorg.atlassian.net/browse/P20-398)