### PR TITLE
Dispatch API results as they come in instead of waiting for the slowest one (TEACH-705)

### DIFF
--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -28,7 +28,7 @@ class TeacherSections extends Component {
     plSectionIds: PropTypes.array,
     hiddenPlSectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
     hiddenStudentSectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
-    asyncLoadComplete: PropTypes.bool,
+    sectionsAreLoaded: PropTypes.bool,
   };
 
   componentDidMount() {
@@ -55,7 +55,7 @@ class TeacherSections extends Component {
       <div id="classroom-sections">
         <ContentContainer heading={i18n.createSection()}>
           <SetUpSections />
-          {!this.props.asyncLoadComplete && (
+          {!this.props.sectionsAreLoaded && (
             <Spinner size="large" style={styles.spinner} />
           )}
         </ContentContainer>
@@ -91,7 +91,7 @@ export default connect(
     plSectionIds: state.teacherSections.plSectionIds,
     hiddenPlSectionIds: hiddenPlSectionIds(state),
     hiddenStudentSectionIds: hiddenStudentSectionIds(state),
-    asyncLoadComplete: state.teacherSections.asyncLoadComplete,
+    sectionsAreLoaded: state.teacherSections.sectionsAreLoaded,
   }),
   {
     asyncLoadCoteacherInvite,


### PR DESCRIPTION
The dashboard homepage calls `asyncLoadSectionData`, which makes three API calls to retrieve information about sections, valid course offerings, and allowed participant types. This function currently waits for all three API calls to complete before dispatching any of the results to our redux state. This causes the spinner blocking the sections table to run for an unnecessarily long time when the sections API call finishes faster than the others (which is often the case).

In this PR I move the `dispatch` events outside of the `Promise.all.then` callback so that they each run when their respective API call finishes, instead of waiting for the slowest one.

I then switch the spinner condition in the `TeacherSections` component to wait for the `sectionsAreLoaded` boolean to be populated, rather than the `asyncLoadComplete` boolean that is set once all three API calls complete.

The result of this change is that the teacher should see their sections table appear sooner much of the time.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[JIRA](https://codedotorg.atlassian.net/browse/TEACH-705)

## Testing story



<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
