### PR TITLE
Adds PII/Profanity failure exception cases on AI assessment

### DIFF
--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -104,6 +104,10 @@ class EvaluateRubricJob < ApplicationJob
     channel_id = get_channel_id(user, script_level)
     code, project_version = read_user_code(channel_id)
 
+    # Check for PII / sharing failures
+    share_failure = ShareFiltering.find_share_failure(code, user.locale)
+    raise "ShareFailure #{share_failure.type}" if share_failure
+
     openai_params = get_openai_params(lesson_s3_name, code)
     ai_evaluations = get_openai_evaluations(openai_params)
 

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -141,8 +141,7 @@ class EvaluateRubricJob < ApplicationJob
     # Check for PII / sharing failures
     # Get the 2-character language code from the user's preferred locale
     locale = (user.locale || 'en')[0...2]
-    share_failure = ShareFiltering.find_share_failure(code, locale, exceptions: true)
-    raise "ShareFailure #{share_failure.type}" if share_failure
+    ShareFiltering.find_share_failure(code, locale, exceptions: true)
 
     openai_params = get_openai_params(lesson_s3_name, code)
     ai_evaluations = get_openai_evaluations(openai_params)

--- a/dashboard/app/models/rubric_ai_evaluation.rb
+++ b/dashboard/app/models/rubric_ai_evaluation.rb
@@ -46,4 +46,32 @@ class RubricAiEvaluation < ApplicationRecord
       num_learning_goal_ai_evaluations: learning_goal_ai_evaluations.count,
     }
   end
+
+  def queued?
+    status == SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:QUEUED]
+  end
+
+  def running?
+    status == SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:RUNNING]
+  end
+
+  def succeeded?
+    status == SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:SUCCESS] && !failed?
+  end
+
+  def failed?
+    status >= SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:FAILURE]
+  end
+
+  def pii_failure?
+    status == SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:PII_VIOLATION]
+  end
+
+  def profanity_failure?
+    status == SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:PROFANITY_VIOLATION]
+  end
+
+  def share_failure?
+    pii_failure? || profanity_failure?
+  end
 end

--- a/dashboard/app/models/rubric_ai_evaluation.rb
+++ b/dashboard/app/models/rubric_ai_evaluation.rb
@@ -71,7 +71,7 @@ class RubricAiEvaluation < ApplicationRecord
     status == SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:PROFANITY_VIOLATION]
   end
 
-  def share_failure?
+  def share_filtering_failure?
     pii_failure? || profanity_failure?
   end
 end

--- a/dashboard/test/controllers/api/v1/ml_models_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/ml_models_controller_test.rb
@@ -5,8 +5,6 @@ class Api::V1::MlModelsControllerTest < ActionController::TestCase
     FirehoseClient.instance.stubs(:put_record).with do |stream, args|
       @firehose_record = args
       @firehose_stream = stream
-      puts args
-      puts stream
       true
     end
   end

--- a/dashboard/test/models/rubric_ai_evaluation_test.rb
+++ b/dashboard/test/models/rubric_ai_evaluation_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+class RubricAiEvaluationTest < ActiveSupport::TestCase
+  test 'failed? returns true when the status reflects a PII failure' do
+    rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:PII_VIOLATION]
+    assert rubric.failed?
+  end
+
+  test 'failed? returns true when the status reflects a profanity failure' do
+    rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:PROFANITY_VIOLATION]
+    assert rubric.failed?
+  end
+
+  test 'failed? returns true when the status reflects a normal failure' do
+    rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:FAILURE]
+    assert rubric.failed?
+  end
+
+  test 'failed? returns false when the status reflects a success' do
+    rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]
+    refute rubric.failed?
+  end
+
+  test 'succeeded? returns true when the status reflects a success' do
+    rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]
+    assert rubric.succeeded?
+  end
+
+  test 'succeeded? returns false when the status reflects a failure' do
+    rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:FAILURE]
+    refute rubric.succeeded?
+  end
+
+  test 'queued? returns true when the status reflects the job has been queued' do
+    rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:QUEUED]
+    assert rubric.queued?
+  end
+
+  test 'running? returns true when the status reflects the job is running' do
+    rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:RUNNING]
+    assert rubric.running?
+  end
+
+  test 'pii_failure? returns true when the status reflects a PII failure' do
+    rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:PII_VIOLATION]
+    assert rubric.pii_failure?
+  end
+
+  test 'profanity_failure? returns true when the status reflects a profanity failure' do
+    rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:PROFANITY_VIOLATION]
+    assert rubric.profanity_failure?
+  end
+
+  test 'share_failure? returns true when the status reflects a PII failure' do
+    rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:PII_VIOLATION]
+    assert rubric.share_failure?
+  end
+
+  test 'share_failure? returns true when the status reflects a profanity failure' do
+    rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:PROFANITY_VIOLATION]
+    assert rubric.share_failure?
+  end
+end

--- a/dashboard/test/models/rubric_ai_evaluation_test.rb
+++ b/dashboard/test/models/rubric_ai_evaluation_test.rb
@@ -51,13 +51,13 @@ class RubricAiEvaluationTest < ActiveSupport::TestCase
     assert rubric.profanity_failure?
   end
 
-  test 'share_failure? returns true when the status reflects a PII failure' do
+  test 'share_filtering_failure? returns true when the status reflects a PII failure' do
     rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:PII_VIOLATION]
-    assert rubric.share_failure?
+    assert rubric.share_filtering_failure?
   end
 
-  test 'share_failure? returns true when the status reflects a profanity failure' do
+  test 'share_filtering_failure? returns true when the status reflects a profanity failure' do
     rubric = create :rubric_ai_evaluation, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:PROFANITY_VIOLATION]
-    assert rubric.share_failure?
+    assert rubric.share_filtering_failure?
   end
 end

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -6,6 +6,30 @@ require 'dynamic_config/gatekeeper'
 USER_ENTERED_TEXT_INDICATORS = ['TITLE', 'TEXT', 'title name\=\"VAL\"'].freeze
 PLAYLAB_APP_INDICATOR = 'studio_'.freeze
 
+# This is raised if there is any violation and you query with exceptions
+# enabled.
+class ShareFilterException < StandardError
+  attr_reader :share_failure
+
+  def initialize(msg, share_failure)
+    raise TypeError unless share_failure.is_a?(ShareFailure)
+    @share_failure = share_failure
+    super(msg)
+  end
+end
+
+# This is raised if there is a PII violation and you query with exceptions
+# enabled.
+class PIIFilterException < ShareFilterException
+end
+
+# This is raised if there is a profanity violation and you query with exceptions
+# enabled.
+class ProfanityFilterException < ShareFilterException
+end
+
+# This keeps track of the type and the actual offending content of a share
+# violation.
 ShareFailure = Struct.new(:type, :content)
 
 # Utilities for finding personally-identifiable and profane content in user
@@ -26,13 +50,13 @@ module ShareFiltering
   #
   # @param [String] program the student's program text
   # @param [String] locale a two-character ISO 639-1 language code
-  def self.find_share_failure(program, locale)
+  def self.find_share_failure(program, locale, exceptions: false)
     return nil unless should_filter_program(program)
 
     xml_tag_regexp = /<[^>]*>/
     program_tags_removed = program.gsub(xml_tag_regexp, "\n")
 
-    find_failure(program_tags_removed, locale)
+    find_failure(program_tags_removed, locale, exceptions: exceptions)
   end
 
   def self.should_filter_program(program)
@@ -49,10 +73,10 @@ module ShareFiltering
   #
   # @param [String] program_name the student's program's name
   # @param [String] locale a two-character ISO 639-1 language code
-  def self.find_name_failure(program_name, locale)
+  def self.find_name_failure(program_name, locale, exceptions: false)
     return nil unless Gatekeeper.allows('webpurify', default: true)
 
-    find_failure(program_name, locale)
+    find_failure(program_name, locale, {}, exceptions: exceptions)
   end
 
   # Searches for simple sources of PII (personal identifiable information)
@@ -69,15 +93,21 @@ module ShareFiltering
   #
   # @param [String] text The text to search through.
   # @return [ShareFailure, nil]
-  def self.find_pii_failure(text)
+  def self.find_pii_failure(text, exceptions: false)
     email = RegexpUtils.find_potential_email(text)
-    return ShareFailure.new(FailureType::EMAIL, email) if email
+    share_failure = ShareFailure.new(FailureType::EMAIL, email) if email
+    raise PIIFilterException.new("Email PII Filter Violation", share_failure) if share_failure && exceptions
+    return share_failure if share_failure
 
     phone_number = RegexpUtils.find_potential_phone_number(text)
-    return ShareFailure.new(FailureType::PHONE, phone_number) if phone_number
+    share_failure = ShareFailure.new(FailureType::PHONE, phone_number) if phone_number
+    raise PIIFilterException.new("Phone Number PII Filter Violation", share_failure) if share_failure && exceptions
+    return share_failure if share_failure
 
     street_address = Geocoder.find_potential_street_address(text)
-    return ShareFailure.new(FailureType::ADDRESS, street_address) if street_address
+    share_failure = ShareFailure.new(FailureType::ADDRESS, street_address) if street_address
+    raise PIIFilterException.new("Address PII Filter Violation", share_failure) if share_failure && exceptions
+    return share_failure if share_failure
 
     nil
   end
@@ -99,17 +129,19 @@ module ShareFiltering
   # @param [String] locale a two-character ISO 639-1 language code
   # @param [Hash] A set of text to replace before performing a profanity check.
   # @return [ShareFailure, nil]
-  def self.find_failure(text, locale, profanity_filter_replace_text_list = {})
+  def self.find_failure(text, locale, profanity_filter_replace_text_list = {}, exceptions: false)
     # We only fail programs when the webpurity service is enabled
     return nil unless Gatekeeper.allows('webpurify', default: true)
 
     # First, check for PII issues
-    pii_failure = find_pii_failure(text)
-    return pii_failure unless pii_failure.nil?
+    pii_failure = find_pii_failure(text, exceptions: exceptions)
+    return pii_failure if pii_failure
 
     # Search for profanity
     expletive = ProfanityFilter.find_potential_profanity(text, locale, profanity_filter_replace_text_list)
-    return ShareFailure.new(FailureType::PROFANITY, expletive) if expletive
+    share_failure = ShareFailure.new(FailureType::PROFANITY, expletive) if expletive
+    raise ProfanityFilterException.new("Profanity Filter Violation", share_failure) if share_failure && exceptions
+    return share_failure if share_failure
 
     nil
   end

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -615,8 +615,12 @@ module SharedConstants
     RUNNING: 1,
     # Succeeded
     SUCCESS: 2,
-    # General failure
-    FAILURE: 3,
+    # General failure (any anything larger)
+    FAILURE: 1000,
+    # PII Failure
+    PII_VIOLATION: 1001,
+    # Profanity Failure
+    PROFANITY_VIOLATION: 1002,
   }.freeze
 
   EMAIL_LINKS = OpenStruct.new(

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -615,7 +615,7 @@ module SharedConstants
     RUNNING: 1,
     # Succeeded
     SUCCESS: 2,
-    # General failure (any anything larger)
+    # General failure (along with anything larger)
     FAILURE: 1000,
     # PII Failure
     PII_VIOLATION: 1001,


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds checks using `ShareFiltering` to ensure nothing is sent to AI assessment that fails basic PII checks (and profanity checks).

* This refactors the `ShareFiltering` module to allow for exceptions since exceptions trigger the failure case for the job, and it makes sense to have the PII check throw one.
* Refactors `ShareFiltering` such that PII failures happen first before a profanity check since it would send some PII to the third-party profanity service, which seemed counter-intuitive. 
* Refactors to separate PII and profanity so you can elect to query either of them, alone. This was due to us initially only wanting a PII check, but it seemed useful to keep since PII checks are arguably more important and, in our code as it stands, much cheaper to check.

`RubricAiEvaluation` model

* Since this adds complexity to statuses (by adding several different failure cases with reasons), the status field has been expanded to have failures be any value over 1000.
* The `RubricAiEvaluation` model contains helper functions to negotiate which statuses are success and failure.

`EvaluateRubricJob` job

* Adds `rescue_from` hooks to the `EvaluateRubricJob` job for each type of share violation.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [AITT-189](https://codedotorg.atlassian.net/browse/AITT-189)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
