### PR TITLE
Fixes get_ai_assessments to stop it from pulling out the wrong students.

### DIFF
--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -86,7 +86,10 @@ class RubricsController < ApplicationController
     return head :forbidden unless can?(:manage, student)
 
     # Get the latest rubric evaluation
-    rubric_ai_evaluation = RubricAiEvaluation.where(rubric_id: permitted_params[:id]).order(updated_at: :desc).first
+    rubric_ai_evaluation = RubricAiEvaluation.where(
+      rubric_id: permitted_params[:id],
+      user_id: student.id
+    ).order(updated_at: :desc).first
 
     # Get the most recent learning goals based on the most recent graded rubric
     learning_goal_ai_evaluations = rubric_ai_evaluation.learning_goal_ai_evaluations

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -112,6 +112,7 @@ class RubricsControllerTest < ActionController::TestCase
 
   test "gets ai evaluations for student and learning goal" do
     student = create :student
+    classmate = create :student
     create :follower, student_user: student, user: @teacher
     sign_in @teacher
 
@@ -137,6 +138,29 @@ class RubricsControllerTest < ActionController::TestCase
       learning_goal: learning_goal2,
       understanding: 2
     )
+
+    # Create other records for another student
+    travel 1.minute do
+      rubric_ai_evaluation = create(
+        :rubric_ai_evaluation,
+        rubric: @rubric,
+        user: classmate,
+        requester: @teacher,
+        status: 1
+      )
+      create(
+        :learning_goal_ai_evaluation,
+        rubric_ai_evaluation: rubric_ai_evaluation,
+        learning_goal: learning_goal1,
+        understanding: 3
+      )
+      create(
+        :learning_goal_ai_evaluation,
+        rubric_ai_evaluation: rubric_ai_evaluation,
+        learning_goal: learning_goal2,
+        understanding: 3
+      )
+    end
 
     get :get_ai_evaluations, params: {
       id: @rubric.id,


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

A rebase added a regression when switching the tables in the latest merge for the `RubricAiEvaluation` table: `get_ai_assessments` wasn't negotiating with the student's user id and would just grab the latest evaluation for the level as a whole.

## Testing story

Modified the existing test to add a record of an evaluation of a classmate to a given student.

Got a red on the now fixed test.

Fixed the implementation to get a green.

## Impact

The feature is not actually live and we caught it because we expect migrations and are actively testing, so there is no need to worry about data leaking.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
