### PR TITLE
Add More Explicit Error Messages for Prohibited Filenames

### DIFF
--- a/bin/cron/check_invalid_staging_filenames
+++ b/bin/cron/check_invalid_staging_filenames
@@ -10,8 +10,9 @@ require 'cdo/developers_topic'
 require_relative '../../tools/hooks/hooks_utils'
 
 HooksUtils.get_unstaged_files.each do |filename|
-  next unless HooksUtils.prohibited?(filename)
-  msg = "INVALID FILENAME: #{filename}"
+  prohibition_problems = HooksUtils.prohibited?(filename)
+  next unless prohibition_problems
+  msg = "INVALID FILENAME: #{filename} (#{prohibition_problems.join(', ')})"
   ChatClient.log("<@#{DevelopersTopic.dotd}> #{msg}", color: 'red')
   ChatClient.message('content-editors', msg, color: 'red')
 end

--- a/tools/hooks/hooks_utils.rb
+++ b/tools/hooks/hooks_utils.rb
@@ -20,12 +20,14 @@ class HooksUtils
   #   * any file with spaces in the name
   #   * any file in /code.org/public/images/avatars with non-lowercase letters in the filename
   # @param filename [String] A filename.
-  # @return [Boolean] Whether the filename should be prohibited in a commit.
+  # @return [Array<String>, Boolean] An array of error messages if the file is prohibited for one or more reasons; `false` otherwise
   def self.prohibited?(filename)
-    return true if ['.mp4', '.mov'].include? File.extname(filename)
-    return true if File.extname(filename) != File.extname(filename).downcase
-    return true if filename.match?(/\s/)
-    return true if filename.include?('/code.org/public/images/avatars/') && File.basename(filename).downcase != File.basename(filename)
-    false
+    problems = []
+    problems << "file uses a .mp4 or .mov extension" if ['.mp4', '.mov'].include? File.extname(filename)
+    problems << "non-lowercase characters in extension" if File.extname(filename) != File.extname(filename).downcase
+    problems << "spaces in filename" if filename.match?(/\s/)
+    problems << "non-lowercase characters in avatar image" if filename.include?('/code.org/public/images/avatars/') && File.basename(filename).downcase != File.basename(filename)
+    return problems unless problems.empty?
+    return false
   end
 end

--- a/tools/hooks/restrict_staging_changes.rb
+++ b/tools/hooks/restrict_staging_changes.rb
@@ -9,7 +9,8 @@ def main
   exit(0) unless branch_name == 'staging'
 
   HooksUtils.get_staged_files.each do |filename|
-    raise "STAGING FILE BLOCKED: #{filename}" if HooksUtils.prohibited?(filename)
+    prohibition_problems = HooksUtils.prohibited?(filename)
+    raise "STAGING FILE BLOCKED: #{filename} (#{prohibition_problems.join(', ')})" if prohibition_problems
   end
 end
 


### PR DESCRIPTION
Currently, when we report to the `#content-editors` slack channel that a filename is invalid, we don't provide any guidance on exactly *why* it's invalid.

This PR proposes that we start doing so; rather than simply returning `true` if a filename is prohibited for any reason and `false` otherwise, we now return an array of error messages if a filename is prohibited and `false` otherwise. We can then incorporate those results into the report we deliver to slack.

## Links

See thread at https://codedotorg.slack.com/archives/C03A2LG1JLQ/p1698436509257029

## Testing story

Tested locally:

```
INVALID FILENAME: /home/elijah/projects/work/code-dot-org/pegasus/sites.v3/advocacy.code.org/public/images/test with spaces.png (spaces in filename)
INVALID FILENAME: /home/elijah/projects/work/code-dot-org/pegasus/sites.v3/advocacy.code.org/public/spaces and extension.JPG (non-lowercase characters in extension, spaces in filename)
INVALID FILENAME: /home/elijah/projects/work/code-dot-org/pegasus/sites.v3/advocacy.code.org/public/video with spaces.mp4 (file uses a .mp4 or .mov extension, spaces in filename)
INVALID FILENAME: /home/elijah/projects/work/code-dot-org/pegasus/sites.v3/advocacy.code.org/public/video.mp4 (file uses a .mp4 or .mov extension)
INVALID FILENAME: /home/elijah/projects/work/code-dot-org/pegasus/sites.v3/code.org/public/images/avatars/PERSON.png (non-lowercase characters in avatar image)
```