### PR TITLE
Return empty list if AI evaluation hasn't run

### DIFF
--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -92,7 +92,7 @@ class RubricsController < ApplicationController
     ).order(updated_at: :desc).first
 
     # Get the most recent learning goals based on the most recent graded rubric
-    learning_goal_ai_evaluations = rubric_ai_evaluation.learning_goal_ai_evaluations
+    learning_goal_ai_evaluations = rubric_ai_evaluation&.learning_goal_ai_evaluations || []
 
     render json: learning_goal_ai_evaluations.map(&:summarize_for_instructor)
   end

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -251,6 +251,23 @@ class RubricsControllerTest < ActionController::TestCase
     assert_equal 2, json_response[0]['understanding']
   end
 
+  test "returns no ai evaluations if evaluation has not been run" do
+    student = create :student
+    create :follower, student_user: student, user: @teacher
+    sign_in @teacher
+
+    learning_goal = create :learning_goal
+    assert 0, RubricAiEvaluation.where(user: student).count
+
+    get :get_ai_evaluations, params: {
+      id: learning_goal.rubric.id,
+      studentId: student.id,
+    }
+
+    assert_response :success
+    assert_equal 0, json_response.length
+  end
+
   test "gets teacher evaluations for current user" do
     student = create :student
     sign_in student


### PR DESCRIPTION
Simple fix to address [this Honeybadger error](https://app.honeybadger.io/projects/3240/faults/101694718).

I could repro a 500 locally when AI evaluations weren't run. I tested this fix both manually and with a test. TBH, not sure if I needed a test for such a small fix but it was also an easy test to write.