### PR TITLE
[Google Blockly] Flyout button styles

### DIFF
--- a/apps/src/blockly/addons/cdoCss.js
+++ b/apps/src/blockly/addons/cdoCss.js
@@ -1,3 +1,5 @@
+import color from '@cdo/apps/util/color';
+
 export default function initializeCss(blocklyWrapper) {
   blocklyWrapper.Css.register(
     `.fieldGridDropDownContainer.blocklyMenu .blocklyMenuItem {
@@ -17,6 +19,17 @@ export default function initializeCss(blocklyWrapper) {
       width: 32px;
       height: 32px;
       object-fit: contain;
+    }
+
+    .blocklyFlyoutButton {
+      fill: ${color.brand_secondary_default};
+      cursor: pointer;
+    }
+    .blocklyFlyoutButtonShadow {
+      fill: none;
+    }
+    .blocklyFlyoutButton:hover {
+      fill: ${color.brand_secondary_dark};
     }
     `
   );


### PR DESCRIPTION
Add some simple style rules for flyout buttons. Note that I went with flat purple for the buttons as this better aligns to our rebranding efforts. Specifically, I referenced our [`button.module.scss`](https://github.com/code-dot-org/code-dot-org/blob/567f956f0d19ca4a62ec5b7dbd9ab47ee05d2391/apps/src/templates/button.module.scss#L210-L235) file. 

|CDO Blockly | Google Blockly (staging) | Google Blockly (feature branch)|
|-|-|-|
|<img width="149" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/d0743543-4145-4890-928c-fdfcefb6f6b5">|<img width="147" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/ec21e244-61c3-478c-91ae-9b90dff7f360">|<img width="145" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/28a12b02-7ce4-42e1-9730-d12600e17ed0">|
|<img width="142" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/c98edfe2-dad8-4b5e-ad87-bd31668e135c">| <img width="144" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/b7e9379a-ba76-43cf-aff9-b8cd179b65af">|<img width="143" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/06142a5d-f276-4806-af5a-65e565d6245b">|
|n/a|<img width="143" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/4933e5a5-c3cf-4198-bd85-b52efe22747e">|<img width="141" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/35c96989-fc2c-477a-bd87-70f5c342f0a7">|


In open flyout with blocks:
<img width="757" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/44ce6d76-4144-428a-9eab-99555cb9aea0">


Note: While the button module suggests a `line-height` of 30px, this change is out of scope. These buttons are actually SVG elements that are created by Blockly using constants found in their button class. Overriding this would require extending Blockly's `FlyoutButton` class and determining how to register/use it. See https://github.com/google/blockly/blob/925a7b9723ac46217c64a1842668fd0a66549449/core/flyout_button.ts#L176-L179 for where the button margins are computed.
