### PR TITLE
Check that rubricData exists before pulling it in

### DIFF
--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {getStore, registerReducers} from '@cdo/apps/redux';
-import getScriptData from '@cdo/apps/util/getScriptData';
+import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 import ScriptLevelRedirectDialog from '@cdo/apps/code-studio/components/ScriptLevelRedirectDialog';
 import UnversionedScriptRedirectDialog from '@cdo/apps/code-studio/components/UnversionedScriptRedirectDialog';
 import {setIsMiniView} from '@cdo/apps/code-studio/progressRedux';
@@ -55,7 +55,10 @@ function initPage() {
     );
   }
 
-  if (experiments.isEnabled('ai-rubrics')) {
+  if (
+    experiments.isEnabled('ai-rubrics') &&
+    hasScriptData('script[data-rubricdata]')
+  ) {
     const rubricData = getScriptData('rubricdata');
     const {rubric, studentLevelInfo} = rubricData;
     const reportingData = {

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -667,7 +667,7 @@ class TopInstructions extends Component {
       mapReference || (referenceLinks && referenceLinks.length > 0);
 
     const displayHelpTab =
-      (levelVideos && levelVideos.length > 0) || levelResourcesAvailable;
+      (levelVideos && levelVideos.length > 0) || !!levelResourcesAvailable;
 
     const displayFeedbackTab =
       !taRubric &&


### PR DESCRIPTION
We got [this ZenDesk ticket](https://codedotorg.slack.com/archives/C045UAX4WKH/p1698680899007719) letting us know that there was an issue with the non-rubric levels looking for data that wasn't there.  This PR fixes this by checking that the data exists before pulling it in.

A few other notes:

- I considered refactoring the `hasScriptData` so that it followed the same format as the `getScriptData()` function.  However, when I started to do that, I noticed that in [one other place](https://github.com/code-dot-org/code-dot-org/blob/f4f51cb8c215305e4e061eee14611cd086be00fc/apps/src/sites/studio/pages/programming_classes/show.js#L29) where we use `hasScriptData`, we use just a "key" as a parameter.  This seemed odd to me but I wasn't really sure how to see this in the application and the investigation seemed beyond the scope of this ticket. 
- After fixing the issue reported in ZenDesk, I ran into a warning indicating that one of the prop-types was incorrect in `TopInstructionsHeader`.  This didn't seem to impact usability, but after a bit of investigation, it seemed like a straightforward fix to stop that from occurring. This is also addressed in this PR.

Testing
- I tested this locally on different pages and did not run into any other errors or unexpected issues.