### PR TITLE
Reorder routes so that the check action doesn't get swallowed up by the show action

### DIFF
--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -921,6 +921,7 @@ Dashboard::Application.routes.draw do
         get 'peer_review_submissions/index', to: 'peer_review_submissions#index'
         get 'peer_review_submissions/report_csv', to: 'peer_review_submissions#report_csv'
 
+        get 'section_instructors/check', to: 'section_instructors#check'
         resources :section_instructors, only: [:index, :create, :destroy] do
           member do
             put 'accept'
@@ -928,7 +929,6 @@ Dashboard::Application.routes.draw do
           end
         end
         get 'section_instructors/:section_id', to: 'section_instructors#show'
-        get 'section_instructors/check', to: 'section_instructors#check'
 
         resources :ml_models, only: [:show, :destroy] do
           collection do


### PR DESCRIPTION
While the `check` action in the `SectionInstructorsController` was working fine in unit tests, it was encountering errors calling it from the browser. The culprit was in the `routes.rb`: namely requests to `/api/v1/section_instructors/check` were being routed to the `show` action with `id = check`, instead of being routed to the `check` action. Reordering the routes fixes that.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
