### PR TITLE
Revert "Provision Application SQL Users"

### DIFF
--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -78,7 +78,7 @@ KEY=$(aws s3 cp $CURRENT/key.pem - | replace_newline)
 
 <% if database && !rack_env?(:production) -%>
 apt-get install -y  jq
-DB_SECRET_NAME=${DatabaseSecretWriter}
+DB_SECRET_NAME=${DatabaseSecretAdmin}
 DB_SECRET=$(aws --region $REGION secretsmanager get-secret-value --secret-id $DB_SECRET_NAME --version-stage AWSCURRENT | jq -r ".SecretString")
 DB_USERNAME=$(echo $DB_SECRET | jq -r ".username")
 DB_PASSWORD=$(echo $DB_SECRET | jq -r ".password")

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -53,7 +53,7 @@
       Description: !Sub "Database credentials for ${AWS::StackName} writer user."
 <% if database -%>
       GenerateSecretString:
-        SecretStringTemplate: '{"username": "writer"}'
+        SecretStringTemplate: !Sub '{"username": "application-writer"}'
         GenerateStringKey: password
         PasswordLength: 10
         ExcludePunctuation: True
@@ -67,7 +67,7 @@
       Description: !Sub "Database credentials for ${AWS::StackName} reader user."
 <% if database -%>
       GenerateSecretString:
-        SecretStringTemplate: '{"username": "reader"}'
+        SecretStringTemplate: !Sub '{"username": "readonly"}'
         GenerateStringKey: password
         PasswordLength: 10
         ExcludePunctuation: True
@@ -138,7 +138,6 @@
       PermissionsBoundary: !ImportValue IAM-DevPermissions
   ReportingDBProxy:
     Type: AWS::RDS::DBProxy
-    DependsOn: ReaderSQLUser
     Properties:
       DBProxyName: !Sub "${AWS::StackName}-reporting"
       EngineFamily: MYSQL
@@ -185,54 +184,6 @@
         # Ensure that connections to the reader database instances that are carrying out "reporting" queries do not
         # exceed 5% of the total database connection capacity of a reader instance.
         MaxConnectionsPercent: 5
-  WriterSQLUser:
-    Type: Custom::SQLUser
-<%  unless rack_env?(:production)%>
-    # Wait until DB Instances have completed provisioning before using the admin SQL user to provision an application
-    # SQL user.
-    DependsOn: [<%=DB_INSTANCE_RANGE.map {|i| "Aurora#{i}"}.join(',')%>]
-<%  end -%>
-    Properties:
-      ServiceToken: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:SQLUser"
-      DBServerHost: !GetAtt AuroraCluster.Endpoint.Address
-      # Credentials for SQL admin user that will create/update/delete this SQL user resource.
-      DBCredentialAdminSecret: !Ref DatabaseSecretAdmin
-      # Credentials (username and password) for the SQL User this Resource is provisioning.
-      DBCredentialSecret: !Ref DatabaseSecretWriter
-      Privileges:
-        - SELECT
-        - INSERT
-        - UPDATE
-        - DELETE
-        - CREATE
-        - DROP
-        - REFERENCES
-        - INDEX
-        - ALTER
-        - CREATE TEMPORARY TABLES
-        - LOCK TABLES
-        - EXECUTE
-        - CREATE VIEW
-        - SHOW VIEW
-        - CREATE ROUTINE
-        - ALTER ROUTINE
-        - EVENT
-        - TRIGGER
-  ReaderSQLUser:
-    Type: Custom::SQLUser
-<%  unless rack_env?(:production)%>
-    # Wait until DB Instances have completed provisioning before using the admin SQL user to provision an application
-    # SQL user.
-    DependsOn: [<%=DB_INSTANCE_RANGE.map {|i| "Aurora#{i}"}.join(',')%>]
-<%  end -%>
-    Properties:
-      ServiceToken: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:SQLUser"
-      DBServerHost: !GetAtt AuroraCluster.Endpoint.Address
-      # Credentials for SQL admin user that will create/update/delete this SQL user resource.
-      DBCredentialAdminSecret: !Ref DatabaseSecretAdmin
-      # Credentials (username and password) for the SQL User this Resource is provisioning.
-      DBCredentialSecret: !Ref DatabaseSecretReader
-      Privileges: ['SELECT']
 
 # We don't provision these in production via CloudFormation ... yet!
 <%  unless rack_env?(:production)%>
@@ -275,7 +226,6 @@
 
   DBProxy:
     Type: AWS::RDS::DBProxy
-    DependsOn: [WriterSQLUser, ReaderSQLUser]
     Properties:
       DBProxyName: !Ref AWS::StackName
       EngineFamily: MYSQL


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#52796

There were defects in the production-specific logic of this change, such as:

```
Aws::CloudFormation::Errors::ValidationError: Template error: instance of Fn::GetAtt references undefined resource AuroraCluster
```