### PR TITLE
[Google Blockly] Option 3: move modal editor toolbar to bottom

### DIFF
--- a/apps/src/blockly/components/modal-function-editor.module.scss
+++ b/apps/src/blockly/components/modal-function-editor.module.scss
@@ -1,4 +1,4 @@
-@import "color.scss";
+@import 'color.scss';
 
 .container {
   display: none;
@@ -11,7 +11,7 @@
 
 .toolbar {
   position: absolute;
-  top: 10px;
+  bottom: 10px;
   right: 10px;
   z-index: 1;
 }


### PR DESCRIPTION
Before:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/c80e235d-7946-40c4-9f1c-2870f54f8724)

After:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/b420d5b6-1b01-41d9-a6b7-c8182cc6f1db)

Bad edge case, toolbar overlaps code:

![2023-10-31 10-15-18 2023-10-31 10_15_34](https://github.com/code-dot-org/code-dot-org/assets/43474485/f04f6148-7755-4cb5-9d99-faf40cdca96d)
