### PR TITLE
[Google Blockly] Option 2: Move modal editor toolbar down a bit

### DIFF
--- a/apps/src/blockly/components/modal-function-editor.module.scss
+++ b/apps/src/blockly/components/modal-function-editor.module.scss
@@ -1,4 +1,4 @@
-@import "color.scss";
+@import 'color.scss';
 
 .container {
   display: none;
@@ -11,7 +11,7 @@
 
 .toolbar {
   position: absolute;
-  top: 10px;
+  top: 36px;
   right: 10px;
   z-index: 1;
 }


### PR DESCRIPTION
Before:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/c80e235d-7946-40c4-9f1c-2870f54f8724)

After:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/a6545cee-72cd-4e2e-8153-2d92142f24bb)

![2023-10-31 10-16-05 2023-10-31 10_16_19](https://github.com/code-dot-org/code-dot-org/assets/43474485/5da62fa0-77b2-479a-8c3f-b9c2d66e84e5)


Bad edge case with really long procedure name:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/c78d2a55-24a0-4788-85c4-b20aaa6114f0)
