### PR TITLE
Dance AI: stop playback when opening modal

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -182,6 +182,7 @@ Dance.prototype.init = function (config) {
           <DanceVisualizationColumn
             showFinishButton={showFinishButton}
             setSong={this.setSongCallback.bind(this)}
+            resetProgram={this.reset.bind(this)}
           />
         }
         onMount={onMount}

--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -73,6 +73,7 @@ class DanceVisualizationColumn extends React.Component {
     over21: PropTypes.bool.isRequired,
     currentAiModalField: PropTypes.object,
     setCurrentAiModalField: PropTypes.func,
+    resetProgram: PropTypes.func.isRequired,
   };
 
   state = {
@@ -85,6 +86,16 @@ class DanceVisualizationColumn extends React.Component {
   turnFilterOff = () => {
     this.setState({filterOn: false});
   };
+
+  componentDidUpdate(prevProps) {
+    // Reset the program when the AI modal is opened
+    if (
+      prevProps.currentAiModalField === undefined &&
+      this.props.currentAiModalField
+    ) {
+      this.props.resetProgram();
+    }
+  }
 
   render() {
     const filenameToImgUrl = {

--- a/apps/src/dance/ai/AiBlockPreview.tsx
+++ b/apps/src/dance/ai/AiBlockPreview.tsx
@@ -1,5 +1,5 @@
 import {BlockSvg, Workspace, WorkspaceSvg} from 'blockly';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef} from 'react';
 import moduleStyles from './ai-block-preview.module.scss';
 
 interface AiBlockPreviewProps {
@@ -19,12 +19,9 @@ const AiBlockPreview: React.FunctionComponent<AiBlockPreviewProps> = ({
   const blockPreviewContainerRef = useRef<HTMLSpanElement>(null);
   const refTimer = useRef<number | null>(null);
 
-  const [done, setDone] = useState<boolean>(false);
-
   useEffect(() => {
     refTimer.current = window.setTimeout(
       () => {
-        setDone(true);
         onComplete();
         if (refTimer.current) {
           clearTimeout(refTimer.current);
@@ -43,23 +40,25 @@ const AiBlockPreview: React.FunctionComponent<AiBlockPreviewProps> = ({
 
   // Build out the blocks.
   useEffect(() => {
-    if (!done) {
-      const emptyBlockXml = Blockly.utils.xml.textToDom('<xml></xml>');
-      const previewWorkspace: Workspace =
-        Blockly.BlockSpace.createReadOnlyBlockSpace(
-          blockPreviewContainerRef.current,
-          emptyBlockXml,
-          {}
-        );
+    const emptyBlockXml = Blockly.utils.xml.textToDom('<xml></xml>');
+    const previewWorkspace: Workspace =
+      Blockly.BlockSpace.createReadOnlyBlockSpace(
+        blockPreviewContainerRef.current,
+        emptyBlockXml,
+        {}
+      );
 
-      const blocksSvg = generateBlocksFromResult(previewWorkspace);
-      blocksSvg.forEach((blockSvg: BlockSvg) => {
-        blockSvg.initSvg();
-        blockSvg.render();
-      });
-      Blockly.svgResize(previewWorkspace as WorkspaceSvg);
-    }
-  }, [blockPreviewContainerRef, generateBlocksFromResult, done]);
+    const blocksSvg = generateBlocksFromResult(previewWorkspace);
+    blocksSvg.forEach((blockSvg: BlockSvg) => {
+      blockSvg.initSvg();
+      blockSvg.render();
+    });
+    Blockly.svgResize(previewWorkspace as WorkspaceSvg);
+
+    return () => {
+      previewWorkspace.dispose();
+    };
+  }, [blockPreviewContainerRef, generateBlocksFromResult]);
 
   return (
     <div id={fadeIn ? 'fade-in' : undefined}>


### PR DESCRIPTION
A couple of interrelated changes for bugs we've seen when opening the AI modal mid-playback. We decided for performance and usage reason that it would be best to just stop playback when the modal opens, so some of these changes aren't strictly necessary, but they do help alleviate possible bugs in case they surface in other ways, or if we do decide to change our approach and keep the song playing while the modal is open. These changes include

- In ProgramExecutor, instead of stopping all audio on reset (which is what Dance.js does), we only try to stop the song that had been previously started by the executor specifically, if any. This was causing an issue because Dance.js has logic to switch the run/reset buttons when playback stops that we were unintentionally hitting while calling reset() within the ProgramExecutor while previewing in the modal.
- Wrap callbacks to AiBlockPreview in `useCallback` to prevent duplicate sets of blocks from being rendered. We'd occasionally see this because the `useEffect` hook would fire multiple times due to the callback dependencies not being memoized.
- Also call `workspace.dispose()` on the block preview workspace whenever dismounting to be safe.
- I also removed the `done` state in AiBlockPreview since it seemed like wasn't being used to trigger any rendering

## Links

https://trello.com/c/Mau4dYYV

## Testing story

Tested locally on Dance AI levels