### PR TITLE
Fix "Save" button on Exemplars not saving

### DIFF
--- a/apps/src/code-studio/components/header/LevelBuilderSaveButton.jsx
+++ b/apps/src/code-studio/components/header/LevelBuilderSaveButton.jsx
@@ -17,7 +17,7 @@ class LevelBuilderSaveButton extends React.Component {
     setProjectUpdatedSaving: PropTypes.func.isRequired,
     setProjectUpdatedSaved: PropTypes.func.isRequired,
     overrideHeaderText: PropTypes.string,
-    overrideOnSaveURL: PropTypes.string,
+    overrideOnSaveUrl: PropTypes.string,
   };
 
   onSave = () => {
@@ -25,7 +25,7 @@ class LevelBuilderSaveButton extends React.Component {
 
     $.ajax({
       type: 'POST',
-      url: this.props.overrideOnSaveURL || '../update_start_code',
+      url: this.props.overrideOnSaveUrl || '../update_start_code',
       data: JSON.stringify(this.props.getChanges()),
       dataType: 'json',
       error: this.props.setProjectUpdatedError,
@@ -55,7 +55,7 @@ export default connect(
   state => ({
     getChanges: state.header.getLevelBuilderChanges,
     overrideHeaderText: state.header.overrideHeaderText,
-    overrideOnSaveURL: state.header.overrideOnSaveURL,
+    overrideOnSaveUrl: state.header.overrideOnSaveUrl,
   }),
   {
     setProjectUpdatedError,


### PR DESCRIPTION
I think I fixed [Ken's reported](https://codedotorg.slack.com/archives/C045UAX4WKH/p1698786088903699) issue of the LevelBuilder "Save" button not working when editing the exemplars in JavaLab.

It is not clear to me how it got broken in the first place though which makes me a bit nervous.  I checked the last time any of the impacted files were edited and none of them were less than 4 months ago...

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
