### PR TITLE
Sending automated emails fails for CSA pre-workshop emails

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -529,7 +529,7 @@ class Pd::Workshop < ApplicationRecord
   def self.send_teacher_pre_work_csa
     # Collect errors, but do not stop batch. Rethrow all errors below.
     errors = []
-    scheduled_start_in_days(20).each do |workshop|
+    scheduled_start_in_days(20).select {|ws| ws.course == COURSE_CSA}.each do |workshop|
       workshop.enrollments.each do |enrollment|
         Pd::WorkshopMailer.teacher_pre_workshop_csa(enrollment).deliver_now
       rescue => exception
@@ -546,7 +546,7 @@ class Pd::Workshop < ApplicationRecord
     send_reminder_for_upcoming_in_days(10)
     send_reminder_to_close
     send_follow_up_after_days(30)
-    send_teacher_pre_work_csa if course == COURSE_CSA
+    send_teacher_pre_work_csa
   end
 
   # Updates enrollments with resolved users.


### PR DESCRIPTION
Issue: The method to send all the automated emails for different workshop scenarios currently references an instance variable, which is not available as the method is static.

Fix: Move the filtering of CSA workshops to the calling method which iterates over all the workshops and has the course information.

## Links

JIRA: https://codedotorg.atlassian.net/browse/ACQ-996?atlOrigin=eyJpIjoiY2M2NDA1MjkwNWExNDU0ZWFlOWVkYTg0ZDUwNjE1ZDQiLCJwIjoiaiJ9

## Testing story

Manually tested locally by 

 - creating two workshops that are 20 days out (one for CSF and one for CSA) and enrolled a teacher in both
 - from rails console, called the below method to ensure there are no exceptions and that the log says an email will be sent out to the user who was enrolled in CSA, and not CSF. [development] dashboard > Pd::Workshop.send_teacher_pre_work_csa

## Deployment strategy
N/A

## Follow-up work
None

## Privacy
N/A

## Security
N/A

## Caching
N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
