### PR TITLE
Fix callouts on scroll and resize

### DIFF
--- a/apps/src/blockly/eventHandlers.js
+++ b/apps/src/blockly/eventHandlers.js
@@ -1,3 +1,7 @@
+// Event Handlers for Google Blockly.
+
+import {handleWorkspaceResizeOrScroll} from '@cdo/apps/code-studio/callouts';
+
 // A custom version of Blockly's Events.disableOrphans. This makes a couple
 // changes to the original function.
 
@@ -59,5 +63,13 @@ export function disableOrphans(blockEvent) {
         Blockly.Events.setRecordUndo(initialUndoFlag);
       }
     }
+  }
+}
+
+// When the viewport of the workspace is changed (due to scrolling for example),
+// we need to reposition any callouts.
+export function adjustCalloutsOnViewportChange(event) {
+  if (event.type === Blockly.Events.VIEWPORT_CHANGE) {
+    handleWorkspaceResizeOrScroll();
   }
 }

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -650,8 +650,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
     workspace.addChangeListener(adjustCalloutsOnViewportChange);
     workspace
       .getFlyout()
-      .getWorkspace()
-      .addChangeListener(adjustCalloutsOnViewportChange);
+      ?.getWorkspace()
+      ?.addChangeListener(adjustCalloutsOnViewportChange);
 
     document.dispatchEvent(
       utils.createEvent(Blockly.BlockSpace.EVENTS.MAIN_BLOCK_SPACE_CREATED)

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -61,7 +61,7 @@ import {
   ObservableProcedureModel,
   ObservableParameterModel,
 } from '@blockly/block-shareable-procedures';
-import {disableOrphans} from './eventHandlers';
+import {adjustCalloutsOnViewportChange, disableOrphans} from './eventHandlers';
 
 const options = {
   contextMenu: true,
@@ -643,6 +643,15 @@ function initializeBlocklyWrapper(blocklyInstance) {
     if (!blocklyWrapper.isStartMode && !opt_options.isBlockEditMode) {
       workspace.addChangeListener(disableOrphans);
     }
+
+    // When either the main workspace or the toolbox workspace viewport
+    // changes, adjust any callouts so they stay pointing to the appropriate
+    // location.
+    workspace.addChangeListener(adjustCalloutsOnViewportChange);
+    workspace
+      .getFlyout()
+      .getWorkspace()
+      .addChangeListener(adjustCalloutsOnViewportChange);
 
     document.dispatchEvent(
       utils.createEvent(Blockly.BlockSpace.EVENTS.MAIN_BLOCK_SPACE_CREATED)

--- a/apps/src/code-studio/callouts.js
+++ b/apps/src/code-studio/callouts.js
@@ -39,6 +39,7 @@ export default function createCallouts(callouts) {
 
   // Update callout positions when a blockly editor is scrolled.
   $(window).on('block_space_metrics_set', handleWorkspaceResizeOrScroll);
+  // Update callout positions when the browser is resized.
   window.addEventListener('resize', handleWorkspaceResizeOrScroll);
 
   $(window).on('droplet_change', function (e, dropletEvent) {

--- a/apps/src/code-studio/callouts.js
+++ b/apps/src/code-studio/callouts.js
@@ -38,10 +38,8 @@ export default function createCallouts(callouts) {
   });
 
   // Update callout positions when a blockly editor is scrolled.
-  $(window).on('block_space_metrics_set', function () {
-    snapCalloutsToTargets();
-    showHideWorkspaceCallouts();
-  });
+  $(window).on('block_space_metrics_set', handleWorkspaceResizeOrScroll);
+  window.addEventListener('resize', handleWorkspaceResizeOrScroll);
 
   $(window).on('droplet_change', function (e, dropletEvent) {
     switch (dropletEvent) {
@@ -202,6 +200,13 @@ export function addCallouts(callouts) {
       $(selector).qtip(config).qtip('show');
     }
   });
+  // Ensure any callouts pointing to hidden elements are hidden.
+  showHideWorkspaceCallouts();
+}
+
+export function handleWorkspaceResizeOrScroll() {
+  snapCalloutsToTargets();
+  showHideWorkspaceCallouts();
 }
 
 /**
@@ -265,7 +270,7 @@ function showOrHideCalloutsByTargetVisibility(containerSelector) {
         calloutsHiddenByContainerVisibility[api.id] = true;
       }
 
-      if (target && target.overlaps(container).length > 0) {
+      if (target && elementIsInContainer(target, container)) {
         if (calloutsHiddenByScrolling[api.id]) {
           api.show();
           delete calloutsHiddenByScrolling[api.id];
@@ -294,4 +299,16 @@ function reverseDirection(token) {
     default:
       return token;
   }
+}
+
+// Return true if the element is fully contained within the container.
+function elementIsInContainer(element, container) {
+  var elementRect = element[0].getBoundingClientRect();
+  var containerRect = container[0].getBoundingClientRect();
+  return (
+    elementRect.left >= containerRect.left &&
+    elementRect.right <= containerRect.right &&
+    elementRect.top >= containerRect.top &&
+    elementRect.bottom <= containerRect.bottom
+  );
 }


### PR DESCRIPTION
This PR fixes a couple issues with callouts:
- In Google Blockly labs, we weren't updating callout position at all on scroll or resize. This is fixed by adding an event handler on both the main workspace and toolbox workspace viewport changed event, and adding an event when the browser itself resizes.
- For both Google Blockly and CDO Blockly, when a block was scrolled outside of the main workspace the would still show up floating on the page. We had logic to avoid this, but it was broken at some point. Now we check that the block is still inside the workspace, and if it's not we hide it.

### Before (CDO Blockly)
https://github.com/code-dot-org/code-dot-org/assets/33666587/7f310341-cb4c-4344-8583-f5d68908409c

### Before (Google Blockly)
https://github.com/code-dot-org/code-dot-org/assets/33666587/cf4ec0fb-a4be-4cb1-a05c-f69dc82eaff8

### After (CDO Blockly)

https://github.com/code-dot-org/code-dot-org/assets/33666587/20180ade-0333-4885-b14e-16f4f8d61330


### After (Google Blockly)

https://github.com/code-dot-org/code-dot-org/assets/33666587/a766f13b-1916-434a-af6b-b9b2c7ecdd33


## Links

- jira ticket: [CT-56](https://codedotorg.atlassian.net/browse/CT-56)

## Testing story
Tested locally.

## Follow-up work
For Google Blockly labs with the modal function editor enabled there is still one UI quirk remaining. The modal function editor has a duplicate toolbox, which means callouts on the toolbox are created for both the function editor and regular toolboxes. With the new and improved hiding logic these callouts do get hidden, but they briefly flicker in the top left corner on page load. I made a [follow up taks](https://codedotorg.atlassian.net/browse/CT-149) to see if we can solve this.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
