### PR TITLE
 AI Tutor - section setting toggle, UI only

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1002,7 +1002,7 @@
   "emptyTopLevelBlock": "There are no blocks to run. You must attach a block to the {topLevelBlockName} block.",
   "enable": "Enable",
   "enableAITutor": "Enable AI Tutor",
-  "enableAITutorTooltip": "Turning this on will give students in your section access to AI Tutor on certain 4AP CSA levels.",
+  "enableAITutorTooltip": "Turning this on will give students in your section access to AI Tutor on certain AP CSA levels.",
   "enableCodeReview": "Enable Code Review",
   "enableTtsAutoplay": "Automatically read instructions aloud to students? (Only certain courses and web browsers)",
   "enableTtsAutoplayToggle": "Automatically read instructions aloud to students",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1001,6 +1001,8 @@
   "emptyTextResponsesTable": "Most of our classes are designed to work for younger ages and do not require students to type text responses to questions, so you will not see any text responses here. For older students in middle and high school courses, you can see their submissions to open-ended text response questions by choosing the assigned course from the drop down above.",
   "emptyTopLevelBlock": "There are no blocks to run. You must attach a block to the {topLevelBlockName} block.",
   "enable": "Enable",
+  "enableAITutor": "Enable AI Tutor",
+  "enableAITutorTooltip": "Turning this on will give students in your section access to AI Tutor on certain 4AP CSA levels.",
   "enableCodeReview": "Enable Code Review",
   "enableTtsAutoplay": "Automatically read instructions aloud to students? (Only certain courses and web browsers)",
   "enableTtsAutoplayToggle": "Automatically read instructions aloud to students",

--- a/apps/src/templates/sectionsRefresh/AdvancedSettingToggles.jsx
+++ b/apps/src/templates/sectionsRefresh/AdvancedSettingToggles.jsx
@@ -10,6 +10,7 @@ export default function AdvancedSettingToggles({
   section,
   hasLessonExtras,
   hasTextToSpeech,
+  aiTutorAvailable,
 }) {
   const handlePairProgrammingToggle = e => {
     const updatedValue = !section.pairingAllowed;
@@ -29,6 +30,14 @@ export default function AdvancedSettingToggles({
   const handleTtsAutoplayEnabledToggle = e => {
     const updatedValue = !section.ttsAutoplayEnabled;
     updateSection('ttsAutoplayEnabled', updatedValue);
+  };
+
+  const handleAITutorEnabledToggle = e => {
+    // TODO: once aiTutorEnabled is a property of a section, and sections API can handle updating it,
+    // make this toggle actually set the aiTutorEnabled :)
+    // const updatedValue = !section.aiTutorEnabled;
+    // updateSection('aiTutorEnabled', updatedValue);
+    console.log('toggled AI Tutor on/off');
   };
 
   return (
@@ -87,6 +96,20 @@ export default function AdvancedSettingToggles({
           />
         </div>
       )}
+      {aiTutorAvailable && (
+        <div className={style.toolTipContainer}>
+          <ToggleSwitch
+            id={'uitest-ai-tutor-toggle'}
+            isToggledOn={true}
+            onToggle={e => handleAITutorEnabledToggle(e)}
+            label={i18n.enableAITutor()}
+          />
+          <InfoHelpTip
+            id={'ai-tutor-toggle-info'}
+            content={i18n.enableAITutorTooltip()}
+          />
+        </div>
+      )}
     </div>
   );
 }
@@ -96,4 +119,5 @@ AdvancedSettingToggles.propTypes = {
   updateSection: PropTypes.func.isRequired,
   hasLessonExtras: PropTypes.bool,
   hasTextToSpeech: PropTypes.bool,
+  aiTutorAvailable: PropTypes.bool,
 };

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -272,6 +272,11 @@ export default function SectionsSetUpContainer({
   };
 
   const renderAdvancedSettings = () => {
+    // TODO: this will probably eventually be a setting on the course similar to hasTextToSpeech
+    // currently we're working towards piloting in Javalab in CSA only.
+    const aiTutorAvailable =
+      sections[0].course.displayName === 'Computer Science A';
+
     return renderExpandableSection(
       'uitest-expandable-settings',
       () => i18n.advancedSettings(),
@@ -281,6 +286,7 @@ export default function SectionsSetUpContainer({
           section={sections[0]}
           hasLessonExtras={sections[0].course.hasLessonExtras}
           hasTextToSpeech={sections[0].course.hasTextToSpeech}
+          aiTutorAvailable={aiTutorAvailable}
           label={i18n.pairProgramming()}
         />
       ),

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -20,6 +20,7 @@ import {showVideoDialog} from '@cdo/apps/code-studio/videos';
 import ReactTooltip from 'react-tooltip';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import DCDO from '@cdo/apps/dcdo';
+import experiments from '@cdo/apps/util/experiments';
 import color from '@cdo/apps/util/color';
 import CoteacherSettings from './CoteacherSettings';
 
@@ -275,6 +276,7 @@ export default function SectionsSetUpContainer({
     // TODO: this will probably eventually be a setting on the course similar to hasTextToSpeech
     // currently we're working towards piloting in Javalab in CSA only.
     const aiTutorAvailable =
+      experiments.isEnabled('ai-tutor-toggle') &&
       sections[0].course.displayName === 'Computer Science A';
 
     return renderExpandableSection(

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -46,6 +46,8 @@ experiments.GENDER_FEATURE_ENABLED = 'gender';
 experiments.CPA_EXPERIENCE = 'cpa_experience';
 experiments.AI_RUBRICS = 'ai-rubrics';
 experiments.HOC_TUTORIAL_DIALOG = 'hocTutorialDialog';
+// Experiment for showing the toggle a teacher can use to turn on AI Tutor for their section
+experiments.AI_TUTOR_TOGGLE = 'ai-tutor-toggle';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

In preparation for prototyping and piloting AI Tutor, this PR sets up the `ai-tutor-toggle` experiment. If the experiment is enabled, a teacher will be able to see a toggle to turn AI Tutor features on/off for their section if the section is assigned CSA. Right now this is just the experiment set up, the first pass at hide/show logic for the toggle, and the UI for the toggle. The toggle doesn't do anything yet, but that's ok since it's behind the experiment flag.  🙂 

<img width="908" alt="Screenshot 2023-11-02 at 2 36 27 PM" src="https://github.com/code-dot-org/code-dot-org/assets/12300669/73dce816-48c5-4f5c-94ee-cc43832201bc">

<img width="499" alt="Screenshot 2023-11-02 at 2 37 19 PM" src="https://github.com/code-dot-org/code-dot-org/assets/12300669/4c533853-f15d-40ac-afba-f046677c1afb">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

[AI Tutor Prototype Permissions Proposal ](https://docs.google.com/document/d/1v46QAIxtN8SIPbFho9JuhqHaB13kdg1E_okBcpauZzc/edit)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->
I manually confirmed locally that the Enable AI Tutor toggle does not show if the experiment is disable nor if CSA is not selected as the assigned course. 

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

The toggle will be hidden for everyone, unless they enable the experiment.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->
- Future work includes adding a new property `isAITutorEnabled` to sections and having the toggle control whether that field to set to true or false. 
- Then, only students in sections where `section.isAITutorEnabled === true` will be able to see the AI Tutor prototypes, currently in progress ([example](https://github.com/code-dot-org/code-dot-org/pull/54294/files)). 

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

We have a public repo so someone really curious could discover the experiment, enable it and see a useless toggle. We might want to be more mindful of random experiment joiners when functionality to use AI Tutor is fully in place, but the risk seems very low right now. 

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
