### PR TITLE
Rename Minecraft Generation AI constant value

### DIFF
--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -131,7 +131,7 @@ module ScriptConstants
       MINECRAFT_HERO_NAME = 'hero'.freeze,
       MINECRAFT_NAME = 'mc'.freeze,
       MINECRAFT_DESIGNER_NAME = 'minecraft'.freeze,
-      MINECRAFT_AI_NAME = 'generation-ai'.freeze,
+      MINECRAFT_AI_NAME = 'generation_ai'.freeze,
       APPLAB_INTRO = 'applab-intro'.freeze,
       HOC_2013_NAME = 'Hour of Code'.freeze, # 2013 hour of code
       FROZEN_NAME = 'frozen'.freeze,


### PR DESCRIPTION
Changes the consant value for Minecraft Generation AI to `generation_ai` in order to match the way it is being tagged in the gsheets.
The certificate will be accessible using new link: 
https://code.org/api/hour/finish/generation_ai.


## Links


- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?selectedIssue=ACQ-1119)
- Previous PR which adds the Minecraft Generation constant: [here](https://github.com/code-dot-org/code-dot-org/pull/54554)




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
