### PR TITLE
Include co-taught sections in sections#index API response.

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -17,10 +17,10 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
   end
 
   # GET /api/v1/sections
-  # Get the set of sections owned by the current user
+  # Get the set of sections taught by the current user
   def index
     prevent_caching
-    render json: current_user.sections.map(&:summarize_without_students)
+    render json: current_user.sections_owned_or_instructed.map(&:summarize_without_students)
   end
 
   # GET /api/v1/sections/<id>

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -471,6 +471,16 @@ class User < ApplicationRecord
   has_many :followers, through: :sections
   has_many :students, through: :followers, source: :student_user
 
+  has_many :section_instructors, foreign_key: 'instructor_id'
+  has_many :active_section_instructors, -> {where(status: :active)}, class_name: 'SectionInstructor', foreign_key: 'instructor_id'
+  has_many :sections_instructed, through: :active_section_instructors, source: :section
+
+  # TODO once the backfill creates SectionInstructors for every section owner,
+  # this method can be deleted and its references replaced by sections_instructed
+  def sections_owned_or_instructed
+    (sections + sections_instructed).uniq
+  end
+
   # Relationships (sections_as_students/followeds/teachers) from being a
   # student.
   has_many :followeds, -> {order 'followers.id'}, class_name: 'Follower', foreign_key: 'student_user_id', dependent: :destroy

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -96,6 +96,20 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_equal expected, returned_json
   end
 
+  # TODO(TEACH-721): This test is expected to fail after the post-backfill code cleanup.
+  test 'returns owned section even if no SectionInstructor exists' do
+    broken_section = create(:section, user: @teacher, login_type: 'word')
+    # Remove auto-created SectionInstructor to simulate old section that hasn't been backfilled.
+    broken_section.section_instructors.first.really_destroy!
+
+    sign_in @teacher
+    get :index
+    assert_response :success
+
+    expected = [@section, @section_with_unit_group, @section_with_script, broken_section].map(&:summarize_without_students).as_json
+    assert_equal expected, returned_json
+  end
+
   # It's easy to accidentally grant admins permission to `index` all sections
   # in the database - a huge query that we don't want to permit.  Admin users
   # should therefore only get their own sections when indexing sections,

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -84,6 +84,18 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_equal expected, returned_json
   end
 
+  test 'returns all sections instructed by teacher' do
+    cotaught_section = create(:section, user: create(:teacher), login_type: 'word')
+    create(:section_instructor, instructor: @teacher, section: cotaught_section, status: :active)
+
+    sign_in @teacher
+    get :index
+    assert_response :success
+
+    expected = [@section, @section_with_unit_group, @section_with_script, cotaught_section].map(&:summarize_without_students).as_json
+    assert_equal expected, returned_json
+  end
+
   # It's easy to accidentally grant admins permission to `index` all sections
   # in the database - a huge query that we don't want to permit.  Admin users
   # should therefore only get their own sections when indexing sections,


### PR DESCRIPTION
This change will allow teachers to see sections they co-teach along with sections they own, on the dashboard homepage and elsewhere that calls this API endpoint.

## Links
- [Co-teacher spec](https://docs.google.com/document/d/1zyODkc7VXsAb17W3jefNM9JNkQVZ8nU2q5C9Xlp7cZs/edit#heading=h.3hotlme3tb4g)
- [JIRA](https://codedotorg.atlassian.net/browse/TEACH-72)

## Testing story

Automated test included to ensure that owned and co-taught sections are each included exactly once in the response.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
