### PR TITLE
New congrats page is only for Hour of Code

### DIFF
--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -4,8 +4,6 @@ import Certificate from './Certificate';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import style from './certificate_batch.module.scss';
 import i18n from '@cdo/locale';
-import StudentsBeyondHoc from './StudentsBeyondHoc';
-import TeachersBeyondHoc from './TeachersBeyondHoc';
 import PetitionCallToAction from '@cdo/apps/templates/certificates/petition/PetitionCallToAction';
 import GraduateToNextLevel from '@cdo/apps/templates/certificates/GraduateToNextLevel';
 import {
@@ -19,17 +17,6 @@ export default function Congrats(props) {
    * @param tutorial The specific tutorial the student completed i.e. 'dance', 'dance-2019', etc
    * @returns {string} The category type the specific tutorial belongs to i.e. 'dance', 'applab', etc
    */
-  const getTutorialType = tutorial =>
-    ({
-      dance: 'dance',
-      'dance-2019': 'dance',
-      'applab-intro': 'applab',
-      aquatic: '2018Minecraft',
-      hero: '2017Minecraft',
-      minecraft: 'pre2017Minecraft',
-      mc: 'pre2017Minecraft',
-      oceans: 'oceans',
-    }[tutorial] || 'other');
 
   /**
    * Renders links to certificate alternatives when there is a special event going on.
@@ -78,13 +65,11 @@ export default function Congrats(props) {
   const {
     tutorial,
     certificateId,
-    MCShareLink,
     userType,
     under13,
     language,
     randomDonorTwitter,
     randomDonorName,
-    hideDancePartyFollowUp,
     initialCertificateImageUrl,
     isHocTutorial,
     nextCourseScriptName,
@@ -201,10 +186,8 @@ export default function Congrats(props) {
       link: 'https://code.org/educate/professional-development-online',
     },
   ];
-  const isEnglish = language === 'en';
-  const tutorialType = getTutorialType(tutorial);
 
-  return isHocTutorial ? (
+  return (
     <div className={style.wrapper}>
       <div className={style.certificateContainer}>
         <Certificate
@@ -220,137 +203,116 @@ export default function Congrats(props) {
         </Certificate>
       </div>
 
-      <div className={style.continueBeyond}>
-        <Heading3 className={style.textCenter}>
-          {i18n.continueBeyondHourOfCode()}
-        </Heading3>
-        <div
-          className={`${style.actionBlockWrapper} ${style.actionBlockWrapperThreeCol} ${style.courseContainer}`}
-        >
-          {curriculaData.map((item, index) => (
+      {isHocTutorial ? (
+        <div>
+          <div className={style.continueBeyond}>
+            <Heading3 className={style.textCenter}>
+              {i18n.continueBeyondHourOfCode()}
+            </Heading3>
             <div
-              className={`${style.actionBlock} ${style.actionBlockOneCol} ${style.flexSpaceBetween}`}
-              key={index}
+              className={`${style.actionBlockWrapper} ${style.actionBlockWrapperThreeCol} ${style.courseContainer}`}
             >
-              <div className={style.contentWrapper}>
-                <BodyTwoText className={style.overline}>
-                  {item.grade}
-                </BodyTwoText>
-                <Heading3>{item.title}</Heading3>
-                <img src={item.image} alt="" />
-                <BodyTwoText>{item.description}</BodyTwoText>
-              </div>
-              <div className={style.contentFooter}>
-                <a className={style.linkButton} href={item.link}>
-                  {item.buttonText}
-                </a>
-              </div>
-            </div>
-          ))}
-        </div>
-        <hr />
-
-        <div className={style.textCenter}>
-          <Heading4>{i18n.discoverMore()}</Heading4>
-          <BodyTwoText>{i18n.discoverMoreCatalogText()}</BodyTwoText>
-          <div className={style.imageContainer}>
-            {curriculumCatalogImages.map((item, index) => (
-              <img key={index} src={item} alt="" />
-            ))}
-          </div>
-          {userType === 'student' ? (
-            <div className={style.studentButtonsContainer}>
-              <a
-                className={`${style.linkButton} ${style.catalogButton}`}
-                href={'https://code.org/student/elementary'}
-              >
-                {i18n.learningForAgesRange({
-                  youngestAge: '5',
-                  oldestAge: '11',
-                })}
-              </a>
-              <a
-                className={`${style.linkButton} ${style.catalogButton}`}
-                href={'https://code.org/student/middle-high'}
-              >
-                {i18n.learningForAgesPlus({age: '11'})}
-              </a>
-            </div>
-          ) : (
-            <a
-              className={`${style.linkButton} ${style.catalogButton}`}
-              href={'/catalog'}
-            >
-              {i18n.viewCurriculumCatalog()}
-            </a>
-          )}
-        </div>
-      </div>
-
-      {userType !== 'student' && (
-        <div className={style.professionalLearning}>
-          <div
-            className={`${style.actionBlockWrapper} ${style.actionBlockTwoCol}`}
-          >
-            {professionalLearning.map((item, index) => (
-              <div
-                className={`${style.actionBlock} ${style.actionBlockOneCol} ${style.flexSpaceBetween}`}
-                key={index}
-              >
-                <div className={style.contentWrapper}>
-                  <img
-                    src={item.image}
-                    alt=""
-                    className={style.professionalLearningImage}
-                  />
-                  <Heading3>{item.title}</Heading3>
-                  <BodyTwoText>{item.description}</BodyTwoText>
+              {curriculaData.map((item, index) => (
+                <div
+                  className={`${style.actionBlock} ${style.actionBlockOneCol} ${style.flexSpaceBetween}`}
+                  key={index}
+                >
+                  <div className={style.contentWrapper}>
+                    <BodyTwoText className={style.overline}>
+                      {item.grade}
+                    </BodyTwoText>
+                    <Heading3>{item.title}</Heading3>
+                    <img src={item.image} alt="" />
+                    <BodyTwoText>{item.description}</BodyTwoText>
+                  </div>
+                  <div className={style.contentFooter}>
+                    <a className={style.linkButton} href={item.link}>
+                      {item.buttonText}
+                    </a>
+                  </div>
                 </div>
-                <div className={style.contentFooter}>
-                  <a className={style.linkButton} href={item.link}>
-                    {item.buttonText}
+              ))}
+            </div>
+            <hr />
+
+            <div className={style.textCenter}>
+              <Heading4>{i18n.discoverMore()}</Heading4>
+              <BodyTwoText>{i18n.discoverMoreCatalogText()}</BodyTwoText>
+              <div className={style.imageContainer}>
+                {curriculumCatalogImages.map((item, index) => (
+                  <img key={index} src={item} alt="" />
+                ))}
+              </div>
+              {userType === 'student' ? (
+                <div className={style.studentButtonsContainer}>
+                  <a
+                    className={`${style.linkButton} ${style.catalogButton}`}
+                    href={'https://code.org/student/elementary'}
+                  >
+                    {i18n.learningForAgesRange({
+                      youngestAge: '5',
+                      oldestAge: '11',
+                    })}
+                  </a>
+                  <a
+                    className={`${style.linkButton} ${style.catalogButton}`}
+                    href={'https://code.org/student/middle-high'}
+                  >
+                    {i18n.learningForAgesPlus({age: '11'})}
                   </a>
                 </div>
-              </div>
-            ))}
+              ) : (
+                <a
+                  className={`${style.linkButton} ${style.catalogButton}`}
+                  href={'/catalog'}
+                >
+                  {i18n.viewCurriculumCatalog()}
+                </a>
+              )}
+            </div>
           </div>
+
+          {userType !== 'student' && (
+            <div className={style.professionalLearning}>
+              <div
+                className={`${style.actionBlockWrapper} ${style.actionBlockTwoCol}`}
+              >
+                {professionalLearning.map((item, index) => (
+                  <div
+                    className={`${style.actionBlock} ${style.actionBlockOneCol} ${style.flexSpaceBetween}`}
+                    key={index}
+                  >
+                    <div className={style.contentWrapper}>
+                      <img
+                        src={item.image}
+                        alt=""
+                        className={style.professionalLearningImage}
+                      />
+                      <Heading3>{item.title}</Heading3>
+                      <BodyTwoText>{item.description}</BodyTwoText>
+                    </div>
+                    <div className={style.contentFooter}>
+                      <a className={style.linkButton} href={item.link}>
+                        {item.buttonText}
+                      </a>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div>
+          <GraduateToNextLevel
+            scriptName={nextCourseScriptName}
+            courseTitle={nextCourseTitle}
+            courseDesc={nextCourseDesc}
+          />
+          <hr className={style.divider} />
+          <PetitionCallToAction tutorial={tutorial} />
         </div>
       )}
-    </div>
-  ) : (
-    <div style={style.container}>
-      <Certificate
-        tutorial={tutorial}
-        certificateId={certificateId}
-        randomDonorTwitter={randomDonorTwitter}
-        randomDonorName={randomDonorName}
-        under13={under13}
-        initialCertificateImageUrl={initialCertificateImageUrl}
-        isHocTutorial={isHocTutorial}
-      >
-        {renderExtraCertificateLinks(language, tutorial)}
-      </Certificate>
-      {userType === 'teacher' && isEnglish && <TeachersBeyondHoc />}
-      {isHocTutorial && (
-        <StudentsBeyondHoc
-          completedTutorialType={tutorialType}
-          MCShareLink={MCShareLink}
-          userType={userType}
-          under13={under13}
-          isEnglish={isEnglish}
-          hideDancePartyFollowUp={hideDancePartyFollowUp}
-        />
-      )}
-      {!isHocTutorial && (
-        <GraduateToNextLevel
-          scriptName={nextCourseScriptName}
-          courseTitle={nextCourseTitle}
-          courseDesc={nextCourseDesc}
-        />
-      )}
-      {userType === 'signedOut' && isEnglish && <TeachersBeyondHoc />}
-      <hr style={style.divider} />
-      <PetitionCallToAction tutorial={tutorial} />
     </div>
   );
 }

--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -320,13 +320,11 @@ export default function Congrats(props) {
 Congrats.propTypes = {
   certificateId: PropTypes.string,
   tutorial: PropTypes.string,
-  MCShareLink: PropTypes.string,
   userType: PropTypes.oneOf(['signedOut', 'teacher', 'student']).isRequired,
   under13: PropTypes.bool,
   language: PropTypes.string.isRequired,
   randomDonorTwitter: PropTypes.string,
   randomDonorName: PropTypes.string,
-  hideDancePartyFollowUp: PropTypes.bool,
   initialCertificateImageUrl: PropTypes.string.isRequired,
   isHocTutorial: PropTypes.bool,
   nextCourseScriptName: PropTypes.string,

--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -4,7 +4,6 @@ import Certificate from './Certificate';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import style from './certificate_batch.module.scss';
 import i18n from '@cdo/locale';
-import PetitionCallToAction from '@cdo/apps/templates/certificates/petition/PetitionCallToAction';
 import GraduateToNextLevel from '@cdo/apps/templates/certificates/GraduateToNextLevel';
 import {
   BodyTwoText,
@@ -309,8 +308,6 @@ export default function Congrats(props) {
             courseTitle={nextCourseTitle}
             courseDesc={nextCourseDesc}
           />
-          <hr className={style.divider} />
-          <PetitionCallToAction tutorial={tutorial} />
         </div>
       )}
     </div>

--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -4,6 +4,10 @@ import Certificate from './Certificate';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import style from './certificate_batch.module.scss';
 import i18n from '@cdo/locale';
+import StudentsBeyondHoc from './StudentsBeyondHoc';
+import TeachersBeyondHoc from './TeachersBeyondHoc';
+import PetitionCallToAction from '@cdo/apps/templates/certificates/petition/PetitionCallToAction';
+import GraduateToNextLevel from '@cdo/apps/templates/certificates/GraduateToNextLevel';
 import {
   BodyTwoText,
   Heading3,
@@ -15,6 +19,17 @@ export default function Congrats(props) {
    * @param tutorial The specific tutorial the student completed i.e. 'dance', 'dance-2019', etc
    * @returns {string} The category type the specific tutorial belongs to i.e. 'dance', 'applab', etc
    */
+  const getTutorialType = tutorial =>
+    ({
+      dance: 'dance',
+      'dance-2019': 'dance',
+      'applab-intro': 'applab',
+      aquatic: '2018Minecraft',
+      hero: '2017Minecraft',
+      minecraft: 'pre2017Minecraft',
+      mc: 'pre2017Minecraft',
+      oceans: 'oceans',
+    }[tutorial] || 'other');
 
   /**
    * Renders links to certificate alternatives when there is a special event going on.
@@ -63,13 +78,18 @@ export default function Congrats(props) {
   const {
     tutorial,
     certificateId,
+    MCShareLink,
     userType,
     under13,
     language,
     randomDonorTwitter,
     randomDonorName,
+    hideDancePartyFollowUp,
     initialCertificateImageUrl,
     isHocTutorial,
+    nextCourseScriptName,
+    nextCourseTitle,
+    nextCourseDesc,
   } = props;
 
   const teacherCourses = [
@@ -181,8 +201,10 @@ export default function Congrats(props) {
       link: 'https://code.org/educate/professional-development-online',
     },
   ];
+  const isEnglish = language === 'en';
+  const tutorialType = getTutorialType(tutorial);
 
-  return (
+  return isHocTutorial ? (
     <div className={style.wrapper}>
       <div className={style.certificateContainer}>
         <Certificate
@@ -295,17 +317,57 @@ export default function Congrats(props) {
         </div>
       )}
     </div>
+  ) : (
+    <div style={style.container}>
+      <Certificate
+        tutorial={tutorial}
+        certificateId={certificateId}
+        randomDonorTwitter={randomDonorTwitter}
+        randomDonorName={randomDonorName}
+        under13={under13}
+        initialCertificateImageUrl={initialCertificateImageUrl}
+        isHocTutorial={isHocTutorial}
+      >
+        {renderExtraCertificateLinks(language, tutorial)}
+      </Certificate>
+      {userType === 'teacher' && isEnglish && <TeachersBeyondHoc />}
+      {isHocTutorial && (
+        <StudentsBeyondHoc
+          completedTutorialType={tutorialType}
+          MCShareLink={MCShareLink}
+          userType={userType}
+          under13={under13}
+          isEnglish={isEnglish}
+          hideDancePartyFollowUp={hideDancePartyFollowUp}
+        />
+      )}
+      {!isHocTutorial && (
+        <GraduateToNextLevel
+          scriptName={nextCourseScriptName}
+          courseTitle={nextCourseTitle}
+          courseDesc={nextCourseDesc}
+        />
+      )}
+      {userType === 'signedOut' && isEnglish && <TeachersBeyondHoc />}
+      <hr style={style.divider} />
+      <PetitionCallToAction tutorial={tutorial} />
+    </div>
   );
 }
 
 Congrats.propTypes = {
   certificateId: PropTypes.string,
   tutorial: PropTypes.string,
+  MCShareLink: PropTypes.string,
   userType: PropTypes.oneOf(['signedOut', 'teacher', 'student']).isRequired,
   under13: PropTypes.bool,
   language: PropTypes.string.isRequired,
   randomDonorTwitter: PropTypes.string,
   randomDonorName: PropTypes.string,
+  hideDancePartyFollowUp: PropTypes.bool,
   initialCertificateImageUrl: PropTypes.string.isRequired,
   isHocTutorial: PropTypes.bool,
+  nextCourseScriptName: PropTypes.string,
+  nextCourseTitle: PropTypes.string,
+  nextCourseDesc: PropTypes.string,
 };

--- a/apps/test/unit/templates/certificates/CongratsTest.js
+++ b/apps/test/unit/templates/certificates/CongratsTest.js
@@ -4,8 +4,6 @@ import {expect} from '../../../util/reconfiguredChai';
 import Congrats from '@cdo/apps/templates/certificates/Congrats';
 import Certificate from '@cdo/apps/templates/certificates/Certificate';
 import GraduateToNextLevel from '@cdo/apps/templates/certificates/GraduateToNextLevel';
-import TeachersBeyondHoc from '@cdo/apps/templates/certificates/TeachersBeyondHoc';
-import PetitionCallToAction from '@cdo/apps/templates/certificates/petition/PetitionCallToAction';
 
 describe('Congrats', () => {
   const userTypes = ['signedOut', 'teacher', 'student'];
@@ -37,32 +35,6 @@ describe('Congrats', () => {
       );
       expect(wrapper.find(GraduateToNextLevel).exists()).to.be.true;
     });
-
-    it(`renders a PetitionCallToAction component with tutorial for user type ${userType}`, () => {
-      const wrapper = shallow(
-        <Congrats {...defaultProps} userType={userType} tutorial="coursea" />
-      );
-      expect(wrapper.find(PetitionCallToAction).exists()).to.be.true;
-      expect(wrapper.find(PetitionCallToAction).props().tutorial).to.not.be
-        .undefined;
-    });
-  });
-
-  it('renders a TeachersBeyondHoc component, for teachers', () => {
-    const wrapper = shallow(<Congrats {...defaultProps} userType="teacher" />);
-    expect(wrapper.find(TeachersBeyondHoc).exists()).to.be.true;
-  });
-
-  it('renders a TeachersBeyondHoc component, for signed out', () => {
-    const wrapper = shallow(
-      <Congrats {...defaultProps} userType="signedOut" />
-    );
-    expect(wrapper.find(TeachersBeyondHoc).exists()).to.be.true;
-  });
-
-  it('does not render a TeachersBeyondHoc component, for students', () => {
-    const wrapper = shallow(<Congrats {...defaultProps} userType="student" />);
-    expect(wrapper.find(TeachersBeyondHoc).exists()).to.be.false;
   });
 
   //HOC tutorial tests

--- a/apps/test/unit/templates/certificates/CongratsTest.js
+++ b/apps/test/unit/templates/certificates/CongratsTest.js
@@ -3,6 +3,9 @@ import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import Congrats from '@cdo/apps/templates/certificates/Congrats';
 import Certificate from '@cdo/apps/templates/certificates/Certificate';
+import GraduateToNextLevel from '@cdo/apps/templates/certificates/GraduateToNextLevel';
+import TeachersBeyondHoc from '@cdo/apps/templates/certificates/TeachersBeyondHoc';
+import PetitionCallToAction from '@cdo/apps/templates/certificates/petition/PetitionCallToAction';
 
 describe('Congrats', () => {
   const userTypes = ['signedOut', 'teacher', 'student'];
@@ -10,8 +13,16 @@ describe('Congrats', () => {
   const defaultProps = {
     language: 'en',
     initialCertificateImageUrl,
+    isHocTutorial: false,
   };
 
+  const hocProps = {
+    language: 'en',
+    initialCertificateImageUrl,
+    isHocTutorial: true,
+  };
+
+  //Non HOC course Tests
   userTypes.forEach(userType => {
     it(`renders a Certificate component for user type ${userType}`, () => {
       const wrapper = shallow(
@@ -19,15 +30,57 @@ describe('Congrats', () => {
       );
       expect(wrapper.find(Certificate).exists()).to.be.true;
     });
+
+    it(`renders a GraduateToNextLevel for user type ${userType} for CSF course`, () => {
+      const wrapper = shallow(
+        <Congrats {...defaultProps} userType={userType} isHocTutorial={false} />
+      );
+      expect(wrapper.find(GraduateToNextLevel).exists()).to.be.true;
+    });
+
+    it(`renders a PetitionCallToAction component with tutorial for user type ${userType}`, () => {
+      const wrapper = shallow(
+        <Congrats {...defaultProps} userType={userType} tutorial="coursea" />
+      );
+      expect(wrapper.find(PetitionCallToAction).exists()).to.be.true;
+      expect(wrapper.find(PetitionCallToAction).props().tutorial).to.not.be
+        .undefined;
+    });
+  });
+
+  it('renders a TeachersBeyondHoc component, for teachers', () => {
+    const wrapper = shallow(<Congrats {...defaultProps} userType="teacher" />);
+    expect(wrapper.find(TeachersBeyondHoc).exists()).to.be.true;
+  });
+
+  it('renders a TeachersBeyondHoc component, for signed out', () => {
+    const wrapper = shallow(
+      <Congrats {...defaultProps} userType="signedOut" />
+    );
+    expect(wrapper.find(TeachersBeyondHoc).exists()).to.be.true;
+  });
+
+  it('does not render a TeachersBeyondHoc component, for students', () => {
+    const wrapper = shallow(<Congrats {...defaultProps} userType="student" />);
+    expect(wrapper.find(TeachersBeyondHoc).exists()).to.be.false;
+  });
+
+  //HOC tutorial tests
+
+  userTypes.forEach(userType => {
+    it(`renders a Certificate component for user type ${userType}`, () => {
+      const wrapper = shallow(<Congrats {...hocProps} userType={userType} />);
+      expect(wrapper.find(Certificate).exists()).to.be.true;
+    });
   });
 
   it('renders curriculum catalog button, for teachers', () => {
-    const wrapper = shallow(<Congrats {...defaultProps} userType="teacher" />);
+    const wrapper = shallow(<Congrats {...hocProps} userType="teacher" />);
     expect(wrapper.find('a[href="/catalog"]').exists()).to.be.true;
   });
 
   it('renders two learning for ages buttons, for students', () => {
-    const wrapper = shallow(<Congrats {...defaultProps} userType="student" />);
+    const wrapper = shallow(<Congrats {...hocProps} userType="student" />);
 
     expect(
       wrapper.find('a[href="https://code.org/student/elementary"]').exists()
@@ -38,7 +91,7 @@ describe('Congrats', () => {
   });
 
   it('renders a professional learning section, for teachers', () => {
-    const wrapper = shallow(<Congrats {...defaultProps} userType="teacher" />);
+    const wrapper = shallow(<Congrats {...hocProps} userType="teacher" />);
 
     const congratsPageText = wrapper.text();
 
@@ -47,7 +100,7 @@ describe('Congrats', () => {
   });
 
   it('renders a professional learning section, for signed out', () => {
-    const wrapper = shallow(<Congrats {...defaultProps} userType="teacher" />);
+    const wrapper = shallow(<Congrats {...hocProps} userType="teacher" />);
     const congratsPageText = wrapper.text();
 
     expect(congratsPageText).to.include('Teach with Code.org');
@@ -55,7 +108,7 @@ describe('Congrats', () => {
   });
 
   it('does not render a professional learning section, for students', () => {
-    const wrapper = shallow(<Congrats {...defaultProps} userType="student" />);
+    const wrapper = shallow(<Congrats {...hocProps} userType="student" />);
     const congratsPageText = wrapper.text();
 
     expect(congratsPageText).to.not.include('Teach with Code.org');


### PR DESCRIPTION
Makes sure that the new Congrats page is only for Hour of Code.
Non hour of code courses used to display `Graduate to next level section` which was deleted in [this PR](https://github.com/code-dot-org/code-dot-org/pull/54454). This PR conditionally renders the correct page depending if it is an Hour of Code tutorial using the `isHocTutorial` prop.
## Non Hour of Code courses will display the `Graduate to next level section`.
<img width="1792" alt="Screenshot 2023-11-02 at 3 02 58 PM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/256fd3b6-a7a5-4b56-b34c-178f287d0acf">


## HOC tutorial congrats
<img width="1792" alt="Screenshot 2023-11-02 at 3 13 51 PM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/a89a60ee-1726-4b78-b123-2f4b8fee880f">



## Links


- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?selectedIssue=ACQ-1140)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
