### PR TITLE
Always use start libraries for embedded or contained levels

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2284,7 +2284,13 @@ StudioApp.prototype.handleIframeEmbedAppAndCode_ = function () {
  * @param {object} config The object containing all metadata about the project
  */
 StudioApp.prototype.loadLibraryBlocks = function (config) {
-  if (!config.level.libraries && config.level.startLibraries) {
+  // If we have start libraries and we either don't have libraries or we
+  // should ignore existing code (due to an embedded level, for example)
+  // use the start libraries.
+  if (
+    (!config.level.libraries || config.ignoreLastAttempt) &&
+    config.level.startLibraries
+  ) {
     config.level.libraries = JSON.parse(config.level.startLibraries);
   }
   if (!config.level.libraries) {

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2284,11 +2284,15 @@ StudioApp.prototype.handleIframeEmbedAppAndCode_ = function () {
  * @param {object} config The object containing all metadata about the project
  */
 StudioApp.prototype.loadLibraryBlocks = function (config) {
-  // If we have start libraries and we either don't have libraries or we
-  // should ignore existing code (due to an embedded level, for example)
-  // use the start libraries.
+  // We use start libaries if we should ignore last attempt, the level has contained levels,
+  // or if the level does not have libraries saved to it yet.
+  // Always use the source code from the level definition for contained and embed levels,
+  // so that changes made in levelbuilder will show up for users who have
+  // already run the level.
   if (
-    (!config.level.libraries || config.ignoreLastAttempt) &&
+    (!config.level.libraries ||
+      config.ignoreLastAttempt ||
+      config.hasContainedLevels) &&
     config.level.startLibraries
   ) {
     config.level.libraries = JSON.parse(config.level.startLibraries);


### PR DESCRIPTION
If a level is an embed level or if it has contained levels, the user cannot edit the level and cannot start over. If the level is updated by levelbuilders, the user should therefore see the most recent version of the level start code and start libraries. We already [show the most recent start code](https://github.com/code-dot-org/code-dot-org/blob/e84d7838fedcf8fd4154f8cc900f9568314b702d/apps/src/StudioApp.js#L1994) in these scenarios. This PR updates our logic to do the same for start libraries.

## Links

- jira ticket: [CT-155](https://codedotorg.atlassian.net/browse/CT-155)

## Testing story
Tested that embed levels now can see start library updates. I had a hard time getting a contained level to save a `main.json`, so in my testing there we were always loading start libraries anyway because we did not have anything saved. However, since it's just a boolean check it seems safe to me to merge it without a repro.

## Follow-up work
This is a time sensitive bug so I went with the simplest solution here. As a follow up I'm going to investigate if we can avoid saving for embed levels, since we are ignoring any saved sources anyway.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
