### PR TITLE
fix timing issue with polling status after Run AI Assessment click

### DIFF
--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -194,7 +194,7 @@ class RubricsController < ApplicationController
 
   def ai_evaluated_at
     RubricAiEvaluation.
-      where(rubric_id: @rubric.id, user_id: @user.id).
+      where(rubric_id: @rubric.id, user_id: @user.id, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]).
       order(updated_at: :desc).
       first&.
       created_at

--- a/dashboard/app/models/rubric_ai_evaluation.rb
+++ b/dashboard/app/models/rubric_ai_evaluation.rb
@@ -28,4 +28,22 @@ class RubricAiEvaluation < ApplicationRecord
   has_many :learning_goal_ai_evaluations, inverse_of: :rubric_ai_evaluation
 
   validates :status, inclusion: {in: SharedConstants::RUBRIC_AI_EVALUATION_STATUS.values}
+
+  def summarize_debug
+    script_level = rubric.get_script_level
+    {
+      id: id,
+      created_at: created_at,
+      updated_at: updated_at,
+      user_id: user_id,
+      script_level_id: script_level&.id,
+      username: user.username,
+      requester_username: requester&.username,
+      unit_name: script_level&.script&.name,
+      lesson_position: rubric.lesson.absolute_position,
+      level_name: rubric.level.name,
+      status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS.invert[status].to_s,
+      num_learning_goal_ai_evaluations: learning_goal_ai_evaluations.count,
+    }
+  end
 end

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -361,7 +361,7 @@ class RubricsControllerTest < ActionController::TestCase
         rubric: @rubric,
         user: @student,
         requester: @teacher,
-        status: 1
+        status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]
       )
       create(
         :learning_goal_ai_evaluation,
@@ -378,7 +378,7 @@ class RubricsControllerTest < ActionController::TestCase
         rubric: @rubric,
         user: @student,
         requester: @teacher,
-        status: 1
+        status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]
       )
       create(
         :learning_goal_ai_evaluation,


### PR DESCRIPTION
This PR fixes the following issue:
* teacher clicks Run AI Assessment button
* 5 seconds later, the UI says that AI analysis is complete
* teacher goes to the rubric but AI analysis is not present
* teacher waits 1 minute, and then AI analysis is present (or maybe they have to refresh the page, I can't remember)

The new behavior is:
* teacher clicks Run AI Assessment button
* 5 seconds later, the UI says that analysis is still in progress
* ~45 seconds later, UI says AI analysis is complete
* teacher switches to rubric, AI results are present

Root cause analsysis:
* most likely a regression when we switched onto RubricAiEvaluation.

## Testing story

manually verified as listed in PR description (sorry no videos)
fix existing unit tests which broke when I made this change

## Future work

This is a minimal fix for the regression. This PR gets us back to how we were before RubricAiEvaluation. However there are still a few remaining problems in the user flow, captured here: https://codedotorg.atlassian.net/browse/AITT-311
