### PR TITLE
Amplitude Event for Feedback added to TA Rubric

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -85,6 +85,8 @@ const EVENTS = {
   TA_RUBRIC_ON_STUDENT_WORK_LOADED: 'TA Rubric On Student Work Loaded',
   TA_RUBRIC_ON_STUDENT_WORK_UNLOADED: 'TA Rubric On Student Work Unloaded',
   TA_RUBRIC_SUBMITTED: 'TA Rubric Submitted',
+  TA_RUBRIC_SUBMITTEED_WRITTEN_FEEDBACK:
+    'TA Rubric Submitted Written Feedback To Student',
   TA_RUBRIC_EVIDENCE_LEVEL_SELECTED: 'TA Rubric Evidence Level Selected',
   TA_RUBRIC_RUN_BUTTON_CLICKED:
     'TA Rubric Teacher clicked RUN button on student work',

--- a/apps/src/templates/rubrics/LearningGoal.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.jsx
@@ -37,6 +37,8 @@ export default function LearningGoal({
   aiConfidence,
   submittedEvaluation,
   isStudent,
+  feedbackAdded,
+  setFeedbackAdded,
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [isAutosaving, setIsAutosaving] = useState(false);
@@ -104,6 +106,9 @@ export default function LearningGoal({
       .then(() => {
         setIsAutosaving(false);
         setAutosaved(true);
+        if (!feedbackAdded) {
+          setFeedbackAdded(true);
+        }
       })
       .catch(error => {
         console.log(error);
@@ -307,6 +312,8 @@ LearningGoal.propTypes = {
   aiConfidence: PropTypes.number,
   submittedEvaluation: submittedEvaluationShape,
   isStudent: PropTypes.bool,
+  feedbackAdded: PropTypes.bool,
+  setFeedbackAdded: PropTypes.func,
 };
 
 const AiToken = () => {

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -52,6 +52,7 @@ export default function RubricContent({
   const [isSubmittingToStudent, setIsSubmittingToStudent] = useState(false);
   const [errorSubmitting, setErrorSubmitting] = useState(false);
   const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
+  const [feedbackAdded, setFeedbackAdded] = useState(false);
   const submitFeedbackToStudent = () => {
     analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_SUBMITTED, {
       ...reportingData,
@@ -77,6 +78,16 @@ export default function RubricContent({
         setIsSubmittingToStudent(false);
         setErrorSubmitting(true);
       });
+    if (feedbackAdded) {
+      analyticsReporter.sendEvent(
+        EVENTS.TA_RUBRIC_SUBMITTEED_WRITTEN_FEEDBACK,
+        {
+          ...reportingData,
+          studentId: studentLevelInfo.user_id,
+        }
+      );
+      setFeedbackAdded(false);
+    }
   };
 
   const getAiUnderstanding = learningGoalId => {
@@ -177,6 +188,8 @@ export default function RubricContent({
             aiUnderstanding={getAiUnderstanding(lg.id)}
             aiConfidence={getAiConfidence(lg.id)}
             isStudent={false}
+            feedbackAdded={feedbackAdded}
+            setFeedbackAdded={setFeedbackAdded}
           />
         ))}
       </div>


### PR DESCRIPTION
This adds an amplitude event for when a teacher has added written feedback to a rubric for a student.  It does not capture WHAT that feedback was.  

Example of the event info sent back:

<img width="1033" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/cc3296ee-f38f-4de0-81e7-a5d29e55aa7f">


## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70/backlog?selectedIssue=AITT-196)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
