### PR TITLE
Moves AFE events to Amplitude matching firehose

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -40,6 +40,15 @@ const EVENTS = {
   // Marketing site pages
   ADMIN_INTEREST_FORM_SUBMIT_EVENT: 'Administrator Interest Form Submitted',
 
+  // Amazon future engineer
+  AFE_START: 'AFE Start',
+  AFE_SIGN_IN_BUTTON_PRESS: 'AFE Sign In Button Press',
+  AFE_SIGN_UP_BUTTON_PRESS: 'AFE Sign Up Button Press',
+  AFE_SUBMIT_SCHOOL_INFO: 'AFE Submit School Info',
+  AFE_INELIGIBLE: 'AFE Ineligible',
+  AFE_CONTINUE: 'AFE Continue',
+  AFE_SUBMIT: 'AFE Submit',
+
   // Sections
   COMPLETED_EVENT: 'Section Setup Completed',
   CURRICULUM_ASSIGNED: 'Section Curriculum Assigned',

--- a/apps/src/sites/code.org/pages/views/amazon_future_engineer_eligibility.js
+++ b/apps/src/sites/code.org/pages/views/amazon_future_engineer_eligibility.js
@@ -1,4 +1,6 @@
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -27,6 +29,7 @@ function showAmazonFutureEngineerEligibility() {
         study: 'amazon-future-engineer-eligibility',
         event: 'start',
       });
+      analyticsReporter.sendEvent(EVENTS.AFE_START);
 
       amazonFutureEngineerEligibilityElements.each(
         (index, amazonFutureEngineerEligibilityElement) => {

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -1,4 +1,6 @@
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import React from 'react';
 import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {studio, pegasus} from '@cdo/apps/lib/util/urlHelpers';
@@ -19,6 +21,7 @@ export default class AmazonFutureEngineerAccountConfirmation extends React.Compo
       },
       {callback: () => (window.location = SIGN_UP_URL)}
     );
+    analyticsReporter.sendEvent(EVENTS.AFE_SIGN_UP_BUTTON_PRESS);
   };
 
   signInButtonPress = event => {
@@ -31,6 +34,7 @@ export default class AmazonFutureEngineerAccountConfirmation extends React.Compo
       },
       {callback: () => (window.location = SIGN_IN_URL)}
     );
+    analyticsReporter.sendEvent(EVENTS.AFE_SIGN_IN_BUTTON_PRESS);
   };
 
   render() {

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -1,4 +1,6 @@
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {FormGroup, Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
@@ -90,6 +92,7 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
       study: 'amazon-future-engineer-eligibility',
       event: 'submit_school_info',
     });
+    analyticsReporter.sendEvent(EVENTS.AFE_SUBMIT_SCHOOL_INFO);
 
     if (this.state.formData.schoolId === '-1') {
       this.handleEligibility(false);
@@ -167,6 +170,7 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
         },
         {callback: () => (window.location = pegasus('/afe/start-codeorg'))}
       );
+      analyticsReporter.sendEvent(EVENTS.AFE_INELIGIBLE);
     }
   }
 
@@ -180,6 +184,13 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
   };
 
   submitToAFE = () => {
+    if (this.props.signedIn && !this.props.isStudentAccount) {
+      analyticsReporter.sendEvent(EVENTS.AFE_SUBMIT, {
+        formEmail: this.state.formData.email,
+        formSchoolId: this.state.formData.schoolId,
+        formData: JSON.stringify(this.state.formData),
+      });
+    }
     return fetch('/dashboardapi/v1/amazon_future_engineer_submit', {
       method: 'POST',
       headers: {

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -1,4 +1,6 @@
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Button, Checkbox} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
@@ -151,6 +153,9 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
       study: 'amazon-future-engineer-eligibility',
       event: 'continue',
       data_json: JSON.stringify(submitData),
+    });
+    analyticsReporter.sendEvent(EVENTS.AFE_CONTINUE, {
+      submitData: JSON.stringify(submitData),
     });
 
     this.props.updateFormData(submitData);


### PR DESCRIPTION
Most of these were easy (no data params) events. The one tricky case: we are logging a firehose event from a ruby file (submit) that we are unable to replicate with Amplitude because we can't call it from .rb files. I was able to make a substitution for this call with the following:

- Check first that the user is signed in and is not a student to match the current screening in the submit file (currentUser & teacher).
- Grabs data from the form for submission in the body of the analytics event

I am unable to replicate the current user piece to verify the email address and account id directly from the form.

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-952

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
