### PR TITLE
Only Attempt to Download Remote File in Cookbooks if Needed

### DIFF
--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -32,6 +32,7 @@ if %w(staging test adhoc).include?(node.chef_environment)
   remote_file pdftk_local_file do
     source "https://mirrors.kernel.org/ubuntu/pool/universe/p/pdftk-java/#{pdftk_file}"
     checksum "e14dfd5489e7becb5d825baffc67ce1104e154cd5c8b445e1974ce0397078fdb"
+    action :create_if_missing
   end
   # Dependencies of pdftk-java.
   apt_package %w(

--- a/cookbooks/cdo-awscli/recipes/default.rb
+++ b/cookbooks/cdo-awscli/recipes/default.rb
@@ -10,6 +10,7 @@ apt_package 'python2.7'
 
 remote_file '/tmp/awscli-bundle.zip' do
   source "https://s3.amazonaws.com/aws-cli/awscli-bundle-#{node['cdo-awscli']['version']}.zip"
+  action :create_if_missing
 end
 
 archive_file '/tmp/awscli-bundle.zip' do

--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -20,6 +20,7 @@ proxysql_file = "#{Chef::Config[:file_cache_path]}/#{proxysql_filename}"
 remote_file proxysql_file do
   source "https://github.com/wjordan/proxysql/releases/download/v2.0.15-aurora_2.09_fix/#{proxysql_filename}"
   checksum "29fe79e54bce0f532084bfd8e5a13a55f1f8530f92be8a0e7db847aefcb1762f"
+  action :create_if_missing
 end
 dpkg_package('proxysql') do
   source proxysql_file

--- a/cookbooks/cdo-ruby/recipes/ruby-build.rb
+++ b/cookbooks/cdo-ruby/recipes/ruby-build.rb
@@ -10,6 +10,7 @@ RUBY_BUILD_VERSION = '20221225'.freeze
 
 remote_file '/tmp/ruby-build.tar.gz' do
   source "https://github.com/rbenv/ruby-build/archive/refs/tags/v#{RUBY_BUILD_VERSION}.tar.gz"
+  action :create_if_missing
 end
 
 archive_file '/tmp/ruby-build.tar.gz' do


### PR DESCRIPTION
Specifically, use the `:create_if_missing` action for the `remote_file` resource rather than the default `:create` action. Right now, we always attempt to download these files from the remote resources even though the vast majority of the time when these scripts run they are doing so on long-lived servers that already have a version of the file on their local filesystem.

This has the added benefit of making our CI builds much less dependent on these third parties being always available; see for example [this build](https://s3.console.aws.amazon.com/s3/object/cdo-build-logs?prefix=staging/20231103T190706%2B0000) which failed on staging because GitHub was down and it was unable to download `ruby-build.tar.gz`, even though ruby was already fully installed on that machine.

## Links

https://docs.chef.io/resources/remote_file/#actions