### PR TITLE
Update sign-up Amplitude event to include user type as a property

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -96,7 +96,9 @@ $(document).ready(() => {
       cleanSchoolInfo();
       $('#user_age').val('21+');
     }
-    analyticsReporter.sendEvent(EVENTS.SIGN_UP_FINISHED_EVENT);
+    analyticsReporter.sendEvent(EVENTS.SIGN_UP_FINISHED_EVENT, {
+      'user type': user_type,
+    });
   });
 
   function cleanSchoolInfo() {


### PR DESCRIPTION
Updates the [Sign Up Finished](https://app.amplitude.com/data/code-org/Code.org%20Tracking%20Plan/events/main/latest/Sign%20Up%20Finished?view=All&tab=DETAILS&propertyValidityFilter=All%2520Properties) Amplitude event to include user type as a property.

As per [this Slack thread](https://codedotorg.slack.com/archives/C0453TUMLE7/p1698875386464099), we've seen a lot of users tracked as "(none)" by Amplitude after sign-up (i.e. the event itself does not specify). Adding this property will help us track what the user's type actually is when signing up which will hopefully show us a more accurate summary of user types in sign ups and see if there is some sort of loophole in our sign-up flow that's allowing users to sign-up without a user type.

### Correctly shows `user type` property of "student" when selected
![select_student](https://github.com/code-dot-org/code-dot-org/assets/56283563/8d43aed8-8061-45fe-a61e-a0c223f96c46)

### Correctly shows `user type` property of "teacher" when selected
![select_teacher](https://github.com/code-dot-org/code-dot-org/assets/56283563/6603f83d-b95c-4f1f-ab3e-8815578b2f16)

## Links
Slack thread: [here](https://codedotorg.slack.com/archives/C0453TUMLE7/p1698875386464099)
Amplitude event: [here](https://app.amplitude.com/data/code-org/Code.org%20Tracking%20Plan/events/main/latest/Sign%20Up%20Finished?view=All&tab=DETAILS&propertyValidityFilter=All%2520Properties)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
