### PR TITLE
hoc2023: UI localized

### DIFF
--- a/apps/i18n/dance/en_us.json
+++ b/apps/i18n/dance/en_us.json
@@ -28,6 +28,8 @@
   "danceAiModalRegenerateButton": "Regenerate",
   "danceAiModalExplanationFive": "Each emoji contributed to A.I.'s decision. Here are five possible effects and the calculations that A.I. made.",
   "danceAiModalExplanation": "Each emoji contributed to A.I.'s decision. Here are possible effects and the calculations that A.I. made.",
+  "danceAiModalBack": "Back",
+  "danceAiModalClose": "Close",
   "danceAiModalBotAlt": "A.I.",
   "danceAiModalBotBeamAlt": "A.I. Beam",
   "danceFeedbackDidntPress": "Make sure to press the arrow keys while your dance is running.",

--- a/apps/src/dance/ai/dance-ai-modal.module.scss
+++ b/apps/src/dance/ai/dance-ai-modal.module.scss
@@ -117,6 +117,7 @@ $result-red: rgb(235 87 87);
       padding: 5px;
       border-radius: 4px;
       gap: 6px;
+      margin: 0 10px;
       background-color: $ai-block-inputs-color;
       border: solid 2px $ai-block-inputs-border-color;
 
@@ -477,6 +478,10 @@ $result-red: rgb(235 87 87);
 
     &SmallText {
       font-size: 12px;
+    }
+
+    &Icon {
+      margin-right: 10px;
     }
   }
 }


### PR DESCRIPTION
This change localizes the AI modal, using the strings added in https://github.com/code-dot-org/code-dot-org/pull/54619.

It uses a technique similar to that in https://github.com/code-dot-org/ml-playground/pull/296 to localize the modal's header, which has an emoji UI inside of the string.

It also moves the "Regenerate" button to the lower left corner.

<img width="882" alt="Screenshot 2023-11-03 at 8 07 17 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/fc3ba618-8f54-47fe-b125-a842d5ff43e2">
