### PR TITLE
Make the Accessible Dialog scrollable

### DIFF
--- a/apps/src/templates/accessible-dialogue.module.scss
+++ b/apps/src/templates/accessible-dialogue.module.scss
@@ -19,6 +19,7 @@
   z-index: 1350;
   width: 70%;
   max-width: 600px;
+  max-height: 80%;
   background-color: #fff;
   border-radius: 4px;
   padding: 1rem;

--- a/apps/src/templates/multiple-sections-assigner.module.scss
+++ b/apps/src/templates/multiple-sections-assigner.module.scss
@@ -23,17 +23,10 @@
   }
 
   .sectionListOptionsContainer {
-    &:focus {
-      outline: 2px solid blue;  
-      outline-offset: 2px;     
-  }
-  
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
     margin: 12px 0 4px 0;
-    overflow-y: scroll;
-    max-height: 300px;
 
     label {
       width: 280px;


### PR DESCRIPTION
I had worked on a feature so teachers can assign multiple sections content at the same time.  However in [ZenDesk](https://codeorg.zendesk.com/agent/tickets/453722) we have had a few reports of teacher not being able to hit the "submit" button because either they were too zoomed in or they had so many sections that the list was too long that it forced the submit button off the screen.  It seems like this could be an accessibility issue for anyone too zoomed it or for any content too long for the `AccessibleDialog` feature.  

This shows the issue before:
https://github.com/code-dot-org/code-dot-org/assets/24883357/5b51b9fd-d85e-4d17-a754-1a4d711dac58


This shows the fix:

https://github.com/code-dot-org/code-dot-org/assets/24883357/743dd0ce-9579-4040-9c43-5cf0ab712d93



Finally, I am tagging student-learning since I saw they have some items that used this component (esp. in HOC) to make sure this is OK with them.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
