### PR TITLE
[Google Blockly] Modal editor UI updates

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -461,5 +461,5 @@ function simplifyBlockState(block, variableMap) {
 }
 
 export function getBlockColor(block) {
-  return block.style.colourPrimary;
+  return block?.style?.colourPrimary;
 }

--- a/apps/src/blockly/addons/svgFrame.js
+++ b/apps/src/blockly/addons/svgFrame.js
@@ -137,7 +137,7 @@ export default class SvgFrame {
     // We do this because otherwise, the value returned by
     // getBoundingClientRect would take our size into account, and we
     // would 'grow' every time render was called.
-    this.frameGroup_.remove();
+    this.frameGroup_?.remove();
     var groupRect = svgGroup.getBoundingClientRect();
     svgGroup.prepend(this.frameGroup_);
 
@@ -170,24 +170,13 @@ export default class SvgFrame {
     this.frameHeader_.setAttribute('width', width);
     this.frameHeader_.setAttribute('height', height);
     this.frameHeader_.setAttribute('fill', this.headerColor);
-    this.setToolbarColor();
+
     if (isRtl) {
       this.frameClipRect_.setAttribute('x', -width + frameSizes.MARGIN_SIDE);
       this.frameHeader_.setAttribute('x', -width + frameSizes.MARGIN_SIDE);
       this.frameBase_.setAttribute('x', -width + frameSizes.MARGIN_SIDE);
       this.frameText_.setAttribute('x', -width + 2 * frameSizes.MARGIN_SIDE);
     }
-  }
-
-  /**
-   * Sets the color of the associated toolbar to match the frame's header color.
-   * The toolbar typically contains "delete" and "close" buttons.
-   */
-  setToolbarColor() {
-    const toolbarElement = document.getElementsByClassName(
-      'toolbar src-blockly-components-modal-function-editor-module__toolbar'
-    )[0];
-    toolbarElement.style.backgroundColor = this.headerColor;
   }
 }
 

--- a/apps/src/blockly/addons/workspaceSvgFrame.js
+++ b/apps/src/blockly/addons/workspaceSvgFrame.js
@@ -53,7 +53,7 @@ export default class WorkspaceSvgFrame extends SvgFrame {
    * Overrides the standard render to create a frame within the element, rather than around it.
    */
   render() {
-    const minWidth = this.frameText_.getBoundingClientRect().width;
+    const minWidth = this.frameText_?.getBoundingClientRect().width;
     let width =
       Math.max(
         minWidth,
@@ -86,7 +86,7 @@ export default class WorkspaceSvgFrame extends SvgFrame {
     this.frameClipRect_.setAttribute('y', frameY);
     this.frameBase_.setAttribute('y', frameY);
     this.frameHeader_.setAttribute('y', frameY);
-    this.frameText_.setAttribute(
+    this.frameText_?.setAttribute(
       'y',
       frameY + frameSizes.WORKSPACE_HEADER_HEIGHT / 2
     );
@@ -106,7 +106,6 @@ function onWorkspaceChange(event) {
   if (
     [
       Blockly.Events.DELETE,
-      Blockly.Events.MOVE,
       Blockly.Events.THEME_CHANGE,
       Blockly.Events.VIEWPORT_CHANGE,
     ].includes(event.type)

--- a/apps/src/blockly/addons/workspaceSvgFrame.js
+++ b/apps/src/blockly/addons/workspaceSvgFrame.js
@@ -106,6 +106,7 @@ function onWorkspaceChange(event) {
   if (
     [
       Blockly.Events.DELETE,
+      Blockly.Events.MOVE,
       Blockly.Events.THEME_CHANGE,
       Blockly.Events.VIEWPORT_CHANGE,
     ].includes(event.type)

--- a/apps/src/blockly/components/ModalFunctionEditor.jsx
+++ b/apps/src/blockly/components/ModalFunctionEditor.jsx
@@ -8,6 +8,7 @@ import moduleStyles from './modal-function-editor.module.scss';
 import classNames from 'classnames';
 import Button from '@cdo/apps/templates/Button';
 import msg from '@cdo/locale';
+import color from '@cdo/apps/util/color';
 
 export default function ModalFunctionEditor() {
   const buttonSize = Button.ButtonSize.narrow;
@@ -28,22 +29,27 @@ export default function ModalFunctionEditor() {
             type="button"
             id={MODAL_EDITOR_DELETE_ID}
             onClick={emptyOnClick}
-            color={Button.ButtonColor.brandSecondaryDefault}
+            color={Button.ButtonColor.white}
+            style={buttonStyles}
             size={buttonSize}
-          >
-            {msg.delete()}
-          </Button>
+            text={msg.delete()}
+          />
           <Button
             type="button"
             id={MODAL_EDITOR_CLOSE_ID}
             onClick={emptyOnClick}
-            color={Button.ButtonColor.brandSecondaryDefault}
+            color={Button.ButtonColor.white}
+            style={buttonStyles}
             size={buttonSize}
-          >
-            {msg.closeDialog()}
-          </Button>
+            text={msg.closeDialog()}
+          />
         </div>
       </div>
     </div>
   );
 }
+
+const buttonStyles = {
+  border: `2px solid ${color.neutral_dark}`,
+  fontWeight: 'bolder',
+};

--- a/apps/src/blockly/components/ModalFunctionEditor.jsx
+++ b/apps/src/blockly/components/ModalFunctionEditor.jsx
@@ -49,6 +49,7 @@ export default function ModalFunctionEditor() {
   );
 }
 
+// In-line styles are used to avoid conflicting with classes applied by the Button class.
 const buttonStyles = {
   border: `2px solid ${color.neutral_dark}`,
   fontWeight: 'bolder',

--- a/apps/src/blockly/components/modal-function-editor.module.scss
+++ b/apps/src/blockly/components/modal-function-editor.module.scss
@@ -14,8 +14,6 @@
   top: 10px;
   right: 10px;
   z-index: 1;
-  border-radius: 4px;
-  background-color: $light_gray;
 }
 
 .buttons {


### PR DESCRIPTION
The Design Team made the following asks to update the buttons used in the modal function editor:

- Remove the “piece/background chunk” of the header that floats with the buttons
- Change the button color to white with a black border
- Horizontally center text in buttons
- Use semi-bold weight for the font (vs. body weight or whatever they are now)

I used a level context with an instructions panel in order to match the color and border properties of other buttons. (See screenshots.)


**Before:**
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/1773b09d-1ea9-4591-a793-aa9ab63401d7)

**After:**
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/4ffd7096-4244-4b8f-a5e6-cf1b44052c04)

Buttons floating over workspace frame body:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/3734eec7-294a-42f0-921b-dd4468b442ec)

This also adds a couple null checks to svg components to prevent some errors we were seeing.

## Links

https://codedotorg.atlassian.net/browse/CT-154

