### PR TITLE
Fix student AI evaluation triggers on 'milestone'

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -53,7 +53,7 @@ class ActivitiesController < ApplicationController
     is_ai_experiment_enabled = current_user && Experiment.enabled?(user: current_user, script: @script_level&.script, experiment_name: 'ai-rubrics')
     is_level_ai_enabled = EvaluateRubricJob.ai_enabled?(@script_level)
     if is_ai_experiment_enabled && is_level_ai_enabled && params[:submitted] == 'true'
-      EvaluateRubricJob.perform_later(user_id: current_user.id, script_level_id: @script_level.id)
+      EvaluateRubricJob.perform_later(user_id: current_user.id, requester_id: current_user.id, script_level_id: @script_level.id)
     end
 
     sharing_allowed = Gatekeeper.allows('shareEnabled', where: {script_name: script_name}, default: true)

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -1142,7 +1142,7 @@ class ActivitiesControllerTest < ActionController::TestCase
   test 'milestone with student in experiment triggers rubric eval job' do
     create :single_section_experiment, section: @section, name: 'ai-rubrics'
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
-    EvaluateRubricJob.expects(:perform_later).with(user_id: @student.id, script_level_id: @script_level.id).once
+    EvaluateRubricJob.expects(:perform_later).with(user_id: @student.id, requester_id: @student.id, script_level_id: @script_level.id).once
     sign_in @student
 
     post :milestone, params: @milestone_rubric_params


### PR DESCRIPTION
Student evaluations were triggering an exception since we added the `requester` association. There was some kind of regression. The honeybadger errors are linked below.

This just simply attaches the current user (the student) to the requester field so that the request and user match.

## Links

- honeybadger: https://app.honeybadger.io/projects/3240/faults/101726621
- jira ticket: [AITT-288](https://codedotorg.atlassian.net/browse/AITT-288)

## Testing story

Updated existing test. The test did not catch the original issue as the method was stubbed and technically allowed `request_id` to be omitted failing the validation at the model.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
