### PR TITLE
Adds cookie so email capture dialog is not seen for 90 days after being closed

### DIFF
--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import cookies from 'js-cookie';
 import GameButtons from '../templates/GameButtons';
 import ArrowButtons from '../templates/ArrowButtons';
 import BelowVisualization from '../templates/BelowVisualization';
@@ -113,9 +114,10 @@ class DanceVisualizationColumn extends React.Component {
         {!this.props.isShareView && (
           <AgeDialog turnOffFilter={this.turnFilterOff} />
         )}
-        {(this.props.over21 || this.props.userType === 'teacher') && (
-          <HourOfCodeGuideEmailDialog isSignedIn={isSignedIn} />
-        )}
+        {(this.props.over21 || this.props.userType === 'teacher') &&
+          !(cookies.get('HourOfCodeGuideEmailDialogSeen') === 'true') && (
+            <HourOfCodeGuideEmailDialog isSignedIn={isSignedIn} />
+          )}
         <div style={{maxWidth: MAX_GAME_WIDTH}}>
           {!this.props.isShareView && (
             <SongSelector

--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -115,7 +115,7 @@ class DanceVisualizationColumn extends React.Component {
           <AgeDialog turnOffFilter={this.turnFilterOff} />
         )}
         {(this.props.over21 || this.props.userType === 'teacher') &&
-          !(cookies.get('HourOfCodeGuideEmailDialogSeen') === 'true') && (
+          cookies.get('HourOfCodeGuideEmailDialogSeen') !== 'true' && (
             <HourOfCodeGuideEmailDialog isSignedIn={isSignedIn} />
           )}
         <div style={{maxWidth: MAX_GAME_WIDTH}}>

--- a/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
+++ b/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import cookies from 'js-cookie';
 import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import Button from '@cdo/apps/templates/Button';
@@ -14,6 +15,10 @@ function HourOfCodeGuideEmailDialog({isSignedIn}) {
   const [isMarketingChecked, setIsMarketingChecked] = useState(false);
 
   const onClose = () => {
+    cookies.set('HourOfCodeGuideEmailDialogSeen', 'true', {
+      expires: 90,
+      path: '/',
+    });
     setIsOpen(false);
   };
 

--- a/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
+++ b/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
@@ -1,9 +1,11 @@
 import {assert, expect} from 'chai';
 import React from 'react';
 import {UnconnectedHourOfCodeGuideEmailDialog as HourOfCodeGuideEmailDialog} from '@cdo/apps/templates/HourOfCodeGuideEmailDialog';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import i18n from '@cdo/locale';
 import experiments from '@cdo/apps/util/experiments';
+import sinon from 'sinon';
+import cookies from 'js-cookie';
 
 describe('HourOfCodeGuideEmailDialog', () => {
   const defaultProps = {
@@ -28,5 +30,17 @@ describe('HourOfCodeGuideEmailDialog', () => {
     experiments.setEnabled(experiments.HOC_TUTORIAL_DIALOG, false);
     const wrapper = shallow(<HourOfCodeGuideEmailDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);
+  });
+
+  it('cookie is save when dialog is closed', () => {
+    const wrapper = mount(<HourOfCodeGuideEmailDialog {...defaultProps} />);
+    var cookieSetStub = sinon.stub(cookies, 'set');
+    wrapper.find('.uitest-no-email-guide').simulate('click');
+    expect(cookieSetStub).to.have.been.calledWith(
+      'HourOfCodeGuideEmailDialogSeen',
+      'true',
+      {expires: 90, path: '/'}
+    );
+    cookies.set.restore();
   });
 });

--- a/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
+++ b/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
@@ -35,7 +35,7 @@ describe('HourOfCodeGuideEmailDialog', () => {
   it('cookie is save when dialog is closed', () => {
     const wrapper = mount(<HourOfCodeGuideEmailDialog {...defaultProps} />);
     var cookieSetStub = sinon.stub(cookies, 'set');
-    wrapper.find('.uitest-no-email-guide').simulate('click');
+    wrapper.find('Button').at(0).simulate('click');
     expect(cookieSetStub).to.have.been.calledWith(
       'HourOfCodeGuideEmailDialogSeen',
       'true',

--- a/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
+++ b/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
@@ -1,11 +1,9 @@
 import {assert, expect} from 'chai';
 import React from 'react';
 import {UnconnectedHourOfCodeGuideEmailDialog as HourOfCodeGuideEmailDialog} from '@cdo/apps/templates/HourOfCodeGuideEmailDialog';
-import {shallow, mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import i18n from '@cdo/locale';
 import experiments from '@cdo/apps/util/experiments';
-import sinon from 'sinon';
-import cookies from 'js-cookie';
 
 describe('HourOfCodeGuideEmailDialog', () => {
   const defaultProps = {
@@ -30,17 +28,5 @@ describe('HourOfCodeGuideEmailDialog', () => {
     experiments.setEnabled(experiments.HOC_TUTORIAL_DIALOG, false);
     const wrapper = shallow(<HourOfCodeGuideEmailDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);
-  });
-
-  it('cookie is save when dialog is closed', () => {
-    const wrapper = mount(<HourOfCodeGuideEmailDialog {...defaultProps} />);
-    var cookieSetStub = sinon.stub(cookies, 'set');
-    wrapper.find('Button').at(0).simulate('click');
-    expect(cookieSetStub).to.have.been.calledWith(
-      'HourOfCodeGuideEmailDialogSeen',
-      'true',
-      {expires: 90, path: '/'}
-    );
-    cookies.set.restore();
   });
 });


### PR DESCRIPTION
This sets up a cookie so the dialog doesn't display if the user has already seen and closed it in the past 90 days. I followed the logic of the signInCallout (in regards to setting the cookie onClose). I am very open to be swayed in a different direction- I also considered setting the cookie immediately upon rendering.


I'm having a hard time writing a unit test to mount this component (the error has to do with focus-trap) that I believe is related to the AccessibleDialog. I can't find an example of another test that mounts the AccessibleDialog. That being said, I was able to test locally for a signed in user that the dialog now only appears once. 

I can also see that the cookie was correctly set in the developer tools:
<img width="736" alt="Screenshot 2023-11-08 at 10 58 31 AM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/c643c628-e5dc-46f2-b81a-4fe5bacf308f">


## Links

- spec: https://docs.google.com/document/d/1jSmRkX8O-PMDj9y-hvMubOMl1hkcRz8o9_nUO1s7gls/edit?pli=1
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1142

## Testing story

I added a test to the test file to ensure the cookie is being set properly when the dialog is closed.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
