### PR TITLE
Dance AI: Fix live preview flicker

### DIFF
--- a/apps/src/dance/ai/AiVisualizationPreview.tsx
+++ b/apps/src/dance/ai/AiVisualizationPreview.tsx
@@ -1,4 +1,3 @@
-import {BlockSvg} from 'blockly';
 import React, {useEffect, useRef} from 'react';
 import {useSelector} from 'react-redux';
 import {DanceState} from '../danceRedux';
@@ -6,7 +5,7 @@ import ProgramExecutor from '../lab2/ProgramExecutor';
 import moduleStyles from './ai-visualization-preview.module.scss';
 
 interface AiVisualizationPreviewProps {
-  blocks: BlockSvg[];
+  code: string;
 }
 
 const PREVIEW_DIV_ID = 'ai-preview';
@@ -16,7 +15,7 @@ const PREVIEW_DIV_ID = 'ai-preview';
  */
 const AiVisualizationPreview: React.FunctionComponent<
   AiVisualizationPreviewProps
-> = ({blocks}) => {
+> = ({code}) => {
   const songMetadata = useSelector(
     (state: {dance: DanceState}) => state.dance.currentSongMetadata
   );
@@ -32,41 +31,17 @@ const AiVisualizationPreview: React.FunctionComponent<
     );
   }, []);
 
-  // Generate setup code for previewing the given blocks.
-  const generateSetupCode = (blocks: BlockSvg[]): string => {
-    if (blocks.length === 0) {
-      console.log('No blocks to preview');
-      return '';
-    }
-    // Create a temporary setup block
-    const setup: BlockSvg = Blockly.getMainWorkspace().newBlock(
-      'Dancelab_whenSetup'
-    ) as BlockSvg;
-
-    // Attach the blocks to the setup block
-    setup.getInput('DO')?.connection?.connect(blocks[0].previousConnection);
-
-    if (!Blockly.getGenerator().isInitialized) {
-      Blockly.getGenerator().init(Blockly.getMainWorkspace());
-    }
-
-    // Remove the temp setup block from the workspace so it doesn't remain after preview
-    Blockly.getMainWorkspace().removeTopBlock(setup);
-    return Blockly.getGenerator().blockToCode(setup);
-  };
-
   useEffect(() => {
     if (songMetadata === undefined || executorRef.current === null) {
       return;
     }
 
-    const code = generateSetupCode(blocks);
     if (!executorRef.current.isLivePreviewRunning()) {
       executorRef.current.startLivePreview(code, songMetadata);
     } else {
       executorRef.current.updateLivePreview(code, songMetadata);
     }
-  }, [songMetadata, blocks]);
+  }, [songMetadata, code]);
 
   const containerRef = useRef<HTMLDivElement>(null);
 

--- a/apps/src/dance/ai/DanceAiModal.tsx
+++ b/apps/src/dance/ai/DanceAiModal.tsx
@@ -12,7 +12,12 @@ import AiVisualizationPreview from './AiVisualizationPreview';
 import AiBlockPreview from './AiBlockPreview';
 import AiExplanationView from './AiExplanationView';
 import {AiOutput, FieldKey, GeneratedEffect} from '../types';
-import {generateBlocks, generateBlocksFromResult, getLabelMap} from './utils';
+import {
+  generateBlocks,
+  generateBlocksFromResult,
+  generatePreviewCode,
+  getLabelMap,
+} from './utils';
 import color from '@cdo/apps/util/color';
 const ToggleGroup = require('@cdo/apps/templates/ToggleGroup').default;
 const i18n = require('../locale');
@@ -331,6 +336,16 @@ const DanceAiModal: React.FunctionComponent = () => {
     }
   };
 
+  const getPreviewCode = (): string => {
+    const tempWorkspace = new Workspace();
+    const previewCode = generatePreviewCode(
+      tempWorkspace,
+      JSON.stringify(currentGeneratedEffect?.results)
+    );
+    tempWorkspace.dispose();
+    return previewCode;
+  };
+
   const onClose = () => dispatch(closeAiModal());
 
   const showUseButton =
@@ -545,12 +560,7 @@ const DanceAiModal: React.FunctionComponent = () => {
                   id="flip-card-front"
                   className={moduleStyles.flipCardFront}
                 >
-                  <AiVisualizationPreview
-                    blocks={generateBlocksFromResult(
-                      Blockly.getMainWorkspace(),
-                      JSON.stringify(currentGeneratedEffect?.results)
-                    )}
-                  />
+                  <AiVisualizationPreview code={getPreviewCode()} />
                 </div>
                 <div id="flip-card-back" className={moduleStyles.flipCardBack}>
                   {mode === Mode.RESULTS && (

--- a/apps/src/dance/ai/utils.ts
+++ b/apps/src/dance/ai/utils.ts
@@ -53,3 +53,24 @@ export const getLabelMap = (
   });
   return map;
 };
+
+/**
+ * Generate code that can be executed to preview the output of the AI-generated blocks.
+ */
+export const generatePreviewCode = (
+  workspace: Workspace,
+  resultJsonString: string
+): string => {
+  const blocks = generateBlocksFromResult(workspace, resultJsonString);
+  // Create a temporary setup block
+  const setup: BlockSvg = workspace.newBlock('Dancelab_whenSetup') as BlockSvg;
+
+  // Attach the blocks to the setup block
+  setup.getInput('DO')?.connection?.connect(blocks[0].previousConnection);
+
+  if (!Blockly.getGenerator().isInitialized) {
+    Blockly.getGenerator().init(workspace);
+  }
+
+  return Blockly.getGenerator().blockToCode(setup);
+};


### PR DESCRIPTION
Fix the live preview flicker in the Dance AI modal that was being caused by extra re-renders. I moved the preview code generation out into utils so that React can use the code string as the dependency, and therefore won't re-render unless the contents of the actual code string change.

With fix (logs show when the actual live preview function is called, only once per preview):

https://github.com/code-dot-org/code-dot-org/assets/85528507/02f23c4f-c181-4993-a315-174ab17c999b


## Links

https://trello.com/c/FiScfKdf

## Testing story

Tested locally on Dance AI levels