### PR TITLE
Update Code.org homepage banner to generic HoC banner

### DIFF
--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -12,10 +12,7 @@
     "hoc2023-soon-hoc": {
       "hoc_modes": ["soon-hoc"],
       "class": "hoc-banner homepage",
-      "desktopImage": "/images/hoc2023-codeorg-hero-banner.png",
-      "mobileImage": "/images/hoc2023-codeorg-hero-banner-mobile.png",
-      "leftImage": "/images/hoc2023-codeorg-hero-banner-left.svg",
-      "rightImage": "/images/hoc2023-codeorg-hero-banner-right.svg",
+      "desktopImage": "/images/hoc2023-hero-banner.svg",
       "actions": [
         {
           "type": "text",
@@ -23,11 +20,11 @@
         },
         {
           "type": "heading",
-          "text": "curriculum_name_dance_party_ai_edition"
+          "text": "hoc2023_header"
         },
         {
           "type": "heading-two",
-          "text": "codeorg_homepage_hoc2023_body"
+          "text": "hoc2023_hero_desc_homepage"
         },
         {
           "type": "cta_button_solid_yellow",

--- a/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
@@ -66,15 +66,20 @@
   text-align: center;
   color: $white;
   line-height: 1.4;
+  max-width: 70%;
+  margin: 2rem auto 4rem;
+
+  @media screen and (max-width: $width-md) {
+    max-width: 100%;
+  }
 
   h1, h2 {
     color: $white
   }
 
   h1 {
-    font-size: 3.5rem;
-    font-family: var(--main-font);
-    font-weight: var(--bold-font-weight);
+    font-size: 4rem;
+    font-family: var(--barlowSemiCondensed-semibold);
     margin: 0 auto 0.5em;
 
     @media screen and (max-width: $width-lg) {
@@ -94,19 +99,14 @@
     margin: 0 auto 1rem;
     font-family: var(--main-font);
     font-size: 1.25rem;
-
-    @media screen and (max-width: $width-md) {
-      width: 80%;
-      margin-left: auto;
-      margin-right: auto;
-    }
   }
 
   // The Hour of Code is coming/here text
   p {
-    font-size: 2em;
+    font-size: 1.5rem;
     font-family: var(--main-font);
-    font-weight: var(--bold-font-weight);
+    font-weight: var(--semi-bold-font-weight);
+    margin-bottom: 0.25rem;
 
     @media screen and (max-width: $width-md) {
       font-size: 1.75em;


### PR DESCRIPTION
Replacing the Dance Party AI banner on the https://code.org homepage with the generic HoC styles and copy
- Buttons can remain the same
- Fully responsive
- Tested in other languages and LTR and RTL styles

**Jira ticket:** [ACQ-1152](https://codedotorg.atlassian.net/browse/ACQ-1152)

----

## Desktop
<img width="965" alt="Screenshot 2023-11-07 at 8 30 30 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/cc60de98-035e-4903-91b1-71cfc203e97e">

## Tablet
<img width="500" alt="Screenshot 2023-11-07 at 8 31 10 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/50c367fe-b4a4-40d6-b349-2a7936544bcf">

## Mobile
<img width="300" alt="Screenshot 2023-11-07 at 8 31 23 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/0e20e536-29f3-4b85-a8c6-061b4db4620e">
