### PR TITLE
Fix hamburger menu translations for incubator and professional learning

### DIFF
--- a/lib/cdo/hamburger.rb
+++ b/lib/cdo/hamburger.rb
@@ -92,8 +92,8 @@ class Hamburger
       {title: "my_dashboard", url: CDO.studio_url("/home")},
       {title: "course_catalog", url: CDO.studio_url("/catalog")},
       {title: "project_gallery", url: CDO.studio_url("/projects")},
-      {title: I18n.t("professional_learning"), url: CDO.studio_url("/my-professional-learning")},
-      {title: I18n.t("incubator"), url: CDO.studio_url("/incubator")}
+      {title: "professional_learning", url: CDO.studio_url("/my-professional-learning")},
+      {title: "incubator", url: CDO.studio_url("/incubator")}
     ].each do |entry|
       entry[:title] = I18n.t("#{loc_prefix}#{entry[:title]}")
     end
@@ -102,7 +102,7 @@ class Hamburger
       {title: "my_dashboard", url: CDO.studio_url("/home"), id: "hamburger-student-home"},
       {title: "course_catalog", url: CDO.studio_url("/courses")},
       {title: "project_gallery", url: CDO.studio_url("/projects"), id: "hamburger-student-projects"},
-      {title: I18n.t("incubator"), url: CDO.studio_url("/incubator")}
+      {title: "incubator", url: CDO.studio_url("/incubator")}
     ].each do |entry|
       entry[:title] = I18n.t("#{loc_prefix}#{entry[:title]}")
     end
@@ -110,7 +110,7 @@ class Hamburger
     signed_out_entries = [
       {title: "course_catalog", url: CDO.studio_url("/catalog")},
       {title: "project_gallery", url: CDO.studio_url("/projects/public"), id: "hamburger-signed-out-projects"},
-      {title: I18n.t("incubator"), url: CDO.studio_url("/incubator")}
+      {title: "incubator", url: CDO.studio_url("/incubator")}
     ].each do |entry|
       entry[:title] = I18n.t("#{loc_prefix}#{entry[:title]}")
     end

--- a/lib/cdo/hamburger.rb
+++ b/lib/cdo/hamburger.rb
@@ -92,8 +92,8 @@ class Hamburger
       {title: "my_dashboard", url: CDO.studio_url("/home")},
       {title: "course_catalog", url: CDO.studio_url("/catalog")},
       {title: "project_gallery", url: CDO.studio_url("/projects")},
-      {title: I18n.t("#{loc_prefix}professional_learning"), url: CDO.studio_url("/my-professional-learning")},
-      {title: I18n.t("#{loc_prefix}incubator"), url: CDO.studio_url("/incubator")}
+      {title: I18n.t("professional_learning"), url: CDO.studio_url("/my-professional-learning")},
+      {title: I18n.t("incubator"), url: CDO.studio_url("/incubator")}
     ].each do |entry|
       entry[:title] = I18n.t("#{loc_prefix}#{entry[:title]}")
     end
@@ -102,7 +102,7 @@ class Hamburger
       {title: "my_dashboard", url: CDO.studio_url("/home"), id: "hamburger-student-home"},
       {title: "course_catalog", url: CDO.studio_url("/courses")},
       {title: "project_gallery", url: CDO.studio_url("/projects"), id: "hamburger-student-projects"},
-      {title: I18n.t("#{loc_prefix}incubator"), url: CDO.studio_url("/incubator")}
+      {title: I18n.t("incubator"), url: CDO.studio_url("/incubator")}
     ].each do |entry|
       entry[:title] = I18n.t("#{loc_prefix}#{entry[:title]}")
     end
@@ -110,7 +110,7 @@ class Hamburger
     signed_out_entries = [
       {title: "course_catalog", url: CDO.studio_url("/catalog")},
       {title: "project_gallery", url: CDO.studio_url("/projects/public"), id: "hamburger-signed-out-projects"},
-      {title: I18n.t("#{loc_prefix}incubator"), url: CDO.studio_url("/incubator")}
+      {title: I18n.t("incubator"), url: CDO.studio_url("/incubator")}
     ].each do |entry|
       entry[:title] = I18n.t("#{loc_prefix}#{entry[:title]}")
     end


### PR DESCRIPTION
Incubator in the hamburger menu was not translating correctly. I also noticed professional learning was not working in the hamburger menu so fixed that too. 

## Incubator

### Before
![unnamed-1](https://github.com/code-dot-org/code-dot-org/assets/208083/ca9d4484-c313-490e-bef5-f29234632123)

### After
![Screenshot 2023-11-07 at 11 35 27 AM](https://github.com/code-dot-org/code-dot-org/assets/208083/d8a46867-2a60-4914-bb1e-a46674c333df)

## Professional Learning

### Before
![Screenshot 2023-11-07 at 11 37 33 AM](https://github.com/code-dot-org/code-dot-org/assets/208083/589bc8e7-1856-403a-b29d-607468da891e)

### After
![Screenshot 2023-11-07 at 11 38 55 AM](https://github.com/code-dot-org/code-dot-org/assets/208083/ca029a06-66ec-4dd7-9582-7d6b8045d828)

