### PR TITLE
AI Tutor - repurpose AI_CHAT_ACCESS permission 

### DIFF
--- a/dashboard/app/controllers/openai_chat_controller.rb
+++ b/dashboard/app/controllers/openai_chat_controller.rb
@@ -1,6 +1,5 @@
 class OpenaiChatController < ApplicationController
   include OpenaiChatHelper
-  authorize_resource class: false
 
   # POST /openai/chat_completion
   def chat_completion

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -292,10 +292,6 @@ class Ability
         can :dashboard, :peer_reviews
         can :report_csv, :peer_review_submissions
       end
-
-      if user.permission?(UserPermission::AI_CHAT_ACCESS)
-        can :chat_completion, :openai_chat
-      end
     end
 
     # Override UnitGroup, Unit, Lesson and ScriptLevel.

--- a/dashboard/app/models/user_permission.rb
+++ b/dashboard/app/models/user_permission.rb
@@ -44,9 +44,8 @@ class UserPermission < ApplicationRecord
     PROGRAM_MANAGER = 'program_manager'.freeze,
     # Grants ability to be the instructor of any course no matter instructor_audience
     UNIVERSAL_INSTRUCTOR = 'universal_instructor'.freeze,
-    # Grants access to use AI Chat API
-    AI_CHAT_ACCESS = 'ai_chat_access'.freeze,
-
+    # Grants access to use AI Tutor which uses AI Chat API
+    AI_TUTOR_ACCESS = 'ai_tutor_access'.freeze,
   ].freeze
 
   # Do not log the granting/removal of these permissions to slack

--- a/dashboard/test/controllers/openai_chat_controller_test.rb
+++ b/dashboard/test/controllers/openai_chat_controller_test.rb
@@ -7,23 +7,16 @@ class OpenaiChatControllerTest < ActionController::TestCase
     OpenaiChatHelper.stubs(:get_chat_completion_response_message).returns({status: 200, json: {}})
   end
 
-  # User without ai_chat_access is unable to access the chat completion endpoint
+  #  A post request without a messages param returns a bad request
   test_user_gets_response_for :chat_completion,
-  user: :levelbuilder,
-  method: :post,
-  params: {messages: [{role: "user", content: "Say this is a test!"}]},
-  response: :forbidden
-
-  # With ai_chat_access, a post request without a messages param returns a bad request
-  test_user_gets_response_for :chat_completion,
-  user: :ai_chat_access,
+  user: :student,
   method: :post,
   params: {},
   response: :bad_request
 
-  # With ai_chat_access, a post request with a messages param returns a success
+  # A post request with a messages param returns a success
   test_user_gets_response_for :chat_completion,
-  user: :ai_chat_access,
+  user: :student,
   method: :post,
   params: {messages: [{role: "user", content: "Say this is a test!"}]},
   response: :success

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -157,10 +157,10 @@ FactoryBot.define do
           authorized_teacher.save
         end
       end
-      factory :ai_chat_access do
-        after(:create) do |ai_chat_access|
-          ai_chat_access.permission = UserPermission::AI_CHAT_ACCESS
-          ai_chat_access.save
+      factory :ai_tutor_access do
+        after(:create) do |ai_tutor_access|
+          ai_tutor_access.permission = UserPermission::AI_TUTOR_ACCESS
+          ai_tutor_access.save
         end
       end
       factory :facilitator do

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -933,16 +933,6 @@ class AbilityTest < ActiveSupport::TestCase
     refute Ability.new(program_manager).can? :destroy, incomplete_application
   end
 
-  test 'users with AI_CHAT_ACCESS can access Open AI chat completion endpoint' do
-    ai_chat_access_user = create :ai_chat_access
-    assert Ability.new(ai_chat_access_user).can? :chat_completion, :openai_chat
-  end
-
-  test 'user without AI_CHAT_ACCESS cannot access Open AI chat completion endpoint' do
-    levelbuilder = create :levelbuilder
-    refute Ability.new(levelbuilder).can? :chat_completion, :openai_chat
-  end
-
   private
 
   def put_students_in_section_and_code_review_group(students, section)

--- a/dashboard/test/models/concerns/user_permission_grantee_test.rb
+++ b/dashboard/test/models/concerns/user_permission_grantee_test.rb
@@ -123,11 +123,11 @@ class UserPermissionGranteeTest < ActiveSupport::TestCase
     assert user.workshop_organizer?
   end
 
-  test 'ai_chat_access?' do
+  test 'ai_tutor_access?' do
     user = create :teacher
-    refute user.ai_chat_access?
-    user.permission = UserPermission::AI_CHAT_ACCESS
-    assert user.ai_chat_access?
+    refute user.ai_tutor_access?
+    user.permission = UserPermission::AI_TUTOR_ACCESS
+    assert user.ai_tutor_access?
   end
 
   test 'grant admin permission logs to infrasecurity' do


### PR DESCRIPTION
Two things are happening here: 

1.) `AI_CHAT_ACCESS` permission is no longer needed to be able to use the `chat_completion` and `openai_chat` API endpoints. This is because we will need to broaden access for these endpoints for user testing and pilots of AI Tutor. Instead of forbidding access to the endpoints we will be using a series of controls to hide access to the UI that calls into the endpoints. Specifically, to access the chat API via AI Tutor the user will have to be a student in a section assigned CSA viewing a Javalab level, where their section section has `ai_tutor_enabled == true`. Power to enable the  AI Tutor by section will be limited to only verified teachers who have enabled the `ai-tutor-toggle` experiment. 

2.) `AI_CHAT_ACCESS` has been renamed `AI_TUTOR_ACCESS`. If a user has `AI_TUTOR_ACCESS` permission they will ultimately be able to view and interact with the AI Tutor regardless of section affiliation or assignment. This will make it easier for internal users to test AI Tutor even on production. 

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

Details of permissions for the prototypes can be found in this [proposal](https://docs.google.com/document/d/1v46QAIxtN8SIPbFho9JuhqHaB13kdg1E_okBcpauZzc/edit). 

[CT-160](https://codedotorg.atlassian.net/browse/CT-160)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

No external users are currently using features that call these endpoints. For internal users, access to the openai chat_completion endpoint will be broadened rather than restricted so anyone who currently has access to the chat API will continue to do so. 

## Follow-up work

The hide/show logic for the AI Tutor code compilation prototype, currently a [WIP](https://github.com/code-dot-org/code-dot-org/pull/54294) will be updated to reflect the permissions changes outlined above. 
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
