### PR TITLE
Dance AI: Add ability to stop live preview

### DIFF
--- a/apps/src/dance/ai/AiVisualizationPreview.tsx
+++ b/apps/src/dance/ai/AiVisualizationPreview.tsx
@@ -6,6 +6,7 @@ import moduleStyles from './ai-visualization-preview.module.scss';
 
 interface AiVisualizationPreviewProps {
   code: string;
+  durationMs?: number;
 }
 
 const PREVIEW_DIV_ID = 'ai-preview';
@@ -15,7 +16,7 @@ const PREVIEW_DIV_ID = 'ai-preview';
  */
 const AiVisualizationPreview: React.FunctionComponent<
   AiVisualizationPreviewProps
-> = ({code}) => {
+> = ({code, durationMs}) => {
   const songMetadata = useSelector(
     (state: {dance: DanceState}) => state.dance.currentSongMetadata
   );
@@ -37,11 +38,11 @@ const AiVisualizationPreview: React.FunctionComponent<
     }
 
     if (!executorRef.current.isLivePreviewRunning()) {
-      executorRef.current.startLivePreview(code, songMetadata);
+      executorRef.current.startLivePreview(code, songMetadata, durationMs);
     } else {
-      executorRef.current.updateLivePreview(code, songMetadata);
+      executorRef.current.updateLivePreview(code, songMetadata, durationMs);
     }
-  }, [songMetadata, code]);
+  }, [songMetadata, code, durationMs]);
 
   const containerRef = useRef<HTMLDivElement>(null);
 

--- a/apps/src/dance/lab2/ProgramExecutor.ts
+++ b/apps/src/dance/lab2/ProgramExecutor.ts
@@ -135,16 +135,24 @@ export default class ProgramExecutor {
   /**
    * Show a live preview of the program. Compiles student code and calls on the native API to run the live preview.
    */
-  async startLivePreview(code: string, songMetadata: SongMetadata) {
+  async startLivePreview(
+    code: string,
+    songMetadata: SongMetadata,
+    durationMs?: number
+  ) {
     this.reset();
     this.livePreviewActive = true;
-    await this.updateLivePreview(code, songMetadata);
+    await this.updateLivePreview(code, songMetadata, durationMs);
   }
 
   /**
    * Update the currently playing live preview.
    */
-  async updateLivePreview(code: string, songMetadata: SongMetadata) {
+  async updateLivePreview(
+    code: string,
+    songMetadata: SongMetadata,
+    durationMs?: number
+  ) {
     if (!this.livePreviewActive) {
       console.warn('Update live preview called before starting live preview');
       return;
@@ -157,7 +165,10 @@ export default class ProgramExecutor {
     }
 
     this.hooks.runUserSetup();
-    this.nativeAPI.livePreview(utils.getSongMetadataForPreview(songMetadata));
+    this.nativeAPI.livePreview(
+      utils.getSongMetadataForPreview(songMetadata),
+      durationMs
+    );
   }
 
   isLivePreviewRunning() {

--- a/apps/test/unit/dance/lab2/ProgramExecutorTest.ts
+++ b/apps/test/unit/dance/lab2/ProgramExecutorTest.ts
@@ -152,8 +152,13 @@ describe('ProgramExecutor', () => {
       hooks: expectedHooks,
       interpreter: undefined as unknown as CustomMarshalingInterpreter, // unused
     });
+    const durationMs = 1000;
 
-    await programExecutor.startLivePreview(code, currentSongMetadata);
+    await programExecutor.startLivePreview(
+      code,
+      currentSongMetadata,
+      durationMs
+    );
 
     expect(nativeAPI.ensureSpritesAreLoaded).to.have.been.calledOnce;
     expect(evalWithEvents).to.have.been.calledOnce;
@@ -163,7 +168,8 @@ describe('ProgramExecutor', () => {
     expect(fullCode?.includes(code)).to.be.true;
     expect(runUserSetup).to.have.been.calledOnce;
     expect(nativeAPI.livePreview).to.have.been.calledWithExactly(
-      previewMetadata
+      previewMetadata,
+      durationMs
     );
   });
 


### PR DESCRIPTION
Add ability to optionally stop the live preview after a specified duration. The animation will pause on the current frame.

Example (manually configured with a `durationMs` of 3000)

https://github.com/code-dot-org/code-dot-org/assets/85528507/01fd0810-45cb-4057-80fc-6e8c234bc69c


## Links

https://trello.com/c/dgM9NFmO

## Testing story

Tested locally.