### PR TITLE
Fix flaky UI test for AI Rubrics in Safari

### DIFF
--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -210,11 +210,13 @@ export default function RubricContent({
               </BodyThreeText>
             )}
             {!errorSubmitting && !!lastSubmittedTimestamp && (
-              <BodyThreeText>
-                {i18n.feedbackSubmittedAt({
-                  timestamp: lastSubmittedTimestamp,
-                })}
-              </BodyThreeText>
+              <div id="ui-feedback-submitted-timestamp">
+                <BodyThreeText>
+                  {i18n.feedbackSubmittedAt({
+                    timestamp: lastSubmittedTimestamp,
+                  })}
+                </BodyThreeText>
+              </div>
             )}
           </div>
         </div>

--- a/dashboard/test/ui/features/teacher_tools/projects/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/rubrics/teacher_view_of_rubric.feature
@@ -30,12 +30,15 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I press keys "Nice work Lillian!" for element "#ui-teacherFeedback"
   And I wait to see "#ui-autosaveConfirm"
   And I click selector "#ui-submitFeedbackButton" once I see it
+  And I wait to see "#ui-feedback-submitted-timestamp"
+  And I scroll to "#ui-feedback-submitted-timestamp"
   And I wait until element "p:contains(Feedback submitted at)" is visible
 
   # Check that the teacher can see submitted feedback
   Then I reload the page
   And I click selector "#ui-floatingActionButton" once I see it
   And I click selector "strong:contains(Code Quality)" once I see it
+  And I scroll to "#ui-teacherFeedback"
   And I wait until element "textarea:contains(Nice work Lillian!)" is visible
 
   # The teacher given feedback is recieved by the student

--- a/dashboard/test/ui/features/teacher_tools/projects/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/rubrics/teacher_view_of_rubric.feature
@@ -31,14 +31,12 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I wait to see "#ui-autosaveConfirm"
   And I click selector "#ui-submitFeedbackButton" once I see it
   And I wait to see "#ui-feedback-submitted-timestamp"
-  And I scroll to "#ui-feedback-submitted-timestamp"
   And I wait until element "p:contains(Feedback submitted at)" is visible
 
   # Check that the teacher can see submitted feedback
   Then I reload the page
   And I click selector "#ui-floatingActionButton" once I see it
   And I click selector "strong:contains(Code Quality)" once I see it
-  And I scroll to "#ui-teacherFeedback"
   And I wait until element "textarea:contains(Nice work Lillian!)" is visible
 
   # The teacher given feedback is recieved by the student


### PR DESCRIPTION
Based on [this message](https://codedotorg.slack.com/archives/C045UAX4WKH/p1699319561676759) from Elijah.  I ran it 3x on Safari and it passed every time now. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
