### PR TITLE
Fix coteacher add input for new sections

### DIFF
--- a/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
@@ -23,7 +23,7 @@ export const getInputErrorMessage = (email, coteachersToAdd, sectionId) => {
 
   return fetch(
     `/api/v1/section_instructors/check?email=${encodeURIComponent(email)}` +
-      (sectionId && `&section_id=${sectionId}`),
+      (sectionId ? `&section_id=${sectionId}` : ''),
     {
       type: 'GET',
       headers: {
@@ -34,10 +34,10 @@ export const getInputErrorMessage = (email, coteachersToAdd, sectionId) => {
     if (response.ok) {
       return '';
     }
-    if (response.errorThrown === 'Not Found') {
+    if (response.status === 404 && response.statusText === 'Not Found') {
       return i18n.coteacherAddNoAccount({email});
     }
-    if (response.errorThrown === 'Forbidden') {
+    if (response.status === 404 && response.statusText === 'Forbidden') {
       return i18n.coteacherUnableToEditCoteachers();
     }
 

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
@@ -37,24 +37,31 @@ export const getInputErrorMessage = (email, coteachersToAdd, sectionId) => {
     if (response.status === 404 && response.statusText === 'Not Found') {
       return i18n.coteacherAddNoAccount({email});
     }
-    if (response.status === 404 && response.statusText === 'Forbidden') {
+    if (response.status === 403 && response.statusText === 'Forbidden') {
       return i18n.coteacherUnableToEditCoteachers();
     }
 
-    return response.json().then(json => {
-      if (json.error.includes('already invited')) {
-        return i18n.coteacherAddAlreadyExists({email});
-      }
-      if (json.error.includes('section full')) {
-        return i18n.coteacherAddSectionFull();
-      }
-      if (json.error.includes('inviting self')) {
-        return i18n.coteacherCannotInviteSelf();
-      }
-      return i18n.coteacherUnknownValidationError({
-        email,
+    return response
+      .json()
+      .then(json => {
+        if (json.error.includes('already invited')) {
+          return i18n.coteacherAddAlreadyExists({email});
+        }
+        if (json.error.includes('section full')) {
+          return i18n.coteacherAddSectionFull();
+        }
+        if (json.error.includes('inviting self')) {
+          return i18n.coteacherCannotInviteSelf();
+        }
+        return i18n.coteacherUnknownValidationError({
+          email,
+        });
+      })
+      .catch(() => {
+        return i18n.coteacherUnknownValidationError({
+          email,
+        });
       });
-    });
   });
 };
 

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherTable.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherTable.jsx
@@ -65,8 +65,8 @@ export default function CoteacherTable({coteachers, setCoteacherToRemove}) {
   };
 
   return coteachers.length === 0 ? (
-    <div className={classNames(styles.table, styles.tableRow)}>
-      {i18n.coteacherNoCoteachers()}
+    <div className={styles.table}>
+      <div className={styles.tableRow}>{i18n.coteacherNoCoteachers()}</div>
     </div>
   ) : (
     <table className={styles.table}>

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/coteacher-settings.module.scss
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/coteacher-settings.module.scss
@@ -62,10 +62,9 @@
 }
 
 .table {
-  width: 100%;
   border-left: 1px solid $light_gray_200;
   border-right: 1px solid $light_gray_200;
-  padding-bottom: 20px;
+  margin-bottom: 20px;
 
   &Row {
     display: flex;

--- a/apps/test/unit/templates/sectionsRefresh/coteacherSettings/AddCoteacherTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/coteacherSettings/AddCoteacherTest.jsx
@@ -74,7 +74,9 @@ describe('AddCoteacher', () => {
     const setAddErrorSpy = sinon.spy();
 
     const setCoteachersToAddSpy = makeSpyWithAssertions(func => {
-      expect(fetchSpy).to.be.calledOnce;
+      expect(fetchSpy).to.be.calledOnceWith(
+        `/api/v1/section_instructors/check?email=new-email%40code.org`
+      );
       expect(setCoteachersToAddSpy).to.be.calledOnce;
       expect(func([])).to.deep.equal(['new-email@code.org']);
       expect(setAddErrorSpy).to.have.been.calledOnceWith('');
@@ -83,6 +85,31 @@ describe('AddCoteacher', () => {
     const wrapper = shallow(
       <AddCoteacher
         {...DEFAULT_PROPS}
+        coteachersToAdd={['coelophysis@code.org']}
+        setCoteachersToAdd={setCoteachersToAddSpy}
+        setAddError={setAddErrorSpy}
+      />
+    );
+    addTeacher(wrapper, 'new-email@code.org');
+  });
+
+  it('adds coteacher when valid email is added', done => {
+    fetchSpy.returns(Promise.resolve({ok: true}));
+    const setAddErrorSpy = sinon.spy();
+
+    const setCoteachersToAddSpy = makeSpyWithAssertions(func => {
+      expect(fetchSpy).to.be.calledOnceWith(
+        `/api/v1/section_instructors/check?email=new-email%40code.org&section_id=1`
+      );
+      expect(setCoteachersToAddSpy).to.be.calledOnce;
+      expect(func([])).to.deep.equal(['new-email@code.org']);
+      expect(setAddErrorSpy).to.have.been.calledOnceWith('');
+    }, done);
+
+    const wrapper = shallow(
+      <AddCoteacher
+        {...DEFAULT_PROPS}
+        sectionId={1}
         coteachersToAdd={['coelophysis@code.org']}
         setCoteachersToAdd={setCoteachersToAddSpy}
         setAddError={setAddErrorSpy}
@@ -153,7 +180,9 @@ describe('AddCoteacher', () => {
   });
 
   it('calls check method and shows returned error', done => {
-    fetchSpy.returns(Promise.resolve({ok: false, errorThrown: 'Not Found'}));
+    fetchSpy.returns(
+      Promise.resolve({ok: false, statusText: 'Not Found', status: 404})
+    );
     const setCoteachersToAddSpy = sinon.spy();
 
     const setAddErrorSpy = makeSpyWithAssertions(error => {


### PR DESCRIPTION
Small bug fixes for coteacher UI:
* Fixed sending requests to an invalid URL for section creation
  * It was sending to `url.code.org///?email=email@code.orgundefined`
* Fixed not parsing `not found` (no associated user account) and `forbidden` (authentication error) errors correctly from validation endpoint
* Fixed width overflow when no coteachers exist on a smaller screen

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
