### PR TITLE
HoC 2023 - Fix code.org hero banner width for large screens

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
@@ -66,12 +66,8 @@
   text-align: center;
   color: $white;
   line-height: 1.4;
-  max-width: 70%;
+  max-width: 860px;
   margin: 2rem auto 4rem;
-
-  @media screen and (max-width: $width-md) {
-    max-width: 100%;
-  }
 
   h1, h2 {
     color: $white


### PR DESCRIPTION
Fixes the max-width of the hero banner content container so it looks better on large screens

## Before
<img width="1255" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/06ce015e-da41-4f83-9a6d-148a23b9b651">

## After
<img width="1252" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/7f9d8b54-0134-4fd0-9ee0-57580833bae3">
