### PR TITLE
added preserve_hierarchy option to Crowdin projects

### DIFF
--- a/bin/i18n/codeorg-testing_crowdin.yml
+++ b/bin/i18n/codeorg-testing_crowdin.yml
@@ -3,7 +3,7 @@
 #
 "project_identifier" : "codeorg-testing"
 "project_id" : "346087"
-"base_path" : "../../i18n/locales/source"
+"base_path" : "i18n/locales/source"
 "preserve_hierarchy": true
 
 # API Credentials must be loaded from a separate identity file. See

--- a/bin/i18n/codeorg-testing_crowdin.yml
+++ b/bin/i18n/codeorg-testing_crowdin.yml
@@ -3,7 +3,8 @@
 #
 "project_identifier" : "codeorg-testing"
 "project_id" : "346087"
-"base_path" : "i18n/locales"
+"base_path" : "../../i18n/locales/source"
+"preserve_hierarchy": true
 
 # API Credentials must be loaded from a separate identity file. See
 # https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials
@@ -18,7 +19,7 @@ files: [
   # Source files filter
   # e.g. "/resources/en/*.json"
   #
-  "source" : "/source/**/*.yml",
+  "source" : "/**/*.yml",
 
   #
   # where translations live
@@ -32,8 +33,8 @@ files: [
   #
   # hourofcode content is handled by the hourofcode-specific sync
   "ignore" : [
-    "/source/hourofcode/**",
-    "/source/dashboard/restricted.yml"
+    "/hourofcode/**",
+    "/dashboard/restricted.yml"
   ],
 
   #
@@ -43,13 +44,14 @@ files: [
   "update_option" : "update_as_unapproved"
  }, {
   # config for json content
-  "source" : "/source/**/*.json",
+  "source" : "/**/*.json",
   "translation" : "/%language%/**/%original_file_name%",
   "ignore" : [
-    "/source/hourofcode/**",
-    "/source/blockly-mooc/calc.json",
-    "/source/blockly-mooc/eval.json",
-    "/source/blockly-mooc/netsim.json"
+    "/hourofcode/**",
+    "/blockly-mooc/calc.json",
+    "/blockly-mooc/eval.json",
+    "/blockly-mooc/netsim.json",
+    "/blockly-mooc/mlPlayground.json"
   ],
   "update_option" : "update_as_unapproved"
  }

--- a/bin/i18n/codeorg_crowdin.yml
+++ b/bin/i18n/codeorg_crowdin.yml
@@ -3,7 +3,8 @@
 #
 "project_identifier" : "codeorg"
 "project_id" : "26074"
-"base_path" : "i18n/locales"
+"base_path" : "i18n/locales/source"
+"preserve_hierarchy": true
 
 # API Credentials must be loaded from a separate identity file. See
 # https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials
@@ -18,7 +19,7 @@ files: [
   # Source files filter
   # e.g. "/resources/en/*.json"
   #
-  "source" : "/source/**/*.yml",
+  "source" : "/**/*.yml",
 
   #
   # where translations live
@@ -32,8 +33,8 @@ files: [
   #
   # hourofcode content is handled by the hourofcode-specific sync
   "ignore" : [
-    "/source/hourofcode/**",
-    "/source/dashboard/restricted.yml"
+    "/hourofcode/**",
+    "/dashboard/restricted.yml"
   ],
 
   #
@@ -43,14 +44,14 @@ files: [
   "update_option" : "update_as_unapproved"
  }, {
   # config for json content
-  "source" : "/source/**/*.json",
+  "source" : "/**/*.json",
   "translation" : "/%language%/**/%original_file_name%",
   "ignore" : [
-    "/source/hourofcode/**",
-    "/source/blockly-mooc/calc.json",
-    "/source/blockly-mooc/eval.json",
-    "/source/blockly-mooc/netsim.json",
-    "/source/blockly-mooc/mlPlayground.json"
+    "/hourofcode/**",
+    "/blockly-mooc/calc.json",
+    "/blockly-mooc/eval.json",
+    "/blockly-mooc/netsim.json",
+    "/blockly-mooc/mlPlayground.json"
   ],
   "update_option" : "update_as_unapproved"
  }

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -41,16 +41,16 @@ CROWDIN_PROJECTS = {
 
 CROWDIN_TEST_PROJECTS = {
   'codeorg-testing': {
-    config_file: File.join(File.dirname(__FILE__), "codeorg-testing_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
-    etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_etags.json"),
-    files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_files_to_sync_out.json")
+    config_file:            CDO.dir('bin/i18n/codeorg-testing_crowdin.yml'),
+    identity_file:          CDO.dir('bin/i18n/crowdin_credentials.yml'),
+    etags_json:             CDO.dir('bin/i18n/crowdin/codeorg-testing_etags.json'),
+    files_to_sync_out_json: CDO.dir('bin/i18n/crowdin/codeorg-testing_files_to_sync_out.json')
   },
   'codeorg-markdown-testing': {
-    config_file: File.join(File.dirname(__FILE__), "codeorg-testing_markdown_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
-    etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_markdown_etags.json"),
-    files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_markdown_files_to_sync_out.json")
+    config_file:            CDO.dir('bin/i18n/codeorg-testing_markdown_crowdin.yml'),
+    identity_file:          CDO.dir('bin/i18n/crowdin_credentials.yml'),
+    etags_json:             CDO.dir('bin/i18n/crowdin/codeorg-testing_markdown_etags.json'),
+    files_to_sync_out_json: CDO.dir('bin/i18n/crowdin/codeorg-testing_markdown_files_to_sync_out.json')
   }
 }
 


### PR DESCRIPTION
In order to support different file formats without changing the directory structure of the crowdin project, we need to preserve the existing source structure.

Let’s say the file/folder structure on your machine looks like this:
```
i18n
    |
    |-- source
        |-- emails
        |-- app
             |-- foo.json
             |-- bar.yml
```
If we don’t use the `"preserve_hierarchy": true` option in our configuration file at all or use it with the false value, all shared directories will be skipped, and the file structure in Crowdin will be represented as follows:
```
- foo.json
- bar.yml
```
Enabling this option allows for preserving the hierarchy of directories and files in Crowdin.

## Links

- jira ticket: [P20-575](https://codedotorg.atlassian.net/browse/P20-575)
- [Crowdin Doc](https://developer.crowdin.com/configuration-file/#saving-directory-structure-on-server)

## Testing story
I ran the sync-up and checked that the Corwdin project structure was not altered.
<img width="1552" alt="Screenshot 2023-11-07 at 19 29 24" src="https://github.com/code-dot-org/code-dot-org/assets/66776217/cee9672b-e77b-4776-b08e-493a92d0c2a1">


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
