### PR TITLE
Replace email signature of PD emails

### DIFF
--- a/dashboard/app/mailers/pd/regional_partner_mini_contact_mailer.rb
+++ b/dashboard/app/mailers/pd/regional_partner_mini_contact_mailer.rb
@@ -1,6 +1,6 @@
 class Pd::RegionalPartnerMiniContactMailer < ApplicationMailer
   NO_REPLY = 'Code.org <noreply@code.org>'
-  default from: 'Dave Frye <partner@code.org>'
+  default from: 'Sam Morris <partner@code.org>'
   default bcc: MailerConstants::PLC_EMAIL_LOG
 
   def matched(form, rp_pm)

--- a/dashboard/app/views/pd/fit_weekend_registration_mailer/confirmation.html.haml
+++ b/dashboard/app/views/pd/fit_weekend_registration_mailer/confirmation.html.haml
@@ -20,8 +20,8 @@
   Thank you,
 
 %p
-  Sam Morris
+  Andrea Robertson-Nottingham
   %br
-  Regional Partner Network Manager, Code.org
+  Facilitator Network Manager, Code.org
   %br
   Code.org

--- a/dashboard/app/views/pd/fit_weekend_registration_mailer/confirmation.html.haml
+++ b/dashboard/app/views/pd/fit_weekend_registration_mailer/confirmation.html.haml
@@ -20,8 +20,8 @@
   Thank you,
 
 %p
-  Dave Frye
+  Sam Morris
   %br
-  Director of Program Development and Operations, Code.org
+  Regional Partner Network Manager, Code.org
   %br
   Code.org

--- a/dashboard/app/views/pd/regional_partner_mini_contact_mailer/matched.html.haml
+++ b/dashboard/app/views/pd/regional_partner_mini_contact_mailer/matched.html.haml
@@ -28,9 +28,9 @@
   %br
   &nbsp;
   %br
-  Dave Frye
+  Sam Morris
   %br
-  Director of Programs
+  Regional Partner Network Manager
   %br
   partner@code.org
   %br

--- a/dashboard/app/views/pd/regional_partner_mini_contact_mailer/receipt.html.haml
+++ b/dashboard/app/views/pd/regional_partner_mini_contact_mailer/receipt.html.haml
@@ -29,7 +29,7 @@
   Best,
   %br
   %br
-  Dave Frye
+  Sam Morris
   %br
-  Director of Program Development and Operations, Code.org
+  Regional Partner Network Manager, Code.org
 

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
@@ -56,9 +56,9 @@
   Thank you,
   %br
   - if @workshop.course == Pd::Workshop::COURSE_CSF
-    Dave Frye
+    Sam Morris
     %br
-    Director of Program Development and Operations, Code.org
+    Regional Partner Network Manager, Code.org
   - else
     = @workshop.organizer.name
 

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
@@ -55,12 +55,7 @@
 %p
   Thank you,
   %br
-  - if @workshop.course == Pd::Workshop::COURSE_CSF
-    Sam Morris
-    %br
-    Regional Partner Network Manager, Code.org
-  - else
-    = @workshop.organizer.name
+  = @workshop.organizer.name
 
 %p
   P.S. Connect with other computer science teachers on Twitter

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml
@@ -36,6 +36,6 @@
 %p
   Thank you,
   %br
-  Sam Morris
+  Andrea Robertson-Nottingham
   %br
-  Regional Partner Network Manager, Code.org
+  Facilitator Network Manager, Code.org

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml
@@ -36,6 +36,6 @@
 %p
   Thank you,
   %br
-  Dave Frye
+  Sam Morris
   %br
-  Director of Program Development and Operations, Code.org
+  Regional Partner Network Manager, Code.org

--- a/dashboard/app/views/pd/workshop_mailer/exit_survey.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/exit_survey.html.haml
@@ -78,9 +78,9 @@
   %p
     Thank you,
     %br
-    Dave Frye
+    Sam Morris
     %br
-    Director of Program Development and Operations, Code.org
+    Regional Partner Network Manager, Code.org
 
 - else
   %p

--- a/dashboard/app/views/pd/workshop_mailer/exit_survey.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/exit_survey.html.haml
@@ -78,9 +78,7 @@
   %p
     Thank you,
     %br
-    Sam Morris
-    %br
-    Regional Partner Network Manager, Code.org
+    = @workshop.organizer.name
 
 - else
   %p

--- a/dashboard/app/views/pd/workshop_mailer/teacher_cancel_receipt.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_cancel_receipt.html.haml
@@ -30,5 +30,5 @@
 - if @workshop.course == Pd::Workshop::COURSE_CSF
   %p
     Thank you,
-    %br Dave Frye
-    %br Director of Program Development and Operations, Code.org
+    %br Sam Morris
+    %br Regional Partner Network Manager, Code.org

--- a/dashboard/app/views/pd/workshop_mailer/teacher_cancel_receipt.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_cancel_receipt.html.haml
@@ -22,9 +22,7 @@
 
 %p
   If this is a mistake and you did not mean to cancel your workshop registration,
-  contact your workshop organizer
-  = @workshop.organizer.name
-  at
+  please email
   = mail_to(@workshop.organizer.email) + '.'
 
 %p

--- a/dashboard/app/views/pd/workshop_mailer/teacher_cancel_receipt.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_cancel_receipt.html.haml
@@ -27,8 +27,7 @@
   at
   = mail_to(@workshop.organizer.email) + '.'
 
-- if @workshop.course == Pd::Workshop::COURSE_CSF
-  %p
-    Thank you,
-    %br Sam Morris
-    %br Regional Partner Network Manager, Code.org
+%p
+  Thank you,
+  %br
+  = @workshop.organizer.name

--- a/dashboard/app/views/pd/workshop_mailer/teacher_follow_up.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_follow_up.html.haml
@@ -49,5 +49,5 @@
 
   %p
     Thank you,
-    %br Sam Morris
-    %br Regional Partner Network Manager, Code.org
+    %br Danielle Boulden
+    %br K-5 Program Manager, Code.org

--- a/dashboard/app/views/pd/workshop_mailer/teacher_follow_up.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_follow_up.html.haml
@@ -49,5 +49,5 @@
 
   %p
     Thank you,
-    %br Dave Frye
-    %br Director of Program Development and Operations, Code.org
+    %br Sam Morris
+    %br Regional Partner Network Manager, Code.org


### PR DESCRIPTION
Replace Dave Frye with Sam Morris in email signatures.

I'm not sure if all of these replacements are correct so let me know if someone else should be listed instead.