### PR TITLE
Hide Minecraft AI for Earth Tile on code.org/minecraft

### DIFF
--- a/pegasus/sites.v3/code.org/views/minecraft/minecraft_education_activities.haml
+++ b/pegasus/sites.v3/code.org/views/minecraft/minecraft_education_activities.haml
@@ -13,15 +13,19 @@
       desc: hoc_s(:minecraft_education_activity_desc_2021),
       url: "https://education.minecraft.net/en-us/resources/hour-code-2021",
       aria_label: hoc_s(:aria_label_call_to_action_minecraft_2021)
-    },
-    {
-      title: hoc_s(:minecraft_education_activity_title_2020),
-      image: "/images/mc/minecraft-activity-gen-ai-for-earth-2020.png",
-      desc: hoc_s(:minecraft_education_activity_desc_2020),
-      url: "https://education.minecraft.net/en-us/lessons/minecraft-hour-of-code",
-      aria_label: hoc_s(:aria_label_call_to_action_minecraft_2020)
-    },
+    }
   ]
+
+-# Hiding the Minecraft AI for Earth activity until further
+-# notice from Microsoft — put this object back in the activity_item
+-# array if we need to add this back.
+-# {
+-#   title: hoc_s(:minecraft_education_activity_title_2020),
+-#   image: "/images/mc/minecraft-activity-gen-ai-for-earth-2020.png",
+-#   desc: hoc_s(:minecraft_education_activity_desc_2020),
+-#   url: "https://education.minecraft.net/en-us/lessons/minecraft-hour-of-code",
+-#   aria_label: hoc_s(:aria_label_call_to_action_minecraft_2020)
+-# }
 
 -# Hiding this until the activity is ready
 -# .action-block.action-block--two-col
@@ -41,7 +45,7 @@
 -#       = hoc_s(:call_to_action_get_started)
 -#   .clear
 
-.action-block__wrapper.action-block__wrapper--three-col
+.action-block__wrapper.action-block__wrapper--two-col
   - activity_item.each do |activity_item|
     .action-block.action-block--one-col.flex-space-between
       .content-wrapper


### PR DESCRIPTION
Hide the Minecraft AI for Earth activity on https://code.org/minecraft. The activity is broken, and we aren't sure if it'll be fixed. I kept the code for it commented out if we need to add it back.

**Jira ticket:** [ACQ-1160](https://codedotorg.atlassian.net/browse/ACQ-1160)

----

## Before
<img width="1021" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/dfbca96f-cff0-4590-b399-2ec31c6a7199">

## After
<img width="1059" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/57a877ee-66fc-4d13-9660-a3ad7843623e">
