### PR TITLE
Adds receives_marketing to controller and factory

### DIFF
--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import cookies from 'js-cookie';
 import GameButtons from '../templates/GameButtons';
 import ArrowButtons from '../templates/ArrowButtons';
 import BelowVisualization from '../templates/BelowVisualization';
@@ -113,9 +114,10 @@ class DanceVisualizationColumn extends React.Component {
         {!this.props.isShareView && (
           <AgeDialog turnOffFilter={this.turnFilterOff} />
         )}
-        {(this.props.over21 || this.props.userType === 'teacher') && (
-          <HourOfCodeGuideEmailDialog isSignedIn={isSignedIn} />
-        )}
+        {(this.props.over21 || this.props.userType === 'teacher') &&
+          !(cookies.get('HourOfCodeGuideEmailDialogSeen') === 'true') && (
+            <HourOfCodeGuideEmailDialog isSignedIn={isSignedIn} />
+          )}
         <div style={{maxWidth: MAX_GAME_WIDTH}}>
           {!this.props.isShareView && (
             <SongSelector

--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import cookies from 'js-cookie';
 import GameButtons from '../templates/GameButtons';
 import ArrowButtons from '../templates/ArrowButtons';
 import BelowVisualization from '../templates/BelowVisualization';
@@ -114,10 +113,9 @@ class DanceVisualizationColumn extends React.Component {
         {!this.props.isShareView && (
           <AgeDialog turnOffFilter={this.turnFilterOff} />
         )}
-        {(this.props.over21 || this.props.userType === 'teacher') &&
-          !(cookies.get('HourOfCodeGuideEmailDialogSeen') === 'true') && (
-            <HourOfCodeGuideEmailDialog isSignedIn={isSignedIn} />
-          )}
+        {(this.props.over21 || this.props.userType === 'teacher') && (
+          <HourOfCodeGuideEmailDialog isSignedIn={isSignedIn} />
+        )}
         <div style={{maxWidth: MAX_GAME_WIDTH}}>
           {!this.props.isShareView && (
             <SongSelector

--- a/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
+++ b/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
@@ -1,5 +1,4 @@
 import React, {useState} from 'react';
-import cookies from 'js-cookie';
 import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import Button from '@cdo/apps/templates/Button';
@@ -15,10 +14,6 @@ function HourOfCodeGuideEmailDialog({isSignedIn}) {
   const [isMarketingChecked, setIsMarketingChecked] = useState(false);
 
   const onClose = () => {
-    cookies.set('HourOfCodeGuideEmailDialogSeen', 'true', {
-      expires: 90,
-      path: '/',
-    });
     setIsOpen(false);
   };
 

--- a/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
+++ b/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import cookies from 'js-cookie';
 import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import Button from '@cdo/apps/templates/Button';
@@ -14,6 +15,10 @@ function HourOfCodeGuideEmailDialog({isSignedIn}) {
   const [isMarketingChecked, setIsMarketingChecked] = useState(false);
 
   const onClose = () => {
+    cookies.set('HourOfCodeGuideEmailDialogSeen', 'true', {
+      expires: 90,
+      path: '/',
+    });
     setIsOpen(false);
   };
 

--- a/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
+++ b/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
@@ -1,9 +1,11 @@
 import {assert, expect} from 'chai';
 import React from 'react';
 import {UnconnectedHourOfCodeGuideEmailDialog as HourOfCodeGuideEmailDialog} from '@cdo/apps/templates/HourOfCodeGuideEmailDialog';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import i18n from '@cdo/locale';
 import experiments from '@cdo/apps/util/experiments';
+import sinon from 'sinon';
+import cookies from 'js-cookie';
 
 describe('HourOfCodeGuideEmailDialog', () => {
   const defaultProps = {
@@ -28,5 +30,17 @@ describe('HourOfCodeGuideEmailDialog', () => {
     experiments.setEnabled(experiments.HOC_TUTORIAL_DIALOG, false);
     const wrapper = shallow(<HourOfCodeGuideEmailDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);
+  });
+
+  it('cookie is save when dialog is closed', () => {
+    const wrapper = mount(<HourOfCodeGuideEmailDialog {...defaultProps} />);
+    var cookieSetStub = sinon.stub(cookies, 'set');
+    wrapper.find('.uitest-no-email-guide').simulate('click');
+    expect(cookieSetStub).to.have.been.calledWith(
+      'HourOfCodeGuideEmailDialogSeen',
+      'true',
+      {expires: 90, path: '/'}
+    );
+    cookies.set.restore();
   });
 });

--- a/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
+++ b/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
@@ -35,7 +35,7 @@ describe('HourOfCodeGuideEmailDialog', () => {
   it('cookie is save when dialog is closed', () => {
     const wrapper = mount(<HourOfCodeGuideEmailDialog {...defaultProps} />);
     var cookieSetStub = sinon.stub(cookies, 'set');
-    wrapper.find('.uitest-no-email-guide').simulate('click');
+    wrapper.find('Button').at(0).simulate('click');
     expect(cookieSetStub).to.have.been.calledWith(
       'HourOfCodeGuideEmailDialogSeen',
       'true',

--- a/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
+++ b/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
@@ -1,11 +1,9 @@
 import {assert, expect} from 'chai';
 import React from 'react';
 import {UnconnectedHourOfCodeGuideEmailDialog as HourOfCodeGuideEmailDialog} from '@cdo/apps/templates/HourOfCodeGuideEmailDialog';
-import {shallow, mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import i18n from '@cdo/locale';
 import experiments from '@cdo/apps/util/experiments';
-import sinon from 'sinon';
-import cookies from 'js-cookie';
 
 describe('HourOfCodeGuideEmailDialog', () => {
   const defaultProps = {
@@ -30,17 +28,5 @@ describe('HourOfCodeGuideEmailDialog', () => {
     experiments.setEnabled(experiments.HOC_TUTORIAL_DIALOG, false);
     const wrapper = shallow(<HourOfCodeGuideEmailDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);
-  });
-
-  it('cookie is save when dialog is closed', () => {
-    const wrapper = mount(<HourOfCodeGuideEmailDialog {...defaultProps} />);
-    var cookieSetStub = sinon.stub(cookies, 'set');
-    wrapper.find('Button').at(0).simulate('click');
-    expect(cookieSetStub).to.have.been.calledWith(
-      'HourOfCodeGuideEmailDialogSeen',
-      'true',
-      {expires: 90, path: '/'}
-    );
-    cookies.set.restore();
   });
 });

--- a/dashboard/app/controllers/potential_teachers_controller.rb
+++ b/dashboard/app/controllers/potential_teachers_controller.rb
@@ -17,13 +17,14 @@ class PotentialTeachersController < ApplicationController
     @potential_teacher_data = {
       name: @potential_teacher.name,
       email: @potential_teacher.email,
-      source_course_offering: @potential_teacher.source_course_offering_id
+      source_course_offering: @potential_teacher.source_course_offering_id,
+      receives_marketing: @potential_teacher.receives_marketing
     }
     render json: @potential_teacher_data
   end
 
   private def potential_teacher_params
-    params.permit(:name, :email, :source_course_offering_id).to_h
+    params.permit(:name, :email, :source_course_offering_id, :receives_marketing).to_h
   end
 
   def set_potential_teacher

--- a/dashboard/test/controllers/potential_teachers_controller_test.rb
+++ b/dashboard/test/controllers/potential_teachers_controller_test.rb
@@ -7,14 +7,15 @@ class PotentialTeachersControllerTest < ActionDispatch::IntegrationTest
       post potential_teachers_url, params: {
         name: 'foosbars',
         email: 'foobar@example.com',
-        source_course_offering_id: course_offering.id
+        source_course_offering_id: course_offering.id,
+        receives_marketing: true
       }
     end
   end
 
   test "show returns correct information for a potential teacher" do
     course_offering = create :course_offering, key: 'course-offering-1', display_name: "Test"
-    example_potential_teacher = create :potential_teacher, source_course_offering_id: course_offering.id
+    example_potential_teacher = create :potential_teacher, source_course_offering_id: course_offering.id, receives_marketing: true
 
     get "/potential_teachers/#{example_potential_teacher.id}"
 
@@ -22,5 +23,6 @@ class PotentialTeachersControllerTest < ActionDispatch::IntegrationTest
     assert_equal example_potential_teacher.name, response_data['name']
     assert_equal example_potential_teacher.email, response_data['email']
     assert_equal example_potential_teacher.source_course_offering_id, response_data['source_course_offering']
+    assert_equal example_potential_teacher.receives_marketing, response_data['receives_marketing']
   end
 end

--- a/dashboard/test/controllers/potential_teachers_controller_test.rb
+++ b/dashboard/test/controllers/potential_teachers_controller_test.rb
@@ -15,7 +15,7 @@ class PotentialTeachersControllerTest < ActionDispatch::IntegrationTest
 
   test "show returns correct information for a potential teacher" do
     course_offering = create :course_offering, key: 'course-offering-1', display_name: "Test"
-    example_potential_teacher = create :potential_teacher, source_course_offering_id: course_offering.id, receives_marketing: true
+    example_potential_teacher = create :potential_teacher, source_course_offering_id: course_offering.id
 
     get "/potential_teachers/#{example_potential_teacher.id}"
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1872,5 +1872,6 @@ FactoryBot.define do
     association :source_course_offering
     name {"foosbars"}
     email {"foobar@example.com"}
+    receives_marketing {true}
   end
 end


### PR DESCRIPTION
Used [this PR](https://github.com/code-dot-org/code-dot-org/pull/54652) as guidance

I added a [table migration to include a new receives_marketing column](https://github.com/code-dot-org/code-dot-org/pull/54758) yesterday. This PR updates the relevant controller files (and test) to incorporate this new column.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
