### PR TITLE
create engineer role without S3 access

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -325,11 +325,13 @@ roles = {
       '!Ref ContributorSecretsPolicy',
     ]
   },
-  TempS3LessContributorRole: {
-    RoleName: 'Temp_S3less_Contributor',
+  TempS3LessEngineerRole: {
+    RoleName: 'Temp_S3less_Engineer',
     GoogleIdsSSMParameter: 'DeveloperGoogleIDs',
     ManagedPolicyArns: [
-      '!Ref ContributorSecretsPolicy',
+      'arn:aws:iam::aws:policy/PowerUserAccess',
+      'arn:aws:iam::aws:policy/IAMReadOnlyAccess',
+      !Ref NoS3ForYouPolicy,
     ]
   },
   EngineeringMusicLabContributorRole: {
@@ -396,6 +398,18 @@ roles.each do |name, config| %>
         - Key: sqlworkbench-team
           Value: codedotorg
 <%- end -%>
+
+  NoS3ForYouPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: NoS3ForYouPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Deny
+            Action:
+              - s3:*
+            Resource: '*'
 
   DataAnalystPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -331,7 +331,7 @@ roles = {
     ManagedPolicyArns: [
       'arn:aws:iam::aws:policy/PowerUserAccess',
       'arn:aws:iam::aws:policy/IAMReadOnlyAccess',
-      !Ref NoS3ForYouPolicy,
+      '!Ref NoS3ForYouPolicy',
     ]
   },
   EngineeringMusicLabContributorRole: {


### PR DESCRIPTION
Create an engineer role that doesn't have S3 permissions.

## Deployment strategy

deploy manually per local README.

## Follow-up work

Delete this role when no longer needed.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
