### PR TITLE
Fix parsing errors incorrectly on staging

### DIFF
--- a/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
@@ -34,10 +34,10 @@ export const getInputErrorMessage = (email, coteachersToAdd, sectionId) => {
     if (response.ok) {
       return '';
     }
-    if (response.status === 404 && response.statusText === 'Not Found') {
+    if (response.status === 404) {
       return i18n.coteacherAddNoAccount({email});
     }
-    if (response.status === 403 && response.statusText === 'Forbidden') {
+    if (response.status === 403) {
       return i18n.coteacherUnableToEditCoteachers();
     }
 
@@ -53,11 +53,14 @@ export const getInputErrorMessage = (email, coteachersToAdd, sectionId) => {
         if (json.error.includes('inviting self')) {
           return i18n.coteacherCannotInviteSelf();
         }
+
+        console.error(response);
         return i18n.coteacherUnknownValidationError({
           email,
         });
       })
-      .catch(() => {
+      .catch(e => {
+        console.error(e, response);
         return i18n.coteacherUnknownValidationError({
           email,
         });

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
@@ -54,13 +54,13 @@ export const getInputErrorMessage = (email, coteachersToAdd, sectionId) => {
           return i18n.coteacherCannotInviteSelf();
         }
 
-        console.error(response);
+        console.error('Coteacher validation error', response);
         return i18n.coteacherUnknownValidationError({
           email,
         });
       })
       .catch(e => {
-        console.error(e, response);
+        console.error('Coteacher validation error', e, response);
         return i18n.coteacherUnknownValidationError({
           email,
         });


### PR DESCRIPTION
When receiving a `404 Not Found` error from the coteacher validation endpoint we should display a message for `account not found`. On localhost (with newest staging branch) this is working. On staging, this is not.

This PR tests the hypothesis that this is due to a difference in how strings are matched. The 404 and 403 statuses should always have the same text, so we should only ever need to test the status anyways.

Additionally, this logs an error that will be helpful in debugging both if this doesn't work and after the UI is enabled. This error is only displayed when the validation endpoint error is not parseable.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
