### PR TITLE
Fix broken Hour of Code events pages

### DIFF
--- a/pegasus/helper_modules/forms.rb
+++ b/pegasus/helper_modules/forms.rb
@@ -36,7 +36,7 @@ module Forms
         where(kind: kind).
         where(entire_school ? {json('data.entire_school_flag_b') => true} : {}).
         where(review_approved ? {review: 'approved'} : {}).
-        exclude(country_column => except_country).
+        exclude(country_column => except_country.upcase).
         group_and_count(country_column.as(:country_code)).
         tap {|x| puts x.sql, x.explain if explain}.
         all
@@ -54,7 +54,7 @@ module Forms
       FORMS.
         where(
           kind: kind,
-          country_column => country
+          country_column => country.upcase
         ).
         where(entire_school ? {json('data.entire_school_flag_b') => true} : {}).
         where(review_approved ? {review: 'approved'} : {}).
@@ -88,7 +88,7 @@ module Forms
         ).
         where(
           kind: kind,
-          country_column => country
+          country_column => country.upcase
         ).
         where(state ? {state_column => state.upcase} : {}).
         where(entire_school ? {json('data.entire_school_flag_b') => true} : {}).


### PR DESCRIPTION
After [this PR](https://github.com/code-dot-org/code-dot-org/pull/54428) was merged, the events pages at [hourofcode.com/us/events/all](https://hourofcode.com/us/events/all) stopped working because `Forms.find_by_name` wasn't finding any results [here](https://github.com/code-dot-org/code-dot-org/blob/staging/pegasus/sites.v3/hourofcode.com/public/events/all/splat.haml#L30-L31):
![bad_page](https://github.com/code-dot-org/code-dot-org/assets/56283563/bfaa1bb5-8713-4fe0-879e-aa62f26bd992)

The issue was simply that the countries being passed in using the [other field](https://github.com/code-dot-org/code-dot-org/pull/54428/files#diff-c3ef9b25af88e3ca2f19a2be2c57761ffe5d8d1b906ea82f38e7d3458ccb7350R18) were coming in lowercase, so this PR makes them uppercase when comparing country codes. Now, the pages are actually loading properly:

### Original
https://github.com/code-dot-org/code-dot-org/assets/56283563/4052c3da-bb8a-4d93-96e0-a1482b0adde5

### New
https://github.com/code-dot-org/code-dot-org/assets/56283563/af0d5e26-b235-44e1-be5f-5b7068a30af2

## Links
Jira ticket: [here]()
Previous PR that caused this bug: [here](https://github.com/code-dot-org/code-dot-org/pull/54428)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
