### PR TITLE
Fix bug including deleted sections in User.sections_instructed

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -474,7 +474,7 @@ class User < ApplicationRecord
 
   has_many :section_instructors, foreign_key: 'instructor_id'
   has_many :active_section_instructors, -> {where(status: :active)}, class_name: 'SectionInstructor', foreign_key: 'instructor_id'
-  has_many :sections_instructed, through: :active_section_instructors, source: :section
+  has_many :sections_instructed, -> {without_deleted}, through: :active_section_instructors, source: :section
 
   # TODO once the backfill creates SectionInstructors for every section owner,
   # this method can be deleted and its references replaced by sections_instructed

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1829,6 +1829,17 @@ class UserTest < ActiveSupport::TestCase
     refute student.can_change_own_user_type?
   end
 
+  test 'sections_instructed omits deleted sections' do
+    section = create :section
+    teacher = section.teacher
+
+    refute_empty teacher.sections_instructed
+
+    section.destroy!
+
+    assert_empty teacher.sections_instructed
+  end
+
   test 'cannot change own user type as a teacher with sections' do
     section = create :section
     teacher = section.teacher


### PR DESCRIPTION
The new `User.sections_instructed` association meant to show a teacher's sections through the new coteacher relation was not filtering out deleted sections. Now it will.

## Links
[Zendesk ticket 1](https://codeorg.zendesk.com/agent/tickets/470044)
[Zendesk ticket 2](https://codeorg.zendesk.com/agent/tickets/470290)
[Zendesk ticket 3](https://codeorg.zendesk.com/agent/tickets/470349)

## Testing story

Automated test included to verify deleted sections no longer show up in the list.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
