### PR TITLE
Prepare to Decommission Hour of Code Classic Load Balancer

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -71,12 +71,12 @@ Resources:
   HourOfCodeCertificate:
     Type: AWS::CertificateManager::Certificate
     Properties:
-      DomainName: !Sub "www.${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
+      DomainName: !Sub "${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
       SubjectAlternativeNames:
         - !Sub "www.${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
       ValidationMethod: DNS
       DomainValidationOptions:
-        - DomainName: !Sub "www.${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
+        - DomainName: !Sub "${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
           HostedZoneId: !Ref HourOfCodeHostedZoneId
         - DomainName: !Sub "www.${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
           HostedZoneId: !Ref HourOfCodeHostedZoneId

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -2,10 +2,18 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: AWS CloudFormation Template for Code.org application
 Parameters:
+  # ---------------------------------------------
+  # Domain Names - Each Stack operates 5 sites (examples are for production):
+  # 1) Learning Platform ("Dashboard") - https://studio.code.org
+  # 2) Corporate Website ("Pegasus") - https://code.org
+  # 3) Advocacy Website (runs on Pegasus) - https://advocacy.code.org
+  # 4) Hour of Code (runs on Pegasus) - https://hourofcode.com
+  # 5) Code Projects (host user created content) - https://codeprojects.org
+  # ---------------------------------------------
   BaseDomainName:
     Type: String
     Default: code.org
-    Description: Base domain name.
+    Description: Base domain name for primary learning platform and corporate web site.
   DashboardSubdomainName:
     Type: String
     Default: <%=rack_env?(:production) ? 'studio' : "#{stack_name}-studio" %>
@@ -14,6 +22,18 @@ Parameters:
     Type: String
     Default: <%=rack_env?(:production) ? '\'\'' : stack_name %>
     Description: Subdomain name for corporate web site ("Pegasus").
+  HourOfCodeBaseDomainName:
+    Type: String
+    Default: hourofcode.com
+    Description: Hour Of Code base domain name.
+  HourOfCodeHostedZoneId:
+    Type: String
+    Default: ""
+    Description: Route 53 Hosted Zone ID for Hour of Code base domain name.
+  HourOfCodeSubdomainName:
+    Type: String
+    Default: <%=rack_env?(:production) ? '\'\'' : stack_name %>
+    Description: Subdomain name for Hour Of Code site.
   InstanceType:
     Type: String
     Default: <%=INSTANCE_TYPE%>
@@ -44,6 +64,19 @@ Parameters:
     Type: String
 <% end -%>
 Resources:
+
+  HourOfCodeCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Sub "www.${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
+      SubjectAlternativeNames:
+        - !Sub "www.${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: !Sub "www.${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
+          HostedZoneId: !Ref HourOfCodeHostedZoneId
+        - DomainName: !Sub "www.${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
+          HostedZoneId: !Ref HourOfCodeHostedZoneId
 
   # ---------------------------------------------
   # Stack-specific IAM permissions
@@ -215,6 +248,7 @@ Resources:
       Protocol: HTTPS
       Certificates:
       - CertificateArn: <%=certificate_arn%>
+      - CertificateArn: !Ref HourOfCodeCertificate
       SslPolicy: ELBSecurityPolicy-2016-08
       DefaultActions:
       - Type: forward

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -28,7 +28,8 @@ Parameters:
     Description: Hour Of Code base domain name.
   HourOfCodeHostedZoneId:
     Type: String
-    Default: ""
+    # Default to ID for `hourofcode.com`
+    Default: Z3TQLAV9VNIB0G
     Description: Route 53 Hosted Zone ID for Hour of Code base domain name.
   HourOfCodeSubdomainName:
     Type: String

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -249,13 +249,21 @@ Resources:
       LoadBalancerArn: !Ref ALB
       Port: 443
       Protocol: HTTPS
+      # Default certificate. Even though the datatype of the Certificates Property is Array, there can only be one.
       Certificates:
       - CertificateArn: <%=certificate_arn%>
-      - CertificateArn: !Ref HourOfCodeCertificate
       SslPolicy: ELBSecurityPolicy-2016-08
       DefaultActions:
       - Type: forward
         TargetGroupArn: !Ref ALBTargetGroup
+  # Full list of certificates used by the Listener for Viewers that support SNI.xl
+  HTTPSListenerCertificates:
+      Type: AWS::ElasticLoadBalancingV2::ListenerCertificate
+      Properties:
+        Certificates:
+          - CertificateArn: <%=certificate_arn%>
+          - CertificateArn: !Ref HourOfCodeCertificate
+        ListenerArn: !GetAtt HTTPSListener.ListenerArn
 
   ALBTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -35,6 +35,8 @@ Parameters:
     Type: String
     Default: <%=rack_env?(:production) ? '\'\'' : stack_name %>
     Description: Subdomain name for Hour Of Code site.
+    AllowedPattern: "^(?!www$).*"
+    ConstraintDescription: GitHubBranch cannot be `www` as this may conflict with the production environment.
   InstanceType:
     Type: String
     Default: <%=INSTANCE_TYPE%>

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -36,7 +36,7 @@ Parameters:
     Default: <%=rack_env?(:production) ? '\'\'' : stack_name %>
     Description: Subdomain name for Hour Of Code site.
     AllowedPattern: "^(?!www$).*"
-    ConstraintDescription: GitHubBranch cannot be `www` as this may conflict with the production environment.
+    ConstraintDescription: Stack Name (typically the git branch name) cannot be `www` as this may conflict with production.
   InstanceType:
     Type: String
     Default: <%=INSTANCE_TYPE%>


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-1061

Before changing the manually provisioned `hourofcode.com` CloudFront Distributions for each managed environment, enable the primary Application Load Balancer to serve traffic sent to `hourofcode.com`.

## Testing story

``` bash
% bundle exec rake adhoc:cdn:start RAILS_ENV=adhoc FRONTENDS=true
```

The Stack did not fully deploy successfully for a variety of reasons (daemon took longer than 60 minutes to provision, etc.). But the load balancer configuration is correct and verified by manually provisioning a DNS entry for the adhoc's Hour of Code site pointed to the load balancer.

```
% curl 'https://adhoc-hourofcode.hourofcode.com/us/health_check'
Healthy
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
