### PR TITLE
Fix Remove Coteacher sending an invalid HTTP request

### DIFF
--- a/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
@@ -25,7 +25,7 @@ export const getInputErrorMessage = (email, coteachersToAdd, sectionId) => {
     `/api/v1/section_instructors/check?email=${encodeURIComponent(email)}` +
       (sectionId ? `&section_id=${sectionId}` : ''),
     {
-      type: 'GET',
+      method: 'GET',
       headers: {
         'Content-Type': 'application/json; charset=utf-8',
       },

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/RemoveCoteacherDialog.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/RemoveCoteacherDialog.jsx
@@ -36,15 +36,6 @@ export default function RemoveCoteacherDialog({
         }
         closeRemoveDialog();
       });
-      // $.ajax({
-      //   url: `/api/v1/section_instructors/${coteacher.id}`,
-      //   method: 'DELETE',
-      // })
-      //   .done(() => {
-      //     removeSavedCoteacher(coteacher.id);
-      //     closeRemoveDialog();
-      //   })
-      //   .fail(closeRemoveDialog);
     },
     [closeRemoveDialog, setCoteachersToAdd, removeSavedCoteacher]
   );

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/RemoveCoteacherDialog.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/RemoveCoteacherDialog.jsx
@@ -28,13 +28,23 @@ export default function RemoveCoteacherDialog({
         return;
       }
       fetch(`/api/v1/section_instructors/${coteacher.id}`, {
-        type: 'DELETE',
+        headers: {'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')},
+        method: 'DELETE',
       }).then(response => {
         if (response.ok) {
           removeSavedCoteacher(coteacher.id);
         }
         closeRemoveDialog();
       });
+      // $.ajax({
+      //   url: `/api/v1/section_instructors/${coteacher.id}`,
+      //   method: 'DELETE',
+      // })
+      //   .done(() => {
+      //     removeSavedCoteacher(coteacher.id);
+      //     closeRemoveDialog();
+      //   })
+      //   .fail(closeRemoveDialog);
     },
     [closeRemoveDialog, setCoteachersToAdd, removeSavedCoteacher]
   );


### PR DESCRIPTION
Remove Coteacher was sending a request that caused a 422, unprocessable entity error. This fixes it by correctly calling the delete method and adding a necessary header.

## Links
[Co-teacher spec](https://docs.google.com/document/d/1zyODkc7VXsAb17W3jefNM9JNkQVZ8nU2q5C9Xlp7cZs/edit#heading=h.3hotlme3tb4g)
[JIRA](https://codedotorg.atlassian.net/browse/TEACH-72)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Manual testing shows successful API calls: 
![image](https://github.com/code-dot-org/code-dot-org/assets/25193259/dbcede01-df7f-4f0a-a379-d15340804f48)

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
