### PR TITLE
[JIMT][disable-download-button] - disables the DownloadReplayVideoButton

### DIFF
--- a/apps/src/code-studio/components/DownloadReplayVideoButton.jsx
+++ b/apps/src/code-studio/components/DownloadReplayVideoButton.jsx
@@ -239,7 +239,10 @@ class DownloadReplayVideoButton extends React.Component {
   };
 
   shouldRenderButton() {
-    return this.props.channelId && this.hasReplayVideo();
+    // this is temporarily disabled until we decide for sure that we want to remove
+    // it entirely or re-enable it after making sure it's working properly.
+    return false;
+    // return this.props.channelId && this.hasReplayVideo();
   }
 
   render() {

--- a/apps/test/unit/code-studio/components/DownloadReplayVideoButton.js
+++ b/apps/test/unit/code-studio/components/DownloadReplayVideoButton.js
@@ -6,7 +6,8 @@ import {expect} from '../../../util/reconfiguredChai';
 
 import {UnconnectedDownloadReplayVideoButton as DownloadReplayVideoButton} from '@cdo/apps/code-studio/components/DownloadReplayVideoButton';
 
-describe('DownloadReplayVideoButton', () => {
+// temporarily skipped because this button is disabled. Re-enable the test if we re-enable the button.
+describe.skip('DownloadReplayVideoButton', () => {
   let wrapper;
 
   let checkVideoSpy;


### PR DESCRIPTION
The `Download Animation` button isn't working properly, so this just temporarily disables it until we decide what to do next. 

Presumably, we'll either remove the button entirely or make it properly functional, this is just a stopgap.

Old:

<img width="750" alt="Screenshot 2023-11-09 at 4 06 59 PM" src="https://github.com/code-dot-org/code-dot-org/assets/1466175/83306a5f-e068-4e34-8827-de20d159aa8d">

vs New:

<img width="740" alt="Screenshot 2023-11-09 at 4 07 08 PM" src="https://github.com/code-dot-org/code-dot-org/assets/1466175/579f1f16-66f9-4ec4-ac81-3055b61a6847">

And the "I Finished" dialog. Old:
<img width="665" alt="Screenshot 2023-11-09 at 5 55 22 PM" src="https://github.com/code-dot-org/code-dot-org/assets/1466175/1a290ccc-07df-48ae-be3a-0146824b4824">

vs New:

<img width="672" alt="Screenshot 2023-11-09 at 5 55 27 PM" src="https://github.com/code-dot-org/code-dot-org/assets/1466175/281650fa-da1f-4e35-98a8-e2db1f8e9d39">



## Links


- trello: [Remove the "Download" button from Dance](https://trello.com/c/P5MsYU2L/110-remove-the-download-button-from-dance)

## Testing story

Just go to a project backed dance party level, click the Share button, and confirm that the `Download Animation` button is not visible.

## Deployment strategy

## Follow-up work

Confirm whether we want to rip out the button entirely or if we want to re-enable the functionality.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
