### PR TITLE
Dance Party: warn if song no longer available

### DIFF
--- a/apps/i18n/dance/en_us.json
+++ b/apps/i18n/dance/en_us.json
@@ -54,5 +54,6 @@
   "danceFeedbackUseSetSize": "Use the `set backup_dancer2 size` block to make that dancer smaller.",
   "danceFeedbackUseSetTint": "Use the `set tint` block to change a dancer's tint.",
   "danceFeedbackUseStartMapping": "Try adding the <xml><block type=\"Dancelab_startMapping\"><title name=\"SPRITE\">right_unicorn</title><title name=\"PROPERTY\">\"scale\"</title><title name=\"RANGE\">\"bass\"</title></block></xml> block to your program.",
+  "danceSongNoLongerSupported": "Code.org has added new hit songs to Dance Party, but the original song chosen on this project is no longer supported by Code.org.",
   "measure": "Measure:"
 }

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3267,6 +3267,8 @@ StudioApp.prototype.displayPlayspaceAlert = function (type, alertContents) {
 
   const playspaceAlert = React.createElement(Alert, alertProps, alertContents);
   ReactDOM.render(playspaceAlert, renderElement);
+
+  return renderElement;
 };
 
 /**

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -236,6 +236,12 @@ Dance.prototype.initSongs = async function (config) {
           config.level.selectedSong = songId;
         }
       },
+      onSongUnavailable: () => {
+        this.songUnavailableAlert = this.studioApp_.displayPlayspaceAlert(
+          'warning',
+          React.createElement('div', {}, danceMsg.danceSongNoLongerSupported())
+        );
+      },
     })
   );
 };
@@ -259,6 +265,10 @@ Dance.prototype.setSongCallback = function (songId) {
       },
       onSongSelected: songId => {
         this.updateSongMetadata(songId);
+        if (this.songUnavailableAlert) {
+          this.studioApp_.closeAlert(this.songUnavailableAlert);
+          this.songUnavailableAlert = undefined;
+        }
 
         const hasChannel = !!getStore().getState().pageConstants.channelId;
         if (hasChannel) {
@@ -575,6 +585,11 @@ Dance.prototype.runButtonClick = async function () {
   var clickToRunImage = document.getElementById('danceClickToRun');
   if (clickToRunImage) {
     clickToRunImage.style.display = 'none';
+  }
+
+  if (this.songUnavailableAlert) {
+    this.studioApp_.closeAlert(this.songUnavailableAlert);
+    this.songUnavailableAlert = undefined;
   }
 
   // Block re-entrancy since starting a run is async

--- a/apps/src/dance/danceRedux.ts
+++ b/apps/src/dance/danceRedux.ts
@@ -15,6 +15,7 @@ import {
   loadSong,
   unloadSong,
   loadSongMetadata,
+  isSongDeprecated,
 } from './songs';
 import {Field} from 'blockly';
 
@@ -58,11 +59,17 @@ export const initSongs = createAsyncThunk(
       };
       onAuthError: (songId: string) => void;
       onSongSelected?: (songId: string) => void;
+      onSongUnavailable?: () => void;
     },
     {dispatch}
   ) => {
-    const {useRestrictedSongs, onAuthError, selectSongOptions, onSongSelected} =
-      payload;
+    const {
+      useRestrictedSongs,
+      onAuthError,
+      selectSongOptions,
+      onSongSelected,
+      onSongUnavailable,
+    } = payload;
 
     // Check for a user-specified manifest file.
     const userManifest = queryParams('manifest') as string;
@@ -82,6 +89,14 @@ export const initSongs = createAsyncThunk(
         !filteredSongSet.size || filteredSongSet.has(song.id)
     );
     const songData = parseSongOptions(songManifest) as SongData;
+
+    if (
+      selectSongOptions.selectedSong &&
+      isSongDeprecated(selectSongOptions.selectedSong) &&
+      onSongUnavailable
+    ) {
+      onSongUnavailable();
+    }
     const selectedSong = getSelectedSong(songManifest, selectSongOptions);
 
     // Set selectedSong first, so we don't initially show the wrong song.

--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -2,6 +2,21 @@ import Sounds from '../Sounds';
 import {ageDialogSelectedOver13, songFilterOn} from '../templates/AgeDialog';
 import {fetchSignedCookies} from '../utils';
 
+const DEPRECATED_SONGS = [
+  'cantfeelmyface_theweeknd',
+  'countrygirl_lukebryan',
+  'dancinginthedark_brucespringsteen',
+  'levelup_ciara',
+  'macarena_losdelrio',
+  'shapeofyou_edsheeran',
+  'somebodylikeyou_keithurban',
+  'sorry_justinbieber',
+  'wecantstop_mileycyrus',
+  'ymca_villagepeople',
+  'firework_katyperry',
+  'showdaspoderosas_anitta',
+];
+
 /**
  * Requests the song manifest in parallel with signed cloudfront cookies. These cookies
  * are needed before accessing restricted song files.
@@ -140,4 +155,8 @@ export function getFilterStatus(userType, under13) {
   // User is signed in (student or teacher) and the filter override is not turned on.
   // Return true (filter should be turned on) if the user is under 13. Teachers assumed over13.
   return under13;
+}
+
+export function isSongDeprecated(songId) {
+  return DEPRECATED_SONGS.includes(songId);
 }


### PR DESCRIPTION
We are removing some songs from Dance Party in this PR: https://github.com/code-dot-org/code-dot-org/pull/54809

Existing projects that currently use removed songs use a default (Shawn Mendes for the project level, others for curriculum levels) -- this PR warns users who open these projects (either the owner editing their own project, or  that this defaulting is happening.

The warning is dismissed if you select a different song, or hit the "Run" button, but persists across page loads until the user has selected a different song for their project (either explicitly by selecting a new song in the dropdown, or implicitly by hitting "Run").

| **Project owner, standalone project** | **Project owner, project-backed curriculum level** |
| - | - |
| ![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/fc418ba6-de87-4aac-a5ba-fb66073b1b95) | ![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/7cc34e8d-f952-4bc7-8d5f-6c6f81c75c30) |

| **Project non-owner, edit view** | **Project non-owner, share view** |
| - | - |
| <img width="1438" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/c319a3d6-c481-4287-8952-41967896a253"> | <img width="475" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/98c111f5-c308-4c30-a7d2-75b8493ff415"> |

## Testing story

I manually tested each of the cases in the screenshots above, using projects where I:
 1. selected one of the deleted songs using the existed manifest
 2. updated to the new manifest in the PR linked above

Then I:
 - revisited the page and observed the warning
 - changed the song and/or clicked the run button -> warning disappeared
 - reloaded the page as non-project owner -> warning reappears
 - changed the song and/or clicked the run button as the project owner -> warning disappears on next page reload for project owner and non-owner

I did not test:
- how this looks on mobile
- all of the deleted songs, I probably tested 3 or so