### PR TITLE
Require script_id for SingleSectionExperiment and TeacherBasedExperiment

### DIFF
--- a/dashboard/app/models/experiments/single_section_experiment.rb
+++ b/dashboard/app/models/experiments/single_section_experiment.rb
@@ -30,8 +30,8 @@
 class SingleSectionExperiment < Experiment
   belongs_to :section, optional: true
 
-  # mitigates performance problems when calling Experiment.get_all_enabled on hot codepaths
-  validates_presence_of :script_id
+  # requiring this mitigates performance problems when calling Experiment.get_all_enabled on hot codepaths
+  belongs_to :script, class_name: 'Unit'
 
   def enabled?(user: nil)
     return false unless user

--- a/dashboard/app/models/experiments/single_section_experiment.rb
+++ b/dashboard/app/models/experiments/single_section_experiment.rb
@@ -30,6 +30,9 @@
 class SingleSectionExperiment < Experiment
   belongs_to :section, optional: true
 
+  # mitigates performance problems when calling Experiment.get_all_enabled on hot codepaths
+  validates_presence_of :script_id
+
   def enabled?(user: nil)
     return false unless user
 

--- a/dashboard/app/models/experiments/teacher_based_experiment.rb
+++ b/dashboard/app/models/experiments/teacher_based_experiment.rb
@@ -28,10 +28,10 @@
 #
 
 class TeacherBasedExperiment < Experiment
-  validates :percentage, inclusion: 0..100
+  # requiring this mitigates performance problems when calling Experiment.get_all_enabled on hot codepaths
+  belongs_to :script, class_name: 'Unit'
 
-  # mitigates performance problems when calling Experiment.get_all_enabled on hot codepaths
-  validates_presence_of :script_id
+  validates :percentage, inclusion: 0..100
 
   # NOTE: The min_user_id value is inclusive, the max_user_id value is exclusive.
   def enabled?(user: nil)

--- a/dashboard/app/models/experiments/teacher_based_experiment.rb
+++ b/dashboard/app/models/experiments/teacher_based_experiment.rb
@@ -30,6 +30,9 @@
 class TeacherBasedExperiment < Experiment
   validates :percentage, inclusion: 0..100
 
+  # mitigates performance problems when calling Experiment.get_all_enabled on hot codepaths
+  validates_presence_of :script_id
+
   # NOTE: The min_user_id value is inclusive, the max_user_id value is exclusive.
   def enabled?(user: nil)
     return if user.nil?

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -637,7 +637,7 @@ ActiveRecord::Schema.define(version: 2023_11_07_182805) do
     t.index ["user_id"], name: "index_hint_view_requests_on_user_id"
   end
 
-  create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "learning_goal_ai_evaluation_id", null: false
     t.bigint "teacher_id", null: false
     t.boolean "ai_feedback_approval", null: false
@@ -828,7 +828,7 @@ ActiveRecord::Schema.define(version: 2023_11_07_182805) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "lti_courses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "lti_courses", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "lti_integration_id", null: false
     t.bigint "lti_deployment_id", null: false
     t.string "context_id"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -637,7 +637,7 @@ ActiveRecord::Schema.define(version: 2023_11_07_182805) do
     t.index ["user_id"], name: "index_hint_view_requests_on_user_id"
   end
 
-  create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "learning_goal_ai_evaluation_id", null: false
     t.bigint "teacher_id", null: false
     t.boolean "ai_feedback_approval", null: false
@@ -828,7 +828,7 @@ ActiveRecord::Schema.define(version: 2023_11_07_182805) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "lti_courses", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lti_courses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "lti_integration_id", null: false
     t.bigint "lti_deployment_id", null: false
     t.string "context_id"

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -1140,7 +1140,7 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test 'milestone with student in experiment triggers rubric eval job' do
-    create :single_section_experiment, section: @section, name: 'ai-rubrics'
+    create :single_section_experiment, section: @section, name: 'ai-rubrics', script: @script
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).with(user_id: @student.id, requester_id: @student.id, script_level_id: @script_level.id).once
     sign_in @student

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1696,7 +1696,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     script = create(:script)
     lesson_group = create(:lesson_group, script: script)
     lesson = create(:lesson, script: script, lesson_group: lesson_group)
-    experiment = create :single_section_experiment, section: @section
+    experiment = create :single_section_experiment, section: @section, script: script
     level = create :maze, name: 'maze 1'
     level2 = create :maze, name: 'maze 2'
     get_show_script_level_page(

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -64,10 +64,11 @@ FactoryBot.define do
       min_user_id {0}
       max_user_id {0}
       overflow_max_user_id {0}
-      script {nil}
+      script
     end
     factory :single_section_experiment, class: 'SingleSectionExperiment' do
       section
+      script
     end
     factory :single_user_experiment, class: 'SingleUserExperiment' do
     end

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -852,10 +852,13 @@ class LevelsHelperTest < ActionView::TestCase
   test 'section first_activity_at should not be nil when finding experiments' do
     Experiment.stubs(:should_cache?).returns true
     teacher = create(:teacher)
-    experiment = create(:teacher_based_experiment,
+    @script = create :script
+    experiment = create(
+      :teacher_based_experiment,
       earliest_section_at: DateTime.now - 1.day,
       latest_section_at: DateTime.now + 1.day,
       percentage: 100,
+      script: @script
     )
     Experiment.update_cache
     section = create(:section, user: teacher)

--- a/dashboard/test/models/experiment_test.rb
+++ b/dashboard/test/models/experiment_test.rb
@@ -37,21 +37,33 @@ class ExperimentTest < ActiveSupport::TestCase
     refute Experiment.enabled?(user: user_off, experiment_name: experiment.name)
   end
 
-  test "teacher based experiment at 0 percent is not enabled" do
-    experiment = create :teacher_based_experiment, percentage: 0
-    teacher = build :teacher
-    assert_empty Experiment.get_all_enabled(user: teacher)
-    refute Experiment.enabled?(experiment_name: experiment.name, user: teacher)
+  test "creating teacher based experiment without script raises" do
+    assert_raises ActiveRecord::RecordInvalid do
+      create :teacher_based_experiment, script: nil
+    end
   end
 
-  test "teacher based experiment at 100 percent is enabled" do
-    experiment = create :teacher_based_experiment, percentage: 100
-    assert_equal [experiment], Experiment.get_all_enabled(user: @teacher)
-    assert Experiment.enabled?(experiment_name: experiment.name, user: @teacher)
+  test "teacher based experiment at 0 percent is not enabled for matching script" do
+    experiment = create :teacher_based_experiment, percentage: 0, script: @script
+    teacher = build :teacher
+    assert_empty Experiment.get_all_enabled(user: teacher, script: @script)
+    refute Experiment.enabled?(experiment_name: experiment.name, user: teacher, script: @script)
+  end
+
+  test "teacher based experiment at 100 percent is enabled for matching script" do
+    experiment = create :teacher_based_experiment, percentage: 100, script: @script
+    assert_equal [experiment], Experiment.get_all_enabled(user: @teacher, script: @script)
+    assert Experiment.enabled?(experiment_name: experiment.name, user: @teacher, script: @script)
+  end
+
+  test "teacher based experiment at 100 percent is not enabled for nil script" do
+    experiment = create :teacher_based_experiment, percentage: 100, script: @script
+    assert_equal [], Experiment.get_all_enabled(user: @teacher)
+    refute Experiment.enabled?(experiment_name: experiment.name, user: @teacher)
   end
 
   test "teacher based experiment at 50 percent is enabled for only some users" do
-    experiment = create :teacher_based_experiment, percentage: 50
+    experiment = create :teacher_based_experiment, percentage: 50, script: @script
     student_on = create :student
     teacher_on = create :teacher, id: 1025 + experiment.min_user_id
     section_on = create :section, teacher: teacher_on
@@ -62,24 +74,26 @@ class ExperimentTest < ActiveSupport::TestCase
     section_off = create :section, teacher: teacher_off
     create :follower, section: section_off, student_user: student_off
 
-    assert_equal [experiment], Experiment.get_all_enabled(user: student_on)
-    assert Experiment.enabled?(experiment_name: experiment.name, user: student_on)
-    assert_empty Experiment.get_all_enabled(user: student_off)
-    refute Experiment.enabled?(experiment_name: experiment.name, user: student_off)
+    assert_equal [experiment], Experiment.get_all_enabled(user: student_on, script: @script)
+    assert Experiment.enabled?(experiment_name: experiment.name, user: student_on, script: @script)
+    assert_empty Experiment.get_all_enabled(user: student_off, script: @script)
+    refute Experiment.enabled?(experiment_name: experiment.name, user: student_off, script: @script)
   end
 
   test "teacher based experiment is disabled if start time is too late" do
     experiment = create :teacher_based_experiment,
       percentage: 100,
-      earliest_section_at: DateTime.now + 1.day
+      earliest_section_at: DateTime.now + 1.day,
+      script: @script
     assert_empty Experiment.get_all_enabled(user: @teacher)
-    refute Experiment.enabled?(experiment_name: experiment.name, user: @teacher)
+    refute Experiment.enabled?(experiment_name: experiment.name, user: @teacher, script: @script)
   end
 
   test "teacher based experiment is disabled if end_time is too early" do
     experiment = create :teacher_based_experiment,
       percentage: 100,
-      latest_section_at: DateTime.now - 1.day
+      latest_section_at: DateTime.now - 1.day,
+      script: @script
     assert_empty Experiment.get_all_enabled
     refute Experiment.enabled?(experiment_name: experiment.name)
   end
@@ -87,36 +101,40 @@ class ExperimentTest < ActiveSupport::TestCase
   test "teacher based experiment is disabled if other script assigned" do
     experiment = create :teacher_based_experiment,
       percentage: 100,
-      script_id: @script.id + 1
+      script: create(:script)
     assert_empty Experiment.get_all_enabled(script: @script)
     refute Experiment.enabled?(script: @script, experiment_name: experiment.name)
   end
 
-  test "teacher based experiment handles nil section start at" do
+  test "teacher based experiment enabled for sections inside time bounds" do
     experiment = create :teacher_based_experiment,
       percentage: 100,
       earliest_section_at: DateTime.now - 1.day,
       latest_section_at: DateTime.now + 1.day,
-      script_id: @script.id + 1
-    assert_empty Experiment.get_all_enabled(user: @teacher, script: @script)
-    refute Experiment.enabled?(user: @teacher, script: @script, experiment_name: experiment.name)
+      script: @script
+    assert_equal [experiment], Experiment.get_all_enabled(user: @teacher, script: @script)
+    assert Experiment.enabled?(user: @teacher, script: @script, experiment_name: experiment.name)
   end
 
-  test "teacher based experiment is enabled if same script assigned" do
+  test "teacher based experiment disabled for sections outside time bounds" do
     experiment = create :teacher_based_experiment,
       percentage: 100,
-      script_id: @script.id
-    assert_equal [experiment], Experiment.get_all_enabled(script: @script, user: @teacher)
-    assert Experiment.enabled?(script: @script, experiment_name: experiment.name, user: @teacher)
+      earliest_section_at: DateTime.now - 3.days,
+      latest_section_at: DateTime.now - 1.day,
+      script: @script
+    assert_empty Experiment.get_all_enabled(user: @teacher, script: @script)
+    refute Experiment.enabled?(user: @teacher, script: @script, experiment_name: experiment.name)
   end
 
   test "teacher is in the same teacher-based experiment as their section" do
     experiment1 = create :teacher_based_experiment,
       min_user_id: 0,
-      max_user_id: 50
+      max_user_id: 50,
+      script: @script
     experiment2 = create :teacher_based_experiment,
       min_user_id: 50,
-      max_user_id: 100
+      max_user_id: 100,
+      script: @script
 
     teacher = mock('teacher')
     teacher.stubs(:id).returns(1125)
@@ -129,28 +147,45 @@ class ExperimentTest < ActiveSupport::TestCase
     student.stubs(:sections_as_student).returns([section])
     teacher.stubs(:sections).returns([section])
 
-    assert Experiment.enabled?(experiment_name: experiment1.name, user: teacher)
-    assert Experiment.enabled?(experiment_name: experiment1.name, user: student)
+    assert Experiment.enabled?(experiment_name: experiment1.name, user: teacher, script: @script)
+    assert Experiment.enabled?(experiment_name: experiment1.name, user: student, script: @script)
 
-    refute Experiment.enabled?(experiment_name: experiment2.name, user: teacher)
-    refute Experiment.enabled?(experiment_name: experiment2.name, user: student)
+    refute Experiment.enabled?(experiment_name: experiment2.name, user: teacher, script: @script)
+    refute Experiment.enabled?(experiment_name: experiment2.name, user: student, script: @script)
   end
 
-  test "single section experiment is enabled" do
+  test "creating single section experiment without script raises" do
+    assert_raises ActiveRecord::RecordInvalid do
+      create :single_section_experiment, script: nil
+    end
+  end
+
+  test "single section experiment is enabled with matching script" do
     experiment = create :single_section_experiment,
-      section_id: @section.id
-    assert_equal [experiment], Experiment.get_all_enabled(user: @teacher)
-    assert Experiment.enabled?(experiment_name: experiment.name, user: @teacher)
-    assert_equal [experiment], Experiment.get_all_enabled(user: @student)
-    assert Experiment.enabled?(experiment_name: experiment.name, user: @student)
+      section_id: @section.id,
+      script: @script
+    assert_equal [experiment], Experiment.get_all_enabled(user: @teacher, script: @script)
+    assert Experiment.enabled?(experiment_name: experiment.name, user: @teacher, script: @script)
+    assert_equal [experiment], Experiment.get_all_enabled(user: @student, script: @script)
+    assert Experiment.enabled?(experiment_name: experiment.name, user: @student, script: @script)
   end
 
-  test "single section experiment is not enabled" do
-    experiment = create :single_section_experiment
+  test "single section experiment is disabled for nil script" do
+    experiment = create :single_section_experiment,
+                        section_id: @section.id,
+                        script: @script
     assert_empty Experiment.get_all_enabled(user: @teacher)
-    refute Experiment.enabled?(experiment_name: experiment.name)
+    refute Experiment.enabled?(experiment_name: experiment.name, user: @teacher)
     assert_empty Experiment.get_all_enabled(user: @student)
     refute Experiment.enabled?(experiment_name: experiment.name, user: @student)
+  end
+
+  test "single section experiment is not enabled without matching section" do
+    experiment = create :single_section_experiment, script: @script
+    assert_empty Experiment.get_all_enabled(user: @teacher, script: @script)
+    refute Experiment.enabled?(experiment_name: experiment.name, script: @script)
+    assert_empty Experiment.get_all_enabled(user: @student, script: @script)
+    refute Experiment.enabled?(experiment_name: experiment.name, user: @student, script: @script)
   end
 
   test "creating experiments does not break get_all_enabled for signed out user" do
@@ -163,8 +198,8 @@ class ExperimentTest < ActiveSupport::TestCase
   end
 
   test "teacher is included in single-section experiment" do
-    experiment = create :single_section_experiment
-    assert Experiment.enabled?(experiment_name: experiment.name, user: experiment.section.user)
+    experiment = create :single_section_experiment, script: @script
+    assert Experiment.enabled?(experiment_name: experiment.name, user: experiment.section.user, script: @script)
   end
 
   test 'single user experiment is enabled' do


### PR DESCRIPTION
When we added sections 20-40 to the ai-rubrics experiment, we discovered that the presence of so many SingleSectionExperiment objects in production was causing high DB usage, because we would look up the sections of the current user on every page load. Details here: https://codedotorg.slack.com/archives/C0T0PNTM3/p1698947153623759?thread_ts=1698936572.562019&cid=C0T0PNTM3

We mitigated the problem by adding script_id to every SingleSectionExperiment in the DB. this works because the main hot codepath for looking up user experiments does not specify a script_id: 
* https://github.com/code-dot-org/code-dot-org/blob/a1a2775f9cf5001123c5403eb1e248c9567ad80a/dashboard/config/initializers/devise.rb#L361
* https://github.com/code-dot-org/code-dot-org/blob/97abdf838a3b1a33f8de7202d00bb93865d8daf8/dashboard/app/models/user.rb#L1691-L1692

Which causes the experiment lookup to short circuit without querying the database, here: https://github.com/code-dot-org/code-dot-org/blob/51d2f42518a09766ce702c45ceddb0c10c4ac74f/dashboard/app/models/experiments/experiment.rb#L62

**This PR generalizes the solution by requiring that SingleSectionExperiment and TeacherBasedExperiment have a script_id, causing DB lookups to be skipped in most cases.**

It's worth noting that there will still be some DB activity for each SingleSectionExperiment, because users who are viewing levels in the unit matching the script_id of any SingleSectionExperiment will trigger DB access, here: 
* https://github.com/code-dot-org/code-dot-org/blob/bca7559f523585abb260f15ef2cecbe73a882310/dashboard/app/helpers/levels_helper.rb#L398
* https://github.com/code-dot-org/code-dot-org/blob/51d2f42518a09766ce702c45ceddb0c10c4ac74f/dashboard/app/models/experiments/experiment.rb#L63
* https://github.com/code-dot-org/code-dot-org/blob/d96ebb30d78472a9b254ff2286f608794c9696fa/dashboard/app/models/experiments/single_section_experiment.rb#L39

However, empirical evidence suggests that we have sufficient headroom in database CPU that this won't become a problem with moderate numbers of SingleSectionExperiment objects, especially if they are assigned to units which are not frequently visited (i.e. not HOC units).

## Testing story

added / updated unit tests

## Follow-up work

open to ideas here