### PR TITLE
HoC 2023 - Update promo video

### DIFF
--- a/pegasus/sites.v3/code.org/public/hourofcode/index.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/index.haml
@@ -22,7 +22,7 @@ theme: responsive_full_width
       %p.body-three
         =hoc_s(:hoc_page_desc_2023)
     %div.col-45
-      = view :display_video_thumbnail, id: "hoc_2023", video_code: "KsOIlDT145A", play_button: 'center', letterbox: 'false', download_path: "//videos.code.org/hour_of_code_worldwide_2023.mp4"
+      = view :display_video_thumbnail, id: "hoc_celebrities_2023", video_code: "ybBUd9-0ZJQ", play_button: 'center', letterbox: 'false', download_path: "//videos.code.org/hour_of_code_celebrities_2023.mp4"
       %a.body-three{href: "/educate/resources/videos"}
         =hoc_s(:call_to_action_see_more_insp_videos)
   .clear

--- a/pegasus/sites.v3/hourofcode.com/views/index_video.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/index_video.haml
@@ -1,6 +1,6 @@
 -# Show alternate promo video for LATAM Hour of Code.
 - latam_language_codes = ["la", "es", "pt", "po"]
-- video_link = latam_language_codes.include?(@language) ? "EGgdCryC8Uo" : "KsOIlDT145A"
+- video_link = latam_language_codes.include?(@language) ? "EGgdCryC8Uo" : "ybBUd9-0ZJQ"
 
 %figure.video-responsive
   %div

--- a/pegasus/src/social_metadata.rb
+++ b/pegasus/src/social_metadata.rb
@@ -30,7 +30,7 @@ def get_social_metadata_for_page(request)
   videos = {
     what_most_schools_dont_teach: {youtube_key: "nKIu9yen5nc", width: 640, height: 360},
     computer_science_is_changing_everything: {youtube_key: "QvyTEx1wyOY", width: 640, height: 360},
-    hour_of_code_worldwide: {youtube_key: "KsOIlDT145A", width: 640, height: 360},
+    hour_of_code_worldwide: {youtube_key: "ybBUd9-0ZJQ", width: 640, height: 360},
     creativity_is: {youtube_key: "VYqHGIR7a_k", width: 640, height: 640}
   }
   # rubocop:enable Lint/UselessAssignment


### PR DESCRIPTION
Update the main promo video on https://hourofcode.com and https://code.org/hourofcode
- Also swapped on `social_metadata.rb` just in case

**Jira ticket:** [ACQ-1166](https://codedotorg.atlassian.net/browse/ACQ-1166)

----

## hourofcode.com
<img width="1042" alt="Screenshot 2023-11-13 at 10 17 05 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/910a040b-c301-4174-bf37-c28624eff3cf">


## code.org/hourofcode
<img width="1019" alt="Screenshot 2023-11-13 at 10 17 29 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/ff99b3e3-27ff-4a27-be14-3564627a5fa3">
