### PR TITLE
Removing span which was missed in latest account signup changes

### DIFF
--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -73,7 +73,6 @@
         -# Sign-up user type original
         .span5{:id => 'select-user-type-original'}
           = f.select :user_type, user_type_options, {include_blank: true}, {disabled: @user.should_disable_user_type?}
-      .span2
     .row#parent-email-container
       .span8#parent-email-section
         .padded-container


### PR DESCRIPTION
We made some recent changes to the account signup UI but missed a `span` which is no longer needed.
# Before
![Screenshot 2023-11-13 at 9 47 14 AM](https://github.com/code-dot-org/code-dot-org/assets/1372238/595c73ca-13af-4b6c-b1a6-986c7bb54fc9)

# After
![Screenshot 2023-11-13 at 10 00 22 AM](https://github.com/code-dot-org/code-dot-org/assets/1372238/0a1d7329-9281-4e98-ae0d-62d588908b47)



## Testing story
* tested on localhost
