### PR TITLE
updated start_libraries test to fix flaky blockly test

### DIFF
--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -1238,83 +1238,95 @@ class BlocklyTest < ActiveSupport::TestCase
     assert_equal parsed_xml.at_xpath('//block[@type="studio_ask"]/*[@name="VAR"]').content, localized_variable_str
   end
 
-  class I18nStartLibrariesTest < BlocklyTest
-    setup do
-      test_locale = 'te-ST'
-      @level_name = 'test localize start_libraries'
-      @i18n_library_name = 'i18n_library_test'
-      @level = create(
-        :level,
-        :blockly,
-        name: @level_name,
-        )
-      # Add translation mapping to the I18n backend
-      custom_i18n_libraries = {
-        'data' => {
-          'start_libraries' => {
-            @level_name => {
-              @i18n_library_name => {
-                test_key_1: 'localized_string_1'
-              }
+  test 'localizes start_libraries when i18n_library is present' do
+    test_locale = 'te-ST'
+    level_name = 'test localize start_libraries'
+    i18n_library_name = 'i18n_library_test'
+    level = create(
+      :level,
+      :blockly,
+      name: level_name,
+      )
+    # Add translation mapping to the I18n backend
+    custom_i18n_libraries = {
+      'data' => {
+        'start_libraries' => {
+          level_name => {
+            i18n_library_name => {
+              test_key_1: 'localized_string_1'
             }
           }
         }
       }
-      I18n.locale = test_locale
-      I18n.backend.store_translations test_locale, custom_i18n_libraries
-    end
+    }
+    I18n.locale = test_locale
+    I18n.backend.store_translations test_locale, custom_i18n_libraries
+    # Create a start_libraries JSON structure containing a translatable library and a non-translatable library.
+    start_libraries = JSON.generate(
+      [{name: i18n_library_name,
+        description: "Test Library that gets translated",
+        source: "var TRANSLATIONTEXT = {\n \"test_key_1\": \"expected_string_1\",\n \"test_key_2\": \"expected_string_2\"\n};\n\n//This library is translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"},
+       {name: "non_translated_library",
+        description: "Test Library that does not get translated",
+        source: "var TRANSLATIONTEXT = {\n \"not_translated_key\": \"not_translated_string\"\n};\n\n//This library is not translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"}]
+    )
 
-    teardown do
-      @level.destroy
-      I18n.locale = I18n.default_locale
-    end
+    # Localized output to be tested
+    localized_start_libraries = level.localized_start_libraries(start_libraries)
 
-    test 'localizes start_libraries when i18n_library is present' do
-      # Create a start_libraries JSON structure containing a translatable library and a non-translatable library.
-      start_libraries = JSON.generate(
-        [{name: @i18n_library_name,
-          description: "Test Library that gets translated",
-          source: "var TRANSLATIONTEXT = {\n \"test_key_1\": \"expected_string_1\",\n \"test_key_2\": \"expected_string_2\"\n};\n\n//This library is translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"},
-         {name: "non_translated_library",
-          description: "Test Library that does not get translated",
-          source: "var TRANSLATIONTEXT = {\n \"not_translated_key\": \"not_translated_string\"\n};\n\n//This library is not translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"}]
+    # Expected output
+    expected_localized_library = JSON.generate(
+      [{name: i18n_library_name,
+        description: "Test Library that gets translated",
+        source: "var TRANSLATIONTEXT = {\n  \"test_key_1\": \"localized_string_1\",\n  \"test_key_2\": \"expected_string_2\"\n};\n\n//This library is translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"},
+       {name: "non_translated_library",
+        description: "Test Library that does not get translated",
+        source: "var TRANSLATIONTEXT = {\n \"not_translated_key\": \"not_translated_string\"\n};\n\n//This library is not translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"}]
+    )
+    assert_equal expected_localized_library, localized_start_libraries
+  end
+
+  test 'does not localize start_libraries when there is not an i18n library' do
+    test_locale = 'te-ST'
+    level_name = 'test localize start_libraries'
+    i18n_library_name = 'i18n_library_test'
+    level = create(
+      :level,
+      :blockly,
+      name: level_name,
       )
+    # Add translation mapping to the I18n backend
+    custom_i18n_libraries = {
+      'data' => {
+        'start_libraries' => {
+          level_name => {
+            i18n_library_name => {
+              test_key_1: 'localized_string_1'
+            }
+          }
+        }
+      }
+    }
+    I18n.locale = test_locale
+    I18n.backend.store_translations test_locale, custom_i18n_libraries
+    # Create a start_libraries blockly level JSON structure containing the
+    # a translatable library and a non-translatable library.
+    start_libraries = JSON.generate(
+      [{name: "non_translated_library",
+        description: "Test Library that does not get translated",
+        source: "var TRANSLATIONTEXT = {\n \"not_translated_key\": \"not_translated_string\"\n};\n\n//This library is not translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"}]
+    )
 
-      # Localized output to be tested
-      localized_start_libraries = @level.localized_start_libraries(start_libraries)
+    # Localized output to be tested
+    localized_start_libraries = level.localized_start_libraries(start_libraries)
 
-      # Expected output
-      expected_localized_library = JSON.generate(
-        [{name: @i18n_library_name,
-          description: "Test Library that gets translated",
-          source: "var TRANSLATIONTEXT = {\n  \"test_key_1\": \"localized_string_1\",\n  \"test_key_2\": \"expected_string_2\"\n};\n\n//This library is translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"},
-         {name: "non_translated_library",
-          description: "Test Library that does not get translated",
-          source: "var TRANSLATIONTEXT = {\n \"not_translated_key\": \"not_translated_string\"\n};\n\n//This library is not translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"}]
-      )
-      assert_equal expected_localized_library, localized_start_libraries
-    end
-
-    test 'does not localize start_libraries when there is not an i18n library' do
-      # Create a start_libraries blockly level JSON structure containing the
-      # a translatable library and a non-translatable library.
-      start_libraries = JSON.generate(
-        [{name: "non_translated_library",
-          description: "Test Library that does not get translated",
-          source: "var TRANSLATIONTEXT = {\n \"not_translated_key\": \"not_translated_string\"\n};\n\n//This library is not translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"}]
-      )
-
-      # Localized output to be tested
-      localized_start_libraries = @level.localized_start_libraries(start_libraries)
-
-      # Expected output
-      expected_localized_library = JSON.generate(
-        [{name: "non_translated_library",
-          description: "Test Library that does not get translated",
-          source: "var TRANSLATIONTEXT = {\n \"not_translated_key\": \"not_translated_string\"\n};\n\n//This library is not translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"}]
-      )
-      assert_equal expected_localized_library, localized_start_libraries
-    end
+    # Expected output
+    expected_localized_library = JSON.generate(
+      [{name: "non_translated_library",
+        description: "Test Library that does not get translated",
+        source: "var TRANSLATIONTEXT = {\n \"not_translated_key\": \"not_translated_string\"\n};\n\n//This library is not translated\nfunction someFunction(key) {\n return TRANSLATIONTEXT[key];\n}\n"}]
+    )
+    assert_equal expected_localized_library, localized_start_libraries
   end
 
   test 'get_localized_property returns property translation when level should be localized' do


### PR DESCRIPTION
This PR fixes a flaky test introduced in [PR #54161](https://github.com/code-dot-org/code-dot-org/pull/54161)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
