### PR TITLE
Reload sections list after accepting a co-teacher invitation

### DIFF
--- a/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
+++ b/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
@@ -3,7 +3,10 @@ import React from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
-import {asyncLoadCoteacherInvite} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {
+  asyncLoadCoteacherInvite,
+  asyncLoadSectionData,
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import Button from '../Button';
 import {BodyTwoText, StrongText} from '@cdo/apps/componentLibrary/typography';
 import HttpClient from '@cdo/apps/util/HttpClient';
@@ -15,6 +18,7 @@ export const showCoteacherInviteNotification = coteacherInvite => {
 
 const CoteacherInviteNotification = ({
   asyncLoadCoteacherInvite,
+  asyncLoadSectionData,
   coteacherInvite,
 }) => {
   if (!showCoteacherInviteNotification(coteacherInvite)) {
@@ -25,6 +29,7 @@ const CoteacherInviteNotification = ({
     HttpClient.put(api, '', true)
       .then(() => {
         asyncLoadCoteacherInvite();
+        asyncLoadSectionData();
       })
       .catch(err => console.error(err));
   };
@@ -81,11 +86,13 @@ export default connect(
   }),
   {
     asyncLoadCoteacherInvite,
+    asyncLoadSectionData,
   }
 )(CoteacherInviteNotification);
 
 CoteacherInviteNotification.propTypes = {
   asyncLoadCoteacherInvite: PropTypes.func.isRequired,
+  asyncLoadSectionData: PropTypes.func.isRequired,
   coteacherInvite: PropTypes.object,
 };
 

--- a/apps/test/unit/templates/studioHomepages/CoteacherInviteNotificationTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoteacherInviteNotificationTest.jsx
@@ -8,6 +8,7 @@ import DCDO from '@cdo/apps/dcdo';
 describe('CoteacherInviteNotification', () => {
   const defaultProps = {
     asyncLoadCoteacherInvite: () => {},
+    asyncLoadSectionData: () => {},
     coteacherInvite: {
       id: 1,
       invited_by_name: 'The Great Pumpkin',


### PR DESCRIPTION
When a teacher accepts a co-teacher invitation, this PR causes the sections list to be reloaded to include that section.

https://github.com/code-dot-org/code-dot-org/assets/4108328/a5955ef4-33a6-40cf-8f1a-5727b7764f69

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
