### PR TITLE
Revert "Add sections where user is a coteacher to API responses (#54805)"

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -217,7 +217,7 @@ class ApiController < ApplicationController
       return
     end
 
-    data = current_user.sections_owned_or_instructed.each_with_object({}) do |section, section_hash|
+    data = current_user.sections.each_with_object({}) do |section, section_hash|
       next if section.hidden
       script = load_script(section)
 
@@ -392,7 +392,7 @@ class ApiController < ApplicationController
   # Get /api/teacher_panel_section
   def teacher_panel_section
     prevent_caching
-    teacher_sections = current_user&.sections_owned_or_instructed&.where(hidden: false)
+    teacher_sections = current_user&.sections&.where(hidden: false)
 
     if teacher_sections.blank?
       head :no_content

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -3,13 +3,13 @@ class TeacherDashboardController < ApplicationController
 
   def show
     @section_summary = @section.summarize
-    @sections = current_user.sections_owned_or_instructed.map(&:summarize)
+    @sections = current_user.sections.map(&:summarize)
     @locale_code = request.locale
   end
 
   def parent_letter
     @section_summary = @section.summarize
-    @sections = current_user.sections_owned_or_instructed.map(&:summarize)
+    @sections = current_user.sections.map(&:summarize)
     render layout: false
   end
 end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -481,11 +481,7 @@ class User < ApplicationRecord
   # TODO once the backfill creates SectionInstructors for every section owner,
   # this method can be deleted and its references replaced by sections_instructed
   def sections_owned_or_instructed
-    Section.
-      left_outer_joins(:active_section_instructors).
-      where('section_instructors.instructor_id' => id).
-      or(Section.where(user_id: id)).
-      distinct
+    (sections + sections_instructed).uniq
   end
 
   # Relationships (sections_as_students/followeds/teachers) from being a

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -326,21 +326,6 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal @student_flappy_1.name, flappy_section_response['lessons'][lesson.id.to_s][0]['name']
   end
 
-  test "should get lock state when coteacher of section" do
-    script, _level, _lesson = create_script_with_lockable_lesson
-
-    section_owner = create :teacher
-    section = create :section, user: section_owner
-    create :section_instructor, section: section, instructor: @teacher, status: :active
-
-    get :lockable_state, params: {
-      section_id: section.id,
-      script_id: script.id
-    }
-    assert_response :success
-    assert_match "no-store", response.headers["Cache-Control"]
-  end
-
   # Helper for setting up student lock tests
   def get_student_response(script, level, lesson, student_number)
     get :lockable_state, params: {section_id: @section.id, script_id: script.id}
@@ -1483,35 +1468,6 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal @section.id, response["id"]
     assert_equal @teacher.name, response["teacherName"]
     assert_equal 7, response["students"].length
-  end
-
-  test "teacher_panel_section returns summarized section when passed section id with teacher as section_instructor" do
-    section_owner = create :teacher
-    section = create :section, user: section_owner
-    create :section_instructor, section: section, instructor: @teacher, status: :active
-
-    get :teacher_panel_section, params: {
-      section_id: section.id
-    }
-
-    assert_response :success
-    assert_match "no-store", response.headers["Cache-Control"]
-
-    response = JSON.parse(@response.body)
-    assert_equal section.id, response["id"]
-    assert_equal section_owner.name, response["teacherName"]
-  end
-
-  test "teacher_panel_section does not return summarized section when passed section id with teacher as invited section_instructor" do
-    section_owner = create :teacher
-    section = create :section, user: section_owner
-    create :section_instructor, section: section, instructor: @teacher, status: :invited
-
-    get :teacher_panel_section, params: {
-      section_id: section.id
-    }
-
-    assert_response :no_content
   end
 
   test "teacher_panel_section returns teacher's section when no section id is passed and teacher has 1 visible section" do

--- a/dashboard/test/controllers/teacher_dashboard_controller_test.rb
+++ b/dashboard/test/controllers/teacher_dashboard_controller_test.rb
@@ -33,13 +33,4 @@ class TeacherDashboardControllerTest < ActionController::TestCase
     get :show, params: {section_id: section.id}
     assert_response :success
   end
-
-  test 'index: returns success if teacher is section_instructor of section' do
-    sign_in @teacher
-    section_owner = create :teacher
-    section = create :section, user: section_owner
-    create :section_instructor, section: section, instructor: @teacher, status: :active
-    get :show, params: {section_id: section.id}
-    assert_response :success
-  end
 end


### PR DESCRIPTION
Likely broke a couple of tests related to locking. Reverting to unblock everyone else while we investigate the cause.

This reverts commit dc38ff2cd9731e753cda32fcd97b122d51815c47.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
