### PR TITLE
Fix level 8 emoji input names

### DIFF
--- a/dashboard/config/levels/custom/dance/dance_ai_try_at_measure.level
+++ b/dashboard/config/levels/custom/dance/dance_ai_try_at_measure.level
@@ -105,7 +105,7 @@
           <field name="UNIT">"measures"</field>
           <next>
             <block type="Dancelab_ai" id="AZFax0W2U%3B*@TX0l4o">
-              <field name="VALUE">{"inputs":["spooky","black-and-white","robot"],"backgroundEffect":"squiggles","backgroundColor":"rave","foregroundEffect":"bubbles"}</field>
+              <field name="VALUE">{"inputs":["ghost","chequered-flag","robot"],"backgroundEffect":"squiggles","backgroundColor":"rave","foregroundEffect":"bubbles"}</field>
             </block>
           </next>
         </block>
@@ -114,7 +114,7 @@
           <field name="UNIT">"measures"</field>
           <next>
             <block type="Dancelab_ai" id="+/R%~7O]jGllz)sqjTlr">
-              <field name="VALUE">{"inputs":["rainbow","party","silly"],"backgroundEffect":"rainbow","backgroundColor":"tropical","foregroundEffect":"confetti"}</field>
+              <field name="VALUE">{"inputs":["rainbow","party-popper","grinning-face-with-big-eyes"],"backgroundEffect":"rainbow","backgroundColor":"tropical","foregroundEffect":"confetti"}</field>
             </block>
           </next>
         </block>


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/54849. I missed these two AI blocks in level 8 of the HoC progression because they are not located within the `setup` block.

After update: 


![Screen Shot 2023-11-13 at 7 01 50 PM](https://github.com/code-dot-org/code-dot-org/assets/107423305/e51d7718-2e61-493c-9cd8-975e96353933)

## Links
[Slack thread reporting bug](https://codedotorg.slack.com/archives/C05P12U42F5/p1699915048734829)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
