### PR TITLE
Fix Preparation for Hour of Code Load Balancer

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -35,8 +35,6 @@ Parameters:
     Type: String
     Default: <%=rack_env?(:production) ? '\'\'' : stack_name %>
     Description: Subdomain name for Hour Of Code site.
-    AllowedPattern: "^(?!www$).*"
-    ConstraintDescription: Stack Name (typically the git branch name) cannot be `www` as this may conflict with production.
   InstanceType:
     Type: String
     Default: <%=INSTANCE_TYPE%>
@@ -71,6 +69,17 @@ Resources:
   HourOfCodeCertificate:
     Type: AWS::CertificateManager::Certificate
     Properties:
+<% if rack_env?(:production) -%>
+      DomainName: !Sub "${HourOfCodeBaseDomainName}"
+      SubjectAlternativeNames:
+        - !Sub "www.${HourOfCodeBaseDomainName}"
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: !Sub "${HourOfCodeBaseDomainName}"
+          HostedZoneId: !Ref HourOfCodeHostedZoneId
+        - DomainName: !Sub "www.${HourOfCodeBaseDomainName}"
+          HostedZoneId: !Ref HourOfCodeHostedZoneId
+<% else -%>
       DomainName: !Sub "${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
       SubjectAlternativeNames:
         - !Sub "www.${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
@@ -80,6 +89,7 @@ Resources:
           HostedZoneId: !Ref HourOfCodeHostedZoneId
         - DomainName: !Sub "www.${HourOfCodeSubdomainName}.${HourOfCodeBaseDomainName}"
           HostedZoneId: !Ref HourOfCodeHostedZoneId
+<% end -%>
 
   # ---------------------------------------------
   # Stack-specific IAM permissions


### PR DESCRIPTION
Fixes #54817 which treated the production subdomain name (empty string) as an invalid Stack Parameter value and which generated invalid fully qualified domain names such as `.hourofcode.com` and `www..hourofcode.com`.

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
