### PR TITLE
Refactor two-col action block css to include media margin

### DIFF
--- a/pegasus/sites.v3/code.org/public/ai/pl/101/index.haml
+++ b/pegasus/sites.v3/code.org/public/ai/pl/101/index.haml
@@ -21,10 +21,11 @@ theme: responsive_full_width
           %img{src: "/images/ai/pl/101/iste--w.png", height: "18px", alt: "ISTE"}
           %img{src: "/images/ai/pl/101/khan--w.png", height: "20px", alt: "Khan Academy"}
 
-%section.bg-neutral-light.video-101{id: "ai-pl-callout"}
+%section.bg-neutral-light.video-101
   .wrapper
     %h2=hoc_s(:ai_pl_101_intro_heading)
-    %p.video-101__text=hoc_s(:ai_pl_callout_desc_01)
+    %p.body-two
+      =hoc_s(:ai_pl_callout_desc_01)
     = view :ai_101_videos
 
 %section

--- a/pegasus/sites.v3/code.org/public/css/ai-pl-101-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/ai-pl-101-styles.scss
@@ -110,31 +110,10 @@
   }
 }
 
-.img {
-  &--max {
-    max-width: 100%;
-  }
-}
-
 .video-101 {
-
-  &__text {
-    margin-bottom: 2rem;
-  }
-
   .action-block {
     margin-bottom: 2rem;
     background: $neutral_white;
-  }
-
-  &__image,
-  &__video,
-  &__slides {
-
-    @media (min-width: 971px) {
-      margin: 20px 0 20px 20px;
-      width: calc(50% - 20px);
-    }
   }
 }
 
@@ -153,5 +132,4 @@
       }
     }
   }
-
 }

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -770,8 +770,8 @@ form {
 
   .media-wrapper {
     & > * {
-      margin: 1rem;
-      width: calc(100% - 1rem);
+      margin: 1.25rem;
+      width: calc(100% - 1.25rem);
 
       @media (max-width: $width-md) {
         margin: 0;

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -768,6 +768,8 @@ form {
   flex-wrap: wrap;
   overflow: hidden;
 
+  // Use this wrapper on the image or video
+  // to add a margin around it
   .media-wrapper {
     & > * {
       margin: 1.25rem;

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -768,6 +768,18 @@ form {
   flex-wrap: wrap;
   overflow: hidden;
 
+  .media-wrapper {
+    & > * {
+      margin: 1rem;
+      width: calc(100% - 1rem);
+
+      @media (max-width: $width-md) {
+        margin: 0;
+        width: 100%;
+      }
+    }
+  }
+
   .text-wrapper {
     padding: 1rem 1.5rem;
   }

--- a/pegasus/sites.v3/code.org/public/css/page/hour-of-code-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/page/hour-of-code-styles.scss
@@ -48,18 +48,3 @@
     }
   }
 }
-
-.action-block.action-block--two-col {
-  .media-wrapper {
-    & > * {
-      margin: 1rem;
-      width: calc(100% - 1rem);
-
-      @media (max-width: $width-md) {
-        margin: 0;
-        width: 100%;
-      }
-    }
-  }
-}
-

--- a/pegasus/sites.v3/code.org/views/ai_101_videos.haml
+++ b/pegasus/sites.v3/code.org/views/ai_101_videos.haml
@@ -17,7 +17,7 @@
 
 - video_101_index.times do |index|
   .action-block.action-block--two-col
-    .media-wrapper.col-45
+    .media-wrapper.col-50
       = view :display_video_thumbnail, id: video_id[index], video_code: video_code[index], play_button: 'center', letterbox: 'false', download_path: video_download_path[index]
     .text-wrapper.col-50
       %p.overline
@@ -27,19 +27,19 @@
       %p
         = video_101_desc[index]
       - if index === 1
-        %p.no-margin-bottom
+        %p
           %i{class: "#{icon_book}"}
           %strong=hoc_s(:ai_pl_101_resources_guide)
           %a.has-external-link{href: "https://docs.google.com/presentation/d/1WXvjG9TscUuH5Xz8Pj2okz6lMIKV__g0v6AoYVXKb40/copy", target: "_blank", rel: "noopener noreferrer"}
             =hoc_s(:ai_pl_101_llm_slides_title)
       - if index === 2
-        %p.no-margin-bottom
+        %p
           %i{class: "#{icon_book}"}
           %strong=hoc_s(:ai_pl_101_resources_guide)
           %a.has-external-link{href: "http://bit.ly/TransformLearningAI", target: "_blank", rel: "noopener noreferrer"}
             =hoc_s(:ai_pl_101_resources_3)
       - if index === 3
-        %p.no-margin-bottom
+        %p
           %i{class: "#{icon_book}"}
           %strong=hoc_s(:ai_pl_101_resources_guide)
           %a.has-external-link{href: "http://bit.ly/AIRespUse", target: "_blank", rel: "noopener noreferrer"}

--- a/pegasus/sites.v3/code.org/views/ai_101_videos.haml
+++ b/pegasus/sites.v3/code.org/views/ai_101_videos.haml
@@ -17,7 +17,7 @@
 
 - video_101_index.times do |index|
   .action-block.action-block--two-col
-    %figure.video-101__video.col-50
+    .media-wrapper.col-45
       = view :display_video_thumbnail, id: video_id[index], video_code: video_code[index], play_button: 'center', letterbox: 'false', download_path: video_download_path[index]
     .text-wrapper.col-50
       %p.overline
@@ -27,19 +27,19 @@
       %p
         = video_101_desc[index]
       - if index === 1
-        %p
+        %p.no-margin-bottom
           %i{class: "#{icon_book}"}
           %strong=hoc_s(:ai_pl_101_resources_guide)
           %a.has-external-link{href: "https://docs.google.com/presentation/d/1WXvjG9TscUuH5Xz8Pj2okz6lMIKV__g0v6AoYVXKb40/copy", target: "_blank", rel: "noopener noreferrer"}
             =hoc_s(:ai_pl_101_llm_slides_title)
       - if index === 2
-        %p
+        %p.no-margin-bottom
           %i{class: "#{icon_book}"}
           %strong=hoc_s(:ai_pl_101_resources_guide)
           %a.has-external-link{href: "http://bit.ly/TransformLearningAI", target: "_blank", rel: "noopener noreferrer"}
             =hoc_s(:ai_pl_101_resources_3)
       - if index === 3
-        %p
+        %p.no-margin-bottom
           %i{class: "#{icon_book}"}
           %strong=hoc_s(:ai_pl_101_resources_guide)
           %a.has-external-link{href: "http://bit.ly/AIRespUse", target: "_blank", rel: "noopener noreferrer"}


### PR DESCRIPTION
Adding a reusable `.media-wrapper` class to `design-system-pegasus.scss` for use on two column action blocks:
- Adds a `1.25rem` margin around images or videos
- Reduces the need for specificity and custom CSS per-page
- Examples can be found currently on:
  - https://code.org/hourofcode
  - https://code.org/ai/pl/101

**Jira ticket:** [ACQ-1139](https://codedotorg.atlassian.net/browse/ACQ-1139)

----

### There will be no noticeable visual change, but here's how they look using the new class:

## code.org/hourofcode
<img width="1003" alt="Screenshot 2023-11-14 at 9 27 46 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/11a65463-3850-48ca-ba87-a5ca23f6b0a0">

## code.org/ai/pl/101
<img width="994" alt="Screenshot 2023-11-14 at 9 28 02 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/cee3e715-4a6e-4397-bee8-b82d5a1be8b1">