### PR TITLE
Fix Hour of Code U.S. event counts

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/events/schools/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events/schools/index.haml
@@ -12,12 +12,13 @@ nav: events_nav
 
   events = Forms.events_by_country(kind, entire_school: true)
   us_events = Forms.events_by_state(kind, entire_school: true)
+  us_events_count = us_events.inject(0) {|result, element| result + element[:count]}
 
 %h1= hoc_s(:events_whole_school_title)
 
 %ul
   %li{class: "hoc-event-country"}
-    %span{style: "font-weight: bold;"}= "United States (#{us_events.count rescue '0'} #{hoc_s(:events)})"
+    %span{style: "font-weight: bold;"}= "United States (#{us_events_count rescue '0'} #{hoc_s(:events)})"
     %ul{style: "margin-top: 0; margin-bottom: 0;"}
       -us_events.each do |event|
         %li{class: "hoc-event-state"}

--- a/pegasus/sites.v3/hourofcode.com/public/events/special/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events/special/index.haml
@@ -12,12 +12,13 @@ nav: events_nav
 
   events = Forms.events_by_country(kind, review_approved: true)
   us_events = Forms.events_by_state(kind, review_approved: true)
+  us_events_count = us_events.inject(0) {|result, element| result + element[:count]}
 
 %h1= hoc_s(:events_special_title)
 
 %ul
   %li{class: "hoc-event-country"}
-    %span{style: "font-weight: bold;"}= "United States (#{us_events.count rescue '0'} #{hoc_s(:events)})"
+    %span{style: "font-weight: bold;"}= "United States (#{us_events_count rescue '0'} #{hoc_s(:events)})"
     %ul{style: "margin-top: 0; margin-bottom: 0;"}
       -us_events.each do |event|
         %li{class: "hoc-event-state"}


### PR DESCRIPTION
Currently, the U.S. Hour of Code event counter is not properly summing up the totals of its states listed below on the [special events page](https://hourofcode.com/us/events/special) and the [schools events page](https://hourofcode.com/us/events/schools) (however, the page listing [all events](https://hourofcode.com/us/events/all) is correct).

Since the page with all events is working, I had the other two pages use the [same logic](https://github.com/code-dot-org/code-dot-org/blob/staging/pegasus/sites.v3/hourofcode.com/public/events/all/index.haml#L14) for calculating the totals. For testing locally, I copied over the special events data in the U.S.:

### Before I made any changes, it incorrectly shows "11 events"
![TALLY_WRONG](https://github.com/code-dot-org/code-dot-org/assets/56283563/092c910c-3f0e-4110-83a8-39cd32acddef)

### After I matched the logic to the page with all events, it correctly shows "15 events"
![TALLY_RIGHT](https://github.com/code-dot-org/code-dot-org/assets/56283563/1042b1a3-4a44-43be-a93e-2e2a391e8289)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1148)

## Testing story
Local testing.