### PR TITLE
HoC 2023 - Fix missing string on Educators How-to guide

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/how-to/steps/steps_educators.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/how-to/steps/steps_educators.haml
@@ -110,6 +110,6 @@
               %p.tag.day-of
                 =hoc_s(:after_hoc)
               %p
-                =hoc_s(:hoc_how_to_step_educators_beyond_desc)
+                =hoc_s(:hoc_how_to_step_beyond_hoc_desc_generic)
               %a.link-button{href: resolve_url("/beyond")}
                 =hoc_s(:call_to_action_go_beyond_hoc)


### PR DESCRIPTION
Swapped a deleted string with the correct string on https://hourofcode.com/how-to in Step 8:
<img width="721" alt="Screenshot 2023-11-14 at 2 51 12 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/7702c27d-8384-44a3-915f-a432f8d64a5a">