### PR TITLE
Add soft delete to LTI sections

### DIFF
--- a/dashboard/app/models/lti_course.rb
+++ b/dashboard/app/models/lti_course.rb
@@ -26,7 +26,7 @@ class LtiCourse < ApplicationRecord
   belongs_to :lti_integration
   belongs_to :lti_deployment
   has_many :lti_sections, dependent: :destroy
-  has_many :sections, through: :lti_sections, dependent: :destroy
+  has_many :sections, through: :lti_sections
   validates :context_id, presence: true
   validates_uniqueness_of :context_id, scope: :lti_integration_id
   validates :nrps_url, url: {allow_nil: true}

--- a/dashboard/app/models/lti_section.rb
+++ b/dashboard/app/models/lti_section.rb
@@ -22,9 +22,9 @@ class LtiSection < ApplicationRecord
   belongs_to :section
   validates :section_id, uniqueness: true
   validates :lms_section_id, presence: true
-  after_destroy :destroy_associated_section
+  before_destroy :soft_delete_associated_section
 
-  def destroy_associated_section
-    section.destroy
+  def soft_delete_associated_section
+    section.destroy unless section.deleted?
   end
 end

--- a/dashboard/app/models/lti_section.rb
+++ b/dashboard/app/models/lti_section.rb
@@ -24,6 +24,8 @@ class LtiSection < ApplicationRecord
   validates :lms_section_id, presence: true
   before_destroy :soft_delete_associated_section
 
+  private
+
   def soft_delete_associated_section
     section.destroy unless section.deleted?
   end

--- a/dashboard/app/models/lti_section.rb
+++ b/dashboard/app/models/lti_section.rb
@@ -8,13 +8,16 @@
 #  lms_section_id :string(255)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  deleted_at     :datetime
 #
 # Indexes
 #
+#  index_lti_sections_on_deleted_at     (deleted_at)
 #  index_lti_sections_on_lti_course_id  (lti_course_id)
 #  index_lti_sections_on_section_id     (section_id)
 #
 class LtiSection < ApplicationRecord
+  acts_as_paranoid
   belongs_to :lti_course
   belongs_to :section
   validates :section_id, uniqueness: true

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -67,7 +67,8 @@ class Section < ApplicationRecord
   has_many :section_instructors, dependent: :destroy
   has_many :active_section_instructors, -> {where(status: :active)}, class_name: 'SectionInstructor'
   has_many :instructors, through: :active_section_instructors, class_name: 'User'
-  has_one :lti_section, dependent: :destroy
+  has_one :lti_section
+  after_destroy :soft_delete_lti_section
 
   has_many :followers, dependent: :destroy
   accepts_nested_attributes_for :followers
@@ -100,6 +101,10 @@ class Section < ApplicationRecord
   validate :pl_sections_must_use_email_logins
   validate :pl_sections_must_use_pl_grade
   validate :participant_type_not_changed
+
+  private def soft_delete_lti_section
+    lti_section.destroy if lti_section
+  end
 
   # PL courses which are run with adults should be set up with teacher accounts so they must use
   # email logins

--- a/dashboard/db/migrate/20231114211036_add_deleted_at_to_lti_sections.rb
+++ b/dashboard/db/migrate/20231114211036_add_deleted_at_to_lti_sections.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToLtiSections < ActiveRecord::Migration[6.1]
+  def change
+    add_column :lti_sections, :deleted_at, :datetime
+    add_index :lti_sections, :deleted_at
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_14_173245) do
+ActiveRecord::Schema.define(version: 2023_11_14_211036) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -877,6 +877,8 @@ ActiveRecord::Schema.define(version: 2023_11_14_173245) do
     t.string "lms_section_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_lti_sections_on_deleted_at"
     t.index ["lti_course_id"], name: "index_lti_sections_on_lti_course_id"
     t.index ["section_id"], name: "index_lti_sections_on_section_id"
   end

--- a/dashboard/test/models/lti_course_test.rb
+++ b/dashboard/test/models/lti_course_test.rb
@@ -30,7 +30,6 @@ class LtiCourseTest < ActiveSupport::TestCase
     LtiCourse.destroy(course.id)
     assert LtiCourse.find_by(id: course.id).nil?, "course should be deleted"
     sections.each do |section|
-      puts section.reload.inspect
       assert section.reload.deleted_at.present?, "section should be deleted"
     end
     lti_sections.each do |lti_section|

--- a/dashboard/test/models/lti_course_test.rb
+++ b/dashboard/test/models/lti_course_test.rb
@@ -30,8 +30,11 @@ class LtiCourseTest < ActiveSupport::TestCase
     LtiCourse.destroy(course.id)
     assert LtiCourse.find_by(id: course.id).nil?, "course should be deleted"
     sections.each do |section|
+      puts section.reload.inspect
       assert section.reload.deleted_at.present?, "section should be deleted"
     end
-    assert LtiSection.where(id: lti_sections.map(&:id)).empty?, "LTI sections should be deleted"
+    lti_sections.each do |lti_section|
+      assert lti_section.reload.deleted_at.present?, "lti_section should be deleted"
+    end
   end
 end

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -37,7 +37,8 @@ class SectionTest < ActiveSupport::TestCase
     section = create :section
     lti_section = create :lti_section, section: section
     section.destroy
-    assert LtiSection.where(id: lti_section.id).empty?, "LTI section should be deleted"
+    assert lti_section.reload.deleted_at.present?, "LTI section should be soft deleted"
+    assert LtiSection.without_deleted.where(id: lti_section.id).empty?, "LTI section should be soft deleted"
   end
 
   test "restoring section restores appropriate followers" do


### PR DESCRIPTION
Adds soft-delete to LTI sections. Adding the paranoid behavior messed up some of the cascading deletes, mostly because of the way that we were trying to get deleting a section to delete the LTI section, and vice versa. The only working solution I could find was:
- removing the `dependent: :destroy` from the `has_many :sections through: :lti_sections` relationship in LTI Courses. Deleting the LTI course will delete the LTI section, which in turn will delete the section, so the additional destroy was redundant.
- Removing the `dependent: :destroy` on both sides of the one-to-one relationship between sections and LTI sections. Instead, I added separate methods in each model to delete the corresponding other record. Without doing this, I ended up with endless loops when the two records tried to delete each other.

## Links

[Jira](https://codedotorg.atlassian.net/browse/P20-580)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
