### PR TITLE
Use absolute URLs when sharing to Facebook and Twitter

### DIFF
--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -101,6 +101,10 @@ function Certificate(props) {
     return `/certificates/${encoded}`;
   };
 
+  const getExternalCertificateSharePath = () => {
+    return `${window.location.origin}${getCertificateSharePath()}`;
+  };
+
   const {
     responsiveSize,
     tutorial,
@@ -117,6 +121,7 @@ function Certificate(props) {
     ? personalizedCertificate
     : initialCertificateImageUrl;
   const certificateShareLink = getCertificateSharePath();
+  const externalCertificateShareLink = getExternalCertificateSharePath();
   const desktop =
     responsiveSize === ResponsiveSize.lg ||
     responsiveSize === ResponsiveSize.md;
@@ -124,11 +129,11 @@ function Certificate(props) {
   const certificateStyle = desktop ? style.desktopHalf : style.mobileFull;
 
   const facebook = queryString.stringify({
-    u: certificateShareLink,
+    u: externalCertificateShareLink,
   });
 
   const twitter = queryString.stringify({
-    url: certificateShareLink,
+    url: externalCertificateShareLink,
     related: 'codeorg',
     text: randomDonorTwitter
       ? i18n.justDidHourOfCodeDonor({donor_twitter: randomDonorTwitter})

--- a/apps/src/templates/certificates/SocialShare.jsx
+++ b/apps/src/templates/certificates/SocialShare.jsx
@@ -46,6 +46,7 @@ export default class SocialShare extends Component {
             <button
               type="button"
               style={{background: color.facebook_blue, ...styles.shareButton}}
+              onClick={e => e.preventDefault()}
             >
               <i className="fa fa-facebook" />
             </button>
@@ -61,6 +62,7 @@ export default class SocialShare extends Component {
             <button
               type="button"
               style={{background: color.twitter_blue, ...styles.shareButton}}
+              onClick={e => e.preventDefault()}
             >
               <i className="fa fa-twitter" />
             </button>

--- a/apps/test/unit/templates/certificates/CertificateTest.js
+++ b/apps/test/unit/templates/certificates/CertificateTest.js
@@ -99,5 +99,19 @@ describe('Certificate', () => {
       const expectedSrc = `/certificate_images/${expectedFilename}.jpg`;
       expect(image.prop('src')).to.equal(expectedSrc);
     });
+
+    it('passes down full urls to SocialShare', () => {
+      const initialCertificateImageUrl =
+        'https://code.org/images/placeholder-hoc-image.jpg';
+      const wrapper = wrapperWithParams({
+        tutorial: 'dance',
+        certificateId: 'sessionId',
+        initialCertificateImageUrl,
+        isHocTutorial: true,
+      });
+      const socialShare = wrapper.find('SocialShare');
+      expect(socialShare.props().facebook).to.include('studio.code.org');
+      expect(socialShare.props().twitter).to.include('studio.code.org');
+    });
   });
 });


### PR DESCRIPTION
We received reports that sharing certificates to Facebook and Twitter were broken. Facebook was easy to repro as clicking on the link sent the user to a Facebook error page. Twitter was more subtly broken, see screenshot. Both issues were due to using relative instead of absolute URLs when sharing. The fix here is just to use the absolute URL.

<img width="584" alt="Screenshot 2023-11-15 at 10 22 49 AM" src="https://github.com/code-dot-org/code-dot-org/assets/46464143/256e1ac7-6f66-44cf-8626-40bd0f7020dc">

