### PR TITLE
Adds recording of metrics for tokens used in ai rubrics and enables retries on rubric jobs.

### DIFF
--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -20,8 +20,8 @@ class EvaluateRubricJob < ApplicationJob
     }
   }
 
-  # This is raised if there is a PII violation and you query with exceptions
-  # enabled.
+  # This is raised if there is any raised error due to a rate limit, e.g. a 429
+  # received from the aiproxy service.
   class TooManyRequestsError < StandardError
     attr_reader :response
 
@@ -35,7 +35,7 @@ class EvaluateRubricJob < ApplicationJob
     end
   end
 
-  AI_RUBRIC_METRICS_NAMESPACE = 'AIRubric'.freeze
+  AI_RUBRIC_METRICS_NAMESPACE = 'AiRubric'.freeze
 
   # Write out metrics reflected in the response to CloudWatch
   #

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -35,6 +35,7 @@ class EvaluateRubricJob < ApplicationJob
     end
   end
 
+  # The CloudWatch metric namespace
   AI_RUBRIC_METRICS_NAMESPACE = 'AiRubric'.freeze
 
   # Write out metrics reflected in the response to CloudWatch

--- a/dashboard/test/testing/includes_metrics.rb
+++ b/dashboard/test/testing/includes_metrics.rb
@@ -35,5 +35,29 @@ module Mocha
         "includes_metrics(#{@expected_metrics.mocha_inspect})"
       end
     end
+
+    def includes_dimensions(metrics, dimensions)
+      IncludesDimensions.new(metrics, dimensions)
+    end
+
+    class IncludesDimensions < Base
+      def initialize(metric_name, dimensions)
+        @expected_metric_name = metric_name
+        @expected_dimensions = dimensions
+      end
+
+      def matches?(available_parameters)
+        actual_metrics = available_parameters.shift
+        @expected_dimensions.all? do |expected_dimension_name, expected_value|
+          sought_metric = actual_metrics.find {|m| m[:metric_name] == @expected_metric_name}
+          actual_values = sought_metric&.[](:dimensions)
+          actual_values&.any? {|dim| expected_dimension_name.to_matcher.matches?([dim[:name].intern]) && expected_value.to_matcher.matches?([dim[:value]])}
+        end
+      end
+
+      def mocha_inspect
+        "includes_dimensions(#{@expected_dimensions.mocha_inspect})"
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds CloudWatch metrics to track the tokens used in total and as part of either prompt or response.

This also adds the ability to retry on a rate limiting action bubbled up from the aiproxy service. Additionally, timeouts from the aiproxy service (say, if it is itself restarting, etc) will trigger a retry. The retries are exponentially backed off.

## Links

<!--
- spec: []()
-->

- jira ticket: [AITT-244](https://codedotorg.atlassian.net/browse/AITT-244)
- jira ticket: [AITT-245](https://codedotorg.atlassian.net/browse/AITT-245)

## Testing story

Added a new matcher to the existing Metrics matchers to detect the correct use of dimensionality of the metric.

Otherwise, it is amending to our set of unit tests for the EvaluateRubricJob class.

## Follow-up work

I need to ensure that the aiproxy can bubble up a 429. I tested this by adding a dedicated 429 triggering route on the proxy service. I could commit and push that, at least.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
