### PR TITLE
Add LTI check to teacher_managed_account

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2230,6 +2230,8 @@ class User < ApplicationRecord
     # In some cases, a student might have a password but no e-mail (from our old UI)
     return false if encrypted_password.present? && hashed_email.present?
     return false if encrypted_password.present? && parent_email.present?
+    # LTI created accounts should not be teacher managed
+    return false if Policies::Lti.lti? self
     # Lastly, we check for oauth.
     !oauth?
   end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -524,6 +524,18 @@ FactoryBot.define do
       end
     end
 
+    trait :with_lti_authentication_option do
+      after(:create) do |user|
+        create(:authentication_option,
+          user: user,
+          email: user.email,
+          hashed_email: user.hashed_email,
+          credential_type: AuthenticationOption::LTI_V1,
+          authentication_id: 'https://lms.fake|12345|abcdef',
+        )
+      end
+    end
+
     trait :with_puzzles do
       transient do
         num_puzzles {1}

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1858,6 +1858,12 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_delete_own_account?
   end
 
+  test 'can delete own account if LTI student' do
+    user = create :student, :with_lti_authentication_option
+    refute user.teacher_managed_account?
+    assert user.can_delete_own_account?
+  end
+
   test 'cannot delete own account if teacher-managed student' do
     user = create :student_in_picture_section
     assert user.teacher_managed_account?


### PR DESCRIPTION
Currently, a student can't delete their account if they have logged in/signed up via an LTI launch. This PR adds a condition to the teacher_managed_account that returns false if the user has an LTI authentication_option.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[Jira ticket](https://codedotorg.atlassian.net/browse/P20-582)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

```
bundle exec spring testunit ./test/models/user_test.rb

  424/424: [=========================================================================================] 100% Time: 00:00:53, Time: 00:00:53

Finished in 54.47243s
424 tests, 1059 assertions, 0 failures, 0 errors, 0 skips
```
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
