### PR TITLE
Remove temporary code that was necessary before backfill task completed

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
   # Get the set of sections taught by the current user
   def index
     prevent_caching
-    render json: current_user.sections_owned_or_instructed.map(&:summarize_without_students)
+    render json: current_user.sections_instructed.map(&:summarize_without_students)
   end
 
   # GET /api/v1/sections/<id>

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -480,12 +480,6 @@ class User < ApplicationRecord
   has_many :active_section_instructors, -> {where(status: :active)}, class_name: 'SectionInstructor', foreign_key: 'instructor_id'
   has_many :sections_instructed, -> {without_deleted}, through: :active_section_instructors, source: :section
 
-  # TODO once the backfill creates SectionInstructors for every section owner,
-  # this method can be deleted and its references replaced by sections_instructed
-  def sections_owned_or_instructed
-    (sections + sections_instructed).uniq
-  end
-
   # Relationships (sections_as_students/followeds/teachers) from being a
   # student.
   has_many :followeds, -> {order 'followers.id'}, class_name: 'Follower', foreign_key: 'student_user_id', dependent: :destroy

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -96,20 +96,6 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_equal expected, returned_json
   end
 
-  # TODO(TEACH-721): This test is expected to fail after the post-backfill code cleanup.
-  test 'returns owned section even if no SectionInstructor exists' do
-    broken_section = create(:section, user: @teacher, login_type: 'word')
-    # Remove auto-created SectionInstructor to simulate old section that hasn't been backfilled.
-    broken_section.section_instructors.first.really_destroy!
-
-    sign_in @teacher
-    get :index
-    assert_response :success
-
-    expected = [@section, @section_with_unit_group, @section_with_script, broken_section].map(&:summarize_without_students).as_json
-    assert_equal expected, returned_json
-  end
-
   # It's easy to accidentally grant admins permission to `index` all sections
   # in the database - a huge query that we don't want to permit.  Admin users
   # should therefore only get their own sections when indexing sections,


### PR DESCRIPTION
The [backfill task](https://codedotorg.slack.com/archives/C0T0PNTM3/p1700006886779299) has completed and ensured that all section owners are included in `sections_instructed`. Therefore we are switching from `sections_owned_or_instructed` to `sections_instructed`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[TEACH-72](https://codedotorg.atlassian.net/browse/TEACH-72)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
