### PR TITLE
Update api_controller and tests to support section instructors

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -217,7 +217,7 @@ class ApiController < ApplicationController
       return
     end
 
-    data = current_user.sections.each_with_object({}) do |section, section_hash|
+    data = current_user.sections_instructed.each_with_object({}) do |section, section_hash|
       next if section.hidden
       script = load_script(section)
 
@@ -392,7 +392,7 @@ class ApiController < ApplicationController
   # Get /api/teacher_panel_section
   def teacher_panel_section
     prevent_caching
-    teacher_sections = current_user&.sections&.where(hidden: false)
+    teacher_sections = current_user&.sections_instructed&.where(hidden: false)
 
     if teacher_sections.blank?
       head :no_content

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -484,7 +484,7 @@ class User < ApplicationRecord
   # student.
   has_many :followeds, -> {order 'followers.id'}, class_name: 'Follower', foreign_key: 'student_user_id', dependent: :destroy
   has_many :sections_as_student, through: :followeds, source: :section
-  has_many :teachers, through: :sections_as_student, source: :user
+  has_many :teachers, through: :sections_as_student, source: :instructors
 
   belongs_to :secret_picture, optional: true
   before_create :generate_secret_picture

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -10,7 +10,9 @@ class ApiControllerTest < ActionController::TestCase
 
     @teacher_other = create(:teacher)
 
-    @section = create(:section, user: @teacher, login_type: 'word')
+    @section_owner = create(:teacher)
+    @section = create(:section, user: @section_owner, login_type: 'word')
+    create(:section_instructor, instructor: @teacher, section: @section, status: :active)
 
     @script = create(:script, :with_levels, levels_count: 1)
     @script_level = @script.script_levels[0]
@@ -282,10 +284,7 @@ class ApiControllerTest < ActionController::TestCase
   test "should get lock state when no user_level" do
     script, level, lesson = create_script_with_lockable_lesson
 
-    get :lockable_state, params: {
-      section_id: @section.id,
-      script_id: script.id
-    }
+    get :lockable_state, params: {script_id: script.id}
     assert_response :success
     assert_match "no-store", response.headers["Cache-Control"]
     body = JSON.parse(response.body)
@@ -328,7 +327,7 @@ class ApiControllerTest < ActionController::TestCase
 
   # Helper for setting up student lock tests
   def get_student_response(script, level, lesson, student_number)
-    get :lockable_state, params: {section_id: @section.id, script_id: script.id}
+    get :lockable_state, params: {script_id: script.id}
     assert_response :success
     body = JSON.parse(response.body)
 
@@ -1466,7 +1465,8 @@ class ApiControllerTest < ActionController::TestCase
 
     response = JSON.parse(@response.body)
     assert_equal @section.id, response["id"]
-    assert_equal @teacher.name, response["teacherName"]
+    assert_equal @section_owner.name, response["teacherName"]
+    assert_equal @teacher.name, response['sectionInstructors'].last['instructor_name']
     assert_equal 7, response["students"].length
   end
 

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -152,7 +152,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(unit)
     sign_in student
 
-    assert_cached_queries(16) do
+    assert_cached_queries(17) do
       get "/s/#{unit.name}/lessons/1/levels/1"
       assert_response :success
     end


### PR DESCRIPTION
* Change `User.teachers` association to go through a student's instructors rather than section owners (necessary for updating lockable state to work for a coteacher).
* Change `ApiController#lockable_state` and `ApiController#teacher_panel_section` to use section instructors rather than section owners.
* Update ApiController tests to use a `@section` where the `@teacher` is a coteacher rather than section owner.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
