### PR TITLE
[AI CHAT] CT-178: Add copy paste button to Aichat level

### DIFF
--- a/apps/src/aichat/chatApi.ts
+++ b/apps/src/aichat/chatApi.ts
@@ -62,7 +62,7 @@ export async function getChatCompletionMessage(
   // For now, response will be null if there was an error.
   // TODO: If user message was inappropriate or too personal, update status accordingly.
   if (!response) {
-    return {status: Status.PERSONAL, id: userMessageId}; // TODO: Update more accurately as either too personal or inappropriate.
+    return {status: Status.ERROR, id: userMessageId}; // TODO: Update more accurately as either too personal or inappropriate.
   }
   return {
     status: Status.OK,

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -1,15 +1,16 @@
+import moment from 'moment';
 import {createSlice, PayloadAction, createAsyncThunk} from '@reduxjs/toolkit';
+import {LabState} from '@cdo/apps/lab2/lab2Redux';
+const registerReducers = require('@cdo/apps/redux').registerReducers;
+
+import {initialChatMessages} from '../constants';
+import {getChatCompletionMessage} from '../chatApi';
 import {
   ChatCompletionMessage,
   AichatLevelProperties,
   Status,
   Role,
 } from '../types';
-import {initialChatMessages} from '../constants';
-
-const registerReducers = require('@cdo/apps/redux').registerReducers;
-import {LabState} from '@cdo/apps/lab2/lab2Redux';
-import {getChatCompletionMessage} from '../chatApi';
 
 export interface AichatState {
   // All user and assistant chat messages - includes too personal and inappropriate user messages.
@@ -54,12 +55,14 @@ export const submitChatMessage = createAsyncThunk(
       msg => msg.status === Status.OK
     );
 
+    const currentTimestamp = moment(Date.now()).format('YYYY-MM-DD HH:mm');
     // Create the new user ChatCompleteMessage and add to chatMessages.
     const newMessage: ChatCompletionMessage = {
       id: newMessageId,
       role: Role.USER,
       status: Status.UNKNOWN,
       chatMessageText: message,
+      timestamp: currentTimestamp,
     };
     thunkAPI.dispatch(addChatMessage(newMessage));
 

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -12,6 +12,7 @@ import {
   Role,
 } from '../types';
 
+const getCurrentTimestamp = () => moment(Date.now()).format('YYYY-MM-DD HH:mm');
 export interface AichatState {
   // All user and assistant chat messages - includes too personal and inappropriate user messages.
   // Messages will be logged and stored.
@@ -55,14 +56,13 @@ export const submitChatMessage = createAsyncThunk(
       msg => msg.status === Status.OK
     );
 
-    const currentTimestamp = moment(Date.now()).format('YYYY-MM-DD HH:mm');
     // Create the new user ChatCompleteMessage and add to chatMessages.
     const newMessage: ChatCompletionMessage = {
       id: newMessageId,
       role: Role.USER,
       status: Status.UNKNOWN,
       chatMessageText: message,
-      timestamp: currentTimestamp,
+      timestamp: getCurrentTimestamp(),
     };
     thunkAPI.dispatch(addChatMessage(newMessage));
 
@@ -89,6 +89,9 @@ export const submitChatMessage = createAsyncThunk(
         role: Role.ASSISTANT,
         status: Status.OK,
         chatMessageText: chatApiResponse.assistantResponse,
+        // The accuracy of this timestamp is debatable since it's not when our backend
+        // issued the message, but it's good enough for user testing.
+        timestamp: getCurrentTimestamp(),
       };
       thunkAPI.dispatch(addChatMessage(assistantChatMessage));
     }

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -15,6 +15,7 @@ export type ChatCompletionMessage = {
   role: Role;
   chatMessageText: string;
   status: Status;
+  timestamp?: string;
 };
 
 export enum Role {

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -25,9 +25,10 @@ export enum Role {
 }
 
 export enum Status {
+  ERROR = 'error',
+  INAPPROPRIATE = 'inappropriate',
   OK = 'ok',
   PERSONAL = 'personal',
-  INAPPROPRIATE = 'inappropriate',
   UNKNOWN = 'unknown',
 }
 

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -1,14 +1,16 @@
 /** @file Top-level view for AI Chat Lab */
 
 import React, {useCallback} from 'react';
-import moduleStyles from './aichatView.module.scss';
-import ChatWorkspace from './ChatWorkspace';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {sendSuccessReport} from '@cdo/apps/code-studio/progressRedux';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 const commonI18n = require('@cdo/locale');
 const aichatI18n = require('@cdo/aichat/locale');
+
+import ChatWorkspace from './ChatWorkspace';
+import CopyButton from './CopyButton';
+import moduleStyles from './aichatView.module.scss';
 
 const AichatView: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
@@ -31,6 +33,7 @@ const AichatView: React.FunctionComponent = () => {
         <PanelContainer
           id="aichat-workspace-panel"
           headerText={aichatI18n.aichatWorkspaceHeader()}
+          rightHeaderContent={<CopyButton />}
         >
           <ChatWorkspace />
         </PanelContainer>

--- a/apps/src/aichat/views/ChatMessage.tsx
+++ b/apps/src/aichat/views/ChatMessage.tsx
@@ -36,7 +36,7 @@ const displayUserMessage = (status: string, chatMessageText: string) => {
         {chatMessageText}
       </div>
     );
-  } else if (status === 'inappropriate') {
+  } else if (status === Status.INAPPROPRIATE) {
     return (
       <div
         className={classNames(
@@ -56,6 +56,18 @@ const displayUserMessage = (status: string, chatMessageText: string) => {
         )}
       >
         {TOO_PERSONAL_MESSAGE}
+      </div>
+    );
+  } else if (status === Status.ERROR) {
+    return (
+      <div
+        className={classNames(
+          moduleStyles.message,
+          // TODO: Add dedicated error message styling.
+          moduleStyles.tooPersonalMessage
+        )}
+      >
+        {'There was an error getting a response. Please try again.'}
       </div>
     );
   } else {

--- a/apps/src/aichat/views/CopyButton.tsx
+++ b/apps/src/aichat/views/CopyButton.tsx
@@ -31,6 +31,7 @@ const CopyButton: React.FunctionComponent = () => {
   return (
     <Button
       color={Button.ButtonColor.white}
+      icon={'clipboard'}
       key="copy"
       onClick={() => handleCopy()}
       size={Button.ButtonSize.small}

--- a/apps/src/aichat/views/CopyButton.tsx
+++ b/apps/src/aichat/views/CopyButton.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {useSelector} from 'react-redux';
+
+import Button from '@cdo/apps/templates/Button';
+import {AichatState} from '@cdo/apps/aichat/redux/aichatRedux';
+
+const copyToClipboard = require('@cdo/apps/util/copyToClipboard');
+
+const CopyButton: React.FunctionComponent = () => {
+  const storedMessages = useSelector(
+    (state: {aichat: AichatState}) => state.aichat.chatMessages
+  );
+
+  const handleCopy = () => {
+    const textToCopy = storedMessages
+      .map(
+        message =>
+          `[${message.timestamp || 'XXXX-XX-XX XX:XX'} - ${message.role}] ${
+            message.chatMessageText
+          }`
+      )
+      .join('\n');
+    copyToClipboard(
+      textToCopy,
+      () => alert('Text copied to clipboard'),
+      () => {
+        console.error('Error in copying text');
+      }
+    );
+  };
+
+  return (
+    <Button
+      color={Button.ButtonColor.white}
+      key="copy"
+      onClick={() => handleCopy()}
+      size={Button.ButtonSize.small}
+      text="Copy Conversation History"
+    />
+  );
+};
+
+export default CopyButton;

--- a/apps/src/aichat/views/CopyButton.tsx
+++ b/apps/src/aichat/views/CopyButton.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import {useSelector} from 'react-redux';
 
 import Button from '@cdo/apps/templates/Button';
+import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 import {AichatState} from '@cdo/apps/aichat/redux/aichatRedux';
-
-const copyToClipboard = require('@cdo/apps/util/copyToClipboard');
 
 const CopyButton: React.FunctionComponent = () => {
   const storedMessages = useSelector(

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -32,5 +32,4 @@ $default-spacing: 2px;
 
 .waitingForResponse {
   width: 50px;
-  z-index: 1000;
 }

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -32,4 +32,5 @@ $default-spacing: 2px;
 
 .waitingForResponse {
   width: 50px;
+  z-index: 1000;
 }

--- a/apps/src/util/copyToClipboard.js
+++ b/apps/src/util/copyToClipboard.js
@@ -1,3 +1,9 @@
+/**
+ * Copies a string to the clipboard. Includes a fallback for legacy browsers.
+ * @param {string} str - Text to copy to the clipboard.
+ * @param {function} onSuccess - Callback function to call on success.
+ * @param {function} onFailure - Callback function to call on failure.
+ */
 export default function copyToClipboard(
   str,
   onSuccess = null,


### PR DESCRIPTION
This PR:
- Adds a CopyButton that allows a user to copy their chat history.
- Adds a timestamp field to the messages.
- Makes an error message the default rendered chat message if the response from the server is empty.

## Links

https://codedotorg.atlassian.net/browse/CT-178

## Testing story

Tested locally.

A screenshot of the page, including the new copy button in the upper right-hand corner and a confirmation when copying has succeeded.
<img width="1117" alt="Screenshot 2023-11-16 at 2 51 15 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/c8aa653d-5040-4788-9693-23de4a1e53b5">

The error message is now used as default instead of the "too personal" message. 
<img width="1134" alt="Screenshot 2023-11-16 at 10 41 17 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/74d6cfaf-2545-4851-8cd2-28b8f6acf647">

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
