### PR TITLE
AI Tutor - basic Amplitude logging for Code Compilation

### DIFF
--- a/apps/src/code-studio/components/aiTutor/aiTutorPanel.jsx
+++ b/apps/src/code-studio/components/aiTutor/aiTutorPanel.jsx
@@ -8,18 +8,21 @@ const icon = require('@cdo/static/ai-bot.png');
 
 export default class AITutorPanel extends React.Component {
   static propTypes = {
-    levelType: PropTypes.string,
+    level: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      type: PropTypes.string.isRequired,
+    }),
   };
 
   render() {
-    const {levelType} = this.props;
-    const isCodingLevel = levelType === 'Javalab';
+    const {level} = this.props;
+    const isCodingLevel = level.type === 'Javalab';
 
     return (
-      <AITutorPanelContainer>
+      <AITutorPanelContainer level={level}>
         <h3 id="ai_tutor_panel">AI Tutor</h3>
         <img alt={i18n.aiBot()} src={icon} className={style.aiBotImg} />
-        {isCodingLevel && <CompilationAssistant />}
+        {isCodingLevel && <CompilationAssistant levelId={level.id} />}
       </AITutorPanelContainer>
     );
   }

--- a/apps/src/code-studio/components/aiTutor/aiTutorPanelContainer.jsx
+++ b/apps/src/code-studio/components/aiTutor/aiTutorPanelContainer.jsx
@@ -3,22 +3,38 @@ import React from 'react';
 import classNames from 'classnames';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 export default class AITutorPanelContainer extends React.Component {
   static propTypes = {
     children: PropTypes.node,
+    level: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      type: PropTypes.string.isRequired,
+    }),
   };
 
   state = {open: tryGetLocalStorage('ai-tutor-panel', 'open') !== 'closed'};
 
   hide = () => {
+    const {level} = this.props;
     this.setState({open: false});
     trySetLocalStorage('ai-tutor-panel', 'closed');
+    analyticsReporter.sendEvent(EVENTS.AI_TUTOR_PANEL_CLOSED, {
+      levelId: level.id,
+      levelType: level.type,
+    });
   };
 
   show = () => {
+    const {level} = this.props;
     this.setState({open: true});
     trySetLocalStorage('ai-tutor-panel', 'open');
+    analyticsReporter.sendEvent(EVENTS.AI_TUTOR_PANEL_OPENED, {
+      levelId: level.id,
+      levelType: level.type,
+    });
   };
 
   render() {

--- a/apps/src/code-studio/components/aiTutor/compilationAssistant.jsx
+++ b/apps/src/code-studio/components/aiTutor/compilationAssistant.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Button from '@cdo/apps/templates/Button';
 import style from './ai-tutor.module.scss';
 import {askAITutor} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
 import {useSelector, useDispatch} from 'react-redux';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 // AI Tutor feature that explains to students why their code did not compile.
-const CompilationAssistant = () => {
+const CompilationAssistant = props => {
+  const levelId = props.levelId;
   const dispatch = useDispatch();
   const javalabState = useSelector(state => state.javalabEditor);
   const studentCode =
@@ -15,6 +19,9 @@ const CompilationAssistant = () => {
 
   const handleSend = async studentCode => {
     dispatch(askAITutor(studentCode));
+    analyticsReporter.sendEvent(EVENTS.AI_TUTOR_ASK_ABOUT_COMPILATION, {
+      levelId: levelId,
+    });
   };
 
   return (
@@ -30,6 +37,10 @@ const CompilationAssistant = () => {
       <p id="ai-response">{aiTutorState.aiResponse}</p>
     </div>
   );
+};
+
+CompilationAssistant.propTypes = {
+  levelId: PropTypes.int,
 };
 
 export default CompilationAssistant;

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -100,6 +100,11 @@ const EVENTS = {
   TA_RUBRIC_RUN_BUTTON_CLICKED:
     'TA Rubric Teacher clicked RUN button on student work',
 
+  // AI Tutor
+  AI_TUTOR_PANEL_OPENED: 'AI Tutor Panel Opened',
+  AI_TUTOR_PANEL_CLOSED: 'AI Tutor Panel Closed',
+  AI_TUTOR_ASK_ABOUT_COMPILATION: 'AI Tutor was asked about compilation',
+
   // Hour of Code
   AGE_21_SELECTED_EVENT: 'Age 21+ Selected',
   GUIDE_SENT_EVENT: 'Guide Sent',

--- a/apps/src/sites/studio/pages/levels/_ai_tutor_panel.js
+++ b/apps/src/sites/studio/pages/levels/_ai_tutor_panel.js
@@ -10,17 +10,17 @@ $(document).ready(initPage);
 function initPage() {
   const script = document.querySelector('script[data-aitutorpanel]');
   const aiTutorPanelData = JSON.parse(script.dataset.aitutorpanel);
-  renderAITutorPanel(aiTutorPanelData.level_type);
+  renderAITutorPanel(aiTutorPanelData.level);
 }
 
-function renderAITutorPanel(levelType) {
+function renderAITutorPanel(level) {
   const div = document.createElement('div');
   div.setAttribute('id', 'ai-tutor-panel-container');
   const store = getStore();
 
   ReactDOM.render(
     <Provider store={store}>
-      <AITutorPanel levelType={levelType} />
+      <AITutorPanel level={level} />
     </Provider>,
     div
   );

--- a/dashboard/app/views/levels/_ai_tutor_panel.html.haml
+++ b/dashboard/app/views/levels/_ai_tutor_panel.html.haml
@@ -1,5 +1,5 @@
 - data = {}
-- data[:level_type] = @level&.type
+- data[:level] = @level
 
 - content_for(:head) do
   %script{src: webpack_asset_path('js/levels/_ai_tutor_panel.js'), data: {aitutorpanel: data.to_json }}


### PR DESCRIPTION
I wanted to learn more about Amplitude and used the opportunity to set us up to collect some very basic usage data on the prototypes for upcoming classroom visits while we finalize our [longer term approach](https://docs.google.com/spreadsheets/d/1nfC4ml02zQPzmyxEAZq2xfWWKwwvjVC7FMWQ9uaDZNQ/edit#gid=0) to collecting metrics about AI Tutor usage. 

With this PR, we'll now log to Amplitude:
1.) When the AI Tutor panel is opened, including on which level (id and type)
2.) When the AI Tutor panel is closed, including on which level (id and type)
3.) When the student clicks "Ask AI Tutor" about a compilation error, including which level (id, no type needed since it's always "Javalab" since the compilation tutor only shows up on coding levels)

![Screenshot 2023-11-16 at 1 28 39 PM](https://github.com/code-dot-org/code-dot-org/assets/12300669/e253b8e7-431e-40a6-bc17-523dd297df05)


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Follow-up work

The AI Tutor Panel is still in the prototype phase so this logging is just barebones to help us collect data in upcoming classroom visits. When the UI and functionality is more finalized, we'll need to do another pass at data collection tooling for the feature. 

Notably, when (if?) AI Tutor is out in the wild for general use, we'll want to be able to differentiate between users who have AI Tutor access and those who don't so that we have a good sense of: 
- what % of students have access to AI Tutor 
- of those students with AI Tutor access, what % are using the tutor 
Access to AI Tutor for students is via their teacher's enrollment in the `ai-tutor` experiment, so it will _not_ show up in the `enabledExperiments` `userProperties` in Amplitude ([note](https://github.com/code-dot-org/code-dot-org/pull/54294#discussion_r1393375583)); we'll need to send some concept of `hasAITutorAccess` separately when it's time to cross that bridge. 

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
