### PR TITLE
Dance AI: supply logger to native API

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -56,7 +56,7 @@
     "@code-dot-org/artist": "0.2.1",
     "@code-dot-org/blockly": "4.0.14",
     "@code-dot-org/craft": "0.2.2",
-    "@code-dot-org/dance-party": "1.1.0",
+    "@code-dot-org/dance-party": "1.1.1",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "2.16.0",
     "@code-dot-org/ml-activities": "0.0.26",

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -445,6 +445,7 @@ Dance.prototype.afterInject_ = function () {
     container: 'divDance',
     i18n: danceMsg,
     resourceLoader: new ResourceLoader(ASSET_BASE),
+    logger: Lab2MetricsReporter,
   });
 
   // Expose an interface for testing

--- a/apps/src/dance/lab2/ProgramExecutor.ts
+++ b/apps/src/dance/lab2/ProgramExecutor.ts
@@ -66,6 +66,7 @@ export default class ProgramExecutor {
         container,
         i18n: danceMsg,
         resourceLoader: new ResourceLoader(ASSET_BASE),
+        logger: Lab2MetricsReporter,
       });
   }
 

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -2255,10 +2255,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@code-dot-org/dance-party@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@code-dot-org/dance-party@npm:1.1.0"
-  checksum: 6a6edc534483e2e8db921e2e7ea9e20cdca5be46a7c6e85174a5be9fa65012e3fe78b40a07130cd95e93ee60ddb9866ead44c5546bb0dca0889ec0cfccd110f1
+"@code-dot-org/dance-party@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@code-dot-org/dance-party@npm:1.1.1"
+  checksum: 4aec7af969d2fd59ae8544d138687455de400e8ac50cfd1ceabb01da940cfcfbbf85eafd12ab4cac1638a45fa94db807277f265c3845cb9f57c6e0ced1c81455
   languageName: node
   linkType: hard
 
@@ -7659,7 +7659,7 @@ __metadata:
     "@code-dot-org/artist": 0.2.1
     "@code-dot-org/blockly": 4.0.14
     "@code-dot-org/craft": 0.2.2
-    "@code-dot-org/dance-party": 1.1.0
+    "@code-dot-org/dance-party": 1.1.1
     "@code-dot-org/johnny-five": 2.1.0-cdo.3
     "@code-dot-org/js-interpreter": 1.3.13
     "@code-dot-org/js-numbers": 0.1.0-cdo.0


### PR DESCRIPTION
Companion to https://github.com/code-dot-org/dance-party/pull/671. This change just supplies a logger (in this case the Lab2MetricsReporter) to the native Dance Party API, so it can log cases where it receives unrecognized background/foreground effects.

Will include dance-party version update in this PR once it's merged.

## Links

https://trello.com/c/qUhwOQHI

## Testing story

Tested locally; manually edited cached AI JSON files to have invalid outputs.