### PR TITLE
Update teacher_dashboard_controller and tests to support section instructors

### DIFF
--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -3,13 +3,13 @@ class TeacherDashboardController < ApplicationController
 
   def show
     @section_summary = @section.summarize
-    @sections = current_user.sections.map(&:summarize)
+    @sections = current_user.sections_instructed.map(&:summarize)
     @locale_code = request.locale
   end
 
   def parent_letter
     @section_summary = @section.summarize
-    @sections = current_user.sections.map(&:summarize)
+    @sections = current_user.sections_instructed.map(&:summarize)
     render layout: false
   end
 end

--- a/dashboard/test/controllers/teacher_dashboard_controller_test.rb
+++ b/dashboard/test/controllers/teacher_dashboard_controller_test.rb
@@ -4,8 +4,8 @@ class TeacherDashboardControllerTest < ActionController::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    @teacher = create :teacher
-    @sections = create_list :section, 3, user: @teacher
+    @section_owner = create :teacher
+    @sections = create_list :section, 3, user: @section_owner
     @section = @sections.first
   end
 
@@ -21,16 +21,26 @@ class TeacherDashboardControllerTest < ActionController::TestCase
   end
 
   test 'index: returns forbidden if requested section does not belong to teacher' do
-    sign_in @teacher
+    sign_in @section_owner
     other_teacher_section = create :section
     get :show, params: {section_id: other_teacher_section.id}
     assert_response :forbidden
   end
 
-  test 'index: returns success if requested section belongs to teacher' do
-    sign_in @teacher
-    section = create :section, user: @teacher
+  test 'index: returns success if requested section belongs to the section owner' do
+    sign_in @section_owner
+    section = create :section, user: @section_owner
     get :show, params: {section_id: section.id}
+    assert_response :success
+  end
+
+  test 'index: returns success if requested section is an instructed section for a coteacher' do
+    cotaught_section = create(:section, user: @section_owner, login_type: 'word')
+    other_teacher = create :teacher
+    create(:section_instructor, instructor: other_teacher, section: cotaught_section, status: :active)
+
+    sign_in other_teacher
+    get :show, params: {section_id: cotaught_section.id}
     assert_response :success
   end
 end


### PR DESCRIPTION
- Modified the controller to find all `sections_instructed`.
- Modified the tests so that `section_owner` was used for a variable rather than `teacher` for readability
- Added a test to check that a `section_instructor` (aka "coteacher") could see the teacher dashboard for a co-taught section.

I noticed that there are no tests for `parent_letter` at all, I don't know if we should add that to a backlog???  Happy to create that ticket if ya'll agree that should be added to our back-log of tech debt. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
