### PR TITLE
Centered Assignment Confirmation over filters in Curriculum Catalog page

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -173,17 +173,19 @@ const CurriculumCatalog = ({
         imageUrl={CourseCatalogIllustration01}
       />
       {showAssignSuccessMessage && (
-        <div className={style.assignSuccessMessageContainer}>
-          <BodyTwoText className={style.assignSuccessMessage}>
-            {assignSuccessMessage}
-          </BodyTwoText>
-          <button
-            aria-label="close success message"
-            onClick={handleCloseAssignSuccessMessage}
-            type="button"
-          >
-            <strong>X</strong>
-          </button>
+        <div className={style.assignSuccessMessageCenter}>
+          <div className={style.assignSuccessMessageContainer}>
+            <BodyTwoText className={style.assignSuccessMessage}>
+              {assignSuccessMessage}
+            </BodyTwoText>
+            <button
+              aria-label="close success message"
+              onClick={handleCloseAssignSuccessMessage}
+              type="button"
+            >
+              <strong>X</strong>
+            </button>
+          </div>
         </div>
       )}
       <CurriculumCatalogFilters

--- a/apps/style/code-studio/curriculum_catalog_container.module.scss
+++ b/apps/style/code-studio/curriculum_catalog_container.module.scss
@@ -41,14 +41,12 @@ $container-width: 309px;
 .assignSuccessMessageContainer {
   display: flex;
   min-width: 250px;
-  margin-left: -125px;
   background-color: color.$bootstrap_success_background;
   text-align: center;
   border-radius: 5px;
   border-color: color.$bootstrap_success_border;
   position: fixed;
-  z-index: 1;
-  left: 50%;
+  z-index: 4;
   top: 70px;
 
   button {
@@ -64,4 +62,9 @@ $container-width: 309px;
 .assignSuccessMessage {
   margin: 16px;
   color: color.$bootstrap_success_text;
+}
+
+.assignSuccessMessageCenter {
+  display: flex;
+  justify-content: center;
 }


### PR DESCRIPTION
Centers the Assignment Confirmation message and changes the z-index of the confirmation message so that appears over the sticky filters.

## Centered Assignment Confirmation Message
<img width="1792" alt="Screenshot 2023-11-16 at 1 47 30 PM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/2a36679f-69b4-4372-9fcb-4810243a80ff">

## Confirmation appears over filters
<img width="1792" alt="Screenshot 2023-11-16 at 1 47 36 PM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/0e82d1b5-b1f1-4ad8-9216-367b3c5c0b35">

## Non-English view
<img width="1792" alt="Screenshot 2023-11-16 at 1 56 02 PM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/8e57c05f-ad5b-4612-921d-d285df855a52">



## Links


- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?selectedIssue=ACQ-904) and [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?selectedIssue=ACQ-906)

## Testing story
Local



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
