### PR TITLE
Instructor email fix

### DIFF
--- a/dashboard/app/serializers/api/v1/section_instructor_info_serializer.rb
+++ b/dashboard/app/serializers/api/v1/section_instructor_info_serializer.rb
@@ -8,6 +8,6 @@ class Api::V1::SectionInstructorInfoSerializer < ActiveModel::Serializer
   end
 
   def instructor_email
-    object.instructor.email
+    object.instructor&.email
   end
 end

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -96,6 +96,20 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_equal expected, returned_json
   end
 
+  test 'returns sections co-taught with a deleted instructor' do
+    cotaught_section = create(:section, user: @teacher, login_type: 'word')
+    coteacher = create(:teacher)
+    create(:section_instructor, instructor: coteacher, section: cotaught_section, status: :active)
+    coteacher.destroy!
+
+    sign_in @teacher
+    get :index
+    assert_response :success
+
+    expected = [@section, @section_with_unit_group, @section_with_script, cotaught_section].map(&:summarize_without_students).as_json
+    assert_equal expected, returned_json
+  end
+
   # It's easy to accidentally grant admins permission to `index` all sections
   # in the database - a huge query that we don't want to permit.  Admin users
   # should therefore only get their own sections when indexing sections,


### PR DESCRIPTION
A user teaching a section with a deleted co-teacher was failing to get their section list because the coteachers were failing to serialize. This should fix it.

## Links

[Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/471377)

## Testing story

Added a test to make sure that the `index` route succeeds even with a deleted coteacher.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
