### PR TITLE
Include section instructors in several "/s/..." routes

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -252,11 +252,11 @@ class ScriptLevelsController < ApplicationController
 
     if @script.can_be_instructor?(current_user)
       if params[:section_id]
-        @section = current_user.sections.find_by(id: params[:section_id])
+        @section = current_user.sections_instructed.find_by(id: params[:section_id])
         @user = @section&.students&.find_by(id: params[:user_id])
       # If we have no url param and only one section make sure that is the section we are using
-      elsif current_user.sections.length == 1
-        @section = current_user.sections[0]
+      elsif current_user.sections_instructed.length == 1
+        @section = current_user.sections_instructed[0]
         @user = @section&.students&.find_by(id: params[:user_id])
       end
       # This errs on the side of showing the warning by only if the script we are in
@@ -432,12 +432,9 @@ class ScriptLevelsController < ApplicationController
     if params[:section_id] && params[:section_id] != "undefined"
       section = Section.find(params[:section_id])
 
-      # TODO: This should use cancan/authorize.
-      if section.user == current_user
-        @section = section
-      end
-    elsif current_user.try(:sections).try(:where, hidden: false).try(:count) == 1
-      @section = current_user.sections.where(hidden: false).first
+      @section = section if can?(:manage, section)
+    elsif current_user.try(:sections_instructed).try(:where, hidden: false).try(:count) == 1
+      @section = current_user.sections_instructed.where(hidden: false).first
     end
   end
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -49,8 +49,8 @@ class ScriptsController < ApplicationController
 
     @show_redirect_warning = params[:redirect_warning] == 'true'
     unless current_user&.student?
-      @section = current_user&.sections&.all&.find {|s| s.id.to_s == params[:section_id]}&.summarize
-      sections = current_user.try {|u| u.sections.all.reject(&:hidden).map(&:summarize)}
+      @section = current_user&.sections_instructed&.all&.find {|s| s.id.to_s == params[:section_id]}&.summarize
+      sections = current_user.try {|u| u.sections_instructed.all.reject(&:hidden).map(&:summarize)}
       @sections_with_assigned_info = sections&.map {|section| section.merge!({"isAssigned" => section[:script_id] == @script.id})}
     end
 

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -16,10 +16,14 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     @facilitator = create :facilitator
     @levelbuilder = create(:levelbuilder)
     @project_validator = create :project_validator
-    @section = create :section, user_id: @teacher.id
+    @section_owner = create :teacher
+    @section = create :section, user: @section_owner
+    create :section_instructor, instructor: @teacher, section: @section
     Follower.create!(section_id: @section.id, student_user_id: @student.id, user: @teacher)
 
-    @pl_section = create :section, user_id: @facilitator.id
+    @pl_section_owner = create :facilitator
+    @pl_section = create :section, user: @pl_section_owner
+    create :section_instructor, instructor: @facilitator, section: @pl_section
     Follower.create!(section_id: @pl_section.id, student_user_id: @teacher.id, user: @facilitator)
 
     @custom_script = create(:script, name: 'laurel', hideable_lessons: true)
@@ -60,7 +64,9 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     pilot_lesson = create(:lesson, script: pilot_script, lesson_group: pilot_lesson_group)
     @pilot_script_level = create :script_level, script: pilot_script, lesson: pilot_lesson
     @pilot_teacher = create :teacher, pilot_experiment: 'pilot-experiment'
-    pilot_section = create :section, user: @pilot_teacher, script: pilot_script
+    @pilot_section_owner = create :teacher, pilot_experiment: 'pilot-experiment'
+    pilot_section = create :section, user: @pilot_section_owner, script: pilot_script
+    create :section_instructor, instructor: @pilot_teacher, section: pilot_section
     @pilot_student = create(:follower, section: pilot_section).student_user
 
     pilot_pl_script = create(:script, pilot_experiment: 'pl-pilot-experiment', instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
@@ -68,7 +74,9 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     pilot_pl_lesson = create(:lesson, script: pilot_pl_script, lesson_group: pilot_pl_lesson_group)
     @pilot_pl_script_level = create :script_level, script: pilot_pl_script, lesson: pilot_pl_lesson
     @pilot_instructor = create :facilitator, pilot_experiment: 'pl-pilot-experiment'
-    pilot_pl_section = create :section, user: @pilot_instructor, script: pilot_pl_script
+    @pilot_section_owner = create :facilitator, pilot_experiment: 'pl-pilot-experiment'
+    pilot_pl_section = create :section, user: @pilot_section_owner, script: pilot_pl_script
+    create :section_instructor, instructor: @pilot_instructor, section: pilot_pl_section
     @pilot_participant = create :teacher
     create(:follower, section: pilot_pl_section, student_user: @pilot_participant)
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -1523,14 +1523,18 @@ class ScriptsControllerTest < ActionController::TestCase
 
   class CoursePilotTests < ActionController::TestCase
     setup do
+      @pilot_section_owner = create :teacher, pilot_experiment: 'my-experiment'
       @pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
       @pilot_unit = create :script, pilot_experiment: 'my-experiment', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot
-      @pilot_section = create :section, user: @pilot_teacher, script: @pilot_unit
+      @pilot_section = create :section, user: @pilot_section_owner, script: @pilot_unit
+      create :section_instructor, instructor: @pilot_teacher, section: @pilot_section, status: :active
       @pilot_student = create(:follower, section: @pilot_section).student_user
 
+      @pilot_pl_section_owner = create :teacher, pilot_experiment: 'my-pl-experiment'
       @pilot_instructor = create :facilitator, pilot_experiment: 'my-pl-experiment'
       @pilot_pl_unit = create :script, pilot_experiment: 'my-pl-experiment', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.pilot, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher
-      @pilot_pl_section = create :section, user: @pilot_instructor, script: @pilot_pl_unit
+      @pilot_pl_section = create :section, user: @pilot_pl_section_owner, script: @pilot_pl_unit
+      create :section_instructor, instructor: @pilot_instructor, section: @pilot_pl_section, status: :active
       @pilot_pl_participant = create :facilitator
       create(:follower, section: @pilot_pl_section, student_user: @pilot_pl_participant)
     end


### PR DESCRIPTION
Include `sections_instructed` in the following calls:
* GET /s/{:scriptId}/lessons/{:lessonId}/extras
* GET /s/{:scriptId}/lessons/{:lessonId}/levels/{:id}
* GET /s/{:scriptId}

Modify tests for these files to run as a co-teacher instead of as a section owner.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
