### PR TITLE
User rework

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -474,14 +474,15 @@ class User < ApplicationRecord
   has_many :section_instructors, foreign_key: 'instructor_id'
   has_many :active_section_instructors, -> {where(status: :active)}, class_name: 'SectionInstructor', foreign_key: 'instructor_id'
   has_many :sections_instructed, -> {without_deleted}, through: :active_section_instructors, source: :section
-  #alias_attribute :sections, :sections_instructed
+
+  # "sections" previously referred to what is now called :sections_owned.
   def sections
     sections_instructed
   end
 
-  has_many :followers, through: :sections_instructed
   # Relationships (sections/followers/students) from being a teacher.
   has_many :sections_owned, dependent: :destroy, class_name: 'Section'
+  has_many :followers, through: :sections_instructed
   has_many :students, through: :followers, source: :student_user
 
   # Relationships (sections_as_students/followeds/teachers) from being a
@@ -1376,7 +1377,7 @@ class User < ApplicationRecord
 
   #sections owned by the user AND not deleted
   def owned_section_ids
-    sections_instructed.select(:id).all
+    sections.select(:id).all
   end
 
   # Is the provided script_level hidden, on account of the section(s) that this
@@ -1883,7 +1884,7 @@ class User < ApplicationRecord
   end
 
   def all_sections
-    sections_as_teacher = student? ? [] : sections_instructed.to_a
+    sections_as_teacher = student? ? [] : sections.to_a
     sections_as_teacher.concat(sections_as_student).uniq
   end
 
@@ -2600,13 +2601,13 @@ class User < ApplicationRecord
 
   # Returns a list of all grades that the teacher currently has sections for
   private def grades_being_taught
-    @grades_being_taught ||= sections_instructed.map(&:grades).flatten.uniq
+    @grades_being_taught ||= sections.map(&:grades).flatten.uniq
   end
 
   # Returns a list of all curriculums that the teacher currently has sections for
   # ex: ["csf", "csd"]
   private def curriculums_being_taught
-    @curriculums_being_taught ||= sections_instructed.filter_map {|section| section.script&.curriculum_umbrella}.uniq
+    @curriculums_being_taught ||= sections.filter_map {|section| section.script&.curriculum_umbrella}.uniq
   end
 
   private def has_attended_pd?
@@ -2636,7 +2637,7 @@ class User < ApplicationRecord
     # If we're a teacher, we want to go through each of our sections and return
     # a mapping from section id to hidden lessons/units in that section
     hidden_by_section = {}
-    sections_instructed.each do |section|
+    sections.each do |section|
       hidden_by_section[section.id] = hidden_lessons ? hidden_lesson_ids([section]) : hidden_unit_ids([section])
     end
     hidden_by_section

--- a/dashboard/test/controllers/transfers_controller_test.rb
+++ b/dashboard/test/controllers/transfers_controller_test.rb
@@ -231,8 +231,16 @@ class TransfersControllerTest < ActionController::TestCase
     assert Follower.exists?(student_user: @word_student, section: @word_section)
   end
 
-  test "current section must belong to current user" do
+  test "co-teacher may move students" do
     @word_section.update!(user: @other_teacher)
+
+    post :create, params: @params
+    assert_response :no_content
+  end
+
+  test "removed instructor may not move students" do
+    @word_section.update!(user: @other_teacher)
+    SectionInstructor.find_by(instructor: @teacher, section: @word_section).destroy!
 
     post :create, params: @params
     assert_response :forbidden

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -152,7 +152,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(unit)
     sign_in student
 
-    assert_cached_queries(16) do
+    assert_cached_queries(17) do
       get "/s/#{unit.name}/lessons/1/levels/1"
       assert_response :success
     end


### PR DESCRIPTION
Change `User.sections` to point to the sections instructed rather than the sections owned. We want co-teachers to be able to do and see everything the section owner can (with the exception of kicking the section owner out of the section). This helps accomplish that goal without needing to identify and change every place `User.sections` is called, and reduces the risk we'll miss a spot.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
