### PR TITLE
Only send pre-work email for CSA summer workshops

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -529,7 +529,7 @@ class Pd::Workshop < ApplicationRecord
   def self.send_teacher_pre_work_csa
     # Collect errors, but do not stop batch. Rethrow all errors below.
     errors = []
-    scheduled_start_in_days(20).select {|ws| ws.course == COURSE_CSA}.each do |workshop|
+    scheduled_start_in_days(20).select {|ws| ws.course == COURSE_CSA && ws.subject == Pd::Workshop::SUBJECT_CSA_SUMMER_WORKSHOP}.each do |workshop|
       workshop.enrollments.each do |enrollment|
         Pd::WorkshopMailer.teacher_pre_workshop_csa(enrollment).deliver_now
       rescue => exception

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -873,6 +873,18 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     Pd::Workshop.send_teacher_pre_work_csa
   end
 
+  test 'CSA teacher pre-work doesnt send to non-summer workshops' do
+    mock_mail = stub
+    mock_mail.stubs(:deliver_now).returns(nil)
+
+    workshop = create :csa_academic_year_workshop, num_facilitators: 2
+    create_list :pd_enrollment, 3, workshop: workshop
+    Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
+
+    Pd::WorkshopMailer.expects(:teacher_pre_workshop_csa).returns(mock_mail).never
+    Pd::Workshop.send_teacher_pre_work_csa
+  end
+
   test 'workshop starting date picks the day of the first session' do
     workshop = create :workshop, sessions: [
       session1 = create(:pd_session, start: Time.zone.today + 15.days),


### PR DESCRIPTION
Users enrolled in academic year workshops for CSA were getting the summer CSA pre-work emails. This PR adds a restriction that those emails are only sent for the summer workshops.

Dani also asked for a mini-audit of our emails. All the emails sent for workshops are listed in [this function](https://github.com/code-dot-org/code-dot-org/blob/4d6e2e3e28331d9ce8b3f4f3f0198b9a2454e7f1/dashboard/app/models/pd/workshop.rb#L544C12-L544C33). This logic is run once per day. Expanding on it a bit:
- At 3 and 10 days prior to a workshop starting:
  - [All teachers enrolled](https://github.com/code-dot-org/code-dot-org/blob/4d6e2e3e28331d9ce8b3f4f3f0198b9a2454e7f1/dashboard/app/models/pd/workshop.rb#L455) receive a reminder
  - [All facilitators](https://github.com/code-dot-org/code-dot-org/blob/4d6e2e3e28331d9ce8b3f4f3f0198b9a2454e7f1/dashboard/app/models/pd/workshop.rb#L462) gets a reminder
  - [The organizer](https://github.com/code-dot-org/code-dot-org/blob/4d6e2e3e28331d9ce8b3f4f3f0198b9a2454e7f1/dashboard/app/models/pd/workshop.rb#L472) gets a reminder
- At 10 days prior to a workshop starting, [facilitators for CSA, CSD, or CSP](https://github.com/code-dot-org/code-dot-org/blob/4d6e2e3e28331d9ce8b3f4f3f0198b9a2454e7f1/dashboard/app/models/pd/workshop.rb#L478) (edit: and CSF -- didn't side scroll far enough) get a pre-workshop email
- [The organizer receives a reminder to close](https://github.com/code-dot-org/code-dot-org/blob/9fde615be2d56759348229dd3490f100f35ff26e/dashboard/app/models/pd/workshop.rb#L496) any workshops that are still "in progress" but has a scheduled end date of two or more days prior (they will receive this email every day until they do so)
- [All teachers enrolled in CSF Intro workshops](https://github.com/code-dot-org/code-dot-org/blob/9fde615be2d56759348229dd3490f100f35ff26e/dashboard/app/models/pd/workshop.rb#L512) receive a follow-up 30 days after the workshop ended
- As of this PR, teachers enrolled in CSA summer workshops get a pre-work email 20 days before the start of the workshop