### PR TITLE
Disable PDF Generation

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -131,12 +131,12 @@ namespace :build do
           RakeUtils.git_push
         end
 
-        if rack_env?(:staging)
-          # This step will only complete successfully if we succeed in
-          # generating all curriculum PDFs.
-          ChatClient.log "Generating missing pdfs..."
-          RakeUtils.rake_stream_output 'curriculum_pdfs:generate_missing_pdfs'
-        end
+        # if rack_env?(:staging)
+        #  This step will only complete successfully if we succeed in
+        #  generating all curriculum PDFs.
+        #  ChatClient.log "Generating missing pdfs..."
+        #  RakeUtils.rake_stream_output 'curriculum_pdfs:generate_missing_pdfs'
+        # end
       end
 
       # Skip asset precompile in development.


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#54989

Throwing errors like:
```
/home/ubuntu/staging/bin/generate-pdf/node_modules/puppeteer/lib/Page.js:215
    this.emit('error', new Error('Page crashed!'));
                       ^

Error: Page crashed!
    at Page._onTargetCrashed (/home/ubuntu/staging/bin/generate-pdf/node_modules/puppeteer/lib/Page.js:215:24)
    at CDPSession.<anonymous> (/home/ubuntu/staging/bin/generate-pdf/node_modules/puppeteer/lib/Page.js:123:56)
    at CDPSession.emit (node:events:514:28)
    at CDPSession._onMessage (/home/ubuntu/staging/bin/generate-pdf/node_modules/puppeteer/lib/Connection.js:200:12)
    at Connection._onMessage (/home/ubuntu/staging/bin/generate-pdf/node_modules/puppeteer/lib/Connection.js:112:17)
    at WebSocket.<anonymous> (/home/ubuntu/staging/bin/generate-pdf/node_modules/puppeteer/lib/WebSocketTransport.js:44:24)
    at WebSocket.onMessage (/home/ubuntu/staging/bin/generate-pdf/node_modules/ws/lib/event-target.js:120:16)
    at WebSocket.emit (node:events:514:28)
    at Receiver.receiverOnMessage (/home/ubuntu/staging/bin/generate-pdf/node_modules/ws/lib/websocket.js:789:20)
    at Receiver.emit (node:events:514:28)
Emitted 'error' event on Page instance at:
    at Page._onTargetCrashed (/home/ubuntu/staging/bin/generate-pdf/node_modules/puppeteer/lib/Page.js:215:10)
    at CDPSession.<anonymous> (/home/ubuntu/staging/bin/generate-pdf/node_modules/puppeteer/lib/Page.js:123:56)
    [... lines matching original stack trace ...]
    at Receiver.emit (node:events:514:28)
```

This error is flaky, so pdf generation sometimes succeeds. That mean, if we want to generate a pdf for a unit as a one-off, we should still be able to do that on the staging server by running
```
unit_names = [...]
units = Unit.where(name: unit_names)
Services::CurriculumPdfs.regenerate_pdfs(units)
```