### PR TITLE
Translation Icon Fix Curriculum Catalog Language Filter

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogFilters.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogFilters.jsx
@@ -332,12 +332,12 @@ const CurriculumCatalogFilters = ({
                 numCurricula: numFilteredTranslatedCurricula,
                 language: languageNativeName,
               })}
+              <FontAwesome
+                icon="language"
+                className={`fa-solid ${style.iconVerticalCenter}`}
+                title={i18n.courseInYourLanguage()}
+              />
             </BodyTwoText>
-            <FontAwesome
-              icon="language"
-              className="fa-solid"
-              title={i18n.courseInYourLanguage()}
-            />
           </div>
           <Toggle
             name="filterTranslatedToggle"

--- a/apps/style/code-studio/curriculum_catalog_filters.module.scss
+++ b/apps/style/code-studio/curriculum_catalog_filters.module.scss
@@ -62,8 +62,12 @@ button.catalogClearFiltersButton {
   margin-left: auto;
 }
 
-[dir="rtl"] button.catalogClearFiltersButton {
+[dir='rtl'] button.catalogClearFiltersButton {
   font-size: 16px;
   margin-right: auto;
   margin-left: 0;
+}
+
+.iconVerticalCenter {
+  vertical-align: middle;
 }

--- a/apps/style/code-studio/curriculum_catalog_filters.module.scss
+++ b/apps/style/code-studio/curriculum_catalog_filters.module.scss
@@ -62,7 +62,7 @@ button.catalogClearFiltersButton {
   margin-left: auto;
 }
 
-[dir='rtl'] button.catalogClearFiltersButton {
+[dir="rtl"] button.catalogClearFiltersButton {
   font-size: 16px;
   margin-right: auto;
   margin-left: 0;


### PR DESCRIPTION
Fixes the positioning of the Translation Icon in the Curriculum Catalog Language Filter.

## Non-English when Icon fits on same line
<img width="1792" alt="Screenshot 2023-11-17 at 9 58 58 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/d17d9708-00dd-4cf6-8a76-9cf13d4b29f3">

## Non-English when Icon does not fit in the same line
<img width="1792" alt="Screenshot 2023-11-17 at 9 59 35 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/51a4dd6c-e863-4b30-9999-2c555f513950">


## Links


- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?selectedIssue=ACQ-1131)

## Testing story
Local




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
