### PR TITLE
Fix error messages when adding coteachers to existing sections

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -510,7 +510,6 @@
   "coteacherAddSectionFull": "You can only add up to 5 co-teachers per section.",
   "coteacherCannotInviteSelf": "Unable to invite yourself as a co-teacher",
   "coteacherUnableToEditCoteachers": "You are not able to edit co-teachers for this section.",
-  "coteacherUnknownValidationError": "An unknown error occured when checking if {email} is a valid email.",
   "coteacherAddNoAccount": "{email} is not associated with a Code.org teacher account.",
   "coteacherAddButton": "Add co-teacher",
   "coteacherCount": "{count}/5 co-teachers added",

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
@@ -14,12 +14,59 @@ import {convertAddCoteacherResponse} from './CoteacherUtils';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
-export const getInputErrorMessage = (email, coteachersToAdd, sectionId) => {
+const getErrorMessageFromResponse = (response, email) => {
+  if (response.ok) {
+    return '';
+  }
+  if (response.status === 404) {
+    return i18n.coteacherAddNoAccount({email});
+  }
+  if (response.status === 403) {
+    return i18n.coteacherUnableToEditCoteachers();
+  }
+
+  return response
+    .json()
+    .then(json => {
+      if (json.error.includes('already invited')) {
+        return i18n.coteacherAddAlreadyExists({email});
+      }
+      if (json.error.includes('section full')) {
+        return i18n.coteacherAddSectionFull();
+      }
+      if (json.error.includes('inviting self')) {
+        return i18n.coteacherCannotInviteSelf();
+      }
+      if (json.error.includes('already in section')) {
+        return i18n.coteacherAlreadyInCourse({email});
+      }
+      console.error('Coteacher validation error', response);
+      return i18n.coteacherUnknownSaveError({
+        email,
+      });
+    })
+    .catch(e => {
+      console.error('Coteacher validation error', e, response);
+      return i18n.coteacherUnknownSaveError({
+        email,
+      });
+    });
+};
+
+export const earlyValidation = email => {
   if (email === '') {
-    return Promise.resolve(i18n.coteacherAddNoEmail());
+    return i18n.coteacherAddNoEmail();
   }
   if (!isEmail(email)) {
-    return Promise.resolve(i18n.coteacherAddInvalidEmail({email}));
+    return i18n.coteacherAddInvalidEmail({email});
+  }
+  return null;
+};
+
+export const getInputErrorMessage = (email, coteachersToAdd, sectionId) => {
+  const earlyValidationResult = earlyValidation(email);
+  if (earlyValidationResult !== null) {
+    return Promise.resolve(earlyValidationResult);
   }
   if (coteachersToAdd.some(coteacher => coteacher === email)) {
     return Promise.resolve(i18n.coteacherAddAlreadyExists({email}));
@@ -33,44 +80,7 @@ export const getInputErrorMessage = (email, coteachersToAdd, sectionId) => {
         'Content-Type': 'application/json; charset=utf-8',
       },
     }
-  ).then(response => {
-    if (response.ok) {
-      return '';
-    }
-    if (response.status === 404) {
-      return i18n.coteacherAddNoAccount({email});
-    }
-    if (response.status === 403) {
-      return i18n.coteacherUnableToEditCoteachers();
-    }
-
-    return response
-      .json()
-      .then(json => {
-        if (json.error.includes('already invited')) {
-          return i18n.coteacherAddAlreadyExists({email});
-        }
-        if (json.error.includes('section full')) {
-          return i18n.coteacherAddSectionFull();
-        }
-        if (json.error.includes('inviting self')) {
-          return i18n.coteacherCannotInviteSelf();
-        }
-        if (json.error.includes('already in section')) {
-          return i18n.coteacherAlreadyInCourse({email});
-        }
-        console.error('Coteacher validation error', response);
-        return i18n.coteacherUnknownValidationError({
-          email,
-        });
-      })
-      .catch(e => {
-        console.error('Coteacher validation error', e, response);
-        return i18n.coteacherUnknownValidationError({
-          email,
-        });
-      });
-  });
+  ).then(response => getErrorMessageFromResponse(response, email));
 };
 
 export default function AddCoteacher({
@@ -87,6 +97,11 @@ export default function AddCoteacher({
 
   const saveCoteacher = useCallback(
     (email, sectionId) => {
+      const earlyValidationResult = earlyValidation(email);
+      if (earlyValidationResult !== null) {
+        setAddError(earlyValidationResult);
+        return;
+      }
       fetch(`/api/v1/section_instructors`, {
         method: 'POST',
         headers: {
@@ -110,8 +125,7 @@ export default function AddCoteacher({
               return '';
             });
           }
-
-          return Promise.resolve(i18n.coteacherUnknownSaveError({email}));
+          return getErrorMessageFromResponse(response, email);
         })
         .then(errorMessage => {
           setAddError(errorMessage);

--- a/apps/test/unit/templates/sectionsRefresh/coteacherSettings/AddCoteacherTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/coteacherSettings/AddCoteacherTest.jsx
@@ -148,13 +148,15 @@ describe('AddCoteacher', () => {
   });
 
   it('shows error if add call fails', done => {
-    fetchSpy.returns(Promise.resolve({ok: false}));
+    fetchSpy.returns(
+      Promise.resolve({ok: false, statusText: 'Not Found', status: 404})
+    );
 
     const addSavedCoteacherSpy = sinon.spy();
 
     const setAddErrorSpy = makeSpyWithAssertions(error => {
       expect(error).to.equal(
-        'An unknown error occured when adding pterodactyl@code.org as a coteacher.'
+        'invalid-email@code.org is not associated with a Code.org teacher account.'
       );
       expect(setCoteachersToAddSpy).not.to.have.been.called;
 
@@ -175,7 +177,7 @@ describe('AddCoteacher', () => {
         addSavedCoteacher={addSavedCoteacherSpy}
       />
     );
-    addTeacher(wrapper, 'pterodactyl@code.org');
+    addTeacher(wrapper, 'invalid-email@code.org');
   });
 
   it('trims email for validation', done => {


### PR DESCRIPTION
Error messages when adding coteachers to existing sections was not using the correct error message parsing and was always returning 'unknown error' which was displayed to the user. 

This adds some validation for empty and non-email inputs and fixes the error messages.

## Links
[TEACH-737](https://codedotorg.atlassian.net/browse/TEACH-737)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
