### PR TITLE
Removing experiment flag to launch HOC Guide Dialog

### DIFF
--- a/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
+++ b/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
@@ -7,7 +7,6 @@ import AccessibleDialog from '@cdo/apps/templates/AccessibleDialog';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {Heading1, Heading3} from '@cdo/apps/componentLibrary/typography';
-import experiments from '@cdo/apps/util/experiments';
 import style from './hoc-guide-dialogue.module.scss';
 import {isEmail} from '@cdo/apps/util/formatValidation';
 
@@ -82,7 +81,7 @@ function HourOfCodeGuideEmailDialog({isSignedIn, unitId}) {
 
   return (
     <div>
-      {isOpen && experiments.isEnabled(experiments.HOC_TUTORIAL_DIALOG) && (
+      {isOpen && (
         <AccessibleDialog styles={style} onClose={onClose}>
           <div tabIndex="0">
             <Heading1>{i18n.welcomeToDanceParty()}</Heading1>

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -46,7 +46,6 @@ experiments.GENDER_FEATURE_ENABLED = 'gender';
 experiments.CPA_EXPERIENCE = 'cpa_experience';
 experiments.AI_RUBRICS = 'ai-rubrics';
 experiments.NON_AI_RUBRICS = 'non-ai-rubrics';
-experiments.HOC_TUTORIAL_DIALOG = 'hocTutorialDialog';
 // Experiment for showing the toggle a teacher can use to turn on AI Tutor for their section
 experiments.AI_TUTOR_ACCESS = 'ai-tutor';
 

--- a/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
+++ b/apps/test/unit/templates/HourOfCodeGuideEmailDialogTest.js
@@ -1,9 +1,8 @@
-import {assert, expect} from 'chai';
+import {expect} from 'chai';
 import React from 'react';
 import {UnconnectedHourOfCodeGuideEmailDialog as HourOfCodeGuideEmailDialog} from '@cdo/apps/templates/HourOfCodeGuideEmailDialog';
 import {shallow} from 'enzyme';
 import i18n from '@cdo/locale';
-import experiments from '@cdo/apps/util/experiments';
 
 describe('HourOfCodeGuideEmailDialog', () => {
   const defaultProps = {
@@ -12,22 +11,14 @@ describe('HourOfCodeGuideEmailDialog', () => {
   };
 
   it('renders signed out text in Dialog', () => {
-    experiments.setEnabled(experiments.HOC_TUTORIAL_DIALOG, true);
     const wrapper = shallow(<HourOfCodeGuideEmailDialog {...defaultProps} />);
     expect(wrapper.contains(i18n.emailMeAGuide()));
   });
 
   it('renders correct translations if user is not signed in', () => {
-    experiments.setEnabled(experiments.HOC_TUTORIAL_DIALOG, true);
     const wrapper = shallow(
       <HourOfCodeGuideEmailDialog {...defaultProps} isSignedIn={false} />
     );
     expect(wrapper.contains(i18n.getGuideContinue()));
-  });
-
-  it('renders null if experiment flag is false', () => {
-    experiments.setEnabled(experiments.HOC_TUTORIAL_DIALOG, false);
-    const wrapper = shallow(<HourOfCodeGuideEmailDialog {...defaultProps} />);
-    assert.equal(wrapper.children().length, 0);
   });
 });

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1054,8 +1054,8 @@ end
 
 And /^I dismiss the hoc guide dialog$/ do
   steps <<~GHERKIN
-    And I click selector ".uitest-no-email-guide"
-    And I wait until I don't see selector ".uitest-no-email-guide"
+    And I click selector "#uitest-no-email-guide" once I see it
+    And I wait until I don't see selector "#uitest-no-email-guide"
   GHERKIN
 end
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1052,6 +1052,13 @@ And /^I dismiss the teacher panel$/ do
   GHERKIN
 end
 
+And /^I dismiss the hoc guide dialog$/ do
+  steps <<~GHERKIN
+    And I click selector ".uitest-no-email-guide"
+    And I wait until I don't see selector ".uitest-no-email-guide"
+  GHERKIN
+end
+
 # Call `execute_async_script` on the provided `js` code.
 # Provides a workaround for Appium (mobile) which doesn't support execute_async_script on HTTPS.
 # For Appium, wrap `execute_script` with a polling wait on a window variable that records the result.

--- a/dashboard/test/ui/features/teacher_tools/instructor_in_training.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructor_in_training.feature
@@ -41,6 +41,7 @@ Feature: Self Paced PL Instructor in Training
     And I sign in as "Universal Instructor"
     And I get universal instructor access
     Then I am on "http://studio.code.org/s/alltheselfpacedplthings/lessons/1/levels/2"
+    And I dismiss the hoc guide dialog
     And I wait for the page to fully load
 
     Then I press the first ".uitest-teacherOnlyTab" element
@@ -53,6 +54,7 @@ Feature: Self Paced PL Instructor in Training
     Given I create an authorized teacher-associated student named "Manuel"
     And I sign in as "Teacher_Manuel"
     Then I am on "http://studio.code.org/s/alltheselfpacedplthings/lessons/1/levels/2"
+    And I dismiss the hoc guide dialog
     And I wait for the page to fully load
 
     Then I press the first ".uitest-teacherOnlyTab" element


### PR DESCRIPTION
This will simply remove references of the experiment flag from the code and tests.

This way, teachers and 21+ users will begin to see the dialog offering the HOC guide email.

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1080

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
