### PR TITLE
Make workshop enroll form's email field editable

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -446,7 +446,6 @@ export default class EnrollForm extends React.Component {
             required={true}
             onChange={this.handleChange}
             defaultValue={this.props.email}
-            readOnly={!!this.props.email}
             title={
               this.props.email ? 'Email can be changed in account settings' : ''
             }


### PR DESCRIPTION
Currently the Workshop Enroll Form's email field is only editable if no enrollment email is passed in. With [recent updates](https://github.com/code-dot-org/code-dot-org/pull/53437) pulling in a user's application's alternate email into the form's email field and with considerations for different times of year (e.g. a teacher wanting to use a different email for a summer workshop rather than one during the school year depending on which one they check), it will make more sense to always make it editable so the user can pick which email they want to receive emails to for a given workshop.

### Previously (read only)
![CANNOT EDIT](https://github.com/code-dot-org/code-dot-org/assets/56283563/ea39553b-ba84-45ae-a8a2-3cf90869dbbc)

### New (editable)
![EDITABLE](https://github.com/code-dot-org/code-dot-org/assets/56283563/504d619c-578d-4bb7-8379-df7ffbe6432d)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1185)

## Testing story
Local testing.