### PR TITLE
Add constants for color strings

### DIFF
--- a/apps/src/templates/Lightbulb.jsx
+++ b/apps/src/templates/Lightbulb.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import color from '../util/color';
+import color from '@cdo/apps/util/color';
 
 export default class Lightbulb extends React.Component {
   static propTypes = {
@@ -100,7 +100,7 @@ export default class Lightbulb extends React.Component {
               cy="310"
               r="125"
               fill={color.white}
-              stroke="#dddddd"
+              stroke={color.blockly_flyout_gray}
               strokeWidth="16"
             />
           </g>

--- a/apps/src/templates/instructions/ChatBubble.jsx
+++ b/apps/src/templates/instructions/ChatBubble.jsx
@@ -4,6 +4,7 @@ import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import ChatBubbleTip from './ChatBubbleTip';
 import {shouldDisplayChatTips} from './utils';
 import InlineAudio from './InlineAudio';
+import color from '@cdo/apps/util/color';
 
 const styles = {
   container: {
@@ -11,7 +12,7 @@ const styles = {
   },
 
   main: {
-    backgroundColor: 'white',
+    backgroundColor: color.white,
     borderRadius: 10,
     margin: '5px 0',
     paddingTop: 5,
@@ -51,6 +52,8 @@ var audioStyle = {
   },
 };
 
+const MINECRAFT_COLOR = '#3B3B3B';
+
 const ChatBubble = ({
   children,
   isMinecraft,
@@ -62,8 +65,10 @@ const ChatBubble = ({
   ttsMessage,
   textToSpeechEnabled,
 }) => {
-  borderColor = borderColor || 'white';
-  backgroundColor = isMinecraft ? '#3B3B3B' : backgroundColor || 'white';
+  borderColor = borderColor || color.white;
+  backgroundColor = isMinecraft
+    ? MINECRAFT_COLOR
+    : backgroundColor || color.white;
   isDashed = isDashed || false;
   const showAudioControls = textToSpeechEnabled && (ttsUrl || ttsMessage);
 

--- a/apps/src/templates/instructions/ChatBubble.jsx
+++ b/apps/src/templates/instructions/ChatBubble.jsx
@@ -52,7 +52,7 @@ var audioStyle = {
   },
 };
 
-const MINECRAFT_COLOR = '#3B3B3B';
+const MINECRAFT_VERY_DARK_GRAY_COLOR = '#3B3B3B';
 
 const ChatBubble = ({
   children,
@@ -67,7 +67,7 @@ const ChatBubble = ({
 }) => {
   borderColor = borderColor || color.white;
   backgroundColor = isMinecraft
-    ? MINECRAFT_COLOR
+    ? MINECRAFT_VERY_DARK_GRAY_COLOR
     : backgroundColor || color.white;
   isDashed = isDashed || false;
   const showAudioControls = textToSpeechEnabled && (ttsUrl || ttsMessage);

--- a/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
@@ -14,6 +14,8 @@ import color from '../../util/color';
 import Instructions from './Instructions';
 
 var instructions = require('../../redux/instructions');
+const LIGHT_BLUE_BACKGROUND = '#f0ffff';
+const LIGHT_YELLOW_BACKGROUND = '#fffff0';
 
 class InstructionsCsfMiddleCol extends React.Component {
   static propTypes = {
@@ -180,7 +182,7 @@ class InstructionsCsfMiddleCol extends React.Component {
             <InlineHint
               key={hint.hintId}
               borderColor={color.light_info_500}
-              backgroundColor={'#f0ffff'}
+              backgroundColor={LIGHT_BLUE_BACKGROUND}
               markdown={hint.markdown}
               ttsUrl={hint.ttsUrl}
               ttsMessage={hint.ttsMessage}
@@ -203,7 +205,7 @@ class InstructionsCsfMiddleCol extends React.Component {
                 ? color.white
                 : color.product_caution_default
             }
-            backgroundColor={'#fffff0'}
+            backgroundColor={LIGHT_YELLOW_BACKGROUND}
             message={this.props.feedback.message}
             isMinecraft={this.props.isMinecraft}
             skinId={this.props.skinId}
@@ -213,7 +215,7 @@ class InstructionsCsfMiddleCol extends React.Component {
         {this.props.shouldDisplayHintPrompt() && (
           <HintPrompt
             borderColor={color.light_info_500}
-            backgroundColor={'#f0ffff'}
+            backgroundColor={LIGHT_BLUE_BACKGROUND}
             onConfirm={this.showHint}
             onDismiss={this.props.dismissHintPrompt}
             isMinecraft={this.props.isMinecraft}

--- a/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
@@ -14,8 +14,8 @@ import color from '../../util/color';
 import Instructions from './Instructions';
 
 var instructions = require('../../redux/instructions');
-const LIGHT_BLUE_BACKGROUND = '#f0ffff';
-const LIGHT_YELLOW_BACKGROUND = '#fffff0';
+const VERY_LIGHT_BLUE_COLOR = '#f0ffff';
+const VERY_LIGHT_YELLOW_COLOR = '#fffff0';
 
 class InstructionsCsfMiddleCol extends React.Component {
   static propTypes = {
@@ -182,7 +182,7 @@ class InstructionsCsfMiddleCol extends React.Component {
             <InlineHint
               key={hint.hintId}
               borderColor={color.light_info_500}
-              backgroundColor={LIGHT_BLUE_BACKGROUND}
+              backgroundColor={VERY_LIGHT_BLUE_COLOR}
               markdown={hint.markdown}
               ttsUrl={hint.ttsUrl}
               ttsMessage={hint.ttsMessage}
@@ -205,7 +205,7 @@ class InstructionsCsfMiddleCol extends React.Component {
                 ? color.white
                 : color.product_caution_default
             }
-            backgroundColor={LIGHT_YELLOW_BACKGROUND}
+            backgroundColor={VERY_LIGHT_YELLOW_COLOR}
             message={this.props.feedback.message}
             isMinecraft={this.props.isMinecraft}
             skinId={this.props.skinId}
@@ -215,7 +215,7 @@ class InstructionsCsfMiddleCol extends React.Component {
         {this.props.shouldDisplayHintPrompt() && (
           <HintPrompt
             borderColor={color.light_info_500}
-            backgroundColor={LIGHT_BLUE_BACKGROUND}
+            backgroundColor={VERY_LIGHT_BLUE_COLOR}
             onConfirm={this.showHint}
             onDismiss={this.props.dismissHintPrompt}
             isMinecraft={this.props.isMinecraft}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is a quick follow-up to https://github.com/code-dot-org/code-dot-org/pull/55007 which was blocking curriculum from making HoC screencast videos for the video team.

This PR adds constants for color strings that were updated in the prior PR.

## Links
[trello](https://trello.com/c/gTzUI8Kd/182-follow-up-to-instructions-update-cleanup-refactor-of-color-constants)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally to confirm no changes based on this PR.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
