### PR TITLE
Update the Find a Course button in sections table to point to the Catalog

### DIFF
--- a/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
@@ -157,7 +157,7 @@ class StandardsReport extends Component {
                   markdown={i18n.standardsGetInvolvedDetailsForPrint({
                     adminLink: pegasus('/administrators'),
                     parentLink: pegasus('/help'),
-                    teacherLink: '/courses',
+                    teacherLink: pegasus('/teach'),
                   })}
                 />
               </div>

--- a/apps/src/templates/sectionProgress/standards/StandardsView.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsView.jsx
@@ -49,7 +49,7 @@ class StandardsView extends Component {
             markdown={i18n.standardsGetInvolvedDetails({
               adminLink: pegasus('/administrators'),
               parentLink: pegasus('/help'),
-              teacherLink: '/courses',
+              teacherLink: pegasus('/teach'),
             })}
           />
         </div>

--- a/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
@@ -71,7 +71,7 @@ export const courseLinkFormatter = function (course, {rowData}) {
         <Button
           __useDeprecatedTag
           text={i18n.coursesCardAction()}
-          href={'/courses'}
+          href={'/catalog'}
           color={Button.ButtonColor.neutralDark}
         />
       )}

--- a/apps/test/unit/templates/teacherDashboard/OwnedSectionsTableTest.js
+++ b/apps/test/unit/templates/teacherDashboard/OwnedSectionsTableTest.js
@@ -436,7 +436,7 @@ describe('OwnedSectionsTable', () => {
       const link = courseLinkCol.find(Button).prop('href');
       const text = courseLinkCol.find(Button).prop('text');
       assert.equal(button, '<Button />');
-      assert.equal(link, '/courses');
+      assert.equal(link, '/catalog');
       assert.equal(text, 'Find a course');
     });
 


### PR DESCRIPTION
The "Find a course" button in the sections table was also pointing to the /courses page instead of the catalog. 

## Before
<img width="1473" alt="Screenshot 2023-11-17 at 10 42 49 PM" src="https://github.com/code-dot-org/code-dot-org/assets/208083/db878c7b-0678-42fe-966c-97cee062138a">

## After
<img width="975" alt="Screenshot 2023-11-17 at 10 44 41 PM" src="https://github.com/code-dot-org/code-dot-org/assets/208083/dda8f18c-913f-415e-a60d-300ad5a805dd">

