### PR TITLE
Return expected error when trying to invite oneself to an existing section

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -606,6 +606,7 @@ class Section < ApplicationRecord
 
   public def add_instructor(email, current_user)
     instructor = User.find_by!(email: email, user_type: :teacher)
+    raise ArgumentError.new('inviting self') if instructor == current_user
 
     deleted_section_instructor = validate_instructor(instructor)
     deleted_section_instructor&.really_destroy!

--- a/dashboard/test/controllers/api/v1/section_instructors_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/section_instructors_controller_test.rb
@@ -81,6 +81,13 @@ class Api::V1::SectionInstructorsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
+  test 'instructor receives correct error when adding themself to a section' do
+    sign_in @teacher
+    post :create, params: {section_id: @section.id, email: @teacher.email}
+    assert_response :bad_request
+    assert_equal '{"error":"inviting self"}', @response.body
+  end
+
   test 'instructor cannot add a student to instruct a section' do
     sign_in @teacher
     section = create(:section, :teacher_participants, user: @teacher)


### PR DESCRIPTION
The API path for adding a new coteacher to an existing section wasn't sending the expected error code when a teacher was trying to invite their own email address. This PR fixes that and adds a test to make sure.

![image](https://github.com/code-dot-org/code-dot-org/assets/25193259/9cd8478a-e283-4ac3-8bb0-72acb2e5f3e1)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
