### PR TITLE
HoC 2023 - Add Dance AI tutorial to marketing website

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -790,7 +790,8 @@ form {
     @include heading-sm;
 
     &.heading-md {
-      @include heading-md
+      @include heading-md;
+      font-weight: unset;
     }
   }
 

--- a/pegasus/sites.v3/code.org/views/ai_curricula_blocks.haml
+++ b/pegasus/sites.v3/code.org/views/ai_curricula_blocks.haml
@@ -1,20 +1,20 @@
-- ai_curricula_index = 6
+- ai_curricula_index = 7
 
-- ai_curricula_overline = [hoc_s(:module_grade_7_12), hoc_s(:module_grade_9_12), hoc_s(:module_grade_6_12), hoc_s(:module_grade_6_12), hoc_s(:module_grade_7_12), hoc_s(:module_grade_3_12)]
+- ai_curricula_overline = [hoc_s(:module_grade_7_12), hoc_s(:module_grade_9_12), hoc_s(:module_grade_6_12), hoc_s(:module_grade_6_12), hoc_s(:module_grade_7_12), hoc_s(:module_grade_3_12), hoc_s(:module_grade_3_12)]
 
-- ai_curricula_title = [hoc_s(:ai_curriculum_title_06), hoc_s(:curriculum_name_csa_ai), hoc_s(:ai_curriculum_title_04), hoc_s(:ai_curriculum_title_01), hoc_s(:ai_curriculum_title_02), hoc_s(:ai_curriculum_title_03)]
+- ai_curricula_title = [hoc_s(:ai_curriculum_title_06), hoc_s(:curriculum_name_csa_ai), hoc_s(:ai_curriculum_title_04), hoc_s(:ai_curriculum_title_01), hoc_s(:ai_curriculum_title_02), hoc_s(:ai_curriculum_title_03), hoc_s(:curriculum_name_dance_party_ai_edition)]
 
-- ai_curricula_img = ["/images/ai/ai-curriculum-societal-impacts.png", "/images/ai/ai-curriculum-computer-vision.png", "/images/ai/ai-curriculum-how-ai-works.png", "/images/ai/ai-curriclum-machine-learning.png", "/images/ai/ai-curriclum-ethics.png", "/images/ai/ai-curriclum-oceans.png"]
+- ai_curricula_img = ["/images/ai/ai-curriculum-societal-impacts.png", "/images/ai/ai-curriculum-computer-vision.png", "/images/ai/ai-curriculum-how-ai-works.png", "/images/ai/ai-curriclum-machine-learning.png", "/images/ai/ai-curriclum-ethics.png", "/images/ai/ai-curriclum-oceans.png", "/images/dance-hoc/dance-party-activity-ai-edition-cropped.png"]
 
-- ai_curricula_desc = [hoc_s(:ai_curriculum_desc_06), hoc_s(:curriculum_desc_csa_ai_short), hoc_s(:ai_curriculum_desc_04), hoc_s(:ai_curriculum_desc_01), hoc_s(:ai_curriculum_desc_02), hoc_s(:ai_curriculum_desc_03)]
+- ai_curricula_desc = [hoc_s(:ai_curriculum_desc_06), hoc_s(:curriculum_desc_csa_ai_short), hoc_s(:ai_curriculum_desc_04), hoc_s(:ai_curriculum_desc_01), hoc_s(:ai_curriculum_desc_02), hoc_s(:ai_curriculum_desc_03), hoc_s(:curriculum_desc_dance_party_ai_edition)]
 
-- ai_curricula_duration = [hoc_s(:module_duration_1_hr), hoc_s(:module_duration_5_hrs_plus), hoc_s(:module_duration_8_hrs), hoc_s(:module_duration_20_hrs), hoc_s(:module_duration_1_hr), hoc_s(:module_duration_1_hr)]
+- ai_curricula_duration = [hoc_s(:module_duration_1_hr), hoc_s(:module_duration_5_hrs_plus), hoc_s(:module_duration_8_hrs), hoc_s(:module_duration_20_hrs), hoc_s(:module_duration_1_hr), hoc_s(:module_duration_1_hr), hoc_s(:module_duration_1_hr)]
 
-- ai_curricula_url = [CDO.studio_url("/s/ai-ethics-2023/lessons/2"), "/curriculum/computer-vision", "/ai/how-ai-works", CDO.studio_url("/s/aiml"), CDO.studio_url("/s/ai-ethics-2023/lessons/1"), CDO.studio_url("/s/oceans")]
+- ai_curricula_url = [CDO.studio_url("/s/ai-ethics-2023/lessons/2"), "/curriculum/computer-vision", "/ai/how-ai-works", CDO.studio_url("/s/aiml"), CDO.studio_url("/s/ai-ethics-2023/lessons/1"), CDO.studio_url("/s/oceans"), CDO.studio_url("/s/dance-ai-2023/reset")]
 
-- ai_curricula_aria_label = [hoc_s(:ai_curriculum_btn_aria_label_06), hoc_s(:ai_curriculum_btn_aria_label_05), hoc_s(:ai_curriculum_btn_aria_label_04), hoc_s(:ai_curriculum_btn_aria_label_01), hoc_s(:ai_curriculum_btn_aria_label_02), hoc_s(:ai_curriculum_btn_aria_label_03)]
+- ai_curricula_aria_label = [hoc_s(:ai_curriculum_btn_aria_label_06), hoc_s(:ai_curriculum_btn_aria_label_05), hoc_s(:ai_curriculum_btn_aria_label_04), hoc_s(:ai_curriculum_btn_aria_label_01), hoc_s(:ai_curriculum_btn_aria_label_02), hoc_s(:ai_curriculum_btn_aria_label_03), hoc_s(:ai_curriculum_btn_aria_label_dance_ai)]
 
-- ai_curricula_button_label = [hoc_s(:call_to_action_view_lesson_plan), hoc_s(:call_to_action_explore_module), hoc_s(:call_to_action_explore_lessons), hoc_s(:call_to_action_explore_unit), hoc_s(:call_to_action_view_lesson_plan), hoc_s(:call_to_action_try_activity)]
+- ai_curricula_button_label = [hoc_s(:call_to_action_view_lesson_plan), hoc_s(:call_to_action_explore_module), hoc_s(:call_to_action_explore_lessons), hoc_s(:call_to_action_explore_unit), hoc_s(:call_to_action_view_lesson_plan), hoc_s(:call_to_action_try_activity), hoc_s(:call_to_action_try_activity)]
 
 .action-block__wrapper.action-block__wrapper--three-col
   - ai_curricula_index.times do |index|

--- a/pegasus/sites.v3/code.org/views/dance/dance_party_activities.haml
+++ b/pegasus/sites.v3/code.org/views/dance/dance_party_activities.haml
@@ -30,7 +30,8 @@
   ]
 
 .action-block.action-block--two-col
-  %img.col-50{src: "/images/dance-hoc/dance-party-activity-ai-edition.png", alt: "", style: "height: max-content"}
+  .media-wrapper.col-50
+    %img{src: "/images/dance-hoc/dance-party-activity-ai-edition.png", alt: ""}
   .text-wrapper.col-50
     .flex-container.justify-space-between.align-items-start
       %p.overline

--- a/pegasus/sites.v3/code.org/views/dance/dance_party_activities.haml
+++ b/pegasus/sites.v3/code.org/views/dance/dance_party_activities.haml
@@ -30,7 +30,7 @@
   ]
 
 .action-block.action-block--two-col
-  %img.col-50{src: "/images/dance-hoc/dance-party-activity-ai-edition.png", alt: hoc_s(:hoc_live)}
+  %img.col-50{src: "/images/dance-hoc/dance-party-activity-ai-edition.png", alt: "", style: "height: max-content"}
   .text-wrapper.col-50
     .flex-container.justify-space-between.align-items-start
       %p.overline
@@ -42,8 +42,8 @@
       = hoc_s(:curriculum_name_dance_party_ai_edition)
     %p
       = hoc_s(:curriculum_desc_dance_party_ai_edition)
-    %a.link-button.disabled
-      = hoc_s(:call_to_action_coming_soon)
+    %a.link-button{href: CDO.studio_url("/s/dance-ai-2023/reset")}
+      = hoc_s(:call_to_action_start_dance_party_ai_edition)
   .clear
 
 .action-block__wrapper.action-block__wrapper--three-col

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -244,6 +244,7 @@
   call_to_action_share_on_social_media: "Share on social media"
   call_to_action_explore_all_hoc_activities: "Explore all Hour of Code activities from Code.org"
   call_to_action_start_dance_party: "Start Dance Party"
+  call_to_action_start_dance_party_ai_edition: "Start Dance Party: AI Edition"
   call_to_action_start_part_02: "Start part two"
   call_to_action_start_unplugged_activity: "Start unplugged activity"
   call_to_action_view_promo_resources: "View promo resources"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -846,6 +846,7 @@
   ai_curriculum_title_06: "Societal Impact of Generative AI"
   ai_curriculum_desc_06: "Investigate the impact of generative AI from different perspectives, then collaborate as a team to come up with guidelines that address the most needs from all participants."
   ai_curriculum_btn_aria_label_06: "View Societal Impact of Generative AI lesson plan"
+  ai_curriculum_btn_aria_label_dance_ai: "Try the Dance Party: AI Edition activity"
   ai_carousel_heading: "What teachers say about AI with Code.org:"
   ai_carousel_quote_01: "This lesson also gave my students the opportunity to see that there is an element of opinion in classification systems. Later, when we started to see how bias can end up in AI, I was able to pull them back and remind them that the data used to train their models was based on choices."
   ai_carousel_quote_02: "My students learned that they don't have to just be consumers when it comes to technological advances that they are experiencing on almost a daily basis. They can actually be creators!"


### PR DESCRIPTION
Add Dance Party: AI Edition to https://code.org/dance and https://code.org/ai

**Jira ticket:** [ACQ-1041](https://codedotorg.atlassian.net/browse/ACQ-1041)

----

## code.org/dance
<img width="1003" alt="Screenshot 2023-11-20 at 12 35 51 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/ecfe5b39-9875-4824-94f0-86d977c1eea7">

## code.org/ai
<img width="331" alt="Screenshot 2023-11-20 at 12 51 17 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/6555f81b-9641-473c-83ee-da0e4e0daf9d">
