### PR TITLE
HoC 2023 - Code.org - set Dance Party AI hero banner live

### DIFF
--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -12,7 +12,10 @@
     "hoc2023-soon-hoc": {
       "hoc_modes": ["soon-hoc"],
       "class": "hoc-banner homepage",
-      "desktopImage": "/images/hoc2023-hero-banner.svg",
+      "desktopImage": "/images/hoc2023-codeorg-hero-banner.png",
+      "mobileImage": "/images/hoc2023-codeorg-hero-banner-mobile.png",
+      "leftImage": "/images/hoc2023-codeorg-hero-banner-left.svg",
+      "rightImage": "/images/hoc2023-codeorg-hero-banner-right.svg",
       "actions": [
         {
           "type": "text",
@@ -20,11 +23,11 @@
         },
         {
           "type": "heading",
-          "text": "hoc2023_header"
+          "text": "curriculum_name_dance_party_ai_edition"
         },
         {
           "type": "heading-two",
-          "text": "hoc2023_hero_desc_homepage"
+          "text": "codeorg_homepage_hoc2023_body"
         },
         {
           "type": "cta_button_solid_yellow",

--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -32,7 +32,7 @@
         {
           "type": "cta_button_solid_yellow",
           "text": "hoc2022_cta_primary",
-          "url": "/hourofcode"
+          "url": "/dance"
         },
         {
           "type": "cta_button_solid_white",

--- a/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
@@ -1,5 +1,9 @@
 @import 'color.scss', 'font.scss', 'breakpoints.scss';
 
+#homepage #hero {
+  overflow: hidden;
+}
+
 // Code.org HoC homepage banner
 #bars {
   height: 450px;
@@ -23,10 +27,14 @@
       left: 0;
       top: -10%;
 
-      @media screen and (max-width: $width-md) {
+      @media (min-width: 768px) and (max-width: 1190px) {
         width: 45%;
         left: -9%;
-        top: -3rem;
+        top: -15%;
+      }
+
+      @media screen and (max-width: 800px) {
+        display: none;
       }
     }
 
@@ -38,8 +46,8 @@
       transform: translate(-50%, -50%);
 
       @media screen and (max-width: $width-lg) {
-        width: 570px;
-        margin-top: -0.5rem;
+        width: 610px;
+        margin-top: 0;
       }
 
       @media screen and (max-width: $width-sm) {
@@ -68,6 +76,7 @@
   line-height: 1.4;
   max-width: 860px;
   margin: 2rem auto 4rem;
+  padding: 0 1rem;
 
   h1, h2 {
     color: $white
@@ -76,18 +85,14 @@
   h1 {
     font-size: 4rem;
     font-family: var(--barlowSemiCondensed-semibold);
+    font-weight: var(--bold-font-weight);
     margin: 0 auto 0.5em;
 
-    @media screen and (max-width: $width-lg) {
-      font-size: 3.75em;
+    @media screen and (max-width: 1024px) {
+      font-size: 3.5rem;
     }
-
-    @media screen and (max-width: $width-md) {
-      font-size: 3.5em;
-    }
-
     @media screen and (max-width: $width-sm) {
-      font-size: 2.75em;
+      font-size: 3rem;
     }
   }
 
@@ -95,14 +100,21 @@
     margin: 0 auto 1rem;
     font-family: var(--main-font);
     font-size: 1.25rem;
+
+    @media screen and (max-width: $width-md) {
+      width: 80%;
+    }
+
+    @media screen and (max-width: $width-sm) {
+      width: 100%;
+    }
   }
 
   // The Hour of Code is coming/here text
   p {
-    font-size: 1.5rem;
+    font-size: 2em;
     font-family: var(--main-font);
     font-weight: var(--semi-bold-font-weight);
-    margin-bottom: 0.25rem;
 
     @media screen and (max-width: $width-md) {
       font-size: 1.75em;


### PR DESCRIPTION
Put the Dance Party: AI Edition hero banner back up
- Replaces the current generic HoC banner in `soon-hoc` mode and will continue to show for `actual-hoc` mode

**Jira ticket:** [ACQ-1147](https://codedotorg.atlassian.net/browse/ACQ-1147)

----

## Desktop
<img width="1249" alt="Desktop" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/cf5bedbe-ae03-45df-84e7-42563713685d">

## Tablet
<img width="500" alt="Tablet" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/2df2b452-1dea-4f34-baa4-c255b6e986ad">

## Mobile
<img width="300" alt="Mobile" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/949bed29-d061-4c23-9818-35aeb8a50cb5">
