### PR TITLE
[Google Blockly] CT-180: Add single user experiment to persist Google Blockly across levels

### DIFF
--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -49,8 +49,7 @@ experiments.NON_AI_RUBRICS = 'non-ai-rubrics';
 experiments.HOC_TUTORIAL_DIALOG = 'hocTutorialDialog';
 // Experiment for showing the toggle a teacher can use to turn on AI Tutor for their section
 experiments.AI_TUTOR_ACCESS = 'ai-tutor';
-// Experiment for showing the toggle a teacher can use to turn on AI Tutor for their section
-experiments.AI_TUTOR_TOGGLE = 'ai-tutor-toggle';
+// Uses Google Blockly for a given user across labs/levels until the experiment is disabled
 experiments.GOOGLE_BLOCKLY = 'google_blockly';
 
 /**

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -49,6 +49,9 @@ experiments.NON_AI_RUBRICS = 'non-ai-rubrics';
 experiments.HOC_TUTORIAL_DIALOG = 'hocTutorialDialog';
 // Experiment for showing the toggle a teacher can use to turn on AI Tutor for their section
 experiments.AI_TUTOR_ACCESS = 'ai-tutor';
+// Experiment for showing the toggle a teacher can use to turn on AI Tutor for their section
+experiments.AI_TUTOR_TOGGLE = 'ai-tutor-toggle';
+experiments.GOOGLE_BLOCKLY = 'google_blockly';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/dashboard/app/controllers/experiments_controller.rb
+++ b/dashboard/app/controllers/experiments_controller.rb
@@ -23,10 +23,12 @@ class ExperimentsController < ApplicationController
   end
 
   # Returns whether the given experiment can be joined (or left) via url.
+  # Currently, joining by URL is enabled for:
+  # 1. Pilots where allow_joining_via_url is true
+  # 2. Self-enrolling to use Google Blockly across labs
   def can_join_via_url?(experiment_name)
-    # Currently, the only experiments that can be joined by url are pilots
-    # where allow_joining_via_url is true.
     return true if Pilot.find_by(name: experiment_name).try(:allow_joining_via_url)
+    return true if params[:experiment_name] == 'google_blockly'
     return false
   end
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -438,7 +438,8 @@ module LevelsHelper
       }
   end
 
-  # As we migrate labs from CDO to Google Blockly, there are multiple ways to determine which version a lab uses:
+  # As we migrate labs from CDO to Google Blockly, there are multiple ways to determine which version a lab uses.
+  # In priority order they, are:
   # 1. Enrolling in the google_blockly experiment using the set_single_user_experiment endpoint (persists across levels).
   # 2. Setting the blocklyVersion view_option, usually configured by a URL parameter (not persistent across levels).
   # 3. The corresponding inherited Level model can override Level#uses_google_blockly?. This option is for labs that
@@ -447,7 +448,8 @@ module LevelsHelper
     return true if Experiment.enabled?(experiment_name: 'google_blockly', user: current_user)
     return true if view_options[:blocklyVersion]&.downcase == 'google'
     return false if view_options[:blocklyVersion]&.downcase == 'cdo'
-    return false unless @level.uses_google_blockly?
+    return true if @level.uses_google_blockly?
+    return false
   end
 
   # Options hash for Widget

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -439,18 +439,15 @@ module LevelsHelper
   end
 
   # As we migrate labs from CDO to Google Blockly, there are multiple ways to determine which version a lab uses:
-  #  1. Setting the blocklyVersion view_option, usually configured by a URL parameter.
-  #  2. The corresponding inherited Level model can override Level#uses_google_blockly?. This option is for labs that
-  #     have fully transitioned to Google Blockly.
-  #  3. The disable_google_blockly DCDO flag, which contains an array of strings corresponding to model class names.
-  #     This option will override #2 as an "emergency switch" to go back to CDO Blockly.
+  # 1. Enrolling in the google_blockly experiment using the set_single_user_experiment endpoint (persists across levels).
+  # 2. Setting the blocklyVersion view_option, usually configured by a URL parameter (not persistent across levels).
+  # 3. The corresponding inherited Level model can override Level#uses_google_blockly?. This option is for labs that
+  #    have fully transitioned to Google Blockly.
   def use_google_blockly
+    return true if Experiment.enabled?(experiment_name: 'google_blockly', user: current_user)
     return true if view_options[:blocklyVersion]&.downcase == 'google'
     return false if view_options[:blocklyVersion]&.downcase == 'cdo'
     return false unless @level.uses_google_blockly?
-
-    # Only check DCDO flag if level type uses Google Blockly to avoid performance hit.
-    DCDO.get('disable_google_blockly', []).map(&:downcase).exclude?(@level.class.to_s.downcase)
   end
 
   # Options hash for Widget

--- a/dashboard/app/models/experiments/pilot.rb
+++ b/dashboard/app/models/experiments/pilot.rb
@@ -18,6 +18,6 @@ class Pilot < ApplicationRecord
   validates :name, presence: true, uniqueness: {case_sensitive: true}, format: {with: /\A[a-z0-9-]+\z/}
   validates :display_name, presence: true
 
-  # If allow_joining_via_url is ture, the url to join the pilot is:
+  # If allow_joining_via_url is true, the url to join the pilot is:
   # http://studio.code.org/experiments/set_single_user_experiment/<pilot.name>
 end

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -80,7 +80,7 @@
       %br
       %button{type: 'button', onclick: 'Blockly.mainBlockSpace.clear()', class: 'btn btn-default btn-sm'}
         Clear workspace
-      - if @level.uses_google_blockly? || (params[:blocklyVersion] == 'google')
+      - if @level.uses_google_blockly? || (params[:blocklyVersion] == 'google') || (Experiment.enabled?(experiment_name: 'google_blockly', user: current_user))
         %button{type: 'button', onclick: 'Blockly.getMainWorkspace().undo(false)', class: 'btn btn-default btn-sm'}
           Undo
       %hr

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -352,50 +352,49 @@ class LevelsHelperTest < ActionView::TestCase
     refute_equal channel, get_channel_for(level, script.id)
   end
 
-  test 'uses_google_blockly is false if not set' do
+  test 'use_google_blockly is false if not set' do
+    Experiment.stubs(:enabled?).returns(false)
     @level = build :level
     refute use_google_blockly
+    Experiment.unstub(:enabled?)
+    reset_view_options
   end
 
-  # ****: Change this
+  test 'use_google_blockly is true if Experiment is enabled for google_blockly' do
+    Experiment.stubs(:enabled?).returns(true)
+    @level = build :level
+    assert use_google_blockly
+    Experiment.unstub(:enabled?)
+  end
+
   test 'use_google_blockly is true if blocklyVersion is set to Google in view_options' do
+    Experiment.stubs(:enabled?).returns(false)
     view_options(blocklyVersion: 'google')
     @level = build :level
     assert use_google_blockly
-
+    Experiment.unstub(:enabled?)
     reset_view_options
   end
 
-  # ****: Change this
-  test 'use_google_blockly is false if blocklyVersion is set to Cdo in view_options' do
+  test 'use_google_blockly is false if blocklyVersion is set to Cdo in view_optiond even if level uses google_blockly' do
+    Experiment.stubs(:enabled?).returns(false)
     view_options(blocklyVersion: 'cdo')
     @level = build :level
+    @level.stubs(:uses_google_blockly?).returns(true)
     refute use_google_blockly
-
+    Experiment.unstub(:enabled?)
     reset_view_options
   end
 
-  test 'use_google_blockly is true if level.uses_google_blockly?' do
-    Level.any_instance.stubs(:uses_google_blockly?).returns(true)
+  test 'use_google_blockly is true if level uses google_blockly and blocklyVersion is not set to cdo' do
+    Experiment.stubs(:enabled?).returns(false)
+    view_options(blocklyVersion: nil)
     @level = build :level
+    @level.stubs(:uses_google_blockly?).returns(true)
     assert use_google_blockly
-
-    Level.unstub(:uses_google_blockly?)
-  end
-
-  test 'use_google_blockly is false if level.uses_google_blockly? but disable_google_blockly is set' do
-    GamelabJr.any_instance.stubs(:uses_google_blockly?).returns(true)
-    @level = build :spritelab
-    assert use_google_blockly
-
-    DCDO.stubs(:get).with('disable_google_blockly', []).returns(['GamelabJr'])
-    refute use_google_blockly
-
-    # Should be case insensitive
-    DCDO.stubs(:get).with('disable_google_blockly', []).returns(['gamelabjr'])
-    refute use_google_blockly
-
-    DCDO.unstub(:get)
+    @level.unstub(:uses_google_blockly?)
+    Experiment.unstub(:enabled?)
+    reset_view_options
   end
 
   test 'applab levels should not load channel when viewing student solution of a student without a channel' do

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -357,6 +357,7 @@ class LevelsHelperTest < ActionView::TestCase
     refute use_google_blockly
   end
 
+  # ****: Change this
   test 'use_google_blockly is true if blocklyVersion is set to Google in view_options' do
     view_options(blocklyVersion: 'google')
     @level = build :level
@@ -365,6 +366,7 @@ class LevelsHelperTest < ActionView::TestCase
     reset_view_options
   end
 
+  # ****: Change this
   test 'use_google_blockly is false if blocklyVersion is set to Cdo in view_options' do
     view_options(blocklyVersion: 'cdo')
     @level = build :level


### PR DESCRIPTION
## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

Typically, we control the Blockly version using a URL param that is not sticky between levels, like `?blocklyVersion=google` or `?blocklyVersion=cdo`. Before the bug bash for the Sprite Lab migration to mainline Blockly, we want to allow users to enroll in a SingleUser experiment that would persist their choice between levels/labs. This will also make it easier for those of us working on migrating a specific lab to consistently use a given Blockly version without always having to re-add the URL parameter. 

To enroll: `/experiments/set_single_user_experiment/google_blockly`
To unenroll: `/experiments/disable_single_user_experiment/google_blockly`

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/CT-180

## Testing story

Tested that enrolling and unenrolling from the experiment works and that the existing URL params also still work as intended.

The video is too big for Github so here's a link: https://drive.google.com/file/d/1jyc-P4wo5-CwbyEZZ8dOQyHBRkawo29d/view?usp=sharing

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
