### PR TITLE
Fix Live Reloading of new DynamicConfig Cache in Test

### DIFF
--- a/lib/dynamic_config/datastore_cache.rb
+++ b/lib/dynamic_config/datastore_cache.rb
@@ -98,7 +98,7 @@ class DatastoreCache
   # Updates the local cache with the latest values from the shared cache. Can
   # be called regularly, but only for a small subset of user requests.
   def update_local_cache
-    @local_cache = CDO.shared_cache.read(shared_cache_key)
+    @local_cache = CDO.shared_cache.read(shared_cache_key) || {}
     @local_cache_last_refreshed_at = Time.now
   end
 end


### PR DESCRIPTION
Fix-forward to a DTT-specific problem introduced by https://github.com/code-dot-org/code-dot-org/pull/54601

In the test environment, it's not only possible but expected for the underlying shared cache to be cleared out while the environment is still running. In that situation, when we attempt to update Dynamic Config's new local cache from the shared cache before the shared cache has been updated from the long-term data store, we might accidentally set it to the `nil` value and break tests.

We don't expect to ever encounter this in any production environment, and the simple fix is to make sure that when that specific situation occurs we default to something reasonable rather than something which breaks our assumptions.

## Testing Story

Manually applied this change locally on the test server, then ran `RAILS_ENV=test RACK_ENV=test bundle exec rake test:bin_ci` to confirm that with this change, the tests that were formerly failing now pass. I then reverted the local changes