### PR TITLE
Fix discrepencies in Hour of Code event counts

### DIFF
--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -56,49 +56,40 @@ def main
   # Microsoft provided data about Hour of Code served through their tutorials.
   total_started += 3_774_215
 
-  puts 'Marker 1'
+  today = Date.today
+  day = Date.new(2014, 12, 6)
 
-  #today = Date.today
-  #day = Date.new(2014, 12, 6)
+  while day < today
+    cache_path = pegasus_dir("cache/HourOfActivity_Results_#{day.strftime('%Y-%m-%d')}.json")
+    if (day != today) && File.file?(cache_path)
+      day_data = JSON.parse(File.read(cache_path))
+    else
+      day_data = analyze_day_fast(day)
 
-  # while day < today
-  #   cache_path = pegasus_dir("cache/HourOfActivity_Results_#{day.strftime('%Y-%m-%d')}.json")
-  #   if (day != today) && File.file?(cache_path)
-  #     day_data = JSON.parse(File.read(cache_path))
-  #   else
-  #     day_data = analyze_day_fast(day)
+      File.open(cache_path, 'wt') do |cache_file|
+        cache_file << JSON.pretty_generate(day_data)
+      end
+    end
 
-  #     File.open(cache_path, 'wt') do |cache_file|
-  #       cache_file << JSON.pretty_generate(day_data)
-  #     end
-  #   end
+    total_started += day_data['started'] if day_data['started']
+    total_finished += day_data['finished'] if day_data['finished']
+    total_tutorials = add_hashes(total_tutorials, day_data['tutorials'])
+    total_cities = add_hashes(total_cities, day_data['cities'])
+    total_states = add_hashes(total_states, day_data['states'] || {})
+    total_countries = add_hashes(total_countries, day_data['countries'])
+    total_codedotorg += day_data['codedotorg_tutorial_count'] if day_data['codedotorg_tutorial_count']
 
-  #   total_started += day_data['started'] if day_data['started']
-  #   total_finished += day_data['finished'] if day_data['finished']
-  #   total_tutorials = add_hashes(total_tutorials, day_data['tutorials'])
-  #   total_cities = add_hashes(total_cities, day_data['cities'])
-  #   total_states = add_hashes(total_states, day_data['states'] || {})
-  #   total_countries = add_hashes(total_countries, day_data['countries'])
-  #   total_codedotorg += day_data['codedotorg_tutorial_count'] if day_data['codedotorg_tutorial_count']
-
-  #   day += 1
-  # end
+    day += 1
+  end
 
   hoc_year = DCDO.get("hoc_year", 2017)
 
   # Compute the number of hoc events (the grand total and broken down by company and country).
   hoc_country_totals = Hash.new(0)
   hoc_company_totals = Hash.new(0)
-  puts 'Before pegasus queries'
-  unique_hoc_events = []
-  begin
-    unique_hoc_events = PEGASUS_DB_READER[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:name, :email, :processed_data, :data)
-  rescue => exception
-    puts exception
-  end
-  puts 'Finish unique_hoc_events query'
+
+  unique_hoc_events = PEGASUS_DB_READER[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:name, :email, :processed_data, :data)
   total_hoc_count = PEGASUS_DB_READER[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:email, :name).count
-  puts 'After pegasus queries'
 
   unique_hoc_events.each do |row|
     data = JSON.parse(row[:data])
@@ -106,14 +97,10 @@ def main
     hoc_company_totals[data['hoc_company_s']] += 1
   end
 
-  puts 'Start event count'
   events_by_country = Forms.events_by_country("HocSignup#{hoc_year}")
-  puts events_by_country.count
   events_by_country.each do |country_row|
     hoc_country_totals[country_row[:country_code]] = country_row[:count]
   end
-  puts hoc_country_totals
-  puts 'Event count finished'
 
   Properties.set :hoc_metrics, {
     started: total_started,
@@ -127,8 +114,6 @@ def main
     hoc_country_totals: hoc_country_totals,
     hoc_company_totals: hoc_company_totals,
   }
-
-  puts 'Marker 2'
 
   # In the production environment, begin with a known previous value in case we
   # are unable to obtain a more recent number.
@@ -155,8 +140,6 @@ def main
       end
     end
   end
-
-  puts 'Marker 3'
 
   metrics = Properties.get(:metrics) || Hash.new(0)
 

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -94,10 +94,8 @@ def main
     data['hoc_company_s'] = 'Other' if data['hoc_company_s'].nil_or_empty?
     hoc_company_totals[data['hoc_company_s']] += 1
 
-    next if row[:processed_data].nil?
-    processed_data = JSON.parse(row[:processed_data])
-    processed_data['location_country_code_s'] = 'Other' if processed_data['location_country_code_s'].nil_or_empty?
-    hoc_country_totals[processed_data['location_country_code_s']] += 1
+    data['hoc_event_country_s'] = 'Other' if data['hoc_event_country_s'].nil_or_empty?
+    hoc_country_totals[data['hoc_event_country_s']] += 1
   end
 
   Properties.set :hoc_metrics, {

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -55,33 +55,33 @@ def main
   # Microsoft provided data about Hour of Code served through their tutorials.
   total_started += 3_774_215
 
-  today = Date.today
-  day = Date.new(2014, 12, 6)
-
   puts 'Marker 1'
 
-  while day < today
-    cache_path = pegasus_dir("cache/HourOfActivity_Results_#{day.strftime('%Y-%m-%d')}.json")
-    if (day != today) && File.file?(cache_path)
-      day_data = JSON.parse(File.read(cache_path))
-    else
-      day_data = analyze_day_fast(day)
+  #today = Date.today
+  #day = Date.new(2014, 12, 6)
 
-      File.open(cache_path, 'wt') do |cache_file|
-        cache_file << JSON.pretty_generate(day_data)
-      end
-    end
+  # while day < today
+  #   cache_path = pegasus_dir("cache/HourOfActivity_Results_#{day.strftime('%Y-%m-%d')}.json")
+  #   if (day != today) && File.file?(cache_path)
+  #     day_data = JSON.parse(File.read(cache_path))
+  #   else
+  #     day_data = analyze_day_fast(day)
 
-    total_started += day_data['started'] if day_data['started']
-    total_finished += day_data['finished'] if day_data['finished']
-    total_tutorials = add_hashes(total_tutorials, day_data['tutorials'])
-    total_cities = add_hashes(total_cities, day_data['cities'])
-    total_states = add_hashes(total_states, day_data['states'] || {})
-    total_countries = add_hashes(total_countries, day_data['countries'])
-    total_codedotorg += day_data['codedotorg_tutorial_count'] if day_data['codedotorg_tutorial_count']
+  #     File.open(cache_path, 'wt') do |cache_file|
+  #       cache_file << JSON.pretty_generate(day_data)
+  #     end
+  #   end
 
-    day += 1
-  end
+  #   total_started += day_data['started'] if day_data['started']
+  #   total_finished += day_data['finished'] if day_data['finished']
+  #   total_tutorials = add_hashes(total_tutorials, day_data['tutorials'])
+  #   total_cities = add_hashes(total_cities, day_data['cities'])
+  #   total_states = add_hashes(total_states, day_data['states'] || {})
+  #   total_countries = add_hashes(total_countries, day_data['countries'])
+  #   total_codedotorg += day_data['codedotorg_tutorial_count'] if day_data['codedotorg_tutorial_count']
+
+  #   day += 1
+  # end
 
   hoc_year = DCDO.get("hoc_year", 2017)
 

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -87,7 +87,6 @@ def main
   # Compute the number of hoc events (the grand total and broken down by company and country).
   hoc_country_totals = Hash.new(0)
   hoc_company_totals = Hash.new(0)
-
   unique_hoc_events = PEGASUS_DB_READER[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:name, :email, :processed_data, :data)
   total_hoc_count = PEGASUS_DB_READER[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:email, :name).count
 

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -22,6 +22,7 @@ require 'dynamic_config/dcdo'
 # Provides helper methods (analyze_day_fast and add_hashes) as well as the
 # PEGASUS_DB_READER constant.
 require_relative '../../pegasus/helpers/analyze_hoc_activity_helper'
+require_relative '../../pegasus/helper_modules/forms'
 
 # This default number of lines of code is from 2016-11-23.
 DEFAULT_LINES_OF_CODE = 20_886_942_901

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -58,6 +58,8 @@ def main
   today = Date.today
   day = Date.new(2014, 12, 6)
 
+  puts 'Marker 1'
+
   while day < today
     cache_path = pegasus_dir("cache/HourOfActivity_Results_#{day.strftime('%Y-%m-%d')}.json")
     if (day != today) && File.file?(cache_path)
@@ -86,8 +88,16 @@ def main
   # Compute the number of hoc events (the grand total and broken down by company and country).
   hoc_country_totals = Hash.new(0)
   hoc_company_totals = Hash.new(0)
-  unique_hoc_events = PEGASUS_DB_READER[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:name, :email, :processed_data, :data)
+  puts 'Before pegasus queries'
+  unique_hoc_events = []
+  begin
+    unique_hoc_events = PEGASUS_DB_READER[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:name, :email, :processed_data, :data)
+  rescue => exception
+    puts exception
+  end
+  puts 'Finish unique_hoc_events query'
   total_hoc_count = PEGASUS_DB_READER[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:email, :name).count
+  puts 'After pegasus queries'
 
   unique_hoc_events.each do |row|
     data = JSON.parse(row[:data])
@@ -95,10 +105,14 @@ def main
     hoc_company_totals[data['hoc_company_s']] += 1
   end
 
+  puts 'Start event count'
   events_by_country = Forms.events_by_country("HocSignup#{hoc_year}")
+  puts events_by_country.count
   events_by_country.each do |country_row|
     hoc_country_totals[country_row[:country_code]] = country_row[:count]
   end
+  puts hoc_country_totals
+  puts 'Event count finished'
 
   Properties.set :hoc_metrics, {
     started: total_started,
@@ -112,6 +126,8 @@ def main
     hoc_country_totals: hoc_country_totals,
     hoc_company_totals: hoc_company_totals,
   }
+
+  puts 'Marker 2'
 
   # In the production environment, begin with a known previous value in case we
   # are unable to obtain a more recent number.
@@ -138,6 +154,8 @@ def main
       end
     end
   end
+
+  puts 'Marker 3'
 
   metrics = Properties.get(:metrics) || Hash.new(0)
 

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -93,9 +93,11 @@ def main
     data = JSON.parse(row[:data])
     data['hoc_company_s'] = 'Other' if data['hoc_company_s'].nil_or_empty?
     hoc_company_totals[data['hoc_company_s']] += 1
+  end
 
-    data['hoc_event_country_s'] = 'Other' if data['hoc_event_country_s'].nil_or_empty?
-    hoc_country_totals[data['hoc_event_country_s']] += 1
+  events_by_country = Forms.events_by_country("HocSignup#{hoc_year}")
+  events_by_country.each do |country_row|
+    hoc_country_totals[country_row[:country_code]] = country_row[:count]
   end
 
   Properties.set :hoc_metrics, {

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -12,6 +12,7 @@ style_min: true
 ---
 :ruby
   @header["title"] = hoc_s(:hoc2020_header)
+  @hoc_data = fetch_hoc_metrics['hoc_country_totals']
 
 =inline_css 'homepage.css'
 =inline_css '/generated/hoc-banner.css'
@@ -26,6 +27,8 @@ style_min: true
 
 #homepage.supreme-container
   = view :homepage_hero
+
+  %p= @hoc_data
 
   - if request.language == "en"
     = view :curriculum_banner

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -12,7 +12,6 @@ style_min: true
 ---
 :ruby
   @header["title"] = hoc_s(:hoc2020_header)
-  @hoc_data = fetch_hoc_metrics['hoc_country_totals']
 
 =inline_css 'homepage.css'
 =inline_css '/generated/hoc-banner.css'
@@ -27,8 +26,6 @@ style_min: true
 
 #homepage.supreme-container
   = view :homepage_hero
-
-  %p= @hoc_data
 
   - if request.language == "en"
     = view :curriculum_banner

--- a/pegasus/sites.v3/code.org/public/yourschool.haml
+++ b/pegasus/sites.v3/code.org/public/yourschool.haml
@@ -6,6 +6,9 @@ social:
   "og:description": "Expand computer science at your school or district. Join the thousands of schools who have already incorporated high quality computer science education into their curriculum and provide opportunities for the students in your local area."
 ---
 
+:ruby
+  @hoc_data = fetch_hoc_metrics['hoc_country_totals']
+
 -# =view :professional_learning_marketing_banner, link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more'
 
 %link{:rel=>'stylesheet', :type=>'text/css', :href=>'/css/yourschool.css'}
@@ -52,6 +55,9 @@ social:
 
 #partners
   %hr
+
+  %p= @hoc_data
+
   %center
     %p{style: 'margin: 40px 0 50px 0; font-size: 16px;'}
       Your pledge and information about your school helps expand computer science education across the United States. See K-12 Computer Science Access Report data on an

--- a/pegasus/sites.v3/code.org/public/yourschool.haml
+++ b/pegasus/sites.v3/code.org/public/yourschool.haml
@@ -6,9 +6,6 @@ social:
   "og:description": "Expand computer science at your school or district. Join the thousands of schools who have already incorporated high quality computer science education into their curriculum and provide opportunities for the students in your local area."
 ---
 
-:ruby
-  @hoc_data = fetch_hoc_metrics['hoc_country_totals']
-
 -# =view :professional_learning_marketing_banner, link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more'
 
 %link{:rel=>'stylesheet', :type=>'text/css', :href=>'/css/yourschool.css'}
@@ -55,9 +52,6 @@ social:
 
 #partners
   %hr
-
-  %p= @hoc_data
-
   %center
     %p{style: 'margin: 40px 0 50px 0; font-size: 16px;'}
       Your pledge and information about your school helps expand computer science education across the United States. See K-12 Computer Science Access Report data on an


### PR DESCRIPTION
Currrently, the Hour of Code country-specific event pages (e.g. [for Spain](https://hourofcode.com/es)) show different event counts than the [main list of all Hour of Code events](https://hourofcode.com/us/events/all):
![WRONG_NUM](https://github.com/code-dot-org/code-dot-org/assets/56283563/f2ed840a-87d2-46d1-97be-b11f17e063f7)
![Spain_total](https://github.com/code-dot-org/code-dot-org/assets/56283563/91c4d74d-f1b3-4204-96d8-a8747b237813)

The event pages do [their own counting](https://github.com/code-dot-org/code-dot-org/blob/staging/bin/cron/analyze_hoc_activity#L97-L100) of the events whereas the main events list page [uses the helper function `events_by_country`](https://github.com/code-dot-org/code-dot-org/blob/staging/pegasus/helper_modules/forms.rb#L27). To unify them, I changed the event pages to use the same helper function.

Now, the counts are consistent (since I can't view the hour of code page on an adhoc, I can only view the cronjob output that I printed):
![EVENT_TOTALS_COUNTRY](https://github.com/code-dot-org/code-dot-org/assets/56283563/306be040-94aa-48cc-a33e-cd5c8a789130)
![Spain_total](https://github.com/code-dot-org/code-dot-org/assets/56283563/6a1e5696-8f9c-4466-b289-778bf01da11b)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1178)

## Testing story
Set up an adhoc, ran `./bin/cron/analyze_hoc_activity`, and printed out the resulting country event counts to compare. Since I can't see the Hour of Code pages on an adhoc, I can only view the output from the `analyze_hoc_activity` script (I temporarily added some `puts` statements).
