### PR TITLE
Reinstating the AFE banner on the homepage

### DIFF
--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -95,7 +95,6 @@ function showHomepage() {
             topPlCourse={homepageData.topPlCourse}
             queryStringOpen={query['open']}
             canViewAdvancedTools={homepageData.canViewAdvancedTools}
-            isEnglish={isEnglish}
             ncesSchoolId={homepageData.ncesSchoolId}
             censusQuestion={homepageData.censusQuestion}
             showCensusBanner={homepageData.showCensusBanner}

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -35,7 +35,6 @@ export const UnconnectedTeacherHomepage = ({
   plCourses,
   courses,
   afeEligible,
-  isEnglish,
   joinedStudentSections,
   joinedPlSections,
   ncesSchoolId,
@@ -161,7 +160,7 @@ export const UnconnectedTeacherHomepage = ({
   // Verify background image works for both LTR and RTL languages.
   const backgroundUrl = '/shared/images/banners/teacher-homepage-hero.jpg';
 
-  const showAFEBanner = shouldShowAFEBanner && isEnglish && afeEligible;
+  const showAFEBanner = shouldShowAFEBanner && afeEligible;
 
   // Send one analytics event when a teacher logs in. Use session storage to determine
   // whether they've just logged in.
@@ -321,7 +320,6 @@ UnconnectedTeacherHomepage.propTypes = {
   courses: shapes.courses,
   afeEligible: PropTypes.bool,
   hocLaunch: PropTypes.string,
-  isEnglish: PropTypes.bool.isRequired,
   joinedStudentSections: shapes.sections,
   joinedPlSections: shapes.sections,
   ncesSchoolId: PropTypes.string,

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -61,10 +61,10 @@ export const UnconnectedTeacherHomepage = ({
   const teacherReminders = useRef(null);
   const flashes = useRef(null);
 
-  /* We are hiding the AFE banner to free up space on the Teacher Homepage as of September 2023).
-   * When we want to show the AFE banner again remove the next line and uses of 'shouldShowAFEBanner'.
+  /*
+   * Determines whether the AFE banner will take premium space on the Teacher Homepage
    */
-  const shouldShowAFEBanner = false;
+  const shouldShowAFEBanner = true;
 
   /* We are hiding the Census banner to free up space on the Teacher Homepage (November 2023)
    * when we want to show the Census banner again remove the next line

--- a/apps/src/templates/studioHomepages/TeacherHomepage.story.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.story.jsx
@@ -45,7 +45,6 @@ const Template = args => {
     <Provider store={reduxStore({teacherSections})}>
       <TeacherHomepage
         announcements={[announcement]}
-        isEnglish={true}
         showCensusBanner={false}
         {...args.props}
       />

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -150,13 +150,12 @@ describe('TeacherHomepage', () => {
   });
 
   /*
-    We have disabled the AFE Banner on the Teacher Homepage (September 2023) to conserve
-    space. If we decide to show the banner again this test will need to be updated. See
-    TeacherHomepage.jsx to make the banner show.
+    This test will need to be updated according to whether the banner is showing,
+    as determined by shouldShowAFEBanner in TeacherHomepage.jsx.
    */
-  it('does not render a DonorTeacherBanner even if isEnglish and afeEligible are true', () => {
+  it('renders a DonorTeacherBanner if isEnglish and afeEligible are true', () => {
     const wrapper = setUp({isEnglish: true, afeEligible: true});
-    assert(!wrapper.find('DonorTeacherBanner').exists());
+    assert(wrapper.find('DonorTeacherBanner').exists());
   });
 
   it('renders a TeacherSections component', () => {

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -15,7 +15,6 @@ const DEFAULT_PROPS = {
   topCourse,
   plCourses,
   topPlCourse,
-  isEnglish: true,
   joinedStudentSections: [],
   joinedPlSections: [],
   ncesSchoolId: 'school-id',
@@ -153,8 +152,8 @@ describe('TeacherHomepage', () => {
     This test will need to be updated according to whether the banner is showing,
     as determined by shouldShowAFEBanner in TeacherHomepage.jsx.
    */
-  it('renders a DonorTeacherBanner if isEnglish and afeEligible are true', () => {
-    const wrapper = setUp({isEnglish: true, afeEligible: true});
+  it('renders a DonorTeacherBanner if afeEligible is true', () => {
+    const wrapper = setUp({afeEligible: true});
     assert(wrapper.find('DonorTeacherBanner').exists());
   });
 


### PR DESCRIPTION
This PR puts the AFE banner back up on the homepage. Following [this PR](https://github.com/code-dot-org/code-dot-org/pull/53612) that removed it. Instead of deleting the line and the references, I imagine it would be useful to keep the scaffolding and just update back to 'true'.

<img width="1143" alt="Screenshot 2023-11-20 at 6 46 45 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/43d4b9de-8d87-4257-9d49-cd3d7d16ec69">


## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
