### PR TITLE
Use In-Memory Shared Cache for Parallel Tests

### DIFF
--- a/dashboard/test/lib/feature_mode_manager_test.rb
+++ b/dashboard/test/lib/feature_mode_manager_test.rb
@@ -13,6 +13,7 @@ class FeatureModeManagerTest < ActiveSupport::TestCase
   def setup
     CDO.stubs(hip_chat_logging: false)
     CDO.stubs(slack_endpoint: nil)
+    CDO.stubs(:shared_cache).returns(ActiveSupport::Cache::MemoryStore.new)
     @gatekeeper = GatekeeperBase.create
     @dcdo = DCDOBase.create
   end


### PR DESCRIPTION
Another follow-up to https://github.com/code-dot-org/code-dot-org/pull/54601

When the FeatureModeManager tests are executed with `rake parallel:test` (as they are in the DTT), the flags can now overwrite one another since they are all using the same filesystem-based shared cache. To prevent this, stub out that shared cache for an in-memory one.

## Testing story

Temporarily applied this change manually to the test server, and verified with `RAILS_ENV=test RACK_ENV=test bundle exec rake parallel:test` that the tests which were formerly failing now pass. Specifically, without this change some subset of the FeatureModeManager tests would fail on every run, but not a consistent subset since it would depend on the precise order in which they get parallelized. With this change, the tests consistently pass.