### PR TITLE
P20-428 Remove Korean Special certificates

### DIFF
--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Certificate from './Certificate';
-import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import style from './certificate_batch.module.scss';
 import i18n from '@cdo/locale';
 import GraduateToNextLevel from '@cdo/apps/templates/certificates/GraduateToNextLevel';
@@ -25,23 +24,6 @@ export default function Congrats(props) {
    */
   const renderExtraCertificateLinks = (language, tutorial) => {
     let extraLinkUrl, extraLinkText;
-    // In order to remove the certificate links remove or comment the following section -------------------------------
-    if (language === 'ko') {
-      extraLinkText =
-        '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
-      if (/oceans/.test(tutorial)) {
-        extraLinkUrl = pegasus('/files/online-coding-party-2023-2-oceans.png');
-      } else if (/dance/.test(tutorial)) {
-        extraLinkUrl = pegasus('/files/online-coding-party-2023-2-dance.png');
-      } else if (/frozen/.test(tutorial)) {
-        extraLinkUrl = pegasus('/files/online-coding-party-2023-2-frozen.png');
-      } else if (/hero/.test(tutorial)) {
-        extraLinkUrl = pegasus('/files/online-coding-party-2023-2-hero.png');
-      } else {
-        extraLinkText = null;
-      }
-    }
-    // End of section to be removed or commented ----------------------------------------------------------------------
     // If Adding extra links see this PR: https://github.com/code-dot-org/code-dot-org/pull/48515
     if (!extraLinkUrl || !extraLinkText) {
       // There are no extra links to render.


### PR DESCRIPTION
Our Korean partners were hosting a special event that required to add special certificate links to some of out HoC activities.
The Campaign End Date is Monday, November 20th, Korea Time (UTC/GMT +9) 

This PR removes a link to a certificate provided by our partner when the language is in Korean.

## Screenshots

![Screenshot 2023-11-20 at 20 23 10](https://github.com/code-dot-org/code-dot-org/assets/66776217/04507ca1-5d0c-41ee-bb44-ef2c7afda34e)

## Links

- jira ticket: [P20-428](https://codedotorg.atlassian.net/browse/P20-428)

## Testing story
Before checking on your development server, open the following link in a new incognito window:
* [Setup code.org to be in Korean](http://localhost-studio.code.org:3000/lang/ko-kr)

Click the follow links to the end of a HoC tutorial and observe there are no link under the image of the HoC certificate
* [Finish AI for Oceans](http://localhost.code.org:3000/api/hour/finish/oceans)
* [Finish Minecraft Heroe's Journey](http://localhost.code.org:3000/api/hour/finish/hero)
* [Finish Frozen](http://localhost.code.org:3000/api/hour/finish/frozen)
* [Finish Dance Party](http://localhost.code.org:3000/api/hour/finish/dance-2019)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
