### PR TITLE
Fix authored hint lightbulb number circle in RTL

### DIFF
--- a/apps/src/templates/HintDisplayLightbulb.jsx
+++ b/apps/src/templates/HintDisplayLightbulb.jsx
@@ -8,6 +8,7 @@ class HintDisplayLightbulb extends React.Component {
   static propTypes = {
     unseenHints: PropTypes.arrayOf(PropTypes.object),
     isMinecraft: PropTypes.bool,
+    isRtl: PropTypes.bool.isRequired,
   };
 
   state = {
@@ -31,6 +32,7 @@ class HintDisplayLightbulb extends React.Component {
         <Lightbulb
           count={this.getCount()}
           isMinecraft={this.props.isMinecraft}
+          isRtl={this.props.isRtl}
           lit={this.getCount() > 0}
           shouldAnimate={this.state.shouldAnimate}
         />
@@ -43,5 +45,6 @@ export default connect(function propsFromStore(state) {
   return {
     isMinecraft: !!state.pageConstants.isMinecraft,
     unseenHints: state.authoredHints.unseenHints,
+    isRtl: state.isRtl,
   };
 })(HintDisplayLightbulb);

--- a/apps/src/templates/Lightbulb.jsx
+++ b/apps/src/templates/Lightbulb.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import {connect} from 'react-redux';
 import color from '@cdo/apps/util/color';
 
@@ -141,7 +140,7 @@ export default connect(state => {
   return {
     isRtl: state.isRtl,
   };
-})(Radium(Lightbulb));
+})(Lightbulb);
 
 const styles = {
   count: {

--- a/apps/src/templates/Lightbulb.jsx
+++ b/apps/src/templates/Lightbulb.jsx
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {connect} from 'react-redux';
 import color from '@cdo/apps/util/color';
 
-class Lightbulb extends React.Component {
+export default class Lightbulb extends React.Component {
   static propTypes = {
     shouldAnimate: PropTypes.bool,
     count: PropTypes.number,
@@ -135,12 +134,6 @@ class Lightbulb extends React.Component {
     );
   }
 }
-
-export default connect(state => {
-  return {
-    isRtl: state.isRtl,
-  };
-})(Lightbulb);
 
 const styles = {
   count: {

--- a/apps/src/templates/Lightbulb.jsx
+++ b/apps/src/templates/Lightbulb.jsx
@@ -59,7 +59,7 @@ class Lightbulb extends React.Component {
           <g
             transform={
               this.props.isRtl
-                ? 'translate(50,200) scale(10.0,10.0)'
+                ? 'translate(0,200) scale(10.0,10.0)'
                 : 'translate(245,200) scale(10.0,10.0)'
             }
           >
@@ -99,7 +99,7 @@ class Lightbulb extends React.Component {
           <g>
             <text
               id="hintCount"
-              x={this.props.isRtl ? '425' : '495'}
+              x={this.props.isRtl ? '380' : '495'}
               y="380"
               style={styles.count}
             >
@@ -110,7 +110,7 @@ class Lightbulb extends React.Component {
         numberCircle = (
           <g className={this.props.shouldAnimate ? 'animate-hint' : ''}>
             <circle
-              cx={this.props.isRtl ? '365' : '565'}
+              cx={this.props.isRtl ? '315' : '565'}
               cy="310"
               r="125"
               fill={color.white}

--- a/apps/src/templates/Lightbulb.jsx
+++ b/apps/src/templates/Lightbulb.jsx
@@ -10,7 +10,7 @@ export default class Lightbulb extends React.Component {
     size: PropTypes.number,
     style: PropTypes.object,
     isMinecraft: PropTypes.bool,
-    isRtl: PropTypes.bool.isRequired,
+    isRtl: PropTypes.bool,
   };
 
   static defaultProps = {

--- a/apps/src/templates/Lightbulb.jsx
+++ b/apps/src/templates/Lightbulb.jsx
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import Radium from 'radium'; // eslint-disable-line no-restricted-imports
+import {connect} from 'react-redux';
 import color from '@cdo/apps/util/color';
 
-export default class Lightbulb extends React.Component {
+class Lightbulb extends React.Component {
   static propTypes = {
     shouldAnimate: PropTypes.bool,
     count: PropTypes.number,
@@ -10,6 +12,7 @@ export default class Lightbulb extends React.Component {
     size: PropTypes.number,
     style: PropTypes.object,
     isMinecraft: PropTypes.bool,
+    isRtl: PropTypes.bool.isRequired,
   };
 
   static defaultProps = {
@@ -53,7 +56,13 @@ export default class Lightbulb extends React.Component {
     } else {
       bulbDisplay = (
         <g className={this.props.shouldAnimate ? 'animate-hint' : ''}>
-          <g transform="translate(245,200) scale(10.0,10.0)">
+          <g
+            transform={
+              this.props.isRtl
+                ? 'translate(50,200) scale(10.0,10.0)'
+                : 'translate(245,200) scale(10.0,10.0)'
+            }
+          >
             <path
               d="M22 33H8.25C7.39062 30.3359 5.67188 27.9297 3.95312 25.6094C3.52344 25.0078 3.09375 24.4062 2.66406 23.8047C0.945312 21.3125 0 18.3906 0 15.125C0 6.78906 6.70312 0 15.125 0C23.4609 0 30.25 6.78906 30.25 15.2109C30.25 18.3906 29.2188 21.3125 27.5 23.8047C27.0703 24.4062 26.6406 25.0078 26.2109 25.6094C24.4922 27.9297 22.7734 30.3359 22 33ZM15.125 44C11.2578 44 8.25 40.9922 8.25 37.125V35.75H22V37.125C22 40.9922 18.9062 44 15.125 44ZM8.25 15.125C8.25 11.3438 11.2578 8.25 15.125 8.25C15.8125 8.25 16.5 7.64844 16.5 6.875C16.5 6.1875 15.8125 5.5 15.125 5.5C9.79688 5.5 5.5 9.88281 5.5 15.125C5.5 15.8984 6.10156 16.5 6.875 16.5C7.5625 16.5 8.25 15.8984 8.25 15.125Z"
               fill="#1892E3"
@@ -88,7 +97,12 @@ export default class Lightbulb extends React.Component {
       } else {
         countDisplay = (
           <g>
-            <text id="hintCount" x="495" y="380" style={styles.count}>
+            <text
+              id="hintCount"
+              x={this.props.isRtl ? '425' : '495'}
+              y="380"
+              style={styles.count}
+            >
               {countText}
             </text>
           </g>
@@ -96,7 +110,7 @@ export default class Lightbulb extends React.Component {
         numberCircle = (
           <g className={this.props.shouldAnimate ? 'animate-hint' : ''}>
             <circle
-              cx="565"
+              cx={this.props.isRtl ? '365' : '565'}
               cy="310"
               r="125"
               fill={color.white}
@@ -122,6 +136,12 @@ export default class Lightbulb extends React.Component {
     );
   }
 }
+
+export default connect(state => {
+  return {
+    isRtl: state.isRtl,
+  };
+})(Radium(Lightbulb));
 
 const styles = {
   count: {


### PR DESCRIPTION
This PR updates the location of the Authored hint lightbulb and number circle in RTL languages. Note that this does not update the lightbulb in Minecraft labs.

Before update:

<img width="93" alt="rtl" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/7b5f6057-b881-4f2c-aeb2-e947cce75637">



After update:

![after-full](https://github.com/code-dot-org/code-dot-org/assets/107423305/e51f8833-9387-439b-8193-beb288eecfe9)

![after-small](https://github.com/code-dot-org/code-dot-org/assets/107423305/7cd6e1ca-4f2c-4729-96c7-d4aadb4d15ce)



## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[Trello](https://trello.com/c/zryqKLdt/185-for-rtl-the-hint-number-circle-is-not-displayed-correctly)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Note that the location of the lightbulb in Minecraft labs in RTL languages should probably be updated as well. This can be done in a follow-up.

Minecraft in ltr language:

<img width="93" alt="minecraft-ltr" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/010f5663-d30a-49d0-917f-e1f6bb68b1e9">


Minecraft in rtl language:

<img width="99" alt="minecraft-rtl" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/2f05f170-5e6a-423b-8649-5b1ed996652d">




<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
