### PR TITLE
Set default to true for coteacher flag

### DIFF
--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -376,7 +376,7 @@ export default function SectionsSetUpContainer({
           moduleStyles.withBorderTop
         )}
       >
-        {DCDO.get('show-coteacher-ui', false) && renderCoteacherSection()}
+        {DCDO.get('show-coteacher-ui', true) && renderCoteacherSection()}
         {renderAdvancedSettings()}
       </div>
       <div

--- a/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
+++ b/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
@@ -15,7 +15,7 @@ import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 export const showCoteacherInviteNotification = coteacherInvite => {
-  return !!coteacherInvite && DCDO.get('show-coteacher-ui', false);
+  return !!coteacherInvite && DCDO.get('show-coteacher-ui', true);
 };
 
 const CoteacherInviteNotification = ({

--- a/apps/test/unit/templates/studioHomepages/CoteacherInviteNotificationTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoteacherInviteNotificationTest.jsx
@@ -35,12 +35,14 @@ describe('CoteacherInviteNotification', () => {
     expect(wrapper.find(Notification).length).to.equal(0);
   });
 
-  it('renders nothing if flag is not set', () => {
+  it('renders notification if there is a coteacher invite and flag is not set', () => {
     DCDO.reset();
-    const wrapper = shallow(
-      <CoteacherInviteNotification {...defaultProps} coteacherInvite={null} />
-    );
-    expect(wrapper.find(Notification).length).to.equal(0);
+    const wrapper = shallow(<CoteacherInviteNotification {...defaultProps} />);
+    const notification = wrapper.find(Notification);
+    expect(notification.length).to.equal(1);
+    expect(notification.props().dismissible).to.equal(false);
+    expect(notification.props().type).to.equal(NotificationType.collaborate);
+    expect(notification.props().notice).to.include('The Great Pumpkin');
   });
 
   it('renders notification if there is a coteacher invite and flag is on', () => {


### PR DESCRIPTION
This should effectively be a no-op. The flag is turned on already on staging and prod. This will just make sure that eyes tests on test are running.

## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
