### PR TITLE
HoC 2023 - Add Dance Party AI side-by-side announcement banners

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2385,6 +2385,8 @@
   "studentAnnouncementSpecial2023AiLaunchBody": "AI is changing everything. Learn more about this technology and how it works.",
   "studentAnnouncementHoc2023Heading": "Hour of Code: Creativity with AI",
   "studentAnnouncementHoc2023Body": "Join millions across the globe in organizing an hour of coding, with or without AI and learning how AI works. Anyone, anywhere can do it. No experience needed.",
+  "announcementHoc2023DanceAIHeading": "Dance Party: AI Edition",
+  "announcementHoc2023DanceAIBody": "Learn about artificial intelligence (AI) concepts to create your own virtual dance party showcasing today's top artists. With dozens of songs to choose from, reach every student no matter their music taste. It's time to strut your stuff!",
   "studentAsVerifiedTeacherWarning": "Your account is currently a student account - you will need to update this account to a teacher account to keep verified teacher access.",
   "studentAsVerifiedTeacherDetails": "Click on the link and follow the instructions to upgrade your account. If you do not see the option to upgrade your account, you will need to be removed from all teacher sections.",
   "students": "Students",

--- a/apps/src/templates/studioHomepages/SpecialAnnouncement.jsx
+++ b/apps/src/templates/studioHomepages/SpecialAnnouncement.jsx
@@ -21,25 +21,20 @@ export default class SpecialAnnouncement extends Component {
     const {isEnglish, isTeacher} = this.props;
     const headingText = isTeacher
       ? i18n.teacherAnnouncementSpecialWinter2021Heading()
-      : i18n.studentAnnouncementHoc2023Heading();
+      : i18n.announcementHoc2023DanceAIHeading();
     const descriptionText = isTeacher
       ? i18n.teacherAnnouncementSpecialWinter2021Body()
-      : i18n.studentAnnouncementHoc2023Body();
+      : i18n.announcementHoc2023DanceAIBody();
     const buttonId = isTeacher
       ? 'teacher_homepage_announcement_special_winter2021'
       : 'student_homepage_announcement_special2020';
-    const url =
-      isTeacher && isEnglish ? pegasus('/hourofcode') : pegasus('/hourofcode');
+    const url = isTeacher && isEnglish ? pegasus('/dance') : pegasus('/dance');
     const buttonText =
       isTeacher && isEnglish ? i18n.joinUs() : i18n.learnMore();
     const imageUrl =
       isTeacher && isEnglish
-        ? pegasus(
-            '/shared/images/fill-540x300/announcement/announcement_hoc2020_ai.png'
-          )
-        : pegasus(
-            '/shared/images/fill-540x300/social-media/hoc2023_social.png'
-          );
+        ? pegasus('/images/dance-hoc/dance-party-activity-ai-edition.png')
+        : pegasus('/images/dance-hoc/dance-party-activity-ai-edition.png');
 
     return (
       <TwoColumnActionBlock

--- a/apps/src/templates/studioHomepages/SpecialAnnouncement.jsx
+++ b/apps/src/templates/studioHomepages/SpecialAnnouncement.jsx
@@ -1,40 +1,26 @@
-import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {TwoColumnActionBlock} from './TwoColumnActionBlock';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import i18n from '@cdo/locale';
 
-/* This component differs from the SpecialAnnouncementActionBlock because it
+/*
+This component differs from the SpecialAnnouncementActionBlock because it
 is not managed by the json system and can therefore be fully translated and
-can be shown to users viewing the site in languages other than English. */
+can be shown to users viewing the site in languages other than English.
+
+Note as of Nov 2023: this component may no longer be needed and can be replaced
+by the MarketingAnnouncementBanner component on the StudentHomepage component.
+*/
 export default class SpecialAnnouncement extends Component {
-  static propTypes = {
-    isEnglish: PropTypes.bool,
-    isTeacher: PropTypes.bool,
-  };
-
-  static defaultProps = {
-    isEnglish: true,
-  };
-
   render() {
-    const {isEnglish, isTeacher} = this.props;
-    const headingText = isTeacher
-      ? i18n.teacherAnnouncementSpecialWinter2021Heading()
-      : i18n.announcementHoc2023DanceAIHeading();
-    const descriptionText = isTeacher
-      ? i18n.teacherAnnouncementSpecialWinter2021Body()
-      : i18n.announcementHoc2023DanceAIBody();
-    const buttonId = isTeacher
-      ? 'teacher_homepage_announcement_special_winter2021'
-      : 'student_homepage_announcement_special2020';
-    const url = isTeacher && isEnglish ? pegasus('/dance') : pegasus('/dance');
-    const buttonText =
-      isTeacher && isEnglish ? i18n.joinUs() : i18n.learnMore();
-    const imageUrl =
-      isTeacher && isEnglish
-        ? pegasus('/images/dance-hoc/dance-party-activity-ai-edition.png')
-        : pegasus('/images/dance-hoc/dance-party-activity-ai-edition.png');
+    const headingText = i18n.announcementHoc2023DanceAIHeading();
+    const descriptionText = i18n.announcementHoc2023DanceAIBody();
+    const buttonId = 'student_homepage_announcement_special2020';
+    const url = pegasus('/dance');
+    const buttonText = i18n.learnMore();
+    const imageUrl = pegasus(
+      '/images/dance-hoc/dance-party-activity-ai-edition.png'
+    );
 
     return (
       <TwoColumnActionBlock

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -21,7 +21,6 @@ export default class StudentHomepage extends Component {
     sections: shapes.sections,
     canViewAdvancedTools: PropTypes.bool,
     studentId: PropTypes.number.isRequired,
-    isEnglish: PropTypes.bool.isRequired,
     showVerifiedTeacherWarning: PropTypes.bool,
     showDeprecatedCalcAndEvalWarning: PropTypes.bool,
   };
@@ -37,7 +36,6 @@ export default class StudentHomepage extends Component {
       sections,
       topCourse,
       hasFeedback,
-      isEnglish,
       showVerifiedTeacherWarning,
       showDeprecatedCalcAndEvalWarning,
     } = this.props;
@@ -62,7 +60,7 @@ export default class StudentHomepage extends Component {
               dismissible={false}
             />
           )}
-          {isEnglish && <SpecialAnnouncement isTeacher={false} />}
+          {<SpecialAnnouncement />}
           {showVerifiedTeacherWarning && (
             <Notification
               type={NotificationType.failure}

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -64,18 +64,9 @@ describe('StudentHomepage', () => {
     analyticsSpy.restore();
   });
 
-  it('shows the special announcement for English', () => {
-    const wrapper = shallow(
-      <StudentHomepage {...TEST_PROPS} isEnglish={true} />
-    );
+  it('shows the special announcement for all languages', () => {
+    const wrapper = shallow(<StudentHomepage {...TEST_PROPS} />);
     assert(wrapper.find('SpecialAnnouncement').exists());
-  });
-
-  it('does not show the special announcement for non-English', () => {
-    const wrapper = shallow(
-      <StudentHomepage {...TEST_PROPS} isEnglish={false} />
-    );
-    assert.isFalse(wrapper.find('SpecialAnnouncement').exists());
   });
 
   it('displays a notification for verified teacher permissions if showVerifiedTeacherWarning is true', () => {

--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -2,8 +2,8 @@
   "pages": {
     "/projects": "coldplay",
     "/certificates": "hoc-more",
-    "/courses": "hoc-2023",
-    "/home": "hoc-2023"
+    "/courses": "hoc-2023-dance-ai",
+    "/home": "hoc-2023-dance-ai"
   },
   "banners": {
     "csleadersprize": {
@@ -176,6 +176,14 @@
       "buttonText": "Learn more",
       "buttonUrl": "https://code.org/hourofcode",
       "buttonId": "hoc-2023"
+    },
+    "hoc-2023-dance-ai": {
+      "image": "/images/dance-hoc/dance-party-activity-ai-edition.png",
+      "title": "Dance Party: AI Edition",
+      "body": "Learn about artificial intelligence (AI) concepts to create your own virtual dance party showcasing today's top artists. With dozens of songs to choose from, reach every student no matter their music taste. It's time to strut your stuff!",
+      "buttonText": "Learn more",
+      "buttonUrl": "https://code.org/dance",
+      "buttonId": "hoc-2023-dance-ai"
     }
   }
 }

--- a/i18n/locales/source/dashboard/marketing_announcements.json
+++ b/i18n/locales/source/dashboard/marketing_announcements.json
@@ -104,6 +104,11 @@
       "title": "Hour of Code: Creativity with AI",
       "body": "Join millions across the globe in organizing an hour of coding, with or without AI and learning how AI works. Anyone, anywhere can do it. No experience needed.",
       "buttonText": "Learn more"
+    },
+    "hoc-2023-dance-ai": {
+      "title": "Dance Party: AI Edition",
+      "body": "Learn about artificial intelligence (AI) concepts to create your own virtual dance party showcasing today's top artists. With dozens of songs to choose from, reach every student no matter their music taste. It's time to strut your stuff!",
+      "buttonText": "Learn more"
     }
   }
 }


### PR DESCRIPTION
Add side-by-side announcement banners to the following pages:
- Teacher homepage, logged in - [studio.code.org/home](http://studio.code.org/home)
- Student homepage logged in - [studio.code.org/home](http://studio.code.org/home)
- Student Courses page, logged in - [studio.code.org/courses](http://studio.code.org/courses)
- Learn/Courses page, logged out - [studio.code.org/courses](http://studio.code.org/courses)

**Jira ticket:** [ACQ-1121](https://codedotorg.atlassian.net/browse/ACQ-1121)

----

## Teacher homepage, logged in - [studio.code.org/home](http://studio.code.org/home)
<img width="1000" alt="Screenshot 2023-11-21 at 1 17 33 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/34a7a9f7-aec7-43e5-9be9-8b5ddbe76f60">

## Student homepage, logged in - [studio.code.org/home](http://studio.code.org/home)
<img width="1000" alt="Screenshot 2023-11-21 at 1 15 45 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/2dc77216-68e4-4916-ba1e-22bbfc82b169">

## Student Courses page, logged in - [studio.code.org/courses](http://studio.code.org/courses)
<img width="1000" alt="Screenshot 2023-11-21 at 1 14 35 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/5c60b80f-c727-4314-a583-94a52a2c1540">

## Learn/Courses page, logged out - [studio.code.org/courses](http://studio.code.org/courses)
<img width="1000" alt="Screenshot 2023-11-21 at 1 16 12 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/503392e2-8787-4254-8aae-3973c1465ff3">