### PR TITLE
Move "Sign Up Started" Amplitude event

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_sign_up.js
@@ -3,6 +3,8 @@ import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 $(document).ready(() => {
+  analyticsReporter.sendEvent(EVENTS.SIGN_UP_STARTED_EVENT);
+
   document
     .getElementById('signup_form_submit')
     .addEventListener('click', () => {

--- a/apps/src/sites/studio/pages/devise/sessions/new.js
+++ b/apps/src/sites/studio/pages/devise/sessions/new.js
@@ -14,10 +14,6 @@ $(document).ready(() => {
     window.dashboard.clientState.reset();
   });
 
-  document.getElementById('user_signup').addEventListener('click', () => {
-    analyticsReporter.sendEvent(EVENTS.SIGN_UP_STARTED_EVENT);
-  });
-
   if (window.location.href.includes('user_return_to=/catalog')) {
     analyticsReporter.sendEvent(
       EVENTS.CURRICULUM_CATALOG_SIGN_IN_CLICKED_IN_ASSIGN_DIALOG


### PR DESCRIPTION
When viewing the [Sign Up Amplitude flow](https://app.amplitude.com/analytics/code-org/chart/g0i4osuz), Dani noticed that "Sign Up Started" event counts were lower than "Sign Up Finished" event counts. The "Sign Up Started" event is triggered when a user clicks the "Create an Account" button on [studio.code.org/users/sign_in](https://studio.code.org/users/sign_in), which immediately redirects them to [studio.code.org/users/sign_up](https://studio.code.org/users/sign_up). In the past, there have been [issues with Amplitude events actually logging](https://github.com/code-dot-org/code-dot-org/pull/50527) when a redirect occurs at about the same time.

Since this fits the profile of that previous issue, this PR moves the "Sign Up Started" event to trigger on page load for [studio.code.org/users/sign_up](https://studio.code.org/users/sign_up) rather than right before the redirect to this page. While it is hard to be certain that this will fix it, I'm confident it won't make anything worse since the event is just being triggered right after the redirect rather than right before (meaning at least the same number of logged events).

### Demo of the event triggering on page load
![event_triggered](https://github.com/code-dot-org/code-dot-org/assets/56283563/961abdc5-74f3-41c6-b501-5ec53822bb28)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1114)

## Testing story
Local testing.

## Followup work
Follow the Sign Up Amplitude flow charts to see if "Sign Up Started" passes "Sign Up Finished" in number of triggered events.
