### PR TITLE
hoc2023: fix code flip

### DIFF
--- a/apps/src/dance/ai/ai-block-preview.module.scss
+++ b/apps/src/dance/ai/ai-block-preview.module.scss
@@ -1,4 +1,4 @@
 .container {
   height: 150px;
-  width: 280px;
+  width: 540px;
 }

--- a/apps/src/dance/ai/dance-ai-modal.module.scss
+++ b/apps/src/dance/ai/dance-ai-modal.module.scss
@@ -293,10 +293,15 @@ $ai-modal-border-width: 8px;
           position: absolute;
           backface-visibility: hidden;
           top: 0;
+        }
+
+        &Front {
           left: 0;
+          transform: translateZ(0);
         }
 
         &Back {
+          right: 0;
           transform: rotateY(180deg);
 
           .blockPreview {


### PR DESCRIPTION
This fixes two issues that could be seen when flipping to view code:

- on macOS and iOS Safari 17, and also macOS Firefox 115 and 120, the visualization wasn't properly hidden despite the front having `backface-visibillity: hidden`.  From a couple of online threads, it sounded like applying `transform: translateZ(0)` to that face might assist, and indeed it seems to work.  I don't know the underlying reason why this works, though it seems possible this sends the rendering through an alternative code path or pipeline.  We should keep an eye out for any side effects or additional incompatibilities; an alternative/additional solution could involve hiding the visualization partway through the flip animation.
- the code preview was limited to 280px wide, but sometimes code blocks were wider.  It can now go to 540px wide, making use of the full modal.

### Before (macOS Safari 17)

https://github.com/code-dot-org/code-dot-org/assets/2205926/6eada2fb-0b6b-4901-9b48-5eebafb6cc1a

