### PR TITLE
[Google Blockly] open minitoolbox on procedures by default in modal editor

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -137,14 +137,18 @@ GoogleBlockly.Extensions.register('procedure_def_mini_toolbox', function () {
     return;
   }
 
+  const renderToolboxBeforeStack = true;
   const flyoutToggleButton = Blockly.customBlocks.initializeMiniToolbox.bind(
     this
-  )(undefined, true);
+  )(undefined, renderToolboxBeforeStack);
+  const renderingInFunctionEditor = true;
   Blockly.customBlocks.appendMiniToolboxToggle.bind(this)(
     miniToolboxBlocks,
     flyoutToggleButton,
-    true
+    renderingInFunctionEditor
   );
+  // Open mini-toolbox by default
+  flyoutToggleButton.setIcon(false);
 });
 
 // This extension adds an SVG frame around procedures definition blocks.


### PR DESCRIPTION
This is a small change that forces mini-toolboxes in procedure definition blocks (functions/behaviors in the modal editor) to render with the mini-flyout already open. Can still be closed as normal.

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/f2e643b6-d410-4201-b675-4471e491f968)

Also adds two boolean constants to hopefully improve readability of related code.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
