### PR TITLE
Check if levelbuilder is ahead of staging before doing DTS

### DIFF
--- a/bin/cron/merge_lb_to_staging
+++ b/bin/cron/merge_lb_to_staging
@@ -21,7 +21,7 @@ def slack_permission?
 end
 
 def new_commits?
-  return true if GitHub.behind?(base: 'staging', compare: 'levelbuilder')
+  return true if GitHub.ahead?(base: 'staging', compare: 'levelbuilder')
 
   ChatClient.message 'staging', 'robo-DTS skipped (nothing new on levelbuilder)'
   false

--- a/lib/cdo/github.rb
+++ b/lib/cdo/github.rb
@@ -252,6 +252,21 @@ module GitHub
     true
   end
 
+  # Octokit Documentation: http://octokit.github.io/octokit.rb/Octokit/Client/Commits.html#compare-instance_method
+  # @param base [String] The base branch to compare against.
+  # @param compare [String] The comparison branch to compare.
+  # @return [Boolean] Whether compare is ahead of base, i.e., whether compare has commits
+  #   missing in base.
+  def self.ahead?(base:, compare:)
+    response = Octokit.compare(REPO, base, compare)
+    response.ahead_by > 0
+  rescue Octokit::InternalServerError
+    # This can happen for comparisons with extremely large diffs. See https://developer.github.com/v3/repos/commits/#compare-two-commits
+    # In this case, we can safely assume that we are indeed ahead, since there
+    # otherwise would not be a diff to break on
+    true
+  end
+
   # Octokit Documentation: http://octokit.github.io/octokit.rb/Octokit/Client/Repositories.html#branch-instance_method
   # @param branch [String] The name of the branch.
   # @raise [Octokit::NotFound] If the specified branch does not exist.


### PR DESCRIPTION
Almost every holiday weekend, the DTS fails and staging is auto-closed due to there being nothing to merge from levelbuilder -> staging. I've been surprised that we don't handle this case, so I did a little bit of digging, and it turns out we have been checking if `staging` is ahead of `levelbuilder` (ie `staging` has commits that `levelbuilder` does not) before doing a DTS rather than checking if `levelbuilder` is ahead of `staging` (ie `levelbuilder` has commits that `staging` does not). We only want to perform a DTS if there is new content on the levelbuilder branch.

I did not run `merge_lb_to_staging` locally but I did run the new `ahead?` method locally and it worked as expected.


