### PR TITLE
[Google Blockly] Modal function editor - allow edit/create buttons when modal is open

### DIFF
--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -93,13 +93,11 @@ export default class FunctionEditor {
       .addEventListener('click', this.onDeletePressed.bind(this));
 
     // Editor workspace toolbox procedure category callback
-    // we have to pass the main ws so that the correct procedures are populated
-    // false to not show the new function button inside the modal editor
     this.editorWorkspace.registerToolboxCategoryCallback('PROCEDURE', () =>
-      functionsFlyoutCategory(Blockly.mainBlockSpace, true)
+      functionsFlyoutCategory(this.editorWorkspace, true)
     );
     this.editorWorkspace.registerToolboxCategoryCallback('Behavior', () =>
-      behaviorsFlyoutCategory(Blockly.mainBlockSpace, true)
+      behaviorsFlyoutCategory(this.editorWorkspace, true)
     );
 
     // Set up the "new procedure" button in the toolbox

--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
@@ -184,26 +184,11 @@ GoogleBlockly.Extensions.registerMutator(
  * @param {WorkspaceSvg} workspace The workspace containing procedures.
  * @returns an array of XML block elements
  */
-export function flyoutCategory(workspace, functionEditorOpen = false) {
+export function flyoutCategory(workspace) {
   const blockList = [];
 
-  const behaviorDefinitionBlock = {
-    kind: 'block',
-    type: BLOCK_TYPES.behaviorDefinition,
-    fields: {
-      NAME: Blockly.Msg.PROCEDURES_DEFNORETURN_PROCEDURE,
-    },
-  };
-
-  // If the modal function editor is enabled, we render a button to open the editor
-  // Otherwise, we render a "blank" behavior definition block
-  if (functionEditorOpen) {
-    // No-op - cannot create new behaviors while the modal editor is open
-  } else if (Blockly.useModalFunctionEditor) {
-    const newBehaviorButton = getNewBehaviorButtonWithCallback(
-      workspace,
-      behaviorDefinitionBlock
-    );
+  if (Blockly.useModalFunctionEditor) {
+    const newBehaviorButton = getNewBehaviorButtonWithCallback(workspace);
     blockList.push(newBehaviorButton);
   }
 
@@ -256,14 +241,14 @@ export function flyoutCategory(workspace, functionEditorOpen = false) {
   return blockList;
 }
 
-const getNewBehaviorButtonWithCallback = (
-  workspace,
-  behaviorDefinitionBlock
-) => {
+const getNewBehaviorButtonWithCallback = workspace => {
   const callbackKey = 'newBehaviorCallback';
-  workspace.registerButtonCallback(callbackKey, () => {
+  const callback = () => {
+    workspace.hideChaff();
     Blockly.functionEditor.newProcedureCallback(BLOCK_TYPES.behaviorDefinition);
-  });
+  };
+
+  workspace.registerButtonCallback(callbackKey, callback);
 
   return {
     kind: 'button',


### PR DESCRIPTION
## Context
Currently, if a user is in the modal function editor, we hide flyout buttons for creating new behaviors/functions and also hide edit buttons from their associated call blocks. We have had to do this as a workaround due to a bug in Blockly v9. Essentially, the bug is that a field click might delete a block, and Blockly doesn't check to make sure the block exists before attempting to bring it to the front.

## Proposal
By adding a short timeout, we can give Blockly time to execute the `block.bringToFront` method before performing our "work", which is what causes the block to get deleted.
The buttons to create new procedures are part of a flyout, so they don't hit this issue. For these, I instead just had to make sure that we were registering the toolbox callbacks on the modal editor's workspace. (If we only registered the callbacks on the main workspace, Blockly [can't find the callback keys and the buttons don't do anything](https://github.com/google/blockly/blob/925a7b9723ac46217c64a1842668fd0a66549449/core/flyout_button.ts#L286-L293).) Based on comments I've just removed, it seems like we were worried at one point about being able to find all the procedures if we weren't looking at the main workspace, but this doesn't seem to be a problem any more. The `flyoutCategory` functions now look at both the main and hidden workspaces explicitly. (See: https://github.com/code-dot-org/code-dot-org/pull/53154)

The following video demonstrates various methods of creating new procedures while the modal editor is open:

https://github.com/code-dot-org/code-dot-org/assets/43474485/92fcdcbc-1332-41f1-ba55-effd2e063563



## Links
https://codedotorg.atlassian.net/browse/CT-124

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Connect with Mark and determine if we want "edit" buttons to be rendered on blocks that are still in the flyout. If so, should the buttons be clickable, like they are in CDO Blockly, or should they (current behavior) just be part of the draggable block surface and result in moving the block to the main workspace?

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
