### PR TITLE
Fix bug where teacher accounts that were transferred to another account were added as a coteacher.

### DIFF
--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -41,7 +41,7 @@ module UsersHelper
       # If both users are teachers, transfer ownership of sections
       if source_user.teacher? && destination_user.teacher?
         SectionInstructor.where(instructor: source_user).each do |si|
-          si.update!(instructor: destination_user)
+          si.update! instructor: destination_user
         end
         Section.where(user: source_user).each do |owned_section|
           owned_section.update! user: destination_user

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -40,8 +40,10 @@ module UsersHelper
 
       # If both users are teachers, transfer ownership of sections
       if source_user.teacher? && destination_user.teacher?
+        SectionInstructor.where(instructor: source_user).each do |si|
+          si.update!(instructor: destination_user)
+        end
         Section.where(user: source_user).each do |owned_section|
-          SectionInstructor.where(section: owned_section, instructor: source_user).first!.update!(instructor: destination_user)
           owned_section.update! user: destination_user
         end
       end

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -41,6 +41,7 @@ module UsersHelper
       # If both users are teachers, transfer ownership of sections
       if source_user.teacher? && destination_user.teacher?
         Section.where(user: source_user).each do |owned_section|
+          SectionInstructor.where(section: owned_section, instructor: source_user).first!.update!(instructor: destination_user)
           owned_section.update! user: destination_user
         end
       end

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -243,6 +243,8 @@ class Section < ApplicationRecord
 
     si = SectionInstructor.with_deleted.find_by(instructor: user, section_id: id)
     if si.blank?
+      if SectionInstructor.with_deleted.where(section_id: id).exists?
+      end
       SectionInstructor.create!(section_id: id, instructor: user, status: :active)
     elsif si.deleted?
       si.restore

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -243,8 +243,6 @@ class Section < ApplicationRecord
 
     si = SectionInstructor.with_deleted.find_by(instructor: user, section_id: id)
     if si.blank?
-      if SectionInstructor.with_deleted.where(section_id: id).exists?
-      end
       SectionInstructor.create!(section_id: id, instructor: user, status: :active)
     elsif si.deleted?
       si.restore

--- a/dashboard/test/helpers/users_helper_test.rb
+++ b/dashboard/test/helpers/users_helper_test.rb
@@ -437,4 +437,25 @@ class UsersHelperTest < ActionView::TestCase
     assert_equal(101, level_with_best_progress([101, 102], level_progress))
     assert_equal(101, level_with_best_progress([102, 101], level_progress))
   end
+
+  def test_move_sections_and_destroy_source_user
+    teacher = create :teacher
+    coteacher = create :teacher
+    section = create :section, user: teacher
+    create :section_instructor, section: section, instructor: coteacher
+    section2 = create :section, user: coteacher
+    section_instructor2 = create :section_instructor, section: section2, instructor: teacher
+    destination_teacher = create :teacher
+
+    move_sections_and_destroy_source_user(source_user: teacher, destination_user: destination_teacher, takeover_type: 'type', provider: 'provider')
+
+    section.reload
+    section_instructor2.reload
+
+    assert_equal 2, destination_teacher.sections_instructed.count
+    assert_equal 0, teacher.sections_instructed.count
+    assert_equal 2, coteacher.sections_instructed.count
+    assert_equal section.user.id, destination_teacher.id
+    assert_equal section_instructor2.instructor.id, destination_teacher.id
+  end
 end


### PR DESCRIPTION
When a user account was transferred to a new account, the old accounts sections would get transferred to the new account and the old account would get deleted. However, after coteachers were created, the deleted account would still be added as a coteacher for all sections they were previously an owner. This shouldn't cause any breaks or leaks, because the old account was deleted. The only change is that the settings panel would show the deleted user.

This PR fixes the above bug by removing the deleted account as a coteacher as well as section owner. 

## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
