### PR TITLE
[Google Blockly] Do not apply the Google Blockly SingleUserExperiment to start mode

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -445,7 +445,7 @@ module LevelsHelper
   # 3. The corresponding inherited Level model can override Level#uses_google_blockly?. This option is for labs that
   #    have fully transitioned to Google Blockly.
   def use_google_blockly
-    return true if Experiment.enabled?(experiment_name: 'google_blockly', user: current_user)
+    return true if Experiment.enabled?(experiment_name: 'google_blockly', user: current_user) && !@is_start_mode
     return true if view_options[:blocklyVersion]&.downcase == 'google'
     return false if view_options[:blocklyVersion]&.downcase == 'cdo'
     return true if @level.uses_google_blockly?


### PR DESCRIPTION
## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

Last week, I merged a PR to add a SingleUserExperiment to enable Google Blockly to allow the choice to persist across labs: https://github.com/code-dot-org/code-dot-org/pull/55068

However, the Code Tools team is _not_ planning on migrating the start block-editing levelbuilder experience initially, so we want to be able to test the student experience in Google Blockly while keeping the start mode experience in CDO. More importantly, saving the start blocks with the experiment enabled won't work properly. This PR only applies the experiment if the user is enrolled but not editing start blocks. 

## Links

Ticket: https://codedotorg.atlassian.net/browse/CT-190

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
