### PR TITLE
Fix Generate Animation JSON tool bug

### DIFF
--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -133,9 +133,9 @@ export default class SelectStartAnimations extends React.Component {
             hideAnimationNames={false}
             navigable
             hideBackgrounds={false}
-            hideCostumes={false}
             pickerType={PICKER_TYPE.spritelab}
             selectedAnimations={[]}
+            hideCostumes={false}
             shouldWarnOnAnimationUpload={false}
           />
         </div>

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -51,7 +51,7 @@ export default class SelectStartAnimations extends React.Component {
   addAnimationToList = animation => {
     const key = createUuid();
 
-    let updatedOrderedKeys = [key].concat(this.state.orderedKeys);
+    let updatedOrderedKeys = this.state.orderedKeys.concat([key]);
     this.setState({orderedKeys: updatedOrderedKeys});
 
     let propsByKey = {...this.state.propsByKey};
@@ -86,6 +86,26 @@ export default class SelectStartAnimations extends React.Component {
     });
   };
 
+  displayAnimationPickerBody = libraryManifest => {
+    return (
+      <AnimationPickerBody
+        onDrawYourOwnClick={() => console.log('Not supported at this time')}
+        onPickLibraryAnimation={this.addAnimationToList}
+        onAnimationSelectionComplete={() => {}}
+        onUploadClick={() => console.log('Not supported at this time')}
+        playAnimations={false}
+        libraryManifest={libraryManifest}
+        hideAnimationNames={false}
+        navigable
+        hideBackgrounds={false}
+        pickerType={PICKER_TYPE.animationJson}
+        selectedAnimations={[]}
+        hideCostumes={false}
+        shouldWarnOnAnimationUpload={false}
+      />
+    );
+  };
+
   render() {
     const {orderedKeys, propsByKey} = this.state;
     return (
@@ -99,45 +119,17 @@ export default class SelectStartAnimations extends React.Component {
         {this.props.useAllSprites && (
           <div style={styles.pageBreak}>
             <h3>
-              Hidden Animations (Animations that don't normally appear in the
+              Level-only Animations (Animations that don't normally appear in
               animation library):
             </h3>
-            <AnimationPickerBody
-              onDrawYourOwnClick={() =>
-                console.log('Not supported at this time')
-              }
-              onPickLibraryAnimation={this.addAnimationToList}
-              onAnimationSelectionComplete={() => {}}
-              onUploadClick={() => console.log('Not supported at this time')}
-              playAnimations={false}
-              libraryManifest={this.state.levelAnimationsManifest}
-              hideAnimationNames={false}
-              navigable
-              hideBackgrounds={false}
-              pickerType={PICKER_TYPE.spritelab}
-              selectedAnimations={[]}
-              hideCostumes={false}
-              shouldWarnOnAnimationUpload={false}
-            />
+            {this.displayAnimationPickerBody(
+              this.state.levelAnimationsManifest
+            )}
           </div>
         )}
         <div style={styles.pageBreak}>
           <h3>Library Animations:</h3>
-          <AnimationPickerBody
-            onDrawYourOwnClick={() => console.log('Not supported at this time')}
-            onPickLibraryAnimation={this.addAnimationToList}
-            onAnimationSelectionComplete={() => {}}
-            onUploadClick={() => console.log('Not supported at this time')}
-            playAnimations={false}
-            libraryManifest={this.state.libraryManifest}
-            hideAnimationNames={false}
-            navigable
-            hideBackgrounds={false}
-            pickerType={PICKER_TYPE.spritelab}
-            selectedAnimations={[]}
-            hideCostumes={false}
-            shouldWarnOnAnimationUpload={false}
-          />
+          {this.displayAnimationPickerBody(this.state.libraryManifest)}
         </div>
         <h2>Generated Animation JSON:</h2>
         <p>{JSON.stringify({orderedKeys, propsByKey})}</p>

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -131,8 +131,10 @@ export default class SelectStartAnimations extends React.Component {
             hideAnimationNames={false}
             navigable
             hideBackgrounds={false}
+            hideCostumes={false}
             pickerType={PICKER_TYPE.spritelab}
             selectedAnimations={[]}
+            shouldWarnOnAnimationUpload={false}
           />
         </div>
         <h2>Generated Animation JSON:</h2>

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -112,7 +112,17 @@ export default class SelectStartAnimations extends React.Component {
       <React.Fragment>
         <a href="/sprites">Back to Asset Management</a>
         <h2>Generate Animation JSON for a level</h2>
-        <p>This tool...</p>
+        <p>
+          This tool generates Animation JSON (costumes and backgrounds) for
+          Sprite Lab levels. Costumes and backgrounds, once selected, will show
+          up in the same order that students will view them from their dropdown
+          menu.
+        </p>
+        <p>
+          Level-specific animations contain images uploaded specifically for
+          certain levels. They are not available to students in the default
+          Sprite library.
+        </p>
         <div style={styles.pageBreak}>
           <h3>Selected Animations:</h3>
           {this.displaySelectedSprites()}

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -51,7 +51,7 @@ export default class SelectStartAnimations extends React.Component {
   addAnimationToList = animation => {
     const key = createUuid();
 
-    let updatedOrderedKeys = [key].concat(this.state.orderedKeys);
+    let updatedOrderedKeys = this.state.orderedKeys.concat([key]);
     this.setState({orderedKeys: updatedOrderedKeys});
 
     let propsByKey = {...this.state.propsByKey};

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -51,7 +51,7 @@ export default class SelectStartAnimations extends React.Component {
   addAnimationToList = animation => {
     const key = createUuid();
 
-    let updatedOrderedKeys = this.state.orderedKeys.concat([key]);
+    let updatedOrderedKeys = [key].concat(this.state.orderedKeys);
     this.setState({orderedKeys: updatedOrderedKeys});
 
     let propsByKey = {...this.state.propsByKey};

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -89,10 +89,10 @@ export default class SelectStartAnimations extends React.Component {
   displayAnimationPickerBody = libraryManifest => {
     return (
       <AnimationPickerBody
-        onDrawYourOwnClick={() => console.log('Not supported at this time')}
+        onDrawYourOwnClick={() => {}}
         onPickLibraryAnimation={this.addAnimationToList}
         onAnimationSelectionComplete={() => {}}
-        onUploadClick={() => console.log('Not supported at this time')}
+        onUploadClick={() => {}}
         playAnimations={false}
         libraryManifest={libraryManifest}
         hideAnimationNames={false}

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -113,15 +113,16 @@ export default class SelectStartAnimations extends React.Component {
         <a href="/sprites">Back to Asset Management</a>
         <h2>Generate Animation JSON for a level</h2>
         <p>
-          This tool generates Animation JSON (costumes and backgrounds) for
-          Sprite Lab levels. Costumes and backgrounds, once selected, will show
-          up in the same order that students will view them from their dropdown
-          menu.
+          This tool generates Animation JSON for costumes and backgrounds in
+          Sprite Lab levels (including CS Connections subtypes such as Story and
+          Science levels) and Poetry levels. Costumes and backgrounds, once
+          selected, will show up in the same order that students will view them
+          from their dropdown menu.
         </p>
         <p>
           Level-specific animations contain images uploaded specifically for
-          certain levels. They are not available to students in the default
-          Sprite library.
+          certain levels. They are not available to students in the animations
+          library.
         </p>
         <div style={styles.pageBreak}>
           <h3>Selected Animations:</h3>

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -11,6 +11,7 @@ import {PICKER_TYPE} from '@cdo/apps/p5lab/AnimationPicker/AnimationPicker';
 
 const THUMBNAIL_SIZE = 50;
 const THUMBNAIL_BORDER_WIDTH = 1;
+const noop = () => undefined;
 
 /*
   Renders one or two animation selectors for content writers to choose sprites and generate
@@ -89,10 +90,10 @@ export default class SelectStartAnimations extends React.Component {
   displayAnimationPickerBody = libraryManifest => {
     return (
       <AnimationPickerBody
-        onDrawYourOwnClick={() => {}}
+        onDrawYourOwnClick={noop}
         onPickLibraryAnimation={this.addAnimationToList}
-        onAnimationSelectionComplete={() => {}}
-        onUploadClick={() => {}}
+        onAnimationSelectionComplete={noop}
+        onUploadClick={noop}
         playAnimations={false}
         libraryManifest={libraryManifest}
         hideAnimationNames={false}

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -119,7 +119,7 @@ export default class SelectStartAnimations extends React.Component {
         {this.props.useAllSprites && (
           <div style={styles.pageBreak}>
             <h3>
-              Level-only Animations (Animations that don't normally appear in
+              Level-specific Animations (Animations that do not appear in the
               animation library):
             </h3>
             {this.displayAnimationPickerBody(

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -116,6 +116,8 @@ export default class SelectStartAnimations extends React.Component {
               hideBackgrounds={false}
               pickerType={PICKER_TYPE.spritelab}
               selectedAnimations={[]}
+              hideCostumes={false}
+              shouldWarnOnAnimationUpload={false}
             />
           </div>
         )}

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -72,6 +72,7 @@ export default class SelectStartAnimations extends React.Component {
 
   displaySelectedSprites = () => {
     const {propsByKey, orderedKeys} = this.state;
+    // 'Selected animations will be displayed here'.
     return orderedKeys.map(key => {
       return (
         <img
@@ -117,22 +118,23 @@ export default class SelectStartAnimations extends React.Component {
           Sprite Lab levels (including CS Connections subtypes such as Story and
           Science levels) and Poetry levels. Costumes and backgrounds, once
           selected, will show up in the same order that students will view them
-          from their dropdown menu.
+          from their dropdown menu. Generated Animation JSON will update at the
+          bottom of this page after each animation is selected.
         </p>
         <p>
-          Level-specific animations contain images uploaded specifically for
-          certain levels. They are not available to students in the animations
-          library.
+          <strong>Note:</strong> Level-specific animations contain images
+          uploaded specifically for certain levels. They are not available to
+          students in the Animations Library.
         </p>
         <div style={styles.pageBreak}>
-          <h3>Selected Animations:</h3>
+          <h2>Selected Animations:</h2>
           {this.displaySelectedSprites()}
         </div>
         {this.props.useAllSprites && (
           <div style={styles.pageBreak}>
             <h3>
               Level-specific Animations (Animations that do not appear in the
-              animation library):
+              Library Animations):
             </h3>
             {this.displayAnimationPickerBody(
               this.state.levelAnimationsManifest

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -52,8 +52,7 @@ export default class SelectStartAnimations extends React.Component {
   addAnimationToList = animation => {
     const key = createUuid();
 
-    let updatedOrderedKeys = this.state.orderedKeys.concat([key]);
-    this.setState({orderedKeys: updatedOrderedKeys});
+    this.setState({orderedKeys: [...this.state.orderedKeys, key]});
 
     let propsByKey = {...this.state.propsByKey};
     propsByKey[key] = animation;
@@ -113,6 +112,7 @@ export default class SelectStartAnimations extends React.Component {
       <React.Fragment>
         <a href="/sprites">Back to Asset Management</a>
         <h2>Generate Animation JSON for a level</h2>
+        <p>This tool...</p>
         <div style={styles.pageBreak}>
           <h3>Selected Animations:</h3>
           {this.displaySelectedSprites()}

--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -72,19 +72,26 @@ export default class SelectStartAnimations extends React.Component {
 
   displaySelectedSprites = () => {
     const {propsByKey, orderedKeys} = this.state;
-    // 'Selected animations will be displayed here'.
-    return orderedKeys.map(key => {
+    if (orderedKeys.length === 0) {
       return (
-        <img
-          key={key}
-          src={propsByKey[key].sourceUrl}
-          alt={propsByKey[key].name}
-          style={styles.thumbnail}
-          role="button"
-          onClick={() => this.removeAnimationFromList(key)}
-        />
+        <p>
+          <i>Selected animations will be displayed here.</i>
+        </p>
       );
-    });
+    } else {
+      return orderedKeys.map(key => {
+        return (
+          <img
+            key={key}
+            src={propsByKey[key].sourceUrl}
+            alt={propsByKey[key].name}
+            style={styles.thumbnail}
+            role="button"
+            onClick={() => this.removeAnimationFromList(key)}
+          />
+        );
+      });
+    }
   };
 
   displayAnimationPickerBody = libraryManifest => {
@@ -126,7 +133,7 @@ export default class SelectStartAnimations extends React.Component {
           uploaded specifically for certain levels. They are not available to
           students in the Animations Library.
         </p>
-        <div style={styles.pageBreak}>
+        <div>
           <h2>Selected Animations:</h2>
           {this.displaySelectedSprites()}
         </div>

--- a/apps/src/code-studio/assets/SpriteManagementDirectory.jsx
+++ b/apps/src/code-studio/assets/SpriteManagementDirectory.jsx
@@ -5,7 +5,7 @@ export default class SpriteManagementDirectory extends React.Component {
     return (
       <div>
         <h1>Manage Sprite Lab Assets</h1>
-        <p>This is an internal set of tools for Code.org content authors.</p>
+        <p>This is an internal set of tools for Code.org content editors.</p>
         <h2>Add/Replace Animations</h2>
         <ul>
           <li>

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -318,7 +318,7 @@ export default class AnimationUpload extends React.Component {
       case Status.SUCCEEDED:
         return 'This path and filename are available.';
       case Status.ALERT:
-        return 'Filename already exists at this path. Would you like to replace the existing animation?';
+        return 'Filename already exists at this path. Would you like to replace the existing animation and metadata?';
       case Status.WAITING:
         return 'Select a file and destination above.';
     }

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -22,7 +22,12 @@ import StylizedBaseDialog from '@cdo/apps/componentLibrary/StylizedBaseDialog';
 // though our error message says 100KB, to help users avoid confusion.
 const MAX_UPLOAD_SIZE = 101000;
 
-export const PICKER_TYPE = makeEnum('spritelab', 'gamelab', 'backgrounds');
+export const PICKER_TYPE = makeEnum(
+  'spritelab',
+  'gamelab',
+  'backgrounds',
+  'animationJson'
+);
 
 /**
  * Dialog used for finding/selecting/uploading one or more assets to add to a

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -18,7 +18,7 @@ import {AnimationProps} from '@cdo/apps/p5lab/shapes';
 import {isMobileDevice} from '@cdo/apps/util/browser-detector';
 import {PICKER_TYPE} from './AnimationPicker.jsx';
 import style from './animation-picker-body.module.scss';
-import {UnconnectedAnimationUploadButton as AnimationUploadButton} from './AnimationUploadButton.jsx';
+import AnimationUploadButton from './AnimationUploadButton.jsx';
 
 const MAX_SEARCH_RESULTS = 40;
 

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -180,8 +180,6 @@ export default class AnimationPickerBody extends React.Component {
     let assetType;
     switch (this.props.pickerType) {
       case PICKER_TYPE.animationJson:
-        assetType = msg.costumeMode();
-        break;
       case PICKER_TYPE.spritelab:
         assetType = msg.costumeMode();
         break;
@@ -202,7 +200,8 @@ export default class AnimationPickerBody extends React.Component {
       onAnimationSelectionComplete,
       shouldWarnOnAnimationUpload,
     } = this.props;
-    const animationJsonMode = this.props.pickerType === 'animationJson';
+    const animationJsonMode =
+      this.props.pickerType === PICKER_TYPE.animationJson;
 
     const searching = searchQuery !== '';
     const inCategory = categoryQuery !== '';

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -272,6 +272,12 @@ export default class AnimationPickerBody extends React.Component {
                   onUploadClick={onUploadClick}
                   shouldWarnOnAnimationUpload={shouldWarnOnAnimationUpload}
                   isBackgroundsTab={isBackgroundsTab}
+                  inRestrictedShareMode={false}
+                  teacherHasConfirmedUploadWarning={false}
+                  refreshInRestrictedShareMode={() => {}}
+                  refreshTeacherHasConfirmedUploadWarning={() => {}}
+                  showingUploadWarning={() => {}}
+                  exitedUploadWarning={() => {}}
                 />
               </div>
             )}

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -272,12 +272,6 @@ export default class AnimationPickerBody extends React.Component {
                   onUploadClick={onUploadClick}
                   shouldWarnOnAnimationUpload={shouldWarnOnAnimationUpload}
                   isBackgroundsTab={isBackgroundsTab}
-                  inRestrictedShareMode={false}
-                  teacherHasConfirmedUploadWarning={false}
-                  refreshInRestrictedShareMode={() => {}}
-                  refreshTeacherHasConfirmedUploadWarning={() => {}}
-                  showingUploadWarning={() => {}}
-                  exitedUploadWarning={() => {}}
                 />
               </div>
             )}

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -18,7 +18,7 @@ import {AnimationProps} from '@cdo/apps/p5lab/shapes';
 import {isMobileDevice} from '@cdo/apps/util/browser-detector';
 import {PICKER_TYPE} from './AnimationPicker.jsx';
 import style from './animation-picker-body.module.scss';
-import AnimationUploadButton from './AnimationUploadButton.jsx';
+import {UnconnectedAnimationUploadButton as AnimationUploadButton} from './AnimationUploadButton.jsx';
 
 const MAX_SEARCH_RESULTS = 40;
 

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -210,7 +210,7 @@ export default class AnimationPickerBody extends React.Component {
     // animation picker is loaded. 600 pixels is minimum height of the animation picker.
     const shouldDisplaySecondDoneButton = isMobileDevice();
     // We show the draw your own and upload buttons if the user is:
-    // Either Not currently searching and not in a category, unless that category is backgrounds
+    // Either not currently searching and not in a category, unless that category is backgrounds
     // OR they are searching but there were no results,
     // AND they are not in animationJsonMode.
     // animationJsonMode is used for the Gneerate Animation JSON levelbuilder tool in SelectStartAnimations.

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -213,7 +213,7 @@ export default class AnimationPickerBody extends React.Component {
     // Either not currently searching and not in a category, unless that category is backgrounds
     // OR they are searching but there were no results,
     // AND they are not in animationJsonMode.
-    // animationJsonMode is used for the Gneerate Animation JSON levelbuilder tool in SelectStartAnimations.
+    // animationJsonMode is used for the Generate Animation JSON levelbuilder tool in SelectStartAnimations.
     const showDrawAndUploadButtons =
       ((!searching && (!inCategory || isBackgroundsTab)) ||
         results.length === 0) &&

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -179,7 +179,6 @@ export default class AnimationPickerBody extends React.Component {
   render() {
     let assetType;
     switch (this.props.pickerType) {
-      case PICKER_TYPE.animationJson:
       case PICKER_TYPE.spritelab:
         assetType = msg.costumeMode();
         break;
@@ -229,7 +228,7 @@ export default class AnimationPickerBody extends React.Component {
           />
         )}
         <h1 style={dialogStyles.title}>
-          {msg.animationPicker_title({assetType})}
+          {!animationJsonMode && msg.animationPicker_title({assetType})}
         </h1>
         {showDrawAndUploadButtons && (
           <WarningLabel>{msg.animationPicker_warning()}</WarningLabel>

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -209,9 +209,11 @@ export default class AnimationPickerBody extends React.Component {
     // Display second "Done" button. Useful for mobile, where the original "done" button might not be on screen when
     // animation picker is loaded. 600 pixels is minimum height of the animation picker.
     const shouldDisplaySecondDoneButton = isMobileDevice();
-    // We show the draw your own and upload buttons if the user is either:
-    // Not currently searching and not in a category, unless that category is backgrounds
-    // OR they are searching but there were no results
+    // We show the draw your own and upload buttons if the user is:
+    // Either Not currently searching and not in a category, unless that category is backgrounds
+    // OR they are searching but there were no results,
+    // AND they are not in animationJsonMode.
+    // animationJsonMode is used for the Gneerate Animation JSON levelbuilder tool in SelectStartAnimations.
     const showDrawAndUploadButtons =
       ((!searching && (!inCategory || isBackgroundsTab)) ||
         results.length === 0) &&

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -179,6 +179,9 @@ export default class AnimationPickerBody extends React.Component {
   render() {
     let assetType;
     switch (this.props.pickerType) {
+      case PICKER_TYPE.animationJson:
+        assetType = msg.costumeMode();
+        break;
       case PICKER_TYPE.spritelab:
         assetType = msg.costumeMode();
         break;
@@ -199,6 +202,7 @@ export default class AnimationPickerBody extends React.Component {
       onAnimationSelectionComplete,
       shouldWarnOnAnimationUpload,
     } = this.props;
+    const animationJsonMode = this.props.pickerType === 'animationJson';
 
     const searching = searchQuery !== '';
     const inCategory = categoryQuery !== '';
@@ -210,7 +214,9 @@ export default class AnimationPickerBody extends React.Component {
     // Not currently searching and not in a category, unless that category is backgrounds
     // OR they are searching but there were no results
     const showDrawAndUploadButtons =
-      (!searching && (!inCategory || isBackgroundsTab)) || results.length === 0;
+      ((!searching && (!inCategory || isBackgroundsTab)) ||
+        results.length === 0) &&
+      !animationJsonMode;
 
     return (
       <div style={{marginBottom: 10}}>

--- a/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
@@ -130,12 +130,12 @@ UnconnectedAnimationUploadButton.propTypes = {
   shouldWarnOnAnimationUpload: PropTypes.bool.isRequired,
   isBackgroundsTab: PropTypes.bool.isRequired,
   // populated from redux
-  inRestrictedShareMode: PropTypes.bool,
-  teacherHasConfirmedUploadWarning: PropTypes.bool,
-  refreshInRestrictedShareMode: PropTypes.func,
-  refreshTeacherHasConfirmedUploadWarning: PropTypes.func,
-  showingUploadWarning: PropTypes.func,
-  exitedUploadWarning: PropTypes.func,
+  inRestrictedShareMode: PropTypes.bool.isRequired,
+  teacherHasConfirmedUploadWarning: PropTypes.bool.isRequired,
+  refreshInRestrictedShareMode: PropTypes.func.isRequired,
+  refreshTeacherHasConfirmedUploadWarning: PropTypes.func.isRequired,
+  showingUploadWarning: PropTypes.func.isRequired,
+  exitedUploadWarning: PropTypes.func.isRequired,
   currentUserType: PropTypes.string,
 };
 

--- a/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
@@ -130,12 +130,12 @@ UnconnectedAnimationUploadButton.propTypes = {
   shouldWarnOnAnimationUpload: PropTypes.bool.isRequired,
   isBackgroundsTab: PropTypes.bool.isRequired,
   // populated from redux
-  inRestrictedShareMode: PropTypes.bool.isRequired,
-  teacherHasConfirmedUploadWarning: PropTypes.bool.isRequired,
-  refreshInRestrictedShareMode: PropTypes.func.isRequired,
-  refreshTeacherHasConfirmedUploadWarning: PropTypes.func.isRequired,
-  showingUploadWarning: PropTypes.func.isRequired,
-  exitedUploadWarning: PropTypes.func.isRequired,
+  inRestrictedShareMode: PropTypes.bool,
+  teacherHasConfirmedUploadWarning: PropTypes.bool,
+  refreshInRestrictedShareMode: PropTypes.func,
+  refreshTeacherHasConfirmedUploadWarning: PropTypes.func,
+  showingUploadWarning: PropTypes.func,
+  exitedUploadWarning: PropTypes.func,
   currentUserType: PropTypes.string,
 };
 

--- a/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
+++ b/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
@@ -9,7 +9,7 @@ import AnimationPickerListItem from '@cdo/apps/p5lab/AnimationPicker/AnimationPi
 import testAnimationLibrary from '../testAnimationLibrary.json';
 import {CostumeCategories} from '@cdo/apps/p5lab/spritelab/constants';
 import {PICKER_TYPE} from '@cdo/apps/p5lab/AnimationPicker/AnimationPicker';
-import {UnconnectedAnimationUploadButton as AnimationUploadButton} from '@cdo/apps/p5lab/AnimationPicker/AnimationUploadButton';
+import AnimationUploadButton from '@cdo/apps/p5lab/AnimationPicker/AnimationUploadButton';
 
 const emptyFunction = function () {};
 
@@ -33,6 +33,12 @@ describe('AnimationPickerBody', function () {
     onAnimationSelectionComplete: emptyFunction,
     pickerType: PICKER_TYPE.gamelab,
     shouldWarnOnAnimationUpload: false,
+    isRestrictedMode: false,
+    teacherHasConfirmedUploadWarning: false,
+    refreshInRestrictedShareMode: emptyFunction,
+    refreshTeacherHasConfirmedUploadWarning: emptyFunction,
+    showingUploadWarning: false,
+    exitedUploadWarning: emptyFunction,
   };
 
   describe('upload warning', function () {

--- a/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
+++ b/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
@@ -9,7 +9,7 @@ import AnimationPickerListItem from '@cdo/apps/p5lab/AnimationPicker/AnimationPi
 import testAnimationLibrary from '../testAnimationLibrary.json';
 import {CostumeCategories} from '@cdo/apps/p5lab/spritelab/constants';
 import {PICKER_TYPE} from '@cdo/apps/p5lab/AnimationPicker/AnimationPicker';
-import AnimationUploadButton from '@cdo/apps/p5lab/AnimationPicker/AnimationUploadButton';
+import {UnconnectedAnimationUploadButton as AnimationUploadButton} from '@cdo/apps/p5lab/AnimationPicker/AnimationUploadButton';
 
 const emptyFunction = function () {};
 


### PR DESCRIPTION
This PR fixes the Generate Animation JSON tool located in the Sprite Lab Assets manager at https://levelbuilder-studio.code.org/sprites.

There are two versions of the tool: 
- 'Generate Animation JSON from Library Animations only' which contains only library animations
- 'Generate Animation JSON from Libarary AND Level-Specific Animations' which contains both library animations and level-specific animations (these are mutually exclusive sets of animations).

Content editors use this tool to create JSON blobs to use for Starting Animations JSON in .level files. These starting animations are used to limit the costumes and/or backgrounds in starter blocks of a level.

Example from /allthethings/lessons/36/levels/2 below:

![Screenshot 2023-11-28 at 6 14 55 PM](https://github.com/code-dot-org/code-dot-org/assets/107423305/ed6c0e58-fd9b-47e0-a8b1-c6fc0bd9890f)

@onlinecsteacher (Emma Wingreen) explained how content editors use the tool and confirmed that they do not need the upload button for this animation JSON tool. Therefore, I added a 4th picker type called `animationJson` so that in `SelectStartAnimations`, the `AnimationPickerBody` is rendered without the upload button if it has this picker type.

When chatting with Emma about the tool, she explained that a pain point for content editors is that the animation list acts as a stack, the last animation selected is the first in the ordered list. Thus I made [this update](https://github.com/code-dot-org/code-dot-org/blob/822df5c5a872e1bd7e36f735a6fd753296cde467/apps/src/code-studio/assets/SelectStartAnimations.jsx#L54) to add an animation to the end of the ordered list.  

There are also a handful of UI updates including more detailed instructions on how to use the tool, adding placeholder text where animation images are displayed, and removing 'Costumes Library' as title which is inaccurate.

Before update:

![Screenshot 2023-11-27 at 2 41 40 PM](https://github.com/code-dot-org/code-dot-org/assets/107423305/b6ca9c72-d8af-4515-990e-14e666aa055e)

Screencast of last-selected animation being placed at beginning of ordered 'Selected Animations' list:


https://github.com/code-dot-org/code-dot-org/assets/107423305/3fe81aaf-852e-4baf-9750-e2e2b7156856



After update:

https://github.com/code-dot-org/code-dot-org/assets/107423305/0c595d7d-643a-4f84-880c-5c8836421c4b

After update, placeholder text was added where images of animations will be displayed:



https://github.com/code-dot-org/code-dot-org/assets/107423305/1ceb2a31-b8d0-4ea4-9308-3b9dbc6b870a



This tool seems to have been broken since [this PR](https://github.com/code-dot-org/code-dot-org/pull/52578) removed the 'backgroundsTabs' experiment which removed the `hideUploadOption` prop. More details in [this Slack thread](https://codedotorg.slack.com/archives/C05DMS18MEX/p1701112041669069) which includes the bug report.






## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[Slack thread with report of bug](https://codedotorg.slack.com/archives/C05DMS18MEX/p1701112041669069)
[jira](https://codedotorg.atlassian.net/browse/LABS-251)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I not only tested the levelbuilder tools, but also checked locally to make sure that the upload feature still works as expected in Sprite Lab levels and projects.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Currently, content editors use @dancodedotorg 's [app](https://animation-json-widget.glitch.me/) in addition to the levelbuilder 'Generate Animation JSON' tool to help with a couple other pain points which involve editing an existing JSON blob:
- Adding an animation to the middle of an animation list
- Reordering an existing animation list

Follow-up item 1 is being able to upload an existing JSON blob, and retooling the UI so that a content editor can more easily edit the list.

Follow-up item 2 is to clean up the Level-specific Animations categories. Currently, there are categories which are displayed: Backgrounds, blank, Level Animations, Animals, All.

<img width="1001" alt="Screenshot 2023-12-04 at 10 45 22 AM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/2efd97e3-2cd1-4f79-8f46-d27e7ad317ad">

 If a user clicks on the blank category, an error is thrown and the page breaks - the user has to start over and loses any progress made (animation JSON). Also - there is only 1 animation displayed in the 'Animals' category. @onlinecsteacher requested that these items also be addressed.


<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
