### PR TITLE
HoC 2023 - Update one pager and participation guides on hourofcode.com

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/promote/assets/hoc-one-pager-2023.pdf.fetch
+++ b/pegasus/sites.v3/hourofcode.com/public/promote/assets/hoc-one-pager-2023.pdf.fetch
@@ -1,0 +1,1 @@
+https://cdo-fetch.s3.amazonaws.com/hoc-one-pager-2023.pdf

--- a/pegasus/sites.v3/hourofcode.com/public/promote/assets/hoc-participation-guide-2023.pdf.fetch
+++ b/pegasus/sites.v3/hourofcode.com/public/promote/assets/hoc-participation-guide-2023.pdf.fetch
@@ -1,0 +1,1 @@
+https://cdo-fetch.s3.amazonaws.com/hoc-participation-guide-2023.pdf

--- a/pegasus/sites.v3/hourofcode.com/views/promote_handouts.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/promote_handouts.haml
@@ -2,8 +2,8 @@
   - hoc_one_pager = "/files/hoc-one-pager-canada.pdf"
   - schools_handout = "/files/schools-handout-canada.pdf"
 - else
-  - hoc_one_pager = localized_file('/files/hoc-one-pager.pdf')
-  - schools_handout = localized_file('/files/schools-handout.pdf')
+  - hoc_one_pager = "/promote/assets/hoc-one-pager-2023.pdf"
+  - schools_handout = "/promote/assets/hoc-participation-guide-2023.pdf"
 
 %h2.handouts-header= hoc_s(:handouts_section)
 
@@ -16,7 +16,7 @@
 %a{:id => "participationguide"}
 %div.handout.col-50
   .handout-text= hoc_s(:handouts_participationguide)
-  %a{:href => localized_file('/files/participation-guide.pdf')}
+  %a{:href => schools_handout}
     %img{:src => localized_image('/images/fit-250/participation-guide.png')}
 
 %div{:style => 'clear:both'}


### PR DESCRIPTION
Update one pager and participation guide PDFs on https://hourofcode.com/promote/resources#onepager
- Added the `.pdf` files to AWS and am linking to them with `.pdf.fetch` files
- There are not new Canada guides so I'm leaving them as-is

**Jira ticket:** [ACQ-1192](https://codedotorg.atlassian.net/browse/ACQ-1192)