### PR TITLE
Show missing Hour of Code events on hourofcode.com/us

### DIFF
--- a/apps/src/sites/hourofcode.com/pages/views/hoc_events_map.js
+++ b/apps/src/sites/hourofcode.com/pages/views/hoc_events_map.js
@@ -49,9 +49,9 @@ $(document).ready(function () {
   }
 
   map.on('load', function () {
-    map.addSource('hoctiles-dev', {
+    map.addSource('hoctiles', {
       type: 'vector',
-      url: 'mapbox://codeorg.hoctiles-dev',
+      url: 'mapbox://codeorg.hoctiles',
     });
 
     // The order we add layers matters here as layers are added on top of each
@@ -60,7 +60,7 @@ $(document).ready(function () {
     map.addLayer({
       id: 'hoc-events',
       type: 'symbol',
-      source: 'hoctiles-dev',
+      source: 'hoctiles',
       'source-layer': 'hoc',
       layout: {
         visibility: 'visible',
@@ -74,7 +74,7 @@ $(document).ready(function () {
     map.addLayer({
       id: 'hoc-special-events',
       type: 'symbol',
-      source: 'hoctiles-dev',
+      source: 'hoctiles',
       'source-layer': 'hoc',
       layout: {
         visibility: 'visible',

--- a/apps/src/sites/hourofcode.com/pages/views/hoc_events_map.js
+++ b/apps/src/sites/hourofcode.com/pages/views/hoc_events_map.js
@@ -49,9 +49,9 @@ $(document).ready(function () {
   }
 
   map.on('load', function () {
-    map.addSource('hoctiles', {
+    map.addSource('hoctiles-dev', {
       type: 'vector',
-      url: 'mapbox://codeorg.hoctiles',
+      url: 'mapbox://codeorg.hoctiles-dev',
     });
 
     // The order we add layers matters here as layers are added on top of each
@@ -60,7 +60,7 @@ $(document).ready(function () {
     map.addLayer({
       id: 'hoc-events',
       type: 'symbol',
-      source: 'hoctiles',
+      source: 'hoctiles-dev',
       'source-layer': 'hoc',
       layout: {
         visibility: 'visible',
@@ -74,7 +74,7 @@ $(document).ready(function () {
     map.addLayer({
       id: 'hoc-special-events',
       type: 'symbol',
-      source: 'hoctiles',
+      source: 'hoctiles-dev',
       'source-layer': 'hoc',
       layout: {
         visibility: 'visible',

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -67,7 +67,7 @@ def main
       }
   end
   file = Tempfile.new(['hocevents', 'geojson'])
-  tiles = Tempfile.new(['hoctiles', 'mbtiles'])
+  tiles = Tempfile.new(['hoctiles-dev', 'mbtiles'])
   file.write(JSON.pretty_generate(geojson))
   _stdout, stderr, tippecanoe_status = Open3.capture3(
     # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
@@ -78,7 +78,7 @@ def main
   )
   upload_successful = false
   if tippecanoe_status.success?
-    upload_successful = upload_maptiles(tiles.path, 'hoctiles')
+    upload_successful = upload_maptiles(tiles.path, 'hoctiles-dev')
   end
   unless tippecanoe_status.success? && upload_successful
     Honeybadger.notify(

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -35,11 +35,9 @@ def main
     # update our JS code (hoc_events_map.js) that visualizes these events
     # to handle missing data.
     # ***
-    # In order to be placed on the map, all events require an organization name,
-    # processed location, and city. With the exception that approved special events
-    # don't need a city so we can show events like the Cocos Keeling Islands.
+    # In order to be placed on the map, all events require an organization name and
+    # a processed location.
     next if data['organization_name_s'].nil? || processed_data['location_p'].nil?
-    next if form[:review] != "approved" && processed_data['location_city_s'].nil?
 
     organization_name =
       if !processed_data['nces_school_name_s'].to_s.strip.empty?

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -30,6 +30,9 @@ def main
   DB_READONLY[:forms].where(kind: CURRENT_HOC_SIGNUP).paged_each(rows_per_fetch: 10_000) do |form|
     data = JSON.parse(form[:data])
     processed_data = JSON.parse(form[:processed_data]) rescue {}
+    puts 'Start'
+    puts data
+    puts processed_data
     # ***
     # If these rules are changed and we wish to display a broader set of events,
     # update our JS code (hoc_events_map.js) that visualizes these events
@@ -38,6 +41,8 @@ def main
     # In order to be placed on the map, all events require an organization name and
     # a processed location.
     next if data['organization_name_s'].nil? || processed_data['location_p'].nil?
+
+    puts 'Not skipped'
 
     organization_name =
       if !processed_data['nces_school_name_s'].to_s.strip.empty?
@@ -66,6 +71,8 @@ def main
         type: "Feature"
       }
   end
+  puts geojson["features"]
+  puts 'Done with map info'
   file = Tempfile.new(['hocevents', 'geojson'])
   tiles = Tempfile.new(['hoctiles-dev', 'mbtiles'])
   file.write(JSON.pretty_generate(geojson))
@@ -79,8 +86,11 @@ def main
   upload_successful = false
   if tippecanoe_status.success?
     upload_successful = upload_maptiles(tiles.path, 'hoctiles-dev')
+    puts 'Was it successful?'
+    puts upload_successful
   end
   unless tippecanoe_status.success? && upload_successful
+    puts 'Failure'
     Honeybadger.notify(
       error_message: "Updating HOC map on Mapbox failed",
       error_class: "HOC Map Update Failure",

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -84,6 +84,8 @@ def main
     "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"hoc\" --force #{file.path}"
   )
   upload_successful = false
+  puts stderr
+  puts tippecanoe_status
   if tippecanoe_status.success?
     upload_successful = upload_maptiles(tiles.path, 'hoctiles-dev')
     puts 'Was it successful?'

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -30,9 +30,6 @@ def main
   DB_READONLY[:forms].where(kind: CURRENT_HOC_SIGNUP).paged_each(rows_per_fetch: 10_000) do |form|
     data = JSON.parse(form[:data])
     processed_data = JSON.parse(form[:processed_data]) rescue {}
-    puts 'Start'
-    puts data
-    puts processed_data
     # ***
     # If these rules are changed and we wish to display a broader set of events,
     # update our JS code (hoc_events_map.js) that visualizes these events
@@ -41,8 +38,6 @@ def main
     # In order to be placed on the map, all events require an organization name and
     # a processed location.
     next if data['organization_name_s'].nil? || processed_data['location_p'].nil?
-
-    puts 'Not skipped'
 
     organization_name =
       if !processed_data['nces_school_name_s'].to_s.strip.empty?
@@ -71,11 +66,8 @@ def main
         type: "Feature"
       }
   end
-  puts geojson["features"]
-  puts 'Done with map info'
   file = Tempfile.new(['hocevents', 'geojson'])
-  tiles = Tempfile.new([CDO.mapbox_upload_tileset, 'mbtiles'])
-  puts CDO.mapbox_upload_tileset
+  tiles = Tempfile.new(['hoctiles', 'mbtiles'])
   file.write(JSON.pretty_generate(geojson))
   _stdout, stderr, tippecanoe_status = Open3.capture3(
     # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
@@ -85,15 +77,10 @@ def main
     "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"hoc\" --force #{file.path}"
   )
   upload_successful = false
-  puts stderr
-  puts tippecanoe_status
   if tippecanoe_status.success?
-    upload_successful = upload_maptiles(tiles.path, CDO.mapbox_upload_tileset)
-    puts 'Was it successful?'
-    puts upload_successful
+    upload_successful = upload_maptiles(tiles.path, 'hoctiles')
   end
   unless tippecanoe_status.success? && upload_successful
-    puts 'Failure'
     Honeybadger.notify(
       error_message: "Updating HOC map on Mapbox failed",
       error_class: "HOC Map Update Failure",

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -74,7 +74,8 @@ def main
   puts geojson["features"]
   puts 'Done with map info'
   file = Tempfile.new(['hocevents', 'geojson'])
-  tiles = Tempfile.new(['hoctiles-dev', 'mbtiles'])
+  tiles = Tempfile.new([CDO.mapbox_upload_tileset, 'mbtiles'])
+  puts CDO.mapbox_upload_tileset
   file.write(JSON.pretty_generate(geojson))
   _stdout, stderr, tippecanoe_status = Open3.capture3(
     # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
@@ -87,7 +88,7 @@ def main
   puts stderr
   puts tippecanoe_status
   if tippecanoe_status.success?
-    upload_successful = upload_maptiles(tiles.path, 'hoctiles-dev')
+    upload_successful = upload_maptiles(tiles.path, CDO.mapbox_upload_tileset)
     puts 'Was it successful?'
     puts upload_successful
   end

--- a/bin/cron/upload_to_mapbox.rb
+++ b/bin/cron/upload_to_mapbox.rb
@@ -18,11 +18,14 @@ end
 # Returns response code
 def create_upload(config)
   CDO.log.info "Creating upload"
+  puts 'Mapbox upload token'
+  puts CDO.mapbox_upload_token
   RestClient.post("https://api.mapbox.com/uploads/v1/codeorg?access_token=#{CDO.mapbox_upload_token}", config.to_json, {content_type: :json, accept: :json}).code
 end
 
 # Return true if upload was successful
 def put_file_on_s3(tileset_path, credentials)
+  puts "Putting file on s3 method"
   CDO.log.info "Putting file on s3"
   s3_client = Aws::S3::Resource.new(
     access_key_id: credentials['accessKeyId'],
@@ -36,7 +39,11 @@ end
 
 # Return true if the upload completed without errors
 def upload_maptiles(tileset_path, tileset_name)
+  puts 'Tileset'
+  puts tileset_path
+  puts tileset_name
   credentials = create_upload_credentials
+  puts credentials
   return false unless put_file_on_s3(tileset_path, credentials)
   response_code = create_upload(
     {
@@ -45,5 +52,7 @@ def upload_maptiles(tileset_path, tileset_name)
       name: "codeorg.#{tileset_name}"
     }
   )
+  puts 'Past put file on s3'
+  puts response_code
   return [200, 201].include?(response_code)
 end

--- a/bin/cron/upload_to_mapbox.rb
+++ b/bin/cron/upload_to_mapbox.rb
@@ -18,14 +18,11 @@ end
 # Returns response code
 def create_upload(config)
   CDO.log.info "Creating upload"
-  puts 'Mapbox upload token'
-  puts CDO.mapbox_upload_token
   RestClient.post("https://api.mapbox.com/uploads/v1/codeorg?access_token=#{CDO.mapbox_upload_token}", config.to_json, {content_type: :json, accept: :json}).code
 end
 
 # Return true if upload was successful
 def put_file_on_s3(tileset_path, credentials)
-  puts "Putting file on s3 method"
   CDO.log.info "Putting file on s3"
   s3_client = Aws::S3::Resource.new(
     access_key_id: credentials['accessKeyId'],
@@ -39,11 +36,7 @@ end
 
 # Return true if the upload completed without errors
 def upload_maptiles(tileset_path, tileset_name)
-  puts 'Tileset'
-  puts tileset_path
-  puts tileset_name
   credentials = create_upload_credentials
-  puts credentials
   return false unless put_file_on_s3(tileset_path, credentials)
   response_code = create_upload(
     {
@@ -52,7 +45,5 @@ def upload_maptiles(tileset_path, tileset_name)
       name: "codeorg.#{tileset_name}"
     }
   )
-  puts 'Past put file on s3'
-  puts response_code
   return [200, 201].include?(response_code)
 end


### PR DESCRIPTION
Several Hour of Code events were not showing up on the [Hour of Code map](https://hourofcode.com/us) despite having location data associated with them. For example, the event for [this Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/470749) is not on the map. I tracked down the issue to the Hour of Code event form's "Event location" field with the location address dropdown. While the dropdown provides processed location data (such as the long/lat coordinates) for the user's selected address, it does not always fill in every field. In particular, it does not always fill in the `location_city_s` field.

This field is currently required for a regular event (i.e. not a special event that requires approval) to be placed on the map, otherwise it is skipped. I locally added a form entry with the exact same fields as the one in the Zendesk to confirm that it was being skipped at that step and not placed on the map.

I checked with Dani for a product perspective on the desired outcome, and she said we should just remove the line that skips those events. So, this PR removes the line which skips regular events with a nil `location_city_s` field. This is safe to do as the only place this field is being used is to populate what's in paranthesis when clicking on an event on the Hour of Code map (e.g. Bayard in "COBRE HIGH (Bayard)"). I thought this would also require updating [hoc_events_map.js](https://github.com/code-dot-org/code-dot-org/blob/staging-next/apps/src/sites/hourofcode.com/pages/views/hoc_events_map.js) (where the map layers are rendered) to support the case where a nil `location_city_s` field is passed in, however the file [already supports it](https://github.com/code-dot-org/code-dot-org/blob/staging-next/apps/src/sites/hourofcode.com/pages/views/hoc_events_map.js#L38) by not printing "(city_name)" if the city is nil.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1167)
Zendesk example: [here](https://codeorg.zendesk.com/agent/tickets/470749)

## Testing story
I attempted to test this similar to the way I tested the [`update_census_mapbox` cronjob PR](https://github.com/code-dot-org/code-dot-org/pull/53972) (i.e. setting up an adhoc to run the cronjob on a developer set of mapbox tiles, then locally running hourofcode.com and pointing my local mapbox to the developer set of mapbo tiles that were updated (this setup is required because I cannot locally run the mapbox cronjob, and adhocs do not support hourofcode.com)). Unfortunately, I could not get the `update_hoc_map` cronjob to successfully run on adhoc due to mapbox errors.

As a small proof of concept, I added `puts` statements within the cronjob (but before the upload to mapbox where the errors were occurring) to check whether the event was being skipped (as it was before) or if it was being processed (desired outcome). I ran it and confirmed that the new logic allowed the event to be processed and "Not skipped" was successfully printed in the cronjob output:
![not_skipped](https://github.com/code-dot-org/code-dot-org/assets/56283563/2d8f311b-cba7-4cda-bc71-e440d60b2f7b)

While this does give me confidence that events missing a `location_city_s` field will no longer be skipped, it does not explicitly show that it will then make it onto the map without an error. Since the skipping was the reason it wasn't making it onto the map in the first place and since the `hoc_events_map.js` already has coverage for a nil city field, I believe it is still a safe change to make (but I am fully open to pushback or other testing requests if others have ideas)!