### PR TITLE
Create LtiUserIdentity when creating LTI User

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -273,6 +273,10 @@ class User < ApplicationRecord
 
   after_save :save_email_reg_partner_preference, if: -> {share_teacher_email_reg_partner_opt_in_radio_choice.present?}
 
+  after_create if: -> {Policies::Lti.lti? self} do
+    Services::Lti.create_lti_user_identity(self)
+  end
+
   before_destroy :soft_delete_channels
 
   before_validation on: :create, if: -> {gender.present?} do

--- a/dashboard/lib/queries/lti.rb
+++ b/dashboard/lib/queries/lti.rb
@@ -6,4 +6,8 @@ class Queries::Lti
     auth_id = Policies::Lti.generate_auth_id(id_token)
     User.find_by_credential(type: AuthenticationOption::LTI_V1, id: auth_id)
   end
+
+  def self.get_lti_integration(issuer, client_id)
+    LtiIntegration.find_by(issuer: issuer, client_id: client_id)
+  end
 end

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -29,7 +29,7 @@ class Services::Lti
   end
 
   def self.create_lti_user_identity(user)
-    auth_option = user.authentication_options.find {|ao| ao.credential_type == AuthenticationOption::LTI_V1}
+    auth_option = user.authentication_options.find(&:lti?)
     issuer, client_id, subject = auth_option.authentication_id.split('|')
     lti_integration = Queries::Lti.get_lti_integration(issuer, client_id)
     LtiUserIdentity.create(user: user, subject: subject, lti_integration: lti_integration)

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -1,4 +1,5 @@
 require 'policies/lti'
+require 'queries/lti'
 require 'user'
 require 'authentication_option'
 
@@ -25,6 +26,13 @@ class Services::Lti
     )
     user.authentication_options = [ao]
     user
+  end
+
+  def self.create_lti_user_identity(user)
+    auth_option = user.authentication_options.find {|ao| ao.credential_type == AuthenticationOption::LTI_V1}
+    issuer, client_id, subject = auth_option.authentication_id.split('|')
+    lti_integration = Queries::Lti.get_lti_integration(issuer, client_id)
+    LtiUserIdentity.create(user: user, subject: subject, lti_integration: lti_integration)
   end
 
   def self.get_claim_from_list(id_token, keys_array)

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -544,18 +544,6 @@ FactoryBot.define do
       end
     end
 
-    trait :with_lti_authentication_option do
-      after(:create) do |user|
-        create(:authentication_option,
-          user: user,
-          email: user.email,
-          hashed_email: user.hashed_email,
-          credential_type: AuthenticationOption::LTI_V1,
-          authentication_id: 'https://lms.fake|12345|abcdef',
-        )
-      end
-    end
-
     trait :with_puzzles do
       transient do
         num_puzzles {1}
@@ -600,6 +588,11 @@ FactoryBot.define do
 
     factory :facebook_authentication_option do
       credential_type {AuthenticationOption::FACEBOOK}
+    end
+
+    factory :lti_authentication_option do
+      credential_type {AuthenticationOption::LTI_V1}
+      authentication_id {"#{SecureRandom.alphanumeric}|#{SecureRandom.alphanumeric}|#{SecureRandom.alphanumeric}"}
     end
   end
 
@@ -1779,8 +1772,8 @@ FactoryBot.define do
   end
 
   factory :lti_integration do
-    issuer {"issuer"}
-    client_id {"client_id"}
+    issuer {SecureRandom.alphanumeric}
+    client_id {SecureRandom.alphanumeric}
     platform_name {"platform_name"}
     auth_redirect_url {"http://test.org/auth"}
     jwks_url {"jwks_url"}

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -71,10 +71,12 @@ class Services::LtiTest < ActiveSupport::TestCase
   end
 
   test 'create_lti_user_identity should create an LtiUserIdentity when given LTI User' do
-    @id_token[@roles_key] = ['not-a-teacher-role']
-    user = Services::Lti.initialize_lti_user(@id_token)
-    user.age = 15
+    lti_integration = create :lti_integration
+    auth_id = "#{lti_integration[:issuer]}|#{lti_integration[:client_id]}|#{SecureRandom.alphanumeric}"
+    user = build :student
+    user.authentication_options << build(:lti_authentication_option, user: user, authentication_id: auth_id)
     user.save
+
     lti_user_identity = Services::Lti.create_lti_user_identity(user)
     assert lti_user_identity
   end

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -14,11 +14,12 @@ class Services::LtiTest < ActiveSupport::TestCase
       'http://purl.imsglobal.org/vocab/lis/v2/system/person#SysAdmin',
       'http://purl.imsglobal.org/vocab/lis/v2/system/person#User',
     ]
+    @lti_integration = create :lti_integration
 
     @id_token = {
-      sub: 'some-sub',
-      aud: 'some-aud',
-      iss: 'http://some-iss.com',
+      sub: SecureRandom.uuid,
+      aud: @lti_integration[:client_id],
+      iss: @lti_integration[:issuer],
       @custom_claims_key => {
         display_name: 'hansolo',
         full_name: 'Han Solo',
@@ -67,5 +68,14 @@ class Services::LtiTest < ActiveSupport::TestCase
     @id_token[@custom_claims_key][:full_name] = nil
     student_user = Services::Lti.initialize_lti_user(@id_token)
     assert_equal student_user.name, @id_token[@custom_claims_key][:given_name]
+  end
+
+  test 'create_lti_user_identity should create an LtiUserIdentity when given LTI User' do
+    @id_token[@roles_key] = ['not-a-teacher-role']
+    user = Services::Lti.initialize_lti_user(@id_token)
+    user.age = 15
+    user.save
+    lti_user_identity = Services::Lti.create_lti_user_identity(user)
+    assert lti_user_identity
   end
 end


### PR DESCRIPTION
 Creates LtiUserIdentity when a new User is created that has an AuthenticationOption of type LTI.

The reason I'm not creating this as a nested attribute in the same way we are AuthenticationOption is because, a LtiUserIdentity is unique to only LTI users, whereas AuthenticationOption is not, it applies to all "migrated" users. It felt cleanest to handle this as an `after_create` callback in the User model.

## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[Jira](https://codedotorg.atlassian.net/browse/P20-567)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

test/lib/services/lti_test.rb
```
bundle exec spring testunit test/lib/services/lti_test.rb
Running via Spring preloader in process 80319
Started with run options --seed 63208

  3/3: [=============================================================================================] 100% Time: 00:00:16, Time: 00:00:16

Finished in 20.63171s
3 tests, 16 assertions, 0 failures, 0 errors, 0 skips
```

test/models/user_test.rb
```
bundle exec spring testunit test/models/user_test.rb
Running via Spring preloader in process 80449
Started with run options --seed 44755

  431/431: [=========================================================================================] 100% Time: 00:01:15, Time: 00:01:15

Finished in 75.21149s
431 tests, 1071 assertions, 0 failures, 0 errors, 0 skips
```

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
