### PR TITLE
hoc2023: fix RTL code layout

### DIFF
--- a/apps/src/dance/ai/AiBlockPreview.tsx
+++ b/apps/src/dance/ai/AiBlockPreview.tsx
@@ -32,6 +32,10 @@ const AiBlockPreview: React.FunctionComponent<AiBlockPreviewProps> = ({
       blocks,
       {rtl: isRtl}
     );
+
+    return () => {
+      workspaceRef.current?.clear();
+    };
   }, [blockPreviewContainerRef, isRtl, results]);
 
   // Dispose of the workspace on unmount.

--- a/apps/src/dance/ai/AiBlockPreview.tsx
+++ b/apps/src/dance/ai/AiBlockPreview.tsx
@@ -26,7 +26,7 @@ const AiBlockPreview: React.FunctionComponent<AiBlockPreviewProps> = ({
 
     const xml = `
       <xml>
-        <block type="Dancelab_setForegroundEffectExtended" x="20" y="0">
+        <block type="Dancelab_setForegroundEffectExtended">
           <field name="EFFECT">"${results.foregroundEffect}"</field>
           <next>
             <block type="Dancelab_setBackgroundEffectWithPaletteAI">

--- a/apps/src/dance/ai/AiBlockPreview.tsx
+++ b/apps/src/dance/ai/AiBlockPreview.tsx
@@ -26,7 +26,7 @@ const AiBlockPreview: React.FunctionComponent<AiBlockPreviewProps> = ({
 
     const xml = `
       <xml>
-        <block type="Dancelab_setForegroundEffectExtended" x="-20" y="0">
+        <block type="Dancelab_setForegroundEffectExtended" x="20" y="0">
           <field name="EFFECT">"${results.foregroundEffect}"</field>
           <next>
             <block type="Dancelab_setBackgroundEffectWithPaletteAI">

--- a/apps/src/dance/ai/AiBlockPreview.tsx
+++ b/apps/src/dance/ai/AiBlockPreview.tsx
@@ -1,8 +1,9 @@
-import {BlockSvg, Workspace, WorkspaceSvg} from 'blockly';
+import {Workspace} from 'blockly';
 import React, {useEffect, useRef} from 'react';
 import moduleStyles from './ai-block-preview.module.scss';
 import {GeneratedEffect} from './types';
 import {useSelector} from 'react-redux';
+import {generateAiEffectBlocksXmlFromResult} from './utils';
 
 interface AiBlockPreviewProps {
   results: GeneratedEffect;
@@ -24,20 +25,7 @@ const AiBlockPreview: React.FunctionComponent<AiBlockPreviewProps> = ({
       return;
     }
 
-    const xml = `
-      <xml>
-        <block type="Dancelab_setForegroundEffectExtended">
-          <field name="EFFECT">"${results.foregroundEffect}"</field>
-          <next>
-            <block type="Dancelab_setBackgroundEffectWithPaletteAI">
-              <field name="PALETTE">"${results.backgroundColor}"</field>
-              <field name="EFFECT">"${results.backgroundEffect}"</field>
-            </block>
-          </next>
-        </block>
-      </xml>
-      `;
-
+    const xml = generateAiEffectBlocksXmlFromResult(results);
     const blocks = Blockly.utils.xml.textToDom(xml);
     workspaceRef.current = Blockly.BlockSpace.createReadOnlyBlockSpace(
       blockPreviewContainerRef.current,

--- a/apps/src/dance/ai/AiBlockPreview.tsx
+++ b/apps/src/dance/ai/AiBlockPreview.tsx
@@ -3,6 +3,7 @@ import React, {useEffect, useRef} from 'react';
 import moduleStyles from './ai-block-preview.module.scss';
 import {generateAiEffectBlocksFromResult} from './utils';
 import {GeneratedEffect} from './types';
+import {useSelector} from 'react-redux';
 
 interface AiBlockPreviewProps {
   results: GeneratedEffect;
@@ -16,6 +17,7 @@ const AiBlockPreview: React.FunctionComponent<AiBlockPreviewProps> = ({
 }) => {
   const blockPreviewContainerRef = useRef<HTMLSpanElement>(null);
   const workspaceRef = useRef<Workspace | null>(null);
+  const isRtl = useSelector((state: {isRtl: boolean}) => state.isRtl);
 
   // Create the workspace once the container has been rendered.
   useEffect(() => {
@@ -27,9 +29,9 @@ const AiBlockPreview: React.FunctionComponent<AiBlockPreviewProps> = ({
     workspaceRef.current = Blockly.BlockSpace.createReadOnlyBlockSpace(
       blockPreviewContainerRef.current,
       emptyBlockXml,
-      {}
+      {rtl: isRtl}
     );
-  }, [blockPreviewContainerRef]);
+  }, [blockPreviewContainerRef, isRtl]);
 
   // Build out the blocks.
   useEffect(() => {

--- a/apps/src/dance/ai/AiBlockPreview.tsx
+++ b/apps/src/dance/ai/AiBlockPreview.tsx
@@ -1,7 +1,6 @@
 import {BlockSvg, Workspace, WorkspaceSvg} from 'blockly';
 import React, {useEffect, useRef} from 'react';
 import moduleStyles from './ai-block-preview.module.scss';
-import {generateAiEffectBlocksFromResult} from './utils';
 import {GeneratedEffect} from './types';
 import {useSelector} from 'react-redux';
 
@@ -25,33 +24,27 @@ const AiBlockPreview: React.FunctionComponent<AiBlockPreviewProps> = ({
       return;
     }
 
-    const emptyBlockXml = Blockly.utils.xml.textToDom('<xml></xml>');
+    const xml = `
+      <xml>
+        <block type="Dancelab_setForegroundEffectExtended" x="-20" y="0">
+          <field name="EFFECT">"${results.foregroundEffect}"</field>
+          <next>
+            <block type="Dancelab_setBackgroundEffectWithPaletteAI">
+              <field name="PALETTE">"${results.backgroundColor}"</field>
+              <field name="EFFECT">"${results.backgroundEffect}"</field>
+            </block>
+          </next>
+        </block>
+      </xml>
+      `;
+
+    const blocks = Blockly.utils.xml.textToDom(xml);
     workspaceRef.current = Blockly.BlockSpace.createReadOnlyBlockSpace(
       blockPreviewContainerRef.current,
-      emptyBlockXml,
+      blocks,
       {rtl: isRtl}
     );
-  }, [blockPreviewContainerRef, isRtl]);
-
-  // Build out the blocks.
-  useEffect(() => {
-    if (!blockPreviewContainerRef.current || !workspaceRef.current) {
-      return;
-    }
-    const blocksSvg = generateAiEffectBlocksFromResult(
-      workspaceRef.current,
-      results
-    );
-    blocksSvg.forEach((blockSvg: BlockSvg) => {
-      blockSvg.initSvg();
-      blockSvg.render();
-    });
-    Blockly.svgResize(workspaceRef.current as WorkspaceSvg);
-
-    return () => {
-      workspaceRef.current?.clear();
-    };
-  }, [blockPreviewContainerRef, results]);
+  }, [blockPreviewContainerRef, isRtl, results]);
 
   // Dispose of the workspace on unmount.
   useEffect(() => () => workspaceRef.current?.dispose(), []);

--- a/apps/src/dance/ai/ai-block-preview.module.scss
+++ b/apps/src/dance/ai/ai-block-preview.module.scss
@@ -1,4 +1,3 @@
 .container {
   height: 150px;
-  width: 540px;
 }

--- a/apps/src/dance/ai/dance-ai-modal.module.scss
+++ b/apps/src/dance/ai/dance-ai-modal.module.scss
@@ -19,6 +19,15 @@ $ai-modal-border-width: 8px;
   }
 }
 
+@keyframes flying-emoji-x-rtl {
+  0% {
+    left: 65px;
+  }
+  100% {
+    left: 115px;
+  }
+}
+
 @keyframes flying-emoji-y {
   0% {
     top: 0;
@@ -200,12 +209,20 @@ $ai-modal-border-width: 8px;
       pointer-events: none;
       z-index: 1;
 
+      html[dir='rtl'] & {
+        right: 0;
+      }
+
       .flyingEmoji {
         position: absolute;
         left: 110px;
         top: 100px;
 
         animation: flying-emoji-x 0.4s linear, flying-emoji-y 0.4s ease-in;
+
+        html[dir='rtl'] & {
+          animation: flying-emoji-x-rtl 0.4s linear, flying-emoji-y 0.4s ease-in;
+        }
       }
 
       .botContainer {
@@ -221,8 +238,16 @@ $ai-modal-border-width: 8px;
           transform: rotate(0deg);
           pointer-events: none;
 
+          html[dir='rtl'] & {
+            transform-origin: bottom right;
+          }
+
           &Open {
             transform: rotate(-60deg);
+
+            html[dir='rtl'] & {
+              transform: rotate(60deg);
+            }
           }
         }
 
@@ -318,6 +343,10 @@ $ai-modal-border-width: 8px;
       font-size: 100px;
       color: $yes-color;
       animation: appear 0.05s;
+
+      html[dir='rtl'] & {
+        left: 80px;
+      }
     }
 
     .explanationArea {

--- a/apps/src/dance/ai/dance-ai-modal.module.scss
+++ b/apps/src/dance/ai/dance-ai-modal.module.scss
@@ -205,9 +205,12 @@ $ai-modal-border-width: 8px;
       width: 260px;
       height: 280px;
       top: 50px;
-      left: 0;
       pointer-events: none;
       z-index: 1;
+
+      html[dir='ltr'] & {
+        left: 0;
+      }
 
       html[dir='rtl'] & {
         right: 0;
@@ -218,7 +221,9 @@ $ai-modal-border-width: 8px;
         left: 110px;
         top: 100px;
 
-        animation: flying-emoji-x 0.4s linear, flying-emoji-y 0.4s ease-in;
+        html[dir='ltr'] & {
+          animation: flying-emoji-x 0.4s linear, flying-emoji-y 0.4s ease-in;
+        }
 
         html[dir='rtl'] & {
           animation: flying-emoji-x-rtl 0.4s linear, flying-emoji-y 0.4s ease-in;
@@ -231,19 +236,25 @@ $ai-modal-border-width: 8px;
         .botHead {
           position: absolute;
           width: 97px;
-          left: 81.5px;
           top: 34px;
-          transform-origin: bottom left;
           transition: transform 0.5s 0.25s;
           transform: rotate(0deg);
           pointer-events: none;
 
+          html[dir='ltr'] & {
+            left: 81.5px;
+            transform-origin: bottom left;
+          }
+
           html[dir='rtl'] & {
+            left: 82px;
             transform-origin: bottom right;
           }
 
           &Open {
-            transform: rotate(-60deg);
+            html[dir='ltr'] & {
+              transform: rotate(-60deg);
+            }
 
             html[dir='rtl'] & {
               transform: rotate(60deg);
@@ -326,7 +337,14 @@ $ai-modal-border-width: 8px;
         }
 
         &Back {
-          right: 0;
+          html[dir='ltr'] & {
+            right: 0;
+          }
+
+          html[dir='rtl'] & {
+            left: 0;
+          }
+
           transform: rotateY(180deg);
 
           .blockPreview {
@@ -339,10 +357,14 @@ $ai-modal-border-width: 8px;
     .checkArea {
       position: absolute;
       top: 120px;
-      left: 630px;
+
       font-size: 100px;
       color: $yes-color;
       animation: appear 0.05s;
+
+      html[dir='ltr'] & {
+        left: 630px;
+      }
 
       html[dir='rtl'] & {
         left: 80px;
@@ -361,15 +383,17 @@ $ai-modal-border-width: 8px;
         position: absolute;
         padding-inline-start: 15px;
         box-sizing: border-box;
-        right: 20px;
         width: 110px;
         border-radius: 4px;
         border: solid $neutral_dark10 1px;
         animation: appear 1s;
 
+        html[dir='ltr'] & {
+          right: 20px;
+        }
+
         html[dir='rtl'] & {
           left: 20px;
-          right: initial;
         }
 
         .emojiSlot {

--- a/apps/src/dance/ai/utils/generateAiEffectBlocksXmlFromResult.ts
+++ b/apps/src/dance/ai/utils/generateAiEffectBlocksXmlFromResult.ts
@@ -1,0 +1,20 @@
+import {GeneratedEffect} from '../types';
+
+// Returns XML for a generated effect's blocks.
+export const generateAiEffectBlocksXmlFromResult = (
+  result: GeneratedEffect
+) => {
+  return `
+    <xml>
+      <block type="Dancelab_setForegroundEffectExtended">
+        <field name="EFFECT">"${result.foregroundEffect}"</field>
+        <next>
+          <block type="Dancelab_setBackgroundEffectWithPaletteAI">
+            <field name="PALETTE">"${result.backgroundColor}"</field>
+            <field name="EFFECT">"${result.backgroundEffect}"</field>
+          </block>
+        </next>
+      </block>
+    </xml>
+  `;
+};

--- a/apps/src/dance/ai/utils/index.ts
+++ b/apps/src/dance/ai/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './generateAiEffectBlocks';
 export * from './generateAiEffectBlocksFromResult';
+export * from './generateAiEffectBlocksXmlFromResult';
 export * from './generatePreviewCode';
 export * from './getEmojiImageUrl';
 export * from './getLabelMap';


### PR DESCRIPTION
Until now, the AI modal was previewing code using an LTR layout, even for RTL languages.

It meant that previewing would look like this:

![Screenshot 2023-11-28 at 2 50 16 PM](https://github.com/code-dot-org/code-dot-org/assets/2205926/a1039eac-7d35-4e4b-ac36-da6631e9305e)

But once the code was used, it would look more properly RTL like this:

![Screenshot 2023-11-28 at 2 50 23 PM](https://github.com/code-dot-org/code-dot-org/assets/2205926/03783ffc-f182-41a7-90c8-606cb3c86b68)

With this change, the AI modal now previews code using an RTL layout for RTL languages.

Because we want wider code blocks to make use of the available space on the dialog on the opposite side of the A.I. bot's head, this change moves the head and the checkmark to the opposite sides when running in RTL.  The head opens on the opposite side, and objects fly in the opposite direction.

LTR should not be affected.

### before

https://github.com/code-dot-org/code-dot-org/assets/2205926/fdec7722-3e3f-4f0b-9554-aa94d3575ffc

### after

https://github.com/code-dot-org/code-dot-org/assets/2205926/63b0ec54-4450-4c4e-8d0a-381d10f209e3

Thanks to @bencodeorg for figuring out the core of this solution. 



