### PR TITLE
Temporarily Disable Automated Staging Content Scoop

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -63,19 +63,25 @@
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','collate_pdfs')
       cronjob at:'0 14,15 * * *', do:deploy_dir('bin', 'cron', 'update_dotd')
       cronjob at:'0 * * * *', do:deploy_dir('bin', 'cron', 'start_broken_link_checker'), notify:'dev+crontab@code.org'
-      cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      # Temporarily disabled for Hour of Code 2023.
+      # TODO: reenable
+      #cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'update_dts')
       cronjob at:'0 17 * * *', do:deploy_dir('bin', 'cron', 'commit_trusted_proxies')
 
       # This should be run after the commit_content job that happens on both the levelbuilder
       # and staging environments
       # merge_lb_to_staging is also known as DTS or "deploy to staging"
-      cronjob at:'35 7 * * 1-5', do:deploy_dir('bin', 'cron', 'merge_lb_to_staging')
+      # Temporarily disabled for Hour of Code 2023.
+      # TODO: reenable
+      #cronjob at:'35 7 * * 1-5', do:deploy_dir('bin', 'cron', 'merge_lb_to_staging')
 
 
       # This should be run after the commit_content job that happens on the levelbuilder
       # environment.
-      cronjob at:'20 9 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
+      # Temporarily disabled for Hour of Code 2023.
+      # TODO: reenable
+      #cronjob at:'20 9 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
     end
 
     if node.chef_environment == 'test' && node.name == 'staging-next'
@@ -89,8 +95,10 @@
     end
 
     if node.chef_environment == 'levelbuilder'
-      cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
-      cronjob at:'18 9 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      # Temporarily disabled for Hour of Code 2023.
+      # TODO: reenable
+      #cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      #cronjob at:'18 9 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
     end
 
 

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -79,9 +79,7 @@
 
       # This should be run after the commit_content job that happens on the levelbuilder
       # environment.
-      # Temporarily disabled for Hour of Code 2023.
-      # TODO: reenable
-      #cronjob at:'20 9 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
+      cronjob at:'20 9 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
     end
 
     if node.chef_environment == 'test' && node.name == 'staging-next'
@@ -95,10 +93,8 @@
     end
 
     if node.chef_environment == 'levelbuilder'
-      # Temporarily disabled for Hour of Code 2023.
-      # TODO: reenable
-      #cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
-      #cronjob at:'18 9 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      cronjob at:'18 9 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
     end
 
 


### PR DESCRIPTION
And the associated "merge into branch to trigger deploy" operation. We're entering restricted deployment mode for this year's Hour of Code, and only want to accept manual scoops into the staging branch.

Note that the comparable levelbuilder operations have been left in place.

## Links

documentation: https://docs.google.com/document/d/18RT8brdhNKWtMORAUtQdo3wlKaQ_YKIsj7e5wXLb9BU/edit#heading=h.vxxuturkvxt6

slack thread: https://codedotorg.slack.com/archives/C0T0PNTM3/p1701131566243879