### PR TITLE
Enable Sequel's `connection_validator` By Default

### DIFF
--- a/lib/cdo/db.rb
+++ b/lib/cdo/db.rb
@@ -8,10 +8,11 @@ require 'dynamic_config/gatekeeper'
 #   http://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_validator_rb.html
 # @param writer [String] Write conenction
 # @param reader [String] Read connection
-# @param validation_frequency [number] How often to validate the connection. If set to -1,
-#   validate each time a request is made.
+# @param validation_frequency [number] How often to validate the connection, in seconds.
+#   If set to -1, validate each time a request is made. Defaults to -1 (always revalidate)
+#   in test, 3600 (revalidate every hour) everywhere else.
 # @param query_timeout [number] The execution timeout for SELECT statements, in seconds.
-def sequel_connect(writer, reader, validation_frequency: nil, query_timeout: nil, multi_statements: false)
+def sequel_connect(writer, reader, validation_frequency: rack_env?(:test) ? -1 : 3600, query_timeout: nil, multi_statements: false)
   reader = reader.gsub 'mysql:', 'mysql2:'
   writer = writer.gsub 'mysql:', 'mysql2:'
 


### PR DESCRIPTION
We previously only ever used this in [the metrics helper library](https://github.com/code-dot-org/code-dot-org/blob/a556925514568ff28f14463cc9af21ef08344606/lib/cdo/metrics_helper.rb#L7-L10), but with the deprecation of MYSQL_OPT_RECONNECT we want to start using it everywhere.

I think revalidating every time makes sense in the test environment, but I'm not at all sure what timing we want in production. The default timing if unspecified is an hour, so that's what I've updated our production default to, as well. The documentation says:

> validation checks are only run if the connection has been idle for longer than a certain threshold

So I expect this will have minimal impact in production with the default one-hour threshold.

## Links

http://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_validator_rb.html

## Testing story

Tested locally. Without this change, running `RAILS_ENV=test RACK_ENV=test bundle exec rake test:lib` on the `disable-mysql-client-reconnect` branch will fail inconsistently but frequently with `Lost connection to MySQL server during query (Mysql2::Error::ConnectionError)`. With this change included on that branch, tests pass consistently

## Follow-up work

We will also need to find an ActiveRecord alternative in order to stop relying on MYSQL_OPT_RECONNECT

## Deployment Strategy

Note that this PR is opened against `disable-mysql-client-reconnect`, not `staging`; it will be merged into https://github.com/code-dot-org/code-dot-org/pull/54395, from which it can be deployed.