### PR TITLE
Add teachers that import an existing section as coteacher instead of owner

### DIFF
--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -39,7 +39,14 @@ class OmniAuthSection < Section
     oauth_section = with_deleted.where(code: code).first_or_create
 
     oauth_section.name = section_name || I18n.t('sections.default_name', default: 'Untitled Section')
-    oauth_section.user_id = owner_id
+
+    # Add the user as an owner if the section does not exist. Otherwise add as a coteacher to existing section.
+    if oauth_section.user_id.nil? || oauth_section.deleted?
+      oauth_section.user_id = owner_id
+    else
+      # create a section instructor record if one doesn't exist
+      oauth_section.section_instructors.where(instructor_id: owner_id).first_or_create(status: :active)
+    end
     oauth_section.login_type = type
 
     oauth_section.save! if oauth_section.changed?

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -45,8 +45,10 @@ class OmniAuthSection < Section
       oauth_section.user_id = owner_id
     else
       # create a section instructor record if one doesn't exist
-      section_instructor = oauth_section.section_instructors.where(instructor_id: owner_id).first_or_create(status: :active)
+      section_instructor = oauth_section.section_instructors.with_deleted.where(instructor_id: owner_id).first_or_create(status: :active)
       section_instructor.restore if section_instructor.deleted?
+      section_instructor.status = :active
+      section_instructor.save! if section_instructor.changed?
     end
     oauth_section.login_type = type
 

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -45,7 +45,8 @@ class OmniAuthSection < Section
       oauth_section.user_id = owner_id
     else
       # create a section instructor record if one doesn't exist
-      oauth_section.section_instructors.where(instructor_id: owner_id).first_or_create(status: :active)
+      section_instructor = oauth_section.section_instructors.where(instructor_id: owner_id).first_or_create(status: :active)
+      section_instructor.restore if section_instructor.deleted?
     end
     oauth_section.login_type = type
 

--- a/dashboard/test/models/sections/omni_auth_section_test.rb
+++ b/dashboard/test/models/sections/omni_auth_section_test.rb
@@ -93,6 +93,46 @@ class OmniAuthSectionTest < ActiveSupport::TestCase
     assert_equal new_owner.id, new_section.user_id
   end
 
+  test 'import section twice' do
+    # This happens when a google classroom/clever section with multiple teachers is imported twice.
+    owner = create :teacher
+    coteacher = create :teacher
+    students = [
+      OmniAuth::AuthHash.new(
+        uid: 111,
+        provider: 'google_oauth2',
+        info: {
+          name: 'Sample User',
+        },
+        )
+    ]
+
+    section = OmniAuthSection.from_omniauth(
+      code: 'G-222222',
+      type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM,
+      owner_id: owner.id,
+      students: students,
+      )
+    section.reload
+    assert_equal 'G-222222', section.code
+    assert_equal owner.id, section.user_id
+
+    new_section = OmniAuthSection.from_omniauth(
+      code: 'G-222222',
+      type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM,
+      owner_id: coteacher.id,
+      students: students,
+      )
+    new_section.reload
+    assert_equal section.id, new_section.id
+    assert_equal 'G-222222', new_section.code
+
+    # Section owner doesn't change
+    assert_equal owner.id, new_section.user_id
+    # Coteacher is added
+    assert_equal [owner.id, coteacher.id].sort, new_section.instructors.pluck(:id).sort
+  end
+
   test 'set exact student list' do
     teacher = create :teacher
     section = create :section, user: teacher, login_type: 'clever'

--- a/dashboard/test/models/sections/omni_auth_section_test.rb
+++ b/dashboard/test/models/sections/omni_auth_section_test.rb
@@ -133,6 +133,59 @@ class OmniAuthSectionTest < ActiveSupport::TestCase
     assert_equal [owner.id, coteacher.id].sort, new_section.instructors.pluck(:id).sort
   end
 
+  test 're-establish soft deleted coteacher' do
+    # This happens when a google classroom/clever section with multiple teachers is imported twice.
+    owner = create :teacher
+    coteacher = create :teacher
+    students = [
+      OmniAuth::AuthHash.new(
+        uid: 111,
+        provider: 'google_oauth2',
+        info: {
+          name: 'Sample User',
+        },
+        )
+    ]
+
+    section = OmniAuthSection.from_omniauth(
+      code: 'G-222222',
+      type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM,
+      owner_id: owner.id,
+      students: students,
+      )
+    section.reload
+    assert_equal 'G-222222', section.code
+    assert_equal owner.id, section.user_id
+
+    section_before_delete = OmniAuthSection.from_omniauth(
+      code: 'G-222222',
+      type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM,
+      owner_id: coteacher.id,
+      students: students,
+      )
+    section_before_delete.reload
+
+    coteacher_instructor = section_before_delete.section_instructors.where(instructor: coteacher).first
+
+    coteacher_instructor.destroy
+
+    new_section = OmniAuthSection.from_omniauth(
+      code: 'G-222222',
+      type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM,
+      owner_id: coteacher.id,
+      students: students,
+      )
+    new_section.reload
+    assert_equal section.id, new_section.id
+    assert_equal 'G-222222', new_section.code
+
+    # Section owner doesn't change
+    assert_equal owner.id, new_section.user_id
+    # Coteacher is restored
+    assert_equal 'active', new_section.section_instructors.where(id: coteacher_instructor.id).first.status
+    assert_equal [owner.id, coteacher.id].sort, new_section.instructors.pluck(:id).sort
+  end
+
   test 'set exact student list' do
     teacher = create :teacher
     section = create :section, user: teacher, login_type: 'clever'


### PR DESCRIPTION
It was discovered that google and clever can have multiple teachers. Two different teachers can import the same section from google or clever as long as they are both teachers of the same section.

Before coteacher functionality, if a section was imported twice by different users, the user who imported first would lost all access.

After coteacher functionality, if a section was imported twice by different users, the user who imported first would become a coteacher and maintain access, but the second teacher would become an owner.

This PR makes changes so that if a section is imported twice by different users, the user who imported first will be owner even if a second user imports. The second user will get added as a coteacher.

Note: If an imported section gets deleted and then imported again, the owner will be the user who imports first after deletion.

## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[TEACH-751](https://codedotorg.atlassian.net/browse/TEACH-751)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
