### PR TITLE
Keeping HoC Event Registration open for actual hoc and post hoc

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/events_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/events_signup.haml
@@ -1,5 +1,5 @@
 %a#hocsignupform{name: 'signup'}
-- if ["actual-hoc", "post-hoc", false].include?(hoc_mode)
+- if [false].include?(hoc_mode)
   %p.signup-closed.body-two.no-margin-bottom
     =hoc_s(:signup_registration_closed_2022_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn')})
 - else


### PR DESCRIPTION
This PR expands the timeline for allowed event registrations. In years past, we have disallowed registrations during and after HOC. However, several countries will continue with events through the end of the year, so we are expanding this range. See more conversation and context in the slack conversation linked from the Jira ticket below. 


Testing story:
According to [this pr](https://github.com/code-dot-org/code-dot-org/pull/42581), this change was set up to avoid issues with the hour of code map which is static during actual-hoc. I was able to change my hoc-mode dcdo locally (as well as the post-hoc mode) and submit an event for each using the form (see screenshot below), and see that both those events showed up in the forms table after (second screenshot). 

Regardless, I believe the original issue with having events registration open during actual-hoc was fixed here: https://github.com/code-dot-org/code-dot-org/pull/38135

<img width="754" alt="Screenshot 2023-11-29 at 11 35 07 AM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/aa230a5d-9550-41a5-a1d4-be3a0257781f">
<img width="1060" alt="Screenshot 2023-11-29 at 11 43 44 AM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/fcdbaca4-5c06-4e8e-826a-c53ef6837653">


## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1215

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
