### PR TITLE
Temporarily Disable Honeybadger Reporting of `MYSQL_OPT_RECONNECT` Deprecation Warning

### DIFF
--- a/lib/cdo/honeybadger.rb
+++ b/lib/cdo/honeybadger.rb
@@ -36,6 +36,11 @@ module Honeybadger
   def self.notify_command_error(command, status, stdout, stderr)
     return if stderr.to_s.empty? && status == 0
 
+    # Temporarily ignore this high-volume deprecation warning, until we can
+    # implement alternatives to the deprecated functionality.
+    # TODO: eliminate this warning, and remove this exception
+    return if stderr.start_with?("WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.")
+
     error_message, backtrace = parse_exception_dump stderr
 
     # use entire error when unable to parse error message


### PR DESCRIPTION
As a short-term fix to stop spamming Honeybadger.

In the longer term, we plan to stop using this deprecated feature in favor of other methods for automatically restoring connections.