### PR TITLE
Only show report abuse icon on public projects page

### DIFF
--- a/apps/src/templates/projects/ProjectAppTypeArea.jsx
+++ b/apps/src/templates/projects/ProjectAppTypeArea.jsx
@@ -31,8 +31,6 @@ class ProjectAppTypeArea extends React.Component {
     // Hide projects that don't have thumbnails
     hideWithoutThumbnails: PropTypes.bool,
 
-    showReportAbuseHeader: PropTypes.bool,
-
     // from redux state
     hasOlderProjects: PropTypes.bool.isRequired,
 
@@ -81,7 +79,7 @@ class ProjectAppTypeArea extends React.Component {
         projects={filteredList}
         galleryType={this.props.galleryType}
         isDetailView={this.props.isDetailView}
-        showReportAbuseHeader={this.props.showReportAbuseHeader}
+        showReportAbuseHeader
       />
     );
   }

--- a/apps/src/templates/projects/ProjectAppTypeArea.jsx
+++ b/apps/src/templates/projects/ProjectAppTypeArea.jsx
@@ -31,6 +31,8 @@ class ProjectAppTypeArea extends React.Component {
     // Hide projects that don't have thumbnails
     hideWithoutThumbnails: PropTypes.bool,
 
+    showReportAbuseHeader: PropTypes.bool,
+
     // from redux state
     hasOlderProjects: PropTypes.bool.isRequired,
 
@@ -79,6 +81,7 @@ class ProjectAppTypeArea extends React.Component {
         projects={filteredList}
         galleryType={this.props.galleryType}
         isDetailView={this.props.isDetailView}
+        showReportAbuseHeader={this.props.showReportAbuseHeader}
       />
     );
   }

--- a/apps/src/templates/projects/ProjectCard.jsx
+++ b/apps/src/templates/projects/ProjectCard.jsx
@@ -19,42 +19,43 @@ export default class ProjectCard extends React.Component {
     currentGallery: PropTypes.oneOf(['personal', 'public']).isRequired,
     showFullThumbnail: PropTypes.bool,
     isDetailView: PropTypes.bool,
+    showReportAbuseHeader: PropTypes.bool,
   };
 
   constructor(props) {
     super(props);
 
     this.state = {
-      showReportAbuse: false,
-      showReportHeader: false, // may need to change this state in the future to utilize report cookies - if gallery ever keeps an immediate report
+      isShowingReportAbusePopUp: false,
+      hasBeenReported: false, // may need to change this state in the future to utilize report cookies - if gallery ever keeps an immediate report
     };
     this.showReportAbusePopUp = this.showReportAbusePopUp.bind(this);
     this.closeReportAbusePopUp = this.closeReportAbusePopUp.bind(this);
-    this.showReportedHeader = this.showReportedHeader.bind(this);
+    this.onReportAbuse = this.onReportAbuse.bind(this);
   }
 
   showReportAbusePopUp() {
     this.setState({
-      showReportAbuse: true,
+      isShowingReportAbusePopUp: true,
     });
   }
 
   closeReportAbusePopUp() {
     this.setState({
-      showReportAbuse: false,
+      isShowingReportAbusePopUp: false,
     });
   }
 
-  showReportedHeader() {
+  onReportAbuse() {
     this.setState({
-      showReportHeader: true,
+      hasBeenReported: true,
     });
   }
 
   renderHeader() {
-    const {showReportHeader} = this.state;
+    const {hasBeenReported} = this.state;
 
-    if (!showReportHeader) {
+    if (!hasBeenReported) {
       return (
         <div
           style={{
@@ -91,7 +92,8 @@ export default class ProjectCard extends React.Component {
   }
 
   render() {
-    const {projectData, currentGallery, isDetailView} = this.props;
+    const {projectData, currentGallery, isDetailView, showReportAbuseHeader} =
+      this.props;
     const {type, channel} = this.props.projectData;
     const isPersonalGallery = currentGallery === 'personal';
     const isPublicGallery = currentGallery === 'public';
@@ -108,21 +110,21 @@ export default class ProjectCard extends React.Component {
       isPublicGallery && isDetailView && projectData.publishedAt;
     const noTimeOnCardStyle = shouldShowPublicDetails ? {} : styles.noTime;
 
-    const {showReportAbuse} = this.state;
+    const {isShowingReportAbusePopUp} = this.state;
 
     return (
       <div className="project_card">
-        {showReportAbuse ? (
+        {isShowingReportAbusePopUp && (
           <ReportAbusePopUp
             abuseUrl={url}
             projectData={this.props.projectData}
             onClose={this.closeReportAbusePopUp}
-            onReport={this.showReportedHeader}
+            onReport={this.onReportAbuse}
           />
-        ) : null}
+        )}
 
         <div className={style.card}>
-          {this.renderHeader()}
+          {showReportAbuseHeader && this.renderHeader()}
 
           <div style={thumbnailStyle}>
             <a

--- a/apps/src/templates/projects/ProjectCardGrid.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.jsx
@@ -37,6 +37,7 @@ class ProjectCardGrid extends Component {
     }).isRequired,
     galleryType: PropTypes.oneOf(['personal', 'public']).isRequired,
     selectedGallery: PropTypes.string.isRequired,
+    showReportAbuseHeader: PropTypes.bool,
     // Controls hiding/showing view more links for App Lab and Game Lab.
     limitedGallery: PropTypes.bool,
   };
@@ -88,6 +89,7 @@ class ProjectCardGrid extends Component {
                 navigateFunction={this.onSelectApp}
                 isDetailView={false}
                 hideWithoutThumbnails={true}
+                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             <ProjectAppTypeArea
@@ -100,6 +102,7 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
+              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="poetry"
@@ -111,6 +114,7 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
+              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="gamelab"
@@ -123,6 +127,7 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
+              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="applab"
@@ -135,6 +140,7 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
+              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="spritelab"
@@ -146,6 +152,7 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
+              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="playlab"
@@ -157,6 +164,7 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
+              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="events"
@@ -168,6 +176,7 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
+              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="artist"
@@ -179,6 +188,7 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
+              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="minecraft"
@@ -190,6 +200,7 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
+              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="k1"
@@ -201,6 +212,7 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
+              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
           </div>
         )}
@@ -217,6 +229,7 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={false}
+                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'dance' && (
@@ -229,6 +242,7 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
+                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'poetry' && (
@@ -241,6 +255,7 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
+                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'gamelab' && (
@@ -254,6 +269,7 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
+                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'applab' && (
@@ -267,6 +283,7 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
+                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'spritelab' && (
@@ -279,6 +296,7 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
+                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'playlab' && (
@@ -291,6 +309,7 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
+                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'events' && (
@@ -303,6 +322,7 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
+                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'artist' && (
@@ -315,6 +335,7 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
+                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'minecraft' && (
@@ -327,6 +348,7 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
+                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'k1' && (
@@ -339,6 +361,7 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
+                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
           </div>

--- a/apps/src/templates/projects/ProjectCardGrid.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.jsx
@@ -37,7 +37,6 @@ class ProjectCardGrid extends Component {
     }).isRequired,
     galleryType: PropTypes.oneOf(['personal', 'public']).isRequired,
     selectedGallery: PropTypes.string.isRequired,
-    showReportAbuseHeader: PropTypes.bool,
     // Controls hiding/showing view more links for App Lab and Game Lab.
     limitedGallery: PropTypes.bool,
   };
@@ -89,7 +88,6 @@ class ProjectCardGrid extends Component {
                 navigateFunction={this.onSelectApp}
                 isDetailView={false}
                 hideWithoutThumbnails={true}
-                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             <ProjectAppTypeArea
@@ -102,7 +100,6 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
-              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="poetry"
@@ -114,7 +111,6 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
-              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="gamelab"
@@ -127,7 +123,6 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
-              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="applab"
@@ -140,7 +135,6 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
-              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="spritelab"
@@ -152,7 +146,6 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
-              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="playlab"
@@ -164,7 +157,6 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
-              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="events"
@@ -176,7 +168,6 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
-              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="artist"
@@ -188,7 +179,6 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
-              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="minecraft"
@@ -200,7 +190,6 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
-              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
             <ProjectAppTypeArea
               labKey="k1"
@@ -212,7 +201,6 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
-              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
           </div>
         )}
@@ -229,7 +217,6 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={false}
-                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'dance' && (
@@ -242,7 +229,6 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
-                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'poetry' && (
@@ -255,7 +241,6 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
-                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'gamelab' && (
@@ -269,7 +254,6 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
-                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'applab' && (
@@ -283,7 +267,6 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
-                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'spritelab' && (
@@ -296,7 +279,6 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
-                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'playlab' && (
@@ -309,7 +291,6 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
-                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'events' && (
@@ -322,7 +303,6 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
-                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'artist' && (
@@ -335,7 +315,6 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
-                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'minecraft' && (
@@ -348,7 +327,6 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
-                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
             {this.state.showApp === 'k1' && (
@@ -361,7 +339,6 @@ class ProjectCardGrid extends Component {
                 galleryType={this.props.galleryType}
                 navigateFunction={this.viewAllProjects}
                 isDetailView={true}
-                showReportAbuseHeader={this.props.showReportAbuseHeader}
               />
             )}
           </div>

--- a/apps/src/templates/projects/ProjectCardRow.jsx
+++ b/apps/src/templates/projects/ProjectCardRow.jsx
@@ -20,6 +20,7 @@ export default class ProjectCardRow extends React.Component {
     galleryType: PropTypes.oneOf(['personal', 'public']).isRequired,
     showFullThumbnail: PropTypes.bool,
     isDetailView: PropTypes.bool,
+    showReportAbuseHeader: PropTypes.bool,
   };
 
   render() {
@@ -32,6 +33,7 @@ export default class ProjectCardRow extends React.Component {
               showFullThumbnail={this.props.showFullThumbnail}
               currentGallery={this.props.galleryType}
               isDetailView={this.props.isDetailView}
+              showReportAbuseHeader={this.props.showReportAbuseHeader}
             />
           </div>
         ))}

--- a/apps/src/templates/projects/PublicGallery.jsx
+++ b/apps/src/templates/projects/PublicGallery.jsx
@@ -66,6 +66,7 @@ class PublicGallery extends Component {
           galleryType="public"
           limitedGallery={limitedGallery}
           includeDanceParty={includeDanceParty}
+          showReportAbuseHeader
         />
         <div style={styles.bottomButton}>
           <Button

--- a/apps/src/templates/projects/PublicGallery.jsx
+++ b/apps/src/templates/projects/PublicGallery.jsx
@@ -66,7 +66,6 @@ class PublicGallery extends Component {
           galleryType="public"
           limitedGallery={limitedGallery}
           includeDanceParty={includeDanceParty}
-          showReportAbuseHeader
         />
         <div style={styles.bottomButton}>
           <Button


### PR DESCRIPTION
We have a new report abuse flow that allows abuse reports to be made from "project cards" in the public gallery.

We are (unintentionally) currently showing the option to report abuse in other uses of the `ProjectCard` component, namely at code.org/dance and when signed in at studio.code.org/home. If you try to click the icon to report abuse in either of these places, users currently see errors.

This change makes the report abuse header only visible in the public gallery.

| Page | Before | After |
| - | - | - |
| code.org/dance | <img width="1039" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/42246e50-9ce7-447e-8ccb-e68fa238382b"> | <img width="1014" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/dfc5dbbd-1426-47c2-a93d-251b3ff1ed91"> |
| studio.code.org/home | <img width="1034" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/1085048c-de5e-4d7b-8764-b3146f12bb77"> | <img width="1012" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/765085c6-fa98-41d2-a8a7-636794d95a6d"> |

**Report abuse icon still available on project cards on Public Gallery page (unchanged)**

<img width="1011" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/3cb4af0b-ccd5-4c78-92f0-abb9b8c8c2fc">

## Testing story

I manually looked at each of these three pages (code.org/dance, studio.code.org/dance, studio.code.org/projects/public) and saw the expected behavior (hidden header on the first two, shown on the third). I was able to make abuse reports on the Public Gallery. I looked for other usages of the `ProjectCard` component and didn't see any.
