### PR TITLE
Update code.org/youngwomen page to indicate that applications are now closed 

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/page/young-women-in-cs-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/page/young-women-in-cs-styles.scss
@@ -26,10 +26,10 @@
       left: 0;
       width: 100%;
       height: 100%;
-      background-image: url("/images/banners/banner-bg-mesh-dots-light.png"), url("/images/yw-page-top.png");
-      background-position: center, 82% bottom;
-      background-repeat: repeat, no-repeat;
-      background-size: contain, 580px;
+      background-image: url("/images/yw-page-top.png"), url("/images/banners/banner-bg-mesh-dots-light.png");
+      background-position: 82% bottom, center;
+      background-repeat: no-repeat, repeat;
+      background-size: 580px, contain;
       z-index: 2;
 
       html[dir="rtl"] & {
@@ -37,15 +37,17 @@
       }
 
       @media screen and (min-width: 1605px) {
-        background-position: center, 70% bottom;
+        background-position: 70% bottom, center;
       }
 
       @media screen and (max-width: $width-md) {
-        background-size: contain, 330px;
+        background-image: url("/images/banners/banner-bg-mesh-dots-light.png");
+        background-size: contain;
       }
 
-      @media screen and (max-width: $width-sm) {
-        background-position: center, center bottom;
+      @media screen and (max-width: 490px) {
+        background-image: url("/images/yw-page-top.png"), url("/images/banners/banner-bg-mesh-dots-light.png");
+        background-position: center bottom, center;
       }
     }
   }
@@ -64,6 +66,7 @@
 
     @media screen and (max-width: $width-md) {
       width: 100%;
+      margin-bottom: 2rem;
     }
   }
 }

--- a/pegasus/sites.v3/code.org/public/youngwomen.haml
+++ b/pegasus/sites.v3/code.org/public/youngwomen.haml
@@ -3,6 +3,10 @@ title: Young Women in CS
 theme: responsive_full_width
 ---
 
+-# Set this to true or false when applications open
+-# or close to show the corresponding version of the page.
+- applications_closed = true
+
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/young-women-in-cs-styles.css", rel: "stylesheet"}
 
@@ -13,8 +17,9 @@ theme: responsive_full_width
         =hoc_s(:yw_page_top_heading)
       %p.body-one{style: "color: white"}
         =hoc_s(:yw_page_top_desc)
-      %a.link-button.white.has-external-link{href: "https://docs.google.com/forms/d/e/1FAIpQLScKoT8ttOeWU3mWp_fDaFV0qQ5niXk3tSi1INALHhGWFQtVjw/viewform", target: "_blank", rel: "noopener noreferrer"}
-        =hoc_s(:call_to_action_applications_open)
+      - if !applications_closed
+        %a.link-button.white.has-external-link{href: "https://docs.google.com/forms/d/e/1FAIpQLScKoT8ttOeWU3mWp_fDaFV0qQ5niXk3tSi1INALHhGWFQtVjw/viewform", target: "_blank", rel: "noopener noreferrer"}
+          =hoc_s(:call_to_action_applications_open)
 
 %section.intro
   .wrapper
@@ -31,11 +36,13 @@ theme: responsive_full_width
       .text-wrapper
         %h3.heading-md
           =hoc_s(:cs_ambassador_application_date)
-        %p.heading-xs
-          =hoc_s(:cs_ambassador_application_subhead)
+        - if !applications_closed
+          %p.heading-xs
+            =hoc_s(:cs_ambassador_application_subhead)
         %p.body-three.no-margin-bottom
-          =hoc_s(:cs_ambassador_application_questions, markdown: :inline, locals:{email_url: "mailto:youngwomen@code.org"})
-      = view :"young_women_in_cs/yw_apply_button"
+          =hoc_s((!applications_closed ? :cs_ambassador_application_questions : :cs_ambassador_application_closed_subhead), markdown: :inline, locals:{email_url: "mailto:youngwomen@code.org"})
+      - if !applications_closed
+        = view :"young_women_in_cs/yw_apply_button"
 
 = view :section_divider_line
 
@@ -53,12 +60,14 @@ theme: responsive_full_width
   .wrapper.centered
     %h2=hoc_s(:cs_ambassador_steps_heading)
     = view :"young_women_in_cs/yw_prerequisites"
-    = view :"young_women_in_cs/yw_apply_button"
+    - if !applications_closed
+      = view :"young_women_in_cs/yw_apply_button"
 
 %section
   .wrapper
     %h2.centered
       =hoc_s(:cs_ambassador_benefits_heading)
     = view :"young_women_in_cs/yw_icon_list"
-    .centered
-      = view :"young_women_in_cs/yw_apply_button"
+    - if !applications_closed
+      .centered
+        = view :"young_women_in_cs/yw_apply_button"

--- a/pegasus/sites.v3/code.org/public/youngwomen.haml
+++ b/pegasus/sites.v3/code.org/public/youngwomen.haml
@@ -35,7 +35,7 @@ theme: responsive_full_width
     .flex-container.justify-space-between.align-items-center.wrap.gap-2.rounded-corners
       .text-wrapper
         %h3.heading-md
-          =hoc_s(:cs_ambassador_application_date)
+          =hoc_s((!applications_closed ? :cs_ambassador_application_date : :cs_ambassador_application_closed_title))
         - if !applications_closed
           %p.heading-xs
             =hoc_s(:cs_ambassador_application_subhead)

--- a/pegasus/sites.v3/code.org/public/youngwomen.haml
+++ b/pegasus/sites.v3/code.org/public/youngwomen.haml
@@ -3,8 +3,8 @@ title: Young Women in CS
 theme: responsive_full_width
 ---
 
--# Set this to true or false when applications open
--# or close to show the corresponding version of the page.
+-# Set this to true or false when applications open or
+-# close to show the corresponding version of the page.
 - applications_closed = true
 
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -700,6 +700,8 @@
   cs_ambassador_desc: "Every field, including medicine, entertainment, sports, education, business, fashion, and entrepreneurship is touched by computer science. Yet only 5% of high school aged young women take computer science classes. Ambassadors can help close this gender gap by encouraging their peers to take a computer science class."
   cs_ambassador_application_date: "Applications open until November 8th, 2023"
   cs_ambassador_application_subhead: "Work with a teacher to submit your application today"
+  cs_ambassador_application_closed_title: "Applications have now closed."
+  cs_ambassador_application_closed_subhead: "Questions about future opportunities or want to learn more? Please contact [youngwomen@code.org](%{email_url})."
   cs_ambassador_application_questions: "Questions? Please contact [youngwomen@code.org](%{email_url})"
   cs_ambassador_do_heading: "What do CS Ambassadors do?"
   cs_ambassador_do_desc: "CS Ambassadors encourage young women to explore the subject, and lift each other up as they reclaim their place in computer science. CS Ambassadors connect with their peers to share their excitement and love of computer science. They visit classrooms, host tables at lunch, and speak at assemblies and club meetings. CS Ambassadors work with teachers and school administrators to breakdown stereotypes that hold young women back."


### PR DESCRIPTION
Add logic to show an "Applications closed" version of the Young Women in CS page https://code.org/youngwomen
- If this become a yearly thing we can make a DCDO flag, but for now I just put the logic in the page with a variable
- Hides buttons throughout the page
- Changes copy in the grey box under the intro section at the top of the page
- _Note:_ I had to update the styles on the hero banner so it works responsively with both versions of the page
  - The photo of the young women will be hidden on tablet due to overlapping text, but it will show on mobile

**Jira ticket:** [ACQ-1184](https://codedotorg.atlassian.net/browse/ACQ-1184)

----

## Before - Applications open version
![localhost code org_3000_youngwomen](https://github.com/code-dot-org/code-dot-org/assets/9256643/92677872-6f19-4965-9ebb-27de63b83e8c)

## After - Applications closed version
![localhost code org_3000_youngwomen](https://github.com/code-dot-org/code-dot-org/assets/9256643/7d5bbe2d-433d-4c47-933d-5f5709dc25fe)