### PR TITLE
Canvas Roster Sync

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1509,6 +1509,7 @@
   "loginTypeGoogleClassroomButton": "Use Google Classroom",
   "loginTypeGoogleClassroomDescription": "Sync your Code.org section with an existing Google Classroom. Students must log in with their Google account.",
   "loginTypeGoogleClassroomDescriptionUpdated": "Import a roster from one of your Google Classrooms to create student accounts.",
+  "loginTypeLti": "LTI Integration",
   "loginTypeMicrosoftClassroom": "Microsoft Classroom",
   "loginTypeMicrosoftClassroomButton": "Use Microsoft Classroom",
   "loginTypeMicrosoftClassroomDescription": "Sync your Code.org section with an existing Microsoft Classroom.",

--- a/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
+++ b/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
@@ -15,11 +15,18 @@ import {
 import Button from '../../templates/Button';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import {SectionLoginType} from '@cdo/apps/util/sharedConstants';
 
 const PROVIDER_NAME = {
   [OAuthSectionTypes.clever]: i18n.loginTypeClever(),
   [OAuthSectionTypes.google_classroom]: i18n.loginTypeGoogleClassroom(),
+  [SectionLoginType.lti_v1]: i18n.loginTypeLti(),
 };
+
+const SYNC_PROVIDERS = [
+  ...Object.values(OAuthSectionTypes),
+  SectionLoginType.lti_v1,
+];
 
 export const READY = 'ready';
 export const IN_PROGRESS = 'in-progress';
@@ -33,10 +40,11 @@ export const SUCCESS = 'success';
 class SyncOmniAuthSectionControl extends React.Component {
   static propTypes = {
     sectionId: PropTypes.number.isRequired,
+    studioUrlPrefix: PropTypes.string.isRequired,
     // Provided by Redux
     sectionCode: PropTypes.string,
     sectionName: PropTypes.string,
-    sectionProvider: PropTypes.oneOf(Object.values(OAuthSectionTypes)),
+    sectionProvider: PropTypes.oneOf(SYNC_PROVIDERS),
     updateRoster: PropTypes.func.isRequired,
   };
 
@@ -196,7 +204,7 @@ export function SyncOmniAuthSectionButton({provider, buttonState, onClick}) {
   );
 }
 SyncOmniAuthSectionButton.propTypes = {
-  provider: PropTypes.oneOf(Object.values(OAuthSectionTypes)).isRequired,
+  provider: PropTypes.oneOf(SYNC_PROVIDERS).isRequired,
   buttonState: PropTypes.oneOf([READY, IN_PROGRESS, SUCCESS]).isRequired,
   onClick: PropTypes.func,
 };

--- a/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
+++ b/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
@@ -40,7 +40,7 @@ export const SUCCESS = 'success';
 class SyncOmniAuthSectionControl extends React.Component {
   static propTypes = {
     sectionId: PropTypes.number.isRequired,
-    studioUrlPrefix: PropTypes.string.isRequired,
+    studioUrlPrefix: PropTypes.string,
     // Provided by Redux
     sectionCode: PropTypes.string,
     sectionName: PropTypes.string,

--- a/apps/src/templates/manageStudents/ManageStudents.jsx
+++ b/apps/src/templates/manageStudents/ManageStudents.jsx
@@ -28,7 +28,10 @@ class ManageStudents extends React.Component {
         {isLoadingStudents && <Spinner />}
         {!isLoadingStudents && (
           <div>
-            <SyncOmniAuthSectionControl sectionId={sectionId} />
+            <SyncOmniAuthSectionControl
+              sectionId={sectionId}
+              studioUrlPrefix={this.props.studioUrlPrefix}
+            />
             <ManageStudentsTable studioUrlPrefix={studioUrlPrefix} />
           </div>
         )}

--- a/apps/src/templates/manageStudents/ManageStudents.jsx
+++ b/apps/src/templates/manageStudents/ManageStudents.jsx
@@ -30,7 +30,7 @@ class ManageStudents extends React.Component {
           <div>
             <SyncOmniAuthSectionControl
               sectionId={sectionId}
-              studioUrlPrefix={this.props.studioUrlPrefix}
+              studioUrlPrefix={studioUrlPrefix}
             />
             <ManageStudentsTable studioUrlPrefix={studioUrlPrefix} />
           </div>

--- a/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
@@ -15,7 +15,10 @@ import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpe
 import SectionActionDropdown from './SectionActionDropdown';
 import Button from '@cdo/apps/templates/Button';
 import {stringifyQueryParams} from '../../utils';
-import {StudentGradeLevels} from '@cdo/apps/util/sharedConstants';
+import {
+  StudentGradeLevels,
+  SectionLoginType,
+} from '@cdo/apps/util/sharedConstants';
 
 /** @enum {number} */
 export const COLUMNS = {
@@ -87,6 +90,8 @@ export const loginInfoFormatter = function (loginType, {rowData}) {
     sectionCode = i18n.loginTypeClever();
   } else if (rowData.loginType === OAuthSectionTypes.google_classroom) {
     sectionCode = i18n.loginTypeGoogleClassroom();
+  } else if (rowData.loginType === SectionLoginType.lti_v1) {
+    sectionCode = i18n.loginTypeLti();
   } else {
     sectionCode = rowData.code;
   }

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -45,6 +45,7 @@ const urlByProvider = {
 const importUrlByProvider = {
   [OAuthSectionTypes.google_classroom]: '/dashboardapi/import_google_classroom',
   [OAuthSectionTypes.clever]: '/dashboardapi/import_clever_classroom',
+  [SectionLoginType.lti_v1]: '/lti/v1/sync_course',
 };
 
 //
@@ -549,6 +550,14 @@ export const importOrUpdateRoster =
     let sectionId;
 
     dispatch({type: IMPORT_ROSTER_REQUEST});
+    if (provider === SectionLoginType.lti_v1) {
+      return fetch(`${importSectionUrl}?section_code=${courseId}`).then(() =>
+        dispatch({
+          type: IMPORT_ROSTER_SUCCESS,
+          sectionId,
+        })
+      );
+    }
     return fetchJSON(importSectionUrl, {courseId, courseName})
       .then(newSection => (sectionId = newSection.id))
       .then(() => dispatch(asyncLoadSectionData()))
@@ -1056,7 +1065,10 @@ export default function teacherSections(state = initialState, action) {
   if (action.type === SET_ROSTER_PROVIDER) {
     // No-op if this action is called with a non-OAuth section type,
     // since this action is triggered on every section load.
-    if (OAuthSectionTypes[action.rosterProvider]) {
+    if (
+      OAuthSectionTypes[action.rosterProvider] ||
+      action.rosterProvider === SectionLoginType.lti_v1
+    ) {
       return {
         ...state,
         rosterProvider: action.rosterProvider,

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -104,11 +104,11 @@ class LtiV1Controller < ApplicationController
 
       if user
         sign_in user
-        redirect_to target_link_uri + '?' + redirect_params.to_query
+        redirect_to "#{target_link_uri}?#{redirect_params.to_query}"
       else
         user = Services::Lti.initialize_lti_user(decoded_jwt)
         PartialRegistration.persist_attributes(session, user)
-        session[:user_return_to] = target_link_uri + '?' + redirect_params.to_query
+        session[:user_return_to] = "#{target_link_uri}?#{redirect_params.to_query}"
         redirect_to new_user_registration_url
       end
     else

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -1,7 +1,9 @@
 require "base64"
 require "queries/lti"
 require "services/lti"
+require "policies/lti"
 require "concerns/partial_registration"
+require "clients/lti_advantage_client"
 
 class LtiV1Controller < ApplicationController
   # Don't require an authenticity token because LTI Platforms POST to this
@@ -87,13 +89,26 @@ class LtiV1Controller < ApplicationController
       user = Queries::Lti.get_user(decoded_jwt)
       target_link_uri = decoded_jwt[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri']
 
+      launch_context = decoded_jwt[Policies::Lti::LTI_CONTEXT_CLAIM]
+      nrps_url = decoded_jwt[Policies::Lti::LTI_NRPS_CLAIM][:context_memberships_url]
+      resource_link_id = decoded_jwt[Policies::Lti::LTI_RESOURCE_LINK_CLAIM][:id]
+      deployment_id = decoded_jwt[Policies::Lti::LTI_DEPLOYMENT_ID_CLAIM]
+      deployment = Queries::Lti.get_deployment(integration.id, deployment_id)
+      redirect_params = {
+        lti_integration_id: integration.id,
+        deployment_id: deployment.id,
+        context_id: launch_context[:id],
+        rlid: resource_link_id,
+        nrps_url: nrps_url,
+      }
+
       if user
         sign_in user
-        redirect_to target_link_uri
+        redirect_to target_link_uri + '?' + redirect_params.to_query
       else
         user = Services::Lti.initialize_lti_user(decoded_jwt)
         PartialRegistration.persist_attributes(session, user)
-        session[:user_return_to] = target_link_uri
+        session[:user_return_to] = target_link_uri + '?' + redirect_params.to_query
         redirect_to new_user_registration_url
       end
     else
@@ -106,6 +121,37 @@ class LtiV1Controller < ApplicationController
     response = JSON.parse(HTTParty.get(public_jwk_url).body)
     jwk_set = JSON::JWK::Set.new response
     JSON::JWT.decode(id_token, jwk_set)
+  end
+
+  # GET /lti/v1/sync_course
+  # Syncs an LMS course from an LTI launch or from the teacher dashboard sync button.
+  def sync_course
+    return unauthorized_status unless current_user
+    return redirect_to home_path unless current_user.teacher?
+    params.require([:lti_integration_id, :deployment_id, :context_id, :rlid, :nrps_url]) if params[:section_code].blank?
+
+    lti_course = Section.find_by(code: params[:section_code]).lti_course if params[:section_code].present?
+    lti_integration = lti_course.lti_integration unless lti_course.nil?
+    lti_integration_id = params[:lti_integration_id] || lti_integration.id
+    deployment_id = params[:deployment_id] || lti_course.lti_deployment_id
+    context_id = params[:context_id] || lti_course.context_id
+    resource_link_id = params[:rlid] || lti_course.resource_link_id
+    nrps_url = params[:nrps_url] || lti_course.nrps_url
+
+    lti_course ||= LtiCourse.find_or_create_by(lti_integration_id: lti_integration_id, context_id: context_id) do |c|
+      c.lti_deployment_id = deployment_id
+      c.nrps_url = nrps_url
+      c.resource_link_id = resource_link_id
+    end
+    lti_integration ||= LtiIntegration.find(lti_integration_id)
+    return head :bad_request unless lti_integration
+
+    lti_advantage_client = LtiAdvantageClient.new(lti_integration.client_id, lti_integration.issuer)
+    nrps_response = lti_advantage_client.get_context_membership(nrps_url, resource_link_id)
+    nrps_sections = Services::Lti.parse_nrps_response(nrps_response)
+    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: nrps_sections, section_owner_id: current_user.id)
+
+    redirect_to home_path
   end
 
   private

--- a/dashboard/app/models/lti_integration.rb
+++ b/dashboard/app/models/lti_integration.rb
@@ -29,6 +29,7 @@ class LtiIntegration < ApplicationRecord
   validates :auth_redirect_url, presence: true
   validates :jwks_url, presence: true
   validates :access_token_url, presence: true
+  has_many :lti_courses, dependent: :destroy
 
   before_create :set_uuid
 

--- a/dashboard/app/models/lti_section.rb
+++ b/dashboard/app/models/lti_section.rb
@@ -20,6 +20,7 @@ class LtiSection < ApplicationRecord
   acts_as_paranoid
   belongs_to :lti_course
   belongs_to :section
+  has_many :followers, through: :section
   validates :section_id, uniqueness: true
   validates :lms_section_id, presence: true
   before_destroy :soft_delete_associated_section

--- a/dashboard/app/models/sections/lti_v1_section.rb
+++ b/dashboard/app/models/sections/lti_v1_section.rb
@@ -1,0 +1,38 @@
+# == Schema Information
+#
+# Table name: sections
+#
+#  id                   :integer          not null, primary key
+#  user_id              :integer          not null
+#  name                 :string(255)
+#  created_at           :datetime
+#  updated_at           :datetime
+#  code                 :string(255)
+#  script_id            :integer
+#  course_id            :integer
+#  grade                :string(255)
+#  login_type           :string(255)      default("email"), not null
+#  deleted_at           :datetime
+#  stage_extras         :boolean          default(FALSE), not null
+#  section_type         :string(255)
+#  first_activity_at    :datetime
+#  pairing_allowed      :boolean          default(TRUE), not null
+#  sharing_disabled     :boolean          default(FALSE), not null
+#  hidden               :boolean          default(FALSE), not null
+#  tts_autoplay_enabled :boolean          default(FALSE), not null
+#  restrict_section     :boolean          default(FALSE)
+#  properties           :text(65535)
+#  participant_type     :string(255)      default("student"), not null
+#  lti_integration_id   :bigint
+#  ai_tutor_enabled     :boolean          default(FALSE)
+#
+# Indexes
+#
+#  fk_rails_20b1e5de46        (course_id)
+#  fk_rails_f0d4df9901        (lti_integration_id)
+#  index_sections_on_code     (code) UNIQUE
+#  index_sections_on_user_id  (user_id)
+#
+
+class LtiV1Section < Section
+end

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -68,6 +68,7 @@ class Section < ApplicationRecord
   has_many :active_section_instructors, -> {where(status: :active)}, class_name: 'SectionInstructor'
   has_many :instructors, through: :active_section_instructors, class_name: 'User'
   has_one :lti_section
+  has_one :lti_course, through: :lti_section
   after_destroy :soft_delete_lti_section
 
   has_many :followers, dependent: :destroy
@@ -159,7 +160,8 @@ class Section < ApplicationRecord
     LOGIN_TYPE_PICTURE = 'picture'.freeze,
     LOGIN_TYPE_WORD = 'word'.freeze,
     LOGIN_TYPE_GOOGLE_CLASSROOM = 'google_classroom'.freeze,
-    LOGIN_TYPE_CLEVER = 'clever'.freeze
+    LOGIN_TYPE_CLEVER = 'clever'.freeze,
+    LOGIN_TYPE_LTI_V1 = 'lti_v1'.freeze
   ]
 
   LOGIN_TYPES_OAUTH = [
@@ -456,7 +458,7 @@ class Section < ApplicationRecord
   end
 
   def provider_managed?
-    false
+    login_type == LOGIN_TYPE_LTI_V1
   end
 
   def at_capacity?

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -524,7 +524,7 @@ class User < ApplicationRecord
   validates :name, length: {within: 1..70}, allow_blank: true
   validates :name, no_utf8mb4: true
 
-  defer_age = proc {|user| %w(google_oauth2 clever powerschool).include?(user.provider) || user.sponsored?}
+  defer_age = proc {|user| %w(google_oauth2 clever powerschool migrated).include?(user.provider) || user.sponsored?}
 
   validates :age, presence: true, on: :create, unless: defer_age # only do this on create to avoid problems with existing users
   AGE_DROPDOWN_OPTIONS = (4..20).to_a << "21+"

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -524,7 +524,7 @@ class User < ApplicationRecord
   validates :name, length: {within: 1..70}, allow_blank: true
   validates :name, no_utf8mb4: true
 
-  defer_age = proc {|user| %w(google_oauth2 clever powerschool migrated).include?(user.provider) || user.sponsored?}
+  defer_age = proc {|user| %w(google_oauth2 clever powerschool).include?(user.provider) || user.sponsored? || Policies::Lti.lti?(user)}
 
   validates :age, presence: true, on: :create, unless: defer_age # only do this on create to avoid problems with existing users
   AGE_DROPDOWN_OPTIONS = (4..20).to_a << "21+"

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -602,6 +602,7 @@ Dashboard::Application.routes.draw do
     # LTI API endpoints
     match '/lti/v1/login(/:platform_id)', to: 'lti_v1#login', via: [:get, :post]
     post '/lti/v1/authenticate', to: 'lti_v1#authenticate'
+    match '/lti/v1/sync_course', to: 'lti_v1#sync_course', via: [:get, :post]
 
     # OAuth endpoints
     get '/oauth/jwks', to: 'oauth_jwks#jwks'

--- a/dashboard/lib/clients/lti_advantage_client.rb
+++ b/dashboard/lib/clients/lti_advantage_client.rb
@@ -11,11 +11,17 @@ class LtiAdvantageClient
   # The URL for the API will vary between LMS platforms, and is initially contained in the launch context.
   # See the LTI spec for details:
   # https://www.imsglobal.org/spec/lti-nrps/v2p0/
-  def get_context_membership(url)
-    headers = {
-      'Accept' => Policies::Lti::MEMBERSHIP_CONTAINER_CONTENT_TYPE,
+  def get_context_membership(url, resource_link_id)
+    options = {
+      headers: {
+        'Accept' => Policies::Lti::MEMBERSHIP_CONTAINER_CONTENT_TYPE,
+        'Authorization' => "Bearer #{get_access_token(@client_id, @issuer)}",
+      },
+      query: {
+        rlid: resource_link_id,
+      },
     }
-    res = HTTParty.get(url, headers: headers.merge('Authorization' => "Bearer #{get_access_token(@client_id, @issuer)}"))
+    res = HTTParty.get(url, options)
     raise "Error getting context membership: #{res.code} #{res.body}" unless res.code == HTTP::Status::OK
     JSON.parse(res, symbolize_names: true)
   end

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -32,6 +32,10 @@ class Policies::Lti
   LTI_DEPLOYMENT_ID_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/deployment_id".freeze
   LTI_NRPS_CLAIM = "https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice".freeze
 
+  # Prioritized lists for looking up a user's name from custom LTI variable claims.
+  TEACHER_NAME_KEYS = [:name, :display_name, :full_name, :family_name, :given_name].freeze
+  STUDENT_NAME_KEYS = [:name, :display_name, :full_name, :given_name].freeze
+
   def self.get_account_type(id_token)
     id_token[LTI_ROLES_KEY].each do |role|
       return User::TYPE_TEACHER if TEACHER_ROLES.include? role

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -24,8 +24,13 @@ class Policies::Lti
       'http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator',
     ]
 ).freeze
+  CONTEXT_LEARNER_ROLE = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner'.freeze
   LTI_ROLES_KEY = 'https://purl.imsglobal.org/spec/lti/claim/roles'.freeze
   LTI_CUSTOM_CLAIMS = "https://purl.imsglobal.org/spec/lti/claim/custom".freeze
+  LTI_CONTEXT_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/context".freeze
+  LTI_RESOURCE_LINK_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/resource_link".freeze
+  LTI_DEPLOYMENT_ID_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/deployment_id".freeze
+  LTI_NRPS_CLAIM = "https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice".freeze
 
   def self.get_account_type(id_token)
     id_token[LTI_ROLES_KEY].each do |role|

--- a/dashboard/lib/queries/lti.rb
+++ b/dashboard/lib/queries/lti.rb
@@ -27,4 +27,16 @@ class Queries::Lti
   def self.get_course_from_context(lti_integration_id, context_id)
     LtiCourse.find_by(lti_integration_id: lti_integration_id, context_id: context_id)
   end
+
+  def self.get_lti_course_from_section_code(section_code)
+    Section.find_by(code: section_code).lti_course
+  end
+
+  def self.find_or_create_lti_course(lti_integration_id:, context_id:, deployment_id:, nrps_url:, resource_link_id:)
+    LtiCourse.find_or_create_by(lti_integration_id: lti_integration_id, context_id: context_id) do |c|
+      c.lti_deployment_id = deployment_id
+      c.nrps_url = nrps_url
+      c.resource_link_id = resource_link_id
+    end
+  end
 end

--- a/dashboard/lib/queries/lti.rb
+++ b/dashboard/lib/queries/lti.rb
@@ -9,5 +9,20 @@ class Queries::Lti
 
   def self.get_lti_integration(issuer, client_id)
     LtiIntegration.find_by(issuer: issuer, client_id: client_id)
+  def self.get_user_from_nrps(client_id:, issuer:, nrps_member:)
+    id_token = {
+      sub: nrps_member[:user_id],
+      aud: client_id,
+      iss: issuer,
+    }
+    get_user(id_token)
+  end
+
+  def self.get_deployment(lti_integration_id, deployment_id)
+    LtiDeployment.find_by(lti_integration_id: lti_integration_id, deployment_id: deployment_id)
+  end
+
+  def self.get_course_from_context(lti_integration_id, context_id)
+    LtiCourse.find_by(lti_integration_id: lti_integration_id, context_id: context_id)
   end
 end

--- a/dashboard/lib/queries/lti.rb
+++ b/dashboard/lib/queries/lti.rb
@@ -9,6 +9,8 @@ class Queries::Lti
 
   def self.get_lti_integration(issuer, client_id)
     LtiIntegration.find_by(issuer: issuer, client_id: client_id)
+  end
+
   def self.get_user_from_nrps(client_id:, issuer:, nrps_member:)
     id_token = {
       sub: nrps_member[:user_id],

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -41,5 +41,106 @@ class Services::Lti
 
   def self.get_claim(id_token, key)
     id_token[key] || id_token.dig(Policies::Lti::LTI_CUSTOM_CLAIMS, key)
+  def self.initialize_lti_student_from_nrps(client_id:, issuer:, nrps_member:)
+    # TODO DAYNE don't do [0]
+    custom_claims = nrps_member[:message][0][Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym]
+    user = User.new
+    user.provider = User::PROVIDER_MIGRATED
+    user.user_type = User::TYPE_STUDENT
+    user.name = custom_claims[:display_name] || custom_claims[:full_name] || custom_claims[:given_name]
+    user.family_name = custom_claims[:family_name]
+    id_token = {
+      sub: nrps_member[:user_id],
+      aud: client_id,
+      iss: issuer,
+    }
+    ao = AuthenticationOption.new(
+      authentication_id: Policies::Lti.generate_auth_id(id_token),
+      credential_type: AuthenticationOption::LTI_V1,
+      email: custom_claims[:email],
+      )
+    user.authentication_options = [ao]
+    user
+  end
+
+  def self.parse_nrps_response(nrps_response)
+    sections = {}
+    members = nrps_response[:members]
+    members.each do |member|
+      next if member[:status] == 'Inactive' || member[:roles].exclude?(Policies::Lti::CONTEXT_LEARNER_ROLE)
+      # TODO: handle multiple messages. Shouldn't be needed until we support Deep Linking.
+      message = member[:message].first
+
+      # Custom variables substitutions must be configured in the LMS.
+      custom_variables = message[Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym]
+
+      # Handles the possibility of the LMS not having sectionId variable substitution configured.
+      member_section_ids = custom_variables[:section_ids]&.split(',') || [nil]
+      # :section_names from Canvas is a stringified JSON array
+      member_section_names = JSON.parse(custom_variables[:section_names])
+      member_section_ids.each_with_index do |section_id, index|
+        if sections[section_id].present?
+          sections[section_id][:members] << member
+        else
+          sections[section_id] = {
+            name: member_section_names[index],
+            members: [member],
+          }
+        end
+      end
+    end
+    sections
+  end
+
+  # Takes an LTI section and NRPS members array and syncs a single section.
+  def self.sync_section_roster(lti_integration, lti_section, nrps_members)
+    client_id = lti_integration.client_id
+    issuer = lti_integration.issuer
+    current_students = nrps_members.map do |nrps_member|
+      student = Queries::Lti.get_user_from_nrps(
+        client_id: client_id,
+        issuer: issuer,
+        nrps_member: nrps_member
+      )
+      student ||= initialize_lti_student_from_nrps(
+        client_id: client_id,
+        issuer: issuer,
+        nrps_member: nrps_member
+      )
+      student.save!
+      lti_section.section.add_student(student)
+      student
+    end
+
+    # Prune students who have been removed from the section in the LMS
+    lti_section.followers.each do |follower|
+      current_students.find_index {|s| s.id == follower.student_user_id} || follower.destroy
+    end
+  end
+
+  # Syncs a course and all its sections from an NRPS response.
+  def self.sync_course_roster(lti_integration:, lti_course:, nrps_sections:, section_owner_id:)
+    lti_sections = LtiSection.where(lti_course_id: lti_course.id)
+
+    # Prune sections that have been deleted in the LMS
+    lti_sections.each do |lti_section|
+      lti_section.destroy unless nrps_sections.key?(lti_section.lms_section_id)
+    end
+
+    nrps_sections.keys.each do |lms_section_id|
+      # Check if lti_sections already contains a section with this lms_section_id
+      lti_section = lti_sections.find_by(lms_section_id: lms_section_id)
+      if lti_section.nil?
+        section = Section.new(
+          {
+            user_id: section_owner_id,
+            name: nrps_sections[lms_section_id][:name],
+            login_type: Section::LOGIN_TYPE_LTI_V1,
+          }
+        )
+        lti_section = LtiSection.create(lti_course_id: lti_course.id, lms_section_id: lms_section_id, section: section)
+      end
+      sync_section_roster(lti_integration, lti_section, nrps_sections[lms_section_id][:members])
+    end
   end
 end

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -41,6 +41,8 @@ class Services::Lti
 
   def self.get_claim(id_token, key)
     id_token[key] || id_token.dig(Policies::Lti::LTI_CUSTOM_CLAIMS, key)
+  end
+
   def self.initialize_lti_student_from_nrps(client_id:, issuer:, nrps_member:)
     # TODO DAYNE don't do [0]
     custom_claims = nrps_member[:message][0][Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym]

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -37,12 +37,11 @@ class Services::Lti
   end
 
   def self.get_claim(id_token, key)
-    id_token[key] || id_token.dig(Policies::Lti::LTI_CUSTOM_CLAIMS, key)
+    id_token[key] || id_token.dig(Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym, key)
   end
 
   def self.initialize_lti_student_from_nrps(client_id:, issuer:, nrps_member:)
-    # TODO DAYNE don't do [0]
-    nrps_member_message = nrps_member[:message][0]
+    nrps_member_message = nrps_member[:message].first
     user = User.new
     user.provider = User::PROVIDER_MIGRATED
     user.user_type = User::TYPE_STUDENT

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -16,6 +16,214 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     # create arbitary state and nonce values
     @state = 'state'
     @nonce = 'nonce'
+    @parsed_nrps_sections = {
+      "1" =>
+      {
+        name: "Section 1",
+        members: [
+          {
+            status: "Active",
+            user_id: "0c00f8db-a039-45e1-8e2d-f1e17a047836",
+            roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
+            message: [
+              {
+                'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+                locale: "en",
+                'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                  email: "student0@code.org",
+                  course_id: "115",
+                  full_name: "Test Zero",
+                  given_name: "Test",
+                  family_name: "Zero",
+                  section_ids: "1,2,3",
+                  display_name: "Test Zero",
+                  section_names: "[\"Section 1\", \"Section 2\", \"Section 3\"]"
+                }
+              }
+            ]
+          },
+          {
+            status: "Active",
+            user_id: "8741ee5e-7544-484d-a7a5-9fce2b29b960",
+            roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
+            message: [
+              {
+                'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+                locale: "en",
+                'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                  email: "student1@code.org",
+                  course_id: "115",
+                  full_name: "Test One",
+                  given_name: "Test",
+                  family_name: "One",
+                  section_ids: "1,2,3",
+                  display_name: "Test One",
+                  section_names: "[\"Section 1\", \"Section 2\", \"Section 3\"]"
+                }
+              }
+            ]
+          },
+          {
+            status: "Active",
+            user_id: "cd50bfe6-cd55-4789-8d04-b4930fd8005d",
+            roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
+            message: [
+              {
+                'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+                locale: "en",
+                'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                  email: "test2@code.org",
+                  course_id: "115",
+                  full_name: "Test Two",
+                  given_name: "Test",
+                  family_name: "Two",
+                  section_ids: "1,2,3",
+                  display_name: "Test Two",
+                  section_names: "[\"Section 1\", \"Section 2\", \"Section 3\"]"
+                }
+              }
+            ]
+          }
+        ]
+      },
+     "2" => {
+       name: "Section 2",
+       members: [
+         {
+           status: "Active",
+           user_id: "0c00f8db-a039-45e1-8e2d-f1e17a047836",
+           roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
+           message: [
+             {
+               'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+               locale: "en",
+               'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                 email: "student0@code.org",
+                 course_id: "115",
+                 full_name: "Test Zero",
+                 given_name: "Test",
+                 family_name: "Zero",
+                 section_ids: "1,2,3",
+                 display_name: "Test Zero",
+                 section_names: "[\"Section 1\", \"Section 2\", \"Section 3\"]"
+               }
+             }
+           ]
+         },
+         {
+           status: "Active",
+           user_id: "8741ee5e-7544-484d-a7a5-9fce2b29b960",
+           roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
+           message: [
+             {
+               'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+               locale: "en",
+               'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                 email: "student1@code.org",
+                 course_id: "115",
+                 full_name: "Test One",
+                 given_name: "Test",
+                 family_name: "One",
+                 section_ids: "1,2,3",
+                 display_name: "Test One",
+                 section_names: "[\"Section 1\", \"Section 2\", \"Section 3\"]"
+               }
+             }
+           ]
+         },
+         {
+           status: "Active",
+           user_id: "cd50bfe6-cd55-4789-8d04-b4930fd8005d",
+           roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
+           message: [
+             {
+               'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+               locale: "en",
+               'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                 email: "test2@code.org",
+                 course_id: "115",
+                 full_name: "Test Two",
+                 given_name: "Test",
+                 family_name: "Two",
+                 section_ids: "1,2,3",
+                 display_name: "Test Two",
+                 section_names: "[\"Section 1\", \"Section 2\", \"Section 3\"]"
+               }
+             }
+           ]
+         }
+       ]
+     },
+     "3" =>
+     {
+       name: "Section 3",
+       members: [
+         {
+           status: "Active",
+           user_id: "0c00f8db-a039-45e1-8e2d-f1e17a047836",
+           roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
+           message: [
+             {
+               'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+               locale: "en",
+               'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                 email: "student0@code.org",
+                 course_id: "115",
+                 full_name: "Test Zero",
+                 given_name: "Test",
+                 family_name: "Zero",
+                 section_ids: "1,2,3",
+                 display_name: "Test Zero",
+                 section_names: "[\"Section 1\", \"Section 2\", \"Section 3\"]"
+               }
+             }
+           ]
+         },
+         {
+           status: "Active",
+           user_id: "8741ee5e-7544-484d-a7a5-9fce2b29b960",
+           roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
+           message: [
+             {
+               'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+               locale: "en",
+               'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                 email: "student1@code.org",
+                 course_id: "115",
+                 full_name: "Test One",
+                 given_name: "Test",
+                 family_name: "One",
+                 section_ids: "1,2,3",
+                 display_name: "Test One",
+                 section_names: "[\"Section 1\", \"Section 2\", \"Section 3\"]"
+               }
+             }
+           ]
+         },
+         {
+           status: "Active",
+           user_id: "cd50bfe6-cd55-4789-8d04-b4930fd8005d",
+           roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
+           message: [
+             {
+               'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+               locale: "en",
+               'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                 email: "test2@code.org",
+                 course_id: "115",
+                 full_name: "Test Two",
+                 given_name: "Test",
+                 family_name: "Two",
+                 section_ids: "1,2,3",
+                 display_name: "Test Two",
+                 section_names: "[\"Section 1\", \"Section 2\", \"Section 3\"]"
+               }
+             }
+           ]
+         }
+       ]
+     }
+    }
   end
 
   setup do
@@ -255,5 +463,24 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
     get '/lti/v1/sync_course', params: {section_code: lti_section.section.code}
     assert_response :redirect
+  end
+
+  test 'transaction prevents partial sync from creating a partially-synced state' do
+    user = create :teacher
+    sign_in user
+    lti_integration = create :lti_integration
+    lti_course = create :lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid, resource_link_id: SecureRandom.uuid, nrps_url: 'https://example.com/nrps'
+
+    LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id)
+    Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
+
+    # Set up a situation where a sync has partially progressed, including saving some objects, but then
+    # encounters an error. Raising an exception during the section sync should cause the transaction to rollback after
+    # creating the first Section and LtiSection in the course sync method.
+    Services::Lti.expects(:sync_section_roster).raises(Exception, 'sync error')
+
+    get '/lti/v1/sync_course', params: {lti_integration_id: lti_integration.id, deployment_id: 'foo', context_id: lti_course.context_id, rlid: lti_course.resource_link_id, nrps_url: lti_course.nrps_url}
+    assert_empty lti_course.lti_sections
+    assert_response :internal_server_error
   end
 end

--- a/dashboard/test/lib/clients/lti_advantage_client_test.rb
+++ b/dashboard/test/lib/clients/lti_advantage_client_test.rb
@@ -5,6 +5,7 @@ class LtiAdvantageClientTest < ActiveSupport::TestCase
   setup do
     @client_id = 'expected_client_id'
     @issuer = 'expected_issuer'
+    @rlid = 'expected_rlid'
 
     @lti_client = LtiAdvantageClient.new(@client_id, @issuer)
     @lti_client.stubs(:get_access_token).returns('fake_access_token')
@@ -20,12 +21,15 @@ class LtiAdvantageClientTest < ActiveSupport::TestCase
       'Accept' => 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json',
       'Authorization' => "Bearer #{access_token}"
     }
+    expected_query = {
+      rlid: @rlid
+    }
 
     @lti_client.expects(:sign_jwt).never # should not be called since the get_access_token method is stubbed
     @lti_client.expects(:get_access_token).with(@client_id, @issuer).once.returns(access_token)
-    HTTParty.expects(:get).with(url, headers: expected_headers).once.returns(stub(code: response_code, body: response_body))
+    HTTParty.expects(:get).with(url, headers: expected_headers, query: expected_query).once.returns(stub(code: response_code, body: response_body))
 
-    actual_error = assert_raises(RuntimeError) {@lti_client.get_context_membership(url)}
+    actual_error = assert_raises(RuntimeError) {@lti_client.get_context_membership(url, @rlid)}
     assert_equal "Error getting context membership: #{response_code} #{response_body}", actual_error.message
   end
 

--- a/dashboard/test/lib/queries/lti_test.rb
+++ b/dashboard/test/lib/queries/lti_test.rb
@@ -54,4 +54,24 @@ class Services::LtiTest < ActiveSupport::TestCase
 
     assert_equal lti_course, Queries::Lti.get_course_from_context(lti_integration.id, context_id)
   end
+
+  test 'finds an LTI Course given a section code' do
+    section_code = SecureRandom.alphanumeric(6)
+    lti_course = create :lti_course
+    create :lti_section, lti_course: lti_course, section: create(:section, code: section_code)
+
+    assert_equal lti_course, Queries::Lti.get_lti_course_from_section_code(section_code)
+  end
+
+  test 'creates an LTI course given metadata from an LTI launch ID token' do
+    lti_integration = create :lti_integration
+    lti_course = Queries::Lti.find_or_create_lti_course(lti_integration_id: lti_integration.id, context_id: 'context-id', deployment_id: 'deployment-id', nrps_url: 'http://some-nrps-url.com', resource_link_id: 'rlid')
+    assert lti_course
+  end
+
+  test 'finds an existing LTI course given metadata from an LTI launch ID token' do
+    lti_integration = create :lti_integration
+    lti_course = create :lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid
+    assert_equal lti_course, Queries::Lti.find_or_create_lti_course(lti_integration_id: lti_integration.id, context_id: lti_course.context_id, deployment_id: 'deployment-id', nrps_url: 'http://some-nrps-url.com', resource_link_id: 'rlid')
+  end
 end

--- a/dashboard/test/lib/queries/lti_test.rb
+++ b/dashboard/test/lib/queries/lti_test.rb
@@ -18,4 +18,40 @@ class Services::LtiTest < ActiveSupport::TestCase
 
     assert_equal user, Queries::Lti.get_user(id_token)
   end
+
+  test 'finds a code.org user given LTI integration creds and an NRPS member response' do
+    user = create :user
+    lms_user_id = SecureRandom.uuid
+    lms_issuer = "http://#{SecureRandom.alphanumeric 10}.com"
+    lms_client_id = SecureRandom.uuid
+    id_token = {
+      sub: lms_user_id,
+      aud: lms_client_id,
+      iss: lms_issuer,
+    }
+    user.authentication_options.create(
+      authentication_id: Policies::Lti.generate_auth_id(id_token),
+      credential_type: AuthenticationOption::LTI_V1,
+    )
+    mock_nrps_member = {
+      user_id: lms_user_id,
+    }
+
+    assert_equal user, Queries::Lti.get_user_from_nrps(client_id: lms_client_id, issuer: lms_issuer, nrps_member: mock_nrps_member)
+  end
+
+  test 'finds an LTI Deployment given an LTI integration id and a deployment id' do
+    lti_integration = create :lti_integration
+    lti_deployment = create :lti_deployment, lti_integration: lti_integration
+
+    assert_equal lti_deployment, Queries::Lti.get_deployment(lti_integration.id, lti_deployment.deployment_id)
+  end
+
+  test 'finds an LTI Course given an LTI integration id and an LTI context id' do
+    lti_integration = create :lti_integration
+    context_id = SecureRandom.uuid
+    lti_course = create :lti_course, lti_integration: lti_integration, context_id: context_id
+
+    assert_equal lti_course, Queries::Lti.get_course_from_context(lti_integration.id, context_id)
+  end
 end

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -6,7 +6,7 @@ require 'policies/lti'
 class Services::LtiTest < ActiveSupport::TestCase
   setup do
     @roles_key = Policies::Lti::LTI_ROLES_KEY
-    @custom_claims_key = Policies::Lti::LTI_CUSTOM_CLAIMS
+    @custom_claims_key = Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym
     @teacher_roles = [
       'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator',
       'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor',

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -3,7 +3,7 @@ require 'user'
 require 'authentication_option'
 require 'policies/lti'
 
-class Services::LtiTest < ActiveSupport::TestCase
+class Services::LtiTest < ActionDispatch::IntegrationTest
   setup do
     @roles_key = Policies::Lti::LTI_ROLES_KEY
     @custom_claims_key = Policies::Lti::LTI_CUSTOM_CLAIMS
@@ -15,6 +15,7 @@ class Services::LtiTest < ActiveSupport::TestCase
       'http://purl.imsglobal.org/vocab/lis/v2/system/person#User',
     ]
     @lti_integration = create :lti_integration
+    @student_role = Policies::Lti::CONTEXT_LEARNER_ROLE
 
     @id_token = {
       sub: SecureRandom.uuid,
@@ -27,6 +28,119 @@ class Services::LtiTest < ActiveSupport::TestCase
         family_name: 'Solo',
       }
     }
+
+    @nrps_student = {
+      status: 'Active',
+      user_id: SecureRandom.uuid,
+      roles: [@student_role],
+      message: [{
+        @custom_claims_key => {
+          display_name: 'hansolo',
+          full_name: 'Han Solo',
+          given_name: 'Han',
+          family_name: 'Solo',
+          email: 'foo@test.com'
+        }
+      }],
+    }.deep_symbolize_keys
+
+    @lms_section_ids = [1, 2, 3]
+    @lms_section_names = ['Section 1', 'Section 2', 'Section 3']
+
+    @nrps_full_response = {
+      id: "https://codeorg.instructure.com/api/lti/courses/115/names_and_roles?rlid=foo-id",
+      context: {
+        id: "context-id",
+        label: "Course Label",
+        title: "Course Title"
+      },
+      members: [
+        {
+          status: "Active",
+          user_id: "user-id-1",
+          roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor"],
+          message: [
+            {
+              'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+              locale: "en",
+              'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                email: "teacher@code.org",
+                course_id: "115",
+                full_name: "Test Teacher",
+                given_name: "Test",
+                family_name: "Teacher",
+                section_ids: @lms_section_ids.join(','),
+                display_name: "Test Teacher",
+                section_names: @lms_section_names.to_s
+              },
+            }
+          ]
+        },
+        {
+          status: "Active",
+          user_id: SecureRandom.uuid,
+          roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
+          message: [
+            {
+              'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+              locale: "en",
+              'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                email: "student0@code.org",
+                course_id: "115",
+                full_name: "Test Zero",
+                given_name: "Test",
+                family_name: "Zero",
+                section_ids: @lms_section_ids.join(','),
+                display_name: "Test Zero",
+                section_names: @lms_section_names.to_s
+              },
+            }
+          ]
+        },
+        {
+          status: "Active",
+          user_id: SecureRandom.uuid,
+          roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
+          message: [
+            {
+              'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+              locale: "en",
+              'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                email: "student1@code.org",
+                course_id: "115",
+                full_name: "Test One",
+                given_name: "Test",
+                family_name: "One",
+                section_ids: @lms_section_ids.join(','),
+                display_name: "Test One",
+                section_names: @lms_section_names.to_s
+              },
+            }
+          ]
+        },
+        {
+          status: "Active",
+          user_id: SecureRandom.uuid,
+          roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
+          message: [
+            {
+              'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+              locale: "en",
+              'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                email: "test2@code.org",
+                course_id: "115",
+                full_name: "Test Two",
+                given_name: "Test",
+                family_name: "Two",
+                section_ids: @lms_section_ids.join(','),
+                display_name: "Test Two",
+                section_names: @lms_section_names.to_s
+              },
+            }
+          ]
+        }
+      ]
+    }.deep_symbolize_keys
   end
 
   test 'initialize_lti_user should create User::TYPE_TEACHER when id_token contains teacher/admin roles' do
@@ -79,5 +193,58 @@ class Services::LtiTest < ActiveSupport::TestCase
 
     lti_user_identity = Services::Lti.create_lti_user_identity(user)
     assert lti_user_identity
+  end
+
+  test 'should create a student user given an LTI NRPS member object' do
+    student_user = Services::Lti.initialize_lti_student_from_nrps(client_id: @id_token[:aud], issuer: @id_token[:iss], nrps_member: @nrps_student)
+    assert student_user
+    assert_equal student_user.user_type, User::TYPE_STUDENT
+  end
+
+  test 'should parse the members response from NRPS and return a hash of sections' do
+    parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response)
+    assert_empty parsed_response.keys - @lms_section_ids.map(&:to_s)
+    parsed_response.each do |_, v|
+      assert_empty v.keys - [:name, :members]
+      assert_equal v[:members].length, 3
+    end
+  end
+
+  test 'should add or remove student users when syncing a section' do
+    lti_integration = create :lti_integration
+    lti_course = create :lti_course, lti_integration: lti_integration
+    lti_section = create :lti_section, lti_course: lti_course
+    parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response)
+    members = parsed_response[@lms_section_ids.first.to_s][:members]
+
+    # Create and add brand new users
+    Services::Lti.sync_section_roster(lti_integration, lti_section, members)
+    assert_equal lti_section.followers.length, 3
+
+    # Remove a user
+    user_to_remove = lti_section.followers.last
+    Services::Lti.sync_section_roster(lti_integration, lti_section, members[0...-1])
+    assert_equal lti_section.reload.followers.length, 2
+
+    # Find an existing user add them back in
+    Services::Lti.sync_section_roster(lti_integration, lti_section, members)
+    assert_equal lti_section.reload.followers.length, 3
+    assert_equal lti_section.followers.last, user_to_remove
+  end
+
+  test 'should add or remove sections when syncing a course' do
+    teacher = create :teacher
+    lti_integration = create :lti_integration
+    lti_course = create :lti_course, lti_integration: lti_integration
+    parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response)
+    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
+
+    # Adding new sections
+    assert lti_course.reload.sections.length, 3
+
+    # Removing old sections
+    parsed_response.delete(@lms_section_ids.first.to_s)
+    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
+    assert lti_course.reload.sections.length, 2
   end
 end

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -3,7 +3,7 @@ require 'user'
 require 'authentication_option'
 require 'policies/lti'
 
-class Services::LtiTest < ActionDispatch::IntegrationTest
+class Services::LtiTest < ActiveSupport::TestCase
   setup do
     @roles_key = Policies::Lti::LTI_ROLES_KEY
     @custom_claims_key = Policies::Lti::LTI_CUSTOM_CLAIMS

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -47,6 +47,7 @@ module SharedConstants
       email: 'email',
       google_classroom: 'google_classroom',
       clever: 'clever',
+      lti_v1: 'lti_v1',
     }
   )
 


### PR DESCRIPTION
Enables roster syncing for Canvas via LTI.
- Adds a new route to the lti_v1_controller accessible at `/lti/v1/sync_course`. In order to test locally, the target URI of your module in Canvas will need to point at this endpoint. You can edit this setting at the course module level even if your default target URI in your developer key is set to something different.
- The LTI auth route has been modified to post the parameters required for the sync on the final redirect
- LTI service, policy, and queries have new sync-related methods. The bulk of the work is done in the service.
- There is now an LTI sync button on the manage students tab of the Teacher Dashboard. Clicking it syncs the section and other sections in the same LMS course, since it hits the same code that syncs on launch. The button only shows up for LTI sections, so you will have to launch at least once in order to create LTI sections before you'll see the button.

## Links

Jira tickets: [sync](https://codedotorg.atlassian.net/browse/P20-406), [section UI](https://codedotorg.atlassian.net/browse/P20-409)

## Testing story

```
bundle exec spring testunit test/controllers/lti_v1_controller_test.rb
Running via Spring preloader in process 42682
Started with run options --seed 6864

  22/22: [==================================================] 100% Time: 00:00:13, Time: 00:00:13

Finished in 14.98997s
22 tests, 36 assertions, 0 failures, 0 errors, 0 skips

bundle exec spring testunit test/lib/services/lti_test.rb
Running via Spring preloader in process 42892
Started with run options --seed 15888

  7/7: [====================================================] 100% Time: 00:00:08, Time: 00:00:08

Finished in 11.73772s
7 tests, 35 assertions, 0 failures, 0 errors, 0 skips

bundle exec spring testunit test/lib/queries/lti_test.rb
Running via Spring preloader in process 43055
Started with run options --seed 54007

  4/4: [====================================================] 100% Time: 00:00:07, Time: 00:00:07

Finished in 9.88066s
4 tests, 4 assertions, 0 failures, 0 errors, 0 skips
```

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
