### PR TITLE
[Google Blockly] CT-197: Correctly read userCreated flag

### DIFF
--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -1,5 +1,6 @@
 import {PROCEDURE_DEFINITION_TYPES} from '../constants';
 import {partitionBlocksByType} from './cdoUtils';
+import {readBooleanAttribute} from '../utils';
 
 export default function initializeBlocklyXml(blocklyWrapper) {
   // Clear xml namespace
@@ -133,9 +134,7 @@ export function addMutationToBehaviorDefBlocks(blockElement) {
   // (e.g. shared behaviors).
   // In CDO Blockly, the 'usercreated' flag was set on the block. Google Blockly
   // expects this kind of extra state in a mutator.
-  // Note: Whenever we read these attributes, we expect them to be strings representing booleans.
-  const usercreatedAttribute = blockElement.getAttribute('usercreated');
-  const userCreated = usercreatedAttribute === 'true';
+  const userCreated = readBooleanAttribute(blockElement, 'usercreated');
   mutationElement.setAttribute('userCreated', userCreated);
 
   // In CDO Blockly, behavior ids were stored on the field. Google Blockly

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -133,6 +133,7 @@ export function addMutationToBehaviorDefBlocks(blockElement) {
   // (e.g. shared behaviors).
   // In CDO Blockly, the 'usercreated' flag was set on the block. Google Blockly
   // expects this kind of extra state in a mutator.
+  // Note: Whenever we read these attributes, we expect them to be strings representing booleans.
   const usercreatedAttribute = blockElement.getAttribute('usercreated');
   const userCreated = usercreatedAttribute === 'true';
   mutationElement.setAttribute('userCreated', userCreated);

--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -159,11 +159,14 @@ export default class FunctionEditor {
       Blockly.getHiddenDefinitionWorkspace()
     );
 
+    let type;
     if (existingProcedureBlock) {
+      type = existingProcedureBlock.type;
       // If we already have stored data about the procedure, use that.
       const existingData = Blockly.serialization.blocks.save(
         existingProcedureBlock
       );
+
       // Disable events here so we don't copy an existing block into the hidden definition
       // workspace.
       Blockly.Events.disable();
@@ -171,13 +174,13 @@ export default class FunctionEditor {
         this.addEditorWorkspaceBlockConfig(existingData),
         this.editorWorkspace
       );
-
       Blockly.Events.enable();
     } else {
+      type = procedureType;
       // Otherwise, we need to create a new block from scratch.
       const newDefinitionBlock = {
         kind: 'block',
-        type: procedureType,
+        type,
         extraState: {
           procedureId: procedure.getId(),
           userCreated: true,
@@ -194,19 +197,15 @@ export default class FunctionEditor {
       );
     }
 
-    // We hide the delete button unless it is a function or user-created behavior.
-    const shouldShowDeleteButton =
-      this.block.type === BLOCK_TYPES.procedureDefinition ||
-      this.block.userCreated;
+    const isBehavior = type === BLOCK_TYPES.behaviorDefinition;
+    // We do not want to show the delete button for behaviors that are not user-created
+    const hideDeleteButton = isBehavior && !this.block.userCreated;
     const modalEditorDeleteButton = document.getElementById(
       MODAL_EDITOR_DELETE_ID
     );
-    modalEditorDeleteButton.style.visibility = shouldShowDeleteButton
-      ? 'visible'
-      : 'hidden';
-
-    const type = procedureType || existingProcedureBlock.type;
-    const isBehavior = type === BLOCK_TYPES.behaviorDefinition;
+    modalEditorDeleteButton.style.visibility = hideDeleteButton
+      ? 'hidden'
+      : 'visible';
 
     // Used to create and render an SVG frame instance.
     const getDefinitionBlockColor = () => {

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorDefMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorDefMutator.js
@@ -10,6 +10,7 @@
  */
 
 import {ObservableParameterModel} from '@blockly/block-shareable-procedures';
+import {readBooleanAttribute} from '@cdo/apps/blockly/utils';
 import {
   getBlockDescription,
   setBlockDescription,
@@ -74,7 +75,7 @@ export const behaviorDefMutator = {
       }
     }
     this.behaviorId = xmlElement.getAttribute('behaviorId');
-    this.userCreated = xmlElement.getAttribute('userCreated');
+    this.userCreated = readBooleanAttribute(xmlElement, 'userCreated');
   },
 
   /**

--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
@@ -12,6 +12,7 @@ const INPUTS = {
   STACK: 'STACK',
 };
 import {BLOCK_TYPES, NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
+import {readBooleanAttribute} from '@cdo/apps/blockly/utils';
 import {editButtonHandler} from './proceduresBlocks';
 
 // This file contains customizations to Google Blockly Sprite Lab blocks.
@@ -173,7 +174,7 @@ export const blocks = {
         // Assume default icon if no XML attribute present
         !xmlElement.hasAttribute('useDefaultIcon') ||
         // Coerce string to Boolean
-        xmlElement.getAttribute('useDefaultIcon') === 'true';
+        readBooleanAttribute(xmlElement, 'useDefaultIcon');
       flyoutToggleButton.setIcon(useDefaultIcon);
     };
   },

--- a/apps/src/blockly/utils.js
+++ b/apps/src/blockly/utils.js
@@ -4,15 +4,10 @@ import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
 /**
  * Reads a boolean attribute from an XML element.
  *
- * This function retrieves the value of an attribute from a given XML element
- * and returns a boolean based on the attribute value. It specifically checks
- * if the attribute value is the string 'true'. The function returns false
- * in any other case, including the attribute being absent, null, an empty string,
- * 'false', or any other string.
- *
  * @param {Element} xmlElement - The XML element from which the attribute will be read.
  * @param {string} attribute - The name of the attribute to be read from the XML element.
  * @returns {boolean} True if the attribute value is exactly 'true', otherwise false.
+ * If we ever need to return true for unset attributes, we can update this function.
  */
 export function readBooleanAttribute(xmlElement, attribute) {
   const attributeValue = xmlElement.getAttribute(attribute);

--- a/apps/src/blockly/utils.js
+++ b/apps/src/blockly/utils.js
@@ -1,6 +1,19 @@
 import _ from 'lodash';
 import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
 
+/**
+ * Reads a boolean attribute from an XML element.
+ *
+ * This function retrieves the value of an attribute from a given XML element
+ * and returns a boolean based on the attribute value. It specifically checks
+ * if the attribute value is the string 'true'. The function returns false
+ * in any other case, including the attribute being absent, null, an empty string,
+ * 'false', or any other string.
+ *
+ * @param {Element} xmlElement - The XML element from which the attribute will be read.
+ * @param {string} attribute - The name of the attribute to be read from the XML element.
+ * @returns {boolean} True if the attribute value is exactly 'true', otherwise false.
+ */
 export function readBooleanAttribute(xmlElement, attribute) {
   const attributeValue = xmlElement.getAttribute(attribute);
   return attributeValue === 'true';

--- a/apps/src/blockly/utils.js
+++ b/apps/src/blockly/utils.js
@@ -1,5 +1,10 @@
-import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
 import _ from 'lodash';
+import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
+
+export function readBooleanAttribute(xmlElement, attribute) {
+  const attributeValue = xmlElement.getAttribute(attribute);
+  return attributeValue === 'true';
+}
 
 export function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);


### PR DESCRIPTION
When we were reading the `userCreated` attribute from the block before, we were reading it as a string: https://github.com/code-dot-org/code-dot-org/pull/55234/files#diff-a84e82f512c1c71dc67cb7fc9e444f097a51035fb5f9777c0bc724dcaa3f5035L77

This was causing weird behavior anywhere `userCreated` was read. For example, we are meant to hide the delete button for any shared behavior, and the existing logic was right (although I refactored it to combine it with some unrelated logic below) except that the value of this flag was string "false" instead of boolean false.

Note: Disabling delete on right-click (shown persisting in the after video) is covered in CT-196.

I audited the code in `apps/src/blockly` to see if there was anywhere else we were trying to read an attribute that should be a boolean. The correct examples I updated to use the helper (happy to revert this); I didn't notice any other incorrect examples. 

## Links

Ticket: https://codedotorg.atlassian.net/browse/CT-197

## Testing story

Before 

https://github.com/code-dot-org/code-dot-org/assets/26844240/5a8e3387-233b-49c4-add8-15498503c3a7

After

https://github.com/code-dot-org/code-dot-org/assets/26844240/b8800597-30b5-4ed0-ab6a-32ff9be3bb65

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Follow-up to block deletion by right-click: https://codedotorg.atlassian.net/browse/CT-196

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
