### PR TITLE
[Google Blockly] Blockly.selected points to Blockly.getSelected()

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -229,7 +229,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('removeChangeListener');
   blocklyWrapper.wrapReadOnlyProperty('RTL');
   blocklyWrapper.wrapReadOnlyProperty('Scrollbar');
-  blocklyWrapper.wrapReadOnlyProperty('selected');
   blocklyWrapper.wrapReadOnlyProperty('serialization');
   blocklyWrapper.wrapReadOnlyProperty('SPRITE');
   blocklyWrapper.wrapReadOnlyProperty('svgResize');
@@ -343,6 +342,11 @@ function initializeBlocklyWrapper(blocklyInstance) {
   Object.defineProperty(blocklyWrapper, 'SVG_NS', {
     get: function () {
       return this.blockly_.utils.dom.SVG_NS;
+    },
+  });
+  Object.defineProperty(blocklyWrapper, 'selected', {
+    get: function () {
+      return this.blockly_.getSelected();
     },
   });
 


### PR DESCRIPTION
`Blockly.selected` has been deprecated as of v9 and was deleted in v10. As we use this in a bunch of different places, we have currently have the tendency to hit console warnings like this:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/d42e5411-21fc-4801-87a7-e3b6e1f6f563)

Once we update to v10, these would turn into errors. We can get ahead of this Blockly change by defining `Blockly.selected` (on the wrapper) as pointing to `blockly_.getSelected()` (on the imported Blockly instance). This is similar to how we access `Blockly.mainBlockSpace` to call to the modern `getMainWorkspace()` function. The advantage here is that we don't have to replace each use of `Blockly.selected` across our code base with the modern method (or a util for code files used by both version of Blockly).

Confirmed that the warning no longer appears:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/e12575a3-e26d-436e-9c85-8d3754cf8fc3)


## Links

Jira: https://codedotorg.atlassian.net/browse/CT-1

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
