### PR TITLE
[Google Blockly] only show edit buttons for procedures if toolbox_ exists for workspace

### DIFF
--- a/apps/src/blockly/addons/workspaceSvgFrame.js
+++ b/apps/src/blockly/addons/workspaceSvgFrame.js
@@ -108,7 +108,11 @@ export default class WorkspaceSvgFrame extends SvgFrame {
 
   getFrameX() {
     // In LTR the svg should be to the right of the toolbox, plus a margin.
-    let frameX = this.element_.toolbox_.width_ + frameSizes.MARGIN_SIDE / 2;
+    let frameX = frameSizes.MARGIN_SIDE / 2;
+    const toolbox = this.element_.toolbox_;
+    if (toolbox) {
+      frameX += toolbox.width_;
+    }
     if (this.element_.RTL) {
       // In RTL the toolbox is on the right, so we don't need to leave space for
       // it. However, if the content is wider than the available space, we need to

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -112,6 +112,7 @@ GoogleBlockly.Extensions.register('procedures_edit_button', function () {
     Blockly.useModalFunctionEditor &&
     this.inputList.length &&
     !this.workspace.isFlyout &&
+    this.workspace.toolbox_ &&
     this.workspace.id !== Blockly.functionEditor.getWorkspaceId()
   ) {
     const button = new Blockly.FieldButton({

--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
@@ -316,6 +316,7 @@ export const blocks = {
     if (
       behaviorsFound &&
       Blockly.useModalFunctionEditor &&
+      block.workspace.toolbox_ &&
       // TODO: Support editing behaviors from within a modal editor workspace.
       block.workspace.id === Blockly.getMainWorkspace().id
     ) {


### PR DESCRIPTION
During the recent Bug Bash for Sprite Lab on Google Blockly, @amy-b and @onlinecsteacher both experienced a bug due to behavior edit buttons showing up where they weren't expected. Clicking these buttons leads to a very broken experience:

![d90c85c2-a8d7-4c17-b385-f897046dcc04](https://github.com/code-dot-org/code-dot-org/assets/43474485/86de1ff2-1c90-424c-b320-bfa47360f042)

The error is being hit here, as we make our calculations based on the assumption that there is a toolbox:
https://github.com/code-dot-org/code-dot-org/blob/e27c8f5f1d32bc1a597f4be004f87c88307f5240/apps/src/blockly/addons/workspaceSvgFrame.js#L111

![02d9a5ea-f885-4a28-868c-9d8d2968075f](https://github.com/code-dot-org/code-dot-org/assets/43474485/5cd694f7-6529-4861-bf2d-bb6177b9e868)

This is a case where we missed parity with CDO Blockly's functionality as these edit buttons should not show up on levels unless there is a categorized toolbox. To check for this, we can see if the block's workspace has a `toolbox_`. (Alternatively, I considered calling `workspace.getToolbox()` but this function is only present on workspaces that have one...)

**Before:**

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/7b259305-1041-45f1-9793-581b8ab28d59)

**After:**

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/17e11c5c-4c3a-42b9-9175-2ef2c99a693c)

Theoretically, this should prevent a user from opening the modal editor unless the main workspace has a toolbox, however the calculations still seemed a bit fragile. I updated them to only consider the toolbox width if it exists. Now, if the modal editor is forced open, such as through console commands, it is rendered without errors:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/8c0c80e5-fe3a-4632-b8cc-064de0abd41f)


## Links

Jira: https://codedotorg.atlassian.net/browse/CT-195

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
