### PR TITLE
[Google Blockly] replace can_disconnect_from_parent with movable

### DIFF
--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -56,6 +56,7 @@ export default function initializeBlocklyXml(blocklyWrapper) {
     //  the rendered blocks and the coordinates in an array so that we can
     //  position them.
     partitionedBlockElements.forEach(xmlChild => {
+      makeLockedBlocksImmovable(xmlChild);
       addMutationToBehaviorDefBlocks(xmlChild);
       addMutationToMiniToolboxBlocks(xmlChild);
       const blockly_block = Blockly.Xml.domToBlock(xmlChild, workspace);
@@ -145,6 +146,28 @@ export function addMutationToBehaviorDefBlocks(blockElement) {
     // Create new mutation attribute based on original block attribute.
     mutationElement.setAttribute('behaviorId', idAttribute);
   }
+}
+
+/**
+ * CDO Blockly supported a can_disconnect_from_parent attribute that
+ * effectively worked like the modern movable property. To prevent
+ * unintended movability changes to student code, we convert the unsupported
+ * can_disconnect_from_parentto movable.
+ * @param {Element} blockElement - The XML element for a single block.
+ */
+export function makeLockedBlocksImmovable(block) {
+  const canDisconnectValue = block.getAttribute('can_disconnect_from_parent');
+  // If present, value will be either "true" or "false" (string, not boolean)
+  if (canDisconnectValue) {
+    block.setAttribute('movable', canDisconnectValue);
+    block.removeAttribute('can_disconnect_from_parent');
+  }
+
+  // Blocks can contain other blocks so we must process them recursively.
+  const childBlocks = block.querySelectorAll('block');
+  childBlocks.forEach(childBlock => {
+    makeLockedBlocksImmovable(childBlock);
+  });
 }
 
 /**


### PR DESCRIPTION
Both versions of Blockly support a `movable` property on blocks, however they work in very different ways:

CDO Blockly| Google Blockly
-|-
![cdo blockly immovable](https://github.com/code-dot-org/code-dot-org/assets/43474485/2d303086-d69f-4d89-a729-6e5fabd03ec4)|![google blockly immovable](https://github.com/code-dot-org/code-dot-org/assets/43474485/8e9e0056-0a81-4407-b689-384a6e087bee)
The first `print` block here is immovable. The blocks above or below it can be moved, but the immovable block is effectively glued to the workspace surface with unchanging x/y values.|The first `set title` block is immovable. The immovable block cannot be moved directly, but it can be moved via its parent block.

To deal with this, 8 years ago, we invented our “lock to parent” property for blocks that makes them immovable in the same way that mainline Blockly would eventually adopt for itself. https://github.com/code-dot-org/blockly/commit/35b888584f960300314d4765dbfbd0e5ddfa432a

When a levelbuilder wants blocks to be connected to their parent they use the XML attribute `can_disconnect_from_parent`, however this attribute is ignored by Google Blockly. To see the issue, compare this level using each version of Blockly:

- https://levelbuilder-studio.code.org/s/csc-ecosystems-2023/lessons/1/levels/9?blocklyVersion=cdo
- https://levelbuilder-studio.code.org/s/csc-ecosystems-2023/lessons/1/levels/9?blocklyVersion=google

Notice that in the first version, the lower teal blocks cannot be separated from their parent. Google Blockly ignores this attribute since it’s unsupported.

As such, we need to be able to convert block attributes from `can_disconnect_from_parent` to `movable` when present.

When we flipped Poetry to Google Blockly ahead of its launch, I performed a manual update of a couple dozen level config files. For Sprite Lab, this affects over 1000 levels and countless student projects stored in S3. This means we will always need to be able to load projects containing the old property and properly convert them.

This branch aims to handle the problem by converting the unsupported block attribute to movable. Even though it’s recursive, it completes for a complex project for me in a couple of milliseconds.


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
