### PR TITLE
[JIMT][AMPLITUDE EVENTS] - tweaks close event

### DIFF
--- a/apps/src/dance/ai/DanceAiModal.tsx
+++ b/apps/src/dance/ai/DanceAiModal.tsx
@@ -298,12 +298,17 @@ const DanceAiModal: React.FunctionComponent<DanceAiModalProps> = ({
     }
   };
 
-  const handleGenerateClick = () => {
+  const handleGenerateClick = (
+    _: React.SyntheticEvent,
+    regenerating = false
+  ) => {
     startAi();
 
-    analyticsReporter.sendEvent(EVENTS.DANCE_PARTY_AI_BACKGROUND_GENERATED, {
-      emojis: inputs,
-    });
+    if (!regenerating) {
+      analyticsReporter.sendEvent(EVENTS.DANCE_PARTY_AI_BACKGROUND_GENERATED, {
+        emojis: inputs,
+      });
+    }
 
     setMode(Mode.GENERATING);
   };
@@ -319,14 +324,14 @@ const DanceAiModal: React.FunctionComponent<DanceAiModalProps> = ({
     setMode(Mode.SELECT_INPUTS);
   };
 
-  const handleRegenerateClick = () => {
+  const handleRegenerateClick = (e: React.SyntheticEvent) => {
     analyticsReporter.sendEvent(EVENTS.DANCE_PARTY_AI_BACKGROUND_REGENERATED, {
       emojis: inputs,
     });
     setGeneratingProgress({step: 0, subStep: 0});
     setGeneratedProgress(0);
     setCurrentToggle(Toggle.EFFECT);
-    handleGenerateClick();
+    handleGenerateClick(e, true);
   };
 
   const handleExplanationClick = () => {
@@ -508,6 +513,8 @@ const DanceAiModal: React.FunctionComponent<DanceAiModalProps> = ({
     analyticsReporter.sendEvent(EVENTS.DANCE_PARTY_AI_MODAL_CLOSED, {
       emojis: inputs,
       mode,
+      currentToggle,
+      generatingStep: generatingProgress.step,
     });
 
     onClose();
@@ -644,7 +651,7 @@ const DanceAiModal: React.FunctionComponent<DanceAiModalProps> = ({
   return (
     <AccessibleDialog
       className={moduleStyles.dialog}
-      onClose={onClose}
+      onClose={handleOnClose}
       initialFocus={false}
       styles={{modalBackdrop: moduleStyles.modalBackdrop}}
     >

--- a/apps/src/dance/ai/DanceAiModal.tsx
+++ b/apps/src/dance/ai/DanceAiModal.tsx
@@ -298,19 +298,17 @@ const DanceAiModal: React.FunctionComponent<DanceAiModalProps> = ({
     }
   };
 
-  const handleGenerateClick = (
-    _: React.SyntheticEvent,
-    regenerating = false
-  ) => {
+  const startGenerating = () => {
     startAi();
-
-    if (!regenerating) {
-      analyticsReporter.sendEvent(EVENTS.DANCE_PARTY_AI_BACKGROUND_GENERATED, {
-        emojis: inputs,
-      });
-    }
-
     setMode(Mode.GENERATING);
+  };
+
+  const handleGenerateClick = () => {
+    analyticsReporter.sendEvent(EVENTS.DANCE_PARTY_AI_BACKGROUND_GENERATED, {
+      emojis: inputs,
+    });
+
+    startGenerating();
   };
 
   const handleStartOverClick = () => {
@@ -324,14 +322,14 @@ const DanceAiModal: React.FunctionComponent<DanceAiModalProps> = ({
     setMode(Mode.SELECT_INPUTS);
   };
 
-  const handleRegenerateClick = (e: React.SyntheticEvent) => {
+  const handleRegenerateClick = () => {
     analyticsReporter.sendEvent(EVENTS.DANCE_PARTY_AI_BACKGROUND_REGENERATED, {
       emojis: inputs,
     });
     setGeneratingProgress({step: 0, subStep: 0});
     setGeneratedProgress(0);
     setCurrentToggle(Toggle.EFFECT);
-    handleGenerateClick(e, true);
+    startGenerating();
   };
 
   const handleExplanationClick = () => {


### PR DESCRIPTION
Follow up PR to #55241 that tweaks the tracking a little bit more.

- Will now fire off close events on escape press (NOTE that the escape key can frequently not be pressed, so this won't come up much)
- Regenerate clicks would generate regenerate _and_ generate events. Now only generates regenerate events.
- the amplitude close event will now also include the currentToggle (are they closing on the effect screen or the code screen), as well as the generating step (how many effects were created before the user closed the modal)



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
