### PR TITLE
Fix add back locals yml default

### DIFF
--- a/locals.yml.default
+++ b/locals.yml.default
@@ -1,0 +1,138 @@
+# Example configuration file set up with sensible defaults for local development.
+# See `config.yml.erb` for full list of available configuration options.
+
+# Some items in config.yml.erb are resolved via `!Secret`, which retrieves from
+# AWS Secrets Manager. These will be unavailable to external Contributors, but are
+# also not necessary for basic local development. Override them here to avoid
+# errors accessing Secrets Manager.
+#slack_bot_token: localoverride
+#pardot_private_key: localoverride
+
+# Whether to prefix bundler commands with 'sudo'.
+# It may be useful to set this false when doing local development on Linux.
+#bundler_use_sudo: false
+
+
+# Causes dashboard-server to run pegasus as middleware, starting both in a
+# single command.  This is preferred (and default) in development mode.
+dashboard_enable_pegasus: true
+
+
+# Run dashboard-server with the level editing interface enabled (for admins)
+#levelbuilder_mode: true
+
+# Use different color header for local environment than the one on production to
+# make it easier to tell the difference
+#use_local_header_color: true
+
+# Keeps from taking eyes snapshots when running feature files
+#disable_all_eyes_running: true
+
+# Whether rake:build should rebuild the apps package
+build_apps: true
+
+
+# Whether dashboard should use your local build of the apps package.
+# If false, dashboard will try to use a prepackaged version from S3.
+use_my_apps: true
+
+# Allows your local server to render non-English locales, defaults to false.
+# If false, choosing a locale other than English will have no effect.
+# Note: You may need to be in an incognito window to see changes
+# due to a difference in the language cookie between production and localhost.
+#load_locales: true
+
+
+# Whether to skip the slow `rake seed:all` command during `rake build`.
+# Until you manually run `rake seed:all` or disable this flag, you won't
+# see changes to: videos, concepts, levels, scripts, trophies, prize providers,
+# callouts, hints, secret words, or secret pictures.
+#skip_seed_all: true
+
+
+# Whether to store sprocket asset cache on disk or in memory. Setting this to
+# false reduces memory usage, but significantly slows down dev server startup.
+#cache_assets_in_memory: false
+
+
+# Whether to stub schools and school_districts table with much smaller data,
+# saving a total of 4 min 30 sec during rake seed. Default: true (in development).
+#stub_school_data: false
+
+
+# Encryption key required for decoding certain protected level sources.
+# Code.org engineers with AWS credentials should get this automatically
+# via AWS Secrets Manager in development.
+# Contributors should ask a Code.org engineer for this if needed.
+#properties_encryption_key: ''
+
+
+# Credentials for SauceLabs.com, used to for running selenium tests against
+# multiple browsers
+#saucelabs_username: ''
+#saucelabs_authkey: ''
+
+
+# Credentails for applitools.com, used for running automated visual tests
+#applitools_eyes_api_key: ''
+
+
+# Configuration Options for Pusher.com integration
+# Optional for most devs, very useful if working on Internet Simulator
+#use_pusher: true
+#pusher_app_id: ''
+#pusher_application_key: ''
+#pusher_application_secret: ''
+
+
+# Configuration options for Acapela-Group.com integration
+#acapela_storage_app: ''
+#acapela_storage_password: ''
+#acapela_ephemeral_app: ''
+#acapela_ephemeral_password: ''
+
+
+# Credentials for new relic logging. Used to log apps build times.
+# Log in to https://rpm.newrelic.com/accounts/501463 to get the key
+#new_relic_license_key: ''
+
+
+# Credentials for connecting to Firebase to use data blocks or data browser
+# in Applab.
+#firebase_name: 'cdo-v3-dev'
+#firebase_secret: localoverride
+#firebase_shared_secret localoverride
+
+
+# Configuration and credentials for the Geocoder gem.  Google Maps provides a
+# street address geocoding service, while freegeoip provides an IP address
+# geocoding service.  (The former is "lookup" in the Geocoder config, while the
+# latter is "ip_lookup".)  We send both street address and IP address strings
+# into Geocoder#search and the appropriate service is used.
+#google_maps_client_id:
+#google_maps_secret:
+#freegeoip_host:
+
+
+# Specify `use_mailcatcher: true` if you are running mailcatcher on localhost.
+# See development.rb file for information about how to use mailcatcher.
+#use_mailcatcher: true
+
+
+# Credentials for Twilio, used to share projects to a phone number via SMS.
+#twilio_sid:
+#twilio_auth:
+#twilio_messaging_service:
+
+# Tokens for immersive reader
+# imm_reader_tenant_id:     ''
+# imm_reader_client_id:     ''
+# imm_reader_client_secret: ''
+# imm_reader_subdomain:     'cdo-immersive-reader-staging'
+
+# Local Javabuilder configuration. Set 'use_localhost_javabuilder: true' to point to
+# your Javabuilder WebSocket server running on localhost.
+# Set 'local_javabuilder_stack_name: "your stack name"' to point to a deployed development
+# instance of Javabuilder. This will likely be 'javabuilder-dev-<your_branch_name>'
+# use_localhost_javabuilder: true
+# local_javabuilder_stack_name: javabuilder-dev-<your_branch_name>


### PR DESCRIPTION
The `locals.yml.default` file was mistakenly deleted via a commit linked below through levelbuilder. This is surprising since this is meant to be protected by commit hooks, yet it happened anyway. We could not determine how but believe it was human error.

This adds the file back in the state it was in exactly preceding the commit here: a8374d28b4bdfdd19177326c0c1cc57d187768c7 

## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
