### PR TITLE
Clarity on events page logic

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/events_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/events_signup.haml
@@ -1,5 +1,5 @@
 %a#hocsignupform{name: 'signup'}
-- if [false].include?(hoc_mode)
+- if !!hoc_mode
   %p.signup-closed.body-two.no-margin-bottom
     =hoc_s(:signup_registration_closed_2022_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn')})
 - else

--- a/pegasus/sites.v3/hourofcode.com/views/events_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/events_signup.haml
@@ -1,5 +1,5 @@
 %a#hocsignupform{name: 'signup'}
-- if !!hoc_mode
+- if hoc_mode == false
   %p.signup-closed.body-two.no-margin-bottom
     =hoc_s(:signup_registration_closed_2022_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn')})
 - else


### PR DESCRIPTION
This is a followup to https://github.com/code-dot-org/code-dot-org/pull/55207 where I reinstated the events page during actual-hoc and post-hoc modes. This PR simplifies the logic so it is easier to read.

I considered if !hoc_mode, but I wanted to make it as clear as possible that hoc_mode = false is a state we use outside of the other modes (and it's a smidge easier for my brain to read).

Testing: I was able to test locally that when hoc_mode is false, I can't see the event registration. I tested that the registration still shows when I update hoc_mode to actual-hoc or post-hoc (etc). 

I'm opening this against staging because it will be a followup from the above PR, hopefully before we merge everything from staging-next (as suggested in the restricted deploy meeting 11/30/23). 


## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1239

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
