### PR TITLE
hoc2023: fix scrollbar showing during flip

### DIFF
--- a/apps/src/dance/ai/dance-ai-modal.module.scss
+++ b/apps/src/dance/ai/dance-ai-modal.module.scss
@@ -132,6 +132,7 @@ $ai-modal-border-width: 8px;
     box-sizing: border-box;
     border-radius: 4px;
     background-color: white;
+    overflow: hidden;
 
     .toggleArea {
       position: absolute;


### PR DESCRIPTION
At least prior to https://github.com/code-dot-org/code-dot-org/pull/55184, a system with scrollbars would have them appear momentarily as the large container for the blocks briefly swung out of the modal's container during the 3D flip.

While this should no longer happen regularly, this fix should ensure that even with very wide code blocks, the scrollbars won't appear.

### before https://github.com/code-dot-org/code-dot-org/pull/55184
https://github.com/code-dot-org/code-dot-org/assets/2205926/eadeccf6-632d-4024-8dda-b49faeb4753a

