### PR TITLE
announcement.json ability for student homepage

### DIFF
--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -29,6 +29,7 @@ function showHomepage() {
   const isEnglish = homepageData.isEnglish;
   const announcementOverride = homepageData.announcement;
   const specialAnnouncement = homepageData.specialAnnouncement;
+  const studentSpecialAnnouncement = homepageData.studentSpecialAnnouncement;
   const query = queryString.parse(window.location.search);
   registerReducers({locales, mapbox: mapboxReducer, currentUser});
   const store = getStore();
@@ -134,6 +135,7 @@ function showHomepage() {
             showDeprecatedCalcAndEvalWarning={
               homepageData.showDeprecatedCalcAndEvalWarning
             }
+            specialAnnouncement={studentSpecialAnnouncement}
           />
         )}
       </div>

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 import HeaderBanner from '../HeaderBanner';
-import SpecialAnnouncement from './SpecialAnnouncement';
 import RecentCourses from './RecentCourses';
 import JoinSectionArea from '@cdo/apps/templates/studioHomepages/JoinSectionArea';
 import ProjectWidgetWithData from '@cdo/apps/templates/projects/ProjectWidgetWithData';
@@ -12,6 +11,7 @@ import ProtectedStatefulDiv from '../ProtectedStatefulDiv';
 import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
 import i18n from '@cdo/locale';
 import $ from 'jquery';
+import MarketingAnnouncementBanner from './MarketingAnnouncementBanner';
 
 export default class StudentHomepage extends Component {
   static propTypes = {
@@ -23,6 +23,7 @@ export default class StudentHomepage extends Component {
     studentId: PropTypes.number.isRequired,
     showVerifiedTeacherWarning: PropTypes.bool,
     showDeprecatedCalcAndEvalWarning: PropTypes.bool,
+    specialAnnouncement: shapes.specialAnnouncement,
   };
 
   componentDidMount() {
@@ -38,6 +39,7 @@ export default class StudentHomepage extends Component {
       hasFeedback,
       showVerifiedTeacherWarning,
       showDeprecatedCalcAndEvalWarning,
+      specialAnnouncement,
     } = this.props;
     const {canViewAdvancedTools, studentId} = this.props;
     // Verify background image works for both LTR and RTL languages.
@@ -60,7 +62,12 @@ export default class StudentHomepage extends Component {
               dismissible={false}
             />
           )}
-          {<SpecialAnnouncement />}
+          {specialAnnouncement && (
+            <MarketingAnnouncementBanner
+              announcement={specialAnnouncement}
+              marginBottom="30px"
+            />
+          )}
           {showVerifiedTeacherWarning && (
             <Notification
               type={NotificationType.failure}

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -19,6 +19,17 @@ describe('StudentHomepage', () => {
     studentId: 123,
     isEnglish: true,
     showVerifiedTeacherWarning: false,
+    specialAnnouncement: {
+      id: 'id',
+      image: '/image',
+      title: 'title',
+      body: 'body',
+      link: '/link',
+      description: 'description',
+      buttonUrl: '/url',
+      buttonText: 'press me',
+      heading: 'heading',
+    },
   };
 
   it('shows a Header Banner that says My Dashboard', () => {
@@ -66,7 +77,7 @@ describe('StudentHomepage', () => {
 
   it('shows the special announcement for all languages', () => {
     const wrapper = shallow(<StudentHomepage {...TEST_PROPS} />);
-    assert(wrapper.find('SpecialAnnouncement').exists());
+    assert(wrapper.find('MarketingAnnouncementBanner').exists());
   });
 
   it('displays a notification for verified teacher permissions if showVerifiedTeacherWarning is true', () => {

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -210,6 +210,7 @@ class HomeController < ApplicationController
       @homepage_data[:isTeacher] = false
       @homepage_data[:sections] = student_sections
       @homepage_data[:studentId] = current_user.id
+      @homepage_data[:studentSpecialAnnouncement] = Announcements.get_localized_announcement_for_page("/student-home")
     end
 
     if current_user.school_donor_name

--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -3,7 +3,8 @@
     "/projects": "coldplay",
     "/certificates": "hoc-more",
     "/courses": "hoc-2023-dance-ai",
-    "/home": "hoc-2023-dance-ai"
+    "/home": "hoc-2023-dance-ai",
+    "/student-home": "hoc-2023-dance-ai"
   },
   "banners": {
     "csleadersprize": {


### PR DESCRIPTION
Allows for studio.code.org/home to use announcement.json for students.

In order to change banner on student homepage, within announcement.json, change the value for the `/student-home` key.
<img width="1792" alt="Screenshot 2023-12-01 at 11 37 53 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/594e23b1-c9e7-4165-8acb-c22343bdb9b3">



## Links

- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?selectedIssue=ACQ-1202)


## Testing story
Local



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
