### PR TITLE
Cleaning up AFE controller and tests to reflect address changes

### DIFF
--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -14,9 +14,9 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
     return head :forbidden unless current_user&.teacher?
 
     # Retrieve the school to fill in address (and other) details
+    afe_params = submit_params
     school = School.find_by(id: afe_params['schoolId'])
 
-    afe_params = submit_params
     submission_body = Services::AFEEnrollment.submit(
       first_name: afe_params['firstName'],
       last_name: afe_params['lastName'],

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -13,8 +13,8 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
   def submit
     return head :forbidden unless current_user&.teacher?
 
-    # Retrieve the school to fill in address (and other) details
     afe_params = submit_params
+    # Retrieve the school to fill in address (and other) details
     school = School.find_by(id: afe_params['schoolId'])
 
     submission_body = Services::AFEEnrollment.submit(

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -13,17 +13,20 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
   def submit
     return head :forbidden unless current_user&.teacher?
 
+    # Retrieve the school to fill in address (and other) details
+    school = School.find_by(id: afe_params['schoolId'])
+
     afe_params = submit_params
     submission_body = Services::AFEEnrollment.submit(
       first_name: afe_params['firstName'],
       last_name: afe_params['lastName'],
       email: afe_params['email'],
       nces_id: afe_params['schoolId'],
-      street_1: afe_params['street1'],
-      street_2: afe_params['street2'],
-      city: afe_params['city'],
-      state: afe_params['state'],
-      zip: afe_params['zip'],
+      street_1: school&.address_line1 || '',
+      street_2: school&.address_line2 || '',
+      city: school&.city || '',
+      state: school&.state || '',
+      zip: school&.zip || '',
       marketing_kit: afe_params['inspirationKit'],
       csta_plus: afe_params['csta'],
       amazon_terms: afe_params['consentAFE'],
@@ -47,7 +50,6 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
 
     # If the teacher requested it, submit to CSTA as well
     if to_bool(afe_params['csta'])
-      school = School.find_by(id: afe_params['schoolId'])
       school_district = school&.school_district
 
       Services::CSTAEnrollment.submit(
@@ -56,11 +58,11 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
         email: afe_params['email'],
         school_district_name: school_district&.name || '',
         school_name: school&.name || '',
-        street_1: afe_params['street1'] || school&.address_line1 || '',
-        street_2: afe_params['street2'] || school&.address_line2 || '',
-        city: afe_params['city'] || school&.city || '',
-        state: afe_params['state'] || school&.state || '',
-        zip: afe_params['zip'] || school&.zip || '',
+        street_1: school&.address_line1 || '',
+        street_2: school&.address_line2 || '',
+        city: school&.city || '',
+        state: school&.state || '',
+        zip: school&.zip || '',
         professional_role: afe_params['primaryProfessionalRole'] || '',
         grades_teaching: afe_params['gradesTeaching'] || '',
         privacy_permission: to_bool(afe_params['consentCSTA'])
@@ -83,12 +85,6 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
 
   PERMITTED_PARAMETERS = [
     *REQUIRED_PARAMETERS,
-    'street1',
-    'street2',
-    'street3',
-    'city',
-    'state',
-    'zip',
     'primaryProfessionalRole',
     'gradesTeaching',
     'consentCSTA'

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -69,6 +69,12 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
       last_name: 'test',
       email: 'test@code.org',
       nces_id: '123456789012',
+      # Will not find an nces_id match: address fields will submit empty
+      street_1: '',
+      street_2: '',
+      city: '',
+      state: '',
+      zip: '',
       marketing_kit: '0',
       csta_plus: '0',
       amazon_terms: '1',
@@ -135,6 +141,12 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
         email: 'test@code.org',
         school_district_name: '',
         school_name: '',
+        # Will not find an nces_id match: address fields will submit empty
+        street_1: '',
+        street_2: '',
+        city: '',
+        state: '',
+        zip: '',
         professional_role: 'test role with space',
         grades_teaching: 'K-5, 6-8, ',
         privacy_permission: true

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -181,36 +181,9 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     assert_equal '', actual_args[:school_district_name]
   end
 
-  test 'sends address info from request if preset' do
-    # This scenario reflects what happens when a teacher signs up for CSTA Plus
-    # and also for the AFE Inspirational Marketing Kit, so we asked the teacher
-    # for a school address as part of the form.
-    school = create :school
-    refute_equal 'example-street-1', school.address_line1
-
-    actual_args = capture_csta_args_for_request(
-      valid_params.merge(
-        'csta' => true,
-        'schoolId' => school.id,
-        'street1' => 'example-street-1',
-        'street2' => 'example-street-2',
-        'city' => 'example-city',
-        'state' => 'Florida',
-        'zip' => 'example-zip'
-      )
-    )
-
-    assert_equal 'example-street-1', actual_args[:street_1]
-    assert_equal 'example-street-2', actual_args[:street_2]
-    assert_equal 'example-city', actual_args[:city]
-    assert_equal 'Florida', actual_args[:state]
-    assert_equal 'example-zip', actual_args[:zip]
-  end
-
-  test 'sends address info from our records if request does not include address' do
-    # This scenario reflects what happens when a teacher signs up for CSTA Plus
-    # but does not opt-in to the AFE Inspirational Marketing Kit, so we don't
-    # ask them for a school address on the client.
+  test 'sends address info from our records if teacher signs up for CSTA Plus or Marketing Kit' do
+    # This scenario reflects what happens when a teacher signs up for CSTA Plus or the AFE
+    # Inspirational Marketing Kit, so we pull their school address information using the nces id.
     school = create :school
 
     actual_args = capture_csta_args_for_request(

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -69,11 +69,6 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
       last_name: 'test',
       email: 'test@code.org',
       nces_id: '123456789012',
-      street_1: 'test street',
-      street_2: 'test street 2',
-      city: 'seattle',
-      state: 'Washington',
-      zip: '98105',
       marketing_kit: '0',
       csta_plus: '0',
       amazon_terms: '1',
@@ -140,11 +135,6 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
         email: 'test@code.org',
         school_district_name: '',
         school_name: '',
-        street_1: 'test street',
-        street_2: 'test street 2',
-        city: 'seattle',
-        state: 'Washington',
-        zip: '98105',
         professional_role: 'test role with space',
         grades_teaching: 'K-5, 6-8, ',
         privacy_permission: true
@@ -191,8 +181,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
         merge(
           'csta' => true,
           'schoolId' => school.id,
-        ).
-        except('street1', 'street2', 'city', 'state', 'zip')
+        )
     )
 
     assert_equal school.address_line1, actual_args[:street_1]
@@ -208,8 +197,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
 
     actual_args = capture_csta_args_for_request(
       valid_params.
-        merge('csta' => true).
-        except('street1', 'street2', 'city', 'state', 'zip')
+        merge('csta' => true)
     )
 
     assert_equal '', actual_args[:street_1]
@@ -290,11 +278,6 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
       'lastName' => 'test',
       'email' => 'test@code.org',
       'schoolId' => '123456789012',
-      'street1' => 'test street',
-      'street2' => 'test street 2',
-      'city' => 'seattle',
-      'state' => 'Washington',
-      'zip' => '98105',
       'inspirationKit' => '0',
       'csta' => '0',
       'consentCSTA' => '0',


### PR DESCRIPTION
This is a followup to the work done in https://github.com/code-dot-org/code-dot-org/pull/55059 and https://github.com/code-dot-org/code-dot-org/pull/55197.

The AFE submission will still require address fields, but we will no longer use a hybrid of user entry + retrieval from our school data based on nces id. Instead, we *only* submit address info we already have, removing the necessity of gathering it on the form. This change reflects that in the controller by removing the optional params, updating the way we retrieve address data, and removing the test that checked it would be submitted correctly if entered on the front end.

Testing strategy: There is already a test for this functionality. 

However, to ensure this didn't break anything, I was able to test locally that the form still submits, and used 'puts' statements to validate that my form was correctly retrieving my school info even though it's not coming from the form.


## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1207

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
