### PR TITLE
Update the download button on video lightboxes

### DIFF
--- a/pegasus/sites.v3/code.org/views/index_video_reveal.haml
+++ b/pegasus/sites.v3/code.org/views/index_video_reveal.haml
@@ -3,6 +3,18 @@
     outline: 0;
   }
 
+  .download-link {
+    display: inline-block;
+    margin-top: 1rem;
+    font-size: 1rem;
+
+    i::before {
+      color: var(--brand_secondary_default);
+    }
+  }
+
+- icon_download = "fa-solid fa-download"
+
 %div{style: "text-align:right;"}
   =view :video_with_fallback, video_code: video_code, download_path: download_path
 
@@ -10,11 +22,13 @@
     =view :share_buttons, facebook: facebook, twitter: twitter
 
   - unless download_filename.nil_or_empty?
-    %div
+    %div.download-link
+      %i{class: "#{icon_download}"}
       %a{href: "http://s3.amazonaws.com/cdo-videos/#{download_filename}"}
-        %img{width: 34, height: 34, style: "margin-top: 10px;", src: "/images/download_cropped.png", alt: "Download video"}
+        =hoc_s(:call_to_action_download_video)
 
   - unless download_path.nil_or_empty?
-    %div
+    %div.download-link
+      %i{class: "#{icon_download}"}
       %a{href: download_path}
-        %img{width: 34, height: 34, style: "margin-top: 10px;", src: "/images/download_cropped.png", alt: "Download video"}
+        =hoc_s(:call_to_action_download_video)

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -371,6 +371,7 @@
   call_to_action_learn_more_about_ai: "Learn more about AI"
   call_to_action_get_started: "Get started"
   call_to_action_view_our_supporters: "View our supporters"
+  call_to_action_download_video: "Download video"
 
   aria_label_call_to_action_hoc_how_to_educators: "View how-to guide for Educators"
   aria_label_call_to_action_hoc_how_to_companies: "View how-to guide for Companies"


### PR DESCRIPTION
Replaces the download icon with a text link on all video lightboxes (see an example on https://code.org/hourofcode). This improves accessibility and works better with our updated brand styles.

**Jira ticket:** [ACQ-583](https://codedotorg.atlassian.net/browse/ACQ-583)

----

## Before
<img width="600" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/c87c2e3b-669e-4523-9d6a-ce6891c91981">

## After
<img width="600" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/a0ed816f-4d11-474c-a816-c1f7b6fefbfe">