### PR TITLE
Refactor code.org/student/elementary

### DIFF
--- a/pegasus/sites.v3/code.org/public/student/elementary.haml
+++ b/pegasus/sites.v3/code.org/public/student/elementary.haml
@@ -1,11 +1,9 @@
 ---
 title: Computer Science Curriculum for Grades K-5
-theme: responsive
+theme: responsive_full_width
 ---
 
-%link{type: "text/css", href: "/css/learn-carousel.css", rel: "stylesheet"}
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
-%link{href: "/css/generated/student/school-styles.css", rel: "stylesheet"}
 
 %section.no-padding-bottom
   .wrapper

--- a/pegasus/sites.v3/code.org/public/student/elementary.haml
+++ b/pegasus/sites.v3/code.org/public/student/elementary.haml
@@ -7,135 +7,145 @@ theme: responsive
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/student/school-styles.css", rel: "stylesheet"}
 
-%h1
-  =hoc_s(:elemeentary_page_main_title)
-%p{style: "font-size: 20px;"}
-  =hoc_s(:elementary_page_main_description)
+%section.no-padding-bottom
+  .wrapper
+    %h1=hoc_s(:elemeentary_page_main_title)
+    %p.body-one
+      =hoc_s(:elementary_page_main_description)
 
 %section
-  %h2
-    =hoc_s(:middle_high_page_hero_title)
-  %p
-    =hoc_s(:middle_high_page_hero_description)
-  .action-block.action-block--two-col
-    .media-wrapper.col-50
-      %img{src: "/images/houreofcode-students-banner.png", alt: ""}
-    .text-wrapper.col-50
-      %p.overline
-      %h3
-        =hoc_s(:middle_high_page_hero_title)
-      %p.heading-sm
-        =hoc_s(:middle_high_page_hero_description)
-      %a.link-button{href: "https://hourofcode.com/learn"}
-        =hoc_s(:middle_high_page_hourofcode_link)
+  .wrapper
+    %h2
+      =hoc_s(:middle_high_page_hero_title)
+    %p
+      =hoc_s(:middle_high_page_hero_description)
+    .action-block.action-block--two-col
+      .media-wrapper.col-50
+        %img{src: "/images/houreofcode-students-banner.png", alt: ""}
+      .text-wrapper.col-50
+        %p.overline
+        %h3
+          =hoc_s(:middle_high_page_hero_title)
+        %p.heading-sm
+          =hoc_s(:middle_high_page_hero_description)
+        %a.link-button{href: "https://hourofcode.com/learn"}
+          =hoc_s(:middle_high_page_hourofcode_link)
+
 = view :section_divider_line
 
 %section
-  %h2
-    =hoc_s(:elementary_page_own_pace_title)
-  %p
-    =hoc_s(:elementary_page_own_pace_description)
+  .wrapper
+    %h2
+      =hoc_s(:elementary_page_own_pace_title)
+    %p
+      =hoc_s(:elementary_page_own_pace_description)
 
-  .action-block__wrapper.action-block__wrapper--two-col
-    .action-block.action-block--one-col.flex-space-between
-      .content-wrapper
-        %p.overline
-          =hoc_s(:module_age_05_07)
-        %h3
-          =hoc_s(:elementary_page_own_pace_card_title_1)
-        %img{src: "/images/pre-reader-express-course-banner.png", alt: ""}
-        %p
-          =hoc_s(:elementary_page_own_pace_card_description_1)
-      .content-footer
-        %a.link-button{href: "https://studio.code.org/s/pre-express", target: "_blank", rel: "noopener noreferrer"}
-          =hoc_s(:elementary_page_own_pace_link_1)
-    .action-block.action-block--one-col.flex-space-between
-      .content-wrapper
-        %p.overline
-          =hoc_s(:module_age_07_11)
-        %h3
-          =hoc_s(:elementary_page_own_pace_card_title_2)
-        %img{src: "/images/express-course-banner.png", alt: ""}
-        %p
-          =hoc_s(:elementary_page_own_pace_card_description_1)
-      .content-footer
-        %a.link-button{href: "https://studio.code.org/s/express", target: "_blank", rel: "noopener noreferrer"}
-          =hoc_s(:elementary_page_own_pace_link_2)
+    .action-block__wrapper.action-block__wrapper--two-col
+      .action-block.action-block--one-col.flex-space-between
+        .content-wrapper
+          %p.overline
+            =hoc_s(:module_age_05_07)
+          %h3
+            =hoc_s(:elementary_page_own_pace_card_title_1)
+          %img{src: "/images/pre-reader-express-course-banner.png", alt: ""}
+          %p
+            =hoc_s(:elementary_page_own_pace_card_description_1)
+        .content-footer
+          %a.link-button{href: "https://studio.code.org/s/pre-express", target: "_blank", rel: "noopener noreferrer"}
+            =hoc_s(:elementary_page_own_pace_link_1)
+      .action-block.action-block--one-col.flex-space-between
+        .content-wrapper
+          %p.overline
+            =hoc_s(:module_age_07_11)
+          %h3
+            =hoc_s(:elementary_page_own_pace_card_title_2)
+          %img{src: "/images/express-course-banner.png", alt: ""}
+          %p
+            =hoc_s(:elementary_page_own_pace_card_description_1)
+        .content-footer
+          %a.link-button{href: "https://studio.code.org/s/express", target: "_blank", rel: "noopener noreferrer"}
+            =hoc_s(:elementary_page_own_pace_link_2)
+
 = view :section_divider_line
 
 %section
-  %h2
-    =hoc_s(:elementary_page_make_your_own_games_title)
-  .action-block.action-block--two-col
-    .media-wrapper.col-50
-      %img{src: "/images/sprite-lab-banner.png", alt: ""}
-    .text-wrapper.col-50
-      %p.overline
-        =hoc_s(:module_age_07)
-      %h3
-        =hoc_s(:elementary_page_make_your_own_games_card_title_1)
-      %p.heading-sm
-        =hoc_s(:elementary_page_make_your_own_games_card_description_1)
-      %a.link-button{href: "/spritelab"}
-        =hoc_s(:elementary_page_make_your_own_games_link)
+  .wrapper
+    %h2
+      =hoc_s(:elementary_page_make_your_own_games_title)
+    .action-block.action-block--two-col
+      .media-wrapper.col-50
+        %img{src: "/images/sprite-lab-banner.png", alt: ""}
+      .text-wrapper.col-50
+        %p.overline
+          =hoc_s(:module_age_07)
+        %h3
+          =hoc_s(:elementary_page_make_your_own_games_card_title_1)
+        %p.heading-sm
+          =hoc_s(:elementary_page_make_your_own_games_card_description_1)
+        %a.link-button{href: "/spritelab"}
+          =hoc_s(:elementary_page_make_your_own_games_link)
+
 = view :section_divider_line
 
 %section
-  %h2
-    =hoc_s(:middle_high_page_additional_resources_title)
-  %p=hoc_s(:middle_high_page_additional_resources_description)
-  .action-block.action-block--two-col{style: "margin-bottom: 2rem"}
-    .media-wrapper.col-50
-      %img{src: "/images/video-library-banner.png", alt: ""}
-    .text-wrapper.col-50
-      %h3
-        =hoc_s(:middle_high_page_video_library_title)
-      %p.heading-sm
-        =hoc_s(:middle_high_page_video_library_description)
-      %a.link-button{href: "https://code.org/videos"}
-        =hoc_s(:middle_high_page_video_library_link)
-  .action-block.action-block--two-col
-    .media-wrapper.col-50
-      %img{src: "/images/cs-journeys-banner.png", alt: ""}
-    .text-wrapper.col-50
-      %h3
-        =hoc_s(:middle_high_page_cs_journeys_title)
-      %p.heading-sm
-        =hoc_s(:middle_high_page_cs_journeys_description)
-      %a.link-button{href: "https://code.org/beyond"}
-        =hoc_s(:middle_high_page_cs_journeys_link)
+  .wrapper
+    %h2
+      =hoc_s(:middle_high_page_additional_resources_title)
+    %p=hoc_s(:middle_high_page_additional_resources_description)
+    .action-block.action-block--two-col{style: "margin-bottom: 2rem"}
+      .media-wrapper.col-50
+        %img{src: "/images/video-library-banner.png", alt: ""}
+      .text-wrapper.col-50
+        %h3
+          =hoc_s(:middle_high_page_video_library_title)
+        %p.heading-sm
+          =hoc_s(:middle_high_page_video_library_description)
+        %a.link-button{href: "https://code.org/videos"}
+          =hoc_s(:middle_high_page_video_library_link)
+    .action-block.action-block--two-col
+      .media-wrapper.col-50
+        %img{src: "/images/cs-journeys-banner.png", alt: ""}
+      .text-wrapper.col-50
+        %h3
+          =hoc_s(:middle_high_page_cs_journeys_title)
+        %p.heading-sm
+          =hoc_s(:middle_high_page_cs_journeys_description)
+        %a.link-button{href: "https://code.org/beyond"}
+          =hoc_s(:middle_high_page_cs_journeys_link)
+
 = view :section_divider_line
 
 %section
-  %h2
-    =hoc_s(:elementary_page_computer_science_title)
-  %p
-    =hoc_s(:elementary_page_computer_science_description)
+  .wrapper
+    %h2
+      =hoc_s(:elementary_page_computer_science_title)
+    %p
+      =hoc_s(:elementary_page_computer_science_description)
 
-  .action-block__wrapper.action-block__wrapper--two-col
-    .action-block.action-block--one-col.flex-space-between
-      .content-wrapper
-        %p.overline
-          =hoc_s(:module_label_grades)
-          =hoc_s(:module_grade_k_5)
-        %h3
-          =hoc_s(:elementary_page_computer_science_card_title_1)
-        = view :display_video_thumbnail, id: "cs_fundamentals", video_code: "rNIM1fzJ8u0", play_button: 'center', letterbox: 'false'
-        %p
-          =hoc_s(:elementary_page_computer_science_description_1)
-      .content-footer
-        %a.link-button{href: "https://code.org/csf", target: "_blank", rel: "noopener noreferrer"}
-          =hoc_s(:call_to_action_explore_curricula)
-    .action-block.action-block--one-col.flex-space-between
-      .content-wrapper
-        %p.overline
-          =hoc_s(:module_label_grades)
-          =hoc_s(:module_grade_3_5)
-        %h3
-          =hoc_s(:elementary_page_computer_science_card_title_2)
-        = view :display_video_thumbnail, id: "cs_connections", video_code: "GDcKJ1v2W1s", play_button: 'center', letterbox: 'false'
-        %p
-          =hoc_s(:elementary_page_computer_science_description_2)
-      .content-footer
-        %a.link-button{href: "https://code.org/csc", target: "_blank", rel: "noopener noreferrer"}
-          =hoc_s(:call_to_action_explore_curricula)
+    .action-block__wrapper.action-block__wrapper--two-col
+      .action-block.action-block--one-col.flex-space-between
+        .content-wrapper
+          %p.overline
+            =hoc_s(:module_label_grades)
+            =hoc_s(:module_grade_k_5)
+          %h3
+            =hoc_s(:elementary_page_computer_science_card_title_1)
+          = view :display_video_thumbnail, id: "cs_fundamentals", video_code: "rNIM1fzJ8u0", play_button: 'center', letterbox: 'false'
+          %p
+            =hoc_s(:elementary_page_computer_science_description_1)
+        .content-footer
+          %a.link-button{href: "https://code.org/csf", target: "_blank", rel: "noopener noreferrer"}
+            =hoc_s(:call_to_action_explore_curricula)
+      .action-block.action-block--one-col.flex-space-between
+        .content-wrapper
+          %p.overline
+            =hoc_s(:module_label_grades)
+            =hoc_s(:module_grade_3_5)
+          %h3
+            =hoc_s(:elementary_page_computer_science_card_title_2)
+          = view :display_video_thumbnail, id: "cs_connections", video_code: "GDcKJ1v2W1s", play_button: 'center', letterbox: 'false'
+          %p
+            =hoc_s(:elementary_page_computer_science_description_2)
+        .content-footer
+          %a.link-button{href: "https://code.org/csc", target: "_blank", rel: "noopener noreferrer"}
+            =hoc_s(:call_to_action_explore_curricula)

--- a/pegasus/sites.v3/code.org/public/student/elementary.haml
+++ b/pegasus/sites.v3/code.org/public/student/elementary.haml
@@ -116,7 +116,7 @@ theme: responsive
     .action-block.action-block--one-col.flex-space-between
       .content-wrapper
         %p.overline
-          grades
+          =hoc_s(:module_label_grades)
           =hoc_s(:module_grade_k_5)
         %h3
           =hoc_s(:elementary_page_computer_science_card_title_1)
@@ -129,7 +129,7 @@ theme: responsive
     .action-block.action-block--one-col.flex-space-between
       .content-wrapper
         %p.overline
-          grades
+          =hoc_s(:module_label_grades)
           =hoc_s(:module_grade_3_5)
         %h3
           =hoc_s(:elementary_page_computer_science_card_title_2)


### PR DESCRIPTION
Cleaned up the code on https://code.org/student/elementary by:
- Removed unneeded stylesheets
- Updated theme to `responsive_full_width` just in case we need to add a skinny banner in the future 
  - Similar to this: https://github.com/code-dot-org/code-dot-org/pull/54907
- Added `.wrapper` divs to sections to use spacing set by the `design-system-pegasus.scss` stylesheet
- Updated "grades" with `=hoc_s(:module_label_grades)` string

There are negligible aesthetic changes due to these updates so I didn't include a screenshot.

**Jira ticket:** [ACQ-1179](https://codedotorg.atlassian.net/browse/ACQ-1179)

