### PR TITLE
[Blockly] Fix appendSharedFunctions bug

### DIFF
--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -341,8 +341,16 @@ function initializeBlocklyWrapper(blocklyInstance) {
     partitionBlocksByType() {
       // Google Blockly only. Used to load/render certain block types before others.
     },
-    appendSharedFunctions(blocksXml, functionsXml) {
-      return blockUtils.appendNewFunctions(blocksXml, functionsXml);
+    appendSharedFunctions(source, functionsXml) {
+      const isXml = stringIsXml(source);
+      if (isXml) {
+        return blockUtils.appendNewFunctions(source, functionsXml);
+      } else {
+        // CDO Blockly is not equipped to handle json projects, and we will reset the
+        // project to empty in loadBlocksToWorkspace if it is json. So if we see
+        // json here, we just return the json as-is.
+        return source;
+      }
     },
   };
   blocklyWrapper.customBlocks = customBlocks;


### PR DESCRIPTION
We found a bug after [this PR](https://github.com/code-dot-org/code-dot-org/pull/54820) where loading a project in CDO Blockly after it has been loaded in Google Blockly caused a page crash. This is because we were trying to append xml shared functions to a json project. Since we will clear out the source for a json project when we load CDO Blockly (because CDO Blockly does not support all the json project features), we can have a no-op for json projects in `appendSharedFunctions` in `cdoBlocklyWrapper`.

## Links

- jira ticket: [CT-208](https://codedotorg.atlassian.net/browse/CT-208)


## Testing story
Tested locally that we can now switch between json and xml and will see the warning banner instead of a page crash.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
