### PR TITLE
Update Several Minitest stubs to Mocha stubs

### DIFF
--- a/dashboard/legacy/test/middleware/helpers/test_animation_bucket.rb
+++ b/dashboard/legacy/test/middleware/helpers/test_animation_bucket.rb
@@ -118,13 +118,13 @@ class AnimationBucketTest < FilesApiTestBase
       }
     )
 
-    @animation_bucket.s3.stub :list_object_versions, fake_object_versions_response do
-      @animation_bucket.s3.stub :delete_objects, fake_delete_objects_response do
-        err = assert_raises RuntimeError do
-          @animation_bucket.hard_delete_channel_content @channel
-        end
-        assert_match /Error deleting channel content/, err.message
-      end
+    @animation_bucket.s3.stubs(:list_object_versions).returns(fake_object_versions_response)
+    @animation_bucket.s3.stubs(:delete_objects).returns(fake_delete_objects_response)
+    err = assert_raises RuntimeError do
+      @animation_bucket.hard_delete_channel_content @channel
     end
+    assert_match /Error deleting channel content/, err.message
+    @animation_bucket.s3.unstub(:list_object_versions)
+    @animation_bucket.s3.unstub(:delete_objects)
   end
 end

--- a/dashboard/legacy/test/middleware/helpers/test_asset_bucket.rb
+++ b/dashboard/legacy/test/middleware/helpers/test_asset_bucket.rb
@@ -74,13 +74,13 @@ class AssetBucketTest < FilesApiTestBase
       }
     )
 
-    @asset_bucket.s3.stub :list_object_versions, fake_object_versions_response do
-      @asset_bucket.s3.stub :delete_objects, fake_delete_objects_response do
-        err = assert_raises RuntimeError do
-          @asset_bucket.hard_delete_channel_content @channel
-        end
-        assert_match /Error deleting channel content/, err.message
-      end
+    @asset_bucket.s3.stubs(:list_object_versions).returns(fake_object_versions_response)
+    @asset_bucket.s3.stubs(:delete_objects).returns(fake_delete_objects_response)
+    err = assert_raises RuntimeError do
+      @asset_bucket.hard_delete_channel_content @channel
     end
+    assert_match /Error deleting channel content/, err.message
+    @asset_bucket.s3.unstub(:list_object_versions)
+    @asset_bucket.s3.unstub(:delete_objects)
   end
 end

--- a/dashboard/legacy/test/middleware/helpers/test_file_bucket.rb
+++ b/dashboard/legacy/test/middleware/helpers/test_file_bucket.rb
@@ -118,13 +118,13 @@ class FileBucketTest < FilesApiTestBase
       }
     )
 
-    @file_bucket.s3.stub :list_object_versions, fake_object_versions_response do
-      @file_bucket.s3.stub :delete_objects, fake_delete_objects_response do
-        err = assert_raises RuntimeError do
-          @file_bucket.hard_delete_channel_content @channel
-        end
-        assert_match /Error deleting channel content/, err.message
-      end
+    @file_bucket.s3.stubs(:list_object_versions).returns(fake_object_versions_response)
+    @file_bucket.s3.stubs(:delete_objects).returns(fake_delete_objects_response)
+    err = assert_raises RuntimeError do
+      @file_bucket.hard_delete_channel_content @channel
     end
+    assert_match /Error deleting channel content/, err.message
+    @file_bucket.s3.unstub(:list_object_versions)
+    @file_bucket.s3.unstub(:delete_objects)
   end
 end

--- a/dashboard/legacy/test/middleware/helpers/test_library_bucket.rb
+++ b/dashboard/legacy/test/middleware/helpers/test_library_bucket.rb
@@ -101,13 +101,13 @@ class LibraryBucketTest < FilesApiTestBase
       }
     )
 
-    @library_bucket.s3.stub :list_object_versions, fake_object_versions_response do
-      @library_bucket.s3.stub :delete_objects, fake_delete_objects_response do
-        err = assert_raises RuntimeError do
-          @library_bucket.hard_delete_channel_content @channel
-        end
-        assert_match /Error deleting channel content/, err.message
-      end
+    @library_bucket.s3.stubs(:list_object_versions).returns(fake_object_versions_response)
+    @library_bucket.s3.stubs(:delete_objects).returns(fake_delete_objects_response)
+    err = assert_raises RuntimeError do
+      @library_bucket.hard_delete_channel_content @channel
     end
+    assert_match /Error deleting channel content/, err.message
+    @library_bucket.s3.unstub(:list_object_versions)
+    @library_bucket.s3.unstub(:delete_objects)
   end
 end

--- a/dashboard/legacy/test/middleware/helpers/test_source_bucket.rb
+++ b/dashboard/legacy/test/middleware/helpers/test_source_bucket.rb
@@ -103,13 +103,13 @@ class SourceBucketTest < FilesApiTestBase
       }
     )
 
-    @source_bucket.s3.stub :list_object_versions, fake_object_versions_response do
-      @source_bucket.s3.stub :delete_objects, fake_delete_objects_response do
-        err = assert_raises RuntimeError do
-          @source_bucket.hard_delete_channel_content @channel
-        end
-        assert_match /Error deleting channel content/, err.message
-      end
+    @source_bucket.s3.stubs(:list_object_versions).returns(fake_object_versions_response)
+    @source_bucket.s3.stubs(:delete_objects).returns(fake_delete_objects_response)
+    err = assert_raises RuntimeError do
+      @source_bucket.hard_delete_channel_content @channel
     end
+    assert_match /Error deleting channel content/, err.message
+    @source_bucket.s3.unstub(:list_object_versions)
+    @source_bucket.s3.unstub(:delete_objects)
   end
 end

--- a/dashboard/legacy/test/middleware/test_assets.rb
+++ b/dashboard/legacy/test/middleware/test_assets.rb
@@ -425,46 +425,48 @@ class AssetsTest < FilesApiTestBase
     FilesApi.any_instance.stubs(:max_file_size).returns(5)
     FilesApi.any_instance.stubs(:max_app_size).returns(10)
     AssetBucket.any_instance.stubs(:max_resize_size).returns(5)
-    CDO.stub(:newrelic_logging, true) do
-      post_asset_file(@api, "file1.jpg", "1234567890ABC", 'image/jpeg')
-      assert last_response.client_error?, "Error when file is larger than max file size."
+    CDO.stubs(:newrelic_logging).returns(true)
 
-      assert_assets_custom_metric 1, 'FileTooLarge'
+    post_asset_file(@api, "file1.jpg", "1234567890ABC", 'image/jpeg')
+    assert last_response.client_error?, "Error when file is larger than max file size."
 
-      _, filetodelete1 = post_asset_file(@api, "file2.jpg", "1234", 'image/jpeg')
-      assert successful?, "First small file upload is successful."
+    assert_assets_custom_metric 1, 'FileTooLarge'
 
-      assert_assets_custom_metric 1, 'FileTooLarge', 'still only one custom metric recorded'
+    _, filetodelete1 = post_asset_file(@api, "file2.jpg", "1234", 'image/jpeg')
+    assert successful?, "First small file upload is successful."
 
-      _, filetodelete2 = post_asset_file(@api, "file3.jpg", "5678", 'image/jpeg')
-      assert successful?, "Second small file upload is successful."
+    assert_assets_custom_metric 1, 'FileTooLarge', 'still only one custom metric recorded'
 
-      assert_assets_custom_metric 2, 'QuotaCrossedHalfUsed'
-      assert_assets_custom_event 1, 'QuotaCrossedHalfUsed'
+    _, filetodelete2 = post_asset_file(@api, "file3.jpg", "5678", 'image/jpeg')
+    assert successful?, "Second small file upload is successful."
 
-      post_asset_file(@api, "file4.jpg", "ABCD", 'image/jpeg')
-      assert last_response.client_error?, "Error when exceeding max app size."
+    assert_assets_custom_metric 2, 'QuotaCrossedHalfUsed'
+    assert_assets_custom_event 1, 'QuotaCrossedHalfUsed'
 
-      assert_assets_custom_metric 3, 'QuotaExceeded'
-      assert_assets_custom_event 2, 'QuotaExceeded'
+    post_asset_file(@api, "file4.jpg", "ABCD", 'image/jpeg')
+    assert last_response.client_error?, "Error when exceeding max app size."
 
-      assert_newrelic_metrics %w(
-        Custom/FilesApi/FileTooLarge_assets
-        Custom/ListRequests/AssetBucket/BucketHelper.app_size
-        Custom/ListRequests/AssetBucket/BucketHelper.app_size
-        Custom/FilesApi/QuotaCrossedHalfUsed_assets
-        Custom/ListRequests/AssetBucket/BucketHelper.app_size
-        Custom/FilesApi/QuotaExceeded_assets
-      )
+    assert_assets_custom_metric 3, 'QuotaExceeded'
+    assert_assets_custom_event 2, 'QuotaExceeded'
 
-      @api.delete_object(filetodelete1)
-      @api.delete_object(filetodelete2)
+    assert_newrelic_metrics %w(
+      Custom/FilesApi/FileTooLarge_assets
+      Custom/ListRequests/AssetBucket/BucketHelper.app_size
+      Custom/ListRequests/AssetBucket/BucketHelper.app_size
+      Custom/FilesApi/QuotaCrossedHalfUsed_assets
+      Custom/ListRequests/AssetBucket/BucketHelper.app_size
+      Custom/FilesApi/QuotaExceeded_assets
+    )
 
-      assert @api.list_objects.empty?, "No unexpected assets were written to storage."
-    end
+    @api.delete_object(filetodelete1)
+    @api.delete_object(filetodelete2)
+
+    assert @api.list_objects.empty?, "No unexpected assets were written to storage."
+
     FilesApi.any_instance.unstub(:max_file_size)
     FilesApi.any_instance.unstub(:max_app_size)
     AssetBucket.any_instance.unstub(:max_resize_size)
+    CDO.unstub(:newrelic_logging)
   end
 
   def test_assets_resize

--- a/dashboard/legacy/test/middleware/test_tables.rb
+++ b/dashboard/legacy/test/middleware/test_tables.rb
@@ -13,6 +13,16 @@ class TablesTest < Minitest::Test
 
   def setup
     @table_name = '_testTable'
+
+    CDO.stubs(:firebase_name).returns('my-firebase-name')
+    CDO.stubs(:firebase_secret).returns('my-firebase-secret')
+    CDO.stubs(:firebase_channel_id_suffix).returns(TEST_SUFFIX)
+  end
+
+  def teardown
+    CDO.unstub(:firebase_name)
+    CDO.unstub(:firebase_secret)
+    CDO.unstub(:firebase_channel_id_suffix)
   end
 
   # channel id suffix, used by firebase in development and circleci environments
@@ -60,12 +70,6 @@ class TablesTest < Minitest::Test
   end
 
   def export_firebase(table_name = @table_name)
-    CDO.stub(:firebase_name, 'my-firebase-name') do
-      CDO.stub(:firebase_secret, 'my-firebase-secret') do
-        CDO.stub(:firebase_channel_id_suffix, TEST_SUFFIX) do
-          get "/v3/export-firebase-tables/#{@channel_id}/#{table_name}"
-        end
-      end
-    end
+    get "/v3/export-firebase-tables/#{@channel_id}/#{table_name}"
   end
 end

--- a/lib/test/cdo/test_circle_utils.rb
+++ b/lib/test/cdo/test_circle_utils.rb
@@ -7,49 +7,49 @@ class CircleUtilsTest < Minitest::Test
   end
 
   def test_knows_when_tag_is_present
-    CircleUtils.stub :circle_commit_message, 'message [foo]' do
-      assert CircleUtils.tagged? 'foo'
-      refute CircleUtils.tagged? 'bar'
-    end
+    CircleUtils.stubs(:circle_commit_message).returns('message [foo]')
+
+    assert CircleUtils.tagged? 'foo'
+    refute CircleUtils.tagged? 'bar'
   end
 
   def test_tags_are_case_insensitive
-    CircleUtils.stub :circle_commit_message, 'message [Foo]' do
-      assert CircleUtils.tagged? 'foo'
-      assert CircleUtils.tagged? 'Foo'
-      assert CircleUtils.tagged? 'FOO'
-    end
+    CircleUtils.stubs(:circle_commit_message).returns('message [Foo]')
+
+    assert CircleUtils.tagged? 'foo'
+    assert CircleUtils.tagged? 'Foo'
+    assert CircleUtils.tagged? 'FOO'
   end
 
   def test_does_not_see_commit_message_as_a_tag
-    CircleUtils.stub :circle_commit_message, 'message [foo] suffix' do
-      refute CircleUtils.tagged? 'message'
-      refute CircleUtils.tagged? 'suffix'
-    end
+    CircleUtils.stubs(:circle_commit_message).returns('message [foo] suffix')
+
+    refute CircleUtils.tagged? 'message'
+    refute CircleUtils.tagged? 'suffix'
   end
 
   def test_sees_multiple_tags
-    CircleUtils.stub :circle_commit_message, 'message [foo] [bar]' do
-      assert CircleUtils.tagged? 'foo'
-      assert CircleUtils.tagged? 'bar'
-      refute CircleUtils.tagged? 'baz'
-    end
+    CircleUtils.stubs(:circle_commit_message).returns('message [foo] [bar]')
+
+    assert CircleUtils.tagged? 'foo'
+    assert CircleUtils.tagged? 'bar'
+    refute CircleUtils.tagged? 'baz'
   end
 
   def test_multi_word_tags
-    CircleUtils.stub :circle_commit_message, 'message [foo bar]' do
-      # Detects correct word combination
-      assert CircleUtils.tagged? 'foo bar'
-      refute CircleUtils.tagged? 'bar baz'
+    CircleUtils.stubs(:circle_commit_message).returns('message [foo bar]')
 
-      # Is whitespace-agnostic
-      assert CircleUtils.tagged? 'foo   bar'
+    # Detects correct word combination
+    assert CircleUtils.tagged? 'foo bar'
+    refute CircleUtils.tagged? 'bar baz'
 
-      # Is word-order agnostic
-      assert CircleUtils.tagged? 'bar foo'
+    # Is whitespace-agnostic
+    assert CircleUtils.tagged? 'foo   bar'
 
-      # Ignores repeated words (a tag is a Set)
-      assert CircleUtils.tagged? 'foo foo bar bar bar'
-    end
+    # Is word-order agnostic
+    assert CircleUtils.tagged? 'bar foo'
+
+    # Ignores repeated words (a tag is a Set)
+    assert CircleUtils.tagged? 'foo foo bar bar bar'
   end
 end

--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -80,7 +80,13 @@ module SetupTest
     VCR.use_cassette(cassette_name, record: record_mode) do
       PEGASUS_DB.transaction(rollback: :always) do
         DASHBOARD_DB.transaction(rollback: :always) do
+          # Use Minitest#stub here even though we generally prefer Mocha#stubs.
+          # Mocha keeps its stubbing logic simple in an attempt to avoid
+          # overcomplicating tests, but in this case we specifically do need a
+          # dynamic return value, which Mocha does not support.
+          # rubocop:disable CustomCops/PreferMochaStubsToMinitestStub
           AWS::S3.stub(:random, proc {random.bytes(16).unpack1('H*')}, &block)
+          # rubocop:enable CustomCops/PreferMochaStubsToMinitestStub
         end
       end
     end

--- a/shared/test/middleware/helpers/test_storage_id.rb
+++ b/shared/test/middleware/helpers/test_storage_id.rb
@@ -41,13 +41,13 @@ class StorageIdTest < Minitest::Test
 
     # To simulate a race condition, say the storage id for this user is absent
     # the first time we ask, then present the second time.
-    mock_rows = stub('mock rows')
+    mock_rows = mock('mock rows')
     mock_rows.stubs(:first).
       returns(nil).then.
       returns({id: table_storage_id})
 
     # Mock the DB and table, raising an exception on insert.
-    mock_table = stub('user storage ids table')
+    mock_table = mock('user storage ids table')
     mock_table.stubs(:where).with({user_id: table_user_id}).returns(mock_rows).twice
     mock_table.stubs(:insert).with({user_id: table_user_id}).raises(Sequel::UniqueConstraintViolation).once
 


### PR DESCRIPTION
We currently use Mocha for the vast majority of our stubbing needs, but do also have a few instances where we are using Minitest stubs instead. Because this discrepancy can be confusing, we'd like to standardize around one of them, and plan on eventually adding [an automatic warning](https://github.com/code-dot-org/code-dot-org/pull/55172) which should help maintain consistency. In preparation for adding that warning, this PR fixes up the inconsistencies that currently exist, switching from the Minitest-added method [`stub`](https://www.rubydoc.info/gems/minitest/5.15.0/Object#stub-instance_method) to the Mocha-added [`stubs`](https://www.rubydoc.info/gems/mocha/1.1.0/Mocha/ObjectMethods#stubs-instance_method). 

It is worth noting that there are a few things we can do with Minitest stubs that we cannot with Mocha; most notably, dynamic return values and block-scoped overrides. In both cases, I found comments indicating that the Minitest team has considered and rejected these features on the basis that they encourage excessive complexity in tests. I'm personally inclined to agree, and think it is therefore appropriate for us to encourage the use of Mocha by default, and reserve the use of Minitest only for situations where the need is so great that we won't mind adding a directive to ignore the warning, which as of this PR is true for [exactly one instance](https://github.com/code-dot-org/code-dot-org/pull/55298/files?w=1#diff-4ee31726e88fea721e18a82a4959eef843e630abedd66a1ec1c97115460c9819R83-R89). I am curious to know what other folks think, though; **does anyone have concerns about making any of this Minitest-exclusive functionality harder to use?**

Note: several of the fixes also reduced indentation levels; as such, it may be easiest to review [with whitespace changes ignored](https://github.com/code-dot-org/code-dot-org/pull/55298/files?w=1)

## Testing Story

Verified that with these changes in place, the proposed new automatic warning does not identify any places we are using Minitest's `stub`.

## Follow-up work

- https://github.com/code-dot-org/code-dot-org/pull/55172