### PR TITLE
Enable feedback download menu item in more courses

### DIFF
--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -44,6 +44,10 @@ export const getSelectedScriptDescription = state => {
   return getSelectedUnit(state) ? getSelectedUnit(state).description : null;
 };
 
+export const doesCurrentCourseUseFeedback = state => {
+  return !!getSelectedUnit(state)?.is_feedback_enabled;
+};
+
 // Initial state of unitSelectionRedux
 const initialState = {
   scriptId: null,

--- a/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
+++ b/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
@@ -1,6 +1,7 @@
 import {
   SET_SCRIPT,
   getSelectedScriptName,
+  doesCurrentCourseUseFeedback,
 } from '@cdo/apps/redux/unitSelectionRedux';
 
 export const ALL_STUDENT_FILTER = 0;
@@ -1076,14 +1077,6 @@ export const getExportableFeedbackData = state => {
   });
 
   return feedback;
-};
-
-/*
- * Only show feedback option if its CSD and CSP
- * */
-export const doesCurrentCourseUseFeedback = state => {
-  const scriptName = getSelectedScriptName(state) || '';
-  return scriptName.includes('csp') || scriptName.includes('csd');
 };
 
 export const isCurrentScriptCSD = state => {

--- a/apps/test/unit/templates/sectionAssessments/sectionAssessmentsReduxTest.js
+++ b/apps/test/unit/templates/sectionAssessments/sectionAssessmentsReduxTest.js
@@ -28,7 +28,6 @@ import sectionAssessments, {
   getCurrentQuestion,
   getStudentAnswersForCurrentQuestion,
   setFeedback,
-  doesCurrentCourseUseFeedback,
   getExportableFeedbackData,
   isCurrentScriptCSD,
   notStartedFakeTimestamp,
@@ -182,7 +181,7 @@ describe('sectionAssessmentsRedux', () => {
   });
 
   describe('getCurrentScriptAssessmentList', () => {
-    it('gets a list of assessments - script is not csd or csp', () => {
+    it('gets a list of assessments - teacher feedback disabled', () => {
       const rootState = {
         unitSelection: {
           scriptId: 123,
@@ -190,7 +189,7 @@ describe('sectionAssessmentsRedux', () => {
             {
               id: 321,
               name: 'fake-name',
-              units: [{id: 123, key: 'csf'}],
+              units: [{id: 123, key: 'csx', is_feedback_enabled: false}],
             },
           ],
         },
@@ -220,7 +219,7 @@ describe('sectionAssessmentsRedux', () => {
       assert.deepEqual(result[2], {id: 9, name: 'Survey 9'});
     });
 
-    it('gets a list of assessments - script is csd or csp', () => {
+    it('gets a list of assessments - teacher feedback enabled', () => {
       const rootState = {
         unitSelection: {
           scriptId: 123,
@@ -228,7 +227,7 @@ describe('sectionAssessmentsRedux', () => {
             {
               id: 321,
               name: 'fake-name',
-              units: [{id: 123, key: 'csd'}],
+              units: [{id: 123, key: 'csx', is_feedback_enabled: true}],
             },
           ],
         },
@@ -758,36 +757,6 @@ describe('sectionAssessmentsRedux', () => {
           },
         };
         const result = isCurrentScriptCSD(state);
-        assert.deepEqual(result, false);
-      });
-    });
-
-    describe('doesCurrentCourseUseFeedback', () => {
-      it('returns true when the current script is CSD or CSP', () => {
-        const state = {
-          ...rootState,
-          unitSelection: {
-            scriptId: 2,
-            coursesWithProgress: [
-              {id: 321, name: 'fake-name', units: [{id: 2, key: 'csd'}]},
-            ],
-          },
-        };
-        const result = doesCurrentCourseUseFeedback(state);
-        assert.deepEqual(result, true);
-      });
-
-      it('returns false when the current script is not CSD or CSP', () => {
-        const state = {
-          ...rootState,
-          unitSelection: {
-            scriptId: 2,
-            coursesWithProgress: [
-              {id: 321, name: 'fake-name', units: [{id: 2, key: 'csf'}]},
-            ],
-          },
-        };
-        const result = doesCurrentCourseUseFeedback(state);
         assert.deepEqual(result, false);
       });
     });

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -199,6 +199,8 @@ class Unit < ApplicationRecord
 
   UNIT_DIRECTORY = "#{Rails.root}/config/scripts".freeze
 
+  TEACHER_FEEDBACK_INITIATIVES = %w(CSF CSC CSD CSP CSA).freeze
+
   def prevent_course_version_change?
     resources.any? ||
       student_resources.any? ||
@@ -1908,7 +1910,7 @@ class Unit < ApplicationRecord
 
   private def teacher_feedback_enabled?
     initiative = get_course_version&.course_offering&.marketing_initiative
-    %w(CSF CSC CSD CSP CSA).include? initiative
+    TEACHER_FEEDBACK_INITIATIVES.include? initiative
   end
 
   def summarize_for_assignment_dropdown

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1901,8 +1901,14 @@ class Unit < ApplicationRecord
       version_year: version_year,
       name: launched? ? localized_title : localized_title + " *",
       position: unit_group_units&.first&.position,
-      description: localized_description ? Services::MarkdownPreprocessor.process(localized_description) : nil
+      description: localized_description ? Services::MarkdownPreprocessor.process(localized_description) : nil,
+      is_feedback_enabled: teacher_feedback_enabled?
     }
+  end
+
+  private def teacher_feedback_enabled?
+    initiative = get_course_version&.course_offering&.marketing_initiative
+    %w(CSF CSC CSD CSP CSA).include? initiative
   end
 
   def summarize_for_assignment_dropdown

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -1242,6 +1242,26 @@ class UnitTest < ActiveSupport::TestCase
     assert_equal expected_announcements, summary[:announcements]
   end
 
+  test 'summarize_for_unit_selector determines whether feedback is enabled' do
+    course_version = create :course_version, :with_unit
+    course_offering = course_version.course_offering
+    course_offering.update!(marketing_initiative: 'CSD')
+    unit = course_version.content_root
+    summary = unit.summarize_for_unit_selector
+    assert summary[:is_feedback_enabled]
+
+    course_offering.update!(marketing_initiative: 'HOC')
+    unit.reload
+    summary = unit.summarize_for_unit_selector
+    refute summary[:is_feedback_enabled]
+
+    # no course version means no feedback
+    unit = create :script
+    refute unit.get_course_version
+    summary = unit.summarize_for_unit_selector
+    refute summary[:is_feedback_enabled]
+  end
+
   test 'should generate PLC objects for migrated unit' do
     i18n = {
       'en' => {


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/TEACH-720 . A user reported that the link to download all feedback for a course was missing. the issue was that this had previously only been enabled for units with "csd" and "csp" in the name, e.g. `csd1-2023` but not modular csd courses like `interactive-games-animations`. After some discussion, the resolution was to enable feedback download for all courses under marketing initiatives CSF, CSC, CSD, CSP, and CSA, which this PR does.

## screenshots

### before

problem as reported in zendesk:

<img width="750" alt="All_Feedback" src="https://github.com/code-dot-org/code-dot-org/assets/8001765/bdfe8679-3342-4339-9bff-07664d061c00">

### after

`interactive-games-animations` now shows the menu item:

* ![Screenshot 2023-12-05 at 2 52 17 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/e99892c0-da67-4e7c-bdcb-940539a0c70b)

HOC courses still don't show the menu item, but for a different reason:
* ![Screenshot 2023-12-04 at 4 36 48 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/598c2e55-51ea-4f6f-b283-9be8aae8dec1)

I didn't see any good test cases for units that do have assessments and should not have feedback enabled, but I did highlight in the previous screenshot where you can see that the right data is getting passed to the frontend indicating that feedback should be disabled.

## Testing story

added / updated unit tests
