### PR TITLE
[Google Blockly] CT-191: Replicate logic for xmlToBlocks

### DIFF
--- a/apps/src/blockly/addons/cdoGenerator.js
+++ b/apps/src/blockly/addons/cdoGenerator.js
@@ -10,7 +10,7 @@ export default function initializeGenerator(blocklyWrapper) {
   // so that our code generation logic still works with Google Blockly
   blocklyWrapper.Generator.xmlToBlocks = function (name, xml) {
     var div = document.createElement('div');
-    var blockSpace = Blockly.BlockSpace.createReadOnlyBlockSpace(div, xml, {
+    var blockSpace = blocklyWrapper.createEmbeddedWorkspace(div, xml, {
       disableEventBindings: true,
     });
     return blockSpace.getTopBlocks(true);

--- a/apps/src/blockly/addons/cdoGenerator.js
+++ b/apps/src/blockly/addons/cdoGenerator.js
@@ -9,8 +9,8 @@ export default function initializeGenerator(blocklyWrapper) {
   // This function was a custom addition in CDO Blockly, so we need to add it here
   // so that our code generation logic still works with Google Blockly
   blocklyWrapper.Generator.xmlToBlocks = function (name, xml) {
-    var div = document.createElement('div');
-    var workspace = blocklyWrapper.createEmbeddedWorkspace(div, xml, {
+    const div = document.createElement('div');
+    const workspace = blocklyWrapper.createEmbeddedWorkspace(div, xml, {
       disableEventBindings: true,
     });
     return workspace.getTopBlocks(true);

--- a/apps/src/blockly/addons/cdoGenerator.js
+++ b/apps/src/blockly/addons/cdoGenerator.js
@@ -10,10 +10,10 @@ export default function initializeGenerator(blocklyWrapper) {
   // so that our code generation logic still works with Google Blockly
   blocklyWrapper.Generator.xmlToBlocks = function (name, xml) {
     var div = document.createElement('div');
-    var blockSpace = blocklyWrapper.createEmbeddedWorkspace(div, xml, {
+    var workspace = blocklyWrapper.createEmbeddedWorkspace(div, xml, {
       disableEventBindings: true,
     });
-    return blockSpace.getTopBlocks(true);
+    return workspace.getTopBlocks(true);
   };
 
   // This function was a custom addition in CDO Blockly, so we need to add it here

--- a/apps/src/blockly/addons/cdoGenerator.js
+++ b/apps/src/blockly/addons/cdoGenerator.js
@@ -8,6 +8,16 @@ export default function initializeGenerator(blocklyWrapper) {
 
   // This function was a custom addition in CDO Blockly, so we need to add it here
   // so that our code generation logic still works with Google Blockly
+  blocklyWrapper.Generator.xmlToBlocks = function (name, xml) {
+    var div = document.createElement('div');
+    var blockSpace = Blockly.BlockSpace.createReadOnlyBlockSpace(div, xml, {
+      disableEventBindings: true,
+    });
+    return blockSpace.getTopBlocks(true);
+  };
+
+  // This function was a custom addition in CDO Blockly, so we need to add it here
+  // so that our code generation logic still works with Google Blockly
   blocklyWrapper.Generator.blockSpaceToCode = function (name, opt_typeFilter) {
     const generator = blocklyWrapper.getGenerator();
     generator.init(blocklyWrapper.mainBlockSpace);


### PR DESCRIPTION
⚠️ Removed warning because the base is staging-next. 

During the bug bash, we discovered some levels where the page crashed with the error `Unhandled Promise Rejection: Blockly.Generator.xmlToBlocks is not a function`. The `xmlToBlocks` function is called at https://github.com/code-dot-org/code-dot-org/blob/ed7567cd1157b0f42efcbb4d339f4ed058139047/apps/src/StudioApp.js#L2003 where we support initialization blocks. @mikeharv found that there are 16 Sprite Lab levels that include <initialization_blocks>, and most are not in published scripts.

## Links

Ticket: https://codedotorg.atlassian.net/browse/CT-191

## Testing story

Confirmed the broken level from the bug bash loads.

Local: http://localhost-studio.code.org:3000/s/code-break-younger/lessons/5/levels/3?blocklyVersion=google
Prod: https://studio.code.org:3000/s/code-break-younger/lessons/5/levels/3?blocklyVersion=google

<img width="1372" alt="Screenshot 2023-12-04 at 10 53 12 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/9a5b965c-ea25-4a35-a8da-82de8be009c6">

(Note: This level is meant to be blank.)

## Follow-up work

Other missing generator functions will be tackled in future labs, ex. Maze throws a similar error `Blockly.Generator.blocksToCode is not a function`. However, adding `blocksToCode` significantly increases the amount of functionality we need to add, so I think this is best addressed as a follow-up task. 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
