### PR TITLE
[Google Blockly] Force `when_run` blocks to be undeletable

### DIFF
--- a/apps/src/blockly/addons/cdoBlockSerializer.js
+++ b/apps/src/blockly/addons/cdoBlockSerializer.js
@@ -1,5 +1,5 @@
 import GoogleBlockly from 'blockly/core';
-import {PROCEDURE_DEFINITION_TYPES} from '../constants';
+import {BLOCK_TYPES, PROCEDURE_DEFINITION_TYPES} from '../constants';
 import {partitionBlocksByType} from './cdoUtils';
 
 const unknownBlockState = {type: 'unknown', enabled: false};
@@ -30,6 +30,9 @@ export default class CdoBlockSerializer extends GoogleBlockly.serialization
           blockState.movable = !Blockly.useModalFunctionEditor;
           // Ensure that procedure definitions are editable.
           blockState.editable = true;
+        } else if (blockState.type === BLOCK_TYPES.whenRun) {
+          // Ensures that when run blocks cannot be deleted.
+          blockState.deletable = false;
         }
         GoogleBlockly.serialization.blocks.append(blockState, workspace, {
           recordUndo: Blockly.Events.getRecordUndo(),

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -1,4 +1,4 @@
-import {PROCEDURE_DEFINITION_TYPES} from '../constants';
+import {BLOCK_TYPES, PROCEDURE_DEFINITION_TYPES} from '../constants';
 import {partitionBlocksByType} from './cdoUtils';
 import {readBooleanAttribute} from '../utils';
 
@@ -57,9 +57,14 @@ export default function initializeBlocklyXml(blocklyWrapper) {
     //  the rendered blocks and the coordinates in an array so that we can
     //  position them.
     partitionedBlockElements.forEach(xmlChild => {
+      // Recursively check blocks for XML attributes that need to be manipulated.
       processBlockAndChildren(xmlChild);
+
+      // Further manipulate the XML for specific top block types.
       addMutationToBehaviorDefBlocks(xmlChild);
       addMutationToMiniToolboxBlocks(xmlChild);
+      makeWhenRunUndeletable(xmlChild);
+
       const blockly_block = Blockly.Xml.domToBlock(xmlChild, workspace);
       const x = parseInt(xmlChild.getAttribute('x'), 10);
       const y = parseInt(xmlChild.getAttribute('y'), 10);
@@ -112,6 +117,18 @@ export function addMutationToMiniToolboxBlocks(blockElement) {
 }
 
 /**
+ * Sets the deletable attribute on when_run blocks to false.
+ *
+ * @param {Element} blockElement - The XML element for a single block.
+ */
+export function makeWhenRunUndeletable(blockElement) {
+  if (blockElement.getAttribute('type') !== BLOCK_TYPES.whenRun) {
+    return;
+  }
+  blockElement.setAttribute('deletable', false);
+}
+
+/**
  * Adds a mutation element to a block if it is a behavior definition.
  * CDO Blockly uses an unsupported method for serializing state
  * where arbitrary XML attributes could hold important information.
@@ -121,7 +138,7 @@ export function addMutationToMiniToolboxBlocks(blockElement) {
  * @param {Element} blockElement - The XML element for a single block.
  */
 export function addMutationToBehaviorDefBlocks(blockElement) {
-  if (blockElement.getAttribute('type') !== 'behavior_definition') {
+  if (blockElement.getAttribute('type') !== BLOCK_TYPES.behaviorDefinition) {
     return;
   }
   const mutationElement =


### PR DESCRIPTION
During the recent bug bash Katie F noticed that a `when_run` block could be deleted at: https://studio.code.org/s/coursef-2023/lessons/5/levels/5

Technically, this is a level configuration error rather than a Blockly issue. The block XML is missing the `deletable` attribute and can be deleted using either version of Blockly (Google Blockly's context menu, or using the delete key with CDO/Google Blockly). This potentially affects any number of levels and the curriculum team clarified that the block should never be deletable. We cannot simply find and modify levels in this case because a large number of saved student projects now include the deletable block. Instead, we can flip this property on the block at the time of load. We do this for both XML and JSON pathways to account for both possible saved state formats.

Before:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/9a00630d-e899-42d0-9c49-415f082280ac)

After:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/c3ef6a70-ad63-47ed-862b-7ed12553a614)


## Links

Jira - https://codedotorg.atlassian.net/browse/CT-205


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
