### PR TITLE
Revert "Comment out AFE amplitude events temporarily"

### DIFF
--- a/apps/src/sites/code.org/pages/views/amazon_future_engineer_eligibility.js
+++ b/apps/src/sites/code.org/pages/views/amazon_future_engineer_eligibility.js
@@ -1,6 +1,6 @@
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-//import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-//import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -29,8 +29,7 @@ function showAmazonFutureEngineerEligibility() {
         study: 'amazon-future-engineer-eligibility',
         event: 'start',
       });
-      // TODO: Reenable Amplitude https://codedotorg.atlassian.net/browse/ACQ-1209
-      // analyticsReporter.sendEvent(EVENTS.AFE_START);
+      analyticsReporter.sendEvent(EVENTS.AFE_START);
 
       amazonFutureEngineerEligibilityElements.each(
         (index, amazonFutureEngineerEligibilityElement) => {

--- a/apps/src/templates/DonorTeacherBanner.jsx
+++ b/apps/src/templates/DonorTeacherBanner.jsx
@@ -5,8 +5,8 @@ import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import fontConstants from '@cdo/apps/fontConstants';
 import {putRecord} from '../lib/util/firehose';
-//import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-//import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import color from '../util/color';
 import Button from './Button';
 import i18n from '@cdo/locale';
@@ -37,8 +37,7 @@ export default class DonorTeacherBanner extends Component {
         event: 'submit',
         data_string: $('input[name="nces-id"]').val(),
       });
-      // TODO: Reenable Amplitude https://codedotorg.atlassian.net/browse/ACQ-1209
-      // analyticsReporter.sendEvent(EVENTS.AFE_HOMEPAGE_BANNER_SUBMIT);
+      analyticsReporter.sendEvent(EVENTS.AFE_HOMEPAGE_BANNER_SUBMIT);
 
       // redirect to form on amazon-future-engineer page
       window.location.assign(pegasus('/amazon-future-engineer#sign-up-today'));

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -1,6 +1,6 @@
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-//import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-//import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import React from 'react';
 import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {studio, pegasus} from '@cdo/apps/lib/util/urlHelpers';
@@ -21,8 +21,7 @@ export default class AmazonFutureEngineerAccountConfirmation extends React.Compo
       },
       {callback: () => (window.location = SIGN_UP_URL)}
     );
-    // TODO: Reenable Amplitude https://codedotorg.atlassian.net/browse/ACQ-1209
-    // analyticsReporter.sendEvent(EVENTS.AFE_SIGN_UP_BUTTON_PRESS);
+    analyticsReporter.sendEvent(EVENTS.AFE_SIGN_UP_BUTTON_PRESS);
   };
 
   signInButtonPress = event => {
@@ -35,8 +34,7 @@ export default class AmazonFutureEngineerAccountConfirmation extends React.Compo
       },
       {callback: () => (window.location = SIGN_IN_URL)}
     );
-    // TODO: Reenable Amplitude https://codedotorg.atlassian.net/browse/ACQ-1209
-    // analyticsReporter.sendEvent(EVENTS.AFE_SIGN_IN_BUTTON_PRESS);
+    analyticsReporter.sendEvent(EVENTS.AFE_SIGN_IN_BUTTON_PRESS);
   };
 
   render() {

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -1,6 +1,6 @@
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-//import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-//import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {FormGroup, Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
@@ -92,8 +92,7 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
       study: 'amazon-future-engineer-eligibility',
       event: 'submit_school_info',
     });
-    // TODO: Reenable Amplitude https://codedotorg.atlassian.net/browse/ACQ-1209
-    // analyticsReporter.sendEvent(EVENTS.AFE_SUBMIT_SCHOOL_INFO);
+    analyticsReporter.sendEvent(EVENTS.AFE_SUBMIT_SCHOOL_INFO);
 
     if (this.state.formData.schoolId === '-1') {
       this.handleEligibility(false);
@@ -171,8 +170,7 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
         },
         {callback: () => (window.location = pegasus('/afe/start-codeorg'))}
       );
-      // TODO: Reenable Amplitude https://codedotorg.atlassian.net/browse/ACQ-1209
-      // analyticsReporter.sendEvent(EVENTS.AFE_INELIGIBLE);
+      analyticsReporter.sendEvent(EVENTS.AFE_INELIGIBLE);
     }
   }
 
@@ -186,14 +184,13 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
   };
 
   submitToAFE = () => {
-    // TODO: Reenable Amplitude https://codedotorg.atlassian.net/browse/ACQ-1209
-    /*if (this.props.signedIn && !this.props.isStudentAccount) {
+    if (this.props.signedIn && !this.props.isStudentAccount) {
       analyticsReporter.sendEvent(EVENTS.AFE_SUBMIT, {
         formEmail: this.state.formData.email,
         formSchoolId: this.state.formData.schoolId,
         formData: JSON.stringify(this.state.formData),
       });
-    }*/
+    }
     return fetch('/dashboardapi/v1/amazon_future_engineer_submit', {
       method: 'POST',
       headers: {

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -1,6 +1,6 @@
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-//import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-//import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Button, Checkbox} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
@@ -141,10 +141,9 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
       event: 'continue',
       data_json: JSON.stringify(submitData),
     });
-    // TODO: Reenable Amplitude https://codedotorg.atlassian.net/browse/ACQ-1209
-    /*analyticsReporter.sendEvent(EVENTS.AFE_CONTINUE, {
+    analyticsReporter.sendEvent(EVENTS.AFE_CONTINUE, {
       submitData: JSON.stringify(submitData),
-    });*/
+    });
 
     this.props.updateFormData(submitData);
     this.props.updateFormData(submitData);

--- a/pegasus/sites.v3/code.org/views/amazon_future_engineer.haml
+++ b/pegasus/sites.v3/code.org/views/amazon_future_engineer.haml
@@ -1,1 +1,2 @@
+%script{data: {'amplitude-api-key': CDO.safe_amplitude_api_key}}
 %script{src: webpack_asset_path('js/code.org/views/amazon_future_engineer.js')}

--- a/pegasus/sites.v3/code.org/views/amazon_future_engineer_eligibility.haml
+++ b/pegasus/sites.v3/code.org/views/amazon_future_engineer_eligibility.haml
@@ -5,8 +5,9 @@
   window.dashboard = window.dashboard || {};
   window.dashboard.CODE_ORG_URL = "#{CDO.code_org_url}";
 
--# data needed for dcdo.js
+-# data needed for dcdo.js and amplitude
 %script{data: {'dcdo': DCDO.frontend_config.to_json}}
+%script{data: {'amplitude-api-key': CDO.safe_amplitude_api_key}}
 
 .amazon-future-engineer-eligibility-container
 - js_locale = request.locale.to_s.downcase.tr('-', '_')


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#55157

(The revert removes the commented out Amplitude events.

The second commit is the actual review- adding in the Amplitude API key to the upstream haml files.

Testing:
I no longer see the 'api key missing' message when filling out the form locally. I was able to verify the events send as expected. See photos for examples below.

I believe adding the two keys on those two upstream haml files should cover all cases. All eight events are downstream from the two haml files:

AFE_SIGN_UP_BUTTON_PRESS
AFE_SIGN_IN_BUTTON_PRESS
AFE_START
AFE_CONTINUE
AFE_SUBMIT_SCHOOL_INFO
AFE_INELIGIBLE
AFE_SUBMIT
AFE_HOMEPAGE_BANNER_SUBMIT


<img width="557" alt="Screenshot 2023-12-05 at 12 16 49 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/181e9490-ffb4-4df8-afd9-f4694009a678">
<img width="557" alt="Screenshot 2023-12-05 at 12 25 02 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/cd3bd86d-c3eb-4d5b-8524-f389163768b4">


https://codedotorg.atlassian.net/browse/ACQ-1209
