### PR TITLE
Check if school taught CS based on the latest census

### DIFF
--- a/dashboard/app/models/census/census_summary.rb
+++ b/dashboard/app/models/census/census_summary.rb
@@ -83,4 +83,8 @@ class Census::CensusSummary < ApplicationRecord
 
     census_summaries
   end
+
+  def does_teach?
+    YES? || HISTORICAL_YES?
+  end
 end

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -125,6 +125,11 @@ module Pd::Application
       current_year_index >= 0 ? APPLICATION_YEARS[current_year_index + 1] : nil
     end
 
+    # The census lags by two years, so the census year is the first application year minus 2
+    def census_year
+      application_year.split('-').first.to_i - 1
+    end
+
     # @override
     def set_type_and_year
       self.application_type = TEACHER_APPLICATION
@@ -1076,6 +1081,9 @@ module Pd::Application
             nil
           end
       end
+
+      meets_scholarship_criteria_scores[:not_teaching_in_access_report] =
+        !!Census::CensusSummary.find_by(school_id: school_id, school_year: census_year)&.does_teach? ? NO : YES
 
       update(
         response_scores: response_scores_hash.deep_merge(

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -125,7 +125,7 @@ module Pd::Application
       current_year_index >= 0 ? APPLICATION_YEARS[current_year_index + 1] : nil
     end
 
-    # The census lags by a year years, so the census year is the first application year minus 1
+    # The census lags by a year, so the census year is the first application year minus 1
     # For example, for the 2023-2025 application year, we want to look at 2023 census data
     def census_year
       application_year.split('-').first.to_i - 1

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -1082,8 +1082,13 @@ module Pd::Application
           end
       end
 
+      census_summary = Census::CensusSummary.find_by(school_id: school_id, school_year: census_year)
       meets_scholarship_criteria_scores[:not_teaching_in_access_report] =
-        !!Census::CensusSummary.find_by(school_id: school_id, school_year: census_year)&.does_teach? ? NO : YES
+        if census_summary
+          census_summary.does_teach? ? NO : YES
+        else
+          nil
+        end
 
       update(
         response_scores: response_scores_hash.deep_merge(

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -540,6 +540,7 @@ module Pd::Application
         principal_underrepresented_minority_percent: 50
 
       application = create :pd_teacher_application, form_data_hash: application_hash
+      create :census_summary, school_year: application.census_year, school_id: application.school_id, teaches_cs: Census::CensusSummary::TEACHES[:NO]
       application.auto_score!
 
       assert_equal(
@@ -625,6 +626,7 @@ module Pd::Application
         principal_underrepresented_minority_percent: 50
 
       application = create :pd_teacher_application, form_data_hash: application_hash
+      create :census_summary, school_year: application.census_year, school_id: application.school_id, teaches_cs: Census::CensusSummary::TEACHES[:NO]
       application.auto_score!
 
       assert_equal(
@@ -674,7 +676,7 @@ module Pd::Application
             previous_yearlong_cdo_pd: YES,
           },
           meets_scholarship_criteria_scores: {
-            not_teaching_in_access_report: YES,
+            not_teaching_in_access_report: nil,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -676,7 +676,7 @@ module Pd::Application
             previous_yearlong_cdo_pd: YES,
           },
           meets_scholarship_criteria_scores: {
-            not_teaching_in_access_report: nil,
+            not_teaching_in_access_report: YES,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -966,19 +966,22 @@ module Pd::Application
     test 'meets_scholarship_criteria' do
       application = create :pd_teacher_application
       test_cases = [
-        {underrepresented_minority_percent: YES, free_lunch_percent: YES, verdict: YES},
-        {underrepresented_minority_percent: YES, free_lunch_percent: nil, verdict: YES},
-        {underrepresented_minority_percent: YES, free_lunch_percent: NO, verdict: YES},
-        {underrepresented_minority_percent: nil, free_lunch_percent: YES, verdict: YES},
-        {underrepresented_minority_percent: nil, free_lunch_percent: nil, verdict: REVIEWING_INCOMPLETE},
-        {underrepresented_minority_percent: nil, free_lunch_percent: NO, verdict: REVIEWING_INCOMPLETE},
-        {underrepresented_minority_percent: NO, free_lunch_percent: YES, verdict: YES},
-        {underrepresented_minority_percent: NO, free_lunch_percent: nil, verdict: REVIEWING_INCOMPLETE},
-        {underrepresented_minority_percent: NO, free_lunch_percent: NO, verdict: NO},
+        {underrepresented_minority_percent: YES, free_lunch_percent: YES, not_teaching_in_access_report: YES, verdict: YES},
+        {underrepresented_minority_percent: YES, free_lunch_percent: YES, not_teaching_in_access_report: NO, verdict: YES},
+        {underrepresented_minority_percent: YES, free_lunch_percent: NO, not_teaching_in_access_report: YES, verdict: YES},
+        {underrepresented_minority_percent: NO, free_lunch_percent: YES, not_teaching_in_access_report: YES, verdict: YES},
+        {underrepresented_minority_percent: YES, free_lunch_percent: YES, not_teaching_in_access_report: nil, verdict: YES},
+        {underrepresented_minority_percent: YES, free_lunch_percent: nil, not_teaching_in_access_report: YES, verdict: YES},
+        {underrepresented_minority_percent: nil, free_lunch_percent: YES, not_teaching_in_access_report: YES, verdict: YES},
+        {underrepresented_minority_percent: YES, free_lunch_percent: NO, not_teaching_in_access_report: NO, verdict: YES},
+        {underrepresented_minority_percent: nil, free_lunch_percent: nil, not_teaching_in_access_report: nil, verdict: REVIEWING_INCOMPLETE},
+        {underrepresented_minority_percent: nil, free_lunch_percent: NO, not_teaching_in_access_report: NO, verdict: REVIEWING_INCOMPLETE},
+        {underrepresented_minority_percent: NO, free_lunch_percent: nil, not_teaching_in_access_report: NO, verdict: REVIEWING_INCOMPLETE},
+        {underrepresented_minority_percent: NO, free_lunch_percent: NO, not_teaching_in_access_report: NO, verdict: NO},
       ]
 
       test_cases.each do |test_case|
-        input = test_case.slice(:underrepresented_minority_percent, :free_lunch_percent)
+        input = test_case.slice(:underrepresented_minority_percent, :free_lunch_percent, :not_teaching_in_access_report)
         application.update(response_scores: {meets_scholarship_criteria_scores: input}.to_json)
 
         output = application.meets_scholarship_criteria

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -555,6 +555,7 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: YES,
             underrepresented_minority_percent: YES,
+            not_teaching_in_access_report: YES,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -580,6 +581,7 @@ module Pd::Application
         principal_underrepresented_minority_percent: 50
 
       application = create :pd_teacher_application, form_data_hash: application_hash
+      create :census_summary, school_year: application.census_year, school_id: application.school_id, teaches_cs: Census::CensusSummary::TEACHES[:NO]
       application.auto_score!
 
       assert_equal(
@@ -595,6 +597,7 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: YES,
             underrepresented_minority_percent: YES,
+            not_teaching_in_access_report: YES,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -639,6 +642,7 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: YES,
             underrepresented_minority_percent: YES,
+            not_teaching_in_access_report: YES,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -669,7 +673,9 @@ module Pd::Application
             committed: YES,
             previous_yearlong_cdo_pd: YES,
           },
-          meets_scholarship_criteria_scores: {},
+          meets_scholarship_criteria_scores: {
+            not_teaching_in_access_report: YES,
+          },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
       )
@@ -693,6 +699,7 @@ module Pd::Application
         principal_underrepresented_minority_percent: 49
 
       application = create :pd_teacher_application, form_data_hash: application_hash
+      create :census_summary, school_year: application.census_year, school_id: application.school_id, teaches_cs: Census::CensusSummary::TEACHES[:YES]
       application.auto_score!
 
       assert_equal(
@@ -708,6 +715,7 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: NO,
             underrepresented_minority_percent: NO,
+            not_teaching_in_access_report: NO,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -733,6 +741,7 @@ module Pd::Application
         principal_underrepresented_minority_percent: 49
 
       application = create :pd_teacher_application, form_data_hash: application_hash
+      create :census_summary, school_year: application.census_year, school_id: application.school_id, teaches_cs: Census::CensusSummary::TEACHES[:YES]
       application.auto_score!
 
       assert_equal(
@@ -748,6 +757,7 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: NO,
             underrepresented_minority_percent: NO,
+            not_teaching_in_access_report: NO,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -775,6 +785,7 @@ module Pd::Application
         principal_underrepresented_minority_percent: 49
 
       application = create :pd_teacher_application, form_data_hash: application_hash
+      create :census_summary, school_year: application.census_year, school_id: application.school_id, teaches_cs: Census::CensusSummary::TEACHES[:YES]
       application.auto_score!
 
       assert_equal(
@@ -792,6 +803,7 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: NO,
             underrepresented_minority_percent: NO,
+            not_teaching_in_access_report: NO,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -962,7 +974,7 @@ module Pd::Application
         {underrepresented_minority_percent: nil, free_lunch_percent: NO, verdict: REVIEWING_INCOMPLETE},
         {underrepresented_minority_percent: NO, free_lunch_percent: YES, verdict: YES},
         {underrepresented_minority_percent: NO, free_lunch_percent: nil, verdict: REVIEWING_INCOMPLETE},
-        {underrepresented_minority_percent: NO, free_lunch_percent: NO, verdict: NO}
+        {underrepresented_minority_percent: NO, free_lunch_percent: NO, verdict: NO},
       ]
 
       test_cases.each do |test_case|

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -292,6 +292,7 @@ module Pd
       scholarship_questions: [
         :underrepresented_minority_percent,
         :free_lunch_percent,
+        :not_teaching_in_access_report,
       ],
       criteria_score_questions_csd: [
         :csd_which_grades,


### PR DESCRIPTION
Adds a new scholarship requirement that checks that the teacher's school does not teach computer science according to the last access report. The `CensusSummaries` table has that information and is checked when calling `auto_score!`.

## Links
- [spec](https://docs.google.com/document/d/1q10AMvXibukiMjTwe_sRSgBbH6B4hjUHGs-d_dF_38s/edit)
- [rubric](https://docs.google.com/document/d/1vMGt2u1FExWKjJv9sp3mm7yyp7LalSS4OnRs_tUnEOw/edit#heading=h.sugthxc76yp1)
- [jira](https://codedotorg.atlassian.net/browse/ACQ-371)