### PR TITLE
Make /yourschool "school_name" field editable for non-U.S. countries

### DIFF
--- a/apps/src/templates/census2017/CensusForm.jsx
+++ b/apps/src/templates/census2017/CensusForm.jsx
@@ -394,7 +394,7 @@ class CensusForm extends Component {
                 <input
                   type="text"
                   name="school_name_s"
-                  value={this.state.schoolName}
+                  value={submission.schoolName}
                   onChange={this.handleChange.bind(this, 'schoolName')}
                   style={styles.input}
                 />


### PR DESCRIPTION
Currently, on the [/yourschool](https://code.org/yourschool) page, if a user selects a country other than the U.S. they are shown a single school field to enter their school's name. While the field looks editable, you cannot type anything into it.

When the non-U.S. `schoolName` field is updated, it calls `handleChange` to [update the state's `submission` hash](https://github.com/code-dot-org/code-dot-org/blob/staging-next/apps/src/templates/census2017/CensusForm.jsx#L79-L89) (which contains the `schoolName` value). However, the non-U.S. `schoolName` field's value is [set by `this.state.schoolName`](https://github.com/code-dot-org/code-dot-org/blob/staging-next/apps/src/templates/census2017/CensusForm.jsx#L397), which doesn't exist. This explains why the field doesn't seem editable as every update returns a nil value to populate the field.

This field is instead looking for `this.state.submission.schoolName` (or simply, `submission.schoolName`, as used in the `SchoolNotFound` form's `schoolName` field [right above](https://github.com/code-dot-org/code-dot-org/blob/staging-next/apps/src/templates/census2017/CensusForm.jsx#L379)).

### Previously (in the demo, I'm hitting different letters to try and input something)
https://github.com/code-dot-org/code-dot-org/assets/56283563/d69e53eb-b381-482a-b5eb-baea4b26fabc

### New
https://github.com/code-dot-org/code-dot-org/assets/56283563/50863c72-2d32-4a1f-8c63-7bf4ff7346d8

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-414)

## Testing story
Local testing.
