### PR TITLE
Deflaking tutorial landing pages

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/tutorial_landing_pages.feature
+++ b/dashboard/test/ui/features/hour_of_code/tutorial_landing_pages.feature
@@ -6,7 +6,7 @@ Scenario Outline: Simple page view
   When I open my eyes to test "<test_name>"
   And I am on "<url>"
   And I dismiss the language selector
-  And I wait for 2 seconds
+  And I wait for the video thumbnails to load
   Then I see no difference for "initial load"
   And I close my eyes
   And I sign out
@@ -18,6 +18,4 @@ Examples:
   | http://code.org/athletes                                          | athletes tutorial landing  |
   | http://code.org/educate/applab                                    | app lab tutorial landing   |
   | http://code.org/dance                                             | dance tutorial landing     |
-
-# Disabling temporarily to unblock Test
-#  | http://code.org/oceans                                            | oceans tutorial landing    |
+  | http://code.org/oceans                                            | oceans tutorial landing    |

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -895,7 +895,7 @@ end
 
 Then /^I wait for the video thumbnails to load$/ do
   wait = Selenium::WebDriver::Wait.new(timeout: DEFAULT_WAIT_TIMEOUT)
-  wait.until {@browser.execute_script("Array.from(document.querySelectorAll('img.thumbnail-image')).filter((img) => !img.complete).length == 0;")}
+  wait.until {@browser.execute_script("return Array.from(document.querySelectorAll('img.thumbnail-image')).filter((img) => !img.complete).length == 0;")}
 end
 
 Then /^I see jquery selector (.*)$/ do |selector|

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -893,6 +893,11 @@ Then /^I wait for image "([^"]*)" to load$/ do |selector|
   wait.until {@browser.execute_script("return $('#{selector}').prop('complete');")}
 end
 
+Then /^I wait for the video thumbnails to load$/ do
+  wait = Selenium::WebDriver::Wait.new(timeout: DEFAULT_WAIT_TIMEOUT)
+  wait.until {@browser.execute_script("Array.from(document.querySelectorAll('img.thumbnail-image')).filter((img) => !img.complete).length == 0;")}
+end
+
 Then /^I see jquery selector (.*)$/ do |selector|
   exists = @browser.execute_script("return $(\"#{selector}\").length != 0;")
   expect(exists).to eq(true)


### PR DESCRIPTION
This is a followup attempt based on feedback in https://github.com/code-dot-org/code-dot-org/pull/54533. I opened a new PR because the old one was stale! Shoutout to @davidsbailey and @wilkie for the help on this!

The tutorial landing pages UI tests have given engineers lots of trouble over the past couple months. The flakiness comes from thumbnails failing to load in time for an eyes test, often passing after one (or more) reruns. This PR adds a check that all thumbnail images are 'complete' before moving on to the next step. 

To keep our deploy pipeline moving during the leadup to HOC, I commented out the most troublesome one. This PR reenables it. 


## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1122

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
