### PR TITLE
Fix display of level-specific animations categories

### DIFF
--- a/apps/src/assetManagement/animationLibraryApi.js
+++ b/apps/src/assetManagement/animationLibraryApi.js
@@ -157,13 +157,22 @@ function getStandardizedAliases(metadata) {
 function getStandardizedCategories(metadata) {
   // If the animation doesn't have a category, place it in a section for
   // level-specific/hidden-from-library animations.
-  return metadata.categories || ['level_animations'];
+  // Animations that are level-specific and NOT backgrounds are costumes and
+  // either do not have the `categories` property or have categories assigned to [""]
+  const categories = metadata.categories;
+  const isLevelAnimationCostume =
+    categories === undefined || categories[0] === '';
+  if (isLevelAnimationCostume) {
+    return ['level_animations'];
+  }
+  return categories;
 }
 
 // Generates the json animation manifest for the level_animations folder
 export function generateLevelAnimationsManifest() {
   return getLevelAnimationsFiles().then(files => {
     return buildAnimationMetadata(files).then(animationMetadata => {
+      console.log('animationMetadata', animationMetadata);
       let aliasMap = buildMap(animationMetadata, getStandardizedAliases, null);
 
       let categoryMap = buildMap(

--- a/apps/src/assetManagement/animationLibraryApi.js
+++ b/apps/src/assetManagement/animationLibraryApi.js
@@ -172,7 +172,6 @@ function getStandardizedCategories(metadata) {
 export function generateLevelAnimationsManifest() {
   return getLevelAnimationsFiles().then(files => {
     return buildAnimationMetadata(files).then(animationMetadata => {
-      console.log('animationMetadata', animationMetadata);
       let aliasMap = buildMap(animationMetadata, getStandardizedAliases, null);
 
       let categoryMap = buildMap(

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -146,6 +146,13 @@ export default class AnimationPickerBody extends React.Component {
     if (this.props.hideBackgrounds) {
       categories = categories.filter(category => category !== 'backgrounds');
     }
+    // Library animations have more than 6 categories. Level-specific animations have
+    // fewer than 6 categories. We want to hide the "animals" and "" categories.
+    if (categories.length < 6) {
+      categories = categories.filter(
+        category => category !== '' && category !== 'animals'
+      );
+    }
     categories.push('all');
     return categories.map(category => (
       <AnimationPickerListItem

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -146,26 +146,24 @@ export default class AnimationPickerBody extends React.Component {
     if (this.props.hideBackgrounds) {
       categories = categories.filter(category => category !== 'backgrounds');
     }
-    // Library animations have more than 6 categories. Level-specific animations have
-    // fewer than 6 categories. We want to hide the "animals" and "" categories.
-    if (categories.length < 6) {
-      categories = categories.filter(
-        category => category !== '' && category !== 'animals'
-      );
-    }
     categories.push('all');
-    return categories.map(category => (
-      <AnimationPickerListItem
-        key={category}
-        label={
-          msg[`animationCategory_${category}`]
-            ? msg[`animationCategory_${category}`]()
-            : category
-        }
-        category={category}
-        onClick={this.onCategoryChange}
-      />
-    ));
+
+    return categories.map(category => {
+      let label = msg[`animationCategory_${category}`]
+        ? msg[`animationCategory_${category}`]()
+        : category;
+      if (label === 'Level Animations') {
+        label = 'Costumes'; // This is a more accurate label for level-specific animations that are not backgrounds.
+      }
+      return (
+        <AnimationPickerListItem
+          key={category}
+          label={label}
+          category={category}
+          onClick={this.onCategoryChange}
+        />
+      );
+    });
   }
 
   animationItemsRendering(animations) {
@@ -256,7 +254,11 @@ export default class AnimationPickerBody extends React.Component {
                     {`${msg.animationPicker_allCategories()} > `}
                   </span>
                 )}
-                <span>{msg[`animationCategory_${categoryQuery}`]()}</span>
+                <span>
+                  {categoryQuery !== 'level_animations'
+                    ? msg[`animationCategory_${categoryQuery}`]()
+                    : 'Costumes'}
+                </span>
               </div>
             )}
           </div>

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -147,7 +147,6 @@ export default class AnimationPickerBody extends React.Component {
       categories = categories.filter(category => category !== 'backgrounds');
     }
     categories.push('all');
-
     return categories.map(category => {
       let label = msg[`animationCategory_${category}`]
         ? msg[`animationCategory_${category}`]()


### PR DESCRIPTION
## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
