### PR TITLE
Set up SEO description for marketing pages

### DIFF
--- a/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
+++ b/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
@@ -1,4 +1,8 @@
 - @header['social'].each_pair do |property, content|
+  -# Sets the description name attribute for SEO
+  -# Uses the same og:description from social_metadata.rb
+  - if property == "og:description"
+    %meta{name: "description", content: content}
   %meta{property:property, content:content}
 
 - if @header['noindex']

--- a/pegasus/sites.v3/hourofcode.com/views/theme_common_head_before.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/theme_common_head_before.haml
@@ -1,4 +1,8 @@
 - @header['social'].each_pair do |property, content|
+  -# Sets the description name attribute for SEO
+  -# Uses the same og:description from social_metadata.rb
+  - if property == "og:description"
+    %meta{name: "description", content: content}
   %meta{property:property, content:content}
 
 %meta{name:"viewport", content:"width=device-width, initial-scale=1"}


### PR DESCRIPTION
Adding a meta tag with the `name="description"` attribute to the `<head>` of https://code.org and https://hourofcode.com to improve SEO. 

This is set up to reuse the `description`s set in [/pegasus/src/social_metadata.rb](https://github.com/code-dot-org/code-dot-org/blob/staging-next/pegasus/src/social_metadata.rb).

We currently set OpenGraph meta tags with the [/pegasus/src/social_metadata.rb](https://github.com/code-dot-org/code-dot-org/blob/staging-next/pegasus/src/social_metadata.rb) file, but these tags are not picked up by search engines. Search engines require a `<meta name="description" content="CONTENT HERE">` tag to show a page description in search results (see more about this [here](https://developers.google.com/search/docs/appearance/snippet#meta-descriptions)).

**Relevant files:**
- [/code.org/views/theme_common_head_before.haml](https://github.com/code-dot-org/code-dot-org/blob/bc847dff48083ae8d3ccb91be356d5463138e198/pegasus/sites.v3/code.org/views/theme_common_head_before.haml#L1) - sets the meta tag with the `name="description"` attribute
- [/pegasus/src/social_metadata.rb](https://github.com/code-dot-org/code-dot-org/blob/staging-next/pegasus/src/social_metadata.rb) - uses the same string that's set [here](https://github.com/code-dot-org/code-dot-org/blob/726f233b91a77bc003b2c895da2df0cd2d1e4d51/pegasus/src/social_metadata.rb#L345) (`output["og:description"] = value`)

**Jira ticket:** [ACQ-1100](https://codedotorg.atlassian.net/browse/ACQ-1100)

----

## code.org homepage
<img width="1780" alt="homepage" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/7d18b9b5-fa18-48dd-8367-ce1944c4714c">

## code.org/hourofcode
<img width="1779" alt="hourofcode" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/0b2584d0-8d76-419d-bbe3-7b3215c70ca8">

## hourofcode.com homepage
<img width="1601" alt="Screenshot 2023-12-06 at 9 47 06 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/43d71166-9719-4ff2-a0cf-b91af720d865">
