### PR TITLE
Default storybook deploy on in staging build

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -29,7 +29,7 @@ namespace :build do
       RakeUtils.system "npm run #{npm_target}"
       File.write(commit_hash, calculate_apps_commit_hash)
 
-      if rack_env?(:staging) && DCDO.get('deploy_storybook', false)
+      if rack_env?(:staging) && DCDO.get('deploy_storybook', true)
         ChatClient.log 'Deploying <b>storybook</b>...'
         RakeUtils.system 'npm run storybook:deploy'
       end


### PR DESCRIPTION
We've been deploying Storybook successfully with staging builds with apps changes (several times a day thru most of October, [examples here](https://github.com/code-dot-org/cdo-styleguide/commits/gh-pages?after=8c82a65f9436c2bb22de5859cc99bb9e48e75928+69&branch=gh-pages&qualified_name=refs%2Fheads%2Fgh-pages).

However, the DCDO flag got set to false or removed at some point (no indication in Slack that there was an issue, I wonder if just all staging DCDO flags got reset or something?) I turned it back on last week, and seems to be working fine. This PR sets the deploy to default to happen, but can still be turned off.