### PR TITLE
[Google Blockly] behaviorPicker blocks - add initial behavior value to menu options during loading

### DIFF
--- a/apps/src/blockly/addons/cdoFieldDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldDropdown.js
@@ -20,7 +20,7 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
       // For behavior picker blocks, we need to regenerate menu options each time,
       // in case a behavior has been renamed.
       const useCache = this.name !== 'BEHAVIOR';
-      for (const option of this.getOptions(useCache)) {
+      for (const option of this.getOptions(useCache, newValue)) {
         if (option[1] === newValue) {
           return newValue;
         } else if (option[1] === `"${newValue}"`) {
@@ -41,6 +41,34 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
       }
       return null;
     }
+  }
+
+  /**
+   * Return a list of the options for this dropdown.
+   *
+   * @param useCache For dynamic options, whether or not to use the cached
+   *     options or to re-generate them.
+   * @param {string} newValue The new value to be checked and potentially added
+   *     to the options list (behaviorPicker blocks only).
+   * @returns A non-empty array of option tuples:
+   *     (human-readable text or image, language-neutral name).
+   * @throws {TypeError} If generated options are incorrectly structured.
+   */
+  getOptions(useCache, newValue) {
+    const options = super.getOptions(useCache);
+
+    // Behavior pickers do not populate correctly until the workspace has been loaded.
+    if (this.name === 'BEHAVIOR' && newValue) {
+      // Check whether the initial newValue option already exists
+      const optionExists = options.some(option => option[0] === newValue);
+      // The hidden workspace is created after the main workspace flyout is populated.
+      const loadingFinished = Blockly.getHiddenDefinitionWorkspace();
+      if (!optionExists && !loadingFinished) {
+        // Assume initial value is valid and add it to the menu if not yet present.
+        options.push([newValue, newValue]);
+      }
+    }
+    return options;
   }
 
   /**

--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
@@ -352,8 +352,13 @@ export const blocks = {
   // blocks found on the main workspace.
   getAllBehaviorOptions() {
     const noBehaviorLabel = msg.behaviorsNotFound();
+    const noBehaviorOption = [noBehaviorLabel, NO_OPTIONS_MESSAGE];
     // Behavior definition blocks are always moved to the hidden workspace.
-    const behaviorBlocks = Blockly.getHiddenDefinitionWorkspace()
+    const definitionWorkspace = Blockly.getHiddenDefinitionWorkspace();
+    if (!definitionWorkspace) {
+      return [noBehaviorOption];
+    }
+    const behaviorBlocks = definitionWorkspace
       .getTopBlocks()
       .filter(block => block.type === BLOCK_TYPES.behaviorDefinition);
     // Menu options are an array, each option containing a human-readable part,
@@ -365,7 +370,7 @@ export const blocks = {
     behaviorOptions.sort();
     // Add a "No behaviors found" option, if needed
     if (behaviorOptions.length === 0) {
-      behaviorOptions.push([noBehaviorLabel, NO_OPTIONS_MESSAGE]);
+      behaviorOptions.push(noBehaviorOption);
     }
     return behaviorOptions;
   },


### PR DESCRIPTION
During the recent bug bash, @onlinecsteacher noticed that the level https://studio.code.org/s/csc-bookcovers-2023/lessons/3/levels/9?blocklyVersion=google was crashing due to an error relating to the `menuGenerator` for `behaviorPicker` fields.
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/31a119d2-3c22-41d8-9c33-4da1ff048412)

This was happening due to a timing issue and the specific level configuration: The level's main workspace has a single flyout (uncategorized toolbox) containing the behavior picker block. When this block is rendered, it determines valid options for its dropdown by checking for all behavior definitions (top blocks) on the hidden definition workspace. Unfortunately, Blockly ends up creating the blocks for this flyout before blocks are loaded onto any of the workspaces, so `getHiddenDefinitionWorkspace() was returning `undefined`.

My approach to address this bug consists of two steps:

1. If we don't (yet) have a hidden definition workspace, populate the menu with a single "No behaviors found" option, which is an acceptable default.
2. If we don't (yet) have a hidden definition workspace, assume we are still loading. If that's the case, further assume that the initial field value (set by the levelbuilder) is valid and add it to the list of options, if it doesn't already exist.

The first change happens directly in the menu generator (`getAllBehaviorOptions`). The second change required overriding the field's `getOptions` method, which is what calls the menu generator:

https://github.com/google/blockly/blob/925a7b9723ac46217c64a1842668fd0a66549449/core/field_dropdown.ts#L386-L407

Note: This approach was gut-checked with the Blockly team.

This change makes it so that the level works as expected:
![fluttering](https://github.com/code-dot-org/code-dot-org/assets/43474485/53f1182c-f898-42bf-8e97-3026fffaf08c)

An edge case to consider is what would happen if the block had an invalid initial value. Normally, Blockly gracefully rejects that value and instead uses the first option in the list.  We will no longer follow that flow, but only for blocks that are in (non-runnable) workspaces (ie. flyouts) created before the workspaces containing student code. Once dragged out, the field value is updated to something valid:
![non-existent](https://github.com/code-dot-org/code-dot-org/assets/43474485/02df137b-c4d6-4f97-afd3-99f58570b875)


## Links

See # 22 - https://docs.google.com/document/d/1KGkzjXfUY9_EmYOFLk5mXcknDscFPZKqVz4vhmh5hMY/edit
Jira - https://codedotorg.atlassian.net/browse/CT-200


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
