### PR TITLE
Move join section above projects on student homepage

### DIFF
--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -87,11 +87,11 @@ export default class StudentHomepage extends Component {
             isTeacher={false}
             hasFeedback={hasFeedback}
           />
+          <JoinSectionArea initialJoinedStudentSections={sections} />
           <ProjectWidgetWithData
             canViewFullList={true}
             canViewAdvancedTools={canViewAdvancedTools}
           />
-          <JoinSectionArea initialJoinedStudentSections={sections} />
         </div>
       </div>
     );


### PR DESCRIPTION
When signing in as a student it is more important to be able to see your sections than starting a project (which you can also do through the header with the Create dropdown) so we are switching the order on the page. 

### Before

![Screenshot 2023-11-29 at 12 45 55 PM](https://github.com/code-dot-org/code-dot-org/assets/208083/72bd17ed-f80b-4544-820c-6846ebeba586)


### After

![localhost-studio code org_3000_home](https://github.com/code-dot-org/code-dot-org/assets/208083/9cb1c276-fc14-435a-a2de-2503eba9b067)


### Teacher Homepage not impacted:

![Screenshot 2023-12-07 at 12 38 23 PM](https://github.com/code-dot-org/code-dot-org/assets/208083/2c724d27-1dd2-4fca-9131-a9e61d1fd284)
