### PR TITLE
Add Marketing_ReadOnly role

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -691,8 +691,8 @@ roles.each do |name, config| %>
               - s3:PutObject
               - s3:ListBucket
             Resource: 
-              - arn:aws:s3:::aws-athena-query-results-475661607190-us-east-1/*
-              - arn:aws:s3:::aws-athena-query-results-475661607190-us-east-1
+              - !Sub “arn:aws:s3:::aws-athena-query-results-${AWS::AccountId}-${AWS::Region}/*”
+              - !Sub “arn:aws:s3:::aws-athena-query-results-${AWS::AccountId}-${AWS::Region}”
 
   # Used by FirehoseMicroservice Lambda function.
   # TODO move to Data stack

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -306,7 +306,8 @@ roles = {
     GoogleIdsSSMParameter: 'DeveloperGoogleIDs',
     ManagedPolicyArns: [
       'arn:aws:iam::aws:policy/ReadOnlyAccess',
-      '!Ref DenySecretsPolicy'
+      '!Ref AthenaCloudwatchLogsQueryPolicy',
+      '!Ref DenySecretsPolicy',
     ]
   },
   EngineeringFullAccessRole: {
@@ -348,6 +349,13 @@ roles = {
       '!Ref DataAnalystRedshiftPolicy',
       'arn:aws:iam::aws:policy/AmazonRedshiftQueryEditor',
       'arn:aws:iam::aws:policy/AmazonRedshiftQueryEditorV2FullAccess',
+    ]
+  },
+  MarketingReadOnlyRole: {
+    RoleName: 'Marketing_ReadOnly',
+    ManagedPolicyArns: [
+      'arn:aws:iam::aws:policy/ReadOnlyAccess',
+      '!Ref AthenaCloudwatchLogsQueryPolicy',
     ]
   },
   BillingReadOnlyRole: {
@@ -664,6 +672,27 @@ roles.each do |name, config| %>
       Type: StringList
       Value: initial,value
       Description: List of Google IDs of people being granted billing access.
+
+  AthenaCloudwatchLogsQueryPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: AthenaCloudwatchLogsQueryPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - athena:StartQueryExecution
+              - athena:GetQueryExecution
+            Resource: !Sub 'arn:aws:athena:${AWS::Region}:${AWS::AccountId}:workgroup/primary'
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+              - s3:PutObject
+              - s3:ListBucket
+            Resource: 
+              - arn:aws:s3:::aws-athena-query-results-475661607190-us-east-1/*
+              - arn:aws:s3:::aws-athena-query-results-475661607190-us-east-1
 
   # Used by FirehoseMicroservice Lambda function.
   # TODO move to Data stack

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -684,15 +684,15 @@ roles.each do |name, config| %>
             Action:
               - athena:StartQueryExecution
               - athena:GetQueryExecution
-            Resource: !Sub 'arn:aws:athena:${AWS::Region}:${AWS::AccountId}:workgroup/primary'
+            Resource: !Sub "arn:aws:athena:${AWS::Region}:${AWS::AccountId}:workgroup/primary"
           - Effect: Allow
             Action:
               - s3:GetObject
               - s3:PutObject
               - s3:ListBucket
             Resource: 
-              - !Sub “arn:aws:s3:::aws-athena-query-results-${AWS::AccountId}-${AWS::Region}/*”
-              - !Sub “arn:aws:s3:::aws-athena-query-results-${AWS::AccountId}-${AWS::Region}”
+              - !Sub "arn:aws:s3:::aws-athena-query-results-${AWS::AccountId}-${AWS::Region}/*"
+              - !Sub "arn:aws:s3:::aws-athena-query-results-${AWS::AccountId}-${AWS::Region}"
 
   # Used by FirehoseMicroservice Lambda function.
   # TODO move to Data stack


### PR DESCRIPTION
## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

This access is desired to grant Marketing greater visibility into site traffic than Google Analytics and Amplitude provide.

I'm proposing that this change be deployed Friday 12/8.

## Deployment strategy

Deploy manually via local README

## Follow-up work

Manually add new ARN to appropriate marketing users.

## Privacy

There shouldn't be PII in Athena, or other areas visible to ReadOnly permissions.

## Security

We could iterate on our Athena security by exploring workgroups further. We only have one workgroup today.

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
