### PR TITLE
[Google Blockly] CT-196: Keep initial delete value in extra state and restore on save

### DIFF
--- a/apps/src/blockly/addons/cdoSerializationHelpers.js
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.js
@@ -256,6 +256,11 @@ export const resetEditorWorkspaceBlockConfig = (blocks = []) =>
     block.x = defaultX;
     block.y = defaultY;
     block.movable = true;
+
+    // Since all blocks opened with the function editor are forced to be
+    // undeletable, we need to reset deletable to its initial value
+    // before we save the block data to the project source
+    block.setDeletable(block.extraState?.initialDeleteConfig);
   });
 
 /**

--- a/apps/src/blockly/addons/cdoSerializationHelpers.js
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.js
@@ -260,7 +260,7 @@ export const resetEditorWorkspaceBlockConfig = (blocks = []) =>
     // Since all blocks opened with the function editor are forced to be
     // undeletable, we need to reset deletable to its initial value
     // before we save the block data to the project source
-    block.setDeletable(block.extraState?.initialDeleteConfig);
+    block.deletable = block.extraState?.initialDeleteConfig;
   });
 
 /**

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -2,6 +2,10 @@ import {BLOCK_TYPES, PROCEDURE_DEFINITION_TYPES} from '../constants';
 import {partitionBlocksByType} from './cdoUtils';
 import {FALSEY_DEFAULT, readBooleanAttribute} from '../utils';
 
+// The user created attribute needs to be read from XML start blocks as 'usercreated'.
+// Once this has been done, all subsequent steps in the serialization use userCreated.
+const USER_CREATED_XML_ATTRIBUTE = 'usercreated';
+
 export default function initializeBlocklyXml(blocklyWrapper) {
   // Clear xml namespace
   blocklyWrapper.utils.xml.NAME_SPACE = '';
@@ -156,7 +160,7 @@ export function addMutationToBehaviorDefBlocks(blockElement) {
   // expects this kind of extra state in a mutator.
   const userCreated = readBooleanAttribute(
     blockElement,
-    'usercreated',
+    USER_CREATED_XML_ATTRIBUTE,
     FALSEY_DEFAULT
   );
   mutationElement.setAttribute('userCreated', userCreated);
@@ -194,7 +198,7 @@ export function addMutationToProcedureDefBlocks(blockElement) {
   // expects this kind of extra state in a mutator.
   const userCreated = readBooleanAttribute(
     blockElement,
-    'usercreated',
+    USER_CREATED_XML_ATTRIBUTE,
     FALSEY_DEFAULT
   );
   mutationElement.setAttribute('userCreated', userCreated);

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -173,10 +173,9 @@ export function addMutationToBehaviorDefBlocks(blockElement) {
 
 /**
  * Adds a mutation element to a block if it is a procedure definition.
- * CDO Blockly uses an unsupported method for serializing state
- * where arbitrary XML attributes could hold important information.
- * Mainline Blockly expects a mutator. The presence of the mutation element
- * will trigger the block's domToMutation function to run, if it exists.
+ * Currently, the only reason to have a mutator for procedures is to store
+ * the 'usercreated' property. Behavior definition mutators are more complicated,
+ * see addMutationToBehaviorDefBlocks.
  *
  * @param {Element} blockElement - The XML element for a single block.
  */

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -1,6 +1,6 @@
 import {BLOCK_TYPES, PROCEDURE_DEFINITION_TYPES} from '../constants';
 import {partitionBlocksByType} from './cdoUtils';
-import {readBooleanAttribute} from '../utils';
+import {FALSEY_DEFAULT, readBooleanAttribute} from '../utils';
 
 export default function initializeBlocklyXml(blocklyWrapper) {
   // Clear xml namespace
@@ -153,7 +153,11 @@ export function addMutationToBehaviorDefBlocks(blockElement) {
   // (e.g. shared behaviors).
   // In CDO Blockly, the 'usercreated' flag was set on the block. Google Blockly
   // expects this kind of extra state in a mutator.
-  const userCreated = readBooleanAttribute(blockElement, 'usercreated');
+  const userCreated = readBooleanAttribute(
+    blockElement,
+    'usercreated',
+    FALSEY_DEFAULT
+  );
   mutationElement.setAttribute('userCreated', userCreated);
 
   // In CDO Blockly, behavior ids were stored on the field. Google Blockly

--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -192,7 +192,6 @@ export default class FunctionEditor {
         fields: {
           NAME: procedure.getName(),
         },
-        deletable: false,
       };
 
       this.block = Blockly.serialization.blocks.append(
@@ -200,16 +199,15 @@ export default class FunctionEditor {
         this.editorWorkspace
       );
     }
+    this.block.setDeletable(false);
 
-    const isBehavior = type === BLOCK_TYPES.behaviorDefinition;
-    // We do not want to show the delete button for behaviors that are not user-created
-    const hideDeleteButton = isBehavior && !this.block.userCreated;
+    // We only want to be able to delete things that are user-created (functions and behaviors)
     const modalEditorDeleteButton = document.getElementById(
       MODAL_EDITOR_DELETE_ID
     );
-    modalEditorDeleteButton.style.visibility = hideDeleteButton
-      ? 'hidden'
-      : 'visible';
+    modalEditorDeleteButton.style.visibility = this.block.userCreated
+      ? 'visible'
+      : 'hidden';
 
     // Used to create and render an SVG frame instance.
     const getDefinitionBlockColor = () => {
@@ -218,7 +216,9 @@ export default class FunctionEditor {
 
     this.editorWorkspace.svgFrame_ = new WorkspaceSvgFrame(
       this.editorWorkspace,
-      isBehavior ? msg.behaviorEditorHeader() : msg.function(),
+      type === BLOCK_TYPES.behaviorDefinition
+        ? msg.behaviorEditorHeader()
+        : msg.function(),
       'blocklyWorkspaceSvgFrame',
       getDefinitionBlockColor
     );
@@ -388,6 +388,7 @@ export default class FunctionEditor {
 
     return {
       ...blockConfig,
+      // deletable: false, // TODO: Figure out why this isn't making the block not deletable
       movable: false,
       x,
       y,

--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -202,12 +202,13 @@ export default class FunctionEditor {
     this.block.setDeletable(false);
 
     // We only want to be able to delete things that are user-created (functions and behaviors)
+    const hideDeleteButton = !this.block.userCreated;
     const modalEditorDeleteButton = document.getElementById(
       MODAL_EDITOR_DELETE_ID
     );
-    modalEditorDeleteButton.style.visibility = this.block.userCreated
-      ? 'visible'
-      : 'hidden';
+    modalEditorDeleteButton.style.visibility = hideDeleteButton
+      ? 'hidden'
+      : 'visible';
 
     // Used to create and render an SVG frame instance.
     const getDefinitionBlockColor = () => {

--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -388,7 +388,6 @@ export default class FunctionEditor {
 
     return {
       ...blockConfig,
-      // deletable: false, // TODO: Figure out why this isn't making the block not deletable
       movable: false,
       x,
       y,

--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
@@ -196,7 +196,7 @@ export function flyoutCategory(workspace, functionEditorOpen = false) {
   };
 
   // If the modal function editor is enabled, we render a button to open the editor
-  // Otherwise, we render a "blank" behavior definition block
+  // Behaviors are not editable without the modal editor open
   if (functionEditorOpen) {
     // No-op - cannot create new behaviors while the modal editor is open
   } else if (Blockly.useModalFunctionEditor) {

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorDefMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorDefMutator.js
@@ -81,7 +81,7 @@ export const behaviorDefMutator = {
     this.behaviorId = xmlElement.getAttribute('behaviorId');
     this.userCreated = readBooleanAttribute(
       xmlElement,
-      'userCreated',
+      'usercreated',
       FALSEY_DEFAULT
     );
     const deletableAttribute = readBooleanAttribute(

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorDefMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorDefMutator.js
@@ -10,11 +10,7 @@
  */
 
 import {ObservableParameterModel} from '@blockly/block-shareable-procedures';
-import {
-  FALSEY_DEFAULT,
-  TRUTHY_DEFAULT,
-  readBooleanAttribute,
-} from '@cdo/apps/blockly/utils';
+import {FALSEY_DEFAULT, readBooleanAttribute} from '@cdo/apps/blockly/utils';
 import {
   getBlockDescription,
   setBlockDescription,
@@ -84,12 +80,6 @@ export const behaviorDefMutator = {
       'userCreated',
       FALSEY_DEFAULT
     );
-    const deletableAttribute = readBooleanAttribute(
-      xmlElement,
-      'deletable',
-      TRUTHY_DEFAULT
-    );
-    this.setDeletable(deletableAttribute);
   },
 
   /**
@@ -101,7 +91,6 @@ export const behaviorDefMutator = {
     state['procedureId'] = this.getProcedureModel().getId();
     state['behaviorId'] = this.behaviorId;
     state['userCreated'] = this.userCreated;
-    state['initialDeleteConfig'] = this.isDeletable();
     state['description'] = getBlockDescription(this);
 
     const params = this.getProcedureModel().getParameters();
@@ -158,7 +147,6 @@ export const behaviorDefMutator = {
 
     setBlockDescription(this, state);
     this.doProcedureUpdate();
-    this.setDeletable(state['initialDeleteConfig']);
     this.setStatements_(state['hasStatements'] === false ? false : true);
   },
 

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorDefMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorDefMutator.js
@@ -81,7 +81,7 @@ export const behaviorDefMutator = {
     this.behaviorId = xmlElement.getAttribute('behaviorId');
     this.userCreated = readBooleanAttribute(
       xmlElement,
-      'usercreated',
+      'userCreated',
       FALSEY_DEFAULT
     );
     const deletableAttribute = readBooleanAttribute(

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorDefMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorDefMutator.js
@@ -10,7 +10,11 @@
  */
 
 import {ObservableParameterModel} from '@blockly/block-shareable-procedures';
-import {readBooleanAttribute} from '@cdo/apps/blockly/utils';
+import {
+  FALSEY_DEFAULT,
+  TRUTHY_DEFAULT,
+  readBooleanAttribute,
+} from '@cdo/apps/blockly/utils';
 import {
   getBlockDescription,
   setBlockDescription,
@@ -75,7 +79,17 @@ export const behaviorDefMutator = {
       }
     }
     this.behaviorId = xmlElement.getAttribute('behaviorId');
-    this.userCreated = readBooleanAttribute(xmlElement, 'userCreated');
+    this.userCreated = readBooleanAttribute(
+      xmlElement,
+      'userCreated',
+      FALSEY_DEFAULT
+    );
+    const deletableAttribute = readBooleanAttribute(
+      xmlElement,
+      'deletable',
+      TRUTHY_DEFAULT
+    );
+    this.setDeletable(deletableAttribute);
   },
 
   /**
@@ -87,7 +101,7 @@ export const behaviorDefMutator = {
     state['procedureId'] = this.getProcedureModel().getId();
     state['behaviorId'] = this.behaviorId;
     state['userCreated'] = this.userCreated;
-
+    state['initialDeleteConfig'] = this.isDeletable();
     state['description'] = getBlockDescription(this);
 
     const params = this.getProcedureModel().getParameters();
@@ -143,8 +157,8 @@ export const behaviorDefMutator = {
     }
 
     setBlockDescription(this, state);
-
     this.doProcedureUpdate();
+    this.setDeletable(state['initialDeleteConfig']);
     this.setStatements_(state['hasStatements'] === false ? false : true);
   },
 

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.js
@@ -11,7 +11,11 @@
  */
 
 import {ObservableParameterModel} from '@blockly/block-shareable-procedures';
-import {TRUTHY_DEFAULT, readBooleanAttribute} from '@cdo/apps/blockly/utils';
+import {
+  FALSEY_DEFAULT,
+  TRUTHY_DEFAULT,
+  readBooleanAttribute,
+} from '@cdo/apps/blockly/utils';
 import {
   getBlockDescription,
   setBlockDescription,
@@ -82,6 +86,12 @@ export const procedureDefMutator = {
         this.description = node.textContent;
       }
     }
+
+    this.userCreated = readBooleanAttribute(
+      xmlElement,
+      'usercreated',
+      FALSEY_DEFAULT
+    );
     const deletableAttribute = readBooleanAttribute(
       xmlElement,
       'deletable',
@@ -92,15 +102,15 @@ export const procedureDefMutator = {
   },
 
   /**
-   * Returns the state of this block as a JSON serializable object.
-   * @returns The state of this block, eg the parameters and statements.
+   * Returns a JSON serializable value which represents the extra state of the block.
+   * @returns The state of this block, e.g. the parameters and statements.
    */
   saveExtraState: function () {
     const state = Object.create(null);
-
     state['description'] = getBlockDescription(this);
     state['procedureId'] = this.getProcedureModel().getId();
     state['initialDeleteConfig'] = this.isDeletable();
+    state['userCreated'] = this.userCreated;
 
     const params = this.getProcedureModel().getParameters();
     if (!params.length && this.hasStatements_) return state;
@@ -123,9 +133,8 @@ export const procedureDefMutator = {
   },
 
   /**
-   * Applies the given state to this block.
-   * @param state The state to apply to this block, eg the parameters and
-   *     statements.
+   * Accepts a JSON serializable state value and applies it to the block.
+   * @param state The state to apply to this block (see saveExtraState above).
    */
   loadExtraState: function (state) {
     const map = this.workspace.getProcedureMap();
@@ -156,6 +165,7 @@ export const procedureDefMutator = {
     this.doProcedureUpdate();
     this.setDeletable(state['initialDeleteConfig']);
     this.setStatements_(state['hasStatements'] === false ? false : true);
+    this.userCreated = state['userCreated'];
   },
 
   /**

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.js
@@ -11,11 +11,7 @@
  */
 
 import {ObservableParameterModel} from '@blockly/block-shareable-procedures';
-import {
-  FALSEY_DEFAULT,
-  TRUTHY_DEFAULT,
-  readBooleanAttribute,
-} from '@cdo/apps/blockly/utils';
+import {FALSEY_DEFAULT, readBooleanAttribute} from '@cdo/apps/blockly/utils';
 import {
   getBlockDescription,
   setBlockDescription,
@@ -92,12 +88,6 @@ export const procedureDefMutator = {
       'userCreated',
       FALSEY_DEFAULT
     );
-    const deletableAttribute = readBooleanAttribute(
-      xmlElement,
-      'deletable',
-      TRUTHY_DEFAULT
-    );
-    this.setDeletable(deletableAttribute);
     this.setStatements_(xmlElement.getAttribute('statements') !== 'false');
   },
 

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.js
@@ -89,7 +89,7 @@ export const procedureDefMutator = {
 
     this.userCreated = readBooleanAttribute(
       xmlElement,
-      'usercreated',
+      'userCreated',
       FALSEY_DEFAULT
     );
     const deletableAttribute = readBooleanAttribute(

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.js
@@ -11,6 +11,7 @@
  */
 
 import {ObservableParameterModel} from '@blockly/block-shareable-procedures';
+import {TRUTHY_DEFAULT, readBooleanAttribute} from '@cdo/apps/blockly/utils';
 import {
   getBlockDescription,
   setBlockDescription,
@@ -81,6 +82,12 @@ export const procedureDefMutator = {
         this.description = node.textContent;
       }
     }
+    const deletableAttribute = readBooleanAttribute(
+      xmlElement,
+      'deletable',
+      TRUTHY_DEFAULT
+    );
+    this.setDeletable(deletableAttribute);
     this.setStatements_(xmlElement.getAttribute('statements') !== 'false');
   },
 
@@ -93,6 +100,7 @@ export const procedureDefMutator = {
 
     state['description'] = getBlockDescription(this);
     state['procedureId'] = this.getProcedureModel().getId();
+    state['initialDeleteConfig'] = this.isDeletable();
 
     const params = this.getProcedureModel().getParameters();
     if (!params.length && this.hasStatements_) return state;
@@ -146,6 +154,7 @@ export const procedureDefMutator = {
 
     setBlockDescription(this, state);
     this.doProcedureUpdate();
+    this.setDeletable(state['initialDeleteConfig']);
     this.setStatements_(state['hasStatements'] === false ? false : true);
   },
 

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.js
@@ -163,7 +163,7 @@ export const procedureDefMutator = {
 
     setBlockDescription(this, state);
     this.doProcedureUpdate();
-    this.setDeletable(state['initialDeleteConfig']);
+    this.setDeletable(state['initialDeleteConfig'] === false ? false : true);
     this.setStatements_(state['hasStatements'] === false ? false : true);
     this.userCreated = state['userCreated'];
   },

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -231,6 +231,9 @@ export function flyoutCategory(workspace, functionEditorOpen = false) {
     fields: {
       NAME: Blockly.Msg.PROCEDURES_DEFNORETURN_PROCEDURE,
     },
+    extraState: {
+      userCreated: true,
+    },
   };
 
   if (functionEditorOpen) {

--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
@@ -6,14 +6,14 @@ import {updatePointerBlockImage} from '@cdo/apps/blockly/addons/cdoSpritePointer
 import CdoFieldFlyout from '@cdo/apps/blockly/addons/cdoFieldFlyout';
 import {spriteLabPointers} from '@cdo/apps/p5lab/spritelab/blockly/constants';
 import {blocks as behaviorBlocks} from './behaviorBlocks';
+import {BLOCK_TYPES, NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
+import {FALSEY_DEFAULT, readBooleanAttribute} from '@cdo/apps/blockly/utils';
+import {editButtonHandler} from './proceduresBlocks';
 
 const INPUTS = {
   FLYOUT: 'flyout_input',
   STACK: 'STACK',
 };
-import {BLOCK_TYPES, NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
-import {readBooleanAttribute} from '@cdo/apps/blockly/utils';
-import {editButtonHandler} from './proceduresBlocks';
 
 // This file contains customizations to Google Blockly Sprite Lab blocks.
 export const blocks = {
@@ -174,7 +174,7 @@ export const blocks = {
         // Assume default icon if no XML attribute present
         !xmlElement.hasAttribute('useDefaultIcon') ||
         // Coerce string to Boolean
-        readBooleanAttribute(xmlElement, 'useDefaultIcon');
+        readBooleanAttribute(xmlElement, 'useDefaultIcon', FALSEY_DEFAULT);
       flyoutToggleButton.setIcon(useDefaultIcon);
     };
   },

--- a/apps/src/blockly/utils.js
+++ b/apps/src/blockly/utils.js
@@ -3,8 +3,6 @@ import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
 
 // Considers an attribute true only if it is explicitly set to 'true' (i.e. defaults to false if unset).
 export const FALSEY_DEFAULT = attributeValue => attributeValue === 'true';
-// Considers an attribute true as long as it is not explicitly set to 'false' (i.e. defaults to true if unset).
-export const TRUTHY_DEFAULT = attributeValue => attributeValue !== 'false';
 
 /**
  * Reads a boolean attribute from an XML element and determines its value based on a callback function.

--- a/apps/src/blockly/utils.js
+++ b/apps/src/blockly/utils.js
@@ -1,16 +1,17 @@
 import _ from 'lodash';
 import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
 
-/**
- * Reads a boolean attribute from an XML element.
- * @param {Element} xmlElement - The XML element from which the attribute will be read.
- * @param {string} attribute - The name of the attribute to be read from the XML element.
- * @returns {boolean} True if the attribute value is exactly 'true', otherwise false.
- * If we ever need to return true for unset attributes, we can update this function.
- */
-export function readBooleanAttribute(xmlElement, attribute) {
+export const FALSEY_DEFAULT = attributeValue => attributeValue === 'true';
+export const TRUTHY_DEFAULT = attributeValue => attributeValue !== 'false';
+
+// TODO: Add comment
+export function readBooleanAttribute(
+  xmlElement,
+  attribute,
+  callback = FALSEY_DEFAULT
+) {
   const attributeValue = xmlElement.getAttribute(attribute);
-  return attributeValue === 'true';
+  return callback(attributeValue);
 }
 
 export function capitalizeFirstLetter(string) {

--- a/apps/src/blockly/utils.js
+++ b/apps/src/blockly/utils.js
@@ -1,10 +1,19 @@
 import _ from 'lodash';
 import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
 
+// Considers an attribute true only if it is explicitly set to 'true' (i.e. defaults to false if unset).
 export const FALSEY_DEFAULT = attributeValue => attributeValue === 'true';
+// Considers an attribute true as long as it is not explicitly set to 'false' (i.e. defaults to true if unset).
 export const TRUTHY_DEFAULT = attributeValue => attributeValue !== 'false';
 
-// TODO: Add comment
+/**
+ * Reads a boolean attribute from an XML element and determines its value based on a callback function.
+ * The callback function determines how we interpret the attribute value as a boolean.
+ * @param {Element} xmlElement - The XML element from which to read the attribute.
+ * @param {string} attribute - The name of the attribute to read from the XML element.
+ * @param {function(string): boolean} [callback=FALSEY_DEFAULT] - A callback function that takes the attribute value as a string and returns a boolean.
+ * @returns {boolean} The boolean value of the attribute as determined by the callback function.
+ */
 export function readBooleanAttribute(
   xmlElement,
   attribute,


### PR DESCRIPTION
Issues this PR solves:
- Function definition blocks return to their original deletable state after being opened in the function editor. (Originally, deletable function definition blocks opened in the editor became undeletable.)
- `userCreated` property is the source of truth for the ability to delete a definition block (function or behavior) in the modal editor. This is parity with CDO Blockly.
- `usercreated` values are being appropriately read from XML start blocks for functions and behaviors.
- `deletable` is the source of truth for the ability to delete a function definition block on the main workspace. This is parity with CDO Blockly.
- `deletable` values are being appropriately read from XML start blocks for functions.

Note: Behavior definition blocks are not editable without the modal function editor enabled. This means that behavior definition blocks cannot be deleted from the main workspace and the following cases do not need to be handled.
- The `deletable` need not be read from XML start blocks for behaviors.
- Behavior definition blocks do not need to return to their original deletable state after being opened in the function editor, since opening them on the main workspace is impossible. 
- Since behavior definition blocks are not deletable from the main workspace, `deletable` is not a source of truth for anything with behaviors. 

In the end, here are the XML property combinations and their resultant states.

| Block type            | XML Properties                         | Behavior on main workspace             | Behavior in modal function editor | Notes about this state                                                      |
|-----------------------|----------------------------------------|----------------------------------------|-----------------------------------|------------------------------------------------------------------------------|
| procedure_defnoreturn | usercreated=true<br>deletable=true     | Deletable via drag and select+delete   | Deletable via button only         |     Also covers usercreated=true.                                                                        |
| procedure_defnoreturn | usercreated=true<br>deletable=false    | Not deletable                          | Deletable via button only         | It does not make sense to create a start block with usercreated=true and deletable=false. |
| procedure_defnoreturn | usercreated=false<br>deletable=true<br>or<br>Neither specified | Deletable via drag and select+delete   | Not deletable                    |                         Also covers deletable=true or neither flag specified.                                                     |
| procedure_defnoreturn | usercreated=false<br>deletable=false   | Not deletable                          | Not deletable                    |                                       Also covers deletable=false.                                       |

Behavior definitions follow the same pattern, but only the `usercreated` flag is relevant. 

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/CT-196

## Testing story

Testing journey: Function definition blocks return to their original deletable state after being opened in the function editor. (Originally, deletable function definition blocks opened in the editor became undeletable.)

https://github.com/code-dot-org/code-dot-org/assets/26844240/fcbc63a2-a918-4ae0-a65c-a36c709f2e79

Testing journey: `userCreated` property is the source of truth for the ability to delete a definition block (function or behavior) in the modal editor. This is parity with CDO Blockly.

https://github.com/code-dot-org/code-dot-org/assets/26844240/d5b5fc91-3001-4f7a-9831-833e9e22aa05

<details>
  <summary>Click to toggle XML content</summary>

```xml
<xml>
  <block type="behavior_definition" uservisible="false" deletable="true" usercreated="">
    <mutation>
      <arg name="this sprite" type="Sprite"/>
    </mutation>
    <field name="NAME" id="behaviorDeletableNoUserCreated">behaviorDeletableNoUserCreated</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"cave"</field>
      </block>
    </statement>
  </block>
  <block type="behavior_definition" uservisible="false" deletable="true" usercreated="false">
    <mutation>
      <arg name="this sprite" type="Sprite"/>
    </mutation>
    <field name="NAME" id="behaviorDeletableNotUserCreated">behaviorDeletableNotUserCreated</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"cave"</field>
      </block>
    </statement>
  </block>
  <block type="behavior_definition" uservisible="false" deletable="true" usercreated="true">
    <mutation>
      <arg name="this sprite" type="Sprite"/>
    </mutation>
    <field name="NAME" id="behaviorDeletableUserCreated">behaviorDeletableUserCreated</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"cave"</field>
      </block>
    </statement>
  </block>
  <block type="behavior_definition" deletable="false" uservisible="false" usercreated="false">
    <mutation>
      <arg name="this sprite" type="Sprite"/>
    </mutation>
    <field name="NAME" id="behaviorNotDeletableNotUserCreated">behaviorNotDeletableNotUserCreated</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"cave"</field>
      </block>
    </statement>
  </block>
  <block type="behavior_definition" deletable="false" uservisible="false" usercreated="">
    <mutation>
      <arg name="this sprite" type="Sprite"/>
    </mutation>
    <field name="NAME" id="behaviorNotDeletableNoUserCreated">behaviorNotDeletableNoUserCreated</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"cave"</field>
      </block>
    </statement>
  </block>
  <block type="behavior_definition" deletable="false" uservisible="false" usercreated="true">
    <mutation>
      <arg name="this sprite" type="Sprite"/>
    </mutation>
    <field name="NAME" id="behaviorNotDeletableUserCreated">behaviorNotDeletableUserCreated</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"cave"</field>
      </block>
    </statement>
  </block>
  <block type="behavior_definition" uservisible="false" deletable="">
    <mutation>
      <arg name="this sprite" type="Sprite"/>
    </mutation>
    <field name="NAME" id="noDeletable">noDeletable</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"cave"</field>
      </block>
    </statement>
  </block>
  <block type="procedures_defnoreturn" deletable="false" usercreated="">
    <mutation/>
    <field name="NAME">not deletable no user created</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"floating_grass"</field>
      </block>
    </statement>
  </block>
  <block type="procedures_defnoreturn" deletable="true" usercreated="">
    <mutation/>
    <field name="NAME">deletable no user created</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"floating_grass"</field>
      </block>
    </statement>
  </block>
  <block type="procedures_defnoreturn" deletable="false" usercreated="false">
    <mutation/>
    <field name="NAME">not deletable not user created</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"floating_grass"</field>
      </block>
    </statement>
  </block>
  <block type="procedures_defnoreturn" deletable="true" usercreated="false">
    <mutation/>
    <field name="NAME">deletable not user created</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"floating_grass"</field>
      </block>
    </statement>
  </block>
  <block type="procedures_defnoreturn" deletable="false" usercreated="true">
    <mutation/>
    <field name="NAME">not deletable user created</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"floating_grass"</field>
      </block>
    </statement>
  </block>
  <block type="procedures_defnoreturn" deletable="true" usercreated="true">
    <mutation/>
    <field name="NAME">deletable user created</field>
    <statement name="STACK">
      <block type="gamelab_setBackgroundImageAs">
        <field name="IMG">"floating_grass"</field>
      </block>
    </statement>
  </block>
</details>
```


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
