### PR TITLE
Set Maker skinny banner to full-width

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/maker-skinny-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/maker-skinny-banner.scss
@@ -9,10 +9,10 @@
   position: relative;
 
   @media screen and (max-width: $width-md) {
-    padding: 0 1rem;
+    padding: 0 2rem;
   }
 
-  @media screen and (max-width: $width-sm) {
+  @media screen and (max-width: 546px) {
     height: auto;
     padding: 1rem 2rem;
     margin: 3rem auto 0;
@@ -39,10 +39,11 @@
       padding: 0.5rem 0;
     }
 
-    @media screen and (max-width: $width-sm) {
+    @media screen and (max-width: 546px) {
       justify-content: center;
       width: 100%;
       margin-top: -1rem;
+      gap: 1rem;
     }
   }
 
@@ -53,7 +54,7 @@
       display: none;
     }
 
-    @media screen and (max-width: $width-sm) {
+    @media screen and (max-width: 546px) {
       display: block;
       position: relative;
       top: -8px;
@@ -70,34 +71,35 @@
       right: 0;
     }
 
-    @media screen and (max-width: $width-sm) {
+    @media screen and (max-width: 546px) {
       display: none;
     }
   }
 
   .text-wrapper {
-    color: white;
+    color: var(--neutral_white);
     text-align: center;
+    max-width: 450px;
 
     @media screen and (max-width: $width-md) {
       margin: 0 0 -0.5rem;
       text-align: left;
     }
 
-    @media screen and (max-width: $width-sm) {
+    @media screen and (max-width: 546px) {
       text-align: center;
     }
 
     h1 {
       @include heading-sm;
-      color: $white;
+      color: var(--neutral_white);
       margin: 0 auto 4px;
     }
 
     p {
       @include body-two;
       margin-bottom: 0;
-      color: $white;
+      color: var(--neutral_white);
     }
   }
 
@@ -106,7 +108,7 @@
     border-color: #4E1598;
     margin: 0;
 
-    @media screen and (max-width: $width-sm) {
+    @media screen and (max-width: 546px) {
       margin-top: 1rem;
     }
   }

--- a/pegasus/sites.v3/code.org/public/css/maker-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/maker-styles.scss
@@ -20,12 +20,6 @@ section.device-setup { // /maker/circuitplayground
   }
 }
 
-@media screen and (max-width: $width-sm) {
-  .maker-skinny-banner {
-    margin-top: 0 !important;
-  }
-}
-
 // code.org/maker/index.haml
 section.hero-banner-basic {
   padding: 0 2rem;

--- a/pegasus/sites.v3/code.org/public/maker/circuitplayground.haml
+++ b/pegasus/sites.v3/code.org/public/maker/circuitplayground.haml
@@ -13,10 +13,6 @@ theme: responsive_full_width
 - icon_circle_xmark = "fa-solid fa-circle-xmark"
 - icon_flag = "fa-solid fa-flag-checkered"
 
-%section.skinny-banner.no-padding-bottom
-  .wrapper
-    = view :maker_skinny_banner
-
 %section.intro
   .wrapper
     %h1 The Circuit Playground
@@ -38,6 +34,8 @@ theme: responsive_full_width
       %figure.col-25{style: "margin-top: 2em; text-align: center"}
         %img{src: "/images/maker/circuitplayground-no-bg.gif", alt: ""}
     .clear
+
+= view :maker_skinny_banner
 
 %section.bg-neutral-light.device-setup
   .wrapper

--- a/pegasus/sites.v3/code.org/public/maker/microbit.haml
+++ b/pegasus/sites.v3/code.org/public/maker/microbit.haml
@@ -12,10 +12,6 @@ theme: responsive_full_width
 - icon_circle_check = "fa-solid fa-circle-check"
 - icon_flag = "fa-solid fa-flag-checkered"
 
-%section.skinny-banner.no-padding-bottom
-  .wrapper
-    = view :maker_skinny_banner
-
 %section.intro
   .wrapper
     %h1 The BBC micro:bit
@@ -39,6 +35,8 @@ theme: responsive_full_width
             %h3 Works with App Lab
             %p.no-margin-bottom Using App Lab students can quickly build apps that communicate with external hardware using our block-to-text app development environment.
     .clear
+
+= view :maker_skinny_banner
 
 %section.bg-neutral-light.device-setup
   .wrapper


### PR DESCRIPTION
Set the Maker skinny banner to full-width on the https://code.org/maker/microbit and https://code.org/maker/circuitplayground pages. Previously these were container-width at the top of the pages. 


**Jira ticket:** [ACQ-1278](https://codedotorg.atlassian.net/browse/ACQ-1278)

----

## Desktop
<img width="989" alt="Desktop" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/91cb3059-881b-47d6-9e49-0a572a11ba1d">

## Tablet
<img width="500" alt="Tablet" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/e83ec07d-b181-4438-8226-cb594f5573d6">

## Mobile
<img width="300" alt="Mobile" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/2791e898-669a-4c34-a3a6-b56e96dff2cc">

