### PR TITLE
Temporarily Disable Slack Reporting of `MYSQL_OPT_RECONNECT` Deprecation Warning

### DIFF
--- a/bin/i18n/slack_error
+++ b/bin/i18n/slack_error
@@ -4,5 +4,9 @@ require_relative '../../deployment'
 require 'cdo/chat_client'
 
 ARGF.each_line do |line|
+  # Temporarily ignore this high-volume deprecation warning, until we can
+  # implement alternatives to the deprecated functionality.
+  # TODO: eliminate this warning, and remove this exception
+  next if line.start_with?("WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.")
   ChatClient.log(line, {color: :red})
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/55208, which disabled sending this warning to Honeybadger. We also want to avoid sending it to slack.

## Testing story

@mgc1194 [tested for me](https://codedotorg.slack.com/archives/C03CK49G9/p1702411890472109?thread_ts=1702312257.379689&cid=C03CK49G9); thanks, Mario!