### PR TITLE
Update the secondary brand color purple to pass WCAG AA on code.org (Pegasus) 

### DIFF
--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -12,7 +12,7 @@
   --brand_primary_default: #009EB0;
   --brand_primary_dark: #008291;
   --brand_secondary_light: #E0D1EC;
-  --brand_secondary_default: #9660BF;
+  --brand_secondary_default: #8C52BA;
   --brand_secondary_dark: #6F488E;
   --brand_accent_default: #ED6060;
   --neutral_white: #FFFFFF;

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -146,7 +146,7 @@ $brand_primary_default: #009EB0;
 $brand_primary_dark: #008291;
 
 $brand_secondary_light: #E0D1EC;
-$brand_secondary_default: #9660BF;
+$brand_secondary_default: #8C52BA;
 $brand_secondary_dark: #6F488E;
 
 $brand_accent_default: #ED6060;


### PR DESCRIPTION
Update the secondary brand color purple to improve contrast and pass WCAG AA standards. This will update all instances of the `$brand_secondary_default` (SCSS) and `var(--brand_secondary_default)` (CSS) variables sitewide across https://code.org which includes buttons and text links.  

- Failing color: `#9660BF`
- Passing color: `#8C52BA`
- This should catch everything on [code.org](https://code.org), but [studio.code.org](https://studio.code.org) may still have areas that are not updated.
- See screenshots below for an example of the fix on the https://code.org/teach page:

| Before    | After |
| -------- | ------- |
| <img width="544" alt="Screenshot 2023-12-11 at 2 07 43 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/ca3c7b81-30a1-4c70-bffa-d2b42f6d3fd1"> | <img width="544" alt="Screenshot 2023-12-11 at 2 07 50 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/1f268db2-157d-42a7-bfba-5a237d678a78"> |

**Jira ticket:** [A11Y-263](https://codedotorg.atlassian.net/browse/A11Y-263)

----

## axe DevTools Before
<img width="1752" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/7218132f-852d-4840-84ac-cf63a742d01f">

## axe DevTools After
<img width="1754" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/fe264a54-b15d-4dbc-a552-9e115a00e31d">