### PR TITLE
Set up python lab (try 2)

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -187,6 +187,7 @@ export type AppName =
   | 'studio'
   | 'bounce'
   | 'poetry'
+  | 'pythonlab'
   | 'spritelab'
   | 'standalone_video';
 

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -16,6 +16,7 @@ import ProgressContainer from '../progress/ProgressContainer';
 import {AppName} from '../types';
 import moduleStyles from './lab-views-renderer.module.scss';
 import {DEFAULT_THEME, Theme, ThemeContext} from './ThemeWrapper';
+import PythonlabView from '@cdo/apps/pythonlab/PythonlabView';
 
 // Configuration for how a Lab should be rendered
 interface AppProperties {
@@ -60,6 +61,11 @@ const appsProperties: {[appName in AppName]?: AppProperties} = {
   dance: {
     backgroundMode: false,
     node: <DanceView />,
+    theme: Theme.LIGHT,
+  },
+  pythonlab: {
+    backgroundMode: false,
+    node: <PythonlabView />,
     theme: Theme.LIGHT,
   },
 };

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -1,0 +1,8 @@
+// Pythonlab view
+import React from 'react';
+
+const PythonlabView: React.FunctionComponent = () => {
+  return <div>Welcome to Python lab!</div>;
+};
+
+export default PythonlabView;

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -51,6 +51,7 @@ class LevelsController < ApplicationController
     Pixelation,
     Poetry,
     PublicKeyCryptography,
+    Pythonlab,
     StandaloneVideo,
     StarWarsGrid,
     Studio,
@@ -448,6 +449,8 @@ class LevelsController < ApplicationController
         @game = Game.music
       elsif @type_class == Aichat
         @game = Game.aichat
+      elsif @type_class == Pythonlab
+        @game = Game.pythonlab
       end
       @level = @type_class.new
       render :edit

--- a/dashboard/app/models/game.rb
+++ b/dashboard/app/models/game.rb
@@ -60,6 +60,7 @@ class Game < ApplicationRecord
   POETRY = 'poetry'.freeze
   MUSIC = 'music'.freeze
   AICHAT = 'aichat'.freeze
+  PYTHONLAB = 'pythonlab'.freeze
 
   def self.bounce
     @@game_bounce ||= find_by_name("Bounce")
@@ -189,6 +190,10 @@ class Game < ApplicationRecord
     @@game_aichat ||= find_by_name('Aichat')
   end
 
+  def self.pythonlab
+    @@game_pythonlab ||= find_by_name('Pythonlab')
+  end
+
   def unplugged?
     app == UNPLUG
   end
@@ -235,7 +240,7 @@ class Game < ApplicationRecord
   end
 
   def uses_small_footer?
-    [NETSIM, APPLAB, TEXT_COMPRESSION, GAMELAB, WEBLAB, DANCE, FISH, AILAB, JAVALAB, AICHAT].include? app
+    [NETSIM, APPLAB, TEXT_COMPRESSION, GAMELAB, WEBLAB, DANCE, FISH, AILAB, JAVALAB, AICHAT, PYTHONLAB].include? app
   end
 
   def no_footer?
@@ -345,6 +350,7 @@ class Game < ApplicationRecord
     Poetry:poetry
     Music:music
     Aichat:aichat
+    Pythonlab:pythonlab
   )
 
   def self.setup

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -333,6 +333,7 @@ class Level < ApplicationRecord
     'Pixelation', # widget
     'Poetry', # no ideal solution
     'PublicKeyCryptography', # widget
+    'Pythonlab', # no ideal solution
     'ScriptCompletion', # unknown
     'StandaloneVideo', # no user submitted content
     'TextCompression', # widget

--- a/dashboard/app/models/levels/pythonlab.rb
+++ b/dashboard/app/models/levels/pythonlab.rb
@@ -1,0 +1,52 @@
+# == Schema Information
+#
+# Table name: levels
+#
+#  id                    :integer          not null, primary key
+#  game_id               :integer
+#  name                  :string(255)      not null
+#  created_at            :datetime
+#  updated_at            :datetime
+#  level_num             :string(255)
+#  ideal_level_source_id :bigint           unsigned
+#  user_id               :integer
+#  properties            :text(4294967295)
+#  type                  :string(255)
+#  md5                   :string(255)
+#  published             :boolean          default(FALSE), not null
+#  notes                 :text(65535)
+#  audit_log             :text(65535)
+#
+# Indexes
+#
+#  index_levels_on_game_id    (game_id)
+#  index_levels_on_level_num  (level_num)
+#  index_levels_on_name       (name)
+#
+class Pythonlab < Level
+  serialized_attrs %w(
+    start_sources
+    encrypted_exemplar_sources
+    encrypted_validation
+    hide_share_and_remix
+    is_project_level
+    submittable
+    encrypted_examples
+    starter_assets
+    contained_level_names
+  )
+
+  def self.create_from_level_builder(params, level_params)
+    create!(
+      level_params.merge(
+        user: params[:user],
+        game: Game.pythonlab,
+        level_num: 'custom',
+      )
+    )
+  end
+
+  def uses_lab2?
+    true
+  end
+end

--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -44,6 +44,7 @@
     = render partial: 'levels/editors/javalab', locals: {f: f} if @level.is_a? Javalab
     = render partial: 'levels/editors/poetry', locals: {f: f} if @level.is_a? Poetry
     = render partial: 'levels/editors/music', locals: {f: f} if @level.is_a? Music
+    = render partial: 'levels/editors/pythonlab', locals: {f: f} if @level.is_a? Pythonlab
     -# Widgets
     = render partial: 'levels/editors/frequency_analysis', locals: {f: f} if @level.is_a? FrequencyAnalysis
     = render partial: 'levels/editors/netsim', locals: {f: f} if @level.is_a? NetSim

--- a/dashboard/app/views/levels/editors/_pythonlab.html.haml
+++ b/dashboard/app/views/levels/editors/_pythonlab.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'levels/editors/fields/aichat_fields', locals: {f: f}
+
+= render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_pythonlab.html.haml
+++ b/dashboard/app/views/levels/editors/_pythonlab.html.haml
@@ -1,3 +1,3 @@
-= render partial: 'levels/editors/fields/aichat_fields', locals: {f: f}
+= render partial: 'levels/editors/fields/pythonlab_fields', locals: {f: f}
 
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_pythonlab_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_pythonlab_fields.html.haml
@@ -1,0 +1,1 @@
+%h1 Python Lab Fields

--- a/dashboard/app/views/levels/new.html.haml
+++ b/dashboard/app/views/levels/new.html.haml
@@ -61,6 +61,7 @@
   %li= link_to 'Build an External Link Level', new_level_path(type: 'ExternalLink')
   %li= link_to 'Build a Java Lab level', new_level_path(type: 'Javalab')
   %li= link_to 'Build a Music Lab level', new_level_path(type: 'Music')
+  %li= link_to 'Build a Python Lab level', new_level_path(type: 'Pythonlab')
 
 %h2 Algebra
 %ul

--- a/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 1.level
+++ b/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 1.level
@@ -1,0 +1,12 @@
+<Pythonlab>
+  <config><![CDATA[{
+  "game_id": 72,
+  "created_at": "2023-11-21T22:43:22.000Z",
+  "level_num": "custom",
+  "user_id": 6959,
+  "properties": {
+    "encrypted": "false"
+  },
+  "published": true
+}]]></config>
+</Pythonlab>

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -394,6 +394,8 @@ en:
               name: AI Rubrics
             lesson-52:
               name: Dance Lab2
+            lesson-53:
+              name: Python Lab
         algebraPD2b:
           title: Computer Science in Algebra PD
           description: 'Phase 2 Online: Blended Summer Study'

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2023-11-21 22:51:46 UTC",
+    "serialized_at": "2023-12-11 23:36:24 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -1503,12 +1503,12 @@
       }
     },
     {
-      "key": "ae9a7e04-6820-4764-9d29-9e8d593cb9cc",
+      "key": "5688685c-b8bf-4563-b285-04a9cce9bb6e",
       "position": 1,
       "properties": {
       },
       "seeding_key": {
-        "lesson_activity.key": "ae9a7e04-6820-4764-9d29-9e8d593cb9cc",
+        "lesson_activity.key": "5688685c-b8bf-4563-b285-04a9cce9bb6e",
         "lesson.key": "lesson-53",
         "lesson_group.key": "",
         "script.name": "allthethings"
@@ -2037,13 +2037,13 @@
       }
     },
     {
-      "key": "76a112e1-ed1b-4dba-b33c-575c68d42881",
+      "key": "465bc905-13b5-487c-8fd6-8043676ee607",
       "position": 1,
       "properties": {
       },
       "seeding_key": {
-        "activity_section.key": "76a112e1-ed1b-4dba-b33c-575c68d42881",
-        "lesson_activity.key": "ae9a7e04-6820-4764-9d29-9e8d593cb9cc"
+        "activity_section.key": "465bc905-13b5-487c-8fd6-8043676ee607",
+        "lesson_activity.key": "5688685c-b8bf-4563-b285-04a9cce9bb6e"
       }
     }
   ],
@@ -5247,6 +5247,9 @@
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "allthethings_spritelab_functions"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -5268,6 +5271,9 @@
       "activity_section_position": 4,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "allthethings_spritelab_stress_test"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6484,7 +6490,7 @@
       ]
     },
     {
-      "chapter": 181,
+      "chapter": 183,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6498,7 +6504,7 @@
         "lesson.key": "lesson-53",
         "lesson_group.key": "",
         "script.name": "allthethings",
-        "activity_section.key": "76a112e1-ed1b-4dba-b33c-575c68d42881"
+        "activity_section.key": "465bc905-13b5-487c-8fd6-8043676ee607"
       },
       "level_keys": [
         "Allthethings Python Lab 1"
@@ -7828,6 +7834,19 @@
     },
     {
       "seeding_key": {
+        "level.key": "2-3 Maze 1",
+        "script_level.level_keys": [
+          "2-3 Maze 1",
+          "2-3 Maze 4"
+        ],
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
+      }
+    },
+    {
+      "seeding_key": {
         "level.key": "2-3 Maze 4",
         "script_level.level_keys": [
           "2-3 Maze 1",
@@ -7936,6 +7955,19 @@
         "script_level.level_keys": [
           "2-3 Artist Loops 2",
           "ramp_video_loopsArtist"
+        ],
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 3",
+        "script_level.level_keys": [
+          "2-3 Artist 3",
+          "2-3 Artist Loops 4"
         ],
         "lesson.key": "Swapped Levels",
         "lesson_group.key": "",
@@ -8799,7 +8831,7 @@
         "lesson.key": "lesson-53",
         "lesson_group.key": "",
         "script.name": "allthethings",
-        "activity_section.key": "76a112e1-ed1b-4dba-b33c-575c68d42881"
+        "activity_section.key": "465bc905-13b5-487c-8fd6-8043676ee607"
       }
     }
   ],

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2023-11-17 22:26:57 UTC",
+    "serialized_at": "2023-11-21 22:51:46 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -814,6 +814,21 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
+    },
+    {
+      "key": "lesson-53",
+      "name": "Python Lab",
+      "absolute_position": 53,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 50,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-53",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
     }
   ],
   "lesson_activities": [
@@ -1486,6 +1501,18 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
+    },
+    {
+      "key": "ae9a7e04-6820-4764-9d29-9e8d593cb9cc",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "ae9a7e04-6820-4764-9d29-9e8d593cb9cc",
+        "lesson.key": "lesson-53",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
     }
   ],
   "activity_sections": [
@@ -2007,6 +2034,16 @@
       "seeding_key": {
         "activity_section.key": "c34e51d8-607b-4436-854d-f77eb3240711",
         "lesson_activity.key": "fdc0f83f-442b-47e4-8f5a-8ca827acf9e2"
+      }
+    },
+    {
+      "key": "76a112e1-ed1b-4dba-b33c-575c68d42881",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "76a112e1-ed1b-4dba-b33c-575c68d42881",
+        "lesson_activity.key": "ae9a7e04-6820-4764-9d29-9e8d593cb9cc"
       }
     }
   ],
@@ -6445,6 +6482,27 @@
       "level_keys": [
         "Dance Lab2 Level 2"
       ]
+    },
+    {
+      "chapter": 181,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Allthethings Python Lab 1"
+        ],
+        "lesson.key": "lesson-53",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "76a112e1-ed1b-4dba-b33c-575c68d42881"
+      },
+      "level_keys": [
+        "Allthethings Python Lab 1"
+      ]
     }
   ],
   "levels_script_levels": [
@@ -7783,19 +7841,6 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Maze 1",
-        "script_level.level_keys": [
-          "2-3 Maze 1",
-          "2-3 Maze 4"
-        ],
-        "lesson.key": "Swapped Levels",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
-      }
-    },
-    {
-      "seeding_key": {
         "level.key": "2-3 Maze 2",
         "script_level.level_keys": [
           "2-3 Maze 2",
@@ -7901,19 +7946,6 @@
     {
       "seeding_key": {
         "level.key": "2-3 Artist Loops 4",
-        "script_level.level_keys": [
-          "2-3 Artist 3",
-          "2-3 Artist Loops 4"
-        ],
-        "lesson.key": "Swapped Levels",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "2-3 Artist 3",
         "script_level.level_keys": [
           "2-3 Artist 3",
           "2-3 Artist Loops 4"
@@ -8756,6 +8788,18 @@
         "lesson_group.key": "",
         "script.name": "allthethings",
         "activity_section.key": "c34e51d8-607b-4436-854d-f77eb3240711"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Allthethings Python Lab 1",
+        "script_level.level_keys": [
+          "Allthethings Python Lab 1"
+        ],
+        "lesson.key": "lesson-53",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "76a112e1-ed1b-4dba-b33c-575c68d42881"
       }
     }
   ],

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -1245,7 +1245,7 @@ class LevelTest < ActiveSupport::TestCase
       "Craft", "CurriculumReference", "Dancelab", "Eval", "EvaluationMulti", "External",
       "ExternalLink", "Fish", "Flappy", "FreeResponse", "FrequencyAnalysis", "Gamelab",
       "GamelabJr", "Javalab", "Karel", "LevelGroup", "Map", "Match", "Maze", "Multi", "Music", "NetSim",
-      "Odometer", "Pixelation", "Poetry", "PublicKeyCryptography", "StandaloneVideo",
+      "Odometer", "Pixelation", "Poetry", "PublicKeyCryptography", "Pythonlab", "StandaloneVideo",
       "StarWarsGrid", "Studio", "TextCompression", "TextMatch", "Unplugged",
       "Vigenere", "Weblab"
     ]


### PR DESCRIPTION
Redo of #55216. I had it against staging-next and trying to repair that branch was getting difficult so I needed to cherry-pick to create a new version against staging.

Copied from original PR:

This is the boilerplate to set up a new lab called "Python Lab". This sets up:

- The new game type and level type
- The basic levelbuilder plumbing to create a new Python Lab file
- The plumbing for the frontend
- A new all the things lesson with a single "Python Lab" level

Right now a Python Lab level just looks like this:
<img width="922" alt="Screenshot 2023-11-29 at 9 44 29 AM" src="https://github.com/code-dot-org/code-dot-org/assets/33666587/d9318422-8e8e-40b3-ba2a-7a189ef5ed21">

## Links
- jira ticket: [CT-188](https://codedotorg.atlassian.net/browse/CT-188)


## Testing story
Tested locally that the new level type works.

## Follow up work
There is a lot of work after this to customize the fronted of Python Lab, and to add the appropriate fields to the levelbuilder edit page. Right now this is all just boilerplate to get things started.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked

