### PR TITLE
Add aria-labels to previous and next buttons on code.org/promote stats carousel

### DIFF
--- a/pegasus/sites.v3/code.org/views/stats_carousel.haml
+++ b/pegasus/sites.v3/code.org/views/stats_carousel.haml
@@ -9,12 +9,10 @@
         .slide
           .slide-img<
             %img{:src=>"/images/cs-stats/#{statistic[:code_s]}.png"}
-    %a.slide-prev{:href=>'#'}<
-      %span<
-        %span.label Previous
-    %a.slide-next{:href=>'#'}<
-      %span<
-        %span.label Next
+    %a.slide-prev{href:'#', aria:{label: 'View previous slide'}}
+      %span
+    %a.slide-next{href: '#', aria:{label: 'View next slide'}}
+      %span
   .pagination
     %div{:id => "stats-carousel-pagination"}
 


### PR DESCRIPTION
Add aria-labels to the previous and next buttons on the stats carousel on https://code.org/promote.

**Jira ticket:** [A11Y-50](https://codedotorg.atlassian.net/browse/A11Y-50)

----

**🔊 Might need to turn up the volume to hear!**

https://github.com/code-dot-org/code-dot-org/assets/9256643/124aad9e-97fb-44cf-abb9-9805b3e5aa68

| Previous button | Next button |
| ------------|-------------|
| <img width="500" alt="Screenshot 2023-12-11 at 3 02 32 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/035a6d13-aa47-4ec9-8056-0839da57e9e0"> | <img width="500" alt="Screenshot 2023-12-11 at 3 01 06 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/205cd203-9a94-4a43-8332-f0dacfdb196c"> |


