### PR TITLE
Enable `a11y-media-has-caption`

### DIFF
--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -14,7 +14,6 @@ const rulesToEventuallyReenable = {
   'jsx-a11y/iframe-has-title': 'off',
   'jsx-a11y/interactive-supports-focus': 'off',
   'jsx-a11y/label-has-associated-control': 'off',
-  'jsx-a11y/media-has-caption': 'off',
   'jsx-a11y/mouse-events-have-key-events': 'off',
   'jsx-a11y/no-noninteractive-element-interactions': 'off',
   'jsx-a11y/no-noninteractive-element-to-interactive-role': 'off',

--- a/apps/src/javalab/theater/TheaterVisualizationColumn.jsx
+++ b/apps/src/javalab/theater/TheaterVisualizationColumn.jsx
@@ -66,6 +66,9 @@ class TheaterVisualizationColumn extends React.Component {
               )}
             >
               <img id="theater" className={style.image} />
+              {/* The audio here is generated dynamically from a student's code,
+                  and we don't have text that would appropriately represent the audio being generated. */}
+              {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
               <audio id="theater-audio" preload="auto" />
             </div>
             <JavalabCrosshairOverlay visible={showOverlay} />


### PR DESCRIPTION
Our only warning for this rule is in Javalab's "Theater" project type, where students can write code that will dynamically generate audio.

We'd need to generate text to describe this content dynamically, which seems unlikely. It maybe seems possible that we could hook into AWS's transcribe features, eg [here](https://aws.amazon.com/getting-started/hands-on/create-audio-transcript-transcribe/), and generate text from it if a user uploaded some audio that had words in it:

<img width="855" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/d4fecae0-f4a3-49f6-9f58-4fccb1838b00">

I can create a Jira task to track potentially doing this (although it seems like it would be pretty far down a priority list)?

## Links

- [media-has-caption rule details](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/media-has-caption.md)