### PR TITLE
 [coteacher] Add primary teacher UI component

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -506,6 +506,8 @@
   "coteacherInviteDescription": "{invitedByEmail} has invited you to co-teach",
   "coteacherTooltip": "As a co-teacher, you will be able to manage students in the section, view their work, and track their progress.",
   "coteacherAdd": "Add Co-Teachers",
+  "coteacherLabel": "Co-teachers",
+  "coteacherPrimaryTeacher": "Primary teacher",
   "coteacherAddTooltip": "Co-teachers have the same access as you in managing this section and viewing student work. Co-teachers will see the invitation on their teacher dashboard.",
   "coteacherAddInfo": "Add co-teachers by entering the email address associated with their Code.org account in the field below. Each section can have up to five co-teachers.",
   "coteacherAddNoEmail": "Please enter an email address.",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -507,7 +507,7 @@
   "coteacherTooltip": "As a co-teacher, you will be able to manage students in the section, view their work, and track their progress.",
   "coteacherAdd": "Add Co-Teachers",
   "coteacherLabel": "Co-teachers",
-  "coteacherPrimaryTeacher": "Primary teacher",
+  "coteacherPrimaryTeacher": "Primary Teacher",
   "coteacherAddTooltip": "Co-teachers have the same access as you in managing this section and viewing student work. Co-teachers will see the invitation on their teacher dashboard.",
   "coteacherAddInfo": "Add co-teachers by entering the email address associated with their Code.org account in the field below. Each section can have up to five co-teachers.",
   "coteacherAddNoEmail": "Please enter an email address.",

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
@@ -214,7 +214,7 @@ export default function AddCoteacher({
 
   return (
     <div className={styles.add}>
-      <label className={styles.label}>{i18n.coteacherEmailAddress()}</label>
+      <label className={styles.addLabel}>{i18n.coteacherEmailAddress()}</label>
       <div className={styles.form} onSubmit={handleAddEmail}>
         <input
           className={classNames(styles.input, !!addError && styles.inputError)}

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherSettings.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherSettings.jsx
@@ -73,8 +73,6 @@ export default function CoteacherSettings({
     [setSavedCoteachers]
   );
 
-  console.log('lfm', coteachers);
-
   return (
     <div className={styles.expandedSection}>
       {i18n.coteacherAddInfo()}

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherSettings.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherSettings.jsx
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
 import React, {useCallback, useMemo, useState} from 'react';
 import i18n from '@cdo/locale';
+import {StrongText} from '@cdo/apps/componentLibrary/typography';
 
 import styles from './coteacher-settings.module.scss';
 import AddCoteacher from './AddCoteacher';
 import CoteacherTable from './CoteacherTable';
 import RemoveCoteacherDialog from './RemoveCoteacherDialog';
+import PrimaryTeacher from './PrimaryTeacher';
 
 const statusSortValue = coteacher => {
   switch (coteacher.status) {
@@ -74,6 +76,13 @@ export default function CoteacherSettings({
   return (
     <div className={styles.expandedSection}>
       {i18n.coteacherAddInfo()}
+      <PrimaryTeacher
+        primaryTeacher={primaryTeacher}
+        coteachersExist={coteachers.length > 0}
+      />
+      <label className={styles.label}>
+        <StrongText>{i18n.coteacherLabel()}</StrongText>
+      </label>
       <div className={styles.settings}>
         <AddCoteacher
           sectionId={sectionId}

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherSettings.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherSettings.jsx
@@ -73,12 +73,14 @@ export default function CoteacherSettings({
     [setSavedCoteachers]
   );
 
+  console.log('lfm', coteachers);
+
   return (
     <div className={styles.expandedSection}>
       {i18n.coteacherAddInfo()}
       <PrimaryTeacher
         primaryTeacher={primaryTeacher}
-        coteachersExist={coteachers.length > 0}
+        numCoteachers={coteachers.length}
       />
       <label className={styles.label}>
         <StrongText>{i18n.coteacherLabel()}</StrongText>

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/PrimaryTeacher.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/PrimaryTeacher.jsx
@@ -4,17 +4,19 @@ import styles from './coteacher-settings.module.scss';
 import {StrongText} from '@cdo/apps/componentLibrary/typography';
 import i18n from '@cdo/locale';
 
-export default function PrimaryTeacher({primaryTeacher, coteachersExist}) {
+export default function PrimaryTeacher({primaryTeacher, numCoteachers}) {
   // We explicitely only want to show this component if there are coteachers on initial load.
   // This is so that we the UI doesn't jump around if there are no coteachers and we add one.
-  const shouldDisplayPrimaryTeacher = useState(coteachersExist);
+  const [coteachersExist] = useState(numCoteachers > 0);
 
   const shouldDisplayTeacher = React.useMemo(
-    () => !shouldDisplayPrimaryTeacher || !primaryTeacher,
-    [shouldDisplayPrimaryTeacher, primaryTeacher]
+    () => coteachersExist && !!primaryTeacher,
+    [coteachersExist, primaryTeacher]
   );
 
-  return shouldDisplayTeacher ? null : (
+  console.log('lfm1', shouldDisplayTeacher, coteachersExist);
+
+  return shouldDisplayTeacher ? (
     <div>
       <label className={styles.label}>
         <StrongText>{i18n.coteacherPrimaryTeacher()}</StrongText>
@@ -25,10 +27,10 @@ export default function PrimaryTeacher({primaryTeacher, coteachersExist}) {
         {primaryTeacher.email}
       </div>
     </div>
-  );
+  ) : null;
 }
 
 PrimaryTeacher.propTypes = {
   primaryTeacher: PropTypes.object,
-  coteachersExist: PropTypes.bool.isRequired,
+  numCoteachers: PropTypes.number.isRequired,
 };

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/PrimaryTeacher.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/PrimaryTeacher.jsx
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+import styles from './coteacher-settings.module.scss';
+import {StrongText} from '@cdo/apps/componentLibrary/typography';
+import i18n from '@cdo/locale';
+
+export default function PrimaryTeacher({primaryTeacher, coteachersExist}) {
+  // We explicitely only want to show this component if there are coteachers on initial load.
+  // This is so that we the UI doesn't jump around if there are no coteachers and we add one.
+  const shouldDisplayPrimaryTeacher = useState(coteachersExist);
+
+  const shouldDisplayTeacher = React.useMemo(
+    () => !shouldDisplayPrimaryTeacher || !primaryTeacher,
+    [shouldDisplayPrimaryTeacher, primaryTeacher]
+  );
+
+  return shouldDisplayTeacher ? null : (
+    <div>
+      <label className={styles.label}>
+        <StrongText>{i18n.coteacherPrimaryTeacher()}</StrongText>
+      </label>
+      <div className={styles.primaryTeacher}>
+        <StrongText>{primaryTeacher.name}</StrongText>
+        <br />
+        {primaryTeacher.email}
+      </div>
+    </div>
+  );
+}
+
+PrimaryTeacher.propTypes = {
+  primaryTeacher: PropTypes.object,
+  coteachersExist: PropTypes.bool.isRequired,
+};

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/PrimaryTeacher.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/PrimaryTeacher.jsx
@@ -14,8 +14,6 @@ export default function PrimaryTeacher({primaryTeacher, numCoteachers}) {
     [coteachersExist, primaryTeacher]
   );
 
-  console.log('lfm1', shouldDisplayTeacher, coteachersExist);
-
   return shouldDisplayTeacher ? (
     <div>
       <label className={styles.label}>

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/coteacher-settings.module.scss
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/coteacher-settings.module.scss
@@ -10,8 +10,23 @@
   flex-direction: column;
   justify-content: space-between;
   width: 100%;
-  margin-top: 24px;
   margin-bottom: 24px;
+}
+
+.label {
+  font-size: 16px;
+  margin-top: 24px;
+}
+
+.primaryTeacher {
+  padding: 12px;
+  min-height: 48px;
+  max-height: 48px;
+  border: 1px solid $light_gray_200;
+  align-items: center;
+  font-size: 16px;
+  line-height: 150%;
+
 }
 
 .add {
@@ -36,7 +51,7 @@
     margin: 0;
   }
 
-  .label {
+  &Label {
     @include label-one;
     font-size: 14px;
     margin-bottom: 0;

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/coteacher-settings.module.scss
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/coteacher-settings.module.scss
@@ -20,13 +20,10 @@
 
 .primaryTeacher {
   padding: 12px;
-  min-height: 48px;
-  max-height: 48px;
+  height: 48px;
   border: 1px solid $light_gray_200;
-  align-items: center;
   font-size: 16px;
   line-height: 150%;
-
 }
 
 .add {

--- a/apps/test/unit/templates/sectionsRefresh/coteacherSettings/PrimaryTeacherTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/coteacherSettings/PrimaryTeacherTest.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {mount, shallow} from 'enzyme';
+import {expect} from '../../../../util/reconfiguredChai';
+
+import PrimaryTeacher from '@cdo/apps/templates/sectionsRefresh/coteacherSettings/PrimaryTeacher';
+
+const testPrimaryTeacher = {
+  name: 'Parmesan',
+  email: 'parmesan@code.org',
+};
+
+describe('PrimaryTeacher', () => {
+  it('renders the primary teacher if there are coteachers', () => {
+    const wrapper = mount(
+      <PrimaryTeacher
+        primaryTeacher={testPrimaryTeacher}
+        coteachersExist={true}
+      />
+    );
+    expect(wrapper.text()).to.include('Parmesan');
+    expect(wrapper.text()).to.include('parmesan@code.org');
+  });
+
+  it('renders nothing if there are no coteachers', () => {
+    const wrapper = shallow(
+      <PrimaryTeacher
+        primaryTeacher={testPrimaryTeacher}
+        coteachersExist={false}
+      />
+    );
+    expect(wrapper).to.be.empty;
+  });
+
+  it('renders nothing if coteachers are added', () => {
+    let coteachersExist = false;
+    const wrapper = shallow(
+      <PrimaryTeacher
+        primaryTeacher={testPrimaryTeacher}
+        coteachersExist={coteachersExist}
+      />
+    );
+    expect(wrapper).to.be.empty;
+    coteachersExist = true;
+    wrapper.update();
+
+    expect(wrapper).to.be.empty;
+  });
+});

--- a/apps/test/unit/templates/sectionsRefresh/coteacherSettings/PrimaryTeacherTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/coteacherSettings/PrimaryTeacherTest.jsx
@@ -12,10 +12,7 @@ const testPrimaryTeacher = {
 describe('PrimaryTeacher', () => {
   it('renders the primary teacher if there are coteachers', () => {
     const wrapper = mount(
-      <PrimaryTeacher
-        primaryTeacher={testPrimaryTeacher}
-        coteachersExist={true}
-      />
+      <PrimaryTeacher primaryTeacher={testPrimaryTeacher} numCoteachers={1} />
     );
     expect(wrapper.text()).to.include('Parmesan');
     expect(wrapper.text()).to.include('parmesan@code.org');
@@ -23,24 +20,21 @@ describe('PrimaryTeacher', () => {
 
   it('renders nothing if there are no coteachers', () => {
     const wrapper = shallow(
-      <PrimaryTeacher
-        primaryTeacher={testPrimaryTeacher}
-        coteachersExist={false}
-      />
+      <PrimaryTeacher primaryTeacher={testPrimaryTeacher} numCoteachers={0} />
     );
     expect(wrapper).to.be.empty;
   });
 
   it('renders nothing if coteachers are added', () => {
-    let coteachersExist = false;
+    let numCoteachers = 0;
     const wrapper = shallow(
       <PrimaryTeacher
         primaryTeacher={testPrimaryTeacher}
-        coteachersExist={coteachersExist}
+        numCoteachers={numCoteachers}
       />
     );
     expect(wrapper).to.be.empty;
-    coteachersExist = true;
+    numCoteachers = 3;
     wrapper.update();
 
     expect(wrapper).to.be.empty;


### PR DESCRIPTION
## Warning!!

We have entered Pixel Lock for Hour of Code!

Computer Science Education Week will be happening from Dec 4 - Dec 10. Alongside this event, we will
be launching our new Hour of Code activity. Please consider any risk introduced in this PR that
could affect Dance Lab, instructions, saving and logging student progress, caching, or anything
related to the Hour of Code activities, old or new. Even small changes, such as a different button
color, are considered significant during this time. If this change will affect the new Hour of Code
activity in any way, join the morning change review to get your changes approved prior to merging.
Reach out to the Student Labs team for more details!

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
