### PR TITLE
await visible ui component in rubric window

### DIFF
--- a/apps/src/templates/rubrics/LearningGoal.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.jsx
@@ -168,7 +168,7 @@ export default function LearningGoal({
 
   const renderAutoSaveTextbox = () => {
     return (
-      <div className={`${style.feedbackArea} uitest-learning-goal`}>
+      <div className={style.feedbackArea}>
         <label className={style.evidenceLevelLabel}>
           <span>{i18n.feedback()}</span>
           <textarea
@@ -215,7 +215,7 @@ export default function LearningGoal({
   };
 
   return (
-    <details className={style.learningGoalRow}>
+    <details className={`${style.learningGoalRow} uitest-learning-goal-row`}>
       <summary className={style.learningGoalHeader} onClick={handleClick}>
         <div className={style.learningGoalHeaderLeftSide}>
           {/*TODO: [DES-321] Label-two styles here*/}

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -96,7 +96,7 @@ Feature: Evaluate student code against rubrics using AI
 
     # Teacher views AI evaluation results in rubric tab
     When I click selector ".uitest-rubric-header-tab:contains('Rubric')"
-    And I wait until element ".uitest-learning-goal" is visible
+    And I wait until element ".uitest-learning-goal-row" is visible
     And element ".uitest-uses-ai" is visible
     And I click selector ".uitest-uses-ai:eq(0)"
     And I wait until element ".uitest-ai-assessment" is visible

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -45,7 +45,7 @@ Feature: Evaluate student code against rubrics using AI
 
     # Teacher views AI evaluation results in rubric tab
     When I click selector ".uitest-rubric-header-tab:contains('Rubric')"
-    And I wait until element ".uitest-learning-goal" is visible
+    And I wait until element ".uitest-learning-goal-row" is visible
     And element ".uitest-uses-ai" is visible
     And I click selector ".uitest-uses-ai:eq(0)"
     And I wait until element ".uitest-ai-assessment" is visible

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -51,7 +51,6 @@ Feature: Evaluate student code against rubrics using AI
     And I wait until element ".uitest-ai-assessment" is visible
     Then element ".uitest-ai-assessment" contains text "Aiden has achieved Extensive or Convincing Evidence"
 
-  @chrome
   Scenario: Student code is evaluated by AI when teacher requests it
     Given I create a teacher-associated student named "Aiden"
     And I am on "http://studio.code.org/home"

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -108,7 +108,7 @@ namespace :circle do
     end
     RakeUtils.wait_for_url('http://localhost-studio.code.org:3000')
     Dir.chdir('dashboard/test/ui') do
-      container_features = `find ./features -name '*.feature' | sort`.split("\n").map {|f| f[2..]}
+      container_features = `find ./features -name 'ai_evaluate_student_code.feature' | sort`.split("\n").map {|f| f[2..]}
       eyes_features = `grep -lr '@eyes' features`.split("\n")
       container_eyes_features = container_features & eyes_features
       RakeUtils.system_stream_output "bundle exec ./runner.rb " \

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -108,7 +108,7 @@ namespace :circle do
     end
     RakeUtils.wait_for_url('http://localhost-studio.code.org:3000')
     Dir.chdir('dashboard/test/ui') do
-      container_features = `find ./features -name 'ai_evaluate_student_code.feature' | sort`.split("\n").map {|f| f[2..]}
+      container_features = `find ./features -name '*.feature' | sort`.split("\n").map {|f| f[2..]}
       eyes_features = `grep -lr '@eyes' features`.split("\n")
       container_eyes_features = container_features & eyes_features
       RakeUtils.system_stream_output "bundle exec ./runner.rb " \


### PR DESCRIPTION
in the first DTT after HOC, the ai-eval-student-code ui tests passed in chrome and failed in other browsers ( see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1702336886649639)). Because the UI test was added to staging-next during HOC lockdown and only ever ran in drone, which only runs UI tests in Chrome, it's likely that this UI test has never worked in browsers besides Chrome.

Initial investigation reveals that the UI test is waiting for an element which appears to be hidden within a collapsed summary/details UI component. Therefore, the speculative fix is to wait for a UI component which is always visible:
![Screenshot 2023-12-11 at 3 49 13 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/ba9bcb0c-025f-4504-94d7-57365ffd39d6)

## Testing story

* drone run with `test all browsers` tag demonstrates this is passing in all browsers
![Screenshot 2023-12-12 at 9 24 52 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/a8e50d69-a536-4ac8-b8c2-4443b356ae67)
