### PR TITLE
disable ai eval ui test in firefox

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -1,3 +1,4 @@
+@no_firefox
 # AI evaluation is stubbed out in UI tests via the /api/test/ai_proxy/assessment route.
 Feature: Evaluate student code against rubrics using AI
   Scenario: Student code is evaluated by AI when student submits project


### PR DESCRIPTION
despite passing in firefox in drone, this test is failing in firefox during DTT. working around this by disabling in firefox .

## Testing story

confirmed locally that the test is skipped in firefox