### PR TITLE
[AccHack] Fix tab navigation on lesson dropdowns for unit overview page

### DIFF
--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -158,7 +158,18 @@ class ProgressLesson extends React.Component {
               ...{marginBottom: this.state.collapsed ? 0 : 15},
             }}
           >
-            <div style={styles.headingText} onClick={this.toggleCollapsed}>
+            <div
+              style={styles.headingText}
+              onClick={this.toggleCollapsed}
+              tabIndex="0"
+              role="button"
+              onKeyDown={e => {
+                if ([' ', 'Enter', 'Spacebar'].includes(e.key)) {
+                  e.preventDefault();
+                  this.toggleCollapsed();
+                }
+              }}
+            >
               <FontAwesome icon={caret} style={caretStyle} />
               {hiddenForStudents && (
                 <FontAwesome icon="eye-slash" style={styles.icon} />

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -169,6 +169,7 @@ class ProgressLesson extends React.Component {
                   this.toggleCollapsed();
                 }
               }}
+              aria-label={title}
             >
               <FontAwesome icon={caret} style={caretStyle} />
               {hiddenForStudents && (

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -169,7 +169,7 @@ class ProgressLesson extends React.Component {
                   this.toggleCollapsed();
                 }
               }}
-              aria-label={title}
+              aria-expanded={!this.state.collapsed}
             >
               <FontAwesome icon={caret} style={caretStyle} />
               {hiddenForStudents && (


### PR DESCRIPTION
Makes lesson dropdown tab navigable on unit overview page.

## Links
[A11Y-37](https://codedotorg.atlassian.net/browse/A11Y-37)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
