### PR TITLE
[AccHack '23] reenable no-redundant-roles linter rule

### DIFF
--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -21,7 +21,6 @@ const rulesToEventuallyReenable = {
   'jsx-a11y/no-noninteractive-element-interactions': 'off',
   'jsx-a11y/no-noninteractive-element-to-interactive-role': 'off',
   'jsx-a11y/no-noninteractive-tabindex': 'off',
-  'jsx-a11y/no-redundant-roles': 'off',
   'jsx-a11y/no-static-element-interactions': 'off',
   'jsx-a11y/tabindex-no-positive': 'off',
 };

--- a/apps/src/componentLibrary/link/Link.tsx
+++ b/apps/src/componentLibrary/link/Link.tsx
@@ -61,7 +61,6 @@ const Link: React.FunctionComponent<LinkProps> = ({
         moduleStyles[`link-${size}`],
         className
       )}
-      role="link"
       href={!disabled ? href : undefined}
       id={id}
       onClick={!disabled ? onClick : undefined}

--- a/apps/src/templates/CollapserIcon.jsx
+++ b/apps/src/templates/CollapserIcon.jsx
@@ -25,7 +25,6 @@ function CollapserIcon({
     <button
       id={id}
       onClick={onClick}
-      role="button"
       className={classNames(
         iconClass + ' fa',
         className,


### PR DESCRIPTION
A simple rule to re-enable :) Based on [the docs](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-redundant-roles.md), this rule enforces a best practice more than preventing a user issue.