### PR TITLE
Fixing error message for potential teachers and honeybadger error

### DIFF
--- a/dashboard/app/controllers/potential_teachers_controller.rb
+++ b/dashboard/app/controllers/potential_teachers_controller.rb
@@ -9,8 +9,12 @@ class PotentialTeachersController < ApplicationController
       begin
         @potential_teacher.save!
         render json: {message: 'Potential teacher created successfully'}, status: :created
-      rescue ActiveRecord::RecordInvalid => exception
-        raise "ERROR: #{exception.message}"
+      rescue => exception
+        Honeybadger.notify(
+          exception,
+          error_message: "Error saving potential teacher information"
+        )
+        render status: :internal_server_error, json: {error: exception}
       end
     end
     send_hoc_email(params)


### PR DESCRIPTION
This is the second attempt at https://github.com/code-dot-org/code-dot-org/pull/55342, which was built on staging-next. Reopening here for ease. 

I went in a direction that follows a lot of our existing controller error handling. This will send the exception to honeybadger with a helpful and readable message (if saving a new potential teacher fails), and will render the exception as well. 

Inspiration example [here](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/browser_events_controller.rb#L39)!

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1190

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
