### PR TITLE
Change access token req payload

### DIFF
--- a/dashboard/lib/lti_access_token.rb
+++ b/dashboard/lib/lti_access_token.rb
@@ -27,14 +27,14 @@ module LtiAccessToken
     }
 
     jwt = sign_jwt(jwt_payload)
-    query = {
+    body = {
       grant_type: 'client_credentials',
       client_assertion_type: Policies::Lti::JWT_CLIENT_ASSERTION_TYPE,
       client_assertion: jwt,
       scope: scopes.join(' '),
     }
 
-    res = HTTParty.post(access_token_url, query: query, headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
+    res = HTTParty.post(access_token_url, body: body, headers: {'Content-Type' => 'application/x-www-form-urlencoded'})
     # get access_token and exp from response
     token_response = JSON.parse(res.body).transform_keys(&:to_sym)
     access_token = token_response[:access_token]


### PR DESCRIPTION
Schoology requires the payload of an access_token request to be in the body, rather than the query. I actually don't know why we were using URL query params, I think because the LTI launch requires this, since that handshake is done via browser redirects and thus needs the data in the URL. However for the access token request, that is your typical Client Credential OAuth flow, which is a server side flow. 

Canvas also accepts the payload in request body, probably because Canvas is a Rails application and just references these values via the `params` object ([see here](https://github.com/instructure/canvas-lms/blob/master/app/controllers/oauth2_provider_controller.rb#L143)), and Rails throws a bunch of data in the params object to make things automagical. 

This PR updates the access_token request payload to be in the body.

Invoked on local dev environment, `get_access_token` successfully returns access token from Schoology instance.

```
[development] dashboard > get_access_token("7056265211", "https://schoology.schoology.com")
  LtiIntegration Load (1.1ms)  SELECT `lti_integrations`.* FROM `lti_integrations` WHERE `lti_integrations`.`client_id` = '7056265211' AND `lti_integrations`.`issuer` = 'https://schoology.schoology.com' LIMIT 1
=> "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjlkNDM0OWM5NGYwOT...(redacted)"
```

This change still works invoking `get_access_token` for our Canvas instance.

```
get_access_token("208940000000000105", "https://canvas.instructure.com")
  LtiIntegration Load (3.6ms)  SELECT `lti_integrations`.* FROM `lti_integrations` WHERE `lti_integrations`.`client_id` = '208940000000000105' AND `lti_integrations`.`issuer` = 'https://canvas.instructure.com' LIMIT 1
=> "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2NhbnZ...(redacted)"
```

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[Schoology Spike](https://docs.google.com/document/d/13XMAObdZBOQyxPRlaUVfuR5Bf2P2TU3uQqPEOf1Pwbg/edit#heading=h.24ioakrozy0h)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

```
bundle exec spring testunit test/lib/lti_access_token_test.rb
Running via Spring preloader in process 56144
Started with run options --seed 35728

  4/4: [=====================================================================================================================================================================] 100% Time: 00:00:16, Time: 00:00:16

Finished in 21.81183s
4 tests, 5 assertions, 0 failures, 0 errors, 0 skips
```
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
