### PR TITLE
Make teacher dashboard pages full width, allow progress table to expa…

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
@@ -170,6 +170,7 @@ export default class ProgressTableContentView extends React.Component {
           },
         }}
         columns={columns}
+        style={{width: 'fit-content'}}
       >
         <Sticky.Header
           style={{overflow: 'hidden'}}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
@@ -16,7 +16,6 @@ import {
   getCurrentUnitData,
   jumpToLessonDetails,
 } from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
-import styleConstants from '@cdo/apps/styleConstants';
 import ProgressTableStudentList from './ProgressTableStudentList';
 import ProgressTableContentView from './ProgressTableContentView';
 import SummaryViewLegend from '@cdo/apps/templates/sectionProgress/progressTables/SummaryViewLegend';
@@ -355,7 +354,7 @@ class ProgressTableView extends React.Component {
     return (
       // outer div contains both table and legend
       <div>
-        <div style={styles.container} className="progress-table">
+        <div className="progress-table">
           <div style={styles.studentList} className="student-list">
             <ProgressTableStudentList
               key={key}
@@ -400,16 +399,13 @@ class ProgressTableView extends React.Component {
 }
 
 const styles = {
-  container: {
-    width: styleConstants['content-width'],
-  },
   studentList: {
-    display: 'inline-block',
-    verticalAlign: 'top',
+    position: 'absolute',
   },
   contentView: {
-    display: 'inline-block',
-    width: parseInt(progressTableStyleConstants.CONTENT_VIEW_WIDTH),
+    paddingInlineStart: parseInt(
+      progressTableStyleConstants.STUDENT_LIST_WIDTH
+    ),
   },
 };
 

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -97,7 +97,6 @@
   .content-view {
     thead,
     tbody {
-      max-width: constants.$content-view-width;
       td {
         text-align: center;
       }

--- a/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
@@ -123,7 +123,7 @@ export default class TeacherDashboardNavigation extends Component {
     const links = this.props.links || teacherDashboardLinks;
     const containerStyles = this.state.shouldScroll
       ? {...styles.container, ...styles.scrollableContainer}
-      : {...styles.container, ...styles.centerContainer};
+      : styles.container;
     const chevronStyles = userAgentParser.isSafari()
       ? {...styles.chevron, ...styles.safariSticky}
       : styles.chevron;
@@ -176,9 +176,6 @@ const styles = {
     marginBottom: 10,
     overflow: 'hidden',
     position: 'relative',
-  },
-  centerContainer: {
-    justifyContent: 'center',
   },
   scrollableContainer: {
     overflowX: 'scroll',

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1311,6 +1311,10 @@ input.header_input {
   text-decoration: underline;
 }
 
+#teacher-dashboard {
+  margin: 0 39px;
+}
+
 #alert {
   color: $red;
   font-size: 130%;

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -5,6 +5,7 @@ class TeacherDashboardController < ApplicationController
     @section_summary = @section.summarize
     @sections = current_user.sections_instructed.map(&:summarize)
     @locale_code = request.locale
+    view_options(full_width: true)
   end
 
   def parent_letter


### PR DESCRIPTION
A few visual changes to teacher dashboard pages:
* Make the pages full width (64px of margin on both sides)
* Make tab links left-justified instead of centered
* Allow progress table to fit full page width

<img width="1226" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/4108328/fd387886-a25a-4cdb-867d-64dcd0e8e22f">


https://github.com/code-dot-org/code-dot-org/assets/4108328/7e79b3e9-d7ea-40c6-a1ac-bd46b533a217




## Links

JIRA: [TEACH-759](https://codedotorg.atlassian.net/browse/TEACH-759)

## Testing story

Tested in English and Hebrew

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
