### PR TITLE
Add course name to LMS section name

### DIFF
--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -64,6 +64,7 @@ class Services::Lti
   def self.parse_nrps_response(nrps_response)
     sections = {}
     members = nrps_response[:members]
+    context_title = nrps_response.dig(:context, :title)
     members.each do |member|
       next if member[:status] == 'Inactive' || member[:roles].exclude?(Policies::Lti::CONTEXT_LEARNER_ROLE)
       # TODO: handle multiple messages. Shouldn't be needed until we support Deep Linking.
@@ -81,7 +82,7 @@ class Services::Lti
           sections[section_id][:members] << member
         else
           sections[section_id] = {
-            name: member_section_names[index],
+            name: "#{context_title} #{member_section_names[index]}",
             members: [member],
           }
         end
@@ -126,18 +127,20 @@ class Services::Lti
     end
 
     nrps_sections.keys.each do |lms_section_id|
+      section_name = nrps_sections[lms_section_id][:name]
       # Check if lti_sections already contains a section with this lms_section_id
       lti_section = lti_sections.find_by(lms_section_id: lms_section_id)
       if lti_section.nil?
         section = Section.new(
           {
             user_id: section_owner_id,
-            name: nrps_sections[lms_section_id][:name],
+            name: section_name,
             login_type: Section::LOGIN_TYPE_LTI_V1,
           }
         )
         lti_section = LtiSection.create(lti_course_id: lti_course.id, lms_section_id: lms_section_id, section: section)
       end
+      lti_section.section.update(name: section_name) unless lti_section.section.name == section_name
       sync_section_roster(lti_integration, lti_section, nrps_sections[lms_section_id][:members])
     end
   end

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -82,7 +82,7 @@ class Services::Lti
           sections[section_id][:members] << member
         else
           sections[section_id] = {
-            name: "#{context_title} #{member_section_names[index]}",
+            name: "#{context_title}: #{member_section_names[index]}",
             members: [member],
           }
         end

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -212,7 +212,7 @@ class Services::LtiTest < ActiveSupport::TestCase
   end
 
   test 'should append the course name to each section name when parsing NRPS response' do
-    expected_section_names = @lms_section_names.map {|name| "#{@course_name} #{name}"}
+    expected_section_names = @lms_section_names.map {|name| "#{@course_name}: #{name}"}
     parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response)
     actual_section_names = parsed_response.values.map {|v| v[:name]}
     assert_empty expected_section_names - actual_section_names
@@ -226,7 +226,7 @@ class Services::LtiTest < ActiveSupport::TestCase
     Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
 
     # initial names
-    expected_section_names = @lms_section_names.map {|name| "#{@course_name} #{name}"}
+    expected_section_names = @lms_section_names.map {|name| "#{@course_name}: #{name}"}
     actual_section_names = lti_course.sections.map(&:name)
     assert_empty expected_section_names - actual_section_names
 
@@ -238,7 +238,7 @@ class Services::LtiTest < ActiveSupport::TestCase
     end
     parsed_response = Services::Lti.parse_nrps_response(new_response)
     Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
-    new_expected_names = JSON.parse(new_names).map {|name| "#{@course_name} #{name}"}
+    new_expected_names = JSON.parse(new_names).map {|name| "#{@course_name}: #{name}"}
     actual_section_names = lti_course.reload.sections.map(&:name)
     assert_empty new_expected_names - actual_section_names
   end

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -44,6 +44,7 @@ class Services::LtiTest < ActiveSupport::TestCase
       }],
     }.deep_symbolize_keys
 
+    @course_name = 'Test Course'
     @lms_section_ids = [1, 2, 3]
     @lms_section_names = ['Section 1', 'Section 2', 'Section 3']
 
@@ -52,7 +53,7 @@ class Services::LtiTest < ActiveSupport::TestCase
       context: {
         id: "context-id",
         label: "Course Label",
-        title: "Course Title"
+        title: @course_name,
       },
       members: [
         {
@@ -208,6 +209,38 @@ class Services::LtiTest < ActiveSupport::TestCase
       assert_empty v.keys - [:name, :members]
       assert_equal v[:members].length, 3
     end
+  end
+
+  test 'should append the course name to each section name when parsing NRPS response' do
+    expected_section_names = @lms_section_names.map {|name| "#{@course_name} #{name}"}
+    parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response)
+    actual_section_names = parsed_response.values.map {|v| v[:name]}
+    assert_empty expected_section_names - actual_section_names
+  end
+
+  test 'should update a section name if it has changed' do
+    teacher = create :teacher
+    lti_integration = create :lti_integration
+    lti_course = create :lti_course, lti_integration: lti_integration
+    parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response)
+    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
+
+    # initial names
+    expected_section_names = @lms_section_names.map {|name| "#{@course_name} #{name}"}
+    actual_section_names = lti_course.sections.map(&:name)
+    assert_empty expected_section_names - actual_section_names
+
+    # re-sync with new names
+    new_names = ['Renamed 1', 'Renamed 2', 'Renamed 3'].to_s
+    new_response = @nrps_full_response.deep_dup
+    new_response[:members].each do |member|
+      member[:message][0][@custom_claims_key][:section_names] = new_names
+    end
+    parsed_response = Services::Lti.parse_nrps_response(new_response)
+    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
+    new_expected_names = JSON.parse(new_names).map {|name| "#{@course_name} #{name}"}
+    actual_section_names = lti_course.reload.sections.map(&:name)
+    assert_empty new_expected_names - actual_section_names
   end
 
   test 'should add or remove student users when syncing a section' do


### PR DESCRIPTION
Differentiates LMS-based section names by prepending the course name, e.g. if the course in Canvas is called Course 1 and the section is called Section 1, the name of the section in Code.org would be `Course 1: Section 1`. Schoology uses a colon between course and section names, so we'll use that here for consistency.

Also updates the section name if the name has changed in the LMS since the last sync.

## Links

[Jira](https://codedotorg.atlassian.net/browse/P20-620)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
