### PR TITLE
Change ai rubrics learning goals to carousel layout

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -100,6 +100,7 @@ const EVENTS = {
   TA_RUBRIC_EVIDENCE_LEVEL_SELECTED: 'TA Rubric Evidence Level Selected',
   TA_RUBRIC_RUN_BUTTON_CLICKED:
     'TA Rubric Teacher clicked RUN button on student work',
+  TA_RUBRIC_LEARNING_GOAL_SELECTED: 'TA Rubric Learning Goal Selected',
 
   // AI Tutor
   AI_TUTOR_PANEL_OPENED: 'AI Tutor Panel Opened',

--- a/apps/src/templates/rubrics/EvidenceLevels.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevels.jsx
@@ -12,6 +12,7 @@ export default function EvidenceLevels({
   radioButtonCallback,
   submittedEvaluation,
   isStudent,
+  isAutosaving,
 }) {
   const sortedEvidenceLevels = () => {
     const newArray = [...evidenceLevels];
@@ -32,6 +33,7 @@ export default function EvidenceLevels({
         understanding={understanding}
         radioButtonCallback={radioButtonCallback}
         canProvideFeedback={canProvideFeedback}
+        isAutosaving={isAutosaving}
       />
     );
   }
@@ -45,4 +47,5 @@ EvidenceLevels.propTypes = {
   radioButtonCallback: PropTypes.func,
   submittedEvaluation: submittedEvaluationShape,
   isStudent: PropTypes.bool,
+  isAutosaving: PropTypes.bool,
 };

--- a/apps/src/templates/rubrics/EvidenceLevelsForTeachers.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForTeachers.jsx
@@ -18,6 +18,7 @@ export default function EvidenceLevelsForTeachers({
   understanding,
   radioButtonCallback,
   canProvideFeedback,
+  isAutosaving,
 }) {
   const radioGroupName = `evidence-levels-${learningGoalKey}`;
   if (canProvideFeedback) {
@@ -42,6 +43,7 @@ export default function EvidenceLevelsForTeachers({
                 radioButtonCallback(evidenceLevel.understanding);
               }}
               checked={understanding === evidenceLevel.understanding}
+              disabled={isAutosaving}
             />
             <BodyThreeText
               className={classNames(style.evidenceLevelDescriptionIndented)}
@@ -78,4 +80,5 @@ EvidenceLevelsForTeachers.propTypes = {
   understanding: PropTypes.number,
   radioButtonCallback: PropTypes.func,
   canProvideFeedback: PropTypes.bool,
+  isAutosaving: PropTypes.bool,
 };

--- a/apps/src/templates/rubrics/LearningGoal.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.jsx
@@ -42,10 +42,14 @@ export default function LearningGoal({
   setFeedbackAdded,
   aiEvalInfo,
 }) {
+  const STATUS = Object.freeze({
+    NOT_STARTED: 0,
+    IN_PROGRESS: 1,
+    FINISHED: 2,
+    ERROR: 3,
+  });
   const [isOpen, setIsOpen] = useState(false);
-  const [isAutosaving, setIsAutosaving] = useState(false);
-  const [autosaved, setAutosaved] = useState(false);
-  const [errorAutosaving, setErrorAutosaving] = useState(false);
+  const [autosaveStatus, setAutosaveStatus] = useState(STATUS.notStarted);
   const [learningGoalEval, setLearningGoalEval] = useState(null);
   const [displayFeedback, setDisplayFeedback] = useState('');
   const [displayUnderstanding, setDisplayUnderstanding] =
@@ -88,9 +92,7 @@ export default function LearningGoal({
   };
 
   const autosave = () => {
-    setAutosaved(false);
-    setIsAutosaving(true);
-    setErrorAutosaving(false);
+    setAutosaveStatus(STATUS.IN_PROGRESS);
     const bodyData = JSON.stringify({
       studentId: studentLevelInfo.user_id,
       learningGoalId: learningGoal.id,
@@ -106,16 +108,14 @@ export default function LearningGoal({
       }
     )
       .then(() => {
-        setIsAutosaving(false);
-        setAutosaved(true);
+        setAutosaveStatus(STATUS.FINISHED);
         if (!feedbackAdded) {
           setFeedbackAdded(true);
         }
       })
       .catch(error => {
-        console.log(error);
-        setIsAutosaving(false);
-        setErrorAutosaving(true);
+        console.error(error);
+        setAutosaveStatus(STATUS.ERROR);
       });
     clearTimeout(autosaveTimer.current);
   };
@@ -161,9 +161,7 @@ export default function LearningGoal({
     });
     setDisplayUnderstanding(radioButtonData);
     understandingLevel.current = radioButtonData;
-    if (!isAutosaving) {
-      autosave();
-    }
+    autosave();
   };
 
   const renderAutoSaveTextbox = () => {
@@ -180,16 +178,16 @@ export default function LearningGoal({
             disabled={!canProvideFeedback}
           />
         </label>
-        {isAutosaving ? (
+        {autosaveStatus === STATUS.IN_PROGRESS ? (
           <span className={style.autosaveMessage}>{i18n.saving()}</span>
         ) : (
-          autosaved && (
+          autosaveStatus === STATUS.FINISHED && (
             <span id="ui-autosaveConfirm" className={style.autosaveMessage}>
               <FontAwesome icon="circle-check" /> {i18n.savedToGallery()}
             </span>
           )
         )}
-        {errorAutosaving && (
+        {autosaveStatus === STATUS.ERROR && (
           <span className={style.autosaveMessage}>
             {i18n.feedbackSaveError()}
           </span>

--- a/apps/src/templates/rubrics/LearningGoal.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.jsx
@@ -49,7 +49,7 @@ export default function LearningGoal({
     ERROR: 3,
   });
   const [isOpen, setIsOpen] = useState(false);
-  const [autosaveStatus, setAutosaveStatus] = useState(STATUS.notStarted);
+  const [autosaveStatus, setAutosaveStatus] = useState(STATUS.NOT_STARTED);
   const [learningGoalEval, setLearningGoalEval] = useState(null);
   const [displayFeedback, setDisplayFeedback] = useState('');
   const [displayUnderstanding, setDisplayUnderstanding] =
@@ -288,6 +288,7 @@ export default function LearningGoal({
             radioButtonCallback={radioButtonCallback}
             submittedEvaluation={submittedEvaluation}
             isStudent={isStudent}
+            isAutosaving={autosaveStatus === STATUS.IN_PROGRESS}
           />
           {learningGoal.tips && !isStudent && (
             <div>

--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -145,7 +145,7 @@ export default function LearningGoals({
             understandingLevel.current = json.understanding;
           }
         })
-        .catch(error => console.log(error));
+        .catch(error => console.error(error));
     }
   }, [studentLevelInfo, learningGoals, currentLearningGoal]);
 

--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -1,0 +1,333 @@
+import React, {useEffect, useState, useRef} from 'react';
+import PropTypes from 'prop-types';
+import i18n from '@cdo/locale';
+import classnames from 'classnames';
+import style from './rubrics.module.scss';
+import {
+  learningGoalShape,
+  reportingDataShape,
+  studentLevelInfoShape,
+  submittedEvaluationShape,
+  aiEvaluationShape,
+} from './rubricShapes';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import {
+  BodyThreeText,
+  BodyFourText,
+  ExtraStrongText,
+  StrongText,
+  Heading6,
+} from '@cdo/apps/componentLibrary/typography';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import EvidenceLevels from './EvidenceLevels';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import AiAssessment from './AiAssessment';
+import HttpClient from '@cdo/apps/util/HttpClient';
+import {UNDERSTANDING_LEVEL_STRINGS} from './rubricHelpers';
+
+const invalidUnderstanding = -1;
+
+export default function LearningGoal({
+  learningGoal,
+  teacherHasEnabledAi,
+  canProvideFeedback,
+  reportingData,
+  studentLevelInfo,
+  aiUnderstanding,
+  aiConfidence,
+  submittedEvaluation,
+  isStudent,
+  feedbackAdded,
+  setFeedbackAdded,
+  aiEvalInfo,
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isAutosaving, setIsAutosaving] = useState(false);
+  const [autosaved, setAutosaved] = useState(false);
+  const [errorAutosaving, setErrorAutosaving] = useState(false);
+  const [learningGoalEval, setLearningGoalEval] = useState(null);
+  const [displayFeedback, setDisplayFeedback] = useState('');
+  const [displayUnderstanding, setDisplayUnderstanding] =
+    useState(invalidUnderstanding);
+  const teacherFeedback = useRef('');
+  const understandingLevel = useRef(invalidUnderstanding);
+
+  const aiEnabled = learningGoal.aiEnabled && teacherHasEnabledAi;
+  const base_teacher_evaluation_endpoint = '/learning_goal_teacher_evaluations';
+
+  // Timer variables for autosaving
+  const autosaveTimer = useRef();
+  const saveAfter = 2000;
+
+  const handleClick = () => {
+    if (!isStudent) {
+      const eventName = isOpen
+        ? EVENTS.TA_RUBRIC_LEARNING_GOAL_COLLAPSED_EVENT
+        : EVENTS.TA_RUBRIC_LEARNING_GOAL_EXPANDED_EVENT;
+      analyticsReporter.sendEvent(eventName, {
+        ...(reportingData || {}),
+        learningGoalKey: learningGoal.key,
+        learningGoal: learningGoal.learningGoal,
+      });
+    }
+    setIsOpen(!isOpen);
+  };
+
+  const handleFeedbackChange = event => {
+    if (studentLevelInfo.user_id && learningGoal.id) {
+      if (autosaveTimer.current) {
+        clearTimeout(autosaveTimer.current);
+      }
+      teacherFeedback.current = event.target.value;
+      setDisplayFeedback(teacherFeedback.current);
+      autosaveTimer.current = setTimeout(() => {
+        autosave();
+      }, saveAfter);
+    }
+  };
+
+  const autosave = () => {
+    setAutosaved(false);
+    setIsAutosaving(true);
+    setErrorAutosaving(false);
+    const bodyData = JSON.stringify({
+      studentId: studentLevelInfo.user_id,
+      learningGoalId: learningGoal.id,
+      feedback: teacherFeedback.current,
+      understanding: understandingLevel.current,
+    });
+    HttpClient.put(
+      `${base_teacher_evaluation_endpoint}/${learningGoalEval.id}`,
+      bodyData,
+      true,
+      {
+        'Content-Type': 'application/json',
+      }
+    )
+      .then(() => {
+        setIsAutosaving(false);
+        setAutosaved(true);
+        if (!feedbackAdded) {
+          setFeedbackAdded(true);
+        }
+      })
+      .catch(error => {
+        console.log(error);
+        setIsAutosaving(false);
+        setErrorAutosaving(true);
+      });
+    clearTimeout(autosaveTimer.current);
+  };
+
+  useEffect(() => {
+    if (studentLevelInfo && learningGoal.id) {
+      const body = JSON.stringify({
+        userId: studentLevelInfo.user_id,
+        learningGoalId: learningGoal.id,
+      });
+      HttpClient.post(
+        `${base_teacher_evaluation_endpoint}/get_or_create_evaluation`,
+        body,
+        true,
+        {
+          'Content-Type': 'application/json',
+        }
+      )
+        .then(response => response.json())
+        .then(json => {
+          setLearningGoalEval(json);
+          if (json.feedback) {
+            teacherFeedback.current = json.feedback;
+            setDisplayFeedback(teacherFeedback.current);
+          }
+          if (json.understanding >= 0 && json.understanding !== null) {
+            setDisplayUnderstanding(json.understanding);
+            understandingLevel.current = json.understanding;
+          }
+        })
+        .catch(error => console.log(error));
+    }
+  }, [studentLevelInfo, learningGoal]);
+
+  // Callback to retrieve understanding data from EvidenceLevels
+  const radioButtonCallback = radioButtonData => {
+    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_EVIDENCE_LEVEL_SELECTED, {
+      ...(reportingData || {}),
+      learningGoalId: learningGoal.id,
+      learningGoal: learningGoal.learningGoal,
+      newlySelectedEvidenceLevel: radioButtonData,
+      previouslySelectedEvidenceLevel: understandingLevel.current,
+    });
+    setDisplayUnderstanding(radioButtonData);
+    understandingLevel.current = radioButtonData;
+    if (!isAutosaving) {
+      autosave();
+    }
+  };
+
+  const renderAutoSaveTextbox = () => {
+    return (
+      <div className={`${style.feedbackArea} uitest-learning-goal`}>
+        <label className={style.evidenceLevelLabel}>
+          <span>{i18n.feedback()}</span>
+          <textarea
+            id="ui-teacherFeedback"
+            className={style.inputTextbox}
+            name="teacherFeedback"
+            value={displayFeedback}
+            onChange={handleFeedbackChange}
+            disabled={!canProvideFeedback}
+          />
+        </label>
+        {isAutosaving ? (
+          <span className={style.autosaveMessage}>{i18n.saving()}</span>
+        ) : (
+          autosaved && (
+            <span id="ui-autosaveConfirm" className={style.autosaveMessage}>
+              <FontAwesome icon="circle-check" /> {i18n.savedToGallery()}
+            </span>
+          )
+        )}
+        {errorAutosaving && (
+          <span className={style.autosaveMessage}>
+            {i18n.feedbackSaveError()}
+          </span>
+        )}
+      </div>
+    );
+  };
+
+  const renderSubmittedFeedbackTextbox = () => {
+    return (
+      <div className={style.feedbackArea}>
+        <label className={style.evidenceLevelLabel}>
+          <span>{i18n.feedback()}</span>
+          <textarea
+            className={style.inputTextbox}
+            name="teacherFeedback"
+            value={submittedEvaluation.feedback}
+            disabled
+          />
+        </label>
+      </div>
+    );
+  };
+
+  return (
+    <details className={style.learningGoalRow}>
+      <summary className={style.learningGoalHeader} onClick={handleClick}>
+        <div className={style.learningGoalHeaderLeftSide}>
+          {/*TODO: [DES-321] Label-two styles here*/}
+          <StrongText>{learningGoal.learningGoal}</StrongText>
+        </div>
+        <div className={style.learningGoalHeaderRightSide}>
+          {aiEnabled && displayUnderstanding === invalidUnderstanding && (
+            <AiToken />
+          )}
+          {/*TODO: Display status of feedback*/}
+          {canProvideFeedback &&
+            aiEnabled &&
+            displayUnderstanding === invalidUnderstanding && (
+              <BodyThreeText>{i18n.approve()}</BodyThreeText>
+            )}
+          {canProvideFeedback &&
+            !aiEnabled &&
+            displayUnderstanding === invalidUnderstanding && (
+              <BodyThreeText>{i18n.evaluate()}</BodyThreeText>
+            )}
+          {displayUnderstanding >= 0 && (
+            <BodyThreeText>
+              {UNDERSTANDING_LEVEL_STRINGS[displayUnderstanding]}
+            </BodyThreeText>
+          )}
+          {submittedEvaluation && (
+            <div className={style.submittedEvaluation}>
+              {submittedEvaluation.understanding !== null && (
+                <BodyThreeText>
+                  {
+                    UNDERSTANDING_LEVEL_STRINGS[
+                      submittedEvaluation.understanding
+                    ]
+                  }
+                </BodyThreeText>
+              )}
+              {submittedEvaluation.feedback && (
+                <FontAwesome
+                  icon="message"
+                  className="fa-regular"
+                  title={i18n.feedback()}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      </summary>
+
+      {/*TODO: Pass through data to child component*/}
+      <div>
+        {teacherHasEnabledAi &&
+          !!studentLevelInfo &&
+          !!aiEvalInfo &&
+          aiUnderstanding !== undefined && (
+            <div className={style.openedAiAssessment}>
+              <AiAssessment
+                isAiAssessed={learningGoal.aiEnabled}
+                studentName={studentLevelInfo.name}
+                aiConfidence={aiConfidence}
+                aiUnderstandingLevel={aiUnderstanding}
+                aiEvalInfo={aiEvalInfo}
+              />
+            </div>
+          )}
+        <div className={style.learningGoalExpanded}>
+          {!!submittedEvaluation && renderSubmittedFeedbackTextbox()}
+          <EvidenceLevels
+            learningGoalKey={learningGoal.key}
+            evidenceLevels={learningGoal.evidenceLevels}
+            canProvideFeedback={canProvideFeedback}
+            understanding={displayUnderstanding}
+            radioButtonCallback={radioButtonCallback}
+            submittedEvaluation={submittedEvaluation}
+            isStudent={isStudent}
+          />
+          {learningGoal.tips && !isStudent && (
+            <div>
+              <Heading6>{i18n.tipsForEvaluation()}</Heading6>
+              <div className={style.learningGoalTips}>
+                <SafeMarkdown markdown={learningGoal.tips} />
+              </div>
+            </div>
+          )}
+          {!!studentLevelInfo && renderAutoSaveTextbox()}
+        </div>
+      </div>
+    </details>
+  );
+}
+
+LearningGoal.propTypes = {
+  learningGoal: learningGoalShape.isRequired,
+  teacherHasEnabledAi: PropTypes.bool,
+  canProvideFeedback: PropTypes.bool,
+  reportingData: reportingDataShape,
+  studentLevelInfo: studentLevelInfoShape,
+  aiUnderstanding: PropTypes.number,
+  aiConfidence: PropTypes.number,
+  submittedEvaluation: submittedEvaluationShape,
+  isStudent: PropTypes.bool,
+  feedbackAdded: PropTypes.bool,
+  setFeedbackAdded: PropTypes.func,
+  aiEvalInfo: aiEvaluationShape,
+};
+
+const AiToken = () => {
+  return (
+    <div className="uitest-uses-ai">
+      {' '}
+      <BodyFourText className={classnames(style.aiToken, style.aiTokenText)}>
+        <ExtraStrongText>{i18n.usesAi()}</ExtraStrongText>
+      </BodyFourText>
+    </div>
+  );
+};

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -16,7 +16,7 @@ import {
   studentLevelInfoShape,
 } from './rubricShapes';
 import LearningGoal from './LearningGoal';
-import LearningGoals from'./LearningGoals';
+import LearningGoals from './LearningGoals';
 import Button from '@cdo/apps/templates/Button';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import classnames from 'classnames';
@@ -55,7 +55,6 @@ export default function RubricContent({
   const [errorSubmitting, setErrorSubmitting] = useState(false);
   const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
   const [feedbackAdded, setFeedbackAdded] = useState(false);
-  const [currentLearningGoal, setCurrentLearningGoal] = useState(0);
   const submitFeedbackToStudent = () => {
     analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_SUBMITTED, {
       ...reportingData,
@@ -126,17 +125,6 @@ export default function RubricContent({
     }
   };
 
-  const onCarouselPress = buttonValue => {
-    let currentIndex = currentLearningGoal;
-    currentIndex += buttonValue;
-    if (currentIndex < 0) {
-      currentIndex = rubric.learningGoals.length - 1;
-    } else if (currentIndex >= rubric.learningGoals.length) {
-      currentIndex = 0;
-    }
-    setCurrentLearningGoal(currentIndex);
-  };
-
   let infoText = null;
   if (!onLevelForEvaluation) {
     infoText = i18n.rubricCanOnlyBeEvaluatedOnProjectLevelAlert();
@@ -202,40 +190,17 @@ export default function RubricContent({
         )}
       </div>
       {experiments.isEnabled('ai-rubrics-redesign') ? (
-        <div className={style.learningGoalContainer}>
-          <button
-            type="button"
-            className={style.learningGoalButton}
-            onClick={() => onCarouselPress(-1)}
-          >
-            <FontAwesome icon="angle-left" />
-          </button>
-          <LearningGoals
-            key={rubric.learningGoals[currentLearningGoal].key}
-            learningGoal={rubric.learningGoals[currentLearningGoal]}
-            teacherHasEnabledAi={teacherHasEnabledAi}
-            canProvideFeedback={canProvideFeedback}
-            reportingData={reportingData}
-            studentLevelInfo={studentLevelInfo}
-            aiUnderstanding={getAiUnderstanding(
-              rubric.learningGoals[currentLearningGoal].id
-            )}
-            aiConfidence={getAiConfidence(
-              rubric.learningGoals[currentLearningGoal].id
-            )}
-            isStudent={false}
-            feedbackAdded={feedbackAdded}
-            setFeedbackAdded={setFeedbackAdded}
-            aiEvalInfo={getAiInfo(rubric.learningGoals[currentLearningGoal].id)}
-          />
-          <button
-            type="button"
-            className={style.learningGoalButton}
-            onClick={() => onCarouselPress(1)}
-          >
-            <FontAwesome icon="angle-right" />
-          </button>
-        </div>
+        <LearningGoals
+          learningGoals={rubric.learningGoals}
+          teacherHasEnabledAi={teacherHasEnabledAi}
+          canProvideFeedback={canProvideFeedback}
+          reportingData={reportingData}
+          studentLevelInfo={studentLevelInfo}
+          isStudent={false}
+          feedbackAdded={feedbackAdded}
+          setFeedbackAdded={setFeedbackAdded}
+          aiEvaluations={aiEvaluations}
+        />
       ) : (
         <div className={style.learningGoalContainer}>
           {rubric.learningGoals.map(lg => (

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -53,6 +53,7 @@ export default function RubricContent({
   const [errorSubmitting, setErrorSubmitting] = useState(false);
   const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
   const [feedbackAdded, setFeedbackAdded] = useState(false);
+  const [currentLearningGoal, setCurrentLearningGoal] = useState(0);
   const submitFeedbackToStudent = () => {
     analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_SUBMITTED, {
       ...reportingData,
@@ -123,6 +124,17 @@ export default function RubricContent({
     }
   };
 
+  const onCarouselPress = buttonValue => {
+    let currentIndex = currentLearningGoal;
+    currentIndex += buttonValue;
+    if (currentIndex < 0) {
+      currentIndex = rubric.learningGoals.length - 1;
+    } else if (currentIndex >= rubric.learningGoals.length) {
+      currentIndex = 0;
+    }
+    setCurrentLearningGoal(currentIndex);
+  };
+
   let infoText = null;
   if (!onLevelForEvaluation) {
     infoText = i18n.rubricCanOnlyBeEvaluatedOnProjectLevelAlert();
@@ -188,22 +200,38 @@ export default function RubricContent({
         )}
       </div>
       <div className={style.learningGoalContainer}>
-        {rubric.learningGoals.map(lg => (
-          <LearningGoal
-            key={lg.key}
-            learningGoal={lg}
-            teacherHasEnabledAi={teacherHasEnabledAi}
-            canProvideFeedback={canProvideFeedback}
-            reportingData={reportingData}
-            studentLevelInfo={studentLevelInfo}
-            aiUnderstanding={getAiUnderstanding(lg.id)}
-            aiConfidence={getAiConfidence(lg.id)}
-            isStudent={false}
-            feedbackAdded={feedbackAdded}
-            setFeedbackAdded={setFeedbackAdded}
-            aiEvalInfo={getAiInfo(lg.id)}
-          />
-        ))}
+        <button
+          type="button"
+          className={style.learningGoalButton}
+          onClick={() => onCarouselPress(-1)}
+        >
+          <FontAwesome icon="angle-left" />
+        </button>
+        <LearningGoal
+          key={rubric.learningGoals[currentLearningGoal].key}
+          learningGoal={rubric.learningGoals[currentLearningGoal]}
+          teacherHasEnabledAi={teacherHasEnabledAi}
+          canProvideFeedback={canProvideFeedback}
+          reportingData={reportingData}
+          studentLevelInfo={studentLevelInfo}
+          aiUnderstanding={getAiUnderstanding(
+            rubric.learningGoals[currentLearningGoal].id
+          )}
+          aiConfidence={getAiConfidence(
+            rubric.learningGoals[currentLearningGoal].id
+          )}
+          isStudent={false}
+          feedbackAdded={feedbackAdded}
+          setFeedbackAdded={setFeedbackAdded}
+          aiEvalInfo={getAiInfo(rubric.learningGoals[currentLearningGoal].id)}
+        />
+        <button
+          type="button"
+          className={style.learningGoalButton}
+          onClick={() => onCarouselPress(1)}
+        >
+          <FontAwesome icon="angle-right" />
+        </button>
       </div>
       {canProvideFeedback && (
         <div className={style.rubricContainerFooter}>

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -16,6 +16,7 @@ import {
   studentLevelInfoShape,
 } from './rubricShapes';
 import LearningGoal from './LearningGoal';
+import LearningGoals from'./LearningGoals';
 import Button from '@cdo/apps/templates/Button';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import classnames from 'classnames';
@@ -209,7 +210,7 @@ export default function RubricContent({
           >
             <FontAwesome icon="angle-left" />
           </button>
-          <LearningGoal
+          <LearningGoals
             key={rubric.learningGoals[currentLearningGoal].key}
             learningGoal={rubric.learningGoals[currentLearningGoal]}
             teacherHasEnabledAi={teacherHasEnabledAi}

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -21,6 +21,7 @@ import HttpClient from '@cdo/apps/util/HttpClient';
 import classnames from 'classnames';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import experiments from '@cdo/apps/util/experiments';
 
 const formatTimeSpent = timeSpent => {
   const minutes = Math.floor(timeSpent / 60);
@@ -199,40 +200,62 @@ export default function RubricContent({
           </div>
         )}
       </div>
-      <div className={style.learningGoalContainer}>
-        <button
-          type="button"
-          className={style.learningGoalButton}
-          onClick={() => onCarouselPress(-1)}
-        >
-          <FontAwesome icon="angle-left" />
-        </button>
-        <LearningGoal
-          key={rubric.learningGoals[currentLearningGoal].key}
-          learningGoal={rubric.learningGoals[currentLearningGoal]}
-          teacherHasEnabledAi={teacherHasEnabledAi}
-          canProvideFeedback={canProvideFeedback}
-          reportingData={reportingData}
-          studentLevelInfo={studentLevelInfo}
-          aiUnderstanding={getAiUnderstanding(
-            rubric.learningGoals[currentLearningGoal].id
-          )}
-          aiConfidence={getAiConfidence(
-            rubric.learningGoals[currentLearningGoal].id
-          )}
-          isStudent={false}
-          feedbackAdded={feedbackAdded}
-          setFeedbackAdded={setFeedbackAdded}
-          aiEvalInfo={getAiInfo(rubric.learningGoals[currentLearningGoal].id)}
-        />
-        <button
-          type="button"
-          className={style.learningGoalButton}
-          onClick={() => onCarouselPress(1)}
-        >
-          <FontAwesome icon="angle-right" />
-        </button>
-      </div>
+      {experiments.isEnabled('ai-rubrics-redesign') ? (
+        <div className={style.learningGoalContainer}>
+          <button
+            type="button"
+            className={style.learningGoalButton}
+            onClick={() => onCarouselPress(-1)}
+          >
+            <FontAwesome icon="angle-left" />
+          </button>
+          <LearningGoal
+            key={rubric.learningGoals[currentLearningGoal].key}
+            learningGoal={rubric.learningGoals[currentLearningGoal]}
+            teacherHasEnabledAi={teacherHasEnabledAi}
+            canProvideFeedback={canProvideFeedback}
+            reportingData={reportingData}
+            studentLevelInfo={studentLevelInfo}
+            aiUnderstanding={getAiUnderstanding(
+              rubric.learningGoals[currentLearningGoal].id
+            )}
+            aiConfidence={getAiConfidence(
+              rubric.learningGoals[currentLearningGoal].id
+            )}
+            isStudent={false}
+            feedbackAdded={feedbackAdded}
+            setFeedbackAdded={setFeedbackAdded}
+            aiEvalInfo={getAiInfo(rubric.learningGoals[currentLearningGoal].id)}
+          />
+          <button
+            type="button"
+            className={style.learningGoalButton}
+            onClick={() => onCarouselPress(1)}
+          >
+            <FontAwesome icon="angle-right" />
+          </button>
+        </div>
+      ) : (
+        <div className={style.learningGoalContainer}>
+          {rubric.learningGoals.map(lg => (
+            <LearningGoal
+              key={lg.key}
+              learningGoal={lg}
+              teacherHasEnabledAi={teacherHasEnabledAi}
+              canProvideFeedback={canProvideFeedback}
+              reportingData={reportingData}
+              studentLevelInfo={studentLevelInfo}
+              aiUnderstanding={getAiUnderstanding(lg.id)}
+              aiConfidence={getAiConfidence(lg.id)}
+              isStudent={false}
+              feedbackAdded={feedbackAdded}
+              setFeedbackAdded={setFeedbackAdded}
+              aiEvalInfo={getAiInfo(lg.id)}
+            />
+          ))}
+        </div>
+      )}
+
       {canProvideFeedback && (
         <div className={style.rubricContainerFooter}>
           <div className={style.submitToStudentButtonAndError}>

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -153,17 +153,6 @@
   gap: 0.5rem;
 }
 
-.learningGoalContainer {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  align-self: stretch;
-
-  border-radius: 4px;
-  border: 1px solid $neutral_dark40;
-  background: $neutral_white;
-}
-
 .rubricHeader {
   border-radius: 4px 4px 0 0;
   background: $neutral_dark;
@@ -241,11 +230,27 @@ button.rubricHeaderTab {
     line-height: 1.1875;
   }
 }
+.learningGoalContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: space-between;
+  align-self: stretch;
+  border-radius: 4px;
+  border: 1px solid $neutral_dark40;
+  background: $neutral_white;
+}
+
+.learningGoalButton {
+  background: none;
+  border: none;
+}
 
 .learningGoalRow {
   display: flex;
   align-self: stretch;
-  border-bottom: 1px solid $neutral_dark40;
+  justify-content: space-between;
+  width: 100%;
   min-height: 40px;
 
   // Directly target the <summary> child with the class

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -241,11 +241,6 @@ button.rubricHeaderTab {
   background: $neutral_white;
 }
 
-.learningGoalButton {
-  background: none;
-  border: none;
-}
-
 .learningGoalRow {
   display: flex;
   align-self: stretch;
@@ -374,6 +369,57 @@ h2.studentName {
     line-height: 1.54;
   }
 }
+
+// Start of rubrics redesign
+.learningGoalsContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+  align-self: stretch;
+  border-radius: 4px;
+  border: 1px solid $neutral_dark40;
+  background: $neutral_white;
+}
+
+.learningGoalButton {
+  background: none;
+  border: none;
+}
+
+.learningGoalsHeader {
+  display: flex;
+  flex-direction: row;
+  height: 40px;
+  padding: 0 1rem 0 2rem;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+  line-height: 154%;
+  position: relative;
+}
+
+.learningGoalsHeaderLeftSide {
+  @include main-font-semi-bold;
+  display: flex;
+  align-items: left;
+  //gap: 16px;
+  font-size: 14px;
+}
+
+.learningGoalsHeaderRightSide {
+  display: flex;
+  justify-content: flex-end;
+  align-items: right;
+  //gap: 16px;
+  font-weight: 325;
+  line-height: 154%;
+
+  p {
+    margin-bottom: 0;
+  }
+}
+// End of rubrics redesign
 
 .evidenceLevelSetHorizontal {
   display: flex;

--- a/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
@@ -1,0 +1,305 @@
+import React from 'react';
+import {expect} from '../../../util/reconfiguredChai';
+import {shallow, mount} from 'enzyme';
+import sinon from 'sinon';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {RubricUnderstandingLevels} from '@cdo/apps/util/sharedConstants';
+import LearningGoals from '@cdo/apps/templates/rubrics/LearningGoals';
+
+describe('LearningGoals', () => {
+  const studentLevelInfo = {name: 'Grace Hopper', timeSpent: 706};
+
+  const learningGoals = [
+    {
+      id: 2,
+      key: 'abcd',
+      learningGoal: 'Testing 1',
+      aiEnabled: true,
+      evidenceLevels: [{id: 1, understanding: 1, teacherDescription: 'test'}],
+      tips: 'Tips',
+    },
+    {
+      key: 'efgh',
+      learningGoal: 'Testing 2',
+      aiEnabled: false,
+      evidenceLevels: [{id: 1, understanding: 1, teacherDescription: 'test'}],
+      tips: 'Tips',
+    },
+  ];
+
+  const submittedEvaluation = {
+    feedback: 'test feedback',
+    understanding: RubricUnderstandingLevels.LIMITED,
+  };
+
+  const aiEvaluations = [
+    {
+      id: 2,
+      learning_goal_id: 2,
+      understanding: 2,
+      ai_confidence: 50,
+    },
+  ];
+
+  it('renders EvidenceLevels', () => {
+    const wrapper = shallow(
+      <LearningGoals learningGoals={learningGoals} teacherHasEnabledAi />
+    );
+    expect(wrapper.find('EvidenceLevels')).to.have.lengthOf(1);
+    expect(wrapper.find('EvidenceLevels').props().evidenceLevels).to.deep.equal(
+      [{id: 1, understanding: 1, teacherDescription: 'test'}]
+    );
+    expect(wrapper.find('SafeMarkdown')).to.have.lengthOf(1);
+  });
+
+  it('changes learning goal when left and right buttons are pressed', () => {
+    const wrapper = shallow(
+      <LearningGoals learningGoals={learningGoals} teacherHasEnabledAi />
+    );
+    expect(wrapper.find('StrongText').props().children).to.equal(
+      learningGoals[0].learningGoal
+    );
+    wrapper.find('button').first().simulate('click');
+    expect(wrapper.find('StrongText').props().children).to.equal(
+      learningGoals[1].learningGoal
+    );
+    wrapper.find('button').at(1).simulate('click');
+    expect(wrapper.find('StrongText').props().children).to.equal(
+      learningGoals[0].learningGoal
+    );
+  });
+
+  it('renders AiAssessment when teacher has AiEnabled and the learning goal can be tested by AI', () => {
+    const wrapper = shallow(
+      <LearningGoals
+        learningGoals={learningGoals}
+        teacherHasEnabledAi={true}
+        aiConfidence={50}
+        aiUnderstanding={3}
+        studentLevelInfo={studentLevelInfo}
+        aiEvaluations={aiEvaluations}
+      />
+    );
+    expect(wrapper.find('AiAssessment')).to.have.lengthOf(1);
+    expect(wrapper.find('AiAssessment').props().studentName).to.equal(
+      studentLevelInfo.name
+    );
+    expect(wrapper.find('AiAssessment').props().aiConfidence).to.equal(50);
+    expect(wrapper.find('AiAssessment').props().aiUnderstandingLevel).to.equal(
+      2
+    );
+    expect(wrapper.find('AiAssessment').props().isAiAssessed).to.equal(true);
+  });
+
+  it('does not renders AiAssessment when teacher has disabled ai', () => {
+    const wrapper = shallow(
+      <LearningGoals
+        learningGoals={learningGoals}
+        teacherHasEnabledAi={false}
+        studentLevelInfo={studentLevelInfo}
+      />
+    );
+    expect(wrapper.find('AiAssessment')).to.have.lengthOf(0);
+  });
+
+  it('renders tips for teachers', () => {
+    const wrapper = shallow(
+      <LearningGoals
+        learningGoals={learningGoals}
+        teacherHasEnabledAi
+        isStudent={false}
+      />
+    );
+    expect(wrapper.find('Heading6')).to.have.lengthOf(1);
+    expect(wrapper.find('SafeMarkdown')).to.have.lengthOf(1);
+    expect(wrapper.find('SafeMarkdown').props().markdown).to.equal('Tips');
+  });
+
+  it('does not render tips for students', () => {
+    const wrapper = shallow(
+      <LearningGoals learningGoals={learningGoals} isStudent={true} />
+    );
+    expect(wrapper.find('Heading6')).to.have.lengthOf(0);
+    expect(wrapper.find('SafeMarkdown')).to.have.lengthOf(0);
+  });
+
+  it('shows AI token when AI is enabled', () => {
+    const wrapper = shallow(
+      <LearningGoals learningGoals={learningGoals} teacherHasEnabledAi />
+    );
+    expect(wrapper.find('StrongText').props().children).to.equal(
+      learningGoals[0].learningGoal
+    );
+    expect(wrapper.find('AiToken')).to.have.lengthOf(1);
+  });
+
+  it('does not show AI token when AI is disabled', () => {
+    const wrapper = shallow(
+      <LearningGoals learningGoals={learningGoals} teacherHasEnabledAi />
+    );
+    wrapper.find('button').first().simulate('click');
+    expect(wrapper.find('StrongText').props().children).to.equal(
+      learningGoals[1].learningGoal
+    );
+    expect(wrapper.find('AiToken')).to.have.lengthOf(0);
+  });
+
+  it('does not show AI token when teacher has disabled AI', () => {
+    const wrapper = shallow(
+      <LearningGoals
+        learningGoals={learningGoals}
+        teacherHasEnabledAi={false}
+      />
+    );
+    expect(wrapper.find('StrongText').props().children).to.equal(
+      learningGoals[0].learningGoal
+    );
+    expect(wrapper.find('AiToken')).to.have.lengthOf(0);
+  });
+
+  it('does not show AI token after teacher has submitted evaluation', () => {
+    const wrapper = shallow(
+      <LearningGoals
+        learningGoals={learningGoals}
+        submittedEvaluation={{
+          feedback: 'test feedback',
+          understanding: RubricUnderstandingLevels.LIMITED,
+        }}
+      />
+    );
+    expect(wrapper.find('AiToken')).to.have.lengthOf(0);
+  });
+
+  it('sends event when new learning goal is selected', () => {
+    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
+
+    const wrapper = shallow(
+      <LearningGoals
+        learningGoals={learningGoals}
+        reportingData={{unitName: 'test-2023', levelName: 'test-level'}}
+      />
+    );
+    wrapper.find('button').first().simulate('click');
+    expect(sendEventSpy).to.have.been.calledWith(
+      EVENTS.TA_RUBRIC_LEARNING_GOAL_SELECTED,
+      {
+        unitName: 'test-2023',
+        levelName: 'test-level',
+        learningGoalKey: 'efgh',
+        learningGoal: 'Testing 2',
+      }
+    );
+    wrapper.find('button').first().simulate('click');
+    expect(sendEventSpy).to.have.been.calledWith(
+      EVENTS.TA_RUBRIC_LEARNING_GOAL_SELECTED,
+      {
+        unitName: 'test-2023',
+        levelName: 'test-level',
+        learningGoalKey: 'abcd',
+        learningGoal: 'Testing 1',
+      }
+    );
+    sendEventSpy.restore();
+  });
+
+  it('displays Evaluate when AI is disabled and no understanding has been selected', () => {
+    const wrapper = mount(
+      <LearningGoals
+        learningGoals={learningGoals}
+        teacherHasEnabledAi
+        canProvideFeedback
+      />
+    );
+    wrapper.update();
+    wrapper.find('button').at(1).simulate('click');
+    expect(wrapper.find('BodyThreeText').first().text()).to.include('Evaluate');
+    wrapper.unmount();
+  });
+
+  it('displays Approve when AI is enabled and no understanding has been selected', () => {
+    const wrapper = mount(
+      <LearningGoals
+        learningGoals={learningGoals}
+        teacherHasEnabledAi
+        canProvideFeedback
+      />
+    );
+    wrapper.update();
+    expect(wrapper.find('BodyThreeText').first().text()).to.include('Approve');
+    wrapper.unmount();
+  });
+
+  it('shows feedback in disabled textbox when available', () => {
+    const wrapper = shallow(
+      <LearningGoals
+        learningGoals={learningGoals}
+        submittedEvaluation={{
+          feedback: 'test feedback',
+          understanding: 1,
+        }}
+      />
+    );
+    expect(wrapper.find('textarea').props().value).to.equal('test feedback');
+    expect(wrapper.find('textarea').props().disabled).to.equal(true);
+    expect(wrapper.find('FontAwesome').at(1).props().icon).to.equal('message');
+  });
+
+  it('shows editable textbox for feedback when the teacher can provide feedback', () => {
+    const wrapper = shallow(
+      <LearningGoals
+        canProvideFeedback={true}
+        studentLevelInfo={studentLevelInfo}
+        learningGoals={learningGoals}
+      />
+    );
+    expect(wrapper.find('textarea').props().disabled).to.equal(false);
+  });
+
+  it('shows understanding in header if submittedEvaluation contains understand', () => {
+    const wrapper = shallow(
+      <LearningGoals
+        learningGoals={learningGoals}
+        submittedEvaluation={{
+          feedback: 'test feedback',
+          understanding: RubricUnderstandingLevels.LIMITED,
+        }}
+      />
+    );
+    expect(wrapper.find('BodyThreeText').props().children).to.equal(
+      'Limited Evidence'
+    );
+  });
+
+  it('shows No Evidence understanding in header if submittedEvaluation contains understand', () => {
+    const wrapper = shallow(
+      <LearningGoals
+        learningGoals={learningGoals}
+        submittedEvaluation={{
+          feedback: 'test feedback',
+          understanding: RubricUnderstandingLevels.NONE,
+        }}
+      />
+    );
+    expect(wrapper.find('BodyThreeText').props().children).to.equal(
+      'No Evidence'
+    );
+  });
+
+  it('passes isStudent down to EvidenceLevels', () => {
+    const wrapper = shallow(
+      <LearningGoals
+        learningGoals={learningGoals}
+        submittedEvaluation={submittedEvaluation}
+        isStudent
+      />
+    );
+    expect(wrapper.find('EvidenceLevels').props().isStudent).to.equal(true);
+    expect(wrapper.find('EvidenceLevels').props().submittedEvaluation).to.equal(
+      submittedEvaluation
+    );
+    expect(wrapper.find('EvidenceLevels').props().evidenceLevels).to.equal(
+      learningGoals[0]['evidenceLevels']
+    );
+  });
+});

--- a/apps/test/unit/templates/rubrics/RubricContentTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContentTest.jsx
@@ -4,6 +4,7 @@ import {mount, shallow} from 'enzyme';
 import sinon from 'sinon';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import RubricContent from '@cdo/apps/templates/rubrics/RubricContent';
+import experiments from '@cdo/apps/util/experiments';
 
 describe('RubricContent', () => {
   const defaultRubric = {
@@ -314,5 +315,52 @@ describe('RubricContent', () => {
     expect(wrapper.find('InfoAlert').props().text).to.equal(
       'Select a student from the Teacher Panel to view and evaluate their work.'
     );
+  });
+
+  it('displays new LearningGoals prop when ai-rubrics-redesign experiment is enabled', () => {
+    experiments.setEnabled('ai-rubrics-redesign', true);
+    const wrapper = mount(
+      <RubricContent
+        {...defaultProps}
+        studentLevelInfo={{
+          name: 'Grace Hopper',
+          timeSpent: 305,
+          lastAttempt: '1980-07-31T00:00:00.000Z',
+          attempts: 6,
+        }}
+      />
+    );
+    expect(wrapper.find('LearningGoals').length).to.equal(1);
+    experiments.setEnabled('ai-rubrics-redesign', false);
+  });
+
+  it('passes correct props to LearningGoals component', () => {
+    experiments.setEnabled('ai-rubrics-redesign', true);
+    const aiEvaluations = [
+      {id: 2, learning_goal_id: 2, understanding: 2, ai_confidence: 2},
+    ];
+    const studentLevelInfo = {
+      name: 'Grace Hopper',
+      timeSpent: 305,
+      lastAttempt: '1980-07-31T00:00:00.000Z',
+      attempts: 6,
+    };
+    const wrapper = mount(
+      <RubricContent
+        {...defaultProps}
+        studentLevelInfo={studentLevelInfo}
+        aiEvaluations={aiEvaluations}
+      />
+    );
+    expect(wrapper.find('LearningGoals').prop('studentLevelInfo')).to.equal(
+      studentLevelInfo
+    );
+    expect(wrapper.find('LearningGoals').prop('learningGoals')).to.equal(
+      defaultRubric.learningGoals
+    );
+    expect(wrapper.find('LearningGoals').prop('aiEvaluations')).to.equal(
+      aiEvaluations
+    );
+    experiments.setEnabled('ai-rubrics-redesign', false);
   });
 });


### PR DESCRIPTION
Created a new LearningGoals component that uses a carousel to cycle through each learning goal in a rubric. This component is part of the ai-rubrics-redesign experiment.

![Screenshot 2023-12-13 124923](https://github.com/code-dot-org/code-dot-org/assets/5552007/271dc97c-05a2-4f76-b4cf-40aca93d6b4c)

## Links

[AITT-361](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?assignee=712020%3A250d7a97-0218-4596-992c-547f32c30439&selectedIssue=AITT-361)

## Testing story

Created frontend unit tests for all parts of the LearningGoals component

## Follow-up work

- Create wheel component to indicate progress through LearningGoals
- Adjust design to better match figma mock ups

![Screenshot 2023-12-13 125501](https://github.com/code-dot-org/code-dot-org/assets/5552007/0bbb89db-159f-4520-b22a-ab1de8bc1960)