### PR TITLE
Re-enable `a11y/no-autofocus`

### DIFF
--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -17,7 +17,6 @@ const rulesToEventuallyReenable = {
   'jsx-a11y/label-has-associated-control': 'off',
   'jsx-a11y/media-has-caption': 'off',
   'jsx-a11y/mouse-events-have-key-events': 'off',
-  'jsx-a11y/no-autofocus': 'off',
   'jsx-a11y/no-noninteractive-element-interactions': 'off',
   'jsx-a11y/no-noninteractive-element-to-interactive-role': 'off',
   'jsx-a11y/no-noninteractive-tabindex': 'off',

--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -73,6 +73,7 @@ class JavalabConsole extends React.Component {
 
   jumpToBottom = () => {
     this._consoleLogs.scrollTop = this._consoleLogs.scrollHeight;
+    this.focusInput();
   };
 
   // Transform this.props.consoleLogs into an array of strings, with each string
@@ -134,7 +135,6 @@ class JavalabConsole extends React.Component {
               onKeyDown={this.onInputKeyDown}
               aria-label="console input"
               ref={ref => (this.inputRef = ref)}
-              autoFocus
             />
           </div>
         );
@@ -171,7 +171,7 @@ class JavalabConsole extends React.Component {
       );
     } else {
       return (
-        <div onClick={this.onLogsClick} style={styles.logs}>
+        <div onClick={this.focusInput} style={styles.logs}>
           {this.renderConsoleLogs(displayTheme)}
         </div>
       );
@@ -199,7 +199,7 @@ class JavalabConsole extends React.Component {
     }
   };
 
-  onLogsClick = () => {
+  focusInput = () => {
     // only jump to input if the program is currently in run or test mode.
     if (this.props.shouldJumpToInput) {
       this.inputRef.focus();

--- a/apps/src/javalab/NameFileDialog.jsx
+++ b/apps/src/javalab/NameFileDialog.jsx
@@ -26,6 +26,7 @@ export default class NameFileDialog extends Component {
 
   componentDidUpdate(prevProps) {
     if (!prevProps.isOpen && this.props.isOpen) {
+      this.textInput.focus();
       this.textInput.setSelectionRange(0, 0);
     }
   }
@@ -85,7 +86,6 @@ export default class NameFileDialog extends Component {
               ...(displayTheme === DisplayTheme.DARK && styles.darkDialog),
             }}
             onKeyDown={this.onKeyDown}
-            autoFocus
           />
           <div>
             <button

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewCommentEditor.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewCommentEditor.jsx
@@ -102,7 +102,6 @@ const CodeReviewCommentEditor = ({addCodeReviewComment}) => {
             placeholder={javalabMsg.addACommentToReview()}
             className="editable-text-area"
             spellCheck
-            autoFocus
           />
         </Slate>
       </div>


### PR DESCRIPTION
Interestingly, this is a rule that outlaws React's [own implementation of autoFocus](https://react.dev/reference/react-dom/components/input#props) (rather than [the HTML `autofocus` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)).

Three cases of this in our code base currently (all in Java Lab 😬 ), and they all represent slightly different cases:
1.  **The console:** the existing `autoFocus` usage seems generally not super useful (across users), as it drops the cursor into the console on page load, where you can't really do anything until your program is running. If we were going to `autoFocus` anywhere, I'd expect we'd want to do it into the editor rather than the console. I've updated it to only focus the console when a student is running their program. This is helpful for cases where a program prompts a user for input, so that your cursor remains at the end of the most recent console log (eg, "What's your name?").
2. **The file name editing modal:** this seems more like a fine place to have `autoFocus` across users -- there's not much else you can do in the modal, and we drop you right into the place you'd want to be to edit a file name. That said, I removed the `autoFocus` (and basically reimplemented what I think React generally does by focusing the element when we open the modal), but would be open to just allowing `autoFocus` here if we think that's better. Upside is that we're explicit about when we're focusing (rather than relying on React's logic).
3. **The code review editing experience:** once a user opens the "Review" tab in the Instructions panel in Java Lab, we drop users directly into the input where you can write comments. This seems ok for sighted users, but I think could be confusing for unsighted/low vision users, as there is other functionality in the code review tab that you might want to be aware of before writing a comment (eg, a "Refresh" button, the ability to add code styling to your comment, etc). Removing `autoFocus` here seemed like a good in-between solution, as it still scrolls to the bottom of the content of the Review tab (it can get lengthy if you have a bunch of comments), but requires the student to click into the comment editing area. People using tab navigation would tab from the top, hitting the "Refresh" button, etc before landing in the comment editing area.

## Links

- [no-autofocus rule details](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-autofocus.md)

## Testing story

I tested each of these components manually in Chrome -- in particular, focus in the console when soliciting user input (at /s/allthethings/lessons/44/levels/2) appeared to function as it did previously. The cursor is placed at the end of the last console log -- here's an example:

<img width="420" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/7f2ebde8-b228-402a-8b5b-d1523656865b">
