### PR TITLE
Prevent levelbuilders from accidentally switching a standalone course to non-standalone

### DIFF
--- a/apps/src/lib/levelbuilder/course-editor/CourseUnitsEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseUnitsEditor.js
@@ -24,10 +24,10 @@ export default class CourseUnitsEditor extends Component {
   };
 
   render() {
-    const {unitNames} = this.props;
+    const {unitNames, unitsInCourse} = this.props;
     return (
       <div>
-        {this.props.unitsInCourse.concat('').map((selectedUnit, index) => (
+        {unitsInCourse.concat('').map((selectedUnit, index) => (
           <select
             style={{
               ...this.props.inputStyle,

--- a/apps/src/lib/levelbuilder/course-editor/CourseUnitsEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseUnitsEditor.js
@@ -24,10 +24,10 @@ export default class CourseUnitsEditor extends Component {
   };
 
   render() {
-    const {unitNames, unitsInCourse} = this.props;
+    const {unitNames} = this.props;
     return (
       <div>
-        {unitsInCourse.concat('').map((selectedUnit, index) => (
+        {this.props.unitsInCourse.concat('').map((selectedUnit, index) => (
           <select
             style={{
               ...this.props.inputStyle,

--- a/apps/src/lib/levelbuilder/unit-editor/NewUnitForm.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/NewUnitForm.jsx
@@ -64,8 +64,17 @@ export default function NewUnitForm(props) {
         </select>
         <HelpTip>
           <p>
-            There are two different types of courses we support. A course with
-            multiple units and a standalone course (only a single unit).
+            Standalone units are designed to exist on their own. Use this when
+            the unit won't appear inside of a Course with /courses/ in the URL.
+          </p>
+          <p>
+            Units inside a course can be found within a Course that has a
+            /courses/ URL and shares resources between other units in that
+            course.
+          </p>
+          <p>
+            For example: How AI Works is a standalone unit, but CSD Unit 1 is
+            contained within the CSD course.
           </p>
         </HelpTip>
       </label>

--- a/apps/src/lib/levelbuilder/unit-editor/NewUnitForm.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/NewUnitForm.jsx
@@ -44,7 +44,8 @@ export default function NewUnitForm(props) {
     <form action="/s" method="post">
       <RailsAuthenticityToken />
       <label>
-        Is this unit going to be in a course with one unit or multiple units?
+        Is this unit going to be a standalone unit or part of a course with
+        multiple units?
         <select
           style={styles.dropdown}
           value={isCourse}
@@ -55,16 +56,16 @@ export default function NewUnitForm(props) {
             {''}
           </option>
           <option key={'multi-unit'} value={'false'}>
-            {'Multiple Units'}
+            {'Part of a course'}
           </option>
           <option key={'single-unit'} value={'true'}>
-            {'Single Unit'}
+            {'Standalone unit'}
           </option>
         </select>
         <HelpTip>
           <p>
             There are two different types of courses we support. A course with
-            multiple units and a course that is a single unit.
+            multiple units and a standalone course (only a single unit).
           </p>
         </HelpTip>
       </label>

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -98,7 +98,7 @@ class CoursesController < ApplicationController
     raise ActiveRecord::ReadOnlyRecord if @unit_group.try(:plc_course)
     @unit_group_data = {
       course_summary: @unit_group.summarize(@current_user, for_edit: true),
-      script_names: Unit.all.map(&:name),
+      script_names: Unit.all.select {|unit| unit.is_course? == false}.map(&:name),
       course_families: UnitGroup.family_names,
       version_year_options: UnitGroup.get_version_year_options
     }

--- a/dashboard/test/ui/features/teacher_tools/levelbuilder/new_unit_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/levelbuilder/new_unit_page.feature
@@ -6,7 +6,7 @@ Feature: Using the New Unit Page
     And I am on "http://studio.code.org/s/new"
     And I wait until element ".isCourseSelector" is visible
 
-    When I select the "Single Unit" option in dropdown with class "isCourseSelector"
+    When I select the "Standalone unit" option in dropdown with class "isCourseSelector"
     And I wait until element ".familyNameSelector" is visible
     And element ".familyNameInput" is visible
     And I enter a temp unit name


### PR DESCRIPTION
Yesterday, a standalone course unit (20-hour) was added to a course. It was immediately removed, but the side-effects were that the standalone course was marked as not standalone. This course was used in many tests and no longer showed the same properties, causing test builds to fail and DTP to be delayed until resolution.

The fix for the unit was to revert the changes to the course, however we want to prevent this from happening in the future.

This PR prevents the names of standalone courses from being included in the dropdown to add to other courses. This should prevent the above error from happening in the future.

This PR also updates the language to make it clearer on unit creation what the options for standalone and non-standalone courses do.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
Slack discussion: https://codedotorg.slack.com/archives/C045UAX4WKH/p1702490190936009
[TEACH-774](https://codedotorg.atlassian.net/browse/TEACH-774)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
