### PR TITLE
Kaitie/pl coteachers off staging for review

### DIFF
--- a/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
+++ b/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
@@ -18,13 +18,27 @@ export const showCoteacherInviteNotification = coteacherInvite => {
   return !!coteacherInvite && DCDO.get('show-coteacher-ui', true);
 };
 
+export const showCoteacherForPlInviteNotification = coteacherInviteForPl => {
+  return !!coteacherInviteForPl && DCDO.get('show-coteacher-ui', true);
+};
+
 const CoteacherInviteNotification = ({
+  isForPl,
   asyncLoadCoteacherInvite,
   asyncLoadSectionData,
   coteacherInvite,
   coteacherInviteForPl,
 }) => {
-  if (!showCoteacherInviteNotification(coteacherInvite)) {
+  if (
+    !(
+      showCoteacherInviteNotification(coteacherInvite) ||
+      showCoteacherForPlInviteNotification(coteacherInviteForPl)
+    )
+  ) {
+    console.log(
+      showCoteacherInviteNotification(coteacherInvite) ||
+        showCoteacherForPlInviteNotification(coteacherInviteForPl)
+    );
     return null;
   }
 
@@ -37,55 +51,112 @@ const CoteacherInviteNotification = ({
       .catch(err => console.error(err));
   };
 
-  const acceptCoteacherInvite = id => {
+  const acceptCoteacherInvite = (id, sectionId) => {
     analyticsReporter.sendEvent(EVENTS.COTEACHER_INVITE_ACCEPTED, {
-      sectionId: coteacherInvite.section_id,
+      sectionId: sectionId,
     });
     buttonAction(`/api/v1/section_instructors/${id}/accept`);
   };
 
-  const declineCoteacherInvite = id => {
+  const declineCoteacherInvite = (id, sectionId) => {
     analyticsReporter.sendEvent(EVENTS.COTEACHER_INVITE_DECLINED, {
-      sectionId: coteacherInvite.section_id,
+      sectionId: sectionId,
     });
     buttonAction(`/api/v1/section_instructors/${id}/decline`);
   };
 
-  return (
-    <Notification
-      dismissible={false}
-      type={NotificationType.collaborate}
-      iconStyles={styles.icon}
-      notice={i18n.coteacherInvite({
-        invitedByName: coteacherInvite.invited_by_name,
-      })}
-      details={
-        <BodyTwoText style={{marginBottom: 0}}>
-          {i18n.coteacherInviteDescription({
-            invitedByEmail: coteacherInvite.invited_by_email,
-          })}
-          <br />
-          <StrongText>{coteacherInvite.section_name}</StrongText>
-        </BodyTwoText>
-      }
-      tooltipText={i18n.coteacherTooltip()}
-      buttonsStyles={styles.buttons}
-      buttons={[
-        {
-          text: 'Decline',
-          onClick: () => declineCoteacherInvite(coteacherInvite.id),
-          color: Button.ButtonColor.neutralDark,
-          style: styles.declineButton,
-        },
-        {
-          text: 'Accept',
-          onClick: () => acceptCoteacherInvite(coteacherInvite.id),
-          color: Button.ButtonColor.brandSecondaryDefault,
-          style: styles.acceptButton,
-        },
-      ]}
-    />
-  );
+  if (showCoteacherInviteNotification(coteacherInvite) && !isForPl) {
+    return (
+      <Notification
+        dismissible={false}
+        type={NotificationType.collaborate}
+        iconStyles={styles.icon}
+        notice={i18n.coteacherInvite({
+          invitedByName: coteacherInvite.invited_by_name,
+        })}
+        details={
+          <BodyTwoText style={{marginBottom: 0}}>
+            {i18n.coteacherInviteDescription({
+              invitedByEmail: coteacherInvite.invited_by_email,
+            })}
+            <br />
+            <StrongText>{coteacherInvite.section_name}</StrongText>
+          </BodyTwoText>
+        }
+        tooltipText={i18n.coteacherTooltip()}
+        buttonsStyles={styles.buttons}
+        buttons={[
+          {
+            text: 'Decline',
+            onClick: () =>
+              declineCoteacherInvite(
+                coteacherInvite.id,
+                coteacherInvite.section_id
+              ),
+            color: Button.ButtonColor.neutralDark,
+            style: styles.declineButton,
+          },
+          {
+            text: 'Accept',
+            onClick: () =>
+              acceptCoteacherInvite(
+                coteacherInvite.id,
+                coteacherInvite.section_id
+              ),
+            color: Button.ButtonColor.brandSecondaryDefault,
+            style: styles.acceptButton,
+          },
+        ]}
+      />
+    );
+  }
+  if (showCoteacherForPlInviteNotification(coteacherInviteForPl) && isForPl) {
+    return (
+      <Notification
+        dismissible={false}
+        type={NotificationType.collaborate}
+        iconStyles={styles.icon}
+        notice={i18n.coteacherInvite({
+          invitedByName: coteacherInviteForPl.invited_by_name,
+        })}
+        details={
+          <BodyTwoText style={{marginBottom: 0}}>
+            {i18n.coteacherInviteDescription({
+              invitedByEmail: coteacherInviteForPl.invited_by_email,
+            })}
+            <br />
+            <StrongText>{coteacherInviteForPl.section_name}</StrongText>
+          </BodyTwoText>
+        }
+        tooltipText={i18n.coteacherTooltip()}
+        buttonsStyles={styles.buttons}
+        buttons={[
+          {
+            text: 'Decline',
+            onClick: () =>
+              declineCoteacherInvite(
+                coteacherInviteForPl.id,
+                coteacherInviteForPl.section_id
+              ),
+            color: 'green',
+            style: styles.declineButton,
+          },
+          {
+            text: 'Accept',
+            onClick: () =>
+              acceptCoteacherInvite(
+                coteacherInviteForPl.id,
+                coteacherInviteForPl.section_id
+              ),
+            color: Button.ButtonColor.brandSecondaryDefault,
+            style: styles.acceptButton,
+          },
+        ]}
+      />
+    );
+  } else {
+    return null;
+  }
 };
 
 export const UnconnectedCoteacherInviteNotification =
@@ -103,6 +174,7 @@ export default connect(
 )(CoteacherInviteNotification);
 
 CoteacherInviteNotification.propTypes = {
+  isForPl: PropTypes.bool,
   asyncLoadCoteacherInvite: PropTypes.func.isRequired,
   asyncLoadSectionData: PropTypes.func.isRequired,
   coteacherInvite: PropTypes.object,

--- a/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
+++ b/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
@@ -38,6 +38,14 @@ const CoteacherInviteNotification = ({
     return null;
   }
 
+  let invite;
+
+  if (showCoteacherForPlInviteNotification(coteacherInviteForPl) && isForPl) {
+    invite = coteacherInviteForPl;
+  } else if (showCoteacherInviteNotification(coteacherInvite) && !isForPl) {
+    invite = coteacherInvite;
+  }
+
   const buttonAction = api => {
     HttpClient.put(api, '', true)
       .then(() => {
@@ -61,22 +69,22 @@ const CoteacherInviteNotification = ({
     buttonAction(`/api/v1/section_instructors/${id}/decline`);
   };
 
-  if (showCoteacherInviteNotification(coteacherInvite) && !isForPl) {
+  if (invite) {
     return (
       <Notification
         dismissible={false}
         type={NotificationType.collaborate}
         iconStyles={styles.icon}
         notice={i18n.coteacherInvite({
-          invitedByName: coteacherInvite.invited_by_name,
+          invitedByName: invite.invited_by_name,
         })}
         details={
           <BodyTwoText style={{marginBottom: 0}}>
             {i18n.coteacherInviteDescription({
-              invitedByEmail: coteacherInvite.invited_by_email,
+              invitedByEmail: invite.invited_by_email,
             })}
             <br />
-            <StrongText>{coteacherInvite.section_name}</StrongText>
+            <StrongText>{invite.section_name}</StrongText>
           </BodyTwoText>
         }
         tooltipText={i18n.coteacherTooltip()}
@@ -84,66 +92,13 @@ const CoteacherInviteNotification = ({
         buttons={[
           {
             text: 'Decline',
-            onClick: () =>
-              declineCoteacherInvite(
-                coteacherInvite.id,
-                coteacherInvite.section_id
-              ),
+            onClick: () => declineCoteacherInvite(invite.id, invite.section_id),
             color: Button.ButtonColor.neutralDark,
             style: styles.declineButton,
           },
           {
             text: 'Accept',
-            onClick: () =>
-              acceptCoteacherInvite(
-                coteacherInvite.id,
-                coteacherInvite.section_id
-              ),
-            color: Button.ButtonColor.brandSecondaryDefault,
-            style: styles.acceptButton,
-          },
-        ]}
-      />
-    );
-  }
-  if (showCoteacherForPlInviteNotification(coteacherInviteForPl) && isForPl) {
-    return (
-      <Notification
-        dismissible={false}
-        type={NotificationType.collaborate}
-        iconStyles={styles.icon}
-        notice={i18n.coteacherInvite({
-          invitedByName: coteacherInviteForPl.invited_by_name,
-        })}
-        details={
-          <BodyTwoText style={{marginBottom: 0}}>
-            {i18n.coteacherInviteDescription({
-              invitedByEmail: coteacherInviteForPl.invited_by_email,
-            })}
-            <br />
-            <StrongText>{coteacherInviteForPl.section_name}</StrongText>
-          </BodyTwoText>
-        }
-        tooltipText={i18n.coteacherTooltip()}
-        buttonsStyles={styles.buttons}
-        buttons={[
-          {
-            text: 'Decline',
-            onClick: () =>
-              declineCoteacherInvite(
-                coteacherInviteForPl.id,
-                coteacherInviteForPl.section_id
-              ),
-            color: 'green',
-            style: styles.declineButton,
-          },
-          {
-            text: 'Accept',
-            onClick: () =>
-              acceptCoteacherInvite(
-                coteacherInviteForPl.id,
-                coteacherInviteForPl.section_id
-              ),
+            onClick: () => acceptCoteacherInvite(invite.id, invite.section_id),
             color: Button.ButtonColor.brandSecondaryDefault,
             style: styles.acceptButton,
           },

--- a/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
+++ b/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
@@ -22,6 +22,7 @@ const CoteacherInviteNotification = ({
   asyncLoadCoteacherInvite,
   asyncLoadSectionData,
   coteacherInvite,
+  coteacherInviteForPl,
 }) => {
   if (!showCoteacherInviteNotification(coteacherInvite)) {
     return null;
@@ -93,6 +94,7 @@ export const UnconnectedCoteacherInviteNotification =
 export default connect(
   state => ({
     coteacherInvite: state.teacherSections.coteacherInvite,
+    coteacherInviteForPl: state.teacherSections.coteacherInviteForPl,
   }),
   {
     asyncLoadCoteacherInvite,
@@ -104,6 +106,7 @@ CoteacherInviteNotification.propTypes = {
   asyncLoadCoteacherInvite: PropTypes.func.isRequired,
   asyncLoadSectionData: PropTypes.func.isRequired,
   coteacherInvite: PropTypes.object,
+  coteacherInviteForPl: PropTypes.object,
 };
 
 // The Notification object uses styles instead of className for legacy reasons.

--- a/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
+++ b/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useMemo} from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
@@ -14,12 +14,8 @@ import DCDO from '@cdo/apps/dcdo';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
-export const showCoteacherInviteNotification = coteacherInvite => {
-  return !!coteacherInvite && DCDO.get('show-coteacher-ui', true);
-};
-
-export const showCoteacherForPlInviteNotification = coteacherInviteForPl => {
-  return !!coteacherInviteForPl && DCDO.get('show-coteacher-ui', true);
+export const showCoteacherInviteNotification = invite => {
+  return !!invite && DCDO.get('show-coteacher-ui', true);
 };
 
 const CoteacherInviteNotification = ({
@@ -29,22 +25,14 @@ const CoteacherInviteNotification = ({
   coteacherInvite,
   coteacherInviteForPl,
 }) => {
-  if (
-    !(
-      showCoteacherInviteNotification(coteacherInvite) ||
-      showCoteacherForPlInviteNotification(coteacherInviteForPl)
-    )
-  ) {
+  const invite = useMemo(() => {
+    if (showCoteacherInviteNotification(coteacherInviteForPl) && isForPl) {
+      return coteacherInviteForPl;
+    } else if (showCoteacherInviteNotification(coteacherInvite) && !isForPl) {
+      return coteacherInvite;
+    }
     return null;
-  }
-
-  let invite;
-
-  if (showCoteacherForPlInviteNotification(coteacherInviteForPl) && isForPl) {
-    invite = coteacherInviteForPl;
-  } else if (showCoteacherInviteNotification(coteacherInvite) && !isForPl) {
-    invite = coteacherInvite;
-  }
+  }, [coteacherInvite, coteacherInviteForPl, isForPl]);
 
   const buttonAction = api => {
     HttpClient.put(api, '', true)

--- a/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
+++ b/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
@@ -57,45 +57,44 @@ const CoteacherInviteNotification = ({
     buttonAction(`/api/v1/section_instructors/${id}/decline`);
   };
 
-  if (invite) {
-    return (
-      <Notification
-        dismissible={false}
-        type={NotificationType.collaborate}
-        iconStyles={styles.icon}
-        notice={i18n.coteacherInvite({
-          invitedByName: invite.invited_by_name,
-        })}
-        details={
-          <BodyTwoText style={{marginBottom: 0}}>
-            {i18n.coteacherInviteDescription({
-              invitedByEmail: invite.invited_by_email,
-            })}
-            <br />
-            <StrongText>{invite.section_name}</StrongText>
-          </BodyTwoText>
-        }
-        tooltipText={i18n.coteacherTooltip()}
-        buttonsStyles={styles.buttons}
-        buttons={[
-          {
-            text: 'Decline',
-            onClick: () => declineCoteacherInvite(invite.id, invite.section_id),
-            color: Button.ButtonColor.neutralDark,
-            style: styles.declineButton,
-          },
-          {
-            text: 'Accept',
-            onClick: () => acceptCoteacherInvite(invite.id, invite.section_id),
-            color: Button.ButtonColor.brandSecondaryDefault,
-            style: styles.acceptButton,
-          },
-        ]}
-      />
-    );
-  } else {
+  if (!invite) {
     return null;
   }
+  return (
+    <Notification
+      dismissible={false}
+      type={NotificationType.collaborate}
+      iconStyles={styles.icon}
+      notice={i18n.coteacherInvite({
+        invitedByName: invite.invited_by_name,
+      })}
+      details={
+        <BodyTwoText style={{marginBottom: 0}}>
+          {i18n.coteacherInviteDescription({
+            invitedByEmail: invite.invited_by_email,
+          })}
+          <br />
+          <StrongText>{invite.section_name}</StrongText>
+        </BodyTwoText>
+      }
+      tooltipText={i18n.coteacherTooltip()}
+      buttonsStyles={styles.buttons}
+      buttons={[
+        {
+          text: 'Decline',
+          onClick: () => declineCoteacherInvite(invite.id, invite.section_id),
+          color: Button.ButtonColor.neutralDark,
+          style: styles.declineButton,
+        },
+        {
+          text: 'Accept',
+          onClick: () => acceptCoteacherInvite(invite.id, invite.section_id),
+          color: Button.ButtonColor.brandSecondaryDefault,
+          style: styles.acceptButton,
+        },
+      ]}
+    />
+  );
 };
 
 export const UnconnectedCoteacherInviteNotification =

--- a/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
+++ b/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
@@ -35,10 +35,6 @@ const CoteacherInviteNotification = ({
       showCoteacherForPlInviteNotification(coteacherInviteForPl)
     )
   ) {
-    console.log(
-      showCoteacherInviteNotification(coteacherInvite) ||
-        showCoteacherForPlInviteNotification(coteacherInviteForPl)
-    );
     return null;
   }
 

--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -62,7 +62,7 @@ class TeacherSections extends Component {
         </ContentContainer>
         {this.shouldRenderSections() && (
           <ContentContainer heading={i18n.sectionsTitle()}>
-            <CoteacherInviteNotification />
+            <CoteacherInviteNotification isForPl={false} />
             <OwnedSections
               sectionIds={studentSectionIds}
               hiddenSectionIds={hiddenStudentSectionIds}
@@ -71,6 +71,7 @@ class TeacherSections extends Component {
         )}
         {this.props.plSectionIds?.length > 0 && (
           <ContentContainer heading={i18n.plSectionsTitle()}>
+            <CoteacherInviteNotification isForPl={true} />
             <OwnedSections
               isPlSections={true}
               sectionIds={plSectionIds}

--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -44,6 +44,13 @@ class TeacherSections extends Component {
     );
   }
 
+  shouldRenderPlSections() {
+    return (
+      this.props.plSectionIds?.length > 0 ||
+      showCoteacherInviteNotification(this.props.coteacherInviteForPl)
+    );
+  }
+
   render() {
     const {
       plSectionIds,
@@ -69,7 +76,7 @@ class TeacherSections extends Component {
             />
           </ContentContainer>
         )}
-        {this.props.plSectionIds?.length > 0 && (
+        {this.shouldRenderPlSections() && (
           <ContentContainer heading={i18n.plSectionsTitle()}>
             <CoteacherInviteNotification isForPl={true} />
             <OwnedSections

--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -24,6 +24,7 @@ class TeacherSections extends Component {
     asyncLoadSectionData: PropTypes.func.isRequired,
     asyncLoadCoteacherInvite: PropTypes.func.isRequired,
     coteacherInvite: PropTypes.object,
+    coteacherInviteForPl: PropTypes.object,
     studentSectionIds: PropTypes.array,
     plSectionIds: PropTypes.array,
     hiddenPlSectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
@@ -87,6 +88,7 @@ export const UnconnectedTeacherSections = TeacherSections;
 export default connect(
   state => ({
     coteacherInvite: state.teacherSections.coteacherInvite,
+    coteacherInviteForPl: state.teacherSections.coteacherInviteForPl,
     studentSectionIds: state.teacherSections.studentSectionIds,
     plSectionIds: state.teacherSections.plSectionIds,
     hiddenPlSectionIds: hiddenPlSectionIds(state),

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -455,13 +455,8 @@ export const setCoteacherInviteForPl = coteacherInviteForPl => ({
 });
 
 export const asyncLoadCoteacherInvite = () => dispatch => {
-  // this gets all of the section_instructors for the instuctor
-  // this line below calls the endpoint (this endpoint gets all the section instructors of the current id
-  // this includes sections where they are invited byt not)
   fetchJSON('/api/v1/section_instructors')
     .then(sectionInstructors => {
-      // Find the oldest invite.
-      // this is what returns the NEWEST.
       const invitedPlSections = sectionInstructors.filter(section => {
         return (
           section.status === 'invited' && section.participant_type === 'teacher'
@@ -472,23 +467,15 @@ export const asyncLoadCoteacherInvite = () => dispatch => {
           section.status === 'invited' && section.participant_type === 'student'
         );
       });
-      console.log(invitedPlSections);
-      console.log(invitedClassroomSections);
-      // go through each, and find the ones where the status is "invited"
-      // then grab the section_id and see if that section is a PL section
-
-      // const coteacherInvite = sectionInstructors.find(
-      //   instructor => instructor.status === 'invited'
-      // );
 
       const coteacherInviteForClassrooms =
         invitedClassroomSections.length > 0
           ? invitedClassroomSections[0]
-          : null;
+          : undefined;
 
       const coteacherInviteForPl =
-        invitedPlSections.length > 0 ? invitedPlSections[0] : null;
-      // change this to the variable... still not sure about null
+        invitedPlSections.length > 0 ? invitedPlSections[0] : undefined;
+
       dispatch(setCoteacherInvite(coteacherInviteForClassrooms));
       dispatch(setCoteacherInviteForPl(coteacherInviteForPl));
     })

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -488,17 +488,9 @@ export const asyncLoadCoteacherInvite = () => dispatch => {
 
       const coteacherInviteForPl =
         invitedPlSections.length > 0 ? invitedPlSections[0] : null;
-
-      console.log(coteacherInviteForPl);
-
       // change this to the variable... still not sure about null
-      if (invitedClassroomSections.length > 0) {
-        dispatch(setCoteacherInvite(coteacherInviteForClassrooms));
-      }
-
-      if (invitedPlSections.length > 0) {
-        dispatch(setCoteacherInviteForPl(coteacherInviteForPl));
-      }
+      dispatch(setCoteacherInvite(coteacherInviteForClassrooms));
+      dispatch(setCoteacherInviteForPl(coteacherInviteForPl));
     })
     .catch(err => {
       console.error(err.message);

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -460,7 +460,7 @@ export const asyncLoadCoteacherInvite = () => dispatch => {
       const coteacherInviteForPl = sectionInstructors.find(instructorInvite => {
         return (
           instructorInvite.status === 'invited' &&
-          instructorInvite.participant_type === 'teacher'
+          instructorInvite.participant_type !== 'student'
         );
       });
       const coteacherInviteForClassrooms = sectionInstructors.find(

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -65,6 +65,8 @@ const SET_SHOW_LOCK_SECTION_FIELD =
 const SET_AUTH_PROVIDERS = 'teacherDashboard/SET_AUTH_PROVIDERS';
 const SET_SECTIONS = 'teacherDashboard/SET_SECTIONS';
 const SET_COTEACHER_INVITE = 'teacherDashboard/SET_COTEACHER_INVITE';
+const SET_COTEACHER_INVITE_FOR_PL =
+  'teacherDashboard/SET_COTEACHER_INVITE_FOR_PL';
 export const SELECT_SECTION = 'teacherDashboard/SELECT_SECTION';
 const REMOVE_SECTION = 'teacherDashboard/REMOVE_SECTION';
 const TOGGLE_SECTION_HIDDEN = 'teacherSections/TOGGLE_SECTION_HIDDEN';
@@ -447,15 +449,56 @@ export const setCoteacherInvite = coteacherInvite => ({
   coteacherInvite,
 });
 
+export const setCoteacherInviteForPl = coteacherInviteForPl => ({
+  type: SET_COTEACHER_INVITE_FOR_PL,
+  coteacherInviteForPl,
+});
+
 export const asyncLoadCoteacherInvite = () => dispatch => {
+  // this gets all of the section_instructors for the instuctor
+  // this line below calls the endpoint (this endpoint gets all the section instructors of the current id
+  // this includes sections where they are invited byt not)
   fetchJSON('/api/v1/section_instructors')
     .then(sectionInstructors => {
       // Find the oldest invite.
-      const coteacherInvite = sectionInstructors.find(
-        instructor => instructor.status === 'invited'
-      );
+      // this is what returns the NEWEST.
+      const invitedPlSections = sectionInstructors.filter(section => {
+        return (
+          section.status === 'invited' && section.participant_type === 'teacher'
+        );
+      });
+      const invitedClassroomSections = sectionInstructors.filter(section => {
+        return (
+          section.status === 'invited' && section.participant_type === 'student'
+        );
+      });
+      console.log(invitedPlSections);
+      console.log(invitedClassroomSections);
+      // go through each, and find the ones where the status is "invited"
+      // then grab the section_id and see if that section is a PL section
 
-      dispatch(setCoteacherInvite(coteacherInvite));
+      // const coteacherInvite = sectionInstructors.find(
+      //   instructor => instructor.status === 'invited'
+      // );
+
+      const coteacherInviteForClassrooms =
+        invitedClassroomSections.length > 0
+          ? invitedClassroomSections[0]
+          : null;
+
+      const coteacherInviteForPl =
+        invitedPlSections.length > 0 ? invitedPlSections[0] : null;
+
+      console.log(coteacherInviteForPl);
+
+      // change this to the variable... still not sure about null
+      if (invitedClassroomSections.length > 0) {
+        dispatch(setCoteacherInvite(coteacherInviteForClassrooms));
+      }
+
+      if (invitedPlSections.length > 0) {
+        dispatch(setCoteacherInviteForPl(coteacherInviteForPl));
+      }
     })
     .catch(err => {
       console.error(err.message);
@@ -761,6 +804,13 @@ export default function teacherSections(state = initialState, action) {
     return {
       ...state,
       coteacherInvite: action.coteacherInvite,
+    };
+  }
+
+  if (action.type === SET_COTEACHER_INVITE_FOR_PL) {
+    return {
+      ...state,
+      coteacherInviteForPl: action.coteacherInviteForPl,
     };
   }
 

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -457,24 +457,20 @@ export const setCoteacherInviteForPl = coteacherInviteForPl => ({
 export const asyncLoadCoteacherInvite = () => dispatch => {
   fetchJSON('/api/v1/section_instructors')
     .then(sectionInstructors => {
-      const invitedPlSections = sectionInstructors.filter(section => {
+      const coteacherInviteForPl = sectionInstructors.find(instructorInvite => {
         return (
-          section.status === 'invited' && section.participant_type === 'teacher'
+          instructorInvite.status === 'invited' &&
+          instructorInvite.participant_type === 'teacher'
         );
       });
-      const invitedClassroomSections = sectionInstructors.filter(section => {
-        return (
-          section.status === 'invited' && section.participant_type === 'student'
-        );
-      });
-
-      const coteacherInviteForClassrooms =
-        invitedClassroomSections.length > 0
-          ? invitedClassroomSections[0]
-          : undefined;
-
-      const coteacherInviteForPl =
-        invitedPlSections.length > 0 ? invitedPlSections[0] : undefined;
+      const coteacherInviteForClassrooms = sectionInstructors.find(
+        instructorInvite => {
+          return (
+            instructorInvite.status === 'invited' &&
+            instructorInvite.participant_type === 'student'
+          );
+        }
+      );
 
       dispatch(setCoteacherInvite(coteacherInviteForClassrooms));
       dispatch(setCoteacherInviteForPl(coteacherInviteForPl));

--- a/apps/test/unit/templates/studioHomepages/CoteacherInviteNotificationTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoteacherInviteNotificationTest.jsx
@@ -7,6 +7,7 @@ import DCDO from '@cdo/apps/dcdo';
 
 describe('CoteacherInviteNotification', () => {
   const defaultProps = {
+    isForPl: false,
     asyncLoadCoteacherInvite: () => {},
     asyncLoadSectionData: () => {},
     coteacherInvite: {
@@ -17,12 +18,32 @@ describe('CoteacherInviteNotification', () => {
       status: 'invited',
       instructor_name: 'Linus',
     },
+    coteacherInviteForPl: {
+      id: 2,
+      invited_by_name: 'Ms. Frizzle',
+      invited_by_email: 'magicSchoolBus@code.org',
+      section_name: 'Section for teachers',
+      status: 'invited',
+      instructor_name: 'Larry',
+    },
   };
 
-  it('renders nothing if there is no coteacher invite', () => {
+  it('renders no notification for classroom sections if there is no coteacher invite', () => {
     DCDO.set('show-coteacher-ui', true);
     const wrapper = shallow(
       <CoteacherInviteNotification {...defaultProps} coteacherInvite={null} />
+    );
+    expect(wrapper.find(Notification).length).to.equal(0);
+  });
+
+  it('renders no notification for PL sections if there is no coteacher invite', () => {
+    DCDO.set('show-coteacher-ui', true);
+    const wrapper = shallow(
+      <CoteacherInviteNotification
+        {...defaultProps}
+        isForPl={true}
+        coteacherInviteForPl={null}
+      />
     );
     expect(wrapper.find(Notification).length).to.equal(0);
   });
@@ -53,5 +74,17 @@ describe('CoteacherInviteNotification', () => {
     expect(notification.props().dismissible).to.equal(false);
     expect(notification.props().type).to.equal(NotificationType.collaborate);
     expect(notification.props().notice).to.include('The Great Pumpkin');
+  });
+
+  it('renders PL notification if there is a coteacher invite for PL and flag is on', () => {
+    DCDO.set('show-coteacher-ui', true);
+    const wrapper = shallow(
+      <CoteacherInviteNotification {...defaultProps} isForPl={true} />
+    );
+    const notification = wrapper.find(Notification);
+    expect(notification.length).to.equal(1);
+    expect(notification.props().dismissible).to.equal(false);
+    expect(notification.props().type).to.equal(NotificationType.collaborate);
+    expect(notification.props().notice).to.include('Ms. Frizzle');
   });
 });

--- a/apps/test/unit/templates/studioHomepages/CoteacherInviteNotificationTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoteacherInviteNotificationTest.jsx
@@ -17,6 +17,7 @@ describe('CoteacherInviteNotification', () => {
       section_name: 'The Pumpkin Patch',
       status: 'invited',
       instructor_name: 'Linus',
+      participant_type: 'student',
     },
     coteacherInviteForPl: {
       id: 2,
@@ -25,6 +26,7 @@ describe('CoteacherInviteNotification', () => {
       section_name: 'Section for teachers',
       status: 'invited',
       instructor_name: 'Larry',
+      participant_type: 'teacher',
     },
   };
 

--- a/apps/test/unit/templates/studioHomepages/CoteacherInviteNotificationTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoteacherInviteNotificationTest.jsx
@@ -89,4 +89,17 @@ describe('CoteacherInviteNotification', () => {
     expect(notification.props().type).to.equal(NotificationType.collaborate);
     expect(notification.props().notice).to.include('Ms. Frizzle');
   });
+
+  it('renders no notifications if there is no PL invite and isForPl is true', () => {
+    DCDO.set('show-coteacher-ui', true);
+    const wrapper = shallow(
+      <CoteacherInviteNotification
+        {...defaultProps}
+        isForPl={true}
+        coteacherInvite={null}
+        coteacherInviteForPl={null}
+      />
+    );
+    expect(wrapper.find(Notification).length).to.equal(0);
+  });
 });

--- a/apps/test/unit/templates/studioHomepages/TeacherSectionsTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/TeacherSectionsTest.jsx
@@ -9,6 +9,7 @@ describe('TeacherSections', () => {
     asyncLoadCoteacherInvite: () => {},
     studentSectionIds: [],
     coteacherInvite: null,
+    coteacherInviteForPl: null,
     plSectionIds: [],
     hiddenPlSectionIds: [],
     hiddenStudentSectionIds: [],
@@ -53,6 +54,17 @@ describe('TeacherSections', () => {
     ).to.equal(undefined);
   });
 
+  it('renders PL sections area if coteacher invite for PL', () => {
+    const wrapper = shallow(
+      <TeacherSections {...defaultProps} coteacherInviteForPl={{id: 2}} />
+    );
+    expect(wrapper.find('Connect(ContentContainer)').length).to.equal(2);
+    expect(wrapper.find('Connect(OwnedSections)').length).to.equal(1);
+    expect(
+      wrapper.find('Connect(OwnedSections)').props().isPlSections
+    ).to.equal(true);
+  });
+
   it('renders student sections area if there are student sections', () => {
     const wrapper = shallow(
       <TeacherSections {...defaultProps} studentSectionIds={[1]} />
@@ -82,6 +94,21 @@ describe('TeacherSections', () => {
   it('renders pl sections area if there are pl sections', () => {
     const wrapper = shallow(
       <TeacherSections {...defaultProps} plSectionIds={[1]} />
+    );
+    expect(wrapper.find('Connect(ContentContainer)').length).to.equal(2);
+    expect(wrapper.find('Connect(OwnedSections)').length).to.equal(1);
+    expect(
+      wrapper.find('Connect(OwnedSections)').props().isPlSections
+    ).to.equal(true);
+  });
+
+  it('renders pl sections area if there are pl sections and coteacher invite for PL', () => {
+    const wrapper = shallow(
+      <TeacherSections
+        {...defaultProps}
+        plSectionIds={[1]}
+        coteacherInviteForPl={{id: 2}}
+      />
     );
     expect(wrapper.find('Connect(ContentContainer)').length).to.equal(2);
     expect(wrapper.find('Connect(OwnedSections)').length).to.equal(1);

--- a/dashboard/app/serializers/api/v1/section_instructor_serializer.rb
+++ b/dashboard/app/serializers/api/v1/section_instructor_serializer.rb
@@ -21,7 +21,7 @@
 #
 
 class Api::V1::SectionInstructorSerializer < ActiveModel::Serializer
-  attributes :id, :status, :invited_by_name, :invited_by_email, :section_name, :section_id, :instructor_name, :instructor_email
+  attributes :id, :status, :invited_by_name, :invited_by_email, :section_name, :section_id, :instructor_name, :instructor_email, :participant_type
 
   def invited_by_name
     object.invited_by&.name
@@ -45,5 +45,9 @@ class Api::V1::SectionInstructorSerializer < ActiveModel::Serializer
 
   def instructor_email
     object.instructor&.email
+  end
+
+  def participant_type
+    object.section&.participant_type
   end
 end


### PR DESCRIPTION
NOTE: This was originally started in [this PR](https://github.com/code-dot-org/code-dot-org/pull/55351), but after some errors with rebasing, the intended commits were moved to this PR instead.

This PR adds a notficiation box for when PL sections have a co-teacher invite.  Before, all notifications (for PL and "Classroom" sections) were located below the the "Classroom Sections" list of sections.  This creates a notification under "Professional Learning Sections" for when a PL section has a classroom invite as shown below.

<img width="1000" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/51e8ffa5-6998-4c24-8645-ecbade66357c">


## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-736)

## Testing story

I modified tests as needed.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
