### PR TITLE
[AccHack '23] Fixes to CollapsibleEditorSection and RubricField

### DIFF
--- a/apps/src/lib/levelbuilder/CollapsibleEditorSection.jsx
+++ b/apps/src/lib/levelbuilder/CollapsibleEditorSection.jsx
@@ -1,29 +1,37 @@
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
-import styleConstants from '@cdo/apps/styleConstants';
+import style from './levelbuilder.module.scss';
+import classnames from 'classnames';
 
 export default function CollapsibleEditorSection(props) {
   const [collapsed, setCollapsed] = useState(props.collapsed || false);
 
   const {title, fullWidth} = props;
-  const editorsStyle = {
-    ...styles.editors,
-    width: fullWidth ? null : styleConstants['content-width'],
-  };
 
   return (
     <div>
-      <div style={styles.header}>
-        <h2 onClick={() => setCollapsed(!collapsed)} style={styles.title}>
-          <FontAwesome
-            icon={collapsed ? 'expand' : 'compress'}
-            style={styles.icon}
-          />
-          {title}
+      <div className={style.collapsibleEditorSectionHeader}>
+        <h2 className={style.collapsibleEditorSectionTitle}>
+          <button
+            onClick={() => setCollapsed(!collapsed)}
+            type="button"
+            className={style.headerButton}
+          >
+            <FontAwesome
+              icon={collapsed ? 'expand' : 'compress'}
+              className={style.collapsibleEditorSectionIcon}
+            />
+            {title}
+          </button>
         </h2>
       </div>
-      <div style={editorsStyle} hidden={collapsed}>
+      <div
+        className={classnames(style.collapsibleEditorSectionEditors, {
+          [style.nonFullWidth]: !fullWidth,
+        })}
+        hidden={collapsed}
+      >
         {props.children}
       </div>
     </div>
@@ -35,19 +43,4 @@ CollapsibleEditorSection.propTypes = {
   fullWidth: PropTypes.bool,
   collapsed: PropTypes.bool,
   children: PropTypes.any,
-};
-
-const styles = {
-  header: {
-    borderBottom: '1px solid rgb(204, 204, 204)',
-  },
-  icon: {
-    marginRight: 10,
-  },
-  editors: {
-    padding: 10,
-  },
-  title: {
-    fontSize: 20,
-  },
 };

--- a/apps/src/lib/levelbuilder/levelbuilder.module.scss
+++ b/apps/src/lib/levelbuilder/levelbuilder.module.scss
@@ -1,0 +1,30 @@
+@import '@cdo/apps/mixins.scss';
+@import 'color';
+@import 'style-constants';
+
+.collapsibleEditorSectionHeader {
+  border-bottom: 1px solid $bootstrap-border-color;
+}
+
+.collapsibleEditorSectionIcon {
+  margin-right: 10px;
+}
+
+.collapsibleEditorSectionEditors {
+  padding: 10px;
+
+  .nonFullWidth {
+    width: $content-width;
+  }
+}
+
+p.collapsibleEditorSectionTitle {
+  font-size: 20px;
+}
+
+.headerButton {
+  @include remove-button-styles;
+  font: inherit;
+  color: $teal;
+  font-size: 20px;
+}

--- a/apps/src/templates/instructions/teacherFeedback/RubricField.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/RubricField.jsx
@@ -67,9 +67,8 @@ class RubricField extends Component {
             id={`rubric-details-${this.props.rubricLevel}`}
             style={styles.detailsArea}
             open={this.state.detailsOpen}
-            onClick={this.updateToggle}
           >
-            <summary style={styles.rubricHeader}>
+            <summary style={styles.rubricHeader} onClick={this.updateToggle}>
               {rubricPerformanceHeaders[this.props.rubricLevel]}
             </summary>
             <p style={styles.rubricDetails}>{this.props.rubricValue}</p>

--- a/apps/test/unit/lib/levelbuilder/CollapsibleEditorSectionTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/CollapsibleEditorSectionTest.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {shallow, mount} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
+import moduleStyles from '@cdo/apps/lib/levelbuilder/levelbuilder.module.scss';
 
 describe('CollapsibleEditorSection', () => {
   let defaultProps;
@@ -25,7 +26,9 @@ describe('CollapsibleEditorSection', () => {
     expect(icon.props().icon).to.include('compress');
 
     const editorsWrapper = wrapper.children().last();
-    expect(editorsWrapper.props().style.width).to.equal(970);
+    expect(editorsWrapper.props().className).to.include(
+      moduleStyles.nonFullWidth
+    );
   });
 
   it('renders in full width', () => {
@@ -35,7 +38,9 @@ describe('CollapsibleEditorSection', () => {
       </CollapsibleEditorSection>
     );
     const editorsWrapper = wrapper.children().last();
-    expect(editorsWrapper.props().style.width).to.equal(null);
+    expect(editorsWrapper.props().className).to.not.include(
+      moduleStyles.nonFullWidth
+    );
   });
 
   it('clicking h2 collapses area', () => {
@@ -48,7 +53,7 @@ describe('CollapsibleEditorSection', () => {
     let icon = wrapper.find('FontAwesome');
     expect(icon.props().icon).to.include('compress');
 
-    wrapper.find('h2').simulate('click');
+    wrapper.find('button').simulate('click');
 
     expect(wrapper.find('FontAwesome').props().icon).to.include('expand');
   });

--- a/apps/test/unit/lib/levelbuilder/course-editor/NewCourseFormTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/course-editor/NewCourseFormTest.jsx
@@ -40,6 +40,7 @@ describe('NewCourseFormTest', () => {
     // need to get updated fields
     fields = wrapper.find('NewCourseFields');
     expect(fields.find('.isVersionedSelector').length).to.equal(1);
+    expect(wrapper.find('button').length).to.equal(1);
 
     fields
       .find('.isVersionedSelector')

--- a/apps/test/unit/lib/levelbuilder/course-editor/NewCourseFormTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/course-editor/NewCourseFormTest.jsx
@@ -40,7 +40,6 @@ describe('NewCourseFormTest', () => {
     // need to get updated fields
     fields = wrapper.find('NewCourseFields');
     expect(fields.find('.isVersionedSelector').length).to.equal(1);
-    expect(wrapper.find('button').length).to.equal(0);
 
     fields
       .find('.isVersionedSelector')
@@ -52,7 +51,7 @@ describe('NewCourseFormTest', () => {
     expect(fields.find('.versionYearSelector').props().disabled).to.equal(
       false
     );
-    expect(wrapper.find('button').length).to.equal(0);
+    expect(wrapper.find('button').length).to.equal(1);
 
     fields
       .find('.versionYearSelector')
@@ -62,7 +61,7 @@ describe('NewCourseFormTest', () => {
     fields = wrapper.find('NewCourseFields');
     expect(fields.find('.versionYearSelector').props().value).to.equal('1991');
 
-    expect(wrapper.find('button').length).to.equal(1);
+    expect(wrapper.find('button').length).to.equal(2);
   });
 
   it('course type settings are updated when family name is selected', () => {

--- a/apps/test/unit/lib/levelbuilder/unit-editor/NewUnitFormTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/unit-editor/NewUnitFormTest.jsx
@@ -47,7 +47,7 @@ describe('NewUnitFormTest', () => {
     // need to get updated fields
     fields = wrapper.find('NewCourseFields');
     expect(fields.find('.isVersionedSelector').length).to.equal(1);
-    expect(wrapper.find('button').length).to.equal(0);
+    expect(wrapper.find('button').length).to.equal(1);
 
     fields
       .find('.isVersionedSelector')
@@ -59,7 +59,7 @@ describe('NewUnitFormTest', () => {
     expect(fields.find('.versionYearSelector').props().disabled).to.equal(
       false
     );
-    expect(wrapper.find('button').length).to.equal(0);
+    expect(wrapper.find('button').length).to.equal(1);
 
     fields
       .find('.versionYearSelector')


### PR DESCRIPTION
This is a PR in a series of PRs to re-enable the `no-noninteractive-element-interactions` [rule](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-element-interactions.md). I ended up needing to make meaningful changes to a set of components -- you can see the full set [here](https://github.com/code-dot-org/code-dot-org/pull/55441) -- and decided to roughly break these up by ownership. There are updates to two components in this PR.

### RubricField

This change is pretty straightforward -- moving the onClick handler to the `summary` element instead of the `details` element. However, I couldn't figure out how to reach these components with just the keyboard to test and the click behavior is very slightly changed. In particular, before you could click on any part of the `details` element to close it whereas now it is only closed when clicking on the `summary` element (see videos below). I think this is still a good change because it is more syntactically correct and, if anyone want to copy the text in the `details` component for any reason, it was impossible before.

Before:

https://github.com/code-dot-org/code-dot-org/assets/46464143/dadc9c15-5a64-4699-a45e-13a5ebc64116

After:

https://github.com/code-dot-org/code-dot-org/assets/46464143/7c08e9de-051c-4767-99da-d30936eb182a



### CollapsibleEditorSection

This component is only used on our internal editors, but it is still a win in terms of making our pages tab navigable (see videos). I did need to update some tests after updating this component and I'm very open to feedback on whether those changes were the right ones to make.

I also moved styles to a `levelbuilder.module.scss` file as part of this change. It's easier to style buttons using SCSS modules (at least for me) because I could use existing mixins to easily turn these headers into buttons.

Before:

https://github.com/code-dot-org/code-dot-org/assets/46464143/ed90cab6-fb14-4081-bffe-c2737cf54c90

After: (note that a margin isn't right in this screengrab -- it was since fixed!)

https://github.com/code-dot-org/code-dot-org/assets/46464143/ffd8f657-ca13-4651-a6ca-42cbcce7fec5





