### PR TITLE
Swap the donate links back to the default campaign url

### DIFF
--- a/dashboard/app/views/parent_mailer/parent_email_added_to_student_account.haml
+++ b/dashboard/app/views/parent_mailer/parent_email_added_to_student_account.haml
@@ -47,7 +47,7 @@
   Our coding platform and K-12 computer science curriculum are the most broadly used in the world,
   and we depend on generous donors to keep our resources free for all students.
   If your child enjoyed learning on Code.org, please consider
-  %a{href:"https://donate.code.org/campaign/match-for-10th-anniversary-gala/c529456"}supporting our work
+  %a{href:"https://donate.code.org/campaign/support-computer-science-education/c172233"}supporting our work
   to enable other children to learn too. And explore other
   %a{href:"https://code.org/help"}ways to get involved.
 

--- a/pegasus/sites.v3/code.org/public/donate/index.haml
+++ b/pegasus/sites.v3/code.org/public/donate/index.haml
@@ -20,7 +20,7 @@ theme: responsive_full_width
       %h1=hoc_s(:donate_page_top_heading)
       %p.body-one
         =hoc_s(:donate_page_top_desc)
-      %a.link-button.has-external-link{href: "https://donate.code.org/campaign/match-for-10th-anniversary-gala/c529456", target: "_blank", rel: "noopener noreferrer"}
+      %a.link-button.has-external-link{href: "https://donate.code.org/campaign/support-computer-science-education/c172233", target: "_blank", rel: "noopener noreferrer"}
         =hoc_s(:call_to_action_donate_to_cdo)
     %div.col-45{style: "margin: 1rem 0 0;"}
       = view :display_video_thumbnail, id: "donate_10th_anniv", video_code: "4w9y93ouj8w", play_button: 'center', letterbox: 'false', download_path: "//videos.code.org/donate_10th_anniversary_video.mp4"
@@ -73,7 +73,7 @@ theme: responsive_full_width
       %img{src: "/images/avatars/ballmer_group.png", alt: hoc_s(:ballmer_group_logo_alt)}
       %img{src: "/images/avatars/vista_equity_partners.png", alt: hoc_s(:vista_equity_partners_logo_alt)}
     .button-wrapper.flex-container.justify-center
-      %a.link-button.has-external-link{href: "https://donate.code.org/campaign/match-for-10th-anniversary-gala/c529456", target: "_blank", rel: "noopener noreferrer"}
+      %a.link-button.has-external-link{href: "https://donate.code.org/campaign/support-computer-science-education/c172233", target: "_blank", rel: "noopener noreferrer"}
         =hoc_s(:call_to_action_donate)
       %a.link-button.secondary{href: "/about/supporters"}
         =hoc_s(:call_to_action_view_our_supporters)

--- a/pegasus/sites.v3/code.org/public/help.haml
+++ b/pegasus/sites.v3/code.org/public/help.haml
@@ -18,7 +18,7 @@ theme: responsive_full_width
         %h2=hoc_s(:help_page_top_subhead)
         %p=hoc_s(:help_page_top_desc_02)
         .button-wrapper{style: "margin-bottom: 1rem"}
-          %a.link-button.has-external-link{href: "https://donate.code.org/campaign/match-for-10th-anniversary-gala/c529456", target: "_blank", rel: "noopener noreferrer"}
+          %a.link-button.has-external-link{href: "https://donate.code.org/campaign/support-computer-science-education/c172233", target: "_blank", rel: "noopener noreferrer"}
             =hoc_s(:call_to_action_make_a_donation)
           %a.link-button.secondary{href: "donate"}
             =hoc_s(:call_to_action_other_ways_to_give)


### PR DESCRIPTION
Update the 10th Anniversary specific url (https://donate.code.org/campaign/match-for-10th-anniversary-gala/c529456) with the generic donate url (https://donate.code.org/campaign/support-computer-science-education/c172233) in the following places once the match period is over:
- https://code.org/help
- https://code.org/donate
- `parent_mailer/parent_email_added_to_student_account.haml`

**Note:** I'm going to merge this on Jan 2, 2024 since the match period ends at the end of December.

This reverses this PR: https://github.com/code-dot-org/code-dot-org/pull/55284

**Jira ticket:** https://codedotorg.atlassian.net/browse/ACQ-1273