### PR TITLE
Adding new Role and LogGroup for SecurityMonitoring

### DIFF
--- a/aws/cloudformation/security/monitoring_tools.yml
+++ b/aws/cloudformation/security/monitoring_tools.yml
@@ -1,0 +1,41 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'IAM Role and Log Group for Security Monitoring'
+
+Resources:
+  SecurityMonitoringRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: 'SecurityMonitoringRole'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service: 'vpc-flow-logs.amazonaws.com'
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: 'CloudWatchLogsPolicy'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: 'Allow'
+                Action:
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                  - 'logs:DescribeLogStreams'
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/vpc/security_monitoring:*'
+
+  SecurityMonitoringLogGroup:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: '/aws/vpc/security_monitoring'
+      RetentionInDays: 365
+
+Outputs:
+  SecurityMonitoringRoleArn:
+    Description: 'ARN of the Security Monitoring IAM Role'
+    Value: !GetAtt SecurityMonitoringRole.Arn
+
+  SecurityMonitoringLogGroupName:
+    Description: 'Name of the Security Monitoring Log Group'
+    Value: !Ref SecurityMonitoringLogGroup


### PR DESCRIPTION
Just adding the log group for now.  One example purpose would be to start generating VPC flow logs to watch a specific EC2, or group of them.  Having this role in place allows me to toggle on and examine closely what an instance is doing network-wise.

The first usage of this will be to examine the flow logs for the BugCrowd adhoc, which keeps getting taken down by security researcher pentests.  See this task: https://codedotorg.atlassian.net/browse/INF-1145

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
