### PR TITLE
Restrict pegasus and dashboard requires

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,8 @@ require:
   - './tools/customLinters/rubocop_prefer_mocha_stubs_to_minitest_stub.rb'
   - './tools/customLinters/rubocop_pegasus_db_usage.rb'
   - './tools/customLinters/rubocop_dashboard_db_usage.rb'
+  - './tools/customLinters/rubocop_pegasus_requires.rb'
+  - './tools/customLinters/rubocop_dashboard_requires.rb'
 
 AllCops:
   SuggestExtensions: false

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1,7 +1,9 @@
 require 'test_helper'
 require 'testing/projects_test_utils'
 require 'cdo/delete_accounts_helper'
+# rubocop:disable CustomCops/PegasusRequires
 require_relative '../../../pegasus/test/fixtures/mock_pegasus'
+# rubocop:enable CustomCops/PegasusRequires
 
 #
 # This test is the comprehensive spec on the desired behavior when purging a

--- a/lib/cdo/web_purify.rb
+++ b/lib/cdo/web_purify.rb
@@ -2,7 +2,9 @@ require 'net/http'
 require 'open-uri'
 require 'json'
 require 'dynamic_config/gatekeeper'
+# rubocop:disable CustomCops/PegasusRequires
 require_relative '../../pegasus/src/env'
+# rubocop:enable CustomCops/PegasusRequires
 
 module WebPurify
   # WebPurify limits us to 30,000 characters per request and 4 simultaneous requests per API key

--- a/lib/rake/eyes.rake
+++ b/lib/rake/eyes.rake
@@ -14,7 +14,9 @@ MERGE_EMOJI = "\u{1F500}".freeze
 
 def create_branch(branch)
   require 'eyes_selenium'
+  # rubocop:disable CustomCops/DashboardRequires
   require_relative '../../dashboard/test/ui/utils/selenium_browser'
+  # rubocop:enable CustomCops/DashboardRequires
   EyesUtils.check_eyes_set
   eyes = Applitools::Selenium::Eyes.new
   eyes.api_key = CDO.applitools_eyes_api_key

--- a/pegasus/test/fixtures/fake_dashboard.rb
+++ b/pegasus/test/fixtures/fake_dashboard.rb
@@ -316,7 +316,9 @@ module FakeDashboard
     ActiveRecord::Base.establish_connection
     ActiveRecord::Schema.verbose = false
     ActiveRecord::Base.transaction do
+      # rubocop:disable CustomCops/DashboardRequires
       require_relative('../../../dashboard/db/schema')
+      # rubocop:enable CustomCops/DashboardRequires
     end
 
     # Reuse the same connection in Sequel to share access to the temporary tables.

--- a/pegasus/test/test_minecraft_certificates.rb
+++ b/pegasus/test/test_minecraft_certificates.rb
@@ -1,5 +1,7 @@
 require_relative './test_helper'
+# rubocop:disable CustomCops/DashboardRequires
 require_relative '../../dashboard/lib/script_constants'
+# rubocop:enable CustomCops/DashboardRequires
 require 'minitest/autorun'
 
 class MinecraftCertificatesTest < Minitest::Test

--- a/shared/test/test_poste.rb
+++ b/shared/test/test_poste.rb
@@ -1,5 +1,7 @@
 require_relative 'test_helper'
+# rubocop:disable CustomCops/PegasusRequires
 require_relative '../../pegasus/test/sequel_test_case'
+# rubocop:enable CustomCops/PegasusRequires
 require 'mocha/mini_test'
 require 'cdo/poste'
 require 'digest/md5'

--- a/tools/customLinters/rubocop_dashboard_requires.rb
+++ b/tools/customLinters/rubocop_dashboard_requires.rb
@@ -1,0 +1,31 @@
+module CustomCops
+  # Custom cop that checks for require_relative references into the dashboard/ directory
+  # from outside of dashboard/ directory
+  class DashboardRequires < RuboCop::Cop::Base
+    MSG = 'Do not require dashboard code from outside of dashboard/ directory.'
+
+    def_node_matcher :require_relative_with_string?, <<-PATTERN
+      (send nil? :require_relative (str $_))
+    PATTERN
+
+    def on_send(node)
+      return unless require_relative_with_string?(node) do |path|
+        violation?(path, node)
+      end
+    end
+
+    private
+
+    def violation?(path, node)
+      # Check if the path points to something inside 'dashboard/'
+      if path.include?('../dashboard/')
+        file_path = processed_source.buffer.name
+
+        # Add an offense if the file itself is not in 'dashboard/' or 'bin/'
+        unless file_path.include?('/dashboard/') || file_path.include?('/bin/')
+          add_offense(node, message: MSG)
+        end
+      end
+    end
+  end
+end

--- a/tools/customLinters/rubocop_pegasus_requires.rb
+++ b/tools/customLinters/rubocop_pegasus_requires.rb
@@ -1,0 +1,31 @@
+module CustomCops
+  # Custom cop that checks for require_relative references into the pegasus/ directory
+  # from outside of pegasus/ directory
+  class PegasusRequires < RuboCop::Cop::Base
+    MSG = 'Do not require pegasus code from outside of pegasus/ directory.'
+
+    def_node_matcher :require_relative_with_string?, <<-PATTERN
+      (send nil? :require_relative (str $_))
+    PATTERN
+
+    def on_send(node)
+      return unless require_relative_with_string?(node) do |path|
+        violation?(path, node)
+      end
+    end
+
+    private
+
+    def violation?(path, node)
+      # Check if the path points to something inside 'pegasus/'
+      if path.include?('../pegasus/')
+        file_path = processed_source.buffer.name
+
+        # Add an offense if the file itself is not in 'pegasus/' or 'bin/'
+        unless file_path.include?('/pegasus/') || file_path.include?('/bin/')
+          add_offense(node, message: MSG)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
See https://github.com/code-dot-org/code-dot-org/pull/55417 for background.

This PR raises rubocop violations if pegasus code is required from outside of the pegasus directory, or if dashboard code is required from outside of the dashboard directory.

Checking for `require_relative.*../pegasus` is an imperfect heuristic for detecting requires which reach into the top-level pegasus directory from outside it, while still allowing these kinds of requires from more deeply-nested directories named pegasus: https://github.com/code-dot-org/code-dot-org/blob/0fee4c0ffb740f2e09855fa738371e6897935100/lib/cdo/pegasus.rb#L5

## Testing story

- `rubocop --only PegasusRequires,DashboardRequires` is passing locally
- when I first added the lint rule, I verified that it was in fact catching the violations I would expect, which were then silenced in [21563f8](https://github.com/code-dot-org/code-dot-org/pull/55479/commits/21563f81cc75dbaabae5cdbb20d046e975ce3e93)
- manually verified there are no additional require violations which are not caught by the lint rules

