### PR TITLE
[Google Blockly] Fix icon placement on Safari

### DIFF
--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -47,6 +47,8 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
     if (this.icon) {
       this.icon.style.fill =
         this.colorOverrides?.icon || this.getSourceBlock().style.colourPrimary;
+      // Make the icon centered on Safari.
+      this.icon.setAttribute('dominant-baseline', 'central');
       this.textElement_.appendChild(this.icon);
     }
   }

--- a/apps/src/blockly/addons/cdoFieldDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldDropdown.js
@@ -149,6 +149,33 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     super.toXml(element);
     return element;
   }
+
+  /**
+   * Override of createTextArrow_ to fix the arrow position on Safari.
+   * We need to add dominant-baseline="central" to the arrow element in order to
+   * center it on Safari.
+   *  @override */
+  createTextArrow_() {
+    // TODO: This field changes from arrow_ to arrow with the v10 upgrade.
+    this.arrow_ = Blockly.utils.dom.createSvgElement(
+      Blockly.utils.Svg.TSPAN,
+      {},
+      this.textElement_
+    );
+    this.arrow_.appendChild(
+      document.createTextNode(
+        this.getSourceBlock()?.RTL
+          ? Blockly.FieldDropdown.ARROW_CHAR + ' '
+          : ' ' + Blockly.FieldDropdown.ARROW_CHAR
+      )
+    );
+    this.arrow_.setAttribute('dominant-baseline', 'central');
+    if (this.getSourceBlock()?.RTL) {
+      this.getTextElement().insertBefore(this.arrow_, this.textContent_);
+    } else {
+      this.getTextElement().appendChild(this.arrow_);
+    }
+  }
 }
 
 /**

--- a/apps/src/blockly/addons/cdoFieldDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldDropdown.js
@@ -169,7 +169,17 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
           : ' ' + Blockly.FieldDropdown.ARROW_CHAR
       )
     );
+
+    /**
+     * Begin CDO customization
+     */
     this.arrow_.setAttribute('dominant-baseline', 'central');
+    // This is to make this function forward-compatible with Blockly v10.
+    this.arrow = this.arrow_;
+    /**
+     * End CDO customization
+     */
+
     if (this.getSourceBlock()?.RTL) {
       this.getTextElement().insertBefore(this.arrow_, this.textContent_);
     } else {

--- a/apps/src/blockly/addons/cdoFieldToggle.js
+++ b/apps/src/blockly/addons/cdoFieldToggle.js
@@ -49,6 +49,9 @@ export default class CdoFieldToggle extends GoogleBlockly.Field {
    */
   initView() {
     super.initView();
+    // Make the icon centered on Safari.
+    this.defaultIcon.setAttribute('dominant-baseline', 'central');
+    this.alternateIcon.setAttribute('dominant-baseline', 'central');
     if (this.useDefaultIcon) {
       this.textElement_.appendChild(this.defaultIcon);
     } else {

--- a/apps/src/blockly/addons/cdoFieldVariable.js
+++ b/apps/src/blockly/addons/cdoFieldVariable.js
@@ -70,7 +70,17 @@ export default class CdoFieldVariable extends GoogleBlockly.FieldVariable {
           : ' ' + Blockly.FieldDropdown.ARROW_CHAR
       )
     );
+
+    /**
+     * Begin CDO customization
+     */
     this.arrow_.setAttribute('dominant-baseline', 'central');
+    // This is to make this function forward-compatible with Blockly v10.
+    this.arrow = this.arrow_;
+    /**
+     * End CDO customization
+     */
+
     if (this.getSourceBlock()?.RTL) {
       this.getTextElement().insertBefore(this.arrow_, this.textContent_);
     } else {

--- a/apps/src/blockly/addons/cdoFieldVariable.js
+++ b/apps/src/blockly/addons/cdoFieldVariable.js
@@ -50,6 +50,34 @@ export default class CdoFieldVariable extends GoogleBlockly.FieldVariable {
       }
     }
   }
+
+  /**
+   * Override of createTextArrow_ to fix the arrow position on Safari.
+   * We need to add dominant-baseline="central" to the arrow element in order to
+   * center it on Safari.
+   *  @override */
+  createTextArrow_() {
+    // TODO: This field changes from arrow_ to arrow with the v10 upgrade.
+    this.arrow_ = Blockly.utils.dom.createSvgElement(
+      Blockly.utils.Svg.TSPAN,
+      {},
+      this.textElement_
+    );
+    this.arrow_.appendChild(
+      document.createTextNode(
+        this.getSourceBlock()?.RTL
+          ? Blockly.FieldDropdown.ARROW_CHAR + ' '
+          : ' ' + Blockly.FieldDropdown.ARROW_CHAR
+      )
+    );
+    this.arrow_.setAttribute('dominant-baseline', 'central');
+    if (this.getSourceBlock()?.RTL) {
+      this.getTextElement().insertBefore(this.arrow_, this.textContent_);
+    } else {
+      this.getTextElement().appendChild(this.arrow_);
+    }
+  }
+
   menuGenerator_ = function () {
     const options = CdoFieldVariable.dropdownCreate.call(this);
 


### PR DESCRIPTION
We noticed that our field icons and dropdown arrows were placed too high on Safari. It seems that Safari does not inherit the property `dominant-baseline: "central"` from the parent element. To fix this I added that property to the relevant icons. The issue with the dropdowns is present in mainline blockly, but since we were already subclassing both the field and variable dropdowns it was easy to add in a workaround.

### Before
![Screenshot 2023-12-14 at 4 24 07 PM](https://github.com/code-dot-org/code-dot-org/assets/33666587/9194af8b-d435-4a09-b1f7-c0c4e6a29d5d)


### After
![Screenshot 2023-12-14 at 4 24 15 PM](https://github.com/code-dot-org/code-dot-org/assets/33666587/d3ceacfd-1020-4794-9705-f286356b658d)

## Links
- jira ticket: [CT-198](https://codedotorg.atlassian.net/browse/CT-198)


## Testing story
Tested locally on Safari, Firefox and Chrome. Chrome has been centering things correctly and still does. Safari is now fixed. Firefox has the icons a little below center, but none are off the block like Safari was, and the fix does not change the existing placement. Firefox icons being a little low is consistent with mainline Blockly behavior.
 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
