### PR TITLE
Fix ARGV check in purge_users

### DIFF
--- a/bin/oneoff/purge_accounts/purge_users
+++ b/bin/oneoff/purge_accounts/purge_users
@@ -11,7 +11,7 @@ require 'csv'
 # requests and use this script:
 # https://docs.google.com/document/d/1-Gk66udFdzqvYyT6J-1d5HPSbkVCIQWzxMLyVKF3fuk/edit
 
-if ARGV.length.empty? || ARGV.length > 2
+if ARGV.empty? || ARGV.length > 2
   puts 'Usage: ./bin/oneoff/purge_accounts/purge_users ./bin/oneoff/purge_accounts/yyyy-mm-dd-users.csv [commit]'
   puts 'The CSV needs a column with "user_id" with User ids.'
   puts 'Will do a "dry run" until you specify "for-real" for the "commit" field.'


### PR DESCRIPTION
When we tried running the purge_users one-off script, we hit an error when it tried to check `ARGV.length.empty?`, because length is an integer. This fix changes it to check whether `ARGV` itself is empty.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-636)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
