### PR TITLE
[Google Blockly] Support getting function and behavior names from title element

### DIFF
--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -167,7 +167,7 @@ export function addMutationToBehaviorDefBlocks(blockElement) {
 
   // In CDO Blockly, behavior ids were stored on the field. Google Blockly
   // expects this kind of extra state in a mutator.
-  const nameField = blockElement.querySelector('field[name="NAME"]');
+  const nameField = getNameField(blockElement);
   const idAttribute = nameField && nameField.getAttribute('id');
   if (idAttribute) {
     // Create new mutation attribute based on original block attribute.
@@ -214,7 +214,7 @@ export function addNameToBlockFunctionDefinitionBlock(blockElement) {
   if (blockType !== BLOCK_TYPES.procedureDefinition) {
     return;
   }
-  const fieldElement = blockElement.querySelector('field[name="NAME"]');
+  const fieldElement = getNameField(blockElement);
   if (!fieldElement) {
     return;
   }
@@ -272,6 +272,15 @@ export function addMutationToTextJoinBlock(blockElement) {
   // Google Blockly expects this kind of extra state to be in a mutator.
   const inputCount = blockElement.getAttribute('inputcount');
   mutationElement.setAttribute('items', inputCount);
+}
+
+function getNameField(blockElement) {
+  // Title is the legacy name for field, we support getting name from
+  // either field or title.
+  return (
+    blockElement.querySelector('field[name="NAME"]') ||
+    blockElement.querySelector('title[name="NAME"]')
+  );
 }
 
 /**


### PR DESCRIPTION
We found a bug in some levels where behaviors were using the legacy blockly xml element `title` rather than the more recent `field`. We generally support both, but in getting behavior and function names we were hard-coding looking at `field`. This looks in the `title` element if there is no `field`.

## Links
- [slack discussion](https://codedotorg.slack.com/archives/C05HZFH7BED/p1702596500813399)

## Testing story
Tested locally. This issues surfaced in `/s/express-2023/lessons/6/levels/6`, which was using `title` elements.

## Follow-up work
We should verify we aren't hard-coding `field` anywhere else. [Follow-up task](https://codedotorg.atlassian.net/browse/CT-220)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
