### PR TITLE
Revert "Show learn more button catalog mobile"

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1369,7 +1369,6 @@
   "learnMoreAilab": "Learn about AI Lab",
   "learnMoreApplab": "Learn about App Lab",
   "learnMoreCsJourneys": "Learn about CS Journeys",
-  "learnMoreDescription": "Learn more about {course_name}",
   "learnMoreGamelab": "Learn about Game Lab",
   "learnMoreToolsVideos": "Learn about Video Tools",
   "learnMoreWeblab": "Learn about Web Lab",

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -282,18 +282,7 @@ const CustomizableCurriculumCatalogCard = ({
                 onClick={onQuickViewClick}
                 aria-label={quickViewButtonDescription}
                 text={i18n.quickView()}
-                className={`${style.buttonFlex} ${style.quickViewButton}`}
-              />
-              <Button
-                __useDeprecatedTag
-                color={quickViewButtonColor}
-                type="button"
-                href={pathToCourse}
-                aria-label={i18n.learnMoreDescription({
-                  course_name: courseDisplayName,
-                })}
-                text={i18n.learnMore()}
-                className={`${style.buttonFlex} ${style.learnMoreButton}`}
+                className={style.buttonFlex}
               />
               {(isSignedOut || isTeacher) && (
                 <Button

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -1,6 +1,5 @@
 @use 'sass:math';
 @import 'phase1-design-system';
-@import 'breakpoints';
 
 $border-radius: 4px;
 $container-width: 309px;
@@ -207,34 +206,4 @@ $container-width: 309px;
 
 .buttonFlex {
   flex: 1;
-}
-
-// !important tags needed here in order to override Button styling that makes the Learn More button appear at all times.
-.learnMoreButton {
-  display: none !important;
-  text-align: center;
-}
-
-@media screen and (max-width: $width-md) {
-  .arrowContainer {
-    display: none !important;
-  }
-
-  .centerExpandedCard {
-    display: none !important;
-  }
-
-  .learnMoreButton {
-    display: block !important;
-  }
-
-  .quickViewButton {
-    display: none !important;
-  }
-
-  .expandedCard {
-    .curriculumInfoContainer {
-      border-color: $neutral_dark20 !important;
-    }
-  }
 }

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogExpandedCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogExpandedCardTest.jsx
@@ -58,10 +58,7 @@ describe('CurriculumCatalogExpandedCard', () => {
   it('renders course name', () => {
     renderCurriculumExpandedCard();
 
-    screen.getByRole('heading', {
-      name: defaultProps.courseDisplayName,
-      hidden: true,
-    });
+    screen.getByRole('heading', {name: defaultProps.courseDisplayName});
   });
 
   it('renders grade range with icon', () => {
@@ -114,7 +111,7 @@ describe('CurriculumCatalogExpandedCard', () => {
       video: null,
     });
 
-    screen.getByRole('img', {hidden: true});
+    screen.getByRole('img');
   });
 
   it('renders image with alt text if passed and no video', () => {
@@ -126,7 +123,7 @@ describe('CurriculumCatalogExpandedCard', () => {
     });
 
     // when alt text is present, the img name is the alt text
-    screen.getByRole('img', {name: altText, hidden: true});
+    screen.getByRole('img', {name: altText});
   });
 
   it('renders available resources section when resources are available', () => {
@@ -229,7 +226,6 @@ describe('CurriculumCatalogExpandedCard', () => {
       name: new RegExp(
         `Assign ${defaultProps.courseDisplayName} to your classroom`
       ),
-      hidden: true,
     });
 
     fireEvent.click(assignButton);
@@ -248,7 +244,6 @@ describe('CurriculumCatalogExpandedCard', () => {
 
     const onCloseButton = screen.getByRole('button', {
       name: 'Close Button',
-      hidden: true,
     });
 
     fireEvent.click(onCloseButton);

--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -56,11 +56,9 @@ Feature: Curriculum Catalog Page
     And I wait until element "h2:contains(Have an account already? Sign in)" is visible
 
   Scenario: Signed-in student does not see Assign button
-  Scenario: Signed-in student does not see Assign button
     Given I create a student named "Student Sam"
     Given I am on "http://studio.code.org/catalog"
     And I wait until element "h4:contains(AI for Oceans)" is visible
-    And I wait until element "button:contains(Assign)" is not visible   
     And I wait until element "button:contains(Assign)" is not visible   
 
   Scenario: Signed-in teacher without sections is prompted to created sections when clicking Assign
@@ -141,7 +139,6 @@ Feature: Curriculum Catalog Page
     And I see that "Section 2" is not assigned to "Computer Science Principles" in the section table
 
   #Expanded card scenarios
-  @no_mobile
   Scenario: Signed-out user sees the curriculum catalog with offerings and can expand card
     Given I am on "http://studio.code.org/catalog"
     And I wait until element "h4:contains(AI for Oceans)" is visible
@@ -149,7 +146,6 @@ Feature: Curriculum Catalog Page
     And I click selector "[aria-label='View details about AI for Oceans']"
     And I wait until element "a:contains(See curriculum details)" is visible
 
-  @no_mobile
   Scenario: Signed-out user sees course offering page when clicking on see curriculum details on expanded card
     Given I am on "http://studio.code.org/catalog"
     And I wait until element "h4:contains(AI for Oceans)" is visible
@@ -170,7 +166,6 @@ Feature: Curriculum Catalog Page
     Then I wait for jquery to load
     And I wait until current URL contains "/professional-development-workshops"
 
-  @no_mobile
   Scenario: On expanded card, Signed-in teacher sees professional learning section
     Given I create a teacher named "Teacher Tom"
     Given I am on "http://studio.code.org/catalog"
@@ -179,7 +174,6 @@ Feature: Curriculum Catalog Page
     And I scroll the "h4:contains(CS Fundamentals: Course A)" element into view
     And I wait until element "h4:contains(Professional Learning)" is visible
 
-  @no_mobile
   Scenario: On expanded card, Signed-in student does not see professional learning section
     Given I create a student named "Student Sam"
     Given I am on "http://studio.code.org/catalog"
@@ -188,7 +182,6 @@ Feature: Curriculum Catalog Page
     And I wait until element "h4:contains(Professional Learning)" is not visible
 
   # Expanded Card Assign button scenarios
-  @no_mobile
   Scenario: On expanded card, Signed-out user is redirected to sign-in page when clicking Assign to class sections
     Given I am on "http://studio.code.org/catalog"
     And I wait until element "h4:contains(AI for Oceans)" is visible
@@ -198,16 +191,13 @@ Feature: Curriculum Catalog Page
     Then I click selector "a:contains(Sign in or create account)"
     And I wait until element "h2:contains(Have an account already? Sign in)" is visible
 
-  @no_mobile
   Scenario: On expanded card, Signed-in student does not see Assign button
     Given I create a student named "Student Sam"
     Given I am on "http://studio.code.org/catalog"
     And I wait until element "h4:contains(AI for Oceans)" is visible
     And I click selector "[aria-label='View details about AI for Oceans']"
     And I wait until element "span:contains(Assign to class sections)" is not visible
-    And I wait until element "span:contains(Assign to class sections)" is not visible
 
-  @no_mobile
   Scenario: On the expanded card, Signed-in teacher without sections is prompted to created sections when clicking Assign to class sections
     Given I create a teacher named "Teacher Tom"
     Then I am on "http://studio.code.org/catalog"
@@ -220,7 +210,6 @@ Feature: Curriculum Catalog Page
     Then I click selector "a:contains(Create Section)"
     And I wait until element "h3:contains(Create a new section)" is visible
   
-  @no_mobile
   Scenario: On expanded card, Signed-in teacher with sections assigns and unassigns offerings to sections
     Given I am a teacher with student sections named Section 1 and Section 2
 
@@ -296,14 +285,6 @@ Feature: Curriculum Catalog Page
     And I see that "Section 1" is not assigned to "AI for Oceans" in the section table
     And I see that "Section 2" is not assigned to "Computer Science Principles" in the section table
   
-  @only_mobile
-  Scenario: On mobile, User sees the Learn More button on Catalog Cards
-    Given I am on "http://studio.code.org/catalog"
-    And I rotate to portrait
-    And I wait for 0.5 seconds
-    And I wait until element "h4:contains(AI for Oceans)" is visible
-    And I click selector "span:contains(Learn More)"
-    And I wait until element "h1:contains(AI for Oceans)" is visible
   
   # Curriculum Catalog Filter tests
   


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#55161
Failing mobile UI tests in `curriculum_catalog.feature` need more investigating.