### PR TITLE
update text when no regional partner matches in RegionalPartnerSearch

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -372,9 +372,9 @@ class RegionalPartnerSearch extends Component {
                                   This Regional Partner is not offering{' '}
                                   {currCourse.name} workshops at this time.
                                   Code.org will review your application and
-                                  contact you with options for joining the
-                                  program hosted by a Regional Partner from a
-                                  different region.
+                                  contact you with options for joining a virtual
+                                  cohort of {currCourse.name} teachers from
+                                  another region.
                                 </div>
                               </>
                             }


### PR DESCRIPTION
Small copy change for teacher applications -- see [this discussion](https://docs.google.com/document/d/1jrmraQqFuCxEBOqpYuZpg01sg1H8PMeT09j8AyweKLw/edit?disco=AAABBO8MS0I) from the spec.