### PR TITLE
[Google Blockly] Maintain support for invisible top blocks

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1091,6 +1091,12 @@ exports.createJsWrapperBlockCreator = function (
           );
         }
       },
+      // The following generic mutator functions are only used by Google Blockly
+      // and are intentionally undefined for CDO Blockly.
+      mutationToDom: Blockly.customBlocks.mutationToDom,
+      domToMutation: Blockly.customBlocks.domToMutation,
+      saveExtraState: Blockly.customBlocks.saveExtraState,
+      loadExtraState: Blockly.customBlocks.loadExtraState,
     };
 
     generator[blockName] = function () {

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -76,7 +76,7 @@ function prepareSourcesForWorkspaces(source) {
   if (Blockly.useModalFunctionEditor) {
     procedureTypesToHide.push(BLOCK_TYPES.procedureDefinition);
   }
-  const {mainSource, hiddenDefinitionSource} = moveHiddenProcedures(
+  const {mainSource, hiddenDefinitionSource} = moveHiddenBlocks(
     parsedSource,
     procedureTypesToHide
   );
@@ -106,17 +106,18 @@ function parseSource(source) {
 }
 
 /**
- * Move hidden procedures from the source to a hidden definition object.
+ * Move hidden blocks (e.g. procedures) from the source to a hidden definition object.
  * These will be used to initialize the main and hidden definitions workspaces, respectively.
- * Procedures are hidden if they have a type in the procedureTypesToHide array.
+ * Blocks are hidden if they have a type in the procedureTypesToHide array, or if they
+ * are explicitly marked as invisible in the project source.
  * In addition, copy the procedure model from the source
- * object to the hidden definition object when moving a procedure.
+ * object to the hidden definition object when moving a procedure block.
  * @param {Object} source Project source object, parsed from JSON.
  * @param {Array<string>} procedureTypesToHide procedure types to move to procedures object.
  * @returns void
  * exported for unit testing
  */
-export function moveHiddenProcedures(source = {}, procedureTypesToHide = []) {
+export function moveHiddenBlocks(source = {}, procedureTypesToHide = []) {
   if (procedureTypesToHide.length === 0 || !hasBlocks(source)) {
     return {mainSource: {}, hiddenDefinitionSource: {}};
   }
@@ -131,16 +132,16 @@ export function moveHiddenProcedures(source = {}, procedureTypesToHide = []) {
   hiddenDefinitionSource.procedures = [];
 
   source.blocks.blocks.forEach(block => {
-    const destination = procedureTypesToHide.includes(block.type)
-      ? hiddenDefinitionSource
-      : mainSource;
+    const {invisible, procedureId} = block.extraState || {};
+    const hideBlock = procedureTypesToHide.includes(block.type) || invisible;
+    const destination = hideBlock ? hiddenDefinitionSource : mainSource;
     destination.blocks.blocks.push(block);
 
     // Also copy the procedure model for blocks to that need to be hidden
     // Equality check works because hiddenDefinitionSource and mainSource are different object references
-    if (destination === hiddenDefinitionSource) {
+    if (destination === hiddenDefinitionSource && procedureId) {
       const procedureModel = source.procedures.find(
-        procedure => procedure.id === block.extraState?.procedureId
+        procedure => procedure.id === procedureId
       );
       if (procedureModel) {
         hiddenDefinitionSource.procedures.push(procedureModel);

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -1,6 +1,6 @@
 import {BLOCK_TYPES, PROCEDURE_DEFINITION_TYPES} from '../constants';
 import {partitionBlocksByType} from './cdoUtils';
-import {FALSEY_DEFAULT, readBooleanAttribute} from '../utils';
+import {FALSEY_DEFAULT, TRUTHY_DEFAULT, readBooleanAttribute} from '../utils';
 
 // The user created attribute needs to be read from XML start blocks as 'usercreated'.
 // Once this has been done, all subsequent steps in the serialization use userCreated.
@@ -205,6 +205,34 @@ export function addMutationToProcedureDefBlocks(blockElement) {
 }
 
 /**
+ * Adds a mutation element to a block if it should be invisible.
+ * These blocks will be loaded onto the hidden workspace for procedure definitions.
+ *
+ * @param {Element} blockElement - The XML element for a single block.
+ */
+export function addMutationToInvisibleBlocks(blockElement) {
+  if (PROCEDURE_DEFINITION_TYPES.includes(blockElement.getAttribute('type'))) {
+    return;
+  }
+
+  const invisible = !readBooleanAttribute(
+    blockElement,
+    'uservisible',
+    TRUTHY_DEFAULT
+  );
+
+  if (!invisible) {
+    return;
+  }
+  const mutationElement =
+    blockElement.querySelector('mutation') ||
+    blockElement.ownerDocument.createElement('mutation');
+  // Place mutator before fields, values, and other nested blocks.
+  blockElement.insertBefore(mutationElement, blockElement.firstChild);
+  mutationElement.setAttribute('invisible', invisible);
+}
+
+/**
  * In the event that a legacy project has functions without names, add a name
  * to the definition block's NAME field.
  * @param {Element} blockElement - The XML element for a single block.
@@ -297,6 +325,7 @@ function processIndividualBlock(block) {
   // Convert unsupported can_disconnect_from_parent attributes.
   makeLockedBlockImmovable(block);
   addMutationToTextJoinBlock(block);
+  addMutationToInvisibleBlocks(block);
 }
 
 /**

--- a/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.js
@@ -2,11 +2,55 @@
  * Defines blocks useful in multiple blockly apps
  */
 
+import {readBooleanAttribute} from '../../utils';
+
+const mutatorProperties = [];
+
 export const blocks = {
   installJoinBlock(blockly) {
     // text_join is included with core Blockly. We register a custom text_join_mutator
     // which adds the plus/minus block UI.
     blockly.Blocks.text_join_simple = blockly.Blocks.text_join;
     blockly.JavaScript.text_join_simple = blockly.JavaScript.text_join;
+  },
+  mutationToDom() {
+    var container = Blockly.utils.xml.createElement('mutation');
+    mutatorProperties.forEach(prop => {
+      container.setAttribute(prop, this[prop]);
+    });
+    return container;
+  },
+  domToMutation(mutationElement) {
+    Array.from(mutationElement.attributes).forEach(attr => {
+      const attrName = attr.name;
+      const attrValue = attr.value;
+
+      const parsedInt = parseInt(attrValue);
+      if (!isNaN(parsedInt)) {
+        this[attrName] = parsedInt;
+      } else if (
+        attrValue.toLowerCase() === 'false' ||
+        attrValue.toLowerCase() === 'true'
+      ) {
+        this[attrName] = readBooleanAttribute(mutationElement, attrName);
+      } else {
+        this[attrName] = attrValue;
+      }
+      mutatorProperties.indexOf(attrName) === -1 &&
+        mutatorProperties.push(attrName);
+    });
+  },
+  saveExtraState() {
+    let state = {};
+    mutatorProperties.forEach(prop => {
+      state[prop] = this[prop];
+    });
+    return state;
+  },
+  loadExtraState(state) {
+    for (var prop in state) {
+      this[prop] = state[prop];
+      mutatorProperties.indexOf(prop) === -1 && mutatorProperties.push(prop);
+    }
   },
 };

--- a/apps/src/blockly/utils.js
+++ b/apps/src/blockly/utils.js
@@ -4,6 +4,9 @@ import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
 // Considers an attribute true only if it is explicitly set to 'true' (i.e. defaults to false if unset).
 export const FALSEY_DEFAULT = attributeValue => attributeValue === 'true';
 
+// Considers an attribute true unless it is explicitly set to 'false' (i.e. defaults to true if unset).
+export const TRUTHY_DEFAULT = attributeValue => attributeValue !== 'false';
+
 /**
  * Reads a boolean attribute from an XML element and determines its value based on a callback function.
  * The callback function determines how we interpret the attribute value as a boolean.

--- a/apps/test/unit/blockly/addons/cdoUtilsTest.js
+++ b/apps/test/unit/blockly/addons/cdoUtilsTest.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import {
   getCode,
-  moveHiddenProcedures,
+  moveHiddenBlocks,
   partitionBlocksByType,
 } from '@cdo/apps/blockly/addons/cdoUtils';
 import * as cdoSerializationHelpers from '@cdo/apps/blockly/addons/cdoSerializationHelpers';
@@ -88,8 +88,8 @@ describe('CdoUtils', () => {
       expect(result).to.deep.equal(blockElements);
     });
   });
-  describe('moveHiddenProcedures', () => {
-    it('should not move any blocks if none have the appropriate procedure type', () => {
+  describe('moveHiddenBlocks', () => {
+    it('should not move any blocks if none have the appropriate procedure type and none are invisible', () => {
       const source = {
         blocks: {
           blocks: [{type: 'when_run', id: 1}],
@@ -98,7 +98,7 @@ describe('CdoUtils', () => {
       };
 
       const typesToHide = ['procedures_defnoreturn'];
-      const result = moveHiddenProcedures(source, typesToHide);
+      const result = moveHiddenBlocks(source, typesToHide);
       expect(result).to.deep.equal({
         mainSource: {
           blocks: {
@@ -110,7 +110,7 @@ describe('CdoUtils', () => {
       });
     });
 
-    it('should move all blocks if they all match', () => {
+    it('should move all blocks if they all match a procedure type', () => {
       const source = {
         blocks: {
           blocks: [
@@ -125,7 +125,7 @@ describe('CdoUtils', () => {
       };
 
       const typesToHide = ['procedures_defnoreturn'];
-      const result = moveHiddenProcedures(source, typesToHide);
+      const result = moveHiddenBlocks(source, typesToHide);
       expect(result).to.deep.equal({
         mainSource: {blocks: {blocks: []}, procedures: [{id: 'a'}]},
         hiddenDefinitionSource: {
@@ -149,8 +149,13 @@ describe('CdoUtils', () => {
           blocks: [
             {type: 'when_run', id: 1},
             {
-              type: 'procedures_defnoreturn',
+              type: 'gamelab_everyInterval',
               id: 2,
+              extraState: {invisible: true},
+            },
+            {
+              type: 'procedures_defnoreturn',
+              id: 3,
               extraState: {procedureId: 'a'},
             },
           ],
@@ -159,7 +164,7 @@ describe('CdoUtils', () => {
       };
 
       const typesToHide = ['procedures_defnoreturn'];
-      const result = moveHiddenProcedures(source, typesToHide);
+      const result = moveHiddenBlocks(source, typesToHide);
       expect(result).to.deep.equal({
         mainSource: {
           blocks: {blocks: [{type: 'when_run', id: 1}]},
@@ -169,8 +174,13 @@ describe('CdoUtils', () => {
           blocks: {
             blocks: [
               {
-                type: 'procedures_defnoreturn',
+                type: 'gamelab_everyInterval',
                 id: 2,
+                extraState: {invisible: true},
+              },
+              {
+                type: 'procedures_defnoreturn',
+                id: 3,
                 extraState: {procedureId: 'a'},
               },
             ],
@@ -194,7 +204,7 @@ describe('CdoUtils', () => {
         procedures: [{id: 'a'}],
       };
       const procedureTypesToHide = ['procedures_defnoreturn'];
-      const result = moveHiddenProcedures(source, procedureTypesToHide);
+      const result = moveHiddenBlocks(source, procedureTypesToHide);
       expect(result).to.deep.equal({
         mainSource: {blocks: {blocks: []}, procedures: [{id: 'a'}]},
         hiddenDefinitionSource: {
@@ -235,7 +245,7 @@ describe('CdoUtils', () => {
         'procedures_defnoreturn',
         'behavior_definition',
       ];
-      const result = moveHiddenProcedures(source, procedureTypesToHide);
+      const result = moveHiddenBlocks(source, procedureTypesToHide);
       expect(result).to.deep.equal({
         mainSource: {
           blocks: {blocks: [{type: 'when_run', id: 1}]},


### PR DESCRIPTION
It has been communicated that Google Blockly does not support invisible blocks:

However, they can still be found in certain CSC levels, such as: https://studio.code.org/s/csc-adaptations-2023/lessons/2/levels/10

The start blocks for the level are shown below, with "invisible" blocks looking disabled in this view:
<img width="836" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/364e8778-e6fa-46a9-a517-72c57cc02fae">

CDO Blockly supports this by not rendering the blocks. We can't do that, but we can leverage our hidden definition workspace. If a top block would be invisible, we can move it to the hidden definition block (along with hidden procedures) so that it can't be seen/edited by the student.

**Summary of changes:**
1. Add "generic" mutator functions to all custom blocks
The functions will support serialization of any random properties that are discovered during loading. For example, if the block XML or JSON includes an `invisible` property, we'd add it to the block, and vice versa. These functions are generalized so that if other potentially-important properties are found in a mutator we will serialize them too.
2. Add mutations to XML blocks.
Similar to other cases where extra block state was saved as an attribute on the block, we need to move this to a mutation element. I went with `invisible` as the new attribute and property name since the more common case is for a block to be visible because the property to not exist.
3. Move invisible blocks to the hidden definition source
We already have a separate JSON object representing blocks and procedures that should be loaded onto the hidden workspace. If a top block is invisible, we can lump it in with them.

**Example start blocks:**

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/28326f18-0d9d-4ce5-a352-ccea72c7fe24)

**Video demonstrating that the blocks are hidden but still work, including saving and reloading:**

https://github.com/code-dot-org/code-dot-org/assets/43474485/d803174b-ec30-4639-bc11-4bfa2d1cc3a6

Note that this doesn't maintain support for invisible blocks that are _not_ top blocks. This still feels like a hard/impossible thing to support as moving child blocks to a different workspace would disable them.

## Links

https://codedotorg.atlassian.net/browse/CT-223

## Testing story

As `moveHiddenProcedures` was renamed, I had to update its associated test file. I updated one of the scenarios to add coverage for an invisible top block.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
