### PR TITLE
Alt Text Followup Take Two

### DIFF
--- a/apps/src/maze/SpellingControls.jsx
+++ b/apps/src/maze/SpellingControls.jsx
@@ -31,10 +31,6 @@ var SpellingControls = function (props) {
                 className="spellingButton"
                 disabled
               >
-                {
-                  // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-                  // Verify or update this alt-text as necessary
-                }
                 <img src="/blockly/media/1x1.gif" alt="" />
                 <span id="currentWordContents" />
               </button>

--- a/apps/src/music/views/SoundsPanel.jsx
+++ b/apps/src/music/views/SoundsPanel.jsx
@@ -34,10 +34,6 @@ const FolderPanelRow = ({
   return (
     <div className={classNames('sounds-panel-folder-row', styles.folderRow)}>
       <div className={styles.folderRowLeft}>
-        {
-          // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-          // Verify or update this alt-text as necessary
-        }
         {imageSrc && (
           <img src={imageSrc} className={styles.folderImage} alt="" />
         )}
@@ -100,10 +96,6 @@ const SoundsPanelRow = ({
       onClick={() => onSelect(folder.path + '/' + sound.src)}
     >
       <div className={styles.soundRowLeft}>
-        {
-          // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-          // Verify or update this alt-text as necessary
-        }
         <img src={typeIconPath} className={styles.typeIcon} alt="" />
       </div>
       <div className={styles.soundRowMiddle}>{sound.name}</div>

--- a/apps/src/templates/instructions/codeReviewV2/Comment.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/Comment.jsx
@@ -191,8 +191,6 @@ function Comment({
           ) : (
             <InlineDropdownMenu
               selector={
-                // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-                // Verify or update this alt-text as necessary
                 <img
                   src={
                     '/blockly/media/templates/instructions/codeReview/ellipsis.svg'

--- a/apps/src/templates/sectionsRefresh/SectionCreationCelebrationDialog.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionCreationCelebrationDialog.jsx
@@ -16,10 +16,6 @@ export default function SectionCreationCelebrationDialog() {
       <div className={moduleStyles.celebrationDialogBody}>
         <h2>{i18n.congratulations()}</h2>
         <div>{i18n.sectionCreationCelebrationDialogMessage()}</div>
-        {
-          // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-          // Verify or update this alt-text as necessary
-        }
         <img
           src={CelebrationGif}
           className={moduleStyles.celebrationGif}

--- a/apps/src/templates/teacherDashboard/SignInInstructions.jsx
+++ b/apps/src/templates/teacherDashboard/SignInInstructions.jsx
@@ -81,10 +81,6 @@ export default class SignInInstructions extends React.Component {
             </div>
             <p style={styles.sublistAlign}>{i18n.signingInClever1b()}</p>
             <p style={styles.listAlign}>{i18n.signingInClever2()}</p>
-            {
-              // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-              // Verify or update this alt-text as necessary
-            }
             <img
               style={styles.sublistAlign}
               src="/shared/images/clever_code_org_logo.png"


### PR DESCRIPTION
This PR is a continued followup to implementing the alt-text rule in the accessibility linter ([see PR 1 here](https://github.com/code-dot-org/code-dot-org/pull/55495)). 

For SoundControls: I gave myself pilot access and though the page isn't accessible yet, these icons simply provide a visual for the type of beat. However, I think it would be redundant for a user scrolling through to hear over and over again that the different kinds of drumbeats were in fact 'drums' especially because my screen reader read out the names and they all included 'beat' in the titles. I'm removing the alt text for the icons and trusting the names will be what the user wants anyway.
<img width="381" alt="Screenshot 2024-01-02 at 11 38 25 AM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/21972265-0d37-40ed-bd3f-11ce67308488">

For the Spelling images, they are 1 pixel images on the buttons and serve no important visual purpose. A screen reader should read the buttons instead of the images anyway.
<img width="273" alt="Screenshot 2024-01-02 at 11 29 30 AM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/284d74d4-f6c7-4c6b-8f94-fa69658f3c39">

For the Clever logo, it's just in a visual example of what the logo will look like, which is only useful for visual users.

For the Section Creation Celebration Screen, I am keeping an empty alt text as well. As much as I'd like to communicate more to the user, this is pretty directly in the 'decorative' category, and there are already two congratulations messages that would be read by a screen reader.

For the dropdown menu, the ellipsis is a decorative icon.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
