### PR TITLE
Update MySQL GPG Public Build Key Id

### DIFF
--- a/cookbooks/cdo-mysql/recipes/repo.rb
+++ b/cookbooks/cdo-mysql/recipes/repo.rb
@@ -10,8 +10,8 @@ apt_repository 'mysql' do
   # Pin to MySQL 5.7 until we're ready to update to MySQL 8
   components ['mysql-5.7']
 
-  # https://dev.mysql.com/doc/refman/5.7/en/checking-gpg-signature.html
-  key '3A79BD29'
+  # https://dev.mysql.com/doc/refman/8.0/en/gpg-key-archived-packages.html
+  key '5072E1F5'
   keyserver 'keyserver.ubuntu.com'
   retries 3
 end


### PR DESCRIPTION
The previous MySQL GPG public build key [expired](https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html) 2023-12-14

<img width="933" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/2157034/b10827e8-32a4-45fa-8a1b-0e621dd29a1e">

Update build logic to reference the new key id for pre-MySQL 8.x packages.


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
