### PR TITLE
Handle Long Section names by truncating

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -100,9 +100,6 @@ class ApiController < ApplicationController
     course_id = params[:courseId].to_s
     course_name = params[:courseName].to_s
 
-    if course_name.length > 255
-      course_name = course_name.truncate(255)
-    end
     query_clever_service("v2.1/sections/#{course_id}/students") do |students|
       section = CleverSection.from_service(course_id, current_user.id, students, course_name)
       render json: section.summarize

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -100,6 +100,9 @@ class ApiController < ApplicationController
     course_id = params[:courseId].to_s
     course_name = params[:courseName].to_s
 
+    if course_name.length > 255
+      course_name = course_name.truncate(255)
+    end
     query_clever_service("v2.1/sections/#{course_id}/students") do |students|
       section = CleverSection.from_service(course_id, current_user.id, students, course_name)
       render json: section.summarize

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -38,7 +38,7 @@ class OmniAuthSection < Section
   def self.from_omniauth(code:, type:, owner_id:, students:, section_name: I18n.t('sections.default_name', default: 'Untitled Section'))
     oauth_section = with_deleted.where(code: code).first_or_create
 
-    course_name_limit = type == Section::LOGIN_TYPE_CLEVER ? CleverSection.column_for_attribute(:name).limit : GoogleClassroomSection.column_for_attribute(:name).limit
+    course_name_limit = OmniAuthSection.column_for_attribute(:name).limit
     oauth_section.name = section_name.length > course_name_limit ? section_name.truncate(course_name_limit) : section_name
 
     # Add the user as an owner if the section does not exist. Otherwise add as a coteacher to existing section.

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -38,7 +38,8 @@ class OmniAuthSection < Section
   def self.from_omniauth(code:, type:, owner_id:, students:, section_name: I18n.t('sections.default_name', default: 'Untitled Section'))
     oauth_section = with_deleted.where(code: code).first_or_create
 
-    oauth_section.name = section_name || I18n.t('sections.default_name', default: 'Untitled Section')
+    course_name_limit = type == Section::LOGIN_TYPE_CLEVER ? CleverSection.column_for_attribute(:name).limit : GoogleClassroomSection.column_for_attribute(:name).limit
+    oauth_section.name = section_name.length > course_name_limit ? section_name.truncate(course_name_limit) : section_name
 
     # Add the user as an owner if the section does not exist. Otherwise add as a coteacher to existing section.
     if oauth_section.user_id.nil? || oauth_section.deleted?
@@ -62,7 +63,6 @@ class OmniAuthSection < Section
 
     oauth_section.set_exact_student_list(oauth_students)
 
-    oauth_section.name = section_name
     oauth_section.save! if oauth_section.changed?
 
     oauth_section

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1711,16 +1711,20 @@ class ApiControllerTest < ActionController::TestCase
     sign_in teacher
     course_name = 'test' * 65
 
-    ApiController.any_instance.expects(:query_clever_service).yields(clever_students_response_stub)
-    post :import_clever_classroom, params: {courseName: course_name}
+    ApiController.any_instance.expects(:query_clever_service).yields(clever_service_response_stub)
+    post :import_clever_classroom, params: {courseId: '101', courseName: course_name}
 
     response_json = JSON.parse(response.body)
     assert_equal 255, response_json['name'].length
     assert response_json['name'].end_with?('...')
   end
 
-  def clever_students_response_stub
-    [{"data" => {"created" => "2017-07-13T03:48:03.497Z", "district" => "59484d29ae5dee0001fd3291", "dob" => "", "enrollments" => [], "gender" => "M", "hispanic_ethnicity" => "", "last_modified" => "2017-11-02T00:49:40.494Z", "name" => {"first" => "Ethan", "last" => "Doe", "middle" => ""}, "race" => "", "school" => "5966ed6cf9d478523c000004", "schools" => ["5966ed6cf9d478523c000004"], "sis_id" => "200", "id" => "5966ed736b21538e3c000004"}, "uri" => "/v2.1/students/5966ed736b21538e3c000004"}]
+  def clever_service_response_stub
+    [
+      {'data' => {'dob' => '2002-09-04T00:00:00.000Z', 'name' => {'first' => 'Ethan', 'last' => 'Doe'}, 'id' => '5966ed736b21538e3c000004'}},
+      {'data' => {'dob' => '2000-02-11T00:00:00.000Z', 'name' => {'first' => 'Lily', 'last' => 'Fake'}, 'id' => '5966ed736b21538e3c000005'}},
+      {'data' => {'dob' => '2002-05-21T00:00:00.000Z', 'name' => {'first' => 'Elizabeth', 'last' => 'Smith'}, 'id' => '5966ed736b21538e3c000006'}},
+    ]
   end
 
   #

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1706,6 +1706,23 @@ class ApiControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  test 'clever section name too long' do
+    teacher = create :teacher, :with_clever_authentication_option
+    sign_in teacher
+    course_name = 'test' * 65
+
+    ApiController.any_instance.expects(:query_clever_service).yields(clever_students_response_stub)
+    post :import_clever_classroom, params: {courseName: course_name}
+
+    response_json = JSON.parse(response.body)
+    assert_equal 255, response_json['name'].length
+    assert response_json['name'].end_with?('...')
+  end
+
+  def clever_students_response_stub
+    [{"data" => {"created" => "2017-07-13T03:48:03.497Z", "district" => "59484d29ae5dee0001fd3291", "dob" => "", "enrollments" => [], "gender" => "M", "hispanic_ethnicity" => "", "last_modified" => "2017-11-02T00:49:40.494Z", "name" => {"first" => "Ethan", "last" => "Doe", "middle" => ""}, "race" => "", "school" => "5966ed6cf9d478523c000004", "schools" => ["5966ed6cf9d478523c000004"], "sis_id" => "200", "id" => "5966ed736b21538e3c000004"}, "uri" => "/v2.1/students/5966ed736b21538e3c000004"}]
+  end
+
   #
   # Given two arrays, checks that they represent equivalent bags (or multisets)
   # of elements.

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1705,6 +1705,7 @@ class ApiControllerTest < ActionController::TestCase
     get :import_google_classroom
     assert_response :forbidden
   end
+
   #
   # Given two arrays, checks that they represent equivalent bags (or multisets)
   # of elements.

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1705,46 +1705,6 @@ class ApiControllerTest < ActionController::TestCase
     get :import_google_classroom
     assert_response :forbidden
   end
-
-  test 'clever section name too long' do
-    teacher = create :teacher, :with_clever_authentication_option
-    sign_in teacher
-    course_name = 'test' * 65
-
-    ApiController.any_instance.expects(:query_clever_service).yields(clever_service_response_stub)
-    post :import_clever_classroom, params: {courseId: '101', courseName: course_name}
-
-    response_json = JSON.parse(response.body)
-    assert_equal CleverSection.column_for_attribute(:name).limit, response_json['name'].length
-    assert response_json['name'].end_with?('...')
-  end
-
-  test 'google classroom section name too long' do
-    teacher = create :teacher, :with_google_authentication_option
-    sign_in teacher
-    course_name = 'test' * 65
-
-    mock_service = Google::Apis::ClassroomV1::ClassroomService.new
-
-    mocked_response = Google::Apis::ClassroomV1::ListStudentsResponse.new(students: nil)
-    mock_service.stubs(:list_course_students).with('101', page_token: nil).returns(mocked_response)
-
-    ApiController.any_instance.expects(:query_google_classroom_service).yields(mock_service)
-    post :import_google_classroom, params: {courseId: '101', courseName: course_name}
-
-    response_json = JSON.parse(response.body)
-    assert_equal GoogleClassroomSection.column_for_attribute(:name).limit, response_json['name'].length
-    assert response_json['name'].end_with?('...')
-  end
-
-  def clever_service_response_stub
-    [
-      {'data' => {'dob' => '2002-09-04T00:00:00.000Z', 'name' => {'first' => 'Ethan', 'last' => 'Doe'}, 'id' => '5966ed736b21538e3c000004'}},
-      {'data' => {'dob' => '2000-02-11T00:00:00.000Z', 'name' => {'first' => 'Lily', 'last' => 'Fake'}, 'id' => '5966ed736b21538e3c000005'}},
-      {'data' => {'dob' => '2002-05-21T00:00:00.000Z', 'name' => {'first' => 'Elizabeth', 'last' => 'Smith'}, 'id' => '5966ed736b21538e3c000006'}},
-    ]
-  end
-
   #
   # Given two arrays, checks that they represent equivalent bags (or multisets)
   # of elements.

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1729,14 +1729,11 @@ class ApiControllerTest < ActionController::TestCase
     mocked_response = Google::Apis::ClassroomV1::ListStudentsResponse.new(students: nil)
     mock_service.stubs(:list_course_students).with('101', page_token: nil).returns(mocked_response)
 
-    puts "HEllO 1"
-
     ApiController.any_instance.expects(:query_google_classroom_service).yields(mock_service)
     post :import_google_classroom, params: {courseId: '101', courseName: course_name}
 
     response_json = JSON.parse(response.body)
     assert_equal GoogleClassroomSection.column_for_attribute(:name).limit, response_json['name'].length
-    puts response_json['name']
     assert response_json['name'].end_with?('...')
   end
 

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1715,7 +1715,28 @@ class ApiControllerTest < ActionController::TestCase
     post :import_clever_classroom, params: {courseId: '101', courseName: course_name}
 
     response_json = JSON.parse(response.body)
-    assert_equal 255, response_json['name'].length
+    assert_equal CleverSection.column_for_attribute(:name).limit, response_json['name'].length
+    assert response_json['name'].end_with?('...')
+  end
+
+  test 'google classroom section name too long' do
+    teacher = create :teacher, :with_google_authentication_option
+    sign_in teacher
+    course_name = 'test' * 65
+
+    mock_service = Google::Apis::ClassroomV1::ClassroomService.new
+
+    mocked_response = Google::Apis::ClassroomV1::ListStudentsResponse.new(students: nil)
+    mock_service.stubs(:list_course_students).with('101', page_token: nil).returns(mocked_response)
+
+    puts "HEllO 1"
+
+    ApiController.any_instance.expects(:query_google_classroom_service).yields(mock_service)
+    post :import_google_classroom, params: {courseId: '101', courseName: course_name}
+
+    response_json = JSON.parse(response.body)
+    assert_equal GoogleClassroomSection.column_for_attribute(:name).limit, response_json['name'].length
+    puts response_json['name']
     assert response_json['name'].end_with?('...')
   end
 

--- a/dashboard/test/models/sections/omni_auth_section_test.rb
+++ b/dashboard/test/models/sections/omni_auth_section_test.rb
@@ -205,4 +205,20 @@ class OmniAuthSectionTest < ActiveSupport::TestCase
     section.set_exact_student_list(updated_students)
     assert_equal updated_students.pluck(:id).sort, section.reload.students.pluck(:id).sort
   end
+
+  test 'truncate section name when too long' do
+    owner = create :teacher
+    course_name = 'test' * 65
+
+    section = OmniAuthSection.from_omniauth(
+      code: 'G-222222',
+      type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM,
+      owner_id: owner.id,
+      students: [],
+      section_name: course_name
+    )
+    section.reload
+    assert_equal OmniAuthSection.column_for_attribute(:name).limit, section.name.length
+    assert section.name.end_with?('...')
+  end
 end


### PR DESCRIPTION
Handles long Google Classroom and Clever section names by truncating when creating a section on Code.org using an existing section.
Section name is truncated when length exceeds 255 characters.

## Links
- jira ticket: [here](https://codedotorg.atlassian.net/browse/P20-600)

## Testing story
New test within `dashboard/test/controllers/api_controller_test.rb` which tests for this truncation.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
