### PR TITLE
[Google Blockly] import translated messages based on user locale

### DIFF
--- a/apps/src/blockly/constants.js
+++ b/apps/src/blockly/constants.js
@@ -90,3 +90,73 @@ export const PROCEDURE_DEFINITION_TYPES = [
 
 // A list of block types associated with the Run button.
 export const SETUP_TYPES = [BLOCK_TYPES.whenRun, BLOCK_TYPES.danceWhenSetup];
+
+// A map of user locales supported by Code.org to locales provided by Google Blockly.
+// For more information, see: https://github.com/google/blockly/tree/master/msg/json
+export const blocklyLocaleMap = {
+  'ar-SA': 'ar',
+  'az-AZ': 'az',
+  'bg-BG': 'bg',
+  'bs-BA': 'bs',
+  'ca-ES': 'ca',
+  'cs-CZ': 'cs',
+  'da-DK': 'da',
+  'de-DE': 'de',
+  'el-GR': 'el',
+  'en-US': 'en',
+  'es-ES': 'es',
+  'es-MX': 'es',
+  'et-EE': 'et',
+  'eu-ES': 'eu',
+  'fa-IR': 'fa',
+  'fi-FI': 'fi',
+  'fil-PH': 'ms', // English provided as broader alternative for Filipino
+  'fr-FR': 'fr',
+  'ga-IE': 'en', // English provided as broader alternative for Irish (Gaelic)
+  'gl-ES': 'gl',
+  'he-IL': 'he',
+  'hi-IN': 'hi',
+  'hr-HR': 'hr',
+  'hu-HU': 'hu',
+  'hy-AM': 'hy',
+  'id-ID': 'id',
+  'is-IS': 'is',
+  'it-IT': 'it',
+  'ja-JP': 'ja',
+  'ka-GE': 'ka',
+  'ko-KR': 'ko',
+  'kk-KZ': 'ru', // Russian provided as regional alternative for Kazakh
+  'km-KH': 'km',
+  'ky-KG': 'ky',
+  'lt-LT': 'lt',
+  'lv-LV': 'lv',
+  'mi-NZ': 'en', // English provided as broader alternative for Maori
+  'mn-MN': 'ru', // Russian provided as regional alternative for Mongolian
+  'mr-IN': 'hi', // Hindi provided as regional alternative for Marathi
+  'my-MM': 'my',
+  'nl-NL': 'nl',
+  'nn-NO': 'nb', // Norwegian Bokmål provided as alternative written standard for Norwegian Nynorsk
+  'no-NO': 'nb',
+  'pl-PL': 'pl',
+  'pt-BR': 'pt-br',
+  'pt-PT': 'pt',
+  'ro-RO': 'ro',
+  'ru-RU': 'ru',
+  'se-FI': 'nb', // Norwegian Bokmål provided as regional alternative for Northern Sami
+  'si-LK': 'si',
+  'sk-SK': 'sk',
+  'sl-SI': 'sl',
+  'sm-WS': 'en', // English provided as broader alternative for Samoan
+  'sq-AL': 'sq',
+  'sr-SP': 'sr',
+  'sv-SE': 'sv',
+  'ta-IN': 'ta',
+  'te-IN': 'te',
+  'th-TH': 'th',
+  'tr-TR': 'tr',
+  'uk-UA': 'uk',
+  'uz-UZ': 'uz',
+  'vi-VN': 'vi',
+  'zh-CN': 'zh-hans',
+  'zh-TW': 'zh-hant',
+};

--- a/apps/src/blockly/constants.js
+++ b/apps/src/blockly/constants.js
@@ -110,7 +110,7 @@ export const blocklyLocaleMap = {
   'eu-ES': 'eu',
   'fa-IR': 'fa',
   'fi-FI': 'fi',
-  'fil-PH': 'ms', // English provided as broader alternative for Filipino
+  'fil-PH': 'en', // English provided as broader alternative for Filipino
   'fr-FR': 'fr',
   'ga-IE': 'en', // English provided as broader alternative for Irish (Gaelic)
   'gl-ES': 'gl',

--- a/apps/src/sites/studio/pages/googleblockly.js
+++ b/apps/src/sites/studio/pages/googleblockly.js
@@ -1,7 +1,20 @@
 import GoogleBlockly from 'blockly/core';
-import locale from 'blockly/msg/en';
 import 'blockly/blocks';
-GoogleBlockly.setLocale(locale);
 import initializeGoogleBlocklyWrapper from '@cdo/apps/blockly/googleBlocklyWrapper';
+import cookies from 'js-cookie';
+import {blocklyLocaleMap} from '@cdo/apps/blockly/constants';
+
+// Blockly provides "messages" files, which are JSON-format files containing human-translated
+// strings that are needed by Blockly.
+// These files map closely, but not exactly, to our supported locales.
+// After importing the desired message set, we need set the locale in Blockly.
+// More information at:
+// https://developers.google.com/blockly/guides/configure/web/translations
+// https://github.com/google/blockly/blob/master/msg/json/README.md
+const localeFromCookies = cookies.get('language_') || 'en-US';
+const blocklyLocale = blocklyLocaleMap[localeFromCookies] || 'en';
+const messages = require(`blockly/msg/${blocklyLocale}`);
+
+GoogleBlockly.setLocale(messages);
 
 window.Blockly = initializeGoogleBlocklyWrapper(GoogleBlockly);

--- a/apps/src/sites/studio/pages/googleblockly.js
+++ b/apps/src/sites/studio/pages/googleblockly.js
@@ -7,7 +7,7 @@ import {blocklyLocaleMap} from '@cdo/apps/blockly/constants';
 // Blockly provides "messages" files, which are JSON-format files containing human-translated
 // strings that are needed by Blockly.
 // These files map closely, but not exactly, to our supported locales.
-// After importing the desired message set, we need set the locale in Blockly.
+// After importing the desired message set, we need to set the locale in Blockly.
 // More information at:
 // https://developers.google.com/blockly/guides/configure/web/translations
 // https://github.com/google/blockly/blob/master/msg/json/README.md

--- a/apps/src/sites/studio/pages/googleblockly.js
+++ b/apps/src/sites/studio/pages/googleblockly.js
@@ -13,8 +13,8 @@ import {blocklyLocaleMap} from '@cdo/apps/blockly/constants';
 // https://github.com/google/blockly/blob/master/msg/json/README.md
 const localeFromCookies = cookies.get('language_') || 'en-US';
 const blocklyLocale = blocklyLocaleMap[localeFromCookies] || 'en';
-const messages = require(`blockly/msg/${blocklyLocale}`);
 
-GoogleBlockly.setLocale(messages);
-
-window.Blockly = initializeGoogleBlocklyWrapper(GoogleBlockly);
+import(`blockly/msg/${blocklyLocale}`).then(messages => {
+  GoogleBlockly.setLocale(messages.default);
+  window.Blockly = initializeGoogleBlocklyWrapper(GoogleBlockly);
+});

--- a/apps/src/sites/studio/pages/googleblockly.js
+++ b/apps/src/sites/studio/pages/googleblockly.js
@@ -13,8 +13,8 @@ import {blocklyLocaleMap} from '@cdo/apps/blockly/constants';
 // https://github.com/google/blockly/blob/master/msg/json/README.md
 const localeFromCookies = cookies.get('language_') || 'en-US';
 const blocklyLocale = blocklyLocaleMap[localeFromCookies] || 'en';
+const messages = require(`blockly/msg/${blocklyLocale}.js`);
 
-import(`blockly/msg/${blocklyLocale}`).then(messages => {
-  GoogleBlockly.setLocale(messages.default);
-  window.Blockly = initializeGoogleBlocklyWrapper(GoogleBlockly);
-});
+GoogleBlockly.setLocale(messages);
+
+window.Blockly = initializeGoogleBlocklyWrapper(GoogleBlockly);


### PR DESCRIPTION
Google Blockly labs are failing to translate blocks that are provided by Core. This is because we only import and use the English locale. This has always been true for all our Google Blockly labs (since August 2020). Most our labs' blocks are totally custom and translated correctly, but more standard blocks show up in Sprite Lab.

Blockly provides "messages" files, which are JSON-format files containing human-translated strings that are needed by Blockly. These files map closely, but not exactly, to our supported locales. After importing the desired message set, we need to set the locale in Blockly.

|Language|Before|After|
|-|--|--|
|Spanish|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/ebb9bcca-1717-49e4-9faa-434508a4b4da)|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/327ca4f2-afb0-4b1e-ae5d-ef2266c14d41)|
|Arabic|<img width="588" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/a675779e-5078-420b-939d-460a927d2ce7">|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/022483de-da78-4173-84b6-a4578f74845b)|

For locales with no exact match, we can default to English (similar to what we do when a particular translation is missing). In other cases, we can do a little better:

- Russian is close regional alternative for Kazakh, Mongolian. 95% of Kazakh citizens speak Russian and it is the most popular foreign language in Mongolia. https://en.wikipedia.org/wiki/Languages_of_Kazakhstan
- Hindi is the most common language spoken in India and is a close regional alternative for Marathi. https://en.wikipedia.org/wiki/Marathi_language
- Norwegian has two two separate written standards: Nynorsk ("New Norwegian", "New" in the sense of contemporary or modern as opposed to old Norse) and Bokmål ("Book Language/Tongue/Speech"), both of which are official. We are providing Norwegian Bokmål in place of Norwegian Nynorsk. https://en.wikipedia.org/wiki/Languages_of_Norway
- Northern Sami is an official language of Norway, the country where most of its speakers live. Providing Norwegian Bokmål as a close regional alternative is likely to be better understood than English. https://en.wikipedia.org/wiki/Northern_S%C3%A1mi
- English is used as the fallback for Filipino, Irish (Gaelic), Maori, and Samoan.

## Links

- Block checking Google Doc: https://docs.google.com/document/d/1d9VT3A0EN3nq_kXVg_wlKgin3aPDZcJKM4x2OhJArmM/edit
- Jira: https://codedotorg.atlassian.net/browse/CT-222


## Testing story

I manually tested over a dozen languages in our dropdown and confirmed that the block text was translated as expected each time.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
