### PR TITLE
Remove 'show-coteacher-ui' dcdo flag after feature release

### DIFF
--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -17,7 +17,6 @@ import {
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {showVideoDialog} from '@cdo/apps/code-studio/videos';
-import DCDO from '@cdo/apps/dcdo';
 import CoteacherSettings from '@cdo/apps/templates/sectionsRefresh/coteacherSettings/CoteacherSettings';
 import {getCoteacherMetricInfoFromSection} from './coteacherSettings/CoteacherUtils';
 import InfoHelpTip from '@cdo/apps/lib/ui/InfoHelpTip';
@@ -376,7 +375,7 @@ export default function SectionsSetUpContainer({
           moduleStyles.withBorderTop
         )}
       >
-        {DCDO.get('show-coteacher-ui', true) && renderCoteacherSection()}
+        {renderCoteacherSection()}
         {renderAdvancedSettings()}
       </div>
       <div

--- a/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
+++ b/apps/src/templates/studioHomepages/CoteacherInviteNotification.jsx
@@ -10,13 +10,8 @@ import {
 import Button from '../Button';
 import {BodyTwoText, StrongText} from '@cdo/apps/componentLibrary/typography';
 import HttpClient from '@cdo/apps/util/HttpClient';
-import DCDO from '@cdo/apps/dcdo';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
-
-export const showCoteacherInviteNotification = invite => {
-  return !!invite && DCDO.get('show-coteacher-ui', true);
-};
 
 const CoteacherInviteNotification = ({
   isForPl,
@@ -26,9 +21,9 @@ const CoteacherInviteNotification = ({
   coteacherInviteForPl,
 }) => {
   const invite = useMemo(() => {
-    if (showCoteacherInviteNotification(coteacherInviteForPl) && isForPl) {
+    if (!!coteacherInviteForPl && isForPl) {
       return coteacherInviteForPl;
-    } else if (showCoteacherInviteNotification(coteacherInvite) && !isForPl) {
+    } else if (!!coteacherInvite && !isForPl) {
       return coteacherInvite;
     }
     return null;

--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -14,9 +14,7 @@ import SetUpSections from './SetUpSections';
 import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
 import RosterDialog from '../teacherDashboard/RosterDialog';
 import AddSectionDialog from '../teacherDashboard/AddSectionDialog';
-import CoteacherInviteNotification, {
-  showCoteacherInviteNotification,
-} from './CoteacherInviteNotification';
+import CoteacherInviteNotification from './CoteacherInviteNotification';
 
 class TeacherSections extends Component {
   static propTypes = {
@@ -39,15 +37,13 @@ class TeacherSections extends Component {
 
   shouldRenderSections() {
     return (
-      this.props.studentSectionIds?.length > 0 ||
-      showCoteacherInviteNotification(this.props.coteacherInvite)
+      this.props.studentSectionIds?.length > 0 || !!this.props.coteacherInvite
     );
   }
 
   shouldRenderPlSections() {
     return (
-      this.props.plSectionIds?.length > 0 ||
-      showCoteacherInviteNotification(this.props.coteacherInviteForPl)
+      this.props.plSectionIds?.length > 0 || !!this.props.coteacherInviteForPl
     );
   }
 

--- a/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
@@ -5,12 +5,8 @@ import SectionsSetUpContainer from '@cdo/apps/templates/sectionsRefresh/Sections
 import sinon from 'sinon';
 import * as utils from '@cdo/apps/code-studio/utils';
 import * as windowUtils from '@cdo/apps/utils';
-import DCDO from '@cdo/apps/dcdo';
 
 describe('SectionsSetUpContainer', () => {
-  beforeEach(() => {
-    DCDO.set('show-coteacher-ui', true);
-  });
   it('renders an initial set up section form', () => {
     const wrapper = shallow(<SectionsSetUpContainer />);
 
@@ -39,15 +35,6 @@ describe('SectionsSetUpContainer', () => {
     const wrapper = shallow(<SectionsSetUpContainer />);
 
     expect(wrapper.find('CurriculumQuickAssign').length).to.equal(1);
-  });
-
-  it('does not render coteacher if flag is false', () => {
-    DCDO.set('show-coteacher-ui', false);
-
-    const wrapper = shallow(<SectionsSetUpContainer />);
-
-    expect(wrapper.find('Button').length).to.equal(3);
-    expect(wrapper.find('ReactTooltip').length).to.equal(0);
   });
 
   it('renders coteacher settings', () => {

--- a/apps/test/unit/templates/studioHomepages/CoteacherInviteNotificationTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoteacherInviteNotificationTest.jsx
@@ -3,7 +3,6 @@ import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import {UnconnectedCoteacherInviteNotification as CoteacherInviteNotification} from '@cdo/apps/templates/studioHomepages/CoteacherInviteNotification';
 import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
-import DCDO from '@cdo/apps/dcdo';
 
 describe('CoteacherInviteNotification', () => {
   const defaultProps = {
@@ -31,7 +30,6 @@ describe('CoteacherInviteNotification', () => {
   };
 
   it('renders no notification for classroom sections if there is no coteacher invite', () => {
-    DCDO.set('show-coteacher-ui', true);
     const wrapper = shallow(
       <CoteacherInviteNotification {...defaultProps} coteacherInvite={null} />
     );
@@ -39,7 +37,6 @@ describe('CoteacherInviteNotification', () => {
   });
 
   it('renders no notification for PL sections if there is no coteacher invite', () => {
-    DCDO.set('show-coteacher-ui', true);
     const wrapper = shallow(
       <CoteacherInviteNotification
         {...defaultProps}
@@ -50,16 +47,7 @@ describe('CoteacherInviteNotification', () => {
     expect(wrapper.find(Notification).length).to.equal(0);
   });
 
-  it('renders nothing if flag is off', () => {
-    DCDO.set('show-coteacher-ui', false);
-    const wrapper = shallow(
-      <CoteacherInviteNotification {...defaultProps} coteacherInvite={null} />
-    );
-    expect(wrapper.find(Notification).length).to.equal(0);
-  });
-
-  it('renders notification if there is a coteacher invite and flag is not set', () => {
-    DCDO.reset();
+  it('renders notification if there is a coteacher invite', () => {
     const wrapper = shallow(<CoteacherInviteNotification {...defaultProps} />);
     const notification = wrapper.find(Notification);
     expect(notification.length).to.equal(1);
@@ -68,18 +56,7 @@ describe('CoteacherInviteNotification', () => {
     expect(notification.props().notice).to.include('The Great Pumpkin');
   });
 
-  it('renders notification if there is a coteacher invite and flag is on', () => {
-    DCDO.set('show-coteacher-ui', true);
-    const wrapper = shallow(<CoteacherInviteNotification {...defaultProps} />);
-    const notification = wrapper.find(Notification);
-    expect(notification.length).to.equal(1);
-    expect(notification.props().dismissible).to.equal(false);
-    expect(notification.props().type).to.equal(NotificationType.collaborate);
-    expect(notification.props().notice).to.include('The Great Pumpkin');
-  });
-
-  it('renders PL notification if there is a coteacher invite for PL and flag is on', () => {
-    DCDO.set('show-coteacher-ui', true);
+  it('renders PL notification if there is a coteacher invite for PL', () => {
     const wrapper = shallow(
       <CoteacherInviteNotification {...defaultProps} isForPl={true} />
     );
@@ -91,7 +68,6 @@ describe('CoteacherInviteNotification', () => {
   });
 
   it('renders no notifications if there is no PL invite and isForPl is true', () => {
-    DCDO.set('show-coteacher-ui', true);
     const wrapper = shallow(
       <CoteacherInviteNotification
         {...defaultProps}

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -40,7 +40,6 @@ class DCDOBase < DynamicConfigBase
       'ai-pl-launch-banners': DCDO.get('ai-pl-launch-banners', false),
       cpa_experience: DCDO.get('cpa_experience', false),
       gender: DCDO.get('gender', false),
-      'show-coteacher-ui': DCDO.get('show-coteacher-ui', true),
       'amplitude-event-sample-rates': DCDO.get('amplitude-event-sample-rates', {}),
       # Whether to allow the user to toggle between the v1 and v2 progress tables.
       'progress-table-v2-enabled': DCDO.get('progress-table-v2-enabled', false),


### PR DESCRIPTION
The coteacher feature has been fully released for more than a month now. This removes the DCDO flag used to control release.

Note: I expect this to be a no-op because I manually set the test DCDO flag, however this may cause some eyes diffs if setting the DCDO flag on test did not take. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[TEACH-740](https://codedotorg.atlassian.net/browse/TEACH-740)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
