### PR TITLE
fixed CSS styling for current learningGoal component

### DIFF
--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -230,9 +230,10 @@ button.rubricHeaderTab {
     line-height: 1.1875;
   }
 }
+
 .learningGoalContainer {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: flex-start;
   justify-content: space-between;
   align-self: stretch;
@@ -244,8 +245,7 @@ button.rubricHeaderTab {
 .learningGoalRow {
   display: flex;
   align-self: stretch;
-  justify-content: space-between;
-  width: 100%;
+  border-bottom: 1px solid $neutral_dark40;
   min-height: 40px;
 
   // Directly target the <summary> child with the class


### PR DESCRIPTION
Reverted CSS changes to LearningGoal component elements. This fixes styling issues that were detected on 1/3/24.

![image](https://github.com/code-dot-org/code-dot-org/assets/5552007/fb964cd5-ddc4-441a-9074-c8502a2abf19)
