### PR TITLE
Update Apt Key for Mysql Repository

### DIFF
--- a/cookbooks/cdo-mysql/recipes/repo.rb
+++ b/cookbooks/cdo-mysql/recipes/repo.rb
@@ -11,7 +11,7 @@ apt_repository 'mysql' do
   components ['mysql-5.7']
 
   # https://dev.mysql.com/doc/refman/5.7/en/checking-gpg-signature.html
-  key '3A79BD29'
+  key 'B7B3B788A8D3785C'
   keyserver 'keyserver.ubuntu.com'
   retries 3
 end


### PR DESCRIPTION
The previous key we were using to install MySQL [expired back in December](https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html), and when attempting to spin up a new adhoc we started getting the following failure:


    STDERR: W: GPG error: http://repo.mysql.com/apt/ubuntu bionic InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B7B3B788A8D3785C
    E: The repository 'http://repo.mysql.com/apt/ubuntu bionic InRelease' is not signed.

Updating the resource to use the key referenced in the error message gets things working again.


## Links

- [AskUbuntu Answer](https://askubuntu.com/a/1497141)
- [Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1704222706443369)

## Testing story

Spun up an adhoc with this change, verified that it works.

Notably, however, I was also able to get a working adhoc *without* this change (using the old key), but only once. It appears the old key fails inconsistently, whereas the new one so far seems to work consistently. Still an improvement, but also a bit of a mystery.