### PR TITLE
[Progress] Adds a user setting to show progress table V2

### DIFF
--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -150,9 +150,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
   def post_show_progress_table_v2
     return head :unauthorized unless current_user
 
-    return head :bad_request unless params[:show_progress_table_v2] == "v1" || params[:show_progress_table_v2] == "v2"
-
-    current_user.show_progress_table_v2 = params[:show_progress_table_v2]
+    current_user.show_progress_table_v2 = !!params[:show_progress_table_v2].try(:to_bool)
     current_user.save
 
     head :no_content

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -145,8 +145,12 @@ class Api::V1::UsersController < Api::V1::JSONApiController
     head :no_content
   end
 
+  # POST /api/v1/users/show_progress_table_v2
   def post_show_progress_table_v2
     return head :unauthorized unless current_user
+
+    current_user.show_progress_table_v2 = !!params[:show_progress_table_v2].try(:to_bool)
+    current_user.save
 
     head :no_content
   end

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -145,7 +145,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
     head :no_content
   end
 
-  def post_show_progress_ui_refresh
+  def post_show_progress_table_v2
     return head :unauthorized unless current_user
 
     head :no_content

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,7 @@ require 'cdo/firehose'
 class Api::V1::UsersController < Api::V1::JSONApiController
   before_action :load_user
   skip_before_action :verify_authenticity_token
-  skip_before_action :load_user, only: [:current, :netsim_signed_in, :post_sort_by_family_name]
+  skip_before_action :load_user, only: [:current, :netsim_signed_in, :post_sort_by_family_name, :post_show_progress_table_v2]
   skip_before_action :clear_sign_up_session_vars, only: [:current]
 
   def load_user
@@ -28,7 +28,8 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         mute_music: current_user.mute_music?,
         under_13: current_user.under_13?,
         over_21: current_user.over_21?,
-        sort_by_family_name: current_user.sort_by_family_name?
+        sort_by_family_name: current_user.sort_by_family_name?,
+        show_progress_table_v2: current_user.get_show_progress_table_v2
       }
     else
       render json: {
@@ -149,7 +150,9 @@ class Api::V1::UsersController < Api::V1::JSONApiController
   def post_show_progress_table_v2
     return head :unauthorized unless current_user
 
-    current_user.show_progress_table_v2 = !!params[:show_progress_table_v2].try(:to_bool)
+    return head :bad_request unless params[:show_progress_table_v2] == "v1" || params[:show_progress_table_v2] == "v2"
+
+    current_user.show_progress_table_v2 = params[:show_progress_table_v2]
     current_user.save
 
     head :no_content

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -145,6 +145,12 @@ class Api::V1::UsersController < Api::V1::JSONApiController
     head :no_content
   end
 
+  def post_show_progress_ui_refresh
+    return head :unauthorized unless current_user
+
+    head :no_content
+  end
+
   # POST /api/v1/users/<user_id>/display_theme
   def update_display_theme
     @user.display_theme = params[:display_theme]

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         under_13: current_user.under_13?,
         over_21: current_user.over_21?,
         sort_by_family_name: current_user.sort_by_family_name?,
-        show_progress_table_v2: current_user.get_show_progress_table_v2
+        show_progress_table_v2: current_user.show_progress_table_v2
       }
     else
       render json: {

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1568,12 +1568,6 @@ class User < ApplicationRecord
     !!sort_by_family_name
   end
 
-  def get_show_progress_table_v2
-    return "default" if show_progress_table_v2.nil?
-
-    show_progress_table_v2
-  end
-
   def generate_username
     # skip an expensive db query if the name is not valid anyway. we can't depend on validations being run
     return if name.blank? || name.utf8mb4? || (email&.utf8mb4?)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1568,10 +1568,10 @@ class User < ApplicationRecord
     !!sort_by_family_name
   end
 
-  def show_progress_table_v2?
-    return show_progress_table_v2 unless show_progress_table_v2.nil?
+  def get_show_progress_table_v2
+    return "default" if show_progress_table_v2.nil?
 
-    DCDO.get('progress-table-v2-default-v2', false)
+    show_progress_table_v2
   end
 
   def generate_username

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -145,6 +145,7 @@ class User < ApplicationRecord
     family_name
     ai_rubrics_disabled
     sort_by_family_name
+    show_progress_ui_refresh
   )
 
   attr_accessor(
@@ -1565,6 +1566,12 @@ class User < ApplicationRecord
 
   def sort_by_family_name?
     !!sort_by_family_name
+  end
+
+  def show_progress_ui_refresh?
+    return show_progress_ui_refresh unless show_progress_ui_refresh.nil?
+
+    DCDO.get('progress-ui-refresh-default-new', false)
   end
 
   def generate_username

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -145,7 +145,7 @@ class User < ApplicationRecord
     family_name
     ai_rubrics_disabled
     sort_by_family_name
-    show_progress_ui_refresh
+    show_progress_table_v2
   )
 
   attr_accessor(
@@ -1568,10 +1568,10 @@ class User < ApplicationRecord
     !!sort_by_family_name
   end
 
-  def show_progress_ui_refresh?
-    return show_progress_ui_refresh unless show_progress_ui_refresh.nil?
+  def show_progress_table_v2?
+    return show_progress_table_v2 unless show_progress_table_v2.nil?
 
-    DCDO.get('progress-ui-refresh-default-new', false)
+    DCDO.get('progress-table-v2-default-v2', false)
   end
 
   def generate_username

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -888,7 +888,7 @@ Dashboard::Application.routes.draw do
 
         post 'users/sort_by_family_name', to: 'users#post_sort_by_family_name'
 
-        post 'users/show_progress_ui_refresh', to: 'users#post_show_progress_ui_refresh'
+        post 'users/show_progress_table_v2', to: 'users#post_show_progress_table_v2'
 
         get 'users/:user_id/using_text_mode', to: 'users#get_using_text_mode'
         get 'users/:user_id/display_theme', to: 'users#get_display_theme'

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -888,6 +888,8 @@ Dashboard::Application.routes.draw do
 
         post 'users/sort_by_family_name', to: 'users#post_sort_by_family_name'
 
+        post 'users/show_progress_ui_refresh', to: 'users#post_show_progress_ui_refresh'
+
         get 'users/:user_id/using_text_mode', to: 'users#get_using_text_mode'
         get 'users/:user_id/display_theme', to: 'users#get_display_theme'
         get 'users/:user_id/mute_music', to: 'users#get_mute_music'

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -73,6 +73,30 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
     assert_equal false, !!@user.mute_music
   end
 
+  test 'a post request to show_progress_table_v2 updates show_progress_table_v2' do
+    sign_in(@user)
+    assert_equal "default", @user.get_show_progress_table_v2
+    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: 'v2'}
+    assert_response :success
+    @user.reload
+    assert_equal "v2", @user.get_show_progress_table_v2
+
+    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: 'v1'}
+    assert_response :success
+    @user.reload
+    assert_equal "v1", @user.get_show_progress_table_v2
+  end
+
+  test 'a post request to show_progress_table_v2 fails if not v1 or v2' do
+    sign_in(@user)
+    assert_equal "default", @user.get_show_progress_table_v2
+    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: 'bad'}
+    assert_response :bad_request
+
+    @user.reload
+    assert_equal "default", @user.get_show_progress_table_v2
+  end
+
   test 'a get request to display_theme returns display_theme attribute of user object' do
     sign_in(@user)
     get :get_display_theme, params: {user_id: 'me'}

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -75,26 +75,16 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
 
   test 'a post request to show_progress_table_v2 updates show_progress_table_v2' do
     sign_in(@user)
-    assert_equal "default", @user.get_show_progress_table_v2
-    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: 'v2'}
+    assert_nil @user.show_progress_table_v2
+    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: true}
     assert_response :success
     @user.reload
-    assert_equal "v2", @user.get_show_progress_table_v2
+    assert @user.show_progress_table_v2
 
-    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: 'v1'}
+    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: false}
     assert_response :success
     @user.reload
-    assert_equal "v1", @user.get_show_progress_table_v2
-  end
-
-  test 'a post request to show_progress_table_v2 fails if not v1 or v2' do
-    sign_in(@user)
-    assert_equal "default", @user.get_show_progress_table_v2
-    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: 'bad'}
-    assert_response :bad_request
-
-    @user.reload
-    assert_equal "default", @user.get_show_progress_table_v2
+    refute @user.show_progress_table_v2
   end
 
   test 'a get request to display_theme returns display_theme attribute of user object' do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -796,6 +796,12 @@ class UserTest < ActiveSupport::TestCase
     refute follower.student_user.reload.admin?
   end
 
+  test "show_progress_table_v2? defaults to default" do
+    user = create :user
+
+    assert_equal "default", user.get_show_progress_table_v2
+  end
+
   test "short name" do
     assert_equal 'Laurel', build(:user, name: 'Laurel Fan').short_name # first name last name
     assert_equal 'Winnie', build(:user, name: 'Winnie the Pooh').short_name # middle name

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -796,12 +796,6 @@ class UserTest < ActiveSupport::TestCase
     refute follower.student_user.reload.admin?
   end
 
-  test "show_progress_table_v2? defaults to default" do
-    user = create :user
-
-    assert_equal "default", user.get_show_progress_table_v2
-  end
-
   test "short name" do
     assert_equal 'Laurel', build(:user, name: 'Laurel Fan').short_name # first name last name
     assert_equal 'Winnie', build(:user, name: 'Winnie the Pooh').short_name # middle name


### PR DESCRIPTION
User setting `show-progress-table-v2` will be used to determine whether to show the v1 or v2 progress tables, once built. This will be toggled via a FE toggle component and will eventually be removed once progress table v2 has been fully released.

Values 'v1', 'v2' and 'default'. 'default' will check the DCDO flag `progress-table-v2-default-v2`

This is necessary because we want to be able to change the default behavior

Alternatives considered:
Instead of a value with three options, we could use two booleans: `show-progress-table-v2` and `use-default-progress-table-setting` (or similar). I did not like this approach, because: if using default, the other flag is ignored AND this doubles the amount of fields the FE needs to parse. 

## Links
[TEACH-778](https://codedotorg.atlassian.net/browse/TEACH-778)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
