### PR TITLE
add eyes test for teacher view of rubric and settings tabs

### DIFF
--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -288,6 +288,7 @@ export default function LearningGoals({
           )}
         </div>
         <button
+          id="uitest-next-goal"
           type="button"
           className={style.learningGoalButton}
           onClick={() => onCarouselPress(1)}

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -283,6 +283,10 @@ When /^I wait until element "([^"]*)" is visible within element "([^"]*)"$/ do |
   wait_until {@browser.execute_script("return $(#{selector.dump}, $(#{parent_selector.dump}).contents()).is(':visible')")}
 end
 
+Then /^I wait until element "([^"]*)" is (not )?open$/ do |selector, negation|
+  wait_until {element_open?(selector) == negation.nil?}
+end
+
 When /^I wait until jQuery Ajax requests are finished$/ do
   wait_short_until {@browser.execute_script("return $.active == 0")}
 end

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -49,7 +49,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
 
   @eyes
   @skip
-  Scenario: Teacher views Rubric and Settings tabs, without accordion experiment
+  Scenario: Teacher views Rubric and Settings tabs, without carousel experiment
     Given I create a teacher-associated student named "Aiden"
     And I sign in as "Teacher_Aiden" and go home
     And I wait until element "#homepage-container" is visible
@@ -61,7 +61,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
     And I click selector ".teacher-panel td:eq(1)" to load a new page
     And I wait for the page to fully load
 
-    When I open my eyes to test "teaching assistant rubric without accordion experiment"
+    When I open my eyes to test "teaching assistant rubric without carousel experiment"
     Then I see no difference for "floating action button icon"
 
     When I click selector "#ui-floatingActionButton"

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -47,4 +47,36 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I click selector "strong:contains(Code Quality)" once I see it
   And I wait until element "textarea:contains(Nice work Lillian!)" is visible
 
+  @eyes
+  Scenario: Teacher views Rubric and Settings tabs, without accordion experiment
+    Given I create a teacher-associated student named "Aiden"
+    And I sign in as "Teacher_Aiden" and go home
+    And I wait until element "#homepage-container" is visible
+    And element "#sign_in_or_user" contains text "Teacher_Aiden"
+    And I add the current user to the "ai-rubrics" single user experiment
+    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
+    And I wait for the page to fully load
+    And element ".teacher-panel td:eq(1)" contains text "Aiden"
+    And I click selector ".teacher-panel td:eq(1)" to load a new page
+    And I wait for the page to fully load
 
+    When I open my eyes to test "teaching assistant rubric"
+    Then I see no difference for "floating action button icon - ai bot"
+
+    When I click selector "#ui-floatingActionButton"
+    And I wait until element ".uitest-rubric-header-tab:contains('Settings')" is visible
+    And I wait until element "summary:contains(Code Quality)" is visible
+    And element "details:contains(Code Quality)" is not open
+    Then I see no difference for "rubric tab with learning goals collapsed"
+
+    When I click selector "summary:contains(Code Quality)"
+    And I wait until element "details:contains(Code Quality)" is open
+    Then I see no difference for "rubric tab with learning goal expanded"
+
+    When I click selector ".uitest-rubric-header-tab:contains('Settings')"
+    And I wait until element ".uitest-rubric-settings" is visible
+    And element ".uitest-run-ai-assessment" is disabled
+    And element ".uitest-eval-status-text" is visible
+    Then I see no difference for "rubric settings tab"
+
+    Then I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -48,6 +48,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I wait until element "textarea:contains(Nice work Lillian!)" is visible
 
   @eyes
+  @skip
   Scenario: Teacher views Rubric and Settings tabs, without accordion experiment
     Given I create a teacher-associated student named "Aiden"
     And I sign in as "Teacher_Aiden" and go home
@@ -60,8 +61,8 @@ Scenario: Teachers can give and send feedback on the rubric to students.
     And I click selector ".teacher-panel td:eq(1)" to load a new page
     And I wait for the page to fully load
 
-    When I open my eyes to test "teaching assistant rubric"
-    Then I see no difference for "floating action button icon - ai bot"
+    When I open my eyes to test "teaching assistant rubric without accordion experiment"
+    Then I see no difference for "floating action button icon"
 
     When I click selector "#ui-floatingActionButton"
     And I wait until element ".uitest-rubric-header-tab:contains('Settings')" is visible
@@ -72,6 +73,39 @@ Scenario: Teachers can give and send feedback on the rubric to students.
     When I click selector "summary:contains(Code Quality)"
     And I wait until element "details:contains(Code Quality)" is open
     Then I see no difference for "rubric tab with learning goal expanded"
+
+    When I click selector ".uitest-rubric-header-tab:contains('Settings')"
+    And I wait until element ".uitest-rubric-settings" is visible
+    And element ".uitest-run-ai-assessment" is disabled
+    And element ".uitest-eval-status-text" is visible
+    Then I see no difference for "rubric settings tab"
+
+    Then I close my eyes
+
+  @eyes
+  Scenario: Teacher views Rubric and Settings tabs
+    Given I create a teacher-associated student named "Aiden"
+    And I sign in as "Teacher_Aiden" and go home
+    And I wait until element "#homepage-container" is visible
+    And element "#sign_in_or_user" contains text "Teacher_Aiden"
+    And I add the current user to the "ai-rubrics" single user experiment
+    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2?enableExperiments=ai-rubrics-redesign"
+    And I wait for the page to fully load
+    And element ".teacher-panel td:eq(1)" contains text "Aiden"
+    And I click selector ".teacher-panel td:eq(1)" to load a new page
+    And I wait for the page to fully load
+
+    When I open my eyes to test "teaching assistant rubric"
+    Then I see no difference for "floating action button icon"
+
+    When I click selector "#ui-floatingActionButton"
+    And I wait until element ".uitest-rubric-header-tab:contains('Settings')" is visible
+    And I wait until element "strong:contains(Code Quality)" is visible
+    Then I see no difference for "rubric tab, Code Quality learning goal"
+
+    When I click selector "#uitest-next-goal"
+    And I wait until element "strong:contains(Sprites)" is visible
+    Then I see no difference for "rubric tab, Sprites learning goal"
 
     When I click selector ".uitest-rubric-header-tab:contains('Settings')"
     And I wait until element ".uitest-rubric-settings" is visible


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-404 . Adds two eyes tests, covering ui with / without the new ai-rubrics-redesign "accordion" experiment.

when running eyes tests locally, it doesn't actually capture the screenshots. so, to show that this is doing roughly the right thing, I'm including the relevant parts of the saucelabs videos which show all of the views that will be covered:

### with experiment

https://github.com/code-dot-org/code-dot-org/assets/8001765/c2970c87-b075-4dc5-a2f7-d9537c3bf844

### without experiment

https://github.com/code-dot-org/code-dot-org/assets/8001765/fdb6953c-4406-400b-8c23-71f52e1d56dd

## Future work

@Nokondi when the `ai-rubrics-redesign` experiment launches, please remove the "without experiment" scenario from the eyes test file. 

~also, because eyes tests do not run in drone, you'll likely want to run the eyes tests yourself locally when making visual changes to the new accordion UI. that will make sure that only visual differences in the eyes tests show up in the DTT (which is ok) as opposed to non-visual steps breaking.~ EDIT: no need to specially run eyes tests locally if they are passing in drone. drone DOES run eyes tests, it just doesn't do anything when it gets to the "I see no difference" step, which is the same thing that happens locally. any visual differences are fine to wait until they reach DTT to resolve.
