### PR TITLE
Fix workshop_survey_results_helper averaging

### DIFF
--- a/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
+++ b/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
@@ -143,8 +143,8 @@ module Pd::WorkshopSurveyResultsHelper
               (v / responses_per_facilitator.values.sum.to_f).round(2)
             end
           else
-            # For non facilitator specific answers, take the average over all surveys
-            (v / surveys.count.to_f).round(2)
+            # For non facilitator specific answers, take the average over all survey responses for each facilitator
+            (v / responses_per_facilitator.values.sum.to_f).round(2)
           end
       else
         v.each do |name, value|


### PR DESCRIPTION
While working on [deleting unused Workshop Survey content](https://github.com/code-dot-org/code-dot-org/pull/55349), I had to switch [this test](https://github.com/code-dot-org/code-dot-org/pull/55562/files#diff-5a9f1e0fea4778781ace4f2d7e887a32b0be8052d4b6a47443fd59ac752a424aL112) to use a TeacherCon workshop instead of a Local Summer workshop because it's testing the `summarize_workshop_surveys` method which only works for TeacherCon and Local Summer workshops (and Local Summer workshop content is being deleted in the aforementioned PR).

The test previously used the `how_clearly_presented` question from the Local Summer workshop survey, which was a facilitator-specific numbered/scaled question (i.e. asking about a specific facilitator of the ones that led the workshop, and the question has worded responses that map to scores of 1-5). Since I had to switch to the TeacherCon survey, I had to pick a different question but the TeacherCon survey has no facilitator-specific numbered/scaled questions, only non-facilitator-specific ones. So, I arbitrarily picked the `how_happy_after` one. Assuming the logic that calculated the average worked, that should've been all I needed to change, however I was seeing an output of 5.33 as the average of 1-5 scores.

I dug into the logic and found that because that question wasn't a facilitator-specific question, the logic calculating the average of the participants survey questions went into the lowest `else` path [here](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/helpers/pd/workshop_survey_results_helper.rb#L137-L148) instead. The comment here explains that "For non facilitator specific answers, take the average over all surveys" (which it does) but this doesn't end up calculating the right average since I believe each participant's survey entry about each facilitator is counted when accruing the total (e.g. if a workshop was lead by 3 facilitators, it 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
