### PR TITLE
add confirmation dialog for editing learning goal names

### DIFF
--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import {borderRadius} from '@cdo/apps/lib/levelbuilder/constants';
@@ -10,6 +10,8 @@ export default function LearningGoalItem({
   exisitingLearningGoalData,
   updateLearningGoal,
 }) {
+  const [canEditLearningGoalName, setCanEditLearningGoalName] = useState(false);
+
   const handleCheckboxChange = () => {
     const newAiEnabledValue = !exisitingLearningGoalData.aiEnabled;
     updateLearningGoal(
@@ -25,6 +27,20 @@ export default function LearningGoalItem({
       'learningGoal',
       event.target.value
     );
+  };
+
+  const handleKeyConceptFocus = event => {
+    if (exisitingLearningGoalData.aiEnabled && !canEditLearningGoalName) {
+      if (
+        confirm(
+          'Please contact the teacher tools team before changing the name of any learning goal that uses AI assessment.'
+        )
+      ) {
+        setCanEditLearningGoalName(true);
+      } else {
+        document.activeElement.blur();
+      }
+    }
   };
 
   const handleDelete = event => {
@@ -48,6 +64,7 @@ export default function LearningGoalItem({
                   style={{width: 600}}
                   className="uitest-rubric-key-concept-input"
                   onChange={handleKeyConceptChange}
+                  onFocus={handleKeyConceptFocus}
                 />
               </label>
             </div>

--- a/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
+++ b/apps/src/lib/levelbuilder/rubrics/LearningGoalItem.jsx
@@ -33,7 +33,7 @@ export default function LearningGoalItem({
     if (exisitingLearningGoalData.aiEnabled && !canEditLearningGoalName) {
       if (
         confirm(
-          'Please contact the teacher tools team before changing the name of any learning goal that uses AI assessment.'
+          'Please contact the teacher tools team before changing the name of any key concept that uses AI assessment.'
         )
       ) {
         setCanEditLearningGoalName(true);

--- a/apps/test/unit/lib/levelbuilder/rubrics/LearningGoalItemTest.js
+++ b/apps/test/unit/lib/levelbuilder/rubrics/LearningGoalItemTest.js
@@ -91,4 +91,25 @@ describe('LearningGoalItem', () => {
       ).calledOnce
     ).to.be.true;
   });
+
+  it('displays confirmation dialog when learning goal name input receives focus and AI assessment is checked', () => {
+    const dialogStub = sinon.stub(window, 'confirm').returns(true);
+
+    const enabledAiData = {
+      key: 'learningGoal-1',
+      id: 'learningGoal-1',
+      learningGoal: '',
+      aiEnabled: true,
+    };
+    const wrapper = shallow(
+      <LearningGoalItem
+        {...defaultProps}
+        exisitingLearningGoalData={enabledAiData}
+      />
+    );
+
+    wrapper.find('input').first().prop('onFocus')();
+    expect(dialogStub.calledOnce).to.be.true;
+    dialogStub.restore();
+  });
 });


### PR DESCRIPTION
This update adds a confirmation pop up when the user selects the input to change the name of any learning goal that uses AI assessment. This is a temporary fix to help prevent errors caused by a mismatch between a learning goal name and the AI assessment data stored in S3. We are currently exploring alternative methods for storing and accessing this data that will prevent any errors like this in the future.

![image](https://github.com/code-dot-org/code-dot-org/assets/5552007/2919dc01-86d2-40e7-9562-6678d13d4028)

## Links

[AITT-372](https://codedotorg.atlassian.net/browse/AITT-371)