### PR TITLE
[Google Blockly] Enable Sprite Lab Documentation with Google Blockly

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1215,6 +1215,7 @@
   "gdprDialogVisitPrivacyPolicy": "Visit Code.org’s Privacy Policy to learn more.",
   "gdprDialogLogout": "Log out",
   "gdprDialogYes": "Yes",
+  "getBlockDocs": "Get help with this block",
   "getVerifiedTitle": "Get Verified!",
   "getVerifiedInfo": "To teach {courseName}, you must be a verified teacher. To get verified, [fill out this form](verificationFormUrl). For more details, please read this [article on teacher verification](verificationInfoUrl).",
   "gender": "Gender",

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -961,6 +961,7 @@ exports.createJsWrapperBlockCreator = function (
       extraArgs,
       callbackParams,
       miniToolboxBlocks,
+      docFunc,
     },
     helperCode,
     pool
@@ -1060,7 +1061,7 @@ exports.createJsWrapperBlockCreator = function (
     }
 
     blockly.Blocks[blockName] = {
-      helpUrl: '',
+      helpUrl: getHelpUrl(docFunc), // optional param
       init: function () {
         // Styles should be used over hard-coded colors in Google Blockly blocks
         if (style && this.setStyle) {
@@ -1270,4 +1271,12 @@ const sanitizeOptions = function (dropdownOptions) {
   return dropdownOptions.map(option =>
     option.length === 1 ? [option[0], option[0]] : option
   );
+};
+
+const getHelpUrl = function (docFunc) {
+  if (!docFunc) {
+    return '';
+  }
+  // Documentation is only available for Sprite Lab.
+  return `/docs/spritelab/${docFunc}`;
 };

--- a/apps/src/blockly/addons/contextMenu.js
+++ b/apps/src/blockly/addons/contextMenu.js
@@ -1,6 +1,7 @@
 import GoogleBlockly from 'blockly/core';
 import msg from '@cdo/locale';
 import {Themes, MenuOptionStates, BLOCKLY_THEME} from '../constants.js';
+import LegacyDialog from '../../code-studio/LegacyDialog';
 
 const dark = 'dark';
 
@@ -242,6 +243,46 @@ function registerThemes(themes) {
   });
 }
 
+/**
+ * Option to open help for a block.
+ */
+export function registerHelp() {
+  const helpOption = {
+    displayText() {
+      return 'Get help with this block';
+    },
+    preconditionFn(scope) {
+      const block = scope.block;
+      const url =
+        typeof block.helpUrl === 'function' ? block.helpUrl() : block.helpUrl;
+      if (url) {
+        return 'enabled';
+      }
+      return 'hidden';
+    },
+    callback(scope) {
+      // scope.block.showHelp();
+      const block = scope.block;
+      const url =
+        typeof block.helpUrl === 'function' ? block.helpUrl() : block.helpUrl;
+      const dialog = new LegacyDialog({
+        body: $('<iframe>')
+          .addClass('markdown-instructions-container')
+          .width('100%')
+          .attr('src', url),
+        autoResizeScrollableElement: '.markdown-instructions-container',
+        id: 'block-documentation-lightbox',
+        link: 'url',
+      });
+      dialog.show();
+    },
+    scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.BLOCK,
+    id: 'blockHelp',
+    weight: 11,
+  };
+  GoogleBlockly.ContextMenuRegistry.registry.register(helpOption);
+}
+
 const registerAllContextMenuItems = function () {
   unregisterDefaultOptions();
   registerDeletable();
@@ -252,6 +293,7 @@ const registerAllContextMenuItems = function () {
   registerKeyboardNavigation();
   registerDarkMode();
   registerThemes(themes);
+  registerHelp();
 };
 
 function canBeShadow(block) {
@@ -303,6 +345,7 @@ function unregisterDefaultOptions() {
     GoogleBlockly.ContextMenuRegistry.registry.unregister(
       'blockCollapseExpand'
     );
+    GoogleBlockly.ContextMenuRegistry.registry.unregister('blockHelp');
     GoogleBlockly.ContextMenuRegistry.registry.unregister('blockInline');
     // cleanUp() doesn't currently account for immovable blocks.
     GoogleBlockly.ContextMenuRegistry.registry.unregister('cleanWorkspace');

--- a/apps/src/blockly/addons/contextMenu.js
+++ b/apps/src/blockly/addons/contextMenu.js
@@ -268,7 +268,6 @@ export function registerHelp() {
       return 'hidden';
     },
     callback(scope) {
-      // scope.block.showHelp();
       const block = scope.block;
       const url =
         typeof block.helpUrl === 'function' ? block.helpUrl() : block.helpUrl;

--- a/apps/src/blockly/addons/contextMenu.js
+++ b/apps/src/blockly/addons/contextMenu.js
@@ -2,6 +2,7 @@ import GoogleBlockly from 'blockly/core';
 import msg from '@cdo/locale';
 import {Themes, MenuOptionStates, BLOCKLY_THEME} from '../constants.js';
 import LegacyDialog from '../../code-studio/LegacyDialog';
+import experiments from '@cdo/apps/util/experiments';
 
 const dark = 'dark';
 
@@ -249,9 +250,13 @@ function registerThemes(themes) {
 export function registerHelp() {
   const helpOption = {
     displayText() {
-      return 'Get help with this block';
+      return msg.getBlockDocs();
     },
     preconditionFn(scope) {
+      // This option is limited to an experiment until SL documentation is updated.
+      if (!experiments.isEnabled(experiments.SPRITE_LAB_DOCS)) {
+        return 'hidden';
+      }
       const block = scope.block;
       const url =
         typeof block.helpUrl === 'function' ? block.helpUrl() : block.helpUrl;

--- a/apps/src/blockly/addons/contextMenu.js
+++ b/apps/src/blockly/addons/contextMenu.js
@@ -255,7 +255,9 @@ export function registerHelp() {
       const block = scope.block;
       const url =
         typeof block.helpUrl === 'function' ? block.helpUrl() : block.helpUrl;
-      if (url) {
+      // Some common Blockly blocks have help URLs for pages on Wikipedia, GitHub, etc.
+      // We only want to allow a documentation dialog for one of our local docs links.
+      if (url && url.startsWith('/docs/')) {
         return 'enabled';
       }
       return 'hidden';
@@ -272,7 +274,7 @@ export function registerHelp() {
           .attr('src', url),
         autoResizeScrollableElement: '.markdown-instructions-container',
         id: 'block-documentation-lightbox',
-        link: 'url',
+        link: url,
       });
       dialog.show();
     },

--- a/apps/src/templates/codeDocs/ProgrammingExpressionOverview.jsx
+++ b/apps/src/templates/codeDocs/ProgrammingExpressionOverview.jsx
@@ -71,6 +71,7 @@ export default function ProgrammingExpressionOverview({
           title={programmingExpression.blockName}
           role="heading"
           aria-level="1"
+          style={{paddingBottom: 12}}
         />
       );
     }

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -52,6 +52,8 @@ experiments.AI_RUBRICS_REDESIGN = 'ai-rubrics-redesign';
 experiments.AI_TUTOR_ACCESS = 'ai-tutor';
 // Uses Google Blockly for a given user across labs/levels until the experiment is disabled
 experiments.GOOGLE_BLOCKLY = 'google_blockly';
+// Adds documentation links to block context menus in Sprite Lab (supported with Google Blockly only)
+experiments.SPRITE_LAB_DOCS = 'sl_docs';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/dashboard/app/views/programming_environments/show.html.haml
+++ b/dashboard/app/views/programming_environments/show.html.haml
@@ -1,5 +1,5 @@
 %link{href: asset_path('css/curriculum_navigation.css'), rel: 'stylesheet', type: 'text/css'}
-%script{src: webpack_asset_path('js/blockly.js')}
+%script{src: webpack_asset_path('js/googleblockly.js')}
 %script{src: webpack_asset_path("js/#{js_locale}/blockly_locale.js")}
 %script{src: webpack_asset_path('js/programming_environments/show.js'), data: {programmingEnvironment: @programming_environment.summarize_for_show.to_json, customBlocksConfig: Block.for(@programming_environment.block_pool_name).to_json, categoriesForNavigation: @programming_environment_categories.to_json}}
 #container

--- a/dashboard/app/views/programming_expressions/show.html.haml
+++ b/dashboard/app/views/programming_expressions/show.html.haml
@@ -1,9 +1,9 @@
-//%script{src: webpack_asset_path('js/googleblockly.js')}
+%script{src: webpack_asset_path('js/googleblockly.js')}
 %link{href: asset_path('css/markdown.css'), rel: 'stylesheet', type: 'text/css'}
 %link{href: asset_path('css/curriculum_navigation.css'), rel: 'stylesheet', type: 'text/css'}
 - content_for(:head) do
   = tag 'meta', name: 'description', content: @programming_expression.syntax
-%script{src: webpack_asset_path('js/blockly.js')}
+//%script{src: webpack_asset_path('js/googleblockly.js')}
 %script{src: webpack_asset_path("js/#{js_locale}/blockly_locale.js")}
 %script{src: webpack_asset_path('js/programming_expressions/show.js'),
   data: {programmingExpression: @programming_expression.summarize_for_show.to_json, customBlocksConfig: @programming_expression.get_blocks.to_json, programmingEnvironmentTitle: @programming_expression.programming_environment.title.to_json, programmingEnvironmentName: @programming_expression.programming_environment.name.to_json, programmingEnvironmentLanguage: (@programming_expression.programming_environment.editor_language || '').to_json, categoriesForNavigation: @programming_environment_categories.to_json, currentCategoryKey: @programming_expression.programming_environment_category&.key&.to_json}}

--- a/dashboard/app/views/programming_expressions/show.html.haml
+++ b/dashboard/app/views/programming_expressions/show.html.haml
@@ -3,7 +3,6 @@
 %link{href: asset_path('css/curriculum_navigation.css'), rel: 'stylesheet', type: 'text/css'}
 - content_for(:head) do
   = tag 'meta', name: 'description', content: @programming_expression.syntax
-//%script{src: webpack_asset_path('js/googleblockly.js')}
 %script{src: webpack_asset_path("js/#{js_locale}/blockly_locale.js")}
 %script{src: webpack_asset_path('js/programming_expressions/show.js'),
   data: {programmingExpression: @programming_expression.summarize_for_show.to_json, customBlocksConfig: @programming_expression.get_blocks.to_json, programmingEnvironmentTitle: @programming_expression.programming_environment.title.to_json, programmingEnvironmentName: @programming_expression.programming_environment.name.to_json, programmingEnvironmentLanguage: (@programming_expression.programming_environment.editor_language || '').to_json, categoriesForNavigation: @programming_environment_categories.to_json, currentCategoryKey: @programming_expression.programming_environment_category&.key&.to_json}}


### PR DESCRIPTION
This includes a few updates that would add support for Sprite Lab Docs on Google Blockly. Specifically, it:

* Tells our documentation to use render Blocks with Google Blockly for the Sprite Lab environment index (/docs/ide/spritelab/) and each "expression" page linked on it.
* Adds a context menu option for blocks with `helpUrl` values that opens a modal documentation dialog. (Requires setting an experiment flag.)
* Updated `block_utils.js` to add `helpUrl`s to our custom blocks, based on existing `docFunc` values.

Because Sprite Lab is the only Blockly lab with docs, we can safely flip to Google Blockly in "all" labs. If, for example, Artist also had docs, we would need some conditional logic to choose between the `googleblockly.js` and `blockly.js` scripts.

### Example - `change costume to` block
This block is defined at `pools/GamelabJr/blocks/gamelab_setAnimation/edit`. 
The config JSON includes a `docFunc": "gamelab_setAnimation",` property.
<img width="990" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/51cba086-d828-4a68-9938-1776d6ef0d28">
(I have a local change that renders the above block with Google Blockly. Levelbuilder/staging are still using CDO Blockly.)

The documentation for this block can be viewed at `/docs/spritelab/gamelab_setAnimation`.

With the experiment enabled, a new "Get help with this block" option is shown in the context menu:
<img width="907" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/a1e8e442-34b1-4400-9127-0d8f4fd7eccb">

Selecting the option opens the modal, just like we do for Game Lab and App Lab:
<img width="1512" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/a09da7a8-97a0-41e7-9bf7-505d97a6d8f9">
(Note that the embedded project example shown in the documentation above uses CDO Blockly because the project actually lives on production.)


## Links

Jira: https://codedotorg.atlassian.net/browse/CT-168

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

We will also want to update the helpUrls of existing blocks. That work is handled here:
https://github.com/code-dot-org/code-dot-org/pull/55589

Beginning in April, the curriculum team will be working to update all block documentation as needed for the spring launch. The experiment flag will enable them to test everything as they write without risking that an external user might stumble upon any outdated docs.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
