### PR TITLE
Translate behavior call and definition names the same way

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -666,23 +666,38 @@ class Blockly < Level
     block_xml.xpath("//block[@type=\"gamelab_behavior_get\"]").each do |behavior|
       behavior_name = behavior.at_xpath("./#{tag}[@name=\"VAR\"]")
       next unless behavior_name
-      localized_name = I18n.t(
-        behavior_name.content,
-        scope: [:data, :shared_functions],
-        default: nil,
-        smart: true
-      )
+      localized_name =
+        I18n.t(
+          behavior_name.content,
+          scope: [:data, :shared_functions],
+          default: nil,
+          smart: true
+        ) ||
+        I18n.t(
+          behavior_name.content,
+          scope: [:data, :behavior_names, name],
+          default: nil,
+          smart: true
+        )
       behavior_name.content = localized_name if localized_name
     end
     block_xml.xpath("//block[@type=\"behavior_definition\"]").each do |behavior|
       behavior_name = behavior.at_xpath("./#{tag}[@name=\"NAME\"]")
       next unless behavior_name
-      localized_name = I18n.t(
-        behavior_name.content,
-        scope: [:data, :shared_functions],
-        default: nil,
-        smart: true
-      )
+      puts "localizing #{behavior_name.content}"
+      localized_name =
+        I18n.t(
+          behavior_name.content,
+          scope: [:data, :shared_functions],
+          default: nil,
+          smart: true
+        ) ||
+        I18n.t(
+          behavior_name.content,
+          scope: [:data, :behavior_names, name],
+          default: nil,
+          smart: true
+        )
       behavior_name.content = localized_name if localized_name
     end
 
@@ -911,7 +926,20 @@ class Blockly < Level
       end
 
       behavior.xpath(".//#{tag}[@name=\"NAME\"]").each do |name_element|
-        localized_name = I18n.t(name_element.content, scope: [:data, :shared_functions], default: nil, smart: true)
+        puts "localizing #{name_element.content}"
+        localized_name =
+          I18n.t(
+            name_element.content,
+            scope: [:data, :shared_functions],
+            default: nil,
+            smart: true
+          ) ||
+          I18n.t(
+            name_element.content,
+            scope: [:data, :behavior_names, name],
+            default: nil,
+            smart: true
+          )
         name_element.content = localized_name if localized_name
 
         mutation.xpath('.//description').each do |description|

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -681,26 +681,8 @@ class Blockly < Level
         )
       behavior_name.content = localized_name if localized_name
     end
-    block_xml.xpath("//block[@type=\"behavior_definition\"]").each do |behavior|
-      behavior_name = behavior.at_xpath("./#{tag}[@name=\"NAME\"]")
-      next unless behavior_name
-      puts "localizing #{behavior_name.content}"
-      localized_name =
-        I18n.t(
-          behavior_name.content,
-          scope: [:data, :shared_functions],
-          default: nil,
-          smart: true
-        ) ||
-        I18n.t(
-          behavior_name.content,
-          scope: [:data, :behavior_names, name],
-          default: nil,
-          smart: true
-        )
-      behavior_name.content = localized_name if localized_name
-    end
 
+    # localize_behaviors handles localizing behavior definitions.
     localize_behaviors(block_xml)
     block_xml
   end
@@ -926,7 +908,6 @@ class Blockly < Level
       end
 
       behavior.xpath(".//#{tag}[@name=\"NAME\"]").each do |name_element|
-        puts "localizing #{name_element.content}"
         localized_name =
           I18n.t(
             name_element.content,

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -668,7 +668,7 @@ class Blockly < Level
       next unless behavior_name
       localized_name = I18n.t(
         behavior_name.content,
-        scope: [:data, :behavior_names, name],
+        scope: [:data, :shared_functions],
         default: nil,
         smart: true
       )
@@ -679,7 +679,7 @@ class Blockly < Level
       next unless behavior_name
       localized_name = I18n.t(
         behavior_name.content,
-        scope: [:data, :behavior_names, name],
+        scope: [:data, :shared_functions],
         default: nil,
         smart: true
       )


### PR DESCRIPTION
We were translating behavior call blocks and definition blocks using different scopes, which meant call blocks would often not be translated while definition blocks were. This surfaced in CDO Blockly with untranslated call blocks if they are in start code (which is rare). In Google Blockly it crashes the page because the call block cannot find its definition block (they match up by name). 

The fix for this is to use the same logic for both. Now we first check the `shared_functions` scope, which contains the default behavior names. If the name is not there, we check the `behavior_names` scope, which is per-level and could contain a level-specific behavior. The is [discussion](https://codedotorg.slack.com/archives/CFTFD6BPV/p1704390575517199) with platform as to whether we can unify these, but for now this will fix the issue without potentially missing level-specific translations.

As I was working on this I noticed we are translating the behavior definition name twice, first in `localized_function_blocks_xml`, then in `localize_behaviors`, which is called within `localized_function_blocks_xml`. I removed the duplicate code from `localized_function_blocks_xml`, as `localize_behaviors` is called elsewhere.


### Before (CDO Blockly, Spanish)
![Screenshot 2024-01-04 at 1 11 17 PM](https://github.com/code-dot-org/code-dot-org/assets/33666587/61ad0f07-b3e4-4019-ae1c-234f81482921)

### After (CDO Blockly, Spanish)
<img width="431" alt="Screenshot 2024-01-04 at 1 11 34 PM" src="https://github.com/code-dot-org/code-dot-org/assets/33666587/dfb5d042-358f-4c3a-99ad-953c157b98b5">

## Links

- jira ticket: [CT-172](https://codedotorg.atlassian.net/browse/CT-172)


## Testing story
Tested locally on Google and CDO blockly for levels with and without behavior call blocks in their start code. 

## Follow-up work
This bug mostly fixes the jira ticket linked above, although we have to do a [follow up task](https://codedotorg.atlassian.net/browse/CT-225) relating to another bug around behavior ids being inconsistent.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
