### PR TITLE
Remove commit message check from DTS command

### DIFF
--- a/bin/dotd
+++ b/bin/dotd
@@ -257,8 +257,7 @@ def dotd_menu(dotd_name)
         end
       end
       menu.choice(:DTS) do
-        unless GitHub.compare(base: 'staging', head: 'levelbuilder').
-            any? {|message| message.include?('levelbuilder content changes')}
+        if GitHub.compare(base: 'staging', head: 'levelbuilder').empty?
           warn_and_confirm 'No content commit available to merge from levelbuilder to staging'
           next
         end


### PR DESCRIPTION
The code for the DTS command in the DOTD script currently checks for the string "levelbuilder content changes" in at least one commit message in the diff between `levelbuilder` and `staging` before it will create/merge a PR. This check is troublesome when a developer has to manually make a commit to `levelbuilder`, because they have to remember to use this magic string as their commit message if they want the DTS command to work.

This PR changes the script to check if the array of commits is empty instead. This preserves the spirit of the check by ensuring that at least one commit is included in the DTS PR, but removes the overly-restrictive check on the commit message.

## Links

[Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1704387641100109) where this change was proposed

## Testing story

Checked after doing a DTS, meaning no new commits are present in `levelbuilder`:
```
[development] dashboard > GitHub.compare(base: 'staging', head: 'levelbuilder')
=> []
[development] dashboard > GitHub.compare(base: 'staging', head: 'levelbuilder').empty?
=> true
```

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
