### PR TITLE
Revert "Revert "Make teacher dashboard pages full width, allow progress table to expa…""

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
@@ -170,6 +170,7 @@ export default class ProgressTableContentView extends React.Component {
           },
         }}
         columns={columns}
+        style={{width: 'fit-content'}}
       >
         <Sticky.Header
           style={{overflow: 'hidden'}}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
@@ -173,7 +173,7 @@ export default class ProgressTableContentView extends React.Component {
         style={{width: 'fit-content'}}
       >
         <Sticky.Header
-          style={{overflow: 'hidden'}}
+          style={{overflow: 'unset'}}
           ref={r => (this.header = r && r.getRef())}
           tableBody={this.body}
           headerRows={headerRows}
@@ -184,8 +184,7 @@ export default class ProgressTableContentView extends React.Component {
           rowKey={'id'}
           onScroll={this.props.onScroll}
           style={{
-            overflowX: 'scroll',
-            overflowY: 'auto',
+            overflow: 'unset',
             maxHeight: parseInt(styleConstants.MAX_BODY_HEIGHT),
           }}
           ref={r => {

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
@@ -16,7 +16,6 @@ import {
   getCurrentUnitData,
   jumpToLessonDetails,
 } from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
-import styleConstants from '@cdo/apps/styleConstants';
 import ProgressTableStudentList from './ProgressTableStudentList';
 import ProgressTableContentView from './ProgressTableContentView';
 import SummaryViewLegend from '@cdo/apps/templates/sectionProgress/progressTables/SummaryViewLegend';
@@ -355,7 +354,7 @@ class ProgressTableView extends React.Component {
     return (
       // outer div contains both table and legend
       <div>
-        <div style={styles.container} className="progress-table">
+        <div className="progress-table">
           <div style={styles.studentList} className="student-list">
             <ProgressTableStudentList
               key={key}
@@ -400,16 +399,13 @@ class ProgressTableView extends React.Component {
 }
 
 const styles = {
-  container: {
-    width: styleConstants['content-width'],
-  },
   studentList: {
-    display: 'inline-block',
-    verticalAlign: 'top',
+    position: 'absolute',
   },
   contentView: {
-    display: 'inline-block',
-    width: parseInt(progressTableStyleConstants.CONTENT_VIEW_WIDTH),
+    paddingInlineStart: parseInt(
+      progressTableStyleConstants.STUDENT_LIST_WIDTH
+    ),
   },
 };
 

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
@@ -406,6 +406,7 @@ const styles = {
     paddingInlineStart: parseInt(
       progressTableStyleConstants.STUDENT_LIST_WIDTH
     ),
+    overflow: 'auto',
   },
 };
 

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -5,9 +5,6 @@
 .progress-table {
   table {
     table-layout: fixed;
-    border: 1px solid;
-    border-color: $border-gray;
-    border-collapse: separate;
   }
   th {
     background-color: $table-header;
@@ -54,6 +51,9 @@
     }
   }
   .student-list {
+    background: white;
+    border: 1px solid $border-gray;
+    z-index: 1;
     table,
     th,
     td {
@@ -95,6 +95,7 @@
     background-color: $background_gray;
   }
   .content-view {
+    border: 1px solid $border-gray;
     thead,
     tbody {
       td {

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -97,7 +97,6 @@
   .content-view {
     thead,
     tbody {
-      max-width: constants.$content-view-width;
       td {
         text-align: center;
       }

--- a/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
@@ -123,7 +123,7 @@ export default class TeacherDashboardNavigation extends Component {
     const links = this.props.links || teacherDashboardLinks;
     const containerStyles = this.state.shouldScroll
       ? {...styles.container, ...styles.scrollableContainer}
-      : {...styles.container, ...styles.centerContainer};
+      : styles.container;
     const chevronStyles = userAgentParser.isSafari()
       ? {...styles.chevron, ...styles.safariSticky}
       : styles.chevron;
@@ -176,9 +176,6 @@ const styles = {
     marginBottom: 10,
     overflow: 'hidden',
     position: 'relative',
-  },
-  centerContainer: {
-    justifyContent: 'center',
   },
   scrollableContainer: {
     overflowX: 'scroll',

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1311,6 +1311,10 @@ input.header_input {
   text-decoration: underline;
 }
 
+#teacher-dashboard {
+  margin: 0 39px;
+}
+
 #alert {
   color: $red;
   font-size: 130%;

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -5,6 +5,7 @@ class TeacherDashboardController < ApplicationController
     @section_summary = @section.summarize
     @sections = current_user.sections_instructed.map(&:summarize)
     @locale_code = request.locale
+    view_options(full_width: true)
   end
 
   def parent_letter


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#55489 and fixes the issue where the tables weren't showing up in Safari. This solution works in Chrome and Firefox too.

----

https://github.com/code-dot-org/code-dot-org/assets/9256643/35da965a-6c15-42da-81e0-55ed0ae5e9d4