### PR TITLE
Specify input[type="text"] styles on design-system-pegasus.scss stylesheet

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -516,7 +516,7 @@ form {
     font-weight: var(--semi-bold-font-weight);
   }
 
-  input, select {
+  input[type="text"], select {
     display: block;
     width: 100%;
     margin: .25rem auto 1.5rem;


### PR DESCRIPTION
Fixes an issue where all `input` types were being styled the same which broke checkboxes. This fix allows for text box inputs and select inputs to be styled appropriately, whereas all other input types will inherit existing styles. 

See https://code.org/afe for an example of where the checkboxes where broken.

See relevant Slack convo [here](https://codedotorg.slack.com/archives/C0453TUMLE7/p1704433760541019).

----

| Before | After |
| ------ | ------ |
| ![before](https://github.com/code-dot-org/code-dot-org/assets/9256643/0d1e494b-34a5-4350-bb0f-d4911c2eb2c3) | ![after](https://github.com/code-dot-org/code-dot-org/assets/9256643/d29b9e7d-752b-4524-8513-9fdff6a00319) |