### PR TITLE
[Progress] Add a progress V2 page with a toggle between v1 and v2

### DIFF
--- a/apps/src/lib/util/UserPreferences.js
+++ b/apps/src/lib/util/UserPreferences.js
@@ -50,6 +50,16 @@ export default class UserPreferences extends Record({userId: 'me'}) {
   }
 
   /**
+   * Save the preference to show v1 or v2 progress table.
+   * @param {boolean} showProgressTableV2: True if showing progress table v2, false otherwise.
+   */
+  setShowProgressTableV2(showProgressTableV2) {
+    return $.post(`/api/v1/users/show_progress_table_v2`, {
+      show_progress_table_v2: showProgressTableV2,
+    });
+  }
+
+  /**
    * Save the background music user preference
    * @param {boolean} muteMusic: True if background music muted
    */

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -13,6 +13,7 @@ const SET_HAS_SEEN_STANDARDS_REPORT =
 const SET_INITIAL_DATA = 'currentUser/SET_INITIAL_DATA';
 const SET_MUTE_MUSIC = 'currentUser/SET_MUTE_MUSIC';
 const SET_SORT_BY_FAMILY_NAME = 'currentUser/SET_SORT_BY_FAMILY_NAME';
+const SET_SHOW_PROGRESS_TABLE_V2 = 'currentUser/SET_SHOW_PROGRESS_TABLE_V2';
 
 export const SignInState = makeEnum('Unknown', 'SignedIn', 'SignedOut');
 
@@ -64,6 +65,10 @@ export const setSortByFamilyName = (
   sectionId,
   unitName,
   source,
+});
+export const setShowProgressTableV2 = showProgressTableV2 => ({
+  type: SET_SHOW_PROGRESS_TABLE_V2,
+  showProgressTableV2,
 });
 
 const initialState = {
@@ -145,6 +150,12 @@ export default function currentUser(state = initialState, action) {
       isSortedByFamilyName: action.isSortedByFamilyName,
     };
   }
+  if (action.type === SET_SHOW_PROGRESS_TABLE_V2) {
+    return {
+      ...state,
+      showProgressTableV2: action.showProgressTableV2,
+    };
+  }
   if (action.type === SET_INITIAL_DATA) {
     const {
       id,
@@ -154,6 +165,7 @@ export default function currentUser(state = initialState, action) {
       under_13,
       over_21,
       sort_by_family_name,
+      show_progress_table_v2,
     } = action.serverUser;
     analyticsReport.setUserProperties(
       id,
@@ -169,6 +181,7 @@ export default function currentUser(state = initialState, action) {
       under13: under_13,
       over21: over_21,
       isSortedByFamilyName: sort_by_family_name,
+      showProgressTableV2: show_progress_table_v2,
     };
   }
 

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -1,0 +1,76 @@
+import {connect} from 'react-redux';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {DCDO} from '@cdo/apps/dcdo';
+import SectionProgress from '../sectionProgress/SectionProgress';
+import Button from '@cdo/apps/applab/designElements/button';
+import {setShowProgressTableV2} from '@cdo/apps/templates/currentUserRedux';
+
+function SectionProgressV2({showProgressTableV2, setShowProgressTableV2}) {
+  const toggleV1OrV2Button = React.useCallback(
+    () => (
+      <div>
+        <Button onClick={() => setShowProgressTableV2(!showProgressTableV2)}>
+          Toggle
+        </Button>
+      </div>
+    ),
+
+    [showProgressTableV2, setShowProgressTableV2]
+  );
+
+  // If progress table is disabled, only show the v1 table.
+  if (!DCDO.get('progress-table-v2-enabled', false)) {
+    console.log('progress-table-v2-enabled is false');
+    return <SectionProgress />;
+  }
+  console.log('progress-table-v2-enabled is true');
+
+  // If the user has not selected manually the v1 or v2 table, show the DCDO defined default.
+  if (showProgressTableV2 === undefined) {
+    if (!DCDO.get('progress-table-v2-default-v2', false)) {
+      return (
+        <div>
+          {toggleV1OrV2Button()}
+          <SectionProgress />
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        {toggleV1OrV2Button()}
+        <SectionProgressV2 />
+      </div>
+    );
+  }
+
+  // If a user has selected manually, show that version.
+  if (showProgressTableV2) {
+    return (
+      <div>
+        {toggleV1OrV2Button()}
+        <SectionProgressV2 />
+      </div>
+    );
+  }
+  return (
+    <div>
+      {toggleV1OrV2Button()}
+      <SectionProgress />
+    </div>
+  );
+}
+
+SectionProgressV2.propTypes = {
+  showProgressTableV2: PropTypes.bool,
+  setShowProgressTableV2: PropTypes.func.isRequired,
+};
+
+export default connect(
+  state => ({showProgressTableV2: state.currentUser.showProgressTableV2}),
+  dispatch => ({
+    setShowProgressTableV2: showProgressTableV2 =>
+      dispatch(setShowProgressTableV2(showProgressTableV2)),
+  })
+)(SectionProgressV2);

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -5,8 +5,12 @@ import {DCDO} from '@cdo/apps/dcdo';
 import SectionProgress from '../sectionProgress/SectionProgress';
 import Button from '@cdo/apps/applab/designElements/button';
 import {setShowProgressTableV2} from '@cdo/apps/templates/currentUserRedux';
+import SectionProgressV2 from './SectionProgressV2';
 
-function SectionProgressV2({showProgressTableV2, setShowProgressTableV2}) {
+function SectionProgressSelector({
+  showProgressTableV2,
+  setShowProgressTableV2,
+}) {
   const toggleV1OrV2Button = React.useCallback(
     () => (
       <div>
@@ -62,7 +66,7 @@ function SectionProgressV2({showProgressTableV2, setShowProgressTableV2}) {
   );
 }
 
-SectionProgressV2.propTypes = {
+SectionProgressSelector.propTypes = {
   showProgressTableV2: PropTypes.bool,
   setShowProgressTableV2: PropTypes.func.isRequired,
 };
@@ -73,4 +77,4 @@ export default connect(
     setShowProgressTableV2: showProgressTableV2 =>
       dispatch(setShowProgressTableV2(showProgressTableV2)),
   })
-)(SectionProgressV2);
+)(SectionProgressSelector);

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -12,8 +12,6 @@ function SectionProgressSelector({
   showProgressTableV2,
   setShowProgressTableV2,
 }) {
-  console.log('lfm1');
-
   const onShowProgressTableV2Change = useCallback(
     e => {
       const shouldShowV2 = !showProgressTableV2;
@@ -30,12 +28,8 @@ function SectionProgressSelector({
 
   // If progress table is disabled, only show the v1 table.
   if (!DCDO.get('progress-table-v2-enabled', false)) {
-    console.log('progress-table-v2-enabled is false');
     return <SectionProgress />;
   }
-  console.log('progress-table-v2-enabled is true');
-
-  console.log('lfm2', showProgressTableV2);
 
   // If the user has not selected manually the v1 or v2 table, show the DCDO defined default.
   if (showProgressTableV2 === undefined) {

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -14,16 +14,12 @@ function SectionProgressSelector({
 }) {
   const onShowProgressTableV2Change = useCallback(
     e => {
+      e.preventDefault();
       const shouldShowV2 = !showProgressTableV2;
-      new UserPreferences().setSortByFamilyName(shouldShowV2);
+      new UserPreferences().setShowProgressTableV2(shouldShowV2);
       setShowProgressTableV2(shouldShowV2);
     },
     [showProgressTableV2, setShowProgressTableV2]
-  );
-  const toggleV1OrV2Button = () => (
-    <div>
-      <Button onClick={onShowProgressTableV2Change}>Toggle V1/V2</Button>
-    </div>
   );
 
   // If progress table is disabled, only show the v1 table.
@@ -31,38 +27,22 @@ function SectionProgressSelector({
     return <SectionProgress />;
   }
 
+  const toggleV1OrV2Button = () => (
+    <div>
+      <Button onClick={onShowProgressTableV2Change}>Toggle V1/V2</Button>
+    </div>
+  );
+
   // If the user has not selected manually the v1 or v2 table, show the DCDO defined default.
-  if (showProgressTableV2 === undefined) {
-    if (!DCDO.get('progress-table-v2-default-v2', false)) {
-      return (
-        <div>
-          {toggleV1OrV2Button()}
-          <SectionProgress />
-        </div>
-      );
-    }
-
-    return (
-      <div>
-        {toggleV1OrV2Button()}
-        <SectionProgressV2 />
-      </div>
-    );
-  }
-
   // If a user has selected manually, show that version.
-  if (showProgressTableV2) {
-    return (
-      <div>
-        {toggleV1OrV2Button()}
-        <SectionProgressV2 />
-      </div>
-    );
-  }
+  const isPreferenceSet = showProgressTableV2 !== undefined;
+  const displayV2 = isPreferenceSet
+    ? showProgressTableV2
+    : DCDO.get('progress-table-v2-default-v2', false);
   return (
     <div>
       {toggleV1OrV2Button()}
-      <SectionProgress />
+      {displayV2 ? <SectionProgressV2 /> : <SectionProgress />}
     </div>
   );
 }

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -1,26 +1,31 @@
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
-import React from 'react';
-import {DCDO} from '@cdo/apps/dcdo';
+import React, {useCallback} from 'react';
+import DCDO from '@cdo/apps/dcdo';
 import SectionProgress from '../sectionProgress/SectionProgress';
-import Button from '@cdo/apps/applab/designElements/button';
+import Button from '@cdo/apps/templates/Button';
 import {setShowProgressTableV2} from '@cdo/apps/templates/currentUserRedux';
 import SectionProgressV2 from './SectionProgressV2';
+import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 
 function SectionProgressSelector({
   showProgressTableV2,
   setShowProgressTableV2,
 }) {
-  const toggleV1OrV2Button = React.useCallback(
-    () => (
-      <div>
-        <Button onClick={() => setShowProgressTableV2(!showProgressTableV2)}>
-          Toggle
-        </Button>
-      </div>
-    ),
+  console.log('lfm1');
 
+  const onShowProgressTableV2Change = useCallback(
+    e => {
+      const shouldShowV2 = !showProgressTableV2;
+      new UserPreferences().setSortByFamilyName(shouldShowV2);
+      setShowProgressTableV2(shouldShowV2);
+    },
     [showProgressTableV2, setShowProgressTableV2]
+  );
+  const toggleV1OrV2Button = () => (
+    <div>
+      <Button onClick={onShowProgressTableV2Change}>Toggle V1/V2</Button>
+    </div>
   );
 
   // If progress table is disabled, only show the v1 table.
@@ -29,6 +34,8 @@ function SectionProgressSelector({
     return <SectionProgress />;
   }
   console.log('progress-table-v2-enabled is true');
+
+  console.log('lfm2', showProgressTableV2);
 
   // If the user has not selected manually the v1 or v2 table, show the DCDO defined default.
   if (showProgressTableV2 === undefined) {

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {Heading1} from '@cdo/apps/componentLibrary/typography';
+
+export default function SectionProgressV2() {
+  return (
+    <div>
+      <Heading1>Progress</Heading1>
+    </div>
+  );
+}

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -6,7 +6,6 @@ import TeacherDashboardNavigation, {
 } from './TeacherDashboardNavigation';
 import TeacherDashboardHeader from './TeacherDashboardHeader';
 import StatsTableWithData from './StatsTableWithData';
-import SectionProgress from '@cdo/apps/templates/sectionProgress/SectionProgress';
 import ManageStudents from '@cdo/apps/templates/manageStudents/ManageStudents';
 import SectionProjectsListWithData from '@cdo/apps/templates/projects/SectionProjectsListWithData';
 import TextResponses from '@cdo/apps/templates/textResponses/TextResponses';
@@ -20,6 +19,7 @@ import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import StandardsReport from '../sectionProgress/standards/StandardsReport';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import i18n from '@cdo/locale';
+import SectionProgressSelector from '../sectionProgressV2/SectionProgressSelector';
 
 function TeacherDashboard({
   studioUrlPrefix,
@@ -142,7 +142,7 @@ function TeacherDashboard({
         )}
         <Route
           path={TeacherDashboardPath.progress}
-          component={props => <SectionProgress />}
+          component={props => <SectionProgressSelector />}
         />
         <Route
           path={TeacherDashboardPath.textResponses}

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -150,7 +150,9 @@ class Api::V1::UsersController < Api::V1::JSONApiController
   def post_show_progress_table_v2
     return head :unauthorized unless current_user
 
-    current_user.show_progress_table_v2 = !!params[:show_progress_table_v2].try(:to_bool)
+    return head :bad_request unless params[:show_progress_table_v2] == "v1" || params[:show_progress_table_v2] == "v2"
+
+    current_user.show_progress_table_v2 = params[:show_progress_table_v2]
     current_user.save
 
     head :no_content

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -150,9 +150,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
   def post_show_progress_table_v2
     return head :unauthorized unless current_user
 
-    return head :bad_request unless params[:show_progress_table_v2] == "v1" || params[:show_progress_table_v2] == "v2"
-
-    current_user.show_progress_table_v2 = params[:show_progress_table_v2]
+    current_user.show_progress_table_v2 = !!params[:show_progress_table_v2].try(:to_bool)
     current_user.save
 
     head :no_content

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1566,12 +1566,6 @@ class User < ApplicationRecord
     !!sort_by_family_name
   end
 
-  def get_show_progress_table_v2
-    return "default" if show_progress_table_v2.nil?
-
-    show_progress_table_v2
-  end
-
   def generate_username
     # skip an expensive db query if the name is not valid anyway. we can't depend on validations being run
     return if name.blank? || name.utf8mb4? || (email&.utf8mb4?)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1566,10 +1566,10 @@ class User < ApplicationRecord
     !!sort_by_family_name
   end
 
-  def show_progress_table_v2?
-    return show_progress_table_v2 unless show_progress_table_v2.nil?
+  def get_show_progress_table_v2
+    return "default" if show_progress_table_v2.nil?
 
-    DCDO.get('progress-table-v2-default-v2', false)
+    show_progress_table_v2
   end
 
   def generate_username

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1566,10 +1566,10 @@ class User < ApplicationRecord
     !!sort_by_family_name
   end
 
-  def show_progress_ui_refresh?
-    return show_progress_ui_refresh unless show_progress_ui_refresh.nil?
+  def show_progress_table_v2?
+    return show_progress_table_v2 unless show_progress_table_v2.nil?
 
-    DCDO.get('progress-ui-refresh-default-new', false)
+    DCDO.get('progress-table-v2-default-v2', false)
   end
 
   def generate_username

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1566,6 +1566,12 @@ class User < ApplicationRecord
     !!sort_by_family_name
   end
 
+  def show_progress_ui_refresh?
+    return show_progress_ui_refresh unless show_progress_ui_refresh.nil?
+
+    DCDO.get('progress-ui-refresh-default-new', false)
+  end
+
   def generate_username
     # skip an expensive db query if the name is not valid anyway. we can't depend on validations being run
     return if name.blank? || name.utf8mb4? || (email&.utf8mb4?)

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -796,6 +796,12 @@ class UserTest < ActiveSupport::TestCase
     refute follower.student_user.reload.admin?
   end
 
+  test "show_progress_table_v2? defaults to default" do
+    user = create :user
+
+    assert_equal "default", user.get_show_progress_table_v2
+  end
+
   test "short name" do
     assert_equal 'Laurel', build(:user, name: 'Laurel Fan').short_name # first name last name
     assert_equal 'Winnie', build(:user, name: 'Winnie the Pooh').short_name # middle name

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -796,12 +796,6 @@ class UserTest < ActiveSupport::TestCase
     refute follower.student_user.reload.admin?
   end
 
-  test "show_progress_table_v2? defaults to default" do
-    user = create :user
-
-    assert_equal "default", user.get_show_progress_table_v2
-  end
-
   test "short name" do
     assert_equal 'Laurel', build(:user, name: 'Laurel Fan').short_name # first name last name
     assert_equal 'Winnie', build(:user, name: 'Winnie the Pooh').short_name # middle name


### PR DESCRIPTION
NOOP without `'progress-table-v2-enabled'` set to `true.

This adds an empty progress V2 page to the progress tab. This page is only shown by toggling the user setting to show the v2 button using an (unstyled) button. 

In order to see the v2 page:
* set `'progress-table-v2-enabled'` to `true` in ruby console
* Go to the progress tab of any section
* Click `toggle V1/V2` button


v1 with `progress-table-v2-enabled` set to `false`
![image](https://github.com/code-dot-org/code-dot-org/assets/25193259/56c182e3-f86f-4d48-860f-7724a94b59f4)


v2 with `progress-table-v2-enabled` set to `true`
![image](https://github.com/code-dot-org/code-dot-org/assets/25193259/39f2652b-0a80-46b6-94c6-48adcd26c792)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
