### PR TITLE
[Google Blockly] Add behavior ids to block fields where missing

### DIFF
--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -285,8 +285,6 @@ function addMissingBehaviorId(blockElement) {
     setIdFromTextContent(getFieldOrTitle(blockElement, 'VAR'));
   } else if (blockType === BLOCK_TYPES.behaviorDefinition) {
     setIdFromTextContent(getFieldOrTitle(blockElement, 'NAME'));
-  } else {
-    return;
   }
 }
 

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -167,7 +167,7 @@ export function addMutationToBehaviorDefBlocks(blockElement) {
 
   // In CDO Blockly, behavior ids were stored on the field. Google Blockly
   // expects this kind of extra state in a mutator.
-  const nameField = getNameField(blockElement);
+  const nameField = getFieldOrTitle(blockElement, 'NAME');
   const idAttribute = nameField && nameField.getAttribute('id');
   if (idAttribute) {
     // Create new mutation attribute based on original block attribute.
@@ -242,7 +242,7 @@ export function addNameToBlockFunctionDefinitionBlock(blockElement) {
   if (blockType !== BLOCK_TYPES.procedureDefinition) {
     return;
   }
-  const fieldElement = getNameField(blockElement);
+  const fieldElement = getFieldOrTitle(blockElement, 'NAME');
   if (!fieldElement) {
     return;
   }
@@ -274,6 +274,34 @@ export function addNameToBlockFunctionCallBlock(blockElement) {
 }
 
 /**
+ * If a field should was serialized before we had behavior ids, manually add
+ * one based on the behavior name found in the field.
+ *
+ * @param {Element} blockElement - The XML element for a single block.
+ */
+function addMissingBehaviorId(blockElement) {
+  const blockType = blockElement.getAttribute('type');
+  if (blockType === BLOCK_TYPES.behaviorGet) {
+    setIdFromTextContent(getFieldOrTitle(blockElement, 'VAR'));
+  } else if (blockType === BLOCK_TYPES.behaviorDefinition) {
+    setIdFromTextContent(getFieldOrTitle(blockElement, 'NAME'));
+  } else {
+    return;
+  }
+}
+
+/**
+ * If a field should was serialized before we had behavior ids, manually add
+ * one based on the behavior name found in the field.
+ *
+ * @param {Element} element - The XML element (title or field) for a block.
+ */
+function setIdFromTextContent(element) {
+  if (!element.getAttribute('id')) {
+    element.setAttribute('id', element.textContent);
+  }
+}
+/**
  * Adds a mutation element to a block if it's a text join block with an input count.
  * CDO Blockly uses an unsupported method for serializing input count state
  * where an arbitrary block attribute could be used to manage extra state.
@@ -302,12 +330,12 @@ export function addMutationToTextJoinBlock(blockElement) {
   mutationElement.setAttribute('items', inputCount);
 }
 
-function getNameField(blockElement) {
+function getFieldOrTitle(blockElement, name) {
   // Title is the legacy name for field, we support getting name from
   // either field or title.
   return (
-    blockElement.querySelector('field[name="NAME"]') ||
-    blockElement.querySelector('title[name="NAME"]')
+    blockElement.querySelector(`field[name="${name}"]`) ||
+    blockElement.querySelector(`title[name="${name}"]`)
   );
 }
 
@@ -331,6 +359,7 @@ function processBlockAndChildren(block) {
  */
 function processIndividualBlock(block) {
   addNameToBlockFunctionCallBlock(block);
+  addMissingBehaviorId(block);
   // Convert unsupported can_disconnect_from_parent attributes.
   makeLockedBlockImmovable(block);
   addMutationToTextJoinBlock(block);


### PR DESCRIPTION
In Sprite Lab levels and projects last saved before Nov 2020, behavior blocks were serialized without ids. (https://github.com/code-dot-org/blockly/pull/254)
This causes problems because we are assuming behaviors will always have ids.
We can manually add ids if they are missing just by looking at the field (or title) text and using that for the id. Until fixed, levels like `/s/coursef-2020/lessons/17/levels/3?no_redirect=true` will crash with Google Blockly due to XML like these:

Definition block:
```
<block type="behavior_definition" editable="false">
    <mutation>
      <arg name="this sprite" type="Sprite"/>
      <description>move a sprite to the right across the screen</description>
    </mutation>
    <title name="NAME">zooming east</title>
    <statement name="STACK"/>
  </block>
```
Call block:
```
<block type="gamelab_behavior_get">
  <mutation/>
  <title name="VAR">driving east</title>
</block>
```

Adding ids to all the `<title/>` elements related to behavior blocks allows the level to load in Google Blockly.

**Before:**|**After:**
-|-
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/4317ef78-caac-40a7-a8e2-53a61367e32a)|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/9688b41a-761e-49f5-ae91-75f1ecdf955e)

Once the level loaded, I also confirmed that you can open the modal editors for each call block and that we are generating the expected code. I also confirmed that the level works in non-English.