### PR TITLE
Modify how we read the gdrive_secret on staging

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -173,7 +173,7 @@ module Services
         def fetch_url_to_path(url, path)
           service = Drive::DriveService.new
           service.authorization = Google::Auth::ServiceAccountCredentials.make_creds(
-            json_key_io: StringIO.new(JSON.generate(CDO.gdrive_export_secret) || ""),
+            json_key_io: StringIO.new(CDO.gdrive_export_secret.to_json || ""),
             scope: Google::Apis::DriveV3::AUTH_DRIVE,
           )
           if url.start_with?("https://docs.google.com/document/d/")

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -173,7 +173,7 @@ module Services
         def fetch_url_to_path(url, path)
           service = Drive::DriveService.new
           service.authorization = Google::Auth::ServiceAccountCredentials.make_creds(
-            json_key_io: StringIO.new(CDO.gdrive_export_secret || ""),
+            json_key_io: StringIO.new(JSON.generate(CDO.gdrive_export_secret) || ""),
             scope: Google::Apis::DriveV3::AUTH_DRIVE,
           )
           if url.start_with?("https://docs.google.com/document/d/")


### PR DESCRIPTION
Context: PDF resource generation was working locally, but when merged into staging, it stopped working because the way the `gdrive_secret` was stored for the org was different than the way I had it stored locally.  This PR fixes this issue. 

Additional context:

- This was originally raised in this thread.
- While investigating, I saw that when running the steps outlined in this document, I was frequently getting timeout errors.  I don't think this PR fixes the time-out errors, but this is a first step toward ensuring we can at least run the script on staging in the future successfully.
- Also while investigating, I saw that for this to eventually run automatically, we need to uncomment this part of the [`build.rake` file](https://github.com/code-dot-org/code-dot-org/blob/f83a341ee8816456bdb537fbc1ad545ca9de5f6d/lib/rake/build.rake#L136).  Again, until we can get this running on staging reliably and successfully, this will be a future task ([TEACH-788)](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-788). 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
