### PR TITLE
Clean up text link CSS on code.org

### DIFF
--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -195,14 +195,14 @@ a:is(:link, :visited) {
   color: var(--brand_secondary_default);
   text-decoration: underline;
   transition: color ease-in-out .2s;
+}
 
-  &:is(:hover, :active) {
-    color: var(--brand_secondary_dark);
-  }
+a:is(:hover, :active) {
+  color: var(--brand_secondary_dark);
+}
 
-  &:link:has(*) {
-    text-decoration: none;
-  }
+a:link:has(*) {
+  text-decoration: none;
 }
 
 /* Button styles */

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -188,26 +188,21 @@ em {
   font-style: italic;
 }
 
-a,
-a:link {
+/* Text link styles */
+a:is(:link, :visited) {
   font-family: var(--main-font);
   font-weight: var(--semi-bold-font-weight);
   color: var(--brand_secondary_default);
   text-decoration: underline;
   transition: color ease-in-out .2s;
-}
 
-a:visited {
-  color: var(--brand_secondary_default);
-}
+  &:is(:hover, :active) {
+    color: var(--brand_secondary_dark);
+  }
 
-a:hover,
-a:active {
-  color: var(--brand_secondary_dark);
-}
-
-a:link:has(*) {
-  text-decoration: none;
+  &:link:has(*) {
+    text-decoration: none;
+  }
 }
 
 /* Button styles */


### PR DESCRIPTION
Refactored text link `<a>` styles to use more modern CSS.
- Uses the `:is` pseudo selector (read more: [:is](https://developer.mozilla.org/en-US/docs/Web/CSS/:is))
- There are no visual changes with these updates

**Jira ticket:** [ACQ-1282](https://codedotorg.atlassian.net/browse/ACQ-1282)