### PR TITLE
Fix when enoughCourseHours is required

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/ImplementationPlan.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ImplementationPlan.jsx
@@ -103,9 +103,9 @@ ImplementationPlan.associatedFields = [
 ];
 
 const uniqueRequiredFields = {
-  [PROGRAM_CSD]: ['csdWhichGrades'],
-  [PROGRAM_CSP]: ['cspWhichGrades', 'cspHowOffer'],
-  [PROGRAM_CSA]: ['csaWhichGrades', 'csaHowOffer'],
+  [PROGRAM_CSD]: ['csdWhichGrades', 'enoughCourseHours'],
+  [PROGRAM_CSP]: ['cspWhichGrades', 'cspHowOffer', 'enoughCourseHours'],
+  [PROGRAM_CSA]: ['csaWhichGrades', 'csaHowOffer', 'enoughCourseHours'],
 };
 
 ImplementationPlan.getDynamicallyRequiredFields = data => {

--- a/apps/src/code-studio/pd/application/teacher/ImplementationPlan.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ImplementationPlan.jsx
@@ -103,16 +103,19 @@ ImplementationPlan.associatedFields = [
 ];
 
 const uniqueRequiredFields = {
-  [PROGRAM_CSD]: ['csdWhichGrades', 'enoughCourseHours'],
-  [PROGRAM_CSP]: ['cspWhichGrades', 'cspHowOffer', 'enoughCourseHours'],
-  [PROGRAM_CSA]: ['csaWhichGrades', 'csaHowOffer', 'enoughCourseHours'],
+  [PROGRAM_CSD]: ['csdWhichGrades'],
+  [PROGRAM_CSP]: ['cspWhichGrades', 'cspHowOffer'],
+  [PROGRAM_CSA]: ['csaWhichGrades', 'csaHowOffer'],
 };
 
 ImplementationPlan.getDynamicallyRequiredFields = data => {
   const requiredFields = ['willTeach'];
 
-  if (data.program && data.willTeach === 'Yes') {
-    requiredFields.push(...uniqueRequiredFields[data.program]);
+  if (data.willTeach === 'Yes') {
+    requiredFields.push('enoughCourseHours');
+    if (data.program) {
+      requiredFields.push(...uniqueRequiredFields[data.program]);
+    }
   }
 
   return requiredFields;

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -682,7 +682,6 @@ module Pd::Application
         previous_yearlong_cdo_pd
 
         program
-        enough_course_hours
 
         gender_identity
         race
@@ -709,6 +708,7 @@ module Pd::Application
 
         # If the applicant will teach the course, we require extra information
         if hash[:will_teach] == 'Yes'
+          required << :enough_course_hours
           if hash[:program] == PROGRAMS[:csd]
             required << :csd_which_grades
           elsif hash[:program] == PROGRAMS[:csp]


### PR DESCRIPTION
Fixes an issue where selecting anything other than "Yes" to the question "Are you planning to teach this course...?" prevented the application from being submitted. The issue was that `enoughCourseHours` should only be required when the answer to that question is "Yes". I tested locally and confirmed this fix worked.