### PR TITLE
Alt Text Update part Three

### DIFF
--- a/apps/src/lib/tools/jsdebugger/DebugButtons.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugButtons.jsx
@@ -114,10 +114,6 @@ export default connect(
               onClick={this.togglePause}
               style={{display: canRunNext ? 'inline-block' : 'none'}}
             >
-              {
-                // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-                // Verify or update this alt-text as necessary
-              }
               <img
                 src="/blockly/media/1x1.gif"
                 className="continue-btn icon21"
@@ -136,10 +132,6 @@ export default connect(
               disabled={!isPaused || !isAttached || isEditWhileRun}
               title={isEditWhileRun ? i18n.editDuringRunMessage() : undefined}
             >
-              {
-                // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-                // Verify or update this alt-text as necessary
-              }
               <img
                 src="/blockly/media/1x1.gif"
                 className="step-over-btn icon21"
@@ -156,10 +148,6 @@ export default connect(
               disabled={!isPaused || !isAttached || isEditWhileRun}
               title={isEditWhileRun ? i18n.editDuringRunMessage() : undefined}
             >
-              {
-                // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-                // Verify or update this alt-text as necessary
-              }
               <img
                 src="/blockly/media/1x1.gif"
                 className="step-out-btn icon21"
@@ -178,10 +166,6 @@ export default connect(
               disabled={(!isPaused && isAttached) || isEditWhileRun}
               title={isEditWhileRun ? i18n.editDuringRunMessage() : undefined}
             >
-              {
-                // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-                // Verify or update this alt-text as necessary
-              }
               <img
                 src="/blockly/media/1x1.gif"
                 className="step-in-btn icon21"

--- a/apps/src/turtle/ArtistVisualizationColumn.jsx
+++ b/apps/src/turtle/ArtistVisualizationColumn.jsx
@@ -54,10 +54,6 @@ export default class ArtistVisualizationColumn extends React.Component {
             {
               ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
             }
-            {
-              // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-              // Verify or update this alt-text as necessary
-            }
             <img
               id="spinner"
               style={styles.invisible}


### PR DESCRIPTION
This is a part three to the alt text update project. See [part 2 here](https://github.com/code-dot-org/code-dot-org/pull/55523). 

I removed the comments on the debug buttons. These images are not useful in addition to the information already provided by a button label, so should not have alt text. 

I also removed the comments for the spinner in the visualization column. The loader isn't visible most of the time, and is only decorative.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
