### PR TITLE
Maintain URL params when redirecting an unversioned course URL

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -163,7 +163,11 @@ class CoursesController < ApplicationController
     # When the url of a course family is requested, redirect to a specific course version.
     if UnitGroup.family_names.include?(params[:course_name])
       unit_group = UnitGroup.latest_stable_version(params[:course_name])
-      redirect_to action: params[:action], course_name: unit_group.name if unit_group
+      if unit_group
+        redirect_path = url_for(action: params[:action], course_name: unit_group.name)
+        redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"
+        redirect_to "#{redirect_path}#{redirect_query_string}"
+      end
     end
 
     unit_group

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -141,6 +141,16 @@ class CoursesControllerTest < ActionController::TestCase
     assert_redirected_to '/courses/csd-2019'
   end
 
+  test "show: redirect to latest stable version in course family with params" do
+    offering = create :course_offering, key: 'csp'
+    ug2019 = create :unit_group, name: 'csp-2019', family_name: 'csp', version_year: '2019', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    create :course_version, course_offering: offering, content_root: ug2019, key: '2019'
+    ug2020 = create :unit_group, name: 'csp-2020', family_name: 'csp', version_year: '2020', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
+    create :course_version, course_offering: offering, content_root: ug2020, key: '2020'
+    get :show, params: {course_name: 'csp', url_param: 'foo'}
+    assert_redirected_to '/courses/csp-2019?url_param=foo'
+  end
+
   test "get_unit_group for family name with no stable versions does not redirect" do
     Rails.cache.delete("course_version/course_offering_keys/UnitGroup")
     offering = create :course_offering, key: 'csd'


### PR DESCRIPTION
Makes a URL like `/course/csd?viewAs=Instructor` redirect to the latest version of CSD, while maintaining the URL params. This was largely modeled off of similar behavior in scripts_controller [here](https://github.com/code-dot-org/code-dot-org/blob/7b231c450144e49b7762d103f6c8a677b40f64db/dashboard/app/controllers/scripts_controller.rb#L22).