### PR TITLE
Put curriculum_launch_skinny_banner partial back on the homepage

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/banners-curriculum-launch-2023.scss
+++ b/pegasus/sites.v3/code.org/public/css/banners-curriculum-launch-2023.scss
@@ -1,0 +1,93 @@
+@import 'breakpoints.scss';
+
+// Skinny banner
+.curriculum-banner-skinny {
+  box-sizing: content-box;
+  height: 130px;
+  background: url("/images/banners/banner-bg-school-supplies-dark-black.png") center repeat;
+  background-size: cover;
+  margin: 0 5px 16px;
+
+  @media screen and (max-width: $width-lg) {
+    padding: 0 1.5em;
+  }
+
+  @media screen and (max-width: $width-sm) {
+    padding: 2em;
+    height: unset;
+  }
+
+  a:hover,
+  a:active,
+  a:visited,
+  a:link {
+    text-decoration: none;
+  }
+
+  .wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    max-width: 1020px;
+    margin: 0 auto;
+    gap: 1.5em 1em;
+
+    @media screen and (max-width: $width-sm) {
+      justify-content: center;
+    }
+  }
+
+  img {
+    width: 105px;
+  }
+
+  .text-wrapper {
+    text-align: center;
+    width: 60%;
+
+    @media screen and (max-width: $width-sm) {
+      width: 98%;
+    }
+
+    h1 {
+      font-size: 1.75em;
+      font-family: var(--barlowSemiCondensed-semibold);
+      line-height: 1.2;
+      color: var(--neutral_white);
+      margin: 0 auto 6px;
+
+      @media screen and (max-width: $width-md) {
+        font-size: 1.5em;
+      }
+
+      @media screen and (max-width: $width-sm) {
+        font-size: 1.75em;
+      }
+    }
+
+    p {
+      font-family: var(--main-font);
+      font-weight: var(--regular-font-weight);
+      font-size: 1.15em;
+      line-height: 1.3;
+      margin-bottom: 0;
+      color: var(--neutral_white);
+
+      @media screen and (max-width: $width-md) {
+        font-size: 1em;
+      }
+    }
+  }
+
+  button {
+    background: var(--neutral_white);
+    border-color: var(--neutral_white);
+    color: var(--neutral_dark);
+    font-family: var(--main-font);
+    font-weight: var(--semi-bold-font-weight);
+    height: unset;
+    padding: 0.625em 1.5em;
+    margin: 0;
+  }
+}

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -33,7 +33,7 @@ style_min: true
   - else
     = view :homepage_below_hero_announcement
 
-  = view :homepage_tenth_anniversary
+  = view :curriculum_launch_skinny_banner
   = view :homepage_sections
   = view :homepage_gallery
   = view :homepage_supporters

--- a/pegasus/sites.v3/code.org/views/curriculum_launch_skinny_banner.haml
+++ b/pegasus/sites.v3/code.org/views/curriculum_launch_skinny_banner.haml
@@ -1,0 +1,12 @@
+= inline_css 'generated/banners-curriculum-launch-2023.css'
+
+.curriculum-banner-skinny
+  %a{href: CDO.studio_url("/catalog")}
+    .wrapper
+      %img{src: "/images/banners/banner-curriculum-catalog-illustration-black.png", alt: ""}
+      .text-wrapper
+        %h1=hoc_s(:curriculum_launch_2023_title)
+        %p=hoc_s(:curriculum_launch_2023_desc)
+      .button-wrapper
+        %button=hoc_s(:call_to_action_learn_more)
+.clear


### PR DESCRIPTION
The Curriculum Catalog skinny banner was removed in [this PR](https://github.com/code-dot-org/code-dot-org/pull/55604), but I realized it should stay!

<img width="1238" alt="Screenshot 2024-01-08 at 8 31 57 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/f81aeb9c-bb98-44c8-89bf-bb41f3a5dce4">
