### PR TITLE
set published: true when creating new level from within lesson editor

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/CreateNewLevelInputs.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/CreateNewLevelInputs.jsx
@@ -49,6 +49,7 @@ export default class CreateNewLevelInputs extends Component {
         data: JSON.stringify({
           type: this.state.levelType,
           name: this.state.levelName,
+          published: true,
         }),
         contentType: 'application/json;charset=UTF-8',
       })


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/TEACH-785. Fixes the problem where creating a level from within the lesson editor fails to create a new level file:
![image (13)](https://github.com/code-dot-org/code-dot-org/assets/8001765/eb7e282c-0529-4d4f-9f59-f468a1b23204)

debugging notes here: https://codedotorg.slack.com/archives/C045UAX4WKH/p1704479715689099?thread_ts=1704401708.665399&cid=C045UAX4WKH

## Testing story

verified locally that level files are now created after clicking "Create and Add"