### PR TITLE
Fix mobile menu hidden overflow issue

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
@@ -1,9 +1,5 @@
 @import 'color.scss', 'font.scss', 'breakpoints.scss';
 
-#homepage #hero {
-  overflow: hidden;
-}
-
 #pageheader-wrapper #pageheader {
   position: relative;
   z-index: 10;


### PR DESCRIPTION
Fixes the top nav menu dropdown from showing fully on mobile.

**Jira ticket:** [ACQ-1328](https://codedotorg.atlassian.net/browse/ACQ-1328)

----

| Before | After |
| ------ | ----- |
| <img width="397" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/83e770ff-1e19-4228-a608-aa7110046112"> | <img width="397" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/bea2101f-bc6c-4437-9150-35eb5a8a8dd5"> |

