### PR TITLE
hide level edit controls on standalone projects

### DIFF
--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -8,7 +8,7 @@
       %li= link_to "see callouts (#{@level.available_callouts(@script_level).count})", show_callouts: '1'
       - if @level.is_a? Gamelab
         %li= link_to 'view animation JSON', '', onclick: 'window.viewExportableAnimationList(); return false'
-      - if Rails.application.config.levelbuilder_mode
+      - if Rails.application.config.levelbuilder_mode  && !params[:channel_id]
         - if can? :edit, @level
           %li
             = link_to '[E]dit', edit_level_path(@level), { accesskey: 'e', title: "Edit this level. Can use the browser-dependent accesskey shortcut for quick access." }

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -8,6 +8,9 @@
       %li= link_to "see callouts (#{@level.available_callouts(@script_level).count})", show_callouts: '1'
       - if @level.is_a? Gamelab
         %li= link_to 'view animation JSON', '', onclick: 'window.viewExportableAnimationList(); return false'
+      -# take away the option to edit the level if we are on a projects page, as opposed to a level or script level page,
+      -# because curriculum writers usually don't need to make these kinds of edits and accidental edits to the underlying
+      -# STANDALONE_PROJECTS levels can be very disruptive. see routes.rb to see why channel_id is set only on projects pages.
       - if Rails.application.config.levelbuilder_mode  && !params[:channel_id]
         - if can? :edit, @level
           %li

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -8,10 +8,10 @@
       %li= link_to "see callouts (#{@level.available_callouts(@script_level).count})", show_callouts: '1'
       - if @level.is_a? Gamelab
         %li= link_to 'view animation JSON', '', onclick: 'window.viewExportableAnimationList(); return false'
-      -# take away the option to edit the level if we are on a projects page, as opposed to a level or script level page,
-      -# because curriculum writers usually don't need to make these kinds of edits and accidental edits to the underlying
-      -# STANDALONE_PROJECTS levels can be very disruptive. see routes.rb to see why channel_id is set only on projects pages.
-      - if Rails.application.config.levelbuilder_mode  && !params[:channel_id]
+      -# Curriculum writers rarely need to edit STANDALONE_PROJECTS levels, and accidental edits to these levels
+      -# can be quite disruptive. As a workaround you can navigate directly to the edit url for these levels.
+      - is_standalone_project = ProjectsController::STANDALONE_PROJECTS.values.map {|h| h[:name]}.include?(@level.name)
+      - if Rails.application.config.levelbuilder_mode  && !is_standalone_project
         - if can? :edit, @level
           %li
             = link_to '[E]dit', edit_level_path(@level), { accesskey: 'e', title: "Edit this level. Can use the browser-dependent accesskey shortcut for quick access." }


### PR DESCRIPTION
see [slack](https://codedotorg.slack.com/archives/C05DMS18MEX/p1704724584483279) for background. we recently had an incident where a curriculum writer accidentally clicked the "edit" button when viewing a standalone project, and this unintentionally changed the level which all users see when they create a new project of that type:
![Screenshot 2024-01-08 at 11 48 36 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/cb629c98-c2aa-429e-ad23-064665c183b9)

The fix is to hide these controls when viewing standalone projects, since levelbuilders should rarely (if ever) need to edit these levels:
| before | after |
|--------|--------|
| ![Screenshot 2024-01-08 at 11 43 34 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/43272d4a-725e-456f-b81d-4a7dfaaec2b3) | ![Screenshot 2024-01-08 at 11 44 55 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/4d521853-3d61-4f47-b3f3-990ff303ffd5) | 

if you really want to edit the level, you can click the link `/levels/12345` and then append `/edit` to the url, e.g. `/levels/12345/edit`.

## Testing story

* manual verification shown in screenshots
* also made sure edit / delete / clone still show up on a random other script level page