### PR TITLE
Include user name in abuse reports

### DIFF
--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -25,7 +25,6 @@ const alert = window.alert;
 export default class ReportAbuseForm extends React.Component {
   static propTypes = {
     abuseUrl: PropTypes.string.isRequired,
-    name: PropTypes.string,
     email: PropTypes.string,
     age: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     requireCaptcha: PropTypes.bool,
@@ -106,7 +105,6 @@ export default class ReportAbuseForm extends React.Component {
             name="channel_id"
             defaultValue={this.getChannelId()}
           />
-          <input type="hidden" name="name" defaultValue={this.props.name} />
           <div style={{display: this.props.email ? 'none' : 'block'}}>
             <label htmlFor="uitest-email">{msg.email()}</label>
             <input

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -40,7 +40,7 @@ class ReportAbuseController < ApplicationController
         return head :forbidden
       end
 
-      name = current_user&.name
+      name = current_user&.name || ''
       email = current_user&.email
       age = current_user&.age
       username = current_user&.username

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -43,6 +43,7 @@ class ReportAbuseController < ApplicationController
       name = current_user&.name
       email = current_user&.email
       age = current_user&.age
+      username = current_user&.username
       abuse_url = CDO.studio_url(params[:abuse_url], CDO.default_scheme)
 
       # submit abuse reports from
@@ -51,7 +52,7 @@ class ReportAbuseController < ApplicationController
       if email.nil? || email == ''
         email = UNKNOWN_ACCOUNT_ZENDESK_REPORT_EMAIL
       end
-      send_abuse_report(name, email, age, abuse_url)
+      send_abuse_report(name, email, age, abuse_url, username)
       update_abuse_score
 
       return head :ok
@@ -66,7 +67,8 @@ class ReportAbuseController < ApplicationController
         return
       end
 
-      send_abuse_report(params[:name], params[:email], params[:age], params[:abuse_url])
+      username = current_user&.username
+      send_abuse_report(params[:name], params[:email], params[:age], params[:abuse_url], username)
       update_abuse_score
     end
     redirect_to "https://support.code.org"
@@ -170,7 +172,7 @@ class ReportAbuseController < ApplicationController
     abuse_score
   end
 
-  private def send_abuse_report(name, email, age, abuse_url)
+  private def send_abuse_report(name, email, age, abuse_url, username)
     unless Rails.env.development? || Rails.env.test?
       subject = FeaturedProject.featured_channel_id?(params[:channel_id]) ?
         'Featured Project: Abuse Reported' :
@@ -188,6 +190,7 @@ class ReportAbuseController < ApplicationController
             comment: {
               body: [
                 "URL: #{abuse_url}",
+                "username: #{username}",
                 "abuse type: #{params[:abuse_type]}",
                 "user detail:",
                 params[:abuse_detail]

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -67,8 +67,13 @@ class ReportAbuseController < ApplicationController
         return
       end
 
-      username = current_user&.username
-      send_abuse_report(params[:name], params[:email], params[:age], params[:abuse_url], username)
+      send_abuse_report(
+        current_user&.name || '',
+        params[:email],
+        params[:age],
+        params[:abuse_url],
+        current_user&.username
+      )
       update_abuse_score
     end
     redirect_to "https://support.code.org"
@@ -76,7 +81,6 @@ class ReportAbuseController < ApplicationController
 
   def report_abuse_form
     @react_props = {
-      name: current_user&.name,
       email: current_user&.email,
       age: current_user&.age,
       requireCaptcha: require_captcha?,


### PR DESCRIPTION
When submitting an abuse report to Zendesk, include the user name (if available). This change should make abuse report triage easier for our support team (details in ticket).

Example new abuse report (includes username):

<img width="1015" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/eb14bef4-6e66-4a9c-9cff-6e6067bb886c">

## Links

- jira ticket: [LABS-239](https://codedotorg.atlassian.net/browse/LABS-239)

## Testing story

I tested manually submitting tickets as a signed in and signed out user using the report abuse icon available on each project card at /projects, as well as signed in and signed out users at /report_abuse.