### PR TITLE
Create shared constant for Dance Party manifest file name

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -95,7 +95,7 @@ def main
     EMAIL_LINKS
     CHILD_ACCOUNT_COMPLIANCE_STATES
     CENSUS_CONSTANTS
-    DANCE_SONG_MANIFEST
+    DANCE_SONG_MANIFEST_FILENAME
   )
 
   generate_shared_js_file(shared_content, "#{REPO_DIR}/apps/src/util/sharedConstants.js")

--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -95,6 +95,7 @@ def main
     EMAIL_LINKS
     CHILD_ACCOUNT_COMPLIANCE_STATES
     CENSUS_CONSTANTS
+    DANCE_SONG_MANIFEST
   )
 
   generate_shared_js_file(shared_content, "#{REPO_DIR}/apps/src/util/sharedConstants.js")

--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -1,5 +1,6 @@
 import Sounds from '../Sounds';
 import {ageDialogSelectedOver13, songFilterOn} from '../templates/AgeDialog';
+import {DanceSongManifest} from '../util/sharedConstants';
 import {fetchSignedCookies} from '../utils';
 
 const DEPRECATED_SONGS = [
@@ -30,7 +31,7 @@ const DEPRECATED_SONGS = [
 export async function getSongManifest(useRestrictedSongs, manifestFilename) {
   if (!manifestFilename || manifestFilename.length === 0) {
     manifestFilename = useRestrictedSongs
-      ? 'songManifest2023_v4.json'
+      ? DanceSongManifest
       : 'testManifest.json';
   }
 

--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -1,6 +1,6 @@
 import Sounds from '../Sounds';
 import {ageDialogSelectedOver13, songFilterOn} from '../templates/AgeDialog';
-import {DanceSongManifest} from '../util/sharedConstants';
+import {DanceSongManifestFilename} from '../util/sharedConstants';
 import {fetchSignedCookies} from '../utils';
 
 const DEPRECATED_SONGS = [
@@ -31,7 +31,7 @@ const DEPRECATED_SONGS = [
 export async function getSongManifest(useRestrictedSongs, manifestFilename) {
   if (!manifestFilename || manifestFilename.length === 0) {
     manifestFilename = useRestrictedSongs
-      ? DanceSongManifest
+      ? DanceSongManifestFilename
       : 'testManifest.json';
   }
 

--- a/dashboard/app/models/levels/dancelab.rb
+++ b/dashboard/app/models/levels/dancelab.rb
@@ -66,7 +66,7 @@ class Dancelab < GamelabJr
 
   # Used by levelbuilders to set a default song on a Dance Party level.
   def self.hoc_songs
-    manifest_json = AWS::S3.create_client.get_object(bucket: 'cdo-sound-library', key: "hoc_song_meta/#{DANCE_SONG_MANIFEST}")[:body].read
+    manifest_json = AWS::S3.create_client.get_object(bucket: 'cdo-sound-library', key: "hoc_song_meta/#{DANCE_SONG_MANIFEST_FILENAME}")[:body].read
     manifest = JSON.parse(manifest_json)
     manifest['songs'].map do |song|
       name = song['text']

--- a/dashboard/app/models/levels/dancelab.rb
+++ b/dashboard/app/models/levels/dancelab.rb
@@ -66,7 +66,7 @@ class Dancelab < GamelabJr
 
   # Used by levelbuilders to set a default song on a Dance Party level.
   def self.hoc_songs
-    manifest_json = AWS::S3.create_client.get_object(bucket: 'cdo-sound-library', key: 'hoc_song_meta/songManifest2023_v4.json')[:body].read
+    manifest_json = AWS::S3.create_client.get_object(bucket: 'cdo-sound-library', key: "hoc_song_meta/#{DANCE_SONG_MANIFEST}")[:body].read
     manifest = JSON.parse(manifest_json)
     manifest['songs'].map do |song|
       name = song['text']

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -645,4 +645,9 @@ module SharedConstants
   CENSUS_CONSTANTS = OpenStruct.new(
     {CURRENT_CENSUS_SCHOOL_YEAR: 2023}
   )
+
+  # Current song manifest file name for Dance Party. Note that different manifests
+  # can be tested using query params (?manifest=...), but once this value is updated
+  # the default manifest will change for all users.
+  DANCE_SONG_MANIFEST = 'songManifest2023_v4.json'
 end

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -649,5 +649,5 @@ module SharedConstants
   # Current song manifest file name for Dance Party. Note that different manifests
   # can be tested using query params (?manifest=...), but once this value is updated
   # the default manifest will change for all users.
-  DANCE_SONG_MANIFEST = 'songManifest2023_v4.json'
+  DANCE_SONG_MANIFEST_FILENAME = 'songManifest2023_v4.json'
 end


### PR DESCRIPTION
Create a shared constant for the Dance Party manifest file name that can be referenced from both apps code (which drives the song dropdown) and dashboard code (which drives the song selection on the level edit page). Whenever we update the manifest name, we need to update both of these values, so I figured it would be good to have a single source of truth.

## Testing story

Tested locally on Dance levels and Dance edit pages. No user-facing changes.