### PR TITLE
Bump dance party to v2

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -55,7 +55,7 @@
     "@code-dot-org/artist": "0.2.1",
     "@code-dot-org/blockly": "4.0.14",
     "@code-dot-org/craft": "0.2.2",
-    "@code-dot-org/dance-party": "1.1.1",
+    "@code-dot-org/dance-party": "2.0.0",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "2.16.0",
     "@code-dot-org/ml-activities": "0.0.26",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -2264,10 +2264,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@code-dot-org/dance-party@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@code-dot-org/dance-party@npm:1.1.1"
-  checksum: 4aec7af969d2fd59ae8544d138687455de400e8ac50cfd1ceabb01da940cfcfbbf85eafd12ab4cac1638a45fa94db807277f265c3845cb9f57c6e0ced1c81455
+"@code-dot-org/dance-party@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@code-dot-org/dance-party@npm:2.0.0"
+  checksum: 95b6f2f771e53517beee69d09881d0b37724daac4e9209f1be4b70e8b700d2090e7275ad754a42052f674c9ce05f59ff97fa6bae1044e8d7206bbefd7131ce87
   languageName: node
   linkType: hard
 
@@ -7782,7 +7782,7 @@ __metadata:
     "@code-dot-org/artist": 0.2.1
     "@code-dot-org/blockly": 4.0.14
     "@code-dot-org/craft": 0.2.2
-    "@code-dot-org/dance-party": 1.1.1
+    "@code-dot-org/dance-party": 2.0.0
     "@code-dot-org/johnny-five": 2.1.0-cdo.3
     "@code-dot-org/js-interpreter": 1.3.13
     "@code-dot-org/js-numbers": 0.1.0-cdo.0


### PR DESCRIPTION
Bumps us to `dance-party` 2.0.0, which includes a refactor of our effects code that breaks our external API (but in a way that does not require changes to `code-dot-org`, but will require us to change the code in `p5-replay` [here at some point](https://github.com/code-dot-org/p5-replay/blob/d26c5b120cf1799a089237918045c3ade794945b/src/replayToMovie.js#L108-L109).

More detail on the changes in the new version of `dance-party` in release notes here: https://github.com/code-dot-org/dance-party/releases/tag/v2.0.0

Functionally, there should be no change as a result of this PR.

## Links

- jira ticket: [LABS-281](https://codedotorg.atlassian.net/browse/LABS-281)

## Testing story

I tested a handful of effects (in preview/regular mode) in a standalone dance party project, which continued to work correctly. I did a lot of manual testing when working on this before merging into the `dance-party` repo, as well as unit tests there that cover individual effect behavior.