### PR TITLE
Fix: Rename localhost->studio in dance modal eyes test

### DIFF
--- a/dashboard/test/ui/features/star_labs/dance/dance_ai_modal_eyes.feature
+++ b/dashboard/test/ui/features/star_labs/dance/dance_ai_modal_eyes.feature
@@ -26,7 +26,7 @@ Feature: Dance Party AI Modal Eyes
     And I see no difference for "selecting new emojis"
 
     # In RTL language
-    Then I am on "http://localhost-studio.code.org:3000/s/allthethings/lessons/37/levels/4/lang/ar-sa"
+    Then I am on "http://studio.code.org/s/allthethings/lessons/37/levels/4/lang/ar-sa"
     And I wait for the page to fully load
     # Toggle to code in RTL
     And I click block field "[data-id='setup'] > [data-id='dance_ai'] > .blocklyEditableText"


### PR DESCRIPTION
This test should reference `studio.code.org` instead of localhost, which I believe is causing the following timeout: https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_star_labs_dance_dance_ai_modal_eyes_eyes_output.html?versionId=WlziMuptbGsXN.XaUbRP3bFb4Ejkh42a

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
