### PR TITLE
Clean up .button-wrapper class on code.org

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -154,6 +154,10 @@ hr {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
+
+  &.centered {
+    justify-content: center;
+  }
 }
 
 // Basic hero banner

--- a/pegasus/sites.v3/code.org/public/districts.haml
+++ b/pegasus/sites.v3/code.org/public/districts.haml
@@ -43,7 +43,7 @@ theme: responsive_full_width
         %li Invest in teachers and administrators through <a href="/educate/professional-learning" target="_blank" rel="noopener noreferrer">high-quality professional learning</a> experiences
         %li Tap into the energy, aspirations, and potential of all students to close equity gaps in computer science education and career pathways
         %li Align with the education-to-workforce priorities of employers and policymakers
-      .button-wrapper.flex-container
+      .button-wrapper
         %a.link-button{href: url_learn_more} Learn more
         %a.link-button.secondary{href: url_enroll_now, target: "_blank", rel: "noopener noreferrer"} Enroll now
     %div.col-45{style: "float:right; margin-top: 3px"}
@@ -105,7 +105,7 @@ theme: responsive_full_width
         .text-wrapper
           %h3 Scholarships for schools serving underserved students
           %p Access to $1.5M in Professional Learning scholarships for teachers serving students traditionally underrepresented in CS.
-    .button-wrapper.flex-container.justify-center
+    .button-wrapper.centered
       %a.link-button{href: url_learn_more} Learn more
       %a.link-button.secondary{href: url_enroll_now, target: "_blank", rel: "noopener noreferrer"} Enroll now
 

--- a/pegasus/sites.v3/code.org/public/donate/index.haml
+++ b/pegasus/sites.v3/code.org/public/donate/index.haml
@@ -72,7 +72,7 @@ theme: responsive_full_width
       %img{src: "/images/avatars/coinbase.png", alt: hoc_s(:coinbase_logo_alt)}
       %img{src: "/images/avatars/ballmer_group.png", alt: hoc_s(:ballmer_group_logo_alt)}
       %img{src: "/images/avatars/vista_equity_partners.png", alt: hoc_s(:vista_equity_partners_logo_alt)}
-    .button-wrapper.flex-container.justify-center
+    .button-wrapper.centered
       %a.link-button.has-external-link{href: "https://donate.code.org/campaign/support-computer-science-education/c172233", target: "_blank", rel: "noopener noreferrer"}
         =hoc_s(:call_to_action_donate)
       %a.link-button.secondary{href: "/about/supporters"}

--- a/pegasus/sites.v3/code.org/public/help.haml
+++ b/pegasus/sites.v3/code.org/public/help.haml
@@ -27,7 +27,7 @@ theme: responsive_full_width
   .wrapper.centered
     %h2=hoc_s(:help_page_partners_heading)
     %p=hoc_s(:help_page_partners_desc)
-    .button-wrapper.flex-container.justify-center
+    .button-wrapper.centered
       %a.link-button{href: "/educate/regional-partner"}
         =hoc_s(:call_to_action_become_partner_usa)
       %a.link-button{href: "/international/apply"}

--- a/pegasus/sites.v3/code.org/public/teach.haml
+++ b/pegasus/sites.v3/code.org/public/teach.haml
@@ -85,7 +85,7 @@ theme: responsive_full_width
     %hr.dark
     %div.centered
       %h4=hoc_s(:teach_page_free_curriculum_heading_02)
-      %div.flex-container.justify-center.wrap{style: "gap: 1rem"}
+      .button-wrapper.centered
         %a.link-button{href: "/educate/curriculum/elementary-school"}
           =hoc_s(:grade_level_label_elementary)
         %a.link-button{href: "/educate/curriculum/middle-school"}


### PR DESCRIPTION
Cleans up the `.button-wrapper` container class on pages that use it. Also adds a `.centered` class to use instead of inline `flex-container` classes.

This won't cause any visual differences. 

**Jira ticket:** [ACQ-1136](https://codedotorg.atlassian.net/browse/ACQ-1136)