### PR TITLE
Refactor .has-external-link class

### DIFF
--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -336,22 +336,13 @@ input[type=submit] {
 a.has-external-link::after {
   font: var(--fa-font-solid);
   content: "\f08e";
-  margin: 0 2px 0 4px;
-}
-
-html[dir="rtl"] .has-external-link a::after,
-html[dir="rtl"] a.has-external-link::after {
-  margin: 0 4px 0 2px;
+  font-size: 0.875em;
+  margin-inline: 4px 2px;
 }
 
 .has-external-link a.link-button::after,
 a.link-button.has-external-link::after {
-  margin: 0 0 0 4px;
-}
-
-html[dir="rtl"] .has-external-link a.link-button::after,
-html[dir="rtl"] a.link-button.has-external-link::after {
-  margin: 0 4px 0 0;
+  margin-inline: 4px 0;
 }
 
 li > ul {


### PR DESCRIPTION
Reactors the `.has-external-link` class:
-  Works better with LTR and RTL languages
- Made the icon a but smaller to keep button heights consistent w/ plain buttons

**Jira ticket:** [ACQ-1325](https://codedotorg.atlassian.net/browse/ACQ-1325)

----

## Button
| LTR | RTL |
| -- | -- |
| <img width="500" alt="button-ltr" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/a7d65ecb-3695-4d65-9959-d81e720e6efe"> | <img width="500" alt="button-rtl" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/4ce2130e-3750-4103-a087-a08962da72bc"> |

## Social links
| LTR | RTL |
| -- | -- |
| <img width="500" alt="social-ltr" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/3a59f645-9739-4442-9ddb-90c75afc08db"> | <img width="500" alt="social-rtl" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/17ad649a-34e4-46d4-9b84-dd290385a456"> |

## Inline text links
| LTR | RTL |
| -- | -- |
| <img width="495" alt="inline-ltr" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/22adc5ad-6e5a-44de-b0ba-c80e5618840d"> | <img width="488" alt="inline-rtl" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/97ad7a6c-10ae-4dcb-967f-77c1acb0ca0e"> |

