### PR TITLE
Use Ubuntu 20 in All Managed Environments

### DIFF
--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -27,10 +27,8 @@ module Cdo::CloudFormation
     # Hard-coded constants and default values.
     CHEF_BIN = '/usr/local/bin/chef-cdo-app'
     CHEF_KEY = rack_env?(:adhoc) ? 'adhoc/chef' : 'chef'
-    # Temporarily introduce per-environment differences, so we can gradually roll out this update.
-    # Use Ubuntu 20 (ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230517) for adhocs and our main build pipeline: staging, test, and production
-    # Use Ubuntu 18 (ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1) everywhere else (ie, levelbuilder and gateway)
-    IMAGE_ID = ENV['IMAGE_ID'] || (rack_env?(:staging, :test, :production, :adhoc) ? 'ami-0261755bbcb8c4a84' : 'ami-07d0cf3af28718ef8')
+    # Use AMI for Ubuntu 20 (ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230517)
+    IMAGE_ID = ENV['IMAGE_ID'] || 'ami-0261755bbcb8c4a84'
     INSTANCE_TYPE = rack_env?(:production) ? 'm5.12xlarge' : 't2.2xlarge'
     ORIGIN = "https://github.com/code-dot-org/code-dot-org.git"
     CHEF_VERSION = '17.6.18'


### PR DESCRIPTION
Alternatively, "Update Levelbuilder Environment to use Ubuntu 20".

This PR removes the per-environment logic we added to facilitate a gradual rollout of Ubuntu 20, finally uniting all our environments onto the same version again. Currently, the only managed environment not yet using Ubuntu 20 is Levelbuilder, which this PR will update.

## Links

Rollout plan documentation: https://docs.google.com/document/d/1icoCcfsajs1eqP1w7cymXjsrbC9DIW-1Im6p4EE3OJ8/edit#heading=h.s2ptfnkrfvjz

Previous work:

- https://github.com/code-dot-org/code-dot-org/pull/54269
- https://github.com/code-dot-org/code-dot-org/pull/54271
- https://github.com/code-dot-org/code-dot-org/pull/54272

## Deployment strategy

Because merging this PR will cause the levelbuilder server to be replaced, we plan to do so during a dedicated deployment which will include taking snapshots of the machine and manually scooping any content that might be on it.

## Follow-up work

After this, the only long-running server of ours yet to be updated to Ubuntu 20 is the gateway server, which we plan to update in-place rather than via CloudFormation replacement.