### PR TITLE
Allow either 'Grade' or 'Label' key names in aiproxy response

### DIFF
--- a/dashboard/app/controllers/test_ai_proxy_controller.rb
+++ b/dashboard/app/controllers/test_ai_proxy_controller.rb
@@ -17,7 +17,7 @@ class TestAiProxyController < ApplicationController
     response_data = key_concepts.map do |key_concept|
       {
         'Key Concept' => key_concept,
-        'Grade' => 'Convincing Evidence'
+        'Label' => 'Convincing Evidence'
       }
     end
     render json: {data: response_data}

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -385,10 +385,11 @@ class EvaluateRubricJob < ApplicationJob
       rubric.learning_goals.each do |lg|
         next unless ai_mapping.key?(lg.learning_goal)
         ai_evaluation = ai_mapping[lg.learning_goal]
+        label = ai_evaluation.key?('Grade') ? ai_evaluation['Grade'] : ai_evaluation['Label']
         LearningGoalAiEvaluation.create!(
           learning_goal_id: lg.id,
           rubric_ai_evaluation_id: rubric_ai_evaluation.id,
-          understanding: understanding_s_to_i(ai_evaluation['Grade']),
+          understanding: understanding_s_to_i(label),
           ai_confidence: ai_evaluation['Confidence'],
         )
       end

--- a/dashboard/test/controllers/test_ai_proxy_controller_test.rb
+++ b/dashboard/test/controllers/test_ai_proxy_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class TestAiProxyControllerTest < ActionController::TestCase
   test 'assessment: returns convincing evidence for all key concepts' do
     rubric = <<~CSV
-      Key Concept,Grade
+      Key Concept,Label
       Concept 1,
       Concept 2,
       Concept 3,
@@ -14,8 +14,8 @@ class TestAiProxyControllerTest < ActionController::TestCase
 
     response_data = JSON.parse(@response.body)['data']
     assert_equal 3, response_data.count
-    assert_equal 'Convincing Evidence', response_data[0]['Grade']
-    assert_equal 'Convincing Evidence', response_data[1]['Grade']
-    assert_equal 'Convincing Evidence', response_data[2]['Grade']
+    assert_equal 'Convincing Evidence', response_data[0]['Label']
+    assert_equal 'Convincing Evidence', response_data[1]['Label']
+    assert_equal 'Convincing Evidence', response_data[2]['Label']
   end
 end

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -298,7 +298,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       'model' => 'gpt-4-0613',
       'remove-comments' => '1',
       'num-responses' => '3',
-      'num-passing-levels' => '2',
+      'num-passing-labels' => '2',
       'temperature' => '0.2'
     }.to_json
     bucket = {
@@ -341,7 +341,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       "model" => "gpt-4-0613",
       "remove-comments" => "1",
       "num-responses" => "3",
-      "num-passing-levels" => "2",
+      "num-passing-labels" => "2",
       "temperature" => "0.2",
       "code" => code,
       "prompt" => 'fake-system-prompt',

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -13,7 +13,8 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     @rubric = create :rubric, level: @script_level.level, lesson: @script_level.lesson
     create :learning_goal, rubric: @rubric, learning_goal: 'learning-goal-1'
     create :learning_goal, rubric: @rubric, learning_goal: 'learning-goal-2'
-    assert_equal 2, @rubric.learning_goals.count
+    create :learning_goal, rubric: @rubric, learning_goal: 'learning-goal-3'
+    assert_equal 3, @rubric.learning_goals.count
 
     # Don't actually talk to S3 when running SourceBucket.new
     AWS::S3.stubs :create_client
@@ -291,12 +292,13 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     fake_confidence_levels = {
       'learning-goal-1': "MEDIUM",
       'learning-goal-2': "MEDIUM",
+      'learning-goal-3': "MEDIUM",
     }.to_json
     fake_params = {
       'model' => 'gpt-4-0613',
       'remove-comments' => '1',
       'num-responses' => '3',
-      'num-passing-grades' => '2',
+      'num-passing-levels' => '2',
       'temperature' => '0.2'
     }.to_json
     bucket = {
@@ -339,7 +341,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       "model" => "gpt-4-0613",
       "remove-comments" => "1",
       "num-responses" => "3",
-      "num-passing-grades" => "2",
+      "num-passing-levels" => "2",
       "temperature" => "0.2",
       "code" => code,
       "prompt" => 'fake-system-prompt',
@@ -355,6 +357,10 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       {
         'Key Concept' => 'learning-goal-2',
         'Grade' => 'Extensive Evidence'
+      },
+      {
+        'Key Concept' => 'learning-goal-3',
+        'Label' => 'Extensive Evidence'
       }
     ]
     ai_proxy_origin = 'http://fake-ai-proxy-origin'


### PR DESCRIPTION
Small PR to allow either "Grade" or "Label" key names in the aiproxy response while we switch to using conventional ML terms

## Links

Related to: https://github.com/code-dot-org/aiproxy/pull/33#pullrequestreview-1806889570
Jira ticket: https://codedotorg.atlassian.net/browse/AITT-405

## Testing story

Updated test to add a learning goal response with the key "Label"

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
