### PR TITLE
Hide applications closed banner after changing RP and add tests

### DIFF
--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -95,7 +95,6 @@ const FormController = props => {
     ...getInitialStored(sessionStorageKey, 'data'),
     ...getInitialData(),
   }));
-  console.log(data);
   const [regionalPartner] = useRegionalPartner(data);
   const [submitting, setSubmitting] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -129,9 +128,7 @@ const FormController = props => {
   // when updating regional partner, determine if we should show
   // the application closed message
   useEffect(() => {
-    console.log('regionalPartner', regionalPartner);
     if (regionalPartner?.are_apps_closed) {
-      console.log('applications are closed!');
       setShowApplicationClosedMessage(true);
       scrollToTop();
       return;

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -95,6 +95,7 @@ const FormController = props => {
     ...getInitialStored(sessionStorageKey, 'data'),
     ...getInitialData(),
   }));
+  console.log(data);
   const [regionalPartner] = useRegionalPartner(data);
   const [submitting, setSubmitting] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -125,12 +126,17 @@ const FormController = props => {
     onSetPageInternal(initialPage);
   }, [onInitialize, onSetPageInternal, initialPage]);
 
-  // on matching to an RP with apps closed
+  // when updating regional partner, determine if we should show
+  // the application closed message
   useEffect(() => {
+    console.log('regionalPartner', regionalPartner);
     if (regionalPartner?.are_apps_closed) {
+      console.log('applications are closed!');
       setShowApplicationClosedMessage(true);
       scrollToTop();
       return;
+    } else {
+      setShowApplicationClosedMessage(false);
     }
   }, [regionalPartner]);
 

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -276,9 +276,6 @@ describe('FormController', () => {
     });
 
     it('Shows apps closed message if', async () => {
-      //const server = sinon.fakeServer.create();
-      //server.respondWith(serverResponse(200, {}));
-
       sinon.stub(window, 'fetch').returns(
         Promise.resolve({
           ok: true,


### PR DESCRIPTION
Resolves an issue found in the bug bash where, if a user selects an RP who has closed applications then switches to an RP that still has open applications, the application closed banner doesn't go away ([task](https://codedotorg.atlassian.net/browse/ACQ-1338)). In doing this change, I realized I already had a [task](https://codedotorg.atlassian.net/browse/ACQ-580) to add tests to this part of the code base.

To write those tests, I took what Meg tried in https://github.com/code-dot-org/code-dot-org/pull/51631/commits/82823f6578aebdf202696805044bfcac79dcd9ff (linked from https://github.com/code-dot-org/code-dot-org/pull/51631) and updated it to pass. I then added a second test to test switching RPs.

