### PR TITLE
[Google Blockly] Stop serializing Edit button fields. Start serializing name fields.

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
@@ -85,6 +85,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
     helpUrl: '/docs/spritelab/spritelab_adding-and-removing-behaviors',
     extensions: [
       'procedures_edit_button',
+      'procedure_caller_serialize_name',
       'procedure_caller_get_def_mixin',
       'procedure_caller_var_mixin',
       'procedure_caller_update_shape_mixin',

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -81,6 +81,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
     helpUrl: '/docs/spritelab/codestudio_callingFunction',
     extensions: [
       'procedures_edit_button',
+      'procedure_caller_serialize_name',
       'procedure_caller_get_def_mixin',
       'procedure_caller_var_mixin',
       'procedure_caller_update_shape_mixin',
@@ -121,9 +122,20 @@ GoogleBlockly.Extensions.register('procedures_edit_button', function () {
       colorOverrides: {button: 'blue', text: 'white'},
       allowReadOnlyClick: true, // We support showing the editor even if viewing in read only mode.
     });
+    button.EDITABLE = false;
+    button.SERIALIZABLE = false;
     this.inputList[this.inputList.length - 1].appendField(button, 'EDIT');
   }
 });
+
+// This extension make the NAME fields of caller/getter blocks serializable.
+GoogleBlockly.Extensions.register(
+  'procedure_caller_serialize_name',
+  function () {
+    const labelField = this.getField('NAME');
+    labelField.SERIALIZABLE = true;
+  }
+);
 
 // This extension renders function and behavior definitions as mini toolboxes
 // The only toolbox blocks are a comment (for functions) or a comment + "this sprite" block (for behaviors)


### PR DESCRIPTION
I've noticed that whenever we save procedure callers as JSON, we are serializing the edit button field unnecessarily.

This hasn't seemed problematic, but I did find a case where it leads to some unexpected behavior. Because we were saving the translated value (e.g. 'Edit'), we were forcing the project to always use that value for that block even if it was later translated. The last value of the field is irrelevant since we can translate it freshly on load. See video:

https://github.com/code-dot-org/code-dot-org/assets/43474485/377c9072-59f6-424b-bd30-efac3d938782

Similarly, but the opposite case, we have not been serializing the name fields. By doing so, we can better align to the XML serialization that CDO Blockly supports. Doing so is also necessary if we want a levelbuilder to be able to get comprehensive block XML for a procedure block once we are on Google Blockly. While we aren't saving workspaces with XML, we still should be able to serialize individual blocks correctly, for tasks like embedding blocks in instructions.

This table demonstrates the differences between serializations of the same `growing` block, shown selected below:
<img width="225" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/d32f27d3-7ce5-4831-a486-be7046124f40">

<table>
<tbody>
<tr >
<td >
</td>
<td>CDO XML (Baseline)</td>
<td>Staging XML</td>
<td>Branch XML</td>
<td>Staging JSON</td>
<td>Branch JSON</td>
</tr>
<tr>
<td>

```



Serialization



```

</td>
<td>

```
<block type="gamelab_behavior_get">
   <mutation />
   <field name="VAR" id="growing">growing</field>
</block>
```

</td>
<td>

```
<block type="gamelab_behavior_get" id="k5dMADe{*c*nBC_m]0Zs">
   <mutation behaviorId="growing" />
   <field name="EDIT">Edit</field>
</block>
```

</td>
<td>

```
<block type="gamelab_behavior_get" id="=D?`@A[$Z#Qab%!JYEBL">
   <mutation behaviorId="growing" />
   <field name="NAME">growing</field>
</block>
```

</td>
<td>

```
{
    "type": "gamelab_behavior_get",
    "id": "k5dMADe{*c*nBC_m]0Zs",
    "extraState": {
        "behaviorId": "growing",
        "name": "growing"
    },
    "fields": {
        "EDIT": "Edit"
    }
}
```

</td>
<td>

```
{
    "type": "gamelab_behavior_get",
    "id": "=D?`@A[$Z#Qab%!JYEBL",
    "extraState": {
        "behaviorId": "growing",
        "name": "growing"
    },
    "fields": {
        "NAME": "growing"
    }
}
```

</td>
</tr>
<tr>
<td>

`Embedded Block`

</td>
<td>

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/450d826f-0fad-49c7-b39f-cce0686f30e5)

</td>
<td>

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/6e72178a-3c90-412c-bd32-68a5c3f37940)

</td>
<td>

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/2f19d2ac-1e8a-4509-9e99-9ef02c22d7a2)

</td>
<td>n/a</td>
<td>n/a</td>
<td>
</tr>
</tbody>
</table>

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Manually tested loading XML projects, saving, reloading, etc.

Tested levels with embedded blocks and translating a project to non-English.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
