### PR TITLE
HoC - When hoc_mode is false show interest form instead of event registration

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -87,7 +87,7 @@
   social_hoc_anybody: 'Hour of Code: Anybody can Learn'
 
   hoc_interest_form_header: "Get notified when Hour of Code registration opens!"
-  hoc_interest_form_desc: "Be the first to know about this years Hour of Code, including new activities and when registrations for Hour of Code events begin."
+  hoc_interest_form_desc: "Be the first to know about this year's Hour of Code, including new activities and when registrations for Hour of Code events begin."
 
   oceans_landing_title: 'AI for Oceans'
   oceans_landing_description: 'Learn about machine learning and ethical use of AI.'

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -86,6 +86,9 @@
   social_hoc2019_dance: 'Featuring Katy Perry, Shawn Mendes, Panic! At The Disco, Lil Nas X, Jonas Brothers, Nicki Minaj, and 34 more!'
   social_hoc_anybody: 'Hour of Code: Anybody can Learn'
 
+  hoc_interest_form_header: "Get notified when Hour of Code registration opens!"
+  hoc_interest_form_desc: "Be the first to know about this years Hour of Code, including new activities and when registrations for Hour of Code events begin."
+
   oceans_landing_title: 'AI for Oceans'
   oceans_landing_description: 'Learn about machine learning and ethical use of AI.'
   cs_for_good_hashtag: '#CSforGood'

--- a/pegasus/sites.v3/hourofcode.com/public/css/interest-form.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/interest-form.scss
@@ -1,0 +1,62 @@
+@import 'breakpoints';
+
+$border-radius: 4px;
+
+.interest-form {
+  background-color: var(--neutral_dark);
+  border-radius: $border-radius;
+  padding: 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: row;
+  gap: 1rem;
+
+  @media screen and (max-width: $width-md) {
+    flex-direction: column;
+  }
+
+  @media screen and (max-width: $width-sm) {
+    padding: 1.5rem;
+  }
+
+  .text-wrapper {
+    flex: 1;
+
+    h2, p {
+      color: var(--neutral_light);
+      margin-top: 0;
+    }
+
+    h2 {
+      font-weight: var(--semi-bold-font-weight);
+    }
+  }
+
+  figure {
+    flex: 1;
+    width: 100%;
+    background: var(--neutral_light);
+    border-radius: $border-radius;
+    padding: 1rem 0 0;
+
+    @media screen and (max-width: $width-sm) {
+      iframe {
+        height: 410px !important;
+      }
+    }
+  }
+
+  .clear-styles & {
+    all: unset;
+
+    h2, p {
+      color: var(--neutral_dark);
+    }
+
+    figure {
+      max-width: 475px;
+      width: 100%;
+    }
+  }
+}

--- a/pegasus/sites.v3/hourofcode.com/public/events/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events/index.haml
@@ -25,7 +25,11 @@ nav: resources_nav
 
 %h1=hoc_s(:hoc_events_heading)
 
-= view :events_signup, hoc_mode: hoc_mode
+- if hoc_mode == "false"
+  .clear-styles
+    = view :off_season_interest_form
+- else
+  = view :events_signup, hoc_mode: hoc_mode
 
 %hr{style: "margin-top: 4rem"}
 

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -8,8 +8,6 @@ social:
 :ruby
   @header["title"] = hoc_s(:front_title, locals: {campaign_date: campaign_date('full-year')})
 
-  hoc_mode = DCDO.get("hoc_mode", CDO.default_hoc_mode)
-
 %link{href: "/css/generated/front-page.css", rel: "stylesheet", type: "text/css"}
 %link{href: "/css/generated/hoc-banner.css", rel: "stylesheet", type: "text/css"}
 %link{href: "/css/generated/highlights-homepage.css", rel: "stylesheet", id: "highlight-styles"}
@@ -69,10 +67,11 @@ social:
           = view :hoc_events_counter
       = view :map
       .text-wrapper.centered
-        %p.body-two{style: "margin-bottom: 2rem;"}
+        %p.body-two.no-margin-bottom
           =hoc_s(:hoc_homepage_registration_desc)
-        %a.link-button{href: resolve_url("/events")}
-          =hoc_s(:call_to_action_register_your_hoc)
+        - if hoc_mode != "false"
+          %a.link-button{href: resolve_url("/events"), style: "margin-top: 2rem"}
+            =hoc_s(:call_to_action_register_your_hoc)
 
   -# HoC Live Spanish banner
   - if @language == 'es' || @language == 'la'

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -73,6 +73,13 @@ social:
           %a.link-button{href: resolve_url("/events"), style: "margin-top: 2rem"}
             =hoc_s(:call_to_action_register_your_hoc)
 
+  -# Off season interest form
+  -# This is only shown when hoc_mode is false
+  - if hoc_mode == "false"
+    %section.no-padding-bottom
+      .wrapper
+        = view :off_season_interest_form
+
   -# HoC Live Spanish banner
   - if @language == 'es' || @language == 'la'
     %section.spanish-banner.no-padding-bottom

--- a/pegasus/sites.v3/hourofcode.com/views/events_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/events_signup.haml
@@ -1,9 +1,5 @@
 %a#hocsignupform{name: 'signup'}
-- if hoc_mode == false
-  %p.signup-closed.body-two.no-margin-bottom
-    =hoc_s(:signup_registration_closed_2022_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn')})
-- else
-  %h1#thanks-header{style: "display:none;"}
-    =hoc_s(:census_thanks)
-  %div
-    =view :signup_form
+%h1#thanks-header{style: "display:none;"}
+  =hoc_s(:census_thanks)
+%div
+  =view :signup_form

--- a/pegasus/sites.v3/hourofcode.com/views/off_season_interest_form.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/off_season_interest_form.haml
@@ -9,4 +9,4 @@
     %p.body-three
       %em=hoc_s(:subscribe_form_section_unsubscribe)
   %figure
-    %iframe{allowtransparency: "true", frameborder: "0", height: "375px", src: "https://go.pardot.com/l/153401/2024-01-03/pqtwb6", style: "border: 0", type: "text/html", width: "100%"}
+    %iframe{allowtransparency: "true", frameborder: "0", height: "325px", src: "https://go.pardot.com/l/153401/2024-01-03/pqtwb6", style: "border: 0", type: "text/html", width: "100%"}

--- a/pegasus/sites.v3/hourofcode.com/views/off_season_interest_form.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/off_season_interest_form.haml
@@ -1,0 +1,12 @@
+= inline_css "/generated/interest-form.css"
+
+%div.interest-form
+  .text-wrapper
+    %h2
+      =hoc_s(:hoc_interest_form_header)
+    %p.body-two
+      =hoc_s(:hoc_interest_form_desc)
+    %p.body-three
+      %em=hoc_s(:subscribe_form_section_unsubscribe)
+  %figure
+    %iframe{allowtransparency: "true", frameborder: "0", height: "375px", src: "https://go.pardot.com/l/153401/2024-01-03/pqtwb6", style: "border: 0", type: "text/html", width: "100%"}


### PR DESCRIPTION
When `hoc_mode = "false"` show an external interest form instead of the event registration form that updates the Events map.
- Fully responsive
- Tested with all of the different `hoc_mode`s

**Updates on https://hourofcode.com:**
- Hide the "Register your Hour of Code" button
- Show the interest form

**Updates on https://hourofcode.com/events**
- Hide the Register form, and show the interest form

**Jira ticket:** [ACQ-1305](https://codedotorg.atlassian.net/browse/ACQ-1305)

----

## Homepage
<img width="984" alt="Homepage" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/dde12f99-6d74-4bb0-baa1-f54065041947">

## Events page
<img width="975" alt="Events" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/98f5dc32-1d0b-4cb2-a839-527dda30916c">