### PR TITLE
Make mailer signatures more consistent

### DIFF
--- a/dashboard/app/mailers/pd/application/teacher_application_mailer.rb
+++ b/dashboard/app/mailers/pd/application/teacher_application_mailer.rb
@@ -1,6 +1,7 @@
 module Pd::Application
   class TeacherApplicationMailer < ApplicationMailer
-    CODE_ORG_DEFAULT_NOTIFICATION_EMAIL = 'Becky Kenemuth <teacher@code.org>'
+    # This should be kept consistent with the signature in _partner_signature.html.haml
+    CODE_ORG_DEFAULT_NOTIFICATION_EMAIL = 'Nikki Navta <teacher@code.org>'
     default from: 'Code.org <noreply@code.org>'
     default bcc: MailerConstants::PLC_EMAIL_LOG
 
@@ -15,7 +16,7 @@ module Pd::Application
         )
       else
         mail(
-          from: 'Code.org <teacher@code.org>',
+          from: CODE_ORG_DEFAULT_NOTIFICATION_EMAIL,
           to: @application.formatted_applicant_email,
           subject: "We've received your application for Code.org's Professional Learning Program!"
         )
@@ -33,7 +34,7 @@ module Pd::Application
         )
       else
         mail(
-          from: 'Code.org <teacher@code.org>',
+          from: CODE_ORG_DEFAULT_NOTIFICATION_EMAIL,
           to: @application.formatted_applicant_email,
           subject: "REMINDER - Action Needed: Your application needs Administrator/School Leader approval"
         )
@@ -51,7 +52,7 @@ module Pd::Application
         )
       else
         mail(
-          from: 'Code.org <teacher@code.org>',
+          from: CODE_ORG_DEFAULT_NOTIFICATION_EMAIL,
           to: @application.formatted_applicant_email,
           subject: "Important: Your Application Requires Administrator/School Leader Approval"
         )

--- a/dashboard/app/views/pd/application/teacher_application_mailer/_partner_signature.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/_partner_signature.html.haml
@@ -8,6 +8,7 @@
   - else
     = link_to @application.regional_partner.name, CDO.code_org_url('educate/professional-learning/contact-regional-partner', CDO.default_scheme)
 - else
+  -# Keep this signature consistent with the default notification email in teacher_application_mailer.rb
   Nikki Navta
   %br
   = mail_to 'teacher@code.org'

--- a/dashboard/app/views/pd/application/teacher_application_mailer/admin_approval_completed_partner.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/admin_approval_completed_partner.html.haml
@@ -14,9 +14,9 @@
   Best,
 
 %p
-  Becky Kenemuth
+  Nikki Navta
   %br
-  6-12 Program Manager
+  K12 Adoption Lead
   %br
   Code.org
 


### PR DESCRIPTION
Resolves [ACQ-560](https://codedotorg.atlassian.net/browse/ACQ-560). Pretty much all emails that aren't signed by the regional partner come from Nikki, so I've updated them to have her as the sender. I also added comments about which pieces should stay in sync; not updating one is why the signatures were mismatched in the first place.