### PR TITLE
[AI Tutor] add profanity/pii filtering to AI Tutor chat messages

### DIFF
--- a/dashboard/app/controllers/openai_chat_controller.rb
+++ b/dashboard/app/controllers/openai_chat_controller.rb
@@ -8,6 +8,12 @@ class OpenaiChatController < ApplicationController
       return render(status: :bad_request, json: {})
     end
 
+    # Check for PII / Profanity
+    locale = params[:locale] || "en"
+    messages = params[:messages].collect {|msg| msg[:content]}.join(' ')
+    filter_result = ShareFiltering.find_failure(messages, locale) if messages
+    return render(status: :bad_request, json: {type: filter_result.type, content: filter_result.content}) if filter_result
+
     if has_level_id_param?
       level_id = params[:levelId]
       test_file_contents = get_validated_level_test_file_contents(level_id)

--- a/dashboard/test/controllers/openai_chat_controller_test.rb
+++ b/dashboard/test/controllers/openai_chat_controller_test.rb
@@ -9,6 +9,7 @@ class OpenaiChatControllerTest < ActionController::TestCase
 
   # Student without ai tutor access is unable to access the chat completion endpoint
   test_user_gets_response_for :chat_completion,
+  name: "student_no_access_test",
   user: :student,
   method: :post,
   params: {messages: [{role: "user", content: "Say this is a test!"}]},
@@ -16,6 +17,7 @@ class OpenaiChatControllerTest < ActionController::TestCase
 
   # Teacher without ai tutor access is unable to access the chat completion endpoint
   test_user_gets_response_for :chat_completion,
+  name: "teacher_no_access_test",
   user: :teacher,
   method: :post,
   params: {messages: [{role: "user", content: "Say this is a test!"}]},
@@ -23,6 +25,7 @@ class OpenaiChatControllerTest < ActionController::TestCase
 
   # Student with ai tutor access disabled is unable to access the chat completion endpoint
   test_user_gets_response_for :chat_completion,
+  name: "student_disabled_access_test",
   user: :student_without_ai_tutor_access,
   method: :post,
   params: {messages: [{role: "user", content: "Say this is a test!"}]},
@@ -30,20 +33,39 @@ class OpenaiChatControllerTest < ActionController::TestCase
 
   # User with ai tutor access from permissions, post request with a messages param returns a success
   test_user_gets_response_for :chat_completion,
+  name: "general_success_test",
   user: :ai_tutor_access,
   method: :post,
-  params: {messages: [{role: "user", content: "Say this is a test!"}]},
+  params: {messages: [{role: "user", content: "this is a test!"}]},
   response: :success
 
   # Student with ai tutor access from experiment and section enablement, post request with a messages param returns a success
   test_user_gets_response_for :chat_completion,
+  name: "student_success_test",
   user: :student_with_ai_tutor_access,
   method: :post,
-  params: {messages: [{role: "user", content: "Say this is a test!"}]},
+  params: {messages: [{role: "user", content: "this is also a test!"}]},
   response: :success
+
+  # Post request with a profane messages param returns a failure
+  test_user_gets_response_for :chat_completion,
+  name: "profanity_test",
+  user: :student_with_ai_tutor_access,
+  method: :post,
+  params: {messages: [{role: "user", content: "damn you, robot!"}], locale: "en"},
+  response: :bad_request
+
+  # Post request with a messages param containing PII returns a failure
+  test_user_gets_response_for :chat_completion,
+  name: "pii_test",
+  user: :student_with_ai_tutor_access,
+  method: :post,
+  params: {messages: [{role: "user", content: "my email is l.lovegood@hogwarts.edu"}], locale: "en"},
+  response: :bad_request
 
   # A post request without a messages param returns a bad request
   test_user_gets_response_for :chat_completion,
+  name: "no_messages_test",
   user: :ai_tutor_access,
   method: :post,
   params: {},


### PR DESCRIPTION
[CT-209](https://codedotorg.atlassian.net/browse/CT-209)

Set up to run chat messages attempting to be sent to OpenAI for AI Tutor through our profanity and PII filters. Including tests to ensure that both profane language and personal identifiers are caught. 


### Follow-up 
The immediate next step is to expose if the user's message has been flagged on the front-end by adding messaging in the AI Tutor UI for inappropriate messages [CT-239](https://codedotorg.atlassian.net/browse/CT-239). From there, we can continue to build out features such as logging chat messages, notifying teachers of students abusing AI Tutor and ultimately shutting down AI Tutor for an individual student if they are repeatedly sending inappropriate messages. 

### Deployment strategy
AI Tutor is still tightly controlled behind an experiment and permissions so this change will affect very few people in the short-term. 

### Privacy

This change prevents the sharing of PII with third-party AI tools. 

### PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
