### PR TITLE
Increase Levelbuilder Volume Size to 256

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -582,8 +582,13 @@ Resources:
           # recreating the whole stack. We have been gradually rolling out
           # updates on a per-environment basis, with the goal of eventually
           # upgrading everything to 256.
+          #
+          # TODO: with the addition of levelbuilder, we expect all our
+          # environments to now be standardized around 256; we should verify,
+          # then simplify this logic.
           default_volume_size = 64
           volume_size_overrides = {
+            levelbuilder: 256,
             production: 256,
             staging: 256,
             test: 256


### PR DESCRIPTION
Folding this into [the Ubuntu 20 upgrade](https://github.com/code-dot-org/code-dot-org/pull/55642) for levelbuilder; also bring levelbuilder's volume size up to be in line with our other managed daemons.

Note that this means we could probably simplify this logic to again just hardcode 256 for everything, but I'm saving that for a follow-up after Levelbuilder is back up.