### PR TITLE
Optimize processing of choice levels

### DIFF
--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -291,52 +291,49 @@ module UsersHelper
     script.script_levels.each do |sl|
       sl.level_ids.each do |level_id|
         level = Level.cache_find(level_id)
-        users.each do |user|
-          level_for_progress = level.get_level_for_progress(user, script)
-
-          level_progress = get_level_progress(
-            user_id: user.id,
-            user_level: user_levels_by_level[user.id].try(:[], level_for_progress.id),
-            feedback_review_state:
-              teacher_feedback_by_level[user.id].try(:[], level_for_progress.id)&.review_state,
-            script_level: sl,
-            paired_user_levels: paired_user_levels[user.id],
-            include_timestamp: include_timestamp
-          )
-
-          if level.is_a?(BubbleChoice) # we have a parent level
-            bubble_choice_progress = get_bubble_choice_progress(
-              level, user, user_levels_by_level[user.id], teacher_feedback_by_level[user.id], sl, paired_user_levels[user.id], include_timestamp
+        if level.is_a?(BubbleChoice) # we have a parent level
+          # Load this once outside the users loop so the sublevels aren't
+          # queried anew for each user.
+          sublevels = level.sublevels
+          users.each do |user|
+            progress[user.id].merge!(
+              get_bubble_choice_progress(
+                level: level,
+                sublevels: sublevels,
+                user: user,
+                user_levels_by_level: user_levels_by_level[user.id],
+                teacher_feedback_by_level: teacher_feedback_by_level[user.id],
+                script_level: sl,
+                paired_user_levels: paired_user_levels[user.id],
+                include_timestamp: include_timestamp
+              )
             )
-            if bubble_choice_progress.present?
-              progress[user.id].merge!(bubble_choice_progress.compact)
+          end
+        else
+          level_for_progress_id = level.get_level_for_progress.id
+          users.each do |user|
+            level_progress = get_level_progress(
+              user_id: user.id,
+              user_level: user_levels_by_level[user.id][level_for_progress_id],
+              feedback_review_state:
+                teacher_feedback_by_level[user.id][level_for_progress_id]&.review_state,
+              script_level: sl,
+              paired_user_levels: paired_user_levels[user.id],
+              include_timestamp: include_timestamp
+            )
 
-              sum_time_spent = bubble_choice_progress.values.reduce(0) do |sum, sublevel_progress|
-                sublevel_progress[:time_spent] ? sum + sublevel_progress[:time_spent] : sum
-              end
+            next unless level_progress
 
-              # The existence of level_progress needs to be checked due to a race condition where the user makes sublevel
-              # progress between when user_levels_by_level is fetched and when level_for_progress is fetched. In this
-              # case, user_levels_by_level may not include the user level for the new level_for_progress, resulting in nil
-              # level_progress. This may manifest for the user as a bubble choice bubble looking as though it hasn't been tried
-              # even though there is progress on a sublevel and should be resolved by a page refresh.
-              if level_progress && sum_time_spent > 0
-                level_progress[:time_spent] = sum_time_spent
-              end
+            # if status is nil or not_tried, we don't need to get pages completed
+            status = level_progress[:status]
+            unless status.nil? || status == LEVEL_STATUS.not_tried
+              # if the level has multiple pages, we add an additional
+              # array of booleans indicating which pages have been completed.
+              level_progress[:pages_completed] = get_pages_completed(user, sl)
             end
+
+            progress[user.id][level_id] = level_progress
           end
-
-          next unless level_progress
-
-          # if status is nil or not_tried, we don't need to get pages completed
-          status = level_progress[:status]
-          unless status.nil? || status == LEVEL_STATUS.not_tried
-            # if the level has multiple pages, we add an additional
-            # array of booleans indicating which pages have been completed.
-            level_progress[:pages_completed] = get_pages_completed(user, sl)
-          end
-
-          progress[user.id][level_id] = level_progress.compact
         end
       end
     end
@@ -383,31 +380,59 @@ module UsersHelper
   # Summarizes a user's level progress for bubble choice level
   # (parent level and sublevels)
   private def get_bubble_choice_progress(
-    level,
-    user,
-    user_levels_by_level,
-    teacher_feedback_by_level,
-    script_level,
-    paired_user_levels,
-    include_timestamp
+    level:,
+    sublevels:,
+    user:,
+    user_levels_by_level:,
+    teacher_feedback_by_level:,
+    script_level:,
+    paired_user_levels:,
+    include_timestamp:
   )
+    sublevel_ids = sublevels.map(&:id)
+    sublevels_for_progress_ids = sublevels.map do |sublevel|
+      (sublevel.contained_levels.first || sublevel).id
+    end
+    teacher_feedbacks = teacher_feedback_by_level.slice(*sublevel_ids)
+
+    # This is meant to mimic the logic of BubbleChoice.get_sublevel_for_progress,
+    # but without doing additional queries since we've already fetched
+    # all the relevant data.
+    keep_working_level_id = teacher_feedbacks.values.find do |feedback|
+      feedback.review_state == TeacherFeedback::REVIEW_STATES.keepWorking
+    end&.level_id
+
+    user_levels = user_levels_by_level.slice(*sublevels_for_progress_ids)
+    max_progress_level_id = user_levels.values.max_by(&:best_result)&.level_id
+
+    cloned_level_id = keep_working_level_id || max_progress_level_id
+
     progress = {}
+    time_sum = 0
 
     # get progress for sublevels to save in levels hash
-    level.sublevels.each do |sublevel|
+    sublevels.each do |sublevel|
       level_for_progress = sublevel.get_level_for_progress
       sublevel_progress = get_level_progress(
         user_id: user.id,
-        user_level: user_levels_by_level.try(:[], level_for_progress.id),
-        feedback_review_state: teacher_feedback_by_level.try(:[], sublevel.id)&.review_state,
+        user_level: user_levels_by_level[level_for_progress.id],
+        feedback_review_state: teacher_feedback_by_level[sublevel.id]&.review_state,
         script_level: script_level,
         paired_user_levels: paired_user_levels,
         include_timestamp: include_timestamp
       )
       next unless sublevel_progress
 
+      if sublevel.id == cloned_level_id || level_for_progress.id == cloned_level_id
+        progress[level.id] = sublevel_progress.clone
+      end
+
+      time_sum += (sublevel_progress[:time_spent] || 0)
+
       progress[sublevel.id] = sublevel_progress
     end
+
+    progress[level.id][:time_spent] = time_sum if time_sum > 0
 
     progress
   end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -199,9 +199,9 @@ class BubbleChoice < DSLDefined
       feedback.review_state == TeacherFeedback::REVIEW_STATES.keepWorking
     end&.level_id
 
-    max_progress_level_id = user_levels.max_by(&:best_result)&.level_id
+    return keep_working_level_id if keep_working_level_id
 
-    keep_working_level_id || max_progress_level_id
+    user_levels.max_by(&:best_result)&.level_id
   end
 
   # Returns an array of BubbleChoice parent levels for any given sublevel name.

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -192,6 +192,18 @@ class BubbleChoice < DSLDefined
     return best_result_sublevel(student, script)
   end
 
+  # Use pre-loaded feedback and progress data to get the sublevel ID using the
+  # same criteria as in get_sublevel_for_progress
+  def get_sublevel_for_progress_optimized(teacher_feedbacks:, user_levels:)
+    keep_working_level_id = teacher_feedbacks.find do |feedback|
+      feedback.review_state == TeacherFeedback::REVIEW_STATES.keepWorking
+    end&.level_id
+
+    max_progress_level_id = user_levels.max_by(&:best_result)&.level_id
+
+    keep_working_level_id || max_progress_level_id
+  end
+
   # Returns an array of BubbleChoice parent levels for any given sublevel name.
   # @param [String] level_name. The name of the sublevel.
   # @return [Array<BubbleChoice>] The BubbleChoice parent level(s) of the given sublevel.


### PR DESCRIPTION
A further optimization to reduce the number of queries on the student progress API call.

This one focuses on choice levels. The `get_level_for_progress` call on the parent level was querying for a bunch of level progress and feedback data that we already preloaded at the beginning of the `script_progress_for_users` call. This change uses the already-loaded data instead of going down that other path that queries it again.

Using the same section/unit as in #55607 (where the performance improved from 3552 queries/6367 ms to 1807 queries/2605 ms), the same call now makes 260 queries and took 674 ms in a local test.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/TEACH-776)

## Testing story

Once again I'm using the existing tests to verify that the output isn't changing for choice levels, and also updated the existing tests for `BubbleChoice.get_sublevel_for_progress` match the new optimized version.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
