### PR TITLE
Removing duplicate form save and adding signed in reporting

### DIFF
--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -307,6 +307,7 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
             email={formData.email}
             schoolId={formData.schoolId}
             updateFormData={this.updateAndStoreFormData}
+            isSignedIn={formData.signedIn}
           />
         )}
         {formData.schoolEligible &&

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -67,6 +67,7 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
     email: PropTypes.string,
     schoolId: PropTypes.string,
     updateFormData: PropTypes.func,
+    isSignedIn: PropTypes.bool,
   };
 
   constructor(props) {
@@ -143,9 +144,9 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
     });
     analyticsReporter.sendEvent(EVENTS.AFE_CONTINUE, {
       submitData: JSON.stringify(submitData),
+      isSignedIn: this.props.isSignedIn,
     });
 
-    this.props.updateFormData(submitData);
     this.props.updateFormData(submitData);
   };
 


### PR DESCRIPTION
Updates two things:

1. Adds 'isSignedIn' to the form component and pulls it through to Amplitude logging (see verification below)
2. Removes a duplicate form update command. I'm not sure how this happened and it's years old (see git 'blame' pic below), but it feels like we shouldn't be running this twice...
     To be more specific: There is nothing in [this PR](https://github.com/code-dot-org/code-dot-org/pull/49279) that suggests the duplicate line was intentional.

<img width="650" alt="Screenshot 2024-01-09 at 12 08 09 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/369537f2-44b6-4047-9041-39d08786eb64">

<img width="780" alt="Screenshot 2024-01-09 at 10 24 15 AM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/57c73151-28e8-4daa-8058-e042246ba50d">

## Links

- spec: https://docs.google.com/document/d/1S0Li3rhDEUqU5gICGDpT2NXZiRAhTPuhUodtJEzbbdk/edit
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1290

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
