### PR TITLE
Update Dance Party manifest to 2024_v1

### DIFF
--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -649,5 +649,5 @@ module SharedConstants
   # Current song manifest file name for Dance Party. Note that different manifests
   # can be tested using query params (?manifest=...), but once this value is updated
   # the default manifest will change for all users.
-  DANCE_SONG_MANIFEST_FILENAME = 'songManifest2023_v4.json'
+  DANCE_SONG_MANIFEST_FILENAME = 'songManifest2024_v1.json'
 end


### PR DESCRIPTION
Update the dance party manifest to songManifest2024_v1.json. This removes two songs that we received reports about ("Jawsh 685 & Jason Derulo - Savage Love" & "Masked Wolf - Astronaut in the Ocean").

Currently on prod:
<img width="444" alt="Screenshot 2024-01-09 at 12 19 22 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/f90a3fb5-b03d-4216-b4e6-aef8f6453dcd">

After manifest update on a Dance level:
<img width="402" alt="Screenshot 2024-01-09 at 12 18 57 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/d83011a9-5a3a-49c6-b9fc-4215b49f0dea">

After manifest update on level edit page:
<img width="223" alt="Screenshot 2024-01-09 at 12 20 55 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/2d5c7479-a6fa-4e92-8ea6-aaca9a45dfec">

<img width="224" alt="Screenshot 2024-01-09 at 12 21 02 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/f3783289-613a-4e3e-a053-9c429360b8c4">


## Links

https://codedotorg.atlassian.net/browse/LABS-274

## Testing story

Tested locally and on production with `manifest` query param.