### PR TITLE
Rename `levelbuilder-staging` to `levelbuilder`

### DIFF
--- a/bin/cron/commit_content
+++ b/bin/cron/commit_content
@@ -3,7 +3,7 @@ require_relative 'only_one'
 abort 'Script already running' unless only_one_running?(__FILE__)
 
 # This script commits content on the machine to its associated branch. It is expected to be run only
-# on staging and levelbuilder (levelbuilder-staging).
+# on staging and levelbuilder
 
 require_relative '../../deployment'
 require 'cdo/chat_client'

--- a/bin/dotd
+++ b/bin/dotd
@@ -305,7 +305,7 @@ def dotd_menu(dotd_name)
       end
       menu.choice(:DTP) {do_dtp(dotd_name)}
       menu.choice(:L) do
-        if run_on 'levelbuilder-staging', "levelbuilder/bin/content-push --name=\"#{dotd_name}\""
+        if run_on 'levelbuilder', "levelbuilder/bin/content-push --name=\"#{dotd_name}\""
           @logger.info 'commits content on levelbuilder'
         else
           @logger.info 'error attempting to commit content on levelbuilder'
@@ -478,7 +478,7 @@ end
 # properly set up for all standard Dev of the Day operations.
 def perform_self_check
   puts "Checking access to internal servers"
-  %w(staging test levelbuilder-staging production-console).each do |environment|
+  %w(staging test levelbuilder production-console).each do |environment|
     run_on(environment, "echo 'successfully connected to #{environment}'")
   end
 

--- a/cookbooks/cdo-users/templates/default/ssh_config.erb
+++ b/cookbooks/cdo-users/templates/default/ssh_config.erb
@@ -1,4 +1,4 @@
-Host staging test levelbuilder-* production-daemon production-console i18n-dev adhoc-* *.ec2.internal *.cdn-code.org
+Host staging test levelbuilder production-daemon production-console i18n-dev adhoc-* *.ec2.internal *.cdn-code.org
   User ubuntu
   StrictHostKeyChecking no
   PreferredAuthentications publickey

--- a/docs/reset-password-manually.md
+++ b/docs/reset-password-manually.md
@@ -9,7 +9,7 @@ You might want to do this for a couple reasons:
 
 
 ````
-ubuntu@levelbuilder-staging:~$ dashboard-console
+ubuntu@levelbuilder:~$ dashboard-console
 Loading levelbuilder environment (Rails 4.0.3)
 irb(main):001:0> User.find_by_email_or_hashed_email('thi.phomprida@code.org').send_reset_password_instructions('thi.phomprida@code.org')
 ````

--- a/docs/update-levelbuilder.md
+++ b/docs/update-levelbuilder.md
@@ -10,7 +10,7 @@ This .md file should only contain information which is specific to Code.org engi
 
 ## To commit changes from levelbuilder into staging:
 
-1. `ssh -t gateway.code.org ssh -t levelbuilder-staging levelbuilder/bin/content-push`
+1. `ssh -t gateway.code.org ssh -t levelbuilder levelbuilder/bin/content-push`
 1. On GitHub, open a pull request from `levelbuilder` into `staging`. link: [staging...levelbuilder](https://github.com/code-dot-org/code-dot-org/compare/staging...levelbuilder)
 2. Click the "Merge pull request" button and watch the "infra-staging" room in Slack to make sure the build succeeds. If anything breaks, see the "Did it break section" below. 
 

--- a/lib/cdo/analytics/milestone_parser.rb
+++ b/lib/cdo/analytics/milestone_parser.rb
@@ -20,6 +20,7 @@ class MilestoneParser
     production-daemon
     staging
     test
+    levelbuilder
     development
     react
     adhoc

--- a/lib/cdo/analytics/milestone_parser.rb
+++ b/lib/cdo/analytics/milestone_parser.rb
@@ -20,8 +20,6 @@ class MilestoneParser
     production-daemon
     staging
     test
-    levelbuilder-staging
-    levelbuilder-development
     development
     react
     adhoc


### PR DESCRIPTION
Specifically, update all references to `levelbuilder-staging` in the codebase to instead reference `levelbuilder`. This is in response to the fact that the new version of the server created as part of [the Ubuntu 20 upgrade](https://github.com/code-dot-org/code-dot-org/pull/55642) was created with the name `levelbuilder` instead of the name `levelbuilder-staging`

We believe the server previously used the `-staging` suffix because it was manually given that name when it was originally created, and the name was preserved when the server was imported into CloudFormation. Because this upgrade was the first time that the CloudFormation stack attempted to create the server from scratch, it's only now that we see the suffixless version of the name.

We could alternatively update the underlying template to attempt to preserve the exisiting name, but the suffix has been a common stumbling block and source of confusion, so we've decided to instead embrace this opportunity for standardization.

## Links

[Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1704824002480549)

## Testing story

I have done no testing; hoping the change is simple enough

## Follow-up Work

We'll also want to update references in Google Docs, as noted below (https://github.com/code-dot-org/code-dot-org/pull/55672#issuecomment-1883883078)