### PR TITLE
Hide map on advocacy.code.org

### DIFF
--- a/pegasus/sites.v3/advocacy.code.org/public/index.haml
+++ b/pegasus/sites.v3/advocacy.code.org/public/index.haml
@@ -49,16 +49,6 @@ video_player: false
 
     -# .clear{style: "clear:both"}
 
-    .teach-ai-container
-      %img{src: "/images/teach-ai-logo.svg", alt: ""}
-      .teach-ai-text{style: "text-align: center"}
-        %p.heading-sm{style: "color: white;"}
-          =hoc_s(:teach_ai_title)
-        %p{style: "color: white; margin-bottom: 0"}
-          =hoc_s(:teach_ai_description)
-      %a.link-button.has-external-link{style: "flex: 0 0 auto;", href: "https://teachai.org/toolkit", target: "_blank", rel: "noopener noreferrer"}
-        =hoc_s(:teach_ai_button_label)
-
     %h2
       Drive the change in your state
 
@@ -72,6 +62,16 @@ video_player: false
             = view :homepage_quarterslot_links, entry: block, desktop_column_width: 50, layout_class: 'quarterslot-links-large'
 
     .clear
+
+    .teach-ai-container{style: "margin-top: 3rem"}
+      %img{src: "/images/teach-ai-logo.svg", alt: ""}
+      .teach-ai-text{style: "text-align: center"}
+        %p.heading-sm{style: "color: white;"}
+          =hoc_s(:teach_ai_title)
+        %p{style: "color: white; margin-bottom: 0"}
+          =hoc_s(:teach_ai_description)
+      %a.link-button.has-external-link{style: "flex: 0 0 auto;", href: "https://teachai.org/toolkit", target: "_blank", rel: "noopener noreferrer"}
+        =hoc_s(:teach_ai_button_label)
 
     .coalition
       %h2 Our Coalition

--- a/pegasus/sites.v3/advocacy.code.org/public/index.haml
+++ b/pegasus/sites.v3/advocacy.code.org/public/index.haml
@@ -40,13 +40,14 @@ video_player: false
 
     = view :forum_banner
 
-    %h2.tablet-feature See what’s happening in your state
-    %h3.centered
-      Click the map below for state-specific data on the computer science landscape
-    -state ||= nil
-    = view :interactive_map, use_url: false, advocacy_variation: true
+    -# Hiding the map since the data is 3 years old
+    -# %h2.tablet-feature See what’s happening in your state
+    -# %h3.centered
+    -#   Click the map below for state-specific data on the computer science landscape
+    -# -state ||= nil
+    -# = view :interactive_map, use_url: false, advocacy_variation: true
 
-    .clear{style: "clear:both"}
+    -# .clear{style: "clear:both"}
 
     .teach-ai-container
       %img{src: "/images/teach-ai-logo.svg", alt: ""}


### PR DESCRIPTION
Hiding the map on https://advocacy.code.org since it's outdated (3 years old). Also moved the TeachAI banner below the "Drive the change in your state" section.

**Jira ticket:** [ACQ-1345](https://codedotorg.atlassian.net/browse/ACQ-1345)

----

![localhost-advocacy code org_3000_](https://github.com/code-dot-org/code-dot-org/assets/9256643/fbb5f95d-fe20-4c0a-8be3-1549e4b123ea)