### PR TITLE
Replace color and font variables with css instead of scss on code.org

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -1214,7 +1214,7 @@ section.quote {
 // At a glance sections
 // See code.org/educate/csp and code.org/teach for examples
 .at-a-glance {
-  background: $neutral-white;
+  background: var(--neutral_white);
   border: 1px solid var(--neutral_dark10);
   border-radius: $border-radius;
   padding: 1.5rem;
@@ -1282,7 +1282,7 @@ section.quote {
     }
 
     h2, p {
-      color: $neutral-white;
+      color: var(--neutral_white);
     }
   }
 

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -278,15 +278,19 @@ ul {
         font-size: 1.25em;
 
         &:before {
-          color: $brand_secondary_default;
+          color: var(--brand_secondary_default);
           transition: color ease-in-out .2s;
         }
       }
 
       a {
         @include heading-xs;
-        color: $brand_secondary_default;
+        color: var(--brand_secondary_default);
         margin-bottom: 0;
+
+        &:hover {
+          color: var(--brand_secondary_dark);
+        }
       }
 
       &:hover {

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -17,9 +17,9 @@ p {
 // Use these classes to change a section's background color
 section.bg-neutral-light { background-color: var(--neutral_light); }
 section.bg-neutral-dark { background-color: var(--neutral_dark); }
-section.bg-secondary { background-color: $brand_secondary_light; }
+section.bg-secondary { background-color: var(--brand_secondary_light); }
 section.bg-primary-light {
-  background-color: rgba($brand_primary_light, .5);
+  background-color: rgba(171, 223, 229, 0.5);
 
   p {
     @include strong;
@@ -137,7 +137,7 @@ div.divider {
 // Add a thick box shadow to an element
 // See code.org/teach for an example
 .box-shadow-primary {
-  box-shadow: 8px 8px 0 $brand_primary_light;
+  box-shadow: 8px 8px 0 var(--brand_primary_light);
 }
 
 // Lines (<hr>)
@@ -444,7 +444,7 @@ ol.steps-list {
         right: -8px;
         bottom: -8px;
         left: -8px;
-        border: 6px solid $brand_primary_light;
+        border: 6px solid var(--brand_primary_light);
         border-radius: 100%;
       }
     }
@@ -871,7 +871,7 @@ form {
     }
 
     a{
-      background: $brand_primary_light;
+      background: var(--brand_primary_light);
 
       &.selected {
         background: var(--brand_primary_default);

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -16,7 +16,7 @@ p {
 
 // Use these classes to change a section's background color
 section.bg-neutral-light { background-color: var(--neutral_light); }
-section.bg-neutral-dark { background-color: $neutral_dark; }
+section.bg-neutral-dark { background-color: var(--neutral_dark); }
 section.bg-secondary { background-color: $brand_secondary_light; }
 section.bg-primary-light {
   background-color: rgba($brand_primary_light, .5);
@@ -29,7 +29,7 @@ section.bg-primary-light {
     }
   }
 
-  a { color: $neutral_dark !important;
+  a { color: var(--neutral_dark) !important;
     &:hover { color: $brand_secondary_dark !important; }
     &.link-button { color: $neutral_white !important; }
   }
@@ -118,7 +118,7 @@ div.divider {
 
   hr {
     border: 0;
-    border-top: 1px solid $neutral_dark60;
+    border-top: 1px solid var(--neutral_dark60);
     margin: 0;
     width: 100%;
   }
@@ -131,7 +131,7 @@ div.divider {
 
 // Add border to an element
 .has-border {
-  border: 1px solid $neutral_dark10;
+  border: 1px solid var(--neutral_dark10);
 }
 
 // Add a thick box shadow to an element
@@ -142,11 +142,11 @@ div.divider {
 
 // Lines (<hr>)
 hr {
-  border-top: 1px solid $neutral_dark20;
+  border-top: 1px solid var(--neutral_dark20);
   margin: 3rem 0;
 
   &.dark {
-    border-top: 1px solid $neutral_dark60;
+    border-top: 1px solid var(--neutral_dark60);
   }
 }
 
@@ -463,7 +463,7 @@ ol.steps-list {
 // FAQs
 details {
   padding: 1.5rem 1rem 1rem;
-  border-bottom: 1px solid $neutral_dark80;
+  border-bottom: 1px solid var(--neutral_dark80);
   transition: background ease-in-out .2s;
 
   &:hover {
@@ -574,7 +574,7 @@ form {
 // Action blocks shared styles
 .action-block {
   background: var(--neutral_light);
-  border: 1px solid $neutral_dark20;
+  border: 1px solid var(--neutral_dark20);
   border-radius: $border-radius;
   display: flex;
   align-content: baseline;
@@ -1115,9 +1115,9 @@ section.quote {
     gap: 0.25rem;
 
     button.tab {
-      color: $neutral_dark;
+      color: var(--neutral_dark);
       background: $neutral_white;
-      border: 1px solid $neutral_dark20;
+      border: 1px solid var(--neutral_dark20);
       border-bottom: 0;
       border-radius: 6px 6px 0 0;
       padding: 0.75rem 0.25rem 0.7rem;
@@ -1129,7 +1129,7 @@ section.quote {
       flex: 1;
 
       &:hover {
-        background-color: $neutral_dark10;
+        background-color: var(--neutral_dark10);
       }
 
       // Selected tab's styles
@@ -1143,8 +1143,8 @@ section.quote {
       &:focus {
         outline: unset;
         border-color: var(--brand_primary_default);
-        background-color: $neutral_dark10;
-        color: $neutral_dark;
+        background-color: var(--neutral_dark10);
+        color: var(--neutral_dark);
       }
 
       // Use this class to hide a tab
@@ -1211,7 +1211,7 @@ section.quote {
 // See code.org/educate/csp and code.org/teach for examples
 .at-a-glance {
   background: $neutral-white;
-  border: 1px solid $neutral_dark10;
+  border: 1px solid var(--neutral_dark10);
   border-radius: $border-radius;
   padding: 1.5rem;
   display: grid;
@@ -1257,7 +1257,7 @@ section.quote {
 .subscribe-form {
   background: url("/images/banners/banner-bg-lines-neutral-dark.png") center repeat;
   background-size: 22%;
-  background-color: $neutral_dark;
+  background-color: var(--neutral_dark);
   border-radius: $border-radius;
   padding: 2rem;
 

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -30,7 +30,7 @@ section.bg-primary-light {
   }
 
   a { color: var(--neutral_dark) !important;
-    &:hover { color: $brand_secondary_dark !important; }
+    &:hover { color: var(--brand_secondary_dark) !important; }
     &.link-button { color: $neutral_white !important; }
   }
 }
@@ -292,7 +292,7 @@ ul {
       &:hover {
 
         i:before {
-          color: $brand_secondary_dark;
+          color: var(--brand_secondary_dark);
         }
       }
     }

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -31,7 +31,7 @@ section.bg-primary-light {
 
   a { color: var(--neutral_dark) !important;
     &:hover { color: var(--brand_secondary_dark) !important; }
-    &.link-button { color: $neutral_white !important; }
+    &.link-button { color: var(--neutral_white) !important; }
   }
 }
 
@@ -424,7 +424,7 @@ ol.steps-list {
     width: 100%;
 
     & > span {
-      background: $neutral_white;
+      background: var(--neutral_white);
       display: block;
       width: 2em;
       height: 2em;
@@ -1027,7 +1027,7 @@ section.quote {
 
   p {
     font-size: 1.25rem;
-    color: $neutral_white;
+    color: var(--neutral_white);
     font-family: $barlowSemiCondensed-medium;
 
     &.quote-text {
@@ -1116,7 +1116,7 @@ section.quote {
 
     button.tab {
       color: var(--neutral_dark);
-      background: $neutral_white;
+      background: var(--neutral_white);
       border: 1px solid var(--neutral_dark20);
       border-bottom: 0;
       border-radius: 6px 6px 0 0;
@@ -1136,7 +1136,7 @@ section.quote {
       &.active,
       &.active:focus:not(:focus-visible) {
         background-color: var(--brand_primary_default);
-        color: $neutral_white;
+        color: var(--neutral_white);
         border-color: var(--brand_primary_default);
       }
 

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -5,7 +5,7 @@ $border-radius: 4px;
 
 // Mixins
 @mixin focus-outline {
-  outline: $brand_primary_default solid 2px;
+  outline: var(--brand_primary_default) solid 2px;
   outline-offset: 2px;
 }
 
@@ -15,7 +15,7 @@ p {
 }
 
 // Use these classes to change a section's background color
-section.bg-neutral-light { background-color: $neutral_light; }
+section.bg-neutral-light { background-color: var(--neutral_light); }
 section.bg-neutral-dark { background-color: $neutral_dark; }
 section.bg-secondary { background-color: $brand_secondary_light; }
 section.bg-primary-light {
@@ -467,7 +467,7 @@ details {
   transition: background ease-in-out .2s;
 
   &:hover {
-    background: $neutral_light;
+    background: var(--neutral_light);
   }
 
   summary {
@@ -573,7 +573,7 @@ form {
 
 // Action blocks shared styles
 .action-block {
-  background: $neutral_light;
+  background: var(--neutral_light);
   border: 1px solid $neutral_dark20;
   border-radius: $border-radius;
   display: flex;
@@ -607,7 +607,7 @@ form {
 
     &.overline {
       @include overline-two;
-      color: $brand_primary_default;
+      color: var(--brand_primary_default);
       width: 100%;
     }
   }
@@ -874,7 +874,7 @@ form {
       background: $brand_primary_light;
 
       &.selected {
-        background: $brand_primary_default;
+        background: var(--brand_primary_default);
       }
 
       &:focus {
@@ -943,7 +943,7 @@ form {
 
         &:before, &:after {
           font: var(--fa-font-solid);
-          color: $brand_primary_default;
+          color: var(--brand_primary_default);
         }
 
         &::before {
@@ -1039,7 +1039,7 @@ section.quote {
 
       &:before, &:after {
         font: var(--fa-font-solid);
-        color: $brand_primary_default;
+        color: var(--brand_primary_default);
       }
 
       &::before {
@@ -1109,7 +1109,7 @@ section.quote {
   min-height: 408px;
 
   nav {
-    border-bottom: 6px solid $brand_primary_default;
+    border-bottom: 6px solid var(--brand_primary_default);
     margin: 0 0 3rem;
     align-items: end;
     gap: 0.25rem;
@@ -1135,14 +1135,14 @@ section.quote {
       // Selected tab's styles
       &.active,
       &.active:focus:not(:focus-visible) {
-        background-color: $brand_primary_default;
+        background-color: var(--brand_primary_default);
         color: $neutral_white;
-        border-color: $brand_primary_default;
+        border-color: var(--brand_primary_default);
       }
 
       &:focus {
         outline: unset;
-        border-color: $brand_primary_default;
+        border-color: var(--brand_primary_default);
         background-color: $neutral_dark10;
         color: $neutral_dark;
       }
@@ -1283,7 +1283,7 @@ section.quote {
   }
 
   figure {
-    background: $neutral_light;
+    background: var(--neutral_light);
     border-radius: $border-radius;
     padding: 1rem 0 0;
 
@@ -1300,7 +1300,7 @@ section.quote {
 .action-wrapper {
   background: url("/images/banners/banner-bg-lines-neutral-light.png") center repeat;
   background-size: 10rem;
-  background-color: $brand_primary_default;
+  background-color: var(--brand_primary_default);
   border-radius: $border-radius;
   padding: 2rem;
 }

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -963,7 +963,7 @@ form {
     }
 
     span {
-      color: $brand_accent_default;
+      color: var(--brand_accent_default);
       margin: 0 2px;
     }
   }
@@ -1059,7 +1059,7 @@ section.quote {
   }
 
   span {
-    color: $brand_accent_default;
+    color: var(--brand_accent_default);
     margin: 0 2px;
   }
 }

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -1,4 +1,4 @@
-@import 'color', 'font', 'typography', 'breakpoints', 'barlow-semi-condensed-font';
+@import 'font', 'typography', 'breakpoints';
 
 // Variables
 $border-radius: 4px;

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -852,7 +852,7 @@ form {
   }
 
   p {
-    font-family: $barlowSemiCondensed-medium, sans-serif;
+    font-family: var(--barlowSemiCondensed-medium), sans-serif;
   }
 
   .pagination {
@@ -1032,7 +1032,7 @@ section.quote {
   p {
     font-size: 1.25rem;
     color: var(--neutral_white);
-    font-family: $barlowSemiCondensed-medium;
+    font-family: var(--barlowSemiCondensed-medium);
 
     &.quote-text {
       font-size: 1.35rem;

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -183,7 +183,7 @@ ul {
     margin: 0.5rem 0;
 
     &:before {
-      color: $neutral-dark;
+      color: var(--neutral_dark);
     }
 
     p {
@@ -1023,7 +1023,7 @@ form {
 section.quote {
   background: url("/images/banners/banner-bg-lines-neutral-dark.png") center repeat;
   background-size: 12rem;
-  background-color: $neutral-dark;
+  background-color: var(--neutral_dark);
 
   p {
     font-size: 1.25rem;


### PR DESCRIPTION
Replaces the SCSS color and font variables used on the [design-system-pegasus.scss](https://github.com/code-dot-org/code-dot-org/blob/staging/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss) stylesheet with CSS variables found on [040-page.css](https://github.com/code-dot-org/code-dot-org/blob/5344385bfa86d65c85582d20bc901b82ab0beab8/pegasus/sites.v3/code.org/styles_min/040-page.css#L9-L44).
- Removed unneeded SCSS `@imports`
- There should be no visual changes associated with this change

**Jira ticket:** [ACQ-1029](https://codedotorg.atlassian.net/browse/ACQ-1029)