### PR TITLE
Update Tests for DCDO controlled announcements

### DIFF
--- a/dashboard/test/lib/announcements_test.rb
+++ b/dashboard/test/lib/announcements_test.rb
@@ -74,13 +74,14 @@ class AnnouncementsTest < ActiveSupport::TestCase
   end
 
   test 'returns nil for announcement behind false dcdo flag' do
-    DCDO.instance_variable_get(:@datastore_cache).set('announcement-dcdo-test', false)
+    DCDO.stubs(:get).with('announcement-dcdo-test', false).returns(false)
     announcement = Announcements.get_announcement_for_page("/dcdo-test")
     assert_nil announcement
+    DCDO.unstub(:get)
   end
 
   test 'gets announcement for banner behind true dcdo flag' do
-    DCDO.instance_variable_get(:@datastore_cache).set('announcement-dcdo-test', true)
+    DCDO.stubs(:get).with('announcement-dcdo-test', false).returns(true)
     announcement = Announcements.get_announcement_for_page("/dcdo-test")
     assert announcement
     assert_equal("https://code.org/images/professional-learning-2019-closing-soon.png", announcement[:image])
@@ -93,5 +94,6 @@ class AnnouncementsTest < ActiveSupport::TestCase
     assert_equal("https://code.org/educate/professional-learning", announcement[:buttonUrl2])
     assert_equal("teacher-apps-closing-2020-sign-up-2", announcement[:buttonId2])
     assert_equal("dcdo-flag-test", announcement[:id])
+    DCDO.unstub(:get)
   end
 end


### PR DESCRIPTION
Updates the tests for the DCDO controlled announcements to stub get method instead of making temporary changes to `datastore_cache`.

## Links

- Slack Thread: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1704831859033099)

## Testing story
Tested changed tests within `dashboard/test/lib/announcements_test.rb` locally.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
