### PR TITLE
[LABS-233] Spritelab sound file has invalid ' character, breaks student code

### DIFF
--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -173,7 +173,7 @@ const customInputTypes = {
         );
     },
     generateCode(block, arg) {
-      return `'${block.getFieldValue(arg.name)}'`;
+      return JSON.stringify(block.getFieldValue(arg.name));
     },
   },
   costumePicker: {

--- a/apps/test/unit/p5lab/spritelab/blocksTest.js
+++ b/apps/test/unit/p5lab/spritelab/blocksTest.js
@@ -1,5 +1,5 @@
 import {expect} from '../../../util/reconfiguredChai';
-import {costumeList} from '@cdo/apps/p5lab/spritelab/blocks';
+import {costumeList, customInputTypes} from '@cdo/apps/p5lab/spritelab/blocks';
 import {
   registerReducers,
   stubRedux,
@@ -65,6 +65,22 @@ describe('Gamelab blocks', () => {
         '"drawn"',
       ]);
       expect(items[1]).to.deep.equal(['/v3/library/test.png', '"library"']);
+    });
+  });
+});
+
+describe('Custom Input Types', () => {
+  describe('soundPicker.generateCode()', () => {
+    it('returns a valid json string with quotes escaped', () => {
+      const block = {
+        getFieldValue: function (arg) {
+          return arg;
+        },
+      };
+      const arg = {name: "te'st"};
+      expect(
+        customInputTypes['soundPicker'].generateCode(block, arg)
+      ).to.deep.equal(`"te\'st"`);
     });
   });
 });


### PR DESCRIPTION
 Use JSON.stringify to avoid allowing unescaped quote characters in sound filenames.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LABS-233 Spritelab sound file has invalid ' character, breaks student code](https://codedotorg.atlassian.net/browse/LABS-233)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
