### PR TITLE
Encapsulate AWS EC2 business logic

### DIFF
--- a/bin/i18n/metrics.rb
+++ b/bin/i18n/metrics.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../dashboard/config/environment', __FILE__)
+require 'cdo/aws/ec2'
 require 'cdo/aws/metrics'
 require 'aws-sdk-ec2'
 require 'net/http'
@@ -56,11 +57,7 @@ module I18n
     # returns the EC2 instance ID if we are running the sync from an EC2,
     # and 'local_machine' otherwise
     def self.machine_id
-      @machine_id ||= begin
-        Net::HTTP.get(URI.parse(CDO.ec2_instance_id_endpoint))
-      rescue
-        'local_machine'
-      end
+      @machine_id ||= AWS::EC2.instance_id || 'local_machine'
     end
 
     # logging metrics into cloudwatch under i18n name space

--- a/bin/test/i18n/test_metrics.rb
+++ b/bin/test/i18n/test_metrics.rb
@@ -4,29 +4,28 @@ require_relative '../../i18n/metrics'
 describe I18n::Metrics do
   let(:described_class) {I18n::Metrics}
 
-  let(:cdo_ec2_instance_id_endpoint) {'expected_cdo_ec2_instance_id_endpoint'}
-  let(:cdo_ec2_instance_id_endpoint_uri) {URI(cdo_ec2_instance_id_endpoint)}
-
   before do
     described_class.remove_instance_variable(:@machine_id) if described_class.instance_variable_get(:@machine_id)
-    CDO.stubs(:ec2_instance_id_endpoint).returns(cdo_ec2_instance_id_endpoint)
-    Net::HTTP.stubs(:get).with(cdo_ec2_instance_id_endpoint_uri)
     Cdo::Metrics.client = Aws::CloudWatch::Client.new(stub_responses: true)
   end
 
   describe '.machine_id' do
-    it 'returns the machine id from the EC2 instance_id endpoint'  do
-      expected_machine_id = 'expected_machine_id'
+    let(:machine_id) {described_class.machine_id}
 
-      Net::HTTP.expects(:get).with(cdo_ec2_instance_id_endpoint_uri).returns(expected_machine_id)
+    let(:aws_ec2_instance_id) {'expected_aws_ec2_instance_id'}
 
-      assert_equal expected_machine_id, described_class.machine_id
+    before do
+      AWS::EC2.expects(:instance_id).returns(aws_ec2_instance_id)
     end
 
-    context 'when an error occurred on getting machine_id from the EC2 instance_id endpoint' do
-      it 'returns "local_machine"' do
-        Net::HTTP.stubs(:get).with(cdo_ec2_instance_id_endpoint_uri).raises('expected_error')
+    it 'returns current AWS EC2 instance_id'  do
+      assert_equal aws_ec2_instance_id, described_class.machine_id
+    end
 
+    context 'when server is not an AWS EC2 instance' do
+      let(:aws_ec2_instance_id) {nil}
+
+      it 'returns "local_machine"' do
         assert_equal 'local_machine', described_class.machine_id
       end
     end
@@ -58,7 +57,7 @@ describe I18n::Metrics do
 
     before do
       CDO.stubs(:rack_env).returns(cdo_rack_env)
-      Net::HTTP.stubs(:get).with(cdo_ec2_instance_id_endpoint_uri).returns(machine_id)
+      described_class.stubs(:machine_id).returns(machine_id)
     end
 
     it 'logs metric' do

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -589,9 +589,6 @@ ddconf_api_key: !Secret
 jwks_data: <%=File.read("#{File.expand_path(File.dirname(__FILE__))}/dashboard/public/oauth/jwks.json")%>
 jwk_private_key_data: !Secret
 
-# EC2 Metadata endpoint
-ec2_instance_id_endpoint: 'http://169.254.169.254/latest/meta-data/instance-id'
-
 # Credentials for OpenAI API
 openai_chat_completion_api_key: !Secret
 openai_chat_completion_org_id: !Secret

--- a/lib/cdo/aws/ec2.rb
+++ b/lib/cdo/aws/ec2.rb
@@ -1,0 +1,33 @@
+require 'net/http'
+require 'uri'
+
+module AWS
+  module EC2
+    REQUEST_TIMEOUT = 10 # seconds
+
+    INSTANCE_ID_URI = URI('http://169.254.169.254/latest/meta-data/instance-id').freeze
+    REGION_URI = URI('http://169.254.169.254/latest/meta-data/placement/region').freeze
+
+    def self.instance_id
+      return @instance_id if defined? @instance_id
+      @instance_id = http_get(INSTANCE_ID_URI)
+    end
+
+    def self.region
+      return @region if defined? @region
+      @region = http_get(REGION_URI)
+    end
+
+    private_class_method def self.http_get(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+
+      # Sets a short timeout to fail faster when it is not executed on an EC2 Instance
+      http.open_timeout = REQUEST_TIMEOUT
+      http.read_timeout = REQUEST_TIMEOUT
+
+      http.request_get(uri.path).body
+    rescue Net::OpenTimeout # This code is not executing on an AWS EC2 Instance nor in an ECS container or Lambda.
+      nil
+    end
+  end
+end

--- a/lib/cdo/secrets_config.rb
+++ b/lib/cdo/secrets_config.rb
@@ -1,3 +1,4 @@
+require 'cdo/aws/ec2'
 require 'cdo/config'
 require 'cdo/lazy'
 require 'aws-sdk-ec2'
@@ -102,16 +103,15 @@ module Cdo
         @stack ? "CfnStack/#{@stack}/#{secret_key}" : nil
       end
 
-      EC2_METADATA_SERVICE_BASE_URL = URI('http://169.254.169.254/latest/meta-data/')
-
       # Get the CloudFormation Stack Name that the EC2 Instance this code is executing on belongs to.
       # @return [String]
       def self.current_stack_name
-        metadata_service_request = Net::HTTP.new(EC2_METADATA_SERVICE_BASE_URL.host, EC2_METADATA_SERVICE_BASE_URL.port)
-        # Set a short timeout so that when not executing on an EC2 Instance we fail fast.
-        metadata_service_request.open_timeout = metadata_service_request.read_timeout = 10
-        ec2_instance_id = metadata_service_request.request_get(EC2_METADATA_SERVICE_BASE_URL.path + 'instance-id').body
-        region = metadata_service_request.request_get(EC2_METADATA_SERVICE_BASE_URL.path + 'placement/region').body
+        ec2_instance_id = AWS::EC2.instance_id
+        return unless ec2_instance_id
+
+        region = AWS::EC2.region
+        return unless region
+
         ec2_client = Aws::EC2::Client.new(region: region)
         ec2_client.
           describe_tags({filters: [{name: "resource-id", values: [ec2_instance_id]}]}).
@@ -119,8 +119,6 @@ module Cdo
           select {|tag| tag.key == 'aws:cloudformation:stack-name'}.
           first.
           value
-      rescue Net::OpenTimeout # This code is not executing on an AWS EC2 Instance nor in an ECS container or Lambda.
-        nil
       rescue StandardError
         nil
       end

--- a/lib/test/cdo/aws/test_ec2.rb
+++ b/lib/test/cdo/aws/test_ec2.rb
@@ -1,0 +1,54 @@
+require_relative '../../test_helper'
+require 'cdo/aws/ec2'
+
+describe AWS::EC2 do
+  let(:described_class) {AWS::EC2}
+
+  describe '.instance_id' do
+    let(:instance_id) {described_class.instance_id}
+
+    before do
+      described_class.remove_instance_variable(:@instance_id) if described_class.instance_variable_defined?(:@instance_id)
+    end
+
+    it 'returns current AWS EC2 instance id' do
+      VCR.use_cassette('aws/ec2/instance_id', record: :none) do
+        _(instance_id).must_equal 'expected_aws_ec2_instance_id'
+      end
+    end
+
+    context 'when not running on an AWS EC2 instance' do
+      before do
+        Net::HTTP.any_instance.stubs(:request_get).raises(Net::OpenTimeout)
+      end
+
+      it 'returns nil' do
+        _(instance_id).must_be_nil
+      end
+    end
+  end
+
+  describe '.region' do
+    let(:region) {described_class.region}
+
+    before do
+      described_class.remove_instance_variable(:@region) if described_class.instance_variable_defined?(:@region)
+    end
+
+    it 'returns current AWS EC2 region' do
+      VCR.use_cassette('aws/ec2/region', record: :none) do
+        _(region).must_equal 'expected_aws_ec2_region'
+      end
+    end
+
+    context 'when not running on an AWS EC2 instance' do
+      before do
+        Net::HTTP.any_instance.stubs(:request_get).raises(Net::OpenTimeout)
+      end
+
+      it 'returns nil' do
+        _(region).must_be_nil
+      end
+    end
+  end
+end

--- a/shared/test/fixtures/vcr/aws/ec2/instance_id.yml
+++ b/shared/test/fixtures/vcr/aws/ec2/instance_id.yml
@@ -1,0 +1,32 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://169.254.169.254/latest/meta-data/instance-id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 09 Jan 2024 06:45:12 GMT
+      Server:
+      - sffe
+      Content-Length:
+      - '28'
+      X-Xss-Protection:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: expected_aws_ec2_instance_id
+    http_version:
+  recorded_at: Tue, 09 Jan 2024 06:45:12 GMT
+recorded_with: VCR 3.0.3

--- a/shared/test/fixtures/vcr/aws/ec2/region.yml
+++ b/shared/test/fixtures/vcr/aws/ec2/region.yml
@@ -1,0 +1,32 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://169.254.169.254/latest/meta-data/placement/region
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 09 Jan 2024 06:45:12 GMT
+      Server:
+      - sffe
+      Content-Length:
+      - '28'
+      X-Xss-Protection:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: expected_aws_ec2_region
+    http_version:
+  recorded_at: Tue, 09 Jan 2024 06:45:12 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
1. Created module `AWS::EC2`, which contains information about current EC2 `instance ID` and `region`
2. Updated the code to use the module