### PR TITLE
Use a DCDO flag to lock/unlock scholarships

### DIFF
--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -4,7 +4,7 @@ import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-
 import DCDO from '@cdo/apps/dcdo';
 import Select from 'react-select';
 
-// update this to lock scholarships so that scholarship status can't be updated via the UI.
+// if locked, the scholarship status can't be updated unless the user is a workshop admin.
 const locked = DCDO.get('scholarship-dropdown-locked', true);
 
 const ScholarshipDropdown = ({

--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
+import DCDO from '@cdo/apps/dcdo';
 import Select from 'react-select';
 
 // update this to lock scholarships so that scholarship status can't be updated via the UI.
-const locked = true;
+const locked = DCDO.get('scholarship-dropdown-locked', true);
 
 const ScholarshipDropdown = ({
   scholarshipStatus,

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -40,6 +40,8 @@ class DCDOBase < DynamicConfigBase
       'progress-table-v2-enabled': DCDO.get('progress-table-v2-enabled', false),
       # Whether to show the v1 or v2 progress table by default.
       'progress-table-v2-default-v2': DCDO.get('progress-table-v2-default-v2', false),
+      # Whether the scholarship dropdown is locked on the application dashboard.
+      'scholarship-dropdown-locked': DCDO.get('scholarship-dropdown-locked', true),
     }
   end
 end


### PR DESCRIPTION
I'm not a huge fan of developers needing to make small code changes to turn features on and off, so I've updated the lock/unlock scholarship logic to use a DCDO flag! Once this is merged, I'll add a note to the [FAQ doc](https://docs.google.com/document/d/188mvQ-iY6L55p_FCgJ8OONDUT2IRITJYgr7TqSUjrMI/edit#bookmark=id.lbt7zgdhs0eo) to flip this flag when applications open.

I considered using the gatekeeper flag we have for opening/closing applications, but I _think_ I'd have to thread it through the stack, versus the ease of calling a function here. Also, I'm not 100% sure we always want them to be in sync. Happy to discuss though!