### PR TITLE
Music: loading & controls UI tweaks

### DIFF
--- a/apps/src/music/player/SoundCache.ts
+++ b/apps/src/music/player/SoundCache.ts
@@ -48,6 +48,11 @@ class SoundCache {
     // Filter out sounds that are already loaded
     paths = paths.filter(path => !this.audioBuffers[path]);
 
+    // Reset loading progress if we have sounds to load
+    if (updateLoadProgress && paths.length > 0) {
+      updateLoadProgress(0);
+    }
+
     for (let i = 0; i < paths.length; i++) {
       try {
         const sound = await this.loadSound(paths[i]);

--- a/apps/src/music/views/BeatPad.jsx
+++ b/apps/src/music/views/BeatPad.jsx
@@ -67,7 +67,8 @@ const TriggerButton = ({
       className={classNames(
         styles.triggerButton,
         colorClassName,
-        isSelected && styles.selected
+        isSelected && styles.selected,
+        disabled && styles.disabled
       )}
       onClick={disabled ? null : onClick}
     >

--- a/apps/src/music/views/Controls.jsx
+++ b/apps/src/music/views/Controls.jsx
@@ -18,14 +18,19 @@ import commonI18n from '@cdo/locale';
 const LoadingProgress = () => {
   const progressValue = useSelector(state => state.music.soundLoadingProgress);
 
-  if (progressValue >= 1) {
-    return null;
-  }
-
   return (
-    <div id="loading-progress" className={moduleStyles.loadingProgress}>
+    <div
+      id="loading-progress"
+      className={classNames(
+        moduleStyles.loadingProgress,
+        progressValue >= 1 && moduleStyles.loadingProgressHide
+      )}
+    >
       <div
-        className={moduleStyles.loadingProgressFill}
+        className={classNames(
+          moduleStyles.loadingProgressFill,
+          progressValue === 0 && moduleStyles.loadingProgressFillZero
+        )}
         style={{
           width: `${progressValue * 100}%`,
         }}
@@ -60,26 +65,24 @@ const SkipControls = () => {
       <button
         id="skip-back-button"
         className={classNames(
-          moduleStyles.controlButton,
-          moduleStyles.controlButtonSkip,
-          isPlaying && moduleStyles.controlButtonSkipDisabled
+          moduleStyles.skipButton,
+          isPlaying && moduleStyles.disabled
         )}
         onClick={() => onClickSkip(false)}
         type="button"
       >
-        <FontAwesome icon={'step-backward'} />
+        <FontAwesome icon={'step-backward'} className={moduleStyles.icon} />
       </button>
       <button
         id="skip-forward-button"
         className={classNames(
-          moduleStyles.controlButton,
-          moduleStyles.controlButtonSkip,
-          isPlaying && moduleStyles.controlButtonSkipDisabled
+          moduleStyles.skipButton,
+          isPlaying && moduleStyles.disabled
         )}
         onClick={() => onClickSkip(true)}
         type="button"
       >
-        <FontAwesome icon={'step-forward'} />
+        <FontAwesome icon={'step-forward'} className={moduleStyles.icon} />
       </button>
     </>
   );
@@ -97,6 +100,7 @@ const Controls = ({
 }) => {
   const isPlaying = useSelector(state => state.music.isPlaying);
   const isBeatPadShowing = useSelector(state => state.music.isBeatPadShowing);
+  const isLoading = useSelector(state => state.music.soundLoadingProgress < 1);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -130,13 +134,17 @@ const Controls = ({
         <button
           id="run-button"
           className={classNames(
-            moduleStyles.controlButton,
-            moduleStyles.controlButtonRun
+            moduleStyles.runButton,
+            isLoading && moduleStyles.disabled
           )}
           onClick={() => setPlaying(!isPlaying)}
           type="button"
+          disabled={isLoading}
         >
-          <FontAwesome icon={isPlaying ? 'stop' : 'play'} />
+          <FontAwesome
+            icon={isPlaying ? 'stop' : 'play'}
+            className={moduleStyles.icon}
+          />
           <div className={moduleStyles.text}>
             {isPlaying ? commonI18n.stop() : commonI18n.runProgram()}
           </div>

--- a/apps/src/music/views/beatpad.module.scss
+++ b/apps/src/music/views/beatpad.module.scss
@@ -79,12 +79,19 @@ $hover-opacity: 0.5;
   flex: 1;
   margin-right: 10px;
   border-width: 3px;
+  cursor: pointer;
 
   &.greenTrigger {
-    cursor: pointer;
     border-color: #00bc3e;
     background-color: #00bc3e;
     color: white;
+  }
+
+  &.disabled {
+    cursor: default;
+    opacity: 75%;
+    background-color: $neutral_dark40;
+    border-color: $neutral_dark40;
   }
 
   &.purple {

--- a/apps/src/music/views/controls.module.scss
+++ b/apps/src/music/views/controls.module.scss
@@ -24,7 +24,7 @@
   margin-bottom: 10px;
 }
 
-.controlButton {
+%controlButton {
   text-align: center;
   display: flex;
   width: 100%;
@@ -37,35 +37,51 @@
   margin: 2px;
   padding: 5px 10px;
 
+  .text,
+  .icon {
+    transition: opacity 0.1s ease-in;
+  }
+
   &:active {
     border: initial !important;
   }
 
-  &Run {
-    flex: 2;
-    background-color: #fca401;
-    color: $neutral_light;
-    margin: 0;
-
-    .text {
-      padding-left: 10px;
-    }
-  }
-
-  &Skip {
-    flex: 0.5;
-    background-color: $neutral_dark20;
-    color: $neutral_dark;
-
-    &Disabled {
+  &.disabled {
+    .text,
+    .icon {
       opacity: 50%;
-      cursor: default;
+    }
 
-      &:hover {
-        box-shadow: none;
-      }
+    cursor: default;
+
+    &:hover {
+      box-shadow: none;
     }
   }
+}
+
+.runButton {
+  @extend %controlButton;
+  flex: 2;
+  background-color: #fca401;
+  color: $neutral_light;
+  margin: 0;
+
+  .text {
+    padding-left: 10px;
+  }
+
+  .text,
+  .icon {
+    transition-delay: 0.2s; // Transition after a delay to avoid flickering
+  }
+}
+
+.skipButton {
+  @extend %controlButton;
+  flex: 0.5;
+  background-color: $neutral_dark20;
+  color: $neutral_dark;
 }
 
 .loadingProgress {
@@ -76,10 +92,22 @@
   margin-top: 15px;
   border-radius: 4px;
   overflow: hidden;
+  opacity: 1;
+  transition: opacity 0.1s ease-in 0.2s; // Transition after a delay to avoid flickering
 
   .loadingProgressFill {
+    transition: width 0.2s ease-in;
     height: 5px;
     background-color: $neutral_dark60;
     position: absolute;
+
+    &Zero {
+      transition: none;
+    }
+  }
+
+  &Hide {
+    transition: opacity 0.5s ease-in;
+    opacity: 0;
   }
 }

--- a/apps/src/music/views/controls.module.scss
+++ b/apps/src/music/views/controls.module.scss
@@ -24,7 +24,7 @@
   margin-bottom: 10px;
 }
 
-%controlButton {
+%control-button {
   text-align: center;
   display: flex;
   width: 100%;
@@ -61,7 +61,7 @@
 }
 
 .runButton {
-  @extend %controlButton;
+  @extend %control-button;
   flex: 2;
   background-color: #fca401;
   color: $neutral_light;
@@ -78,7 +78,7 @@
 }
 
 .skipButton {
-  @extend %controlButton;
+  @extend %control-button;
   flex: 0.5;
   background-color: $neutral_dark20;
   color: $neutral_dark;


### PR DESCRIPTION
A few loading/controls UI tweaks:
- Disable the Run button while sounds are loading. However this happens with a delayed transition so there won't be a flicker if a sound loads very quickly.
- Smooth out the loading bar progress and add transitions for showing/hiding. These also happen with a delay to avoid flickering.
- Disable the trigger buttons when playback is stopped.

https://github.com/code-dot-org/code-dot-org/assets/85528507/82cf2f71-4c73-405e-91d5-aeafb701ffce