### PR TITLE
Do not draw all sprites after drawing compass in CSC mapmaking modules

### DIFF
--- a/dashboard/config/libraries/zArrowKeyMonitor.interpreted.js
+++ b/dashboard/config/libraries/zArrowKeyMonitor.interpreted.js
@@ -46,6 +46,5 @@ function monitorButtonPresses () {
     textAlign(RIGHT, CENTER);
     text("E", compassX + midpoint, compassY);
   }
-  drawSprites();
 }
 other.push(monitorButtonPresses);


### PR DESCRIPTION
We received a Zendesk report that speech bubbles are appearing behind sprites in [one of our CSC modules](https://studio.code.org/s/csc-mappinglandmarks-2023/lessons/1/levels/9) (mapmaking), which isn't the typical behavior in Sprite Lab.

If we remove the line to drawSprites() at the end of the library that draws the compass on these levels, sprites continue to be layered behind the speech bubble. The slight difference in behavior is that sprites drawn in the same x/y as the compass will be layered behind the compass instead of in front of it, which I think actually looks better anyway.

I see 22 levels that use this library, so those are the ones that will be affected by this change.

| Old | New |
| - | - |
| <img width="417" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/b5db6b7e-329b-4418-b409-5127a57b3a17"> | <img width="421" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/96dbec5c-7f3d-4d5f-b33e-54abf87ba00f"> |

## Links

- jira ticket: [LABS-176](https://codedotorg.atlassian.net/browse/LABS-176)

## Testing story

I tested manually on the CSC level linked above.