### PR TITLE
Refactor callouts to prevent flicker on load

### DIFF
--- a/apps/src/code-studio/callouts.js
+++ b/apps/src/code-studio/callouts.js
@@ -107,7 +107,6 @@ export function addCallouts(callouts) {
     if ($(selector).length === 0 && !callout.on) {
       return;
     }
-    const container = $('#codeWorkspace');
 
     var defaultConfig = {
       codeStudio: {},
@@ -173,6 +172,12 @@ export function addCallouts(callouts) {
     ) {
       config.style.classes += ' flip-x-close';
     }
+
+    // If the callout is in #codeWorkspace and is not currently visible,
+    // we don't want to show it on page load. This is because Google Blockly
+    // labs can have a hidden (on start) function editor workspace that we don't
+    // want to show callouts for.
+    const container = $('#codeWorkspace');
 
     if (callout.on) {
       $(window).on(callout.on, function (e, action) {
@@ -264,6 +269,9 @@ function showOrHideCalloutsByTargetVisibility(containerSelector) {
     var container = $(containerSelector);
     const invalidCallouts = [];
     allCallouts.forEach(function (selector) {
+      // Callout selector could reference multiple locations (for example, in Sprite Lab
+      // the toolbox is duplicated between the main workspace and the function editor workspace).
+      // Iterate over all matching elements and show/hide the callout for each.
       $(selector).each(function () {
         var api = $(this).qtip('api');
         if (!api) {
@@ -302,7 +310,7 @@ function calloutShouldBeVisible(container, qtipApi) {
   var target = $(qtipApi.elements.target);
   var isTargetInContainer = container.has(target).length > 0;
   if (!isTargetInContainer) {
-    // Case of a callout outside of the workspace, which we always show.
+    // Case of a callout outside of the container (usually the code editor), which we always show.
     return true;
   }
   const isContainerVisible = container.is(':visible');

--- a/apps/src/code-studio/callouts.js
+++ b/apps/src/code-studio/callouts.js
@@ -104,9 +104,7 @@ export function addCallouts(callouts) {
   var showCalloutsMode = document.URL.indexOf('show_callouts=1') !== -1;
   callouts.forEach(function (callout) {
     var selector = callout.element_id; // jquery selector.
-    console.log(`setting up callout ${selector}`);
     if ($(selector).length === 0 && !callout.on) {
-      console.log(`could not find selector ${selector}`);
       return;
     }
     const container = $('#codeWorkspace');
@@ -191,9 +189,7 @@ export function addCallouts(callouts) {
         }
         // 'show' after async delay so that DOM changes that may have taken
         // place inside the 'prepareforcallout' event can complete first
-        console.log('in callout.on');
         setTimeout(function () {
-          console.log('in callout.on setTimeout');
           if ($(config.codeStudio.selector).length > 0) {
             if (
               action === 'hashchange' ||
@@ -227,15 +223,11 @@ export function handleWorkspaceResizeOrScroll() {
 }
 
 function showHideCalloutsOnInit(selector, container) {
-  console.log({selector: $(selector)});
   $(selector).each(function () {
-    console.log($(this));
     const api = $(this).qtip('api');
     if (calloutShouldBeVisible(container, api)) {
-      console.log(`showing ${api.id}`);
       api.show();
     } else {
-      console.log(`keeping ${api.id} hidden`);
       api.hide();
       hiddenCallouts[api.id] = true;
     }
@@ -268,23 +260,21 @@ var showHideDropletGutterCallouts =
  * @function
  */
 function showOrHideCalloutsByTargetVisibility(containerSelector) {
-  // Close around this object, which we use to remember which callouts
-  // were hidden by scrolling and should be shown again when they scroll
-  // back in.
-  /**
-   * Remember callouts hidden due to overlap, keyed by qtip id
-   * @type {Object.<string, boolean>}
-   */
   return function () {
     var container = $(containerSelector);
+    const invalidCallouts = [];
     allCallouts.forEach(function (selector) {
       $(selector).each(function () {
         var api = $(this).qtip('api');
-        console.log(`checking ${api.id}`);
+        if (!api) {
+          invalidCallouts.push(selector);
+          return;
+        }
         var target = $(api.elements.target);
 
         if ($(document).has(target).length === 0) {
-          //api.destroy(true);
+          api.destroy(true);
+          invalidCallouts.push(selector);
           return;
         }
 
@@ -294,17 +284,16 @@ function showOrHideCalloutsByTargetVisibility(containerSelector) {
         }
         const shouldBeVisible = calloutShouldBeVisible(container, api);
         if (shouldBeVisible && hiddenCallouts[api.id]) {
-          console.log(`${api.id} should be visible and is currently hidden`);
           api.show();
           delete hiddenCallouts[api.id];
         } else if (!shouldBeVisible && !hiddenCallouts[api.id]) {
-          console.log(
-            `${api.id} should be not visible and is currently visible`
-          );
           api.hide();
           hiddenCallouts[api.id] = true;
         }
       });
+    });
+    invalidCallouts.forEach(selector => {
+      allCallouts.splice(allCallouts.indexOf(selector), 1);
     });
   };
 }
@@ -318,7 +307,6 @@ function calloutShouldBeVisible(container, qtipApi) {
   }
   const isContainerVisible = container.is(':visible');
   const elementIsContained = target && elementIsInContainer(target, container);
-  console.log({id: qtipApi.id, isContainerVisible, elementIsContained});
   return isContainerVisible && elementIsContained;
 }
 


### PR DESCRIPTION
In Sprite Lab Google Blockly we had a small issue with callouts. Callouts are keyed based on a css selector, and often point to toolbox blocks. In Sprite Lab we often have a hidden modal function editor which has a duplicated toolbox. On load, that toolbox would also get callouts, which would be shown by default, then hidden once a callback ran. Since the toolbox is hidden, those callouts would flicker in the top corner of the page on load.

To fix this, I updated our callout logic to not show all callouts in `#codeWorkspace` by default. This required a little refactoring to track the hidden callouts outside of the `showOrHideCalloutsByTargetVisibility` function, and to also start tracking all the callout selectors so we can iterate over every callout in that function, not just ones that were initially shown. Callouts aren't created in the dom until `show` is called, so the old way of iterating over `.cdo-qtips` did not work.

Now callouts do not flicker on load, otherwise there is no change.

## Links
- jira ticket (includes video of flicker): [CT-149](https://codedotorg.atlassian.net/browse/CT-149)


## Testing story
Tested that App Lab callouts are unchanged, and cdo blockly callouts are unchanged. Also verified we no longer see the flicker for Google Blockly labs with a function editor.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
