### PR TITLE
Add Swiper carousel library

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -223,6 +223,7 @@
     "stylelint": "^15.0.0",
     "stylelint-config-standard": "^33.0.0",
     "stylelint-config-standard-scss": "^9.0.0",
+    "swiper": "^11.0.5",
     "terser-webpack-plugin": "^5.3.6",
     "ts-sinon": "^2.0.2",
     "uglifyjs-webpack-plugin": "^2.2.0",

--- a/apps/src/sites/code.org/pages/views/swiper.js
+++ b/apps/src/sites/code.org/pages/views/swiper.js
@@ -1,0 +1,7 @@
+// This installs the Swiper library WebComponent for use across code.org.
+// See docs here: https://swiperjs.com/swiper-api#web-component.
+
+// import function to register Swiper custom elements
+import {register} from 'swiper/element/bundle';
+// register Swiper custom elements
+register();

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -185,6 +185,7 @@ const PEGASUS_ENTRIES = {
   'code.org/views/amazon_future_engineer_eligibility': './src/sites/code.org/pages/views/amazon_future_engineer_eligibility.js',
   'code.org/views/job_board': './src/sites/code.org/pages/views/job_board.js',
   'code.org/views/analytics_event_log_helper': './src/sites/code.org/pages/views/analytics_event_log_helper.js',
+  'code.org/views/swiper': './src/sites/code.org/pages/views/swiper.js',
 
   // hourofcode.com
   'hourofcode.com/public/events/index': './src/sites/hourofcode.com/pages/public/events/index.js',

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8015,6 +8015,7 @@ __metadata:
     stylelint-config-standard: ^33.0.0
     stylelint-config-standard-scss: ^9.0.0
     survey-react: ^1.9.28
+    swiper: ^11.0.5
     terser-webpack-plugin: ^5.3.6
     timers-browserify: ^2.0.12
     ts-loader: ^9.4.2
@@ -27140,6 +27141,13 @@ es6-shim@latest:
   version: 1.0.0
   resolution: "svg-tags@npm:1.0.0"
   checksum: 407e5ef87cfa2fb81c61d738081c2decd022ce13b922d035b214b49810630bf5d1409255a4beb3a940b77b32f6957806deff16f1bf0ce1ab11c7a184115a0b7f
+  languageName: node
+  linkType: hard
+
+"swiper@npm:^11.0.5":
+  version: 11.0.5
+  resolution: "swiper@npm:11.0.5"
+  checksum: 83b125d16733a66ed5f58627c81263116e39eea5cead92667d2e24692ff94632de9aa05fec1ed80dc352779c0d7525e9a18424fce1c39c5e970823414b212edb
   languageName: node
   linkType: hard
 

--- a/pegasus/sites.v3/code.org/views/swiper.haml
+++ b/pegasus/sites.v3/code.org/views/swiper.haml
@@ -1,0 +1,2 @@
+// Add this view to pages that use the swiper.js library for carousels
+%script{src: webpack_asset_path('js/code.org/views/swiper.js')}


### PR DESCRIPTION
Adds the Swiper carousel library for use on https://code.org.

**Docs:** https://swiperjs.com/swiper-api
- Opted to use the WebComponent implementation version: https://swiperjs.com/element
  - This is recommended in lieu of React since support will likely be removed soon ([ref](https://swiperjs.com/react))
  - WebComponents are supported in all major browsers ([ref](https://developer.mozilla.org/en-US/docs/Web/API/Web_components))

**Followup:** Carousels that use the existing `carouFredsel` plugin will be updated to use `swiper` in additional PRs.

**Jira ticket:** [ACQ-908](https://codedotorg.atlassian.net/browse/ACQ-908)