### PR TITLE
Ties HOC guide email to hoc_mode

### DIFF
--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -13,6 +13,11 @@ import HourOfCodeGuideEmailDialog from '../templates/HourOfCodeGuideEmailDialog'
 import {getFilterStatus} from '@cdo/apps/dance/songs';
 import DanceAiModal from './ai/DanceAiModal';
 import SongSelector from '@cdo/apps/dance/SongSelector';
+import DCDO from '@cdo/apps/dcdo';
+
+const isHocEmailTimeOfYear = ['soon-hoc', 'actual-hoc'].includes(
+  DCDO.get('hoc_mode', false)
+);
 
 class DanceVisualizationColumn extends React.Component {
   static propTypes = {
@@ -70,6 +75,7 @@ class DanceVisualizationColumn extends React.Component {
           <AgeDialog turnOffFilter={this.turnFilterOff} />
         )}
         {(this.props.over21 || this.props.userType === 'teacher') &&
+          isHocEmailTimeOfYear &&
           cookies.get('HourOfCodeGuideEmailDialogSeen') !== 'true' && (
             <HourOfCodeGuideEmailDialog
               isSignedIn={isSignedIn}

--- a/dashboard/test/ui/features/acquisition_products/hoc_guide_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/hoc_guide_dialog.feature
@@ -1,3 +1,6 @@
+@skip
+# This test is useful to reenable during hoc_mode 'soon-hoc' and 'actual-hoc'
+# During all other hoc_modes, this dialog is not shown
 Feature: HOC Guide Email Conversion Dialog
 
   @eyes

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1067,7 +1067,7 @@ end
 
 And /^I dismiss the hoc guide dialog$/ do
   steps <<~GHERKIN
-    And I click selector "#uitest-no-email-guide" once I see it
+    And I click selector "#uitest-no-email-guide" if I see it
     And I wait until I don't see selector "#uitest-no-email-guide"
   GHERKIN
 end

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -42,6 +42,7 @@ class DCDOBase < DynamicConfigBase
       'progress-table-v2-default-v2': DCDO.get('progress-table-v2-default-v2', false),
       # Whether the scholarship dropdown is locked on the application dashboard.
       'scholarship-dropdown-locked': DCDO.get('scholarship-dropdown-locked', true),
+      hoc_mode: DCDO.get('hoc_mode', false),
     }
   end
 end


### PR DESCRIPTION
This PR pulls hoc_mode into the dance visualization column to determine whether its the right time of year to send these emails!

I was able to verify locally that the email dialog did (and then did not) show up when I had my local hoc_mode DCDO flag set to 'actual-hoc', and then 'post-hoc', respectively.

Additionally, this includes disabling the hoc guide dialog ui test file for now. I am keeping it in our codebase as useful for troubleshooting during development or during actual-hoc or soon-hoc, but it shouldn't run the rest of the year. We don't have a current pattern of pulling in a DCDO flag to feature files for scenarios like this. 

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1299

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
