### PR TITLE
A11Y-64 [TabNav] Classroom Sections - Advanced Settings not reachable

### DIFF
--- a/apps/src/templates/tables/QuickActionsCell.jsx
+++ b/apps/src/templates/tables/QuickActionsCell.jsx
@@ -109,6 +109,8 @@ export default class QuickActionsCell extends Component {
       <span ref={span => (this.icon = span)}>
         <a
           onClick={this.state.canOpen ? this.open : undefined}
+          // Dummy hash to href to make it a no-op
+          // adding href to make the icon tab navigable and clickable
           href="#dummy-hash"
         >
           <FontAwesome

--- a/apps/src/templates/tables/QuickActionsCell.jsx
+++ b/apps/src/templates/tables/QuickActionsCell.jsx
@@ -94,8 +94,8 @@ export default class QuickActionsCell extends Component {
 
     const styleByType =
       type === QuickActionsCellType.header
-        ? styles.actionButton['header']
-        : styles.actionButton['body'];
+        ? styles.actionIcon['header']
+        : styles.actionIcon['body'];
 
     const hoverStyle = this.state.open ? styles.hoverFocus['body'] : null;
 
@@ -107,12 +107,16 @@ export default class QuickActionsCell extends Component {
 
     return (
       <span ref={span => (this.icon = span)}>
-        <FontAwesome
-          icon={icons[type]}
-          style={iconStyle}
+        <a
           onClick={this.state.canOpen ? this.open : undefined}
-          className="ui-test-section-dropdown ui-projects-table-dropdown"
-        />
+          href="#dummy-hash"
+        >
+          <FontAwesome
+            icon={icons[type]}
+            style={iconStyle}
+            className="ui-test-section-dropdown ui-projects-table-dropdown"
+          />
+        </a>
         <PopUpMenu
           targetPoint={targetPoint}
           isOpen={this.state.open}

--- a/apps/src/templates/tables/QuickActionsCell.jsx
+++ b/apps/src/templates/tables/QuickActionsCell.jsx
@@ -94,8 +94,8 @@ export default class QuickActionsCell extends Component {
 
     const styleByType =
       type === QuickActionsCellType.header
-        ? styles.actionIcon['header']
-        : styles.actionIcon['body'];
+        ? styles.actionButton['header']
+        : styles.actionButton['body'];
 
     const hoverStyle = this.state.open ? styles.hoverFocus['body'] : null;
 

--- a/apps/src/templates/tables/QuickActionsCell.jsx
+++ b/apps/src/templates/tables/QuickActionsCell.jsx
@@ -107,18 +107,19 @@ export default class QuickActionsCell extends Component {
 
     return (
       <span ref={span => (this.icon = span)}>
-        <a
+        <FontAwesome
+          icon={icons[type]}
+          style={iconStyle}
+          className="ui-test-section-dropdown ui-projects-table-dropdown"
           onClick={this.state.canOpen ? this.open : undefined}
-          // Dummy hash to href to make it a no-op
-          // adding href to make the icon tab navigable and clickable
-          href="#dummy-hash"
-        >
-          <FontAwesome
-            icon={icons[type]}
-            style={iconStyle}
-            className="ui-test-section-dropdown ui-projects-table-dropdown"
-          />
-        </a>
+          tabIndex="0"
+          onKeyDown={e => {
+            if ([' ', 'Enter', 'Spacebar'].includes(e.key)) {
+              e.preventDefault();
+              this.state.canOpen ? this.open() : undefined;
+            }
+          }}
+        />
         <PopUpMenu
           targetPoint={targetPoint}
           isOpen={this.state.open}


### PR DESCRIPTION
Issue: Advanced settings in teacher dashboard section table is not tab navigable. Screen shot below.
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/2b534371-b471-4461-aac1-23c97c7afd29)

Root cause: For an element to be tab navigable, it needs to be an actionable element, i.e., anchor, button etc with a click action associated. The font awesome cogs Icon used for the advanced settings menu was wrapped in a span, which wasn't a clickable element. The onClick handler was directly applied on the icon.

Fix: Including a tabIndex on the FontAwesome element with a key down event handler to open the menu on pressing 'Enter'

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

JIRA https://codedotorg.atlassian.net/browse/A11Y-64

## Testing story

Using existing tests to validate changes

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

Usual DTP 

## Follow-up work

This change only changes the icon to be tab navigable and the drop down to open on pressing 'Enter'. The drop down menu items are currently reachable through tab after all the other elements in the page. Will use the same ticket to track follow up work.

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
