### PR TITLE
P20-585 Fix localizing Progression names with dots

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -336,14 +336,6 @@ class I18nScriptUtils
     {locale => {'data' => {type => i18n_data}}}
   end
 
-  # Removes I18n.default_separator (in our case dots ' . ') from a given string.
-  # Sometimes strings with dots  are used as keys in our i18n data,
-  # as they come from course and curriculum content.
-  # The I18n library uses dots to denote hierarchy in keys, therefore we need to remove dots from keys.
-  def self.to_i18n_key(string)
-    string.gsub(I18n.default_separator, '')
-  end
-
   def self.sort_and_sanitize(hash)
     hash.sort_by {|key, _| key}.each_with_object({}) do |(key, value), result|
       case value

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -336,6 +336,14 @@ class I18nScriptUtils
     {locale => {'data' => {type => i18n_data}}}
   end
 
+  # Removes dots ( . ) from a given string.
+  # We frequently use strigns with dots as keys in our i18n data,
+  # as the come from course and curriculum content.
+  # The I18n gem uses dots to denote hierarchy in keys, so we need to remove them.
+  def self.to_i18n_key(string)
+    string.gsub(I18n.default_separator, '')
+  end
+
   def self.sort_and_sanitize(hash)
     hash.sort_by {|key, _| key}.each_with_object({}) do |(key, value), result|
       case value

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -336,10 +336,10 @@ class I18nScriptUtils
     {locale => {'data' => {type => i18n_data}}}
   end
 
-  # Removes dots ( . ) from a given string.
-  # We frequently use strigns with dots as keys in our i18n data,
-  # as the come from course and curriculum content.
-  # The I18n gem uses dots to denote hierarchy in keys, so we need to remove them.
+  # Removes I18n.default_separator (in our case dots ' . ') from a given string.
+  # Sometimes strings with dots  are used as keys in our i18n data,
+  # as they come from course and curriculum content.
+  # The I18n library uses dots to denote hierarchy in keys, therefore we need to remove dots from keys.
   def self.to_i18n_key(string)
     string.gsub(I18n.default_separator, '')
   end

--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -306,7 +306,8 @@ module I18n
 
                 url = I18nScriptUtils.get_level_url_key(script, level)
                 script_strings[url] = get_i18n_strings(level)
-                progression_strings[script_level.progression] = script_level.progression if script_level.progression
+                progression_key = I18nScriptUtils.to_i18n_key(script_level.progression) if script_level.progression
+                progression_strings[progression_key] = script_level.progression if script_level.progression
 
                 # extract block category strings; although these are defined for each
                 # level, the expectation here is that there is a massive amount of

--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -306,8 +306,7 @@ module I18n
 
                 url = I18nScriptUtils.get_level_url_key(script, level)
                 script_strings[url] = get_i18n_strings(level)
-                progression_key = I18nScriptUtils.to_i18n_key(script_level.progression) if script_level.progression
-                progression_strings[progression_key] = script_level.progression if script_level.progression
+                progression_strings[script_level.progression] = script_level.progression if script_level.progression
 
                 # extract block category strings; although these are defined for each
                 # level, the expectation here is that there is a massive amount of

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -334,7 +334,10 @@ class ScriptLevel < ApplicationRecord
 
       if progression
         summary[:progression] = progression
-        localized_progression_name = I18n.t("data.progressions.#{progression}", default: progression)
+        localized_progression_name = I18n.t(
+          "data.progressions.#{progression.gsub(I18n.default_separator, '')}",
+          default: progression
+        )
         summary[:progression_display_name] = localized_progression_name
       end
 

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -335,8 +335,10 @@ class ScriptLevel < ApplicationRecord
       if progression
         summary[:progression] = progression
         localized_progression_name = I18n.t(
-          "data.progressions.#{progression.gsub(I18n.default_separator, '')}",
-          default: progression
+          progression,
+          scope: %i[data progressions],
+          default: progression,
+          smart: true
         )
         summary[:progression_display_name] = localized_progression_name
       end


### PR DESCRIPTION
Some progression names were not showing their translations in CSC Marine Ecosystems despite of having translations available for several languages. Progressions are each of the levels students progress through within a lesson:
<img width="900" alt="Screenshot 2024-01-12 at 14 31 13" src="https://github.com/code-dot-org/code-dot-org/assets/66776217/a9a48427-096e-4a10-84c3-af6304448e5f">

During the `CourseContent::SyncIn`, progression names are pulled from each `Unit.script_levels`, and stored in `progressions.yml` using the name as key and value. 
```
progression_strings[script_level.progression] = script_level.progression
```
These names are given by curriculum writers and are not designed to be used as keys. The root cause of the "missing" translations is the usage of dots ` . ` in some string keys because our I18n rails library uses dots to indicate hierarchy:
`I18n.t("data.progressions.key")`
```
data:
  progressions:
    key: String
 ```

Fortunately, our[ i18n backend](https://github.com/code-dot-org/code-dot-org/blob/e5488d8173654f82360e8fec21482c85a917915f/lib/cdo/i18n_backend.rb#L22-L25) has an option that avoids this issue by setting the default separator to a character that is not in the key:
```
def self.get_smart_translate_options(locale, key, options = ::I18n::EMPTY_HASH)
        options = options.dup
        options.delete(:smart)

        # If I18n.t was called with an explicit scope and without specifying a
        # separator, try to find a separator character that isn't contained within
        # any of the individual scope or key values, to prevent a situation in
        # which periods in a key name can be mistakenly interpreted as separators
        if options.key?(:scope) && !options.key?(:separator)
          combined_key = [key] + options.fetch(:scope, [])
          options[:separator] = get_valid_separator(combined_key.join)
        end

        options
      end
```
This PR:
- Adds a `smart: true` option when localizing progressions in `script_level.rb`

## Links

- jira ticket: [P-585](https://codedotorg.atlassian.net/browse/P20-585)

## Testing story

Testing links: http://localhost-studio.code.org:3000/s/csc-ecosystems-2023

<img width="1704" alt="Screenshot 2024-01-12 at 00 52 08" src="https://github.com/code-dot-org/code-dot-org/assets/66776217/5de1557d-dff0-44a5-ae37-c1525f54a3d6">

## Follow-up work

Investigate if this issue is affecting other areas of the code base.

## PR Checklist:


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
