### PR TITLE
[Google Blockly] Remove tooltips from procedure definitions

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
@@ -53,7 +53,6 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
     ],
     style: 'behavior_blocks',
     helpUrl: '/docs/spritelab/codestudio_defining-behaviors',
-    tooltip: '%{BKY_PROCEDURES_DEFNORETURN_TOOLTIP}',
     extensions: [
       'procedure_def_get_def_mixin',
       'procedure_def_var_mixin',

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -48,7 +48,6 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
     ],
     style: 'procedure_blocks',
     helpUrl: '/docs/spritelab/codestudio_definingFunction',
-    tooltip: '%{BKY_PROCEDURES_DEFNORETURN_TOOLTIP}',
     extensions: [
       'procedure_def_get_def_mixin',
       'procedure_def_var_mixin',


### PR DESCRIPTION
The tooltips on procedure definitions were not helpful, so we removed them. The tooltip we were use said "Create a function with no output".

## Links

- jira ticket: [https://codedotorg.atlassian.net/browse/CT-136](https://codedotorg.atlassian.net/browse/CT-136)

## Testing story
Tested that the tooltip is gone. The tooltips on call blocks remain, as those are updated when a procedure is renamed by core blockly.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
