### PR TITLE
P20-659 Adding cs_discoveries interpolation to trademark in level_helper.rb

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -731,7 +731,7 @@ module LevelsHelper
       art_from_html: ERB::Util.url_encode(I18n.t('footer.art_from_html', current_year: Time.now.year)),
       code_from_html: ERB::Util.url_encode(I18n.t('footer.code_from_html')),
       powered_by_aws: I18n.t('footer.powered_by_aws'),
-      trademark: ERB::Util.url_encode(I18n.t('footer.trademark', current_year: Time.now.year)),
+      trademark: ERB::Util.url_encode(I18n.t('footer.trademark', current_year: Time.now.year, cs_discoveries: "CS Discoveries&reg;")),
       built_on_github: I18n.t('footer.built_on_github'),
       google_copyright: ERB::Util.url_encode(I18n.t('footer.google_copyright'))
     }


### PR DESCRIPTION
This PR updates the trademark pattern in `level_helper.rb` to include CS Discoveries interpolation pattern.

## Links

- HoneyBadger: [unused interpolation patterns](https://app.honeybadger.io/projects/3240/faults/103675191)
- jira ticket: [P20-659](https://codedotorg.atlassian.net/browse/P20-659)
- Previous PR: #55369 

## Testing story
<img width="1722" alt="Screenshot 2024-01-12 at 20 16 17" src="https://github.com/code-dot-org/code-dot-org/assets/66776217/f8beb34e-83ed-4dbd-abed-0355b8fe1ff8">

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
