### PR TITLE
Undo Custom DNS Patch for Ubuntu 18

### DIFF
--- a/cookbooks/cdo-apps/files/default/resolved
+++ b/cookbooks/cdo-apps/files/default/resolved
@@ -14,7 +14,7 @@
 #   (D) = master script downs interface
 #   (-) = master script does nothing with this
 
-if [ -x /lib/systemd/systemd-resolved ] ; then
+if systemctl is-enabled systemd-resolved > /dev/null 2>&1; then
         # For safety, first undefine the nasty default make_resolv_conf()
         make_resolv_conf() { : ; }
         case "$reason" in
@@ -30,7 +30,7 @@ if [ -x /lib/systemd/systemd-resolved ] ; then
               mkdir -p $statedir
 
               oldstate="$(mktemp)"
-              md5sum $statedir/isc-dhcp-v4-$interface.conf $statedir/isc-dhcp-v6-$interface.conf > $oldstate 2>&1
+              md5sum $statedir/isc-dhcp-v4-$interface.conf $statedir/isc-dhcp-v6-$interface.conf > $oldstate 2> /dev/null
               if [ -n "$new_domain_name_servers" ] ; then
                   cat <<EOF >$statedir/isc-dhcp-v4-$interface.conf
 [Resolve]
@@ -55,8 +55,12 @@ EOF
               fi
 
               newstate="$(mktemp)"
-              md5sum $statedir/isc-dhcp-v4-$interface.conf $statedir/isc-dhcp-v6-$interface.conf > $newstate 2>&1
+              md5sum $statedir/isc-dhcp-v4-$interface.conf $statedir/isc-dhcp-v6-$interface.conf > $newstate 2> /dev/null
               if ! cmp --quiet $oldstate $newstate; then
+                  # We need to reset-failed to reset the start limit counter,
+                  # in case we're processing more than StartLimitBurst interfaces
+                  # LP: #1939255
+                  systemctl reset-failed systemd-resolved.service
                   systemctl try-reload-or-restart systemd-resolved.service
               fi
 


### PR DESCRIPTION
[The underlying bug](https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1805183) that prompted us to add this patch in the first place was fixed in Ubuntu 19; now that we're on Ubuntu 20, we no longer need the patch. However, we can't simply remove the logic that adds the patch, or our existing persistent managed servers will retain the patch as an artifact which may someday introduce unexpected differences between old and new servers. Instead, this PR will update the contents of the patched file on all existing servers to match what the contents would be on a newly-provisioned server without the patch applied.

## Links

- Original Bug Report: https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1805183
- Follow-up PR: https://github.com/code-dot-org/code-dot-org/pull/54427

## Testing story

This version of the file was obtained from an adhoc that did not have the patch applied in the first place, and I confirmed that the adhoc works just fine. I am unfortunately not sure how to attempt to reproduce the original bug this was intended to fix, so I can't be 100% certain that the bug no longer manifests on this version of Ubuntu, and am choosing to trust the [original bug report](https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1805183) when it says this issue has been fixed in the version of Ubuntu we are now using.

## Follow-up work

Once all existing servers have been updated with this "unpatched patch", we can then [remove the patching logic entirely](https://github.com/code-dot-org/code-dot-org/pull/54427).