### PR TITLE
Allow Facilitators and Program Managers to edit Workshop Attendance after the workshop ends

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/attendance/session_attendance.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/attendance/session_attendance.jsx
@@ -13,7 +13,12 @@ import Spinner from '../../components/spinner';
 import {Table} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import IdleTimer from 'react-idle-timer';
 import {COURSE_CSF} from '../workshopConstants';
-import {PermissionPropType, WorkshopAdmin, ProgramManager} from '../permission';
+import {
+  PermissionPropType,
+  WorkshopAdmin,
+  ProgramManager,
+  Facilitator,
+} from '../permission';
 
 // in milliseconds
 const REFRESH_DELAY = 5000;
@@ -146,7 +151,11 @@ export class SessionAttendance extends React.Component {
           accountRequiredForAttendance={this.props.accountRequiredForAttendance}
           scholarshipWorkshop={this.props.scholarshipWorkshop}
           displayYesNoAttendance={
-            !this.props.permission.hasAny(WorkshopAdmin, ProgramManager)
+            !this.props.permission.hasAny(
+              WorkshopAdmin,
+              ProgramManager,
+              Facilitator
+            )
           }
         />
       );

--- a/apps/src/code-studio/pd/workshop_dashboard/attendance/workshop_attendance.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/attendance/workshop_attendance.jsx
@@ -10,7 +10,13 @@ import {connect} from 'react-redux';
 import SessionTime from '../components/session_time';
 import Spinner from '../../components/spinner';
 import SessionAttendance from './session_attendance';
-import {PermissionPropType, WorkshopAdmin, Organizer} from '../permission';
+import {
+  PermissionPropType,
+  WorkshopAdmin,
+  Organizer,
+  Facilitator,
+  ProgramManager,
+} from '../permission';
 import color from '@cdo/apps/util/color';
 import {Row, Col, ButtonToolbar, Button, Tabs, Tab} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
@@ -132,7 +138,12 @@ export class WorkshopAttendance extends React.Component {
 
     const isReadOnly =
       this.hasWorkshopEnded() &&
-      !this.props.permission.hasAny(WorkshopAdmin, Organizer);
+      !this.props.permission.hasAny(
+        WorkshopAdmin,
+        Organizer,
+        Facilitator,
+        ProgramManager
+      );
 
     let intro = null;
     if (isReadOnly) {

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -223,7 +223,7 @@ class Ability
       if user.facilitator?
         can [:read, :start, :end, :workshop_survey_report, :summary, :filter], Pd::Workshop, facilitators: {id: user.id}
         can [:read, :update], Pd::Workshop, organizer_id: user.id
-        can :manage_attendance, Pd::Workshop, facilitators: {id: user.id}, ended_at: nil
+        can :manage_attendance, Pd::Workshop, facilitators: {id: user.id}
         can :read, Pd::CourseFacilitator, facilitator_id: user.id
 
         if Pd::CourseFacilitator.exists?(facilitator: user, course: Pd::Workshop::COURSE_CSF)
@@ -241,7 +241,7 @@ class Ability
         # Regional partner program managers can access workshops assigned to their regional partner
         if user.regional_partners.any?
           can [:read, :start, :end, :update, :destroy, :summary, :filter], Pd::Workshop, regional_partner_id: user.regional_partners.pluck(:id)
-          can :manage_attendance, Pd::Workshop, regional_partner_id: user.regional_partners.pluck(:id), ended_at: nil
+          can :manage_attendance, Pd::Workshop, regional_partner_id: user.regional_partners.pluck(:id)
           can :update_scholarship_info, Pd::Enrollment do |enrollment|
             !!user.regional_partners.pluck(enrollment.workshop.regional_partner_id)
           end

--- a/dashboard/test/controllers/api/v1/pd/workshop_attendance_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_attendance_controller_test.rb
@@ -108,12 +108,12 @@ class Api::V1::Pd::WorkshopAttendanceControllerTest < ActionDispatch::Integratio
     assert_manage_response :success, workshop: @other_workshop, user: @other_teacher
   end
 
-  test 'facilitators can read, but cannot manage, attendance for ended workshops' do
+  test 'facilitators can manage attendance for ended workshops' do
     @workshop.end!
     sign_in @facilitator
 
     assert_read_response :success
-    assert_manage_response :forbidden
+    assert_manage_response :success
   end
 
   test 'organizers can read, but cannot manage, attendance for ended workshops' do
@@ -124,12 +124,12 @@ class Api::V1::Pd::WorkshopAttendanceControllerTest < ActionDispatch::Integratio
     assert_manage_response :forbidden, workshop: @organizer_workshop
   end
 
-  test 'program manager organizers can read, but cannot manage, attendance for ended workshops' do
+  test 'program manager organizers can manage attendance for ended workshops' do
     @workshop.end!
     sign_in @organizer
 
     assert_read_response :success
-    assert_manage_response :forbidden
+    assert_manage_response :success
   end
 
   test 'admins can manage attendance for ended workshops' do


### PR DESCRIPTION
This PR allows Facilitators and Program Managers to edit Worshop Attendances after the workshop ends. We trust people with these permissions to edit attendance and this will hopefully cut down on Zendesk tickets.

## Demos
### Previous attendance page for an ended workshop for Program Managers (uneditable)
https://github.com/code-dot-org/code-dot-org/assets/56283563/f35ee8cd-3ba5-4e6c-b12b-cad4ffa50bb1

2 notes about this demo:
- For clarity, when my mouse hovers over the checkbox, I am clicking it but there is no response
- For the most part previously, the permissions lined up such that if the attendance field was uneditable for the permissions of the user viewing it, the field would instead show "Yes/No" rather than the checkbox. However, the field determining whether the attendance is readonly or not and the field determining whether to show the "Yes/No" values are two separate fields. So, looking at [this line](https://github.com/code-dot-org/code-dot-org/pull/55751/files#diff-3367615e2befb117221165342f07905e1da2e051aecaf363102a32193717680bL149), the Program Managers view it as a checkbox despite them being in readonly mode. This inconsistency will no longer exist after this PR, but I wanted to note why this demo looks different than the facilitators one.

### New attendance page for an ended workshop for Program Managers (editable)
https://github.com/code-dot-org/code-dot-org/assets/56283563/44e23bfd-0c7b-412b-8a82-294c2c534241

### Previous attendance page for an ended workshop for Facilitators (uneditable)
https://github.com/code-dot-org/code-dot-org/assets/56283563/23c06652-71ac-4cb6-b4b9-169cbbd6b232

### New attendance page for an ended workshop for Facilitators (editable)
https://github.com/code-dot-org/code-dot-org/assets/56283563/8080cd0f-6686-44a2-b283-2edf4ce7efdb

### Database still successfully updates (both when checking and unchecking)
For this test workshop, I had an enrolled user mark their attendance for the first session (id = 6) but not the second (id = 7).
![only_first_attendance](https://github.com/code-dot-org/code-dot-org/assets/56283563/346704c3-8a15-48a7-8a38-f2f12fef2ff2)
I then went in as the Program Manager and manually checked the attendance box to say they attended the second session of the workshop. This is reflected in the new `pd_attendance` entry.
![test manually mark attendance](https://github.com/code-dot-org/code-dot-org/assets/56283563/8e2a49a3-ae42-4af0-8079-aee40cd7a9a8)
Lastly, I (still as the Program Manager) manually un-checked the attendance box to say they did not actually attend. This is reflected in the `deleted_at` field being updated for the first session.
![manually unmark attendance](https://github.com/code-dot-org/code-dot-org/assets/56283563/791aec59-dbee-42aa-b973-8a282791bb04)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1253)

## Testing story
I tested locally to check its functionality and make the demos. I also updated tests in `workshop_attendance_controller_test.rb` which effectively tests the `manage_attendance` ability in `ability.rb` since there are no tests for it in `ability_test.rb`.

For front-end tests, I'm wondering if it's worth it to set up additional tests to make sure users with certain permission types are able to toggle the checkbox or not. Currently, there are no tests for it, I think because the components are pretty nested and get the relevant fields at different levels, making it difficult to write a given test that can start with a particular user permission type (e.g. Program Manager) and determine whether there should be a checkbox and if it should be editable:
- `workshop_attendance.jsx`:
   - Uses whether the workshop has ended and user permissions to determine if session attendance should be `readonly` or not. This `readonly` variable is then passed into `session_attendance`
   - Does not have an associated test file
- `session_attendance.jsx`:
   - Passes the `readonly` variable from `workshop_attendance` to `session_attendance_row.jsx` to determine if the row's fields should be editable
   - Performs its own user permissions check to determine whether to show the "Yes/No" values or the checkbox for attendance (I believe it can't use the `readonly` variable since that factors in whether the workshop is closed or not)
   - Has an associated test file
- `session_attendance_row.jsx`:
   - Uses the given `readonly` and `displayYesNoAttendance` parameters to determine whether to show the "Yes/No" or the checkbox, and if the checkbox should be editable or not
   - Has an associated test file

My gut reaction is that this is a spot we could certaintly have more testing in, but I'm wondering if it would make more sense to have a future backlog task that refactors these parameters so that we can write some end-to-end tests more easily. I'm curious about anyone's thoughts and am open to pushback if figuring out a way to get better test coverage for attendance on the front-end seems like a priority (either as part of this PR or an immediate followup)!