### PR TITLE
deflake teacher rubric ui test navigating to dance party level

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -13,7 +13,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I press "submitButton"
   And I wait to see "#confirm-button"
   And I press "confirm-button" to load a new page
-  And I wait to see "#song_selector"
+  And I wait until element ".header_text" contains text "Dance"
 
   # Teacher can see and submit feedback for a student
   Then I sign in as "Teacher_Lillian" and go home


### PR DESCRIPTION
Follows https://github.com/code-dot-org/code-dot-org/pull/55743.

For some reason, the UI test hangs when navigating to the dance party level, after submitting the rubric level. To work around it, try looking for an element that appears to have already loaded in this case: 

![Screenshot 2024-01-16 at 10 50 00 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/d473c93d-5c84-4084-bafa-b142f0bd31f4)
---
![Screenshot 2024-01-16 at 11 00 08 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/79437f46-da9e-4aae-a0ef-4cd0aa053050)
