### PR TITLE
P20-661/removed unused interpolation from translations

### DIFF
--- a/apps/i18n/common/de_de.json
+++ b/apps/i18n/common/de_de.json
@@ -1188,7 +1188,7 @@
   "lastEdited": "Zuletzt bearbeitet ",
   "lastProgress": "Letzter Fortschritt:",
   "lastPublished": "Zuletzt veröffentlicht",
-  "lastUpdated": "Zuletzt aktualisiert {time}",
+  "lastUpdated": "Zuletzt aktualisiert",
   "lastUpdatedByStudent": "Zuletzt aktualisiert von Student",
   "lastUpdatedCurrentTeacher": "Von Ihnen aktualisiert",
   "lastUpdatedDifferentTeacher": "Von einem anderen Lehrer aktualisiert",

--- a/apps/i18n/common/ga_ie.json
+++ b/apps/i18n/common/ga_ie.json
@@ -692,7 +692,7 @@
   "landscapeRecommendedCertificates": "Moltar duit na teastais a phriontáil sa mód **Tírdhreach**.",
   "languages": "Teangacha",
   "lastEdited": "Athraithe",
-  "lastUpdated": "Nuashonrú is déanaí: {time}",
+  "lastUpdated": "Athrú is déanaí",
   "lastUpdatedNoTime": "Nuashonraithe:",
   "learnHow": "Foghlaim anois",
   "learnMore": "Tuilleadh eolais",

--- a/apps/i18n/common/he_il.json
+++ b/apps/i18n/common/he_il.json
@@ -1163,7 +1163,7 @@
   "lastEdited": "נערך לאחרונה",
   "lastProgress": "התקדמות אחרונה:",
   "lastPublished": "פורסם לאחרונה",
-  "lastUpdated": "עודכן לאחרונה {time}",
+  "lastUpdated": "עודכן לאחרונה",
   "lastUpdatedByStudent": "עודכן לאחרונה על ידי סטודנט",
   "lastUpdatedCurrentTeacher": "עודכן על ידך",
   "lastUpdatedDifferentTeacher": "עודכן על ידי מורה אחר",

--- a/apps/i18n/common/hi_in.json
+++ b/apps/i18n/common/hi_in.json
@@ -1187,7 +1187,7 @@
   "lastEdited": "पिछली बार संपादित किया",
   "lastProgress": "पिछली प्रगति:",
   "lastPublished": "पिछली बार प्रकाशित किया",
-  "lastUpdated": "पिछली बार अद्यतन किया {time}",
+  "lastUpdated": "पिछली बार अद्यतन किया",
   "lastUpdatedByStudent": "पिछली बार छात्र द्वारा अपडेट किया",
   "lastUpdatedCurrentTeacher": "आपके द्वारा अपडेट किया गया",
   "lastUpdatedDifferentTeacher": "दूसरे अध्यापक द्वारा अपडेट किया गया",

--- a/apps/i18n/common/hu_hu.json
+++ b/apps/i18n/common/hu_hu.json
@@ -1143,7 +1143,7 @@
   "lastEdited": "Utoljára szerkesztve",
   "lastProgress": "Utolsó haladás:",
   "lastPublished": "Utolsó közzététel",
-  "lastUpdated": "Utolsó frissítés {time}",
+  "lastUpdated": "Legutóbb frissítve",
   "lastUpdatedByStudent": "Diák által történt utolsó frissítés",
   "lastUpdatedCurrentTeacher": "Saját frissítés",
   "lastUpdatedDifferentTeacher": "Egy másik tanár által történt frissítés",

--- a/apps/i18n/common/id_id.json
+++ b/apps/i18n/common/id_id.json
@@ -1241,7 +1241,7 @@
   "lastEdited": "Terakhir Diperbarui",
   "lastProgress": "Kemajuan Terakhir:",
   "lastPublished": "Terakhir Dipublikasikan",
-  "lastUpdated": "Terakhir diperbarui {time}",
+  "lastUpdated": "Terakhir pembaruan",
   "lastUpdatedByStudent": "Terakhir diperbarui oleh siswa",
   "lastUpdatedCurrentTeacher": "Diperbarui oleh Anda",
   "lastUpdatedDifferentTeacher": "Diperbarui oleh guru lain",

--- a/apps/i18n/common/it_it.json
+++ b/apps/i18n/common/it_it.json
@@ -1227,7 +1227,7 @@
   "lastEdited": "Ultima modifica",
   "lastProgress": "Ultimo Progresso:",
   "lastPublished": "Ultimo Pubblicato",
-  "lastUpdated": "Ultimo aggiornamento {time}",
+  "lastUpdated": "Ultimo aggiornamento",
   "lastUpdatedByStudent": "Ultimo aggiornamento dello studente",
   "lastUpdatedCurrentTeacher": "Aggiornato da te",
   "lastUpdatedDifferentTeacher": "Aggiornato da un altro insegnante",

--- a/apps/i18n/common/ka_ge.json
+++ b/apps/i18n/common/ka_ge.json
@@ -1134,7 +1134,7 @@
   "lastEdited": "ბოლოს რედაქტირებული",
   "lastProgress": "ბოლო პროგრესი:",
   "lastPublished": "ბოლოს გამოქვეყნებული",
-  "lastUpdated": "ბოლოს განახლებულია {time}",
+  "lastUpdated": "ბოლო განახლება",
   "lastUpdatedByStudent": "ბოლოს განახლდა მოსწავლის მიერ",
   "lastUpdatedCurrentTeacher": "განახლებულია შენს მიერ",
   "lastUpdatedDifferentTeacher": "განახლებულია სხვა მასწავლებლის მიერ",

--- a/apps/i18n/common/nl_nl.json
+++ b/apps/i18n/common/nl_nl.json
@@ -969,7 +969,7 @@
   "lastEdited": "Laatst bewerkt op",
   "lastProgress": "Meest recente voortgang:",
   "lastPublished": "Laatste publicatiedatum",
-  "lastUpdated": "Bijgewerkt om  {time}",
+  "lastUpdated": "Bijgewerkt om",
   "lastUpdatedNoTime": "Bijgewerkt:",
   "learnHow": "Leer hoe",
   "learnMore": "Leer meer",

--- a/apps/i18n/common/nn_no.json
+++ b/apps/i18n/common/nn_no.json
@@ -756,7 +756,7 @@
   "keyValuePairLink": "Nøkkel-/verdipar",
   "languages": "Språk",
   "lastEdited": "Sist endra",
-  "lastUpdated": "Sist oppdatert {time}",
+  "lastUpdated": "Sist oppdatert",
   "learnHow": "Lær korleis",
   "learnMore": "Lær meir",
   "learnMoreApplab": "Lær om App-lab",

--- a/apps/i18n/common/pt_br.json
+++ b/apps/i18n/common/pt_br.json
@@ -1343,7 +1343,7 @@
   "lastEdited": "Última Edição",
   "lastProgress": "Ultimo progresso:",
   "lastPublished": "Última publicação",
-  "lastUpdated": "Última atualização {time}",
+  "lastUpdated": "Última atualização",
   "lastUpdatedByStudent": "Última atualização pelo aluno",
   "lastUpdatedCurrentTeacher": "Atualizado por você",
   "lastUpdatedDifferentTeacher": "Atualizado por outro professor",

--- a/apps/i18n/common/pt_pt.json
+++ b/apps/i18n/common/pt_pt.json
@@ -1143,7 +1143,7 @@
   "lastEdited": "Última alteração",
   "lastProgress": "Ultimo progresso:",
   "lastPublished": "Última publicação",
-  "lastUpdated": "Última atualização {time}",
+  "lastUpdated": "Última atualização",
   "lastUpdatedByStudent": "Última atualização pelo aluno",
   "lastUpdatedCurrentTeacher": "Atualizado por você",
   "lastUpdatedDifferentTeacher": "Atualizado por outro professor",

--- a/apps/i18n/common/sk_sk.json
+++ b/apps/i18n/common/sk_sk.json
@@ -1176,7 +1176,7 @@
   "lastEdited": "Naposledy upravené",
   "lastProgress": "Posledný postup:",
   "lastPublished": "Naposledy publikované",
-  "lastUpdated": "Posledná aktualizácia {time}",
+  "lastUpdated": "Posledná aktualizácia",
   "lastUpdatedByStudent": "Naposledy aktualizované študentom",
   "lastUpdatedCurrentTeacher": "Aktualizované vami",
   "lastUpdatedDifferentTeacher": "Aktualizované iným učiteľom",

--- a/apps/i18n/common/sl_si.json
+++ b/apps/i18n/common/sl_si.json
@@ -354,7 +354,7 @@
   "keepPlaying": "Igraj naprej",
   "keyValuePairLink": "Ključ/vrednost parov",
   "languages": "Jeziki",
-  "lastUpdated": "Nazadnje posodobljeno {time}",
+  "lastUpdated": "Nazadnje posodobljeno",
   "lastUpdatedNoTime": "Nazadnje posodobljeno:",
   "learnMore": "Več o tem",
   "learnMoreWithPeriod": "Več o tem.",


### PR DESCRIPTION
When teachers were leaving feedback, student's pages would break.

The root cause was old translations that had an interpolation pattern not used anymore.

This PR removed the `{time}` interpolation from translations. I also updated the strings in Crowdin.
## Links

- jira ticket: [P20-661](https://codedotorg.atlassian.net/browse/P20-661)

## Testing story

tested locally on: http://localhost-studio.code.org:3000/s/express-2021/lessons/10/levels/7?lang=pt-PT

https://github.com/code-dot-org/code-dot-org/assets/66776217/4d4db36b-0530-4cde-a920-635423313514


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
