### PR TITLE
Add Microsoft Clarity heatmap tracking code to page header

### DIFF
--- a/dashboard/app/views/layouts/_microsoft_clarity.html.haml
+++ b/dashboard/app/views/layouts/_microsoft_clarity.html.haml
@@ -1,0 +1,7 @@
+-# Code snippet needed for Microsoft Clarity heatmap tracking.
+:javascript
+  (function(c,l,a,r,i,t,y) {
+      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+  })(window, document, "clarity", "script", "kmudotrgtk");

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -19,6 +19,7 @@
     = stylesheet_link_tag    'font-awesome', media: 'all'
     = stylesheet_link_tag    'application', media: 'all'
     = render partial: 'layouts/google_analytics'
+    = render partial: 'layouts/microsoft_clarity'
     -# data needed for dcdo.js. This tag is needed on every page because our translation code is
     -# making use of the dcdo feature.
     %script{data: {'dcdo': DCDO.frontend_config.to_json}}


### PR DESCRIPTION
This adds code to the page header needed for Microsoft Clarity heatmap tracking analytics. 

## Links

- [JIRA](https://codedotorg.atlassian.net/browse/TEACH-812)

## Testing story

Tested locally, supplied function shows up in the header as requested.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
