### PR TITLE
[A11y] Make 'Continue' button on 'External' levels tab-navigable

### DIFF
--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -19,7 +19,8 @@
       - if @script.try(:old_professional_learning_course?) && @script_level
         = link_to @script_level.end_of_lesson? ? t('done_with_module') : t('next_resource'), @script_level.next_level_or_redirect_path_for_user(current_user), class: 'btn btn-large pull-right btn-primary submitButton'
       - elsif !(video && use_large_video_player)
-        %a.btn.btn-large.btn-primary.next-lesson.submitButton.pull-right= t('continue')
+        .buttons.below-content-right{style: "float: right; max-width: 20%"}
+          = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton"
 
   = render partial: 'levels/content', locals: {app: 'external', data: level.properties, content_class: level.properties['options'].try(:[], 'css'), postcontent: postcontent, source_level: level}
   = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => level.localized_teacher_markdown}}

--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -33,8 +33,9 @@
 - if video && use_large_video_player
   .clear
   .video-container.external-video-container{{style: 'max-width: 970px; margin: auto'}}
-  .button-box{{style: 'width: 970px; margin: auto'}}
-    %a.btn.btn-large.btn-primary.next-lesson.submitButton.pull-right= t('continue')
+    .buttons.below-video-right{style: "float: right; max-width: 20%"}
+      = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton"
+
     - if video.download
       %a.video-download.btn.btn-large.pull-left{href: video.download}
         = t('video.download')

--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -19,8 +19,8 @@
       - if @script.try(:old_professional_learning_course?) && @script_level
         = link_to @script_level.end_of_lesson? ? t('done_with_module') : t('next_resource'), @script_level.next_level_or_redirect_path_for_user(current_user), class: 'btn btn-large pull-right btn-primary submitButton'
       - elsif !(video && use_large_video_player)
-        .buttons.below-content-right{style: "float: right; max-width: 20%"}
-          = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton"
+        .buttons.below-content-right
+          = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton pull-right"
 
   = render partial: 'levels/content', locals: {app: 'external', data: level.properties, content_class: level.properties['options'].try(:[], 'css'), postcontent: postcontent, source_level: level}
   = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => level.localized_teacher_markdown}}
@@ -33,12 +33,13 @@
 - if video && use_large_video_player
   .clear
   .video-container.external-video-container{{style: 'max-width: 970px; margin: auto'}}
-    .buttons.below-video-right{style: "float: right; max-width: 20%"}
-      = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton"
-
+  .button-box{{style: 'width: 970px; margin: auto'}}
     - if video.download
       %a.video-download.btn.btn-large.pull-left{href: video.download}
         = t('video.download')
+    .buttons.below-content-right
+      = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton pull-right"
+
 
 .clear
 

--- a/dashboard/app/views/levels/_standalone_video.html.haml
+++ b/dashboard/app/views/levels/_standalone_video.html.haml
@@ -37,8 +37,8 @@
     #fallback-player-caption-dialog-link
 
   - if @level.video_full_width
-    .buttons.below-video-right
-      = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton pull-right"
+    .buttons.below-video-right{style: "float: right; max-width: 20%"}
+      = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton"
 
   %br/
   %br/

--- a/dashboard/app/views/levels/_standalone_video.html.haml
+++ b/dashboard/app/views/levels/_standalone_video.html.haml
@@ -37,8 +37,8 @@
     #fallback-player-caption-dialog-link
 
   - if @level.video_full_width
-    .buttons.below-video-right{style: "float: right; max-width: 20%"}
-      = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton"
+    .buttons.below-video-right
+      = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson pull-right submitButton"
 
   %br/
   %br/

--- a/dashboard/app/views/levels/_standalone_video.html.haml
+++ b/dashboard/app/views/levels/_standalone_video.html.haml
@@ -38,7 +38,7 @@
 
   - if @level.video_full_width
     .buttons.below-video-right
-      = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson pull-right submitButton"
+      = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton pull-right"
 
   %br/
   %br/


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the 'Continue' button on external .level types so that it is tab-navigable, in particular, the [Outbreak Simulator](https://studio.code.org/s/outbreak/lessons/1/levels/1) as described in [this ticket](https://codedotorg.atlassian.net/browse/LABS-220).

I noticed on 'standalone_video' levels such as https://studio.code.org/s/dance-ai-2023/lessons/1/levels/1, the 'Continue' button is already tab-navigable [here](https://github.com/code-dot-org/code-dot-org/blob/22151566501db531b45bf91325e256b5d94670ad/dashboard/app/views/levels/_standalone_video.html.haml#L40-L41). So I replaced the anchor element in `_external.html.haml` with a button (with and without video) in a similar fashion.



Video 1 -  BEFORE update: Note that when the user tabs to navigate elements on the page, the 'Continue' button is skipped.
First level with content: https://studio.code.org/s/outbreak/lessons/1/levels/1
Second level with video but `use_large_video_player` is undefined: https://studio.code.org/s/csp4-2017/lessons/4/levels/2

https://github.com/code-dot-org/code-dot-org/assets/107423305/8f08af86-216d-497d-b703-477b9df9aec0

Video 2 - BEFORE update: Note that when the user tabs to navigate elements on the page, the 'Continue' button is skipped.
Level with video and `use_large_video_player` is set to `true`: https://studio.code.org/s/coursed-2019/lessons/15/levels/1

https://github.com/code-dot-org/code-dot-org/assets/107423305/cf24c48f-3987-417a-8fa3-e0a0f247b838


AFTER update: ¥ou will see that you can now tab-navigate to the 'Continue' button.

https://github.com/code-dot-org/code-dot-org/assets/107423305/2b725b97-bf2c-4390-9294-a4650afbef89

Level with video and `use_large_video_player` is set to `true`:

https://github.com/code-dot-org/code-dot-org/assets/107423305/0c50d27d-d14f-4f7b-83aa-b6d6203fa905




## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-220)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
I noticed that the Authored Hints lightbulb in the Instructions pane is not tab-navigable. Ticket logged https://codedotorg.atlassian.net/browse/LABS-468
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
