### PR TITLE
[Python Lab] Add example multi-file support

### DIFF
--- a/apps/src/pythonlab/pyodideWorkerManager.js
+++ b/apps/src/pythonlab/pyodideWorkerManager.js
@@ -1,6 +1,9 @@
 import {getStore} from '@cdo/apps/redux';
 import {appendOutput} from './pythonlabRedux';
 
+// A default file to import into the user's script.
+const otherFileContents = "def hello():\n  print('hello')\n";
+
 // This syntax doesn't work with typescript, so this file is in js.
 const pyodideWorker = new Worker(
   new URL('./pyodideWebWorker.js', import.meta.url)
@@ -27,17 +30,32 @@ const asyncRun = (() => {
     return new Promise(onSuccess => {
       callbacks[id] = onSuccess;
       // Add code to flush stdout to the user's script.
-      script = 'import sys\nimport os\n' + script;
-      script += '\nsys.stdout.flush()';
-      script += '\nos.fsync(sys.stdout.fileno())\n';
+      // Proof of concept that we can import a local file (in a multi-file scenario)
+      let wrappedScript = importFileCode('helpers.py', otherFileContents);
+      wrappedScript += 'import sys\nimport os\n' + script;
+      wrappedScript += '\nsys.stdout.flush()';
+      wrappedScript += '\nos.fsync(sys.stdout.fileno())\n';
       const messageData = {
         ...context,
-        python: script,
+        python: wrappedScript,
         id,
       };
       pyodideWorker.postMessage(messageData);
     });
   };
 })();
+
+// Helper function that adds code to import a local file for use in the user's script.
+const importFileCode = (fileName, fileContents) => {
+  return `
+import importlib
+from pathlib import Path
+Path("${fileName}").write_text("""\
+${fileContents}
+"""
+)
+importlib.invalidate_caches()
+`;
+};
 
 export {asyncRun};


### PR DESCRIPTION
Add code for how we could support multi-file in Python Lab. The editor is not currently set up for multi-file, this is just showing how we could import student code given a file name and file contents.

The sample code is in a "file" called `helpers.py`. It contains a single `hello` function which prints "hello". With this change, Python Lab can run the following:
```
from helpers import hello

hello()
```

And on run, will print `hello` to the console.

Once we add multi-file, we can repeat the same code for each non `main.py` file in the user's project to import each file in their project for use. 

## Links

- jira ticket: [CT-265](https://codedotorg.atlassian.net/browse/CT-265)

## Testing story
Tested that the above scenario now works. Python Lab is limited to levelbuilders and is only on an allthethings level so the potential impact here is minimal.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
