### PR TITLE
Removing alt-text comment

### DIFF
--- a/apps/src/lib/ui/LegacyDialogContents.js
+++ b/apps/src/lib/ui/LegacyDialogContents.js
@@ -43,10 +43,6 @@ export const LegacyMatchAngiGifDialog = () => (
       <p className="dialog-title">{i18n.instructions()}</p>
       <p>{i18n.dragBlocksToMatch()}</p>
       <div className="aniGif example-image" style={{overflow: 'hidden'}}>
-        {
-          // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-          // Verify or update this alt-text as necessary
-        }
         <img src="/script_assets/images/matching_ani.gif" alt="" />
       </div>
       <div className="farSide">


### PR DESCRIPTION
Accessibility hackathon follow-up work: this is an animated gif with directions for a matching level. The pop-up already includes text (see image) that explains the level so keeping alt-text wouldn't functionally add any more information.

<img width="710" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/95503833/3eb63c2a-39da-4ea8-9a45-c7b1c33c4cd3">


## Links

- jira ticket: https://codedotorg.atlassian.net/browse/A11Y-279

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
