### PR TITLE
Temporarily disable Music Lab UI test on Safari

### DIFF
--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
@@ -1,4 +1,6 @@
 @no_mobile
+@no_safari
+# TODO: This test has been flaky on Safari. Investigate and re-enable.
 
 Feature: Music Lab block can be dragged
 


### PR DESCRIPTION
Temporarily disabling a flaky Music Lab UI test on Safari that has been blocking builds recently.

## Links

JIRA to investigate and re-enable: https://codedotorg.atlassian.net/browse/LABS-457
Slack thread: https://codedotorg.slack.com/archives/C03DBDN67B7/p1705432832639999