### PR TITLE
Use email_address_with_name and add unit tests

### DIFF
--- a/dashboard/app/mailers/pd/application/teacher_application_mailer.rb
+++ b/dashboard/app/mailers/pd/application/teacher_application_mailer.rb
@@ -1,8 +1,8 @@
 module Pd::Application
   class TeacherApplicationMailer < ApplicationMailer
     # This should be kept consistent with the signature in _partner_signature.html.haml
-    CODE_ORG_DEFAULT_NOTIFICATION_EMAIL = 'Nikki Navta <teacher@code.org>'
-    default from: 'Code.org <noreply@code.org>'
+    CODE_ORG_DEFAULT_NOTIFICATION_EMAIL = email_address_with_name('teacher@code.org', 'Nikki Navta')
+    default from: email_address_with_name('noreply@code.org', 'Code.org')
     default bcc: MailerConstants::PLC_EMAIL_LOG
 
     def confirmation(teacher_application)

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -125,7 +125,7 @@ module Pd::Application
         raise "invalid email address for application #{id}"
       end
 
-      "\"#{applicant_full_name}\" <#{applicant_email}>"
+      ActionMailer::Base.email_address_with_name(applicant_email, applicant_full_name)
     end
 
     # Sends an email for this application
@@ -342,9 +342,9 @@ module Pd::Application
       return nil if regional_partner&.contact_email_with_backup.blank?
 
       if regional_partner.contact_name.present? && regional_partner.contact_email.present?
-        "\"#{regional_partner.contact_name}\" <#{regional_partner.contact_email}>"
+        ActionMailer::Base.email_address_with_name(regional_partner.contact_email, regional_partner.contact_name)
       elsif regional_partner.program_managers&.first.present?
-        "\"#{regional_partner.program_managers.first.name}\" <#{regional_partner.program_managers.first.email}>"
+        ActionMailer::Base.email_address_with_name(regional_partner.program_managers.first.email, regional_partner.program_managers.first.name)
       end
     end
 

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -433,7 +433,7 @@ module Pd::Application
     end
 
     def formatted_principal_email
-      "\"#{principal_greeting}\" <#{principal_email}>"
+      ActionMailer::Base.email_address_with_name(principal_email, principal_greeting)
     end
 
     def effective_regional_partner_name

--- a/dashboard/test/mailers/pd/application/teacher_application_mailer_test.rb
+++ b/dashboard/test/mailers/pd/application/teacher_application_mailer_test.rb
@@ -1,0 +1,116 @@
+require 'test_helper'
+
+class TeacherApplicationMailerTest < ActionMailer::TestCase
+  setup do
+    @regional_partner = create :regional_partner
+    @application_with_partner = create :pd_teacher_application
+    @application_with_partner.update!(regional_partner: @regional_partner)
+    @application_without_partner = create :pd_teacher_application, regional_partner: nil
+  end
+
+  test 'confirmation email sends with regional partner' do
+    email = Pd::Application::TeacherApplicationMailer.confirmation(@application_with_partner)
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert email.to.include?(@application_with_partner.user.email)
+    assert email.subject.include?(@regional_partner.name)
+    assert_equal @regional_partner.contact_email, email['reply-to']
+    assert_equal "\"Code.org\" <noreply@code.org>", email['from'].to_s
+  end
+
+  test 'confirmation email sends without regional partner' do
+    email = Pd::Application::TeacherApplicationMailer.confirmation(@application_without_partner)
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert email.to.include?(@application_without_partner.user.email)
+    assert email.subject.include?('We\'ve received your application for Code.org\'s Professional Learning Program!')
+    assert_includes email.from, "teacher@code.org"
+  end
+
+  test 'admin approval teacher reminder email sends with regional partner' do
+    email = Pd::Application::TeacherApplicationMailer.admin_approval_teacher_reminder(@application_with_partner)
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert email.to.include?(@application_with_partner.user.email)
+    assert email.subject.include?('REMINDER - Action Needed: Your application needs Administrator/School Leader approval')
+    assert_equal @regional_partner.contact_email, email['reply-to']
+    assert_equal "\"Code.org\" <noreply@code.org>", email['from'].to_s
+  end
+
+  test 'admin approval teacher reminder email sends without regional partner' do
+    email = Pd::Application::TeacherApplicationMailer.admin_approval_teacher_reminder(@application_without_partner)
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert email.to.include?(@application_without_partner.user.email)
+    assert email.body.include?(@application_without_partner.principal_approval_url)
+    assert email.subject.include?('REMINDER - Action Needed: Your application needs Administrator/School Leader approval')
+    assert_includes email.from, "teacher@code.org"
+  end
+
+  test 'needs admin approval email sends with regional partner' do
+    email = Pd::Application::TeacherApplicationMailer.needs_admin_approval(@application_with_partner)
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert email.to.include?(@application_with_partner.user.email)
+    assert email.subject.include?('Important: Your Application Requires Administrator/School Leader Approval')
+    assert_equal @regional_partner.contact_email, email['reply-to']
+    assert_equal "\"Code.org\" <noreply@code.org>", email['from'].to_s
+  end
+
+  test 'needs admin approval email sends without regional partner' do
+    email = Pd::Application::TeacherApplicationMailer.needs_admin_approval(@application_without_partner)
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert email.to.include?(@application_without_partner.user.email)
+    assert email.body.include?(@application_without_partner.principal_approval_url)
+    assert email.subject.include?('Important: Your Application Requires Administrator/School Leader Approval')
+    assert_includes email.from, "teacher@code.org"
+  end
+
+  test 'admin approval email sends' do
+    email = Pd::Application::TeacherApplicationMailer.admin_approval(@application_with_partner)
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert email.to.include?(@application_with_partner.principal_email)
+  end
+
+  test 'admin approval teacher receipt email sends with regional partner' do
+    email = Pd::Application::TeacherApplicationMailer.admin_approval_completed_teacher_receipt(@application_with_partner)
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert email.to.include?(@application_with_partner.user.email)
+    assert email.subject.include?('Your Administrator/School Leader has approved your application')
+    assert_equal @regional_partner.contact_email, email['reply-to']
+    assert_equal "\"Code.org\" <noreply@code.org>", email['from'].to_s
+  end
+
+  test 'admin approval teacher receipt email sends without regional partner' do
+    email = Pd::Application::TeacherApplicationMailer.admin_approval_completed_teacher_receipt(@application_without_partner)
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert email.to.include?(@application_without_partner.user.email)
+    assert email.subject.include?('Your Administrator/School Leader has approved your application')
+    assert_includes email.from, "teacher@code.org"
+  end
+
+  test 'accepted email sends with regional partner' do
+    @application_with_partner.pd_workshop_id = create(:pd_workshop, regional_partner: @regional_partner).id
+    email = Pd::Application::TeacherApplicationMailer.accepted(@application_with_partner)
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert email.to.include?(@application_with_partner.user.email)
+    assert email.subject.include?('Congratulations from')
+    assert_equal @regional_partner.contact_email, email['reply-to']
+    assert_equal "\"Code.org\" <noreply@code.org>", email['from'].to_s
+  end
+end

--- a/dashboard/test/models/pd/application/application_base_test.rb
+++ b/dashboard/test/models/pd/application/application_base_test.rb
@@ -353,8 +353,7 @@ module Pd::Application
       # name and email
       partner.contact_name = 'We Teach Code'
       partner.contact_email = 'we_teach_code@ex.net'
-      assert_includes application.formatted_partner_contact_email, 'We Teach Code'
-      assert_includes application.formatted_partner_contact_email, 'we_teach_code@ex.net'
+      assert_equal "We Teach Code <we_teach_code@ex.net>", application.formatted_partner_contact_email
     end
 
     test 'formatted_applicant_email uses user account email' do

--- a/dashboard/test/models/pd/application/application_base_test.rb
+++ b/dashboard/test/models/pd/application/application_base_test.rb
@@ -347,12 +347,14 @@ module Pd::Application
 
       # program manager but no contact_name or contact_email
       program_manager = (create :regional_partner_program_manager, regional_partner: partner).program_manager
-      assert_equal "\"#{program_manager.name}\" <#{program_manager.email}>", application.formatted_partner_contact_email
+      assert_includes application.formatted_partner_contact_email, program_manager.name
+      assert_includes application.formatted_partner_contact_email, program_manager.email
 
       # name and email
       partner.contact_name = 'We Teach Code'
       partner.contact_email = 'we_teach_code@ex.net'
-      assert_equal "\"We Teach Code\" <we_teach_code@ex.net>", application.formatted_partner_contact_email
+      assert_includes application.formatted_partner_contact_email, 'We Teach Code'
+      assert_includes application.formatted_partner_contact_email, 'we_teach_code@ex.net'
     end
 
     test 'formatted_applicant_email uses user account email' do
@@ -360,8 +362,8 @@ module Pd::Application
 
       assert application.user.email.present?
 
-      formatted_email = "\"#{application.applicant_full_name}\" <#{application.user.email}>"
-      assert_equal formatted_email, application.formatted_applicant_email
+      assert_includes application.formatted_applicant_email, application.user.email
+      assert_includes application.formatted_applicant_email, application.applicant_full_name
     end
 
     test 'formatted_applicant_email uses alternate email if no user account email' do
@@ -373,8 +375,8 @@ module Pd::Application
 
       assert teacher_without_email.email.blank?
 
-      formatted_alternate_email = "\"#{application.applicant_full_name}\" <#{application.sanitized_form_data_hash[:alternate_email]}>"
-      assert_equal formatted_alternate_email, application.formatted_applicant_email
+      assert_includes application.formatted_applicant_email, application.applicant_full_name
+      assert_includes application.formatted_applicant_email, application.sanitized_form_data_hash[:alternate_email]
     end
 
     test 'formatted_applicant_email raises error if no user email or alternate email' do


### PR DESCRIPTION
A speculative fix for the strange quoting: using `email_address_with_name`. This was added in Rails 6, and therefore likely didn't exist when this code was previously written/updated. It handle escaping special characters for us, which is a generally good improvement. See [this blog](https://www.bigbinary.com/blog/rails-6-adds-actionmailer-email_address_with_name) that Turner found and [the Rails documentation](https://api.rubyonrails.org/classes/ActionMailer/Base.html#method-c-email_address_with_name) for more info!

I also added a mailer test for the teacher application mailer as part of this PR. There isn't super complex logic in the teacher application mailer but there is a fair amount of if-RP-then-else kind of logic. Definitely open to suggestions on things I should test there!