### PR TITLE
Link to self paced PL in decline email

### DIFF
--- a/dashboard/app/views/pd/application/teacher_application_mailer/declined.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/declined.html.haml
@@ -9,12 +9,15 @@
   = @application.course_name + "."
   Our team appreciated the opportunity to review your application and learn about your
   commitment to computer science education. I'm writing to let you know that we are currently
-  unable to offer you a space in the Professional Learning Program this year.
+  unable to offer you a space in the Professional Learning Program this year. We encourage you
+  to explore our
+  = link_to('free, self-paced online Professional Learning', 'https://code.org/educate/professional-development-online')
+  programs.
 
 %p
   We hope that you will continue to use Code.org's resources and materials
-  which are available free for all educators at
-  = link_to('code.org/educate', 'https://code.org/educate') + '.'
+  which are free for all educators at
+  = link_to('code.org/teach', 'https://code.org/teach') + '.'
   If your plans for next year change, we'd like to invite you to
   = link_to('apply again', 'https://code.org/apply')
   next year.


### PR DESCRIPTION
Add a sentence about self-paced PL in the decline email. See the [spec](https://docs.google.com/document/d/1HX7n1stbdmzzWrUi8--Z-6GuCRUqyzoNkZbH9w7TO7I/edit#heading=h.gvl8fl9gu3h5).

How the preview looks now:

<img width="1417" alt="Screenshot 2024-01-17 at 12 09 36 PM" src="https://github.com/code-dot-org/code-dot-org/assets/46464143/3a1216d4-d374-4fbe-8b31-9d2c83703f0c">
