### PR TITLE
Speculative fix for a flaky PL UI test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -26,7 +26,7 @@ Feature: Professional learning Sections
     # TODO TEACH-592: Seed PL courses so we can test course assignment
     # And I click selector "button:contains(Professional Learning)"
     # And I press the first "input[name='Teacher PL Course']" element
-    And I press the first "#uitest-save-section-changes" element
+    And I press the first "#uitest-save-section-changes" element to load a new page
     And I wait until element ".uitest-owned-pl-sections" is visible
 
     # Professional Learning Sections Table
@@ -57,7 +57,7 @@ Feature: Professional learning Sections
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
-    And I press the first "#uitest-save-section-changes" element
+    And I press the first "#uitest-save-section-changes" element to load a new page
     And I wait until element ".uitest-owned-pl-sections" is visible
 
     # Professional Learning Sections Table
@@ -88,7 +88,7 @@ Feature: Professional learning Sections
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
-    And I press the first "#uitest-save-section-changes" element
+    And I press the first "#uitest-save-section-changes" element to load a new page
     And I wait until element ".uitest-owned-pl-sections" is visible
 
     # Professional Learning Sections Table
@@ -119,7 +119,7 @@ Feature: Professional learning Sections
     Then I wait to see "#sections-set-up-container"
     And I press keys "My Section of Teachers" for element "#uitest-section-name-setup"
     And I wait until element "button:contains(Professional Learning)" is visible
-    And I press the first "#uitest-save-section-changes" element
+    And I press the first "#uitest-save-section-changes" element to load a new page
     And I wait until element ".uitest-owned-pl-sections" is visible
 
     # Professional Learning Sections Table


### PR DESCRIPTION
Speculative fix for a flaky UI test for professional learning sections - this adds a `to load a new page` after a click to wait for the page to finish loading before the next step.

## Links

Flaky test log: https://cucumber-logs.s3.amazonaws.com/test/test/Firefox_teacher_tools_pl_sections_output.html?versionId=taGx_HdPobvkMJ.bbNr0_vs1iaycmjD9


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
