### PR TITLE
Admin account deletion warning

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -61,6 +61,8 @@
   "addToProjects": "Add to Projects",
   "addedToProjects": "Added",
   "addingToProjects": "Adding...",
+  "adminAccountDeletionDialog_header": "Delete Admin Account",
+  "adminAccountDeletionDialog_body": "You are about delete an admin account. Are you sure you would like to continue?",
   "administrator": "Administrator",
   "administratorResourcesDescription": "View these resources to get started on expanding computer science opportunities.",
   "administratorResourcesHeading": "Expand computer science in your school or district",

--- a/apps/src/lib/ui/accounts/AdminAccountDialog.jsx
+++ b/apps/src/lib/ui/accounts/AdminAccountDialog.jsx
@@ -1,0 +1,68 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import i18n from '@cdo/locale';
+import color from '@cdo/apps/util/color';
+import BaseDialog from '@cdo/apps/templates/BaseDialog';
+import {Header, ConfirmCancelFooter} from '../SystemDialog/SystemDialog';
+
+const GUTTER = 20;
+
+export default class AdminAccountDialog extends React.Component {
+  static propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    onConfirm: PropTypes.func.isRequired,
+  };
+
+  render() {
+    const {isOpen, onCancel, onConfirm} = this.props;
+
+    return (
+      <BaseDialog
+        useUpdatedStyles
+        fixedWidth={550}
+        isOpen={isOpen}
+        handleClose={onCancel}
+      >
+        <div style={styles.container}>
+          <Header text={i18n.adminAccountDeletionDialog_header()} />
+          <p>
+            <strong style={styles.dangerText}>
+              {i18n.adminAccountDeletionDialog_body()}
+            </strong>
+          </p>
+          <ConfirmCancelFooter
+            confirmText={i18n.continue()}
+            onConfirm={onConfirm}
+            onCancel={onCancel}
+            tabIndex="1"
+          />
+        </div>
+      </BaseDialog>
+    );
+  }
+}
+
+const styles = {
+  container: {
+    margin: GUTTER,
+    color: color.charcoal,
+  },
+  dangerText: {
+    color: color.red,
+  },
+  studentBox: {
+    padding: GUTTER / 2,
+    marginBottom: GUTTER / 2,
+    backgroundColor: color.background_gray,
+    border: `1px solid ${color.lighter_gray}`,
+    borderRadius: 4,
+    height: 50,
+    overflowY: 'scroll',
+  },
+  button: {
+    display: 'block',
+    textAlign: 'center',
+    marginBottom: '1em',
+  },
+};

--- a/apps/src/lib/ui/accounts/AdminAccountDialog.jsx
+++ b/apps/src/lib/ui/accounts/AdminAccountDialog.jsx
@@ -7,41 +7,37 @@ import {Header, ConfirmCancelFooter} from '../SystemDialog/SystemDialog';
 
 const GUTTER = 20;
 
-export default class AdminAccountDialog extends React.Component {
-  static propTypes = {
-    isOpen: PropTypes.bool.isRequired,
-    onCancel: PropTypes.func.isRequired,
-    onConfirm: PropTypes.func.isRequired,
-  };
+const AdminAccountDialog = ({isOpen, onCancel, onConfirm}) => {
+  return (
+    <BaseDialog
+      useUpdatedStyles
+      fixedWidth={550}
+      isOpen={isOpen}
+      handleClose={onCancel}
+    >
+      <div style={styles.container}>
+        <Header text={i18n.adminAccountDeletionDialog_header()} />
+        <p>
+          <strong style={styles.dangerText}>
+            {i18n.adminAccountDeletionDialog_body()}
+          </strong>
+        </p>
+        <ConfirmCancelFooter
+          confirmText={i18n.continue()}
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+          tabIndex="1"
+        />
+      </div>
+    </BaseDialog>
+  );
+};
 
-  render() {
-    const {isOpen, onCancel, onConfirm} = this.props;
-
-    return (
-      <BaseDialog
-        useUpdatedStyles
-        fixedWidth={550}
-        isOpen={isOpen}
-        handleClose={onCancel}
-      >
-        <div style={styles.container}>
-          <Header text={i18n.adminAccountDeletionDialog_header()} />
-          <p>
-            <strong style={styles.dangerText}>
-              {i18n.adminAccountDeletionDialog_body()}
-            </strong>
-          </p>
-          <ConfirmCancelFooter
-            confirmText={i18n.continue()}
-            onConfirm={onConfirm}
-            onCancel={onCancel}
-            tabIndex="1"
-          />
-        </div>
-      </BaseDialog>
-    );
-  }
-}
+AdminAccountDialog.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+};
 
 const styles = {
   container: {
@@ -66,3 +62,5 @@ const styles = {
     marginBottom: '1em',
   },
 };
+
+export default AdminAccountDialog;

--- a/apps/src/lib/ui/accounts/DeleteAccount.jsx
+++ b/apps/src/lib/ui/accounts/DeleteAccount.jsx
@@ -14,6 +14,7 @@ import PersonalLoginDialog, {
   dependentStudentsShape,
 } from './PersonalLoginDialog';
 import DeleteAccountDialog from './DeleteAccountDialog';
+import AdminAccountDialog from './AdminAccountDialog';
 
 export const DELETE_VERIFICATION_STRING =
   i18n.deleteAccountDialog_verificationString();
@@ -21,6 +22,7 @@ export const DELETE_VERIFICATION_STRING =
 const DEFAULT_STATE = {
   isPersonalLoginDialogOpen: false,
   isDeleteAccountDialogOpen: false,
+  isAdminAccountDialogOpen: false,
   password: '',
   passwordError: '',
   deleteVerification: '',
@@ -37,6 +39,7 @@ export default class DeleteAccount extends React.Component {
     isTeacher: PropTypes.bool.isRequired,
     dependentStudents: dependentStudentsShape,
     hasStudents: PropTypes.bool.isRequired,
+    isAdmin: PropTypes.bool.isRequired,
   };
 
   constructor(props) {
@@ -65,6 +68,15 @@ export default class DeleteAccount extends React.Component {
       return {
         ...DEFAULT_STATE,
         isPersonalLoginDialogOpen: !state.isPersonalLoginDialogOpen,
+      };
+    });
+  };
+
+  toggleAdminAccountDialog = () => {
+    this.setState(state => {
+      return {
+        ...DEFAULT_STATE,
+        isAdminAccountDialogOpen: !state.isAdminAccountDialogOpen,
       };
     });
   };
@@ -156,9 +168,11 @@ export default class DeleteAccount extends React.Component {
   };
 
   render() {
-    const {isTeacher, dependentStudents, isPasswordRequired} = this.props;
+    const {isTeacher, dependentStudents, isPasswordRequired, isAdmin} =
+      this.props;
     const {
       isPersonalLoginDialogOpen,
+      isAdminAccountDialogOpen,
       isDeleteAccountDialogOpen,
       checkboxes,
       password,
@@ -183,6 +197,8 @@ export default class DeleteAccount extends React.Component {
             onClick={
               isDependedUponForLogin
                 ? this.togglePersonalLoginDialog
+                : isAdmin
+                ? this.toggleAdminAccountDialog
                 : this.toggleDeleteAccountDialog
             }
           />
@@ -191,6 +207,11 @@ export default class DeleteAccount extends React.Component {
           isOpen={isPersonalLoginDialogOpen}
           dependentStudents={dependentStudents}
           onCancel={this.togglePersonalLoginDialog}
+          onConfirm={this.goToDeleteAccountDialog}
+        />
+        <AdminAccountDialog
+          isOpen={isAdminAccountDialogOpen}
+          onCancel={this.toggleAdminAccountDialog}
           onConfirm={this.goToDeleteAccountDialog}
         />
         <DeleteAccountDialog

--- a/apps/src/lib/ui/accounts/DeleteAccountDialog.story.jsx
+++ b/apps/src/lib/ui/accounts/DeleteAccountDialog.story.jsx
@@ -18,6 +18,7 @@ const DEFAULT_PROPS = {
   onCancel: action('Cancel'),
   disableConfirm: false,
   deleteUser: action('Delete my Account'),
+  isAdmin: false,
 };
 
 export default {

--- a/apps/src/sites/studio/pages/devise/registrations/edit.js
+++ b/apps/src/sites/studio/pages/devise/registrations/edit.js
@@ -21,6 +21,7 @@ const scriptData = getScriptData('edit');
 const {
   userAge,
   userType,
+  isAdmin,
   isPasswordRequired,
   authenticationOptions,
   isGoogleClassroomStudent,
@@ -133,6 +134,7 @@ $(document).ready(() => {
         dependedUponForLogin={dependedUponForLogin}
         dependentStudents={dependentStudents}
         hasStudents={studentCount > 0}
+        isAdmin={isAdmin}
       />,
       deleteAccountMountPoint
     );

--- a/apps/test/unit/lib/ui/accounts/DeleteAccountTest.jsx
+++ b/apps/test/unit/lib/ui/accounts/DeleteAccountTest.jsx
@@ -244,5 +244,21 @@ describe('DeleteAccount', () => {
         );
       });
     });
+
+    describe('for admin', () => {
+      it('displays AdminAccountDialog if trying to delete admin account', () => {
+        const wrapper = mount(
+          <DeleteAccount {...DEFAULT_PROPS} isAdmin={true} />
+        );
+        const deleteAccountButton = wrapper.find('BootstrapButton').at(0);
+        deleteAccountButton.simulate('click');
+        const adminAccountDialog = wrapper.find('AdminAccountDialog');
+        expect(adminAccountDialog).to.exist;
+        const confirmButton = wrapper.find('Button').at(0);
+        confirmButton.simulate('click');
+        const deleteAccountDialog = wrapper.find('DeleteAccountDialog');
+        expect(deleteAccountDialog).to.exist;
+      });
+    });
   });
 });

--- a/apps/test/unit/lib/ui/accounts/DeleteAccountTest.jsx
+++ b/apps/test/unit/lib/ui/accounts/DeleteAccountTest.jsx
@@ -13,6 +13,7 @@ const DEFAULT_PROPS = {
   isTeacher: false,
   hasStudents: false,
   dependentStudents: [],
+  isAdmin: false,
 };
 
 describe('DeleteAccount', () => {

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -258,6 +258,7 @@
     edit: {
       userAge: current_user.age,
       userType: current_user.user_type,
+      isAdmin: current_user.admin,
       isOauth: current_user.oauth?,
       isPasswordRequired: current_user.encrypted_password.present?,
       authenticationOptions: current_user.authentication_options.map(&:summarize),


### PR DESCRIPTION
Creates an "Delete Admin Account" warning if the user is an admin and tries to delete their account. This will help prevent admin users from accidentally deleting their account when assuming an identity.
<img width="1792" alt="Screenshot 2024-01-18 at 10 27 24 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/6e6b6c1c-16e2-4648-be49-96e3e7cbb9c1">

## Links
- jira ticket: [here](https://codedotorg.atlassian.net/browse/P20-346)


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->



## Follow-up work
While this will prevent admin users from accidentally deleting their account, we need to investigate more into why navigating to "Account Settings" when an identity is assumed will sometimes revert back to the admin account's "Account Settings"




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
