### PR TITLE
Quick fix for errors on level extras page for levelbuilder users

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -17,6 +17,7 @@ module LevelsHelper
   include AzureTextToSpeech
 
   def build_script_level_path(script_level, params = {})
+    params ||= {}
     if script_level.script.name == Unit::HOC_NAME
       hoc_chapter_path(script_level.chapter, params)
     elsif script_level.script.name == Unit::FLAPPY_NAME


### PR DESCRIPTION
This fixes an error on level extras pages for users with levelbuilder permissions. When the admin panel tries to load it looks for extra params which were not set by the level extras page so they were nil, preventing the whole page from loading. This sets params to an empty hash if it is nil.

## Links

Slack Thread: https://codedotorg.slack.com/archives/C045UAX4WKH/p1705435309182409

## Testing Story

Reproduced the problem locally with a levelbuilder user not in levelbuilder mode, and this change fixes the problem in the repro

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
