### PR TITLE
Show correct buttons on code.org homepage hero banner when hoc_mode is false

### DIFF
--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -286,7 +286,7 @@ class Homepage
           url: "/hourofcode"
         }
       ]
-    elsif ["post-hoc", "pre-hoc", "false"].include? hoc_mode
+    elsif ["post-hoc", "pre-hoc", "false", false].include? hoc_mode
       [
         {
           text: "homepage_action_text_learn",

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -286,7 +286,7 @@ class Homepage
           url: "/hourofcode"
         }
       ]
-    elsif ["post-hoc", "pre-hoc"].include? hoc_mode
+    elsif ["post-hoc", "pre-hoc", "false"].include? hoc_mode
       [
         {
           text: "homepage_action_text_learn",


### PR DESCRIPTION
Shows the default calls to action when `hoc_mode` is `"false"` or `false`.

**Jira ticket:** [ACQ-1370](https://codedotorg.atlassian.net/browse/ACQ-1370)

----

## Before
<img width="1372" alt="Screenshot 2024-01-17 at 12 43 00 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/d60923b5-8963-484c-8d16-e1e0fa3661bd">

## After
<img width="1370" alt="Screenshot 2024-01-17 at 12 39 49 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/32891046-c792-4459-9815-0e2bd80b3041">
