### PR TITLE
PL Launch 2024 - Show superhero announcement banner on teacher homepage

### DIFF
--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -1,7 +1,7 @@
 {
   "pages": {
     "/courses": "hoc-2023-dance-ai",
-    "/home": "co-teacher",
+    "/home": "superhero",
     "/student-home": "hoc-2023-dance-ai"
   },
   "banners": {


### PR DESCRIPTION
Shows the superhero announcements banner on https://studio.code.org/home Teacher homepage.

_Note:_ Re-using the same graphic and copy from last year so just needed to be swapped in on `announcements.json`.

**Jira ticket:** [ACQ-830](https://codedotorg.atlassian.net/browse/ACQ-830)

----

<img width="1405" alt="Screenshot 2024-01-17 at 12 58 16 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/ba1e7a50-bebe-413c-a545-965cff26a721">
