### PR TITLE
Redirect to next self-paced PL unit if available

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -445,6 +445,10 @@ class CourseOffering < ApplicationRecord
     grade_levels_list.any? {|g| HIGH_SCHOOL_GRADES.include?(g)}
   end
 
+  def self_paced_pl?
+    category == 'pl_self_paced'
+  end
+
   private def grade_levels_format
     return true if grade_levels.nil?
 

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -445,10 +445,6 @@ class CourseOffering < ApplicationRecord
     grade_levels_list.any? {|g| HIGH_SCHOOL_GRADES.include?(g)}
   end
 
-  def self_paced_pl?
-    category == 'pl_self_paced'
-  end
-
   private def grade_levels_format
     return true if grade_levels.nil?
 

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -175,6 +175,10 @@ class ScriptLevel < ApplicationRecord
           script_path(script)
         end
       end
+    elsif script.self_paced_pl?
+      build_script_level_path(level_to_follow) if level_to_follow
+      next_unit = script.next_unit(user)
+      next_unit ? script_path(next_unit) : script_completion_redirect(script)
     elsif bubble_choice? && !bubble_choice_parent
       # Redirect user back to the BubbleChoice activity page from sublevels.
       build_script_level_path(self)

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -175,7 +175,7 @@ class ScriptLevel < ApplicationRecord
           script_path(script)
         end
       end
-    elsif script.self_paced_pl?
+    elsif script.pl_course?
       build_script_level_path(level_to_follow) if level_to_follow
       next_unit = script.next_unit(user)
       next_unit ? script_path(next_unit) : script_completion_redirect(script)

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -721,6 +721,13 @@ class Unit < ApplicationRecord
     user.assigned_script?(self)
   end
 
+  def next_unit(user)
+    return nil unless unit_group
+    other_units = unit_group.units_for_user(user)
+    self_index = other_units.index {|u| u.id == id}
+    other_units[self_index + 1] if self_index
+  end
+
   # @param family_name [String] The family name for a unit family.
   # @param version_year [String] Version year to return. Optional.
   # @param locale [String] User or request locale. Optional.
@@ -919,6 +926,10 @@ class Unit < ApplicationRecord
 
   def csc?
     Unit.unit_in_category?('csc', name)
+  end
+
+  def self_paced_pl?
+    get_course_version&.course_offering&.self_paced_pl?
   end
 
   # TODO: (Dani) Update to use new course types framework.

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -928,10 +928,6 @@ class Unit < ApplicationRecord
     Unit.unit_in_category?('csc', name)
   end
 
-  def self_paced_pl?
-    get_course_version&.course_offering&.self_paced_pl?
-  end
-
   # TODO: (Dani) Update to use new course types framework.
   # Currently this grouping is used to determine whether the script should have # a custom end-of-lesson experience.
   def middle_high?

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -721,6 +721,9 @@ class Unit < ApplicationRecord
     user.assigned_script?(self)
   end
 
+  # If this unit is in a unit group, returns the next unit in the unit group.
+  # If it's the last unit in the unit group, returns nil.
+  # If it's not in a unit group, returns nil.
   def next_unit(user)
     return nil unless unit_group
     other_units = unit_group.units_for_user(user)

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -881,16 +881,6 @@ class CourseOfferingTest < ActiveSupport::TestCase
     assert course7.high_school_level?
   end
 
-  test 'self_paced_pl?' do
-    self_paced_pl_course = create :course_offering, category: 'pl_self_paced'
-    non_self_paced_pl_course = create :course_offering, category: 'pl_other'
-    csf_course = create :course_offering, category: 'csf'
-
-    assert self_paced_pl_course.self_paced_pl?
-    refute non_self_paced_pl_course.self_paced_pl?
-    refute csf_course.self_paced_pl?
-  end
-
   def course_offering_with_versions(num_versions, content_root_trait = :with_unit_group)
     create :course_offering do |offering|
       create_list :course_version, num_versions, content_root_trait, course_offering: offering

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -881,6 +881,16 @@ class CourseOfferingTest < ActiveSupport::TestCase
     assert course7.high_school_level?
   end
 
+  test 'self_paced_pl?' do
+    self_paced_pl_course = create :course_offering, category: 'pl_self_paced'
+    non_self_paced_pl_course = create :course_offering, category: 'pl_other'
+    csf_course = create :course_offering, category: 'csf'
+
+    assert self_paced_pl_course.self_paced_pl?
+    refute non_self_paced_pl_course.self_paced_pl?
+    refute csf_course.self_paced_pl?
+  end
+
   def course_offering_with_versions(num_versions, content_root_trait = :with_unit_group)
     create :course_offering do |offering|
       create_list :course_version, num_versions, content_root_trait, course_offering: offering

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -759,7 +759,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
   test 'next_level_or_redirect_path_for_user returns to next unit if at the end of the current self paced pl unit' do
     unit1 = create :unit
     unit2 = create :unit
-    unit1.stubs(:self_paced_pl?).returns true
+    unit1.stubs(:pl_course?).returns true
     unit1.stubs(:next_unit).returns(unit2)
 
     script_level = create :script_level, script: unit1

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -756,6 +756,19 @@ class ScriptLevelTest < ActiveSupport::TestCase
     assert_equal script_levels[1].path, script_levels[0].next_level_or_redirect_path_for_user(student)
   end
 
+  test 'next_level_or_redirect_path_for_user returns to next unit if at the end of the current self paced pl unit' do
+    unit1 = create :unit
+    unit2 = create :unit
+    unit1.stubs(:self_paced_pl?).returns true
+    unit1.stubs(:next_unit).returns(unit2)
+
+    script_level = create :script_level, script: unit1
+
+    student = create :student
+
+    assert_equal "/s/#{unit2.name}", script_level.next_level_or_redirect_path_for_user(student)
+  end
+
   test 'end of lesson' do
     script = Unit.find_by_name('course1')
 

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -2111,6 +2111,39 @@ class UnitTest < ActiveSupport::TestCase
     assert_equal "test-localized-title-default", unit.localized_title
   end
 
+  test 'next_unit returns next unit if there is another unit in unit group' do
+    unit_group = create :unit_group
+    unit1 = create :unit
+    unit2 = create :unit
+    create :unit_group_unit, unit_group: unit_group, script: unit1, position: 1
+    create :unit_group_unit, unit_group: unit_group, script: unit2, position: 2
+    unit1.reload
+
+    student = create :student
+
+    assert_equal unit2, unit1.next_unit(student)
+  end
+
+  test 'next_unit returns nil if there is no next unit in unit group' do
+    unit1 = create :unit
+    unit2 = create :unit
+    unit_group = create :unit_group
+    create :unit_group_unit, unit_group: unit_group, script: unit1, position: 1
+    create :unit_group_unit, unit_group: unit_group, script: unit2, position: 2
+
+    student = create :student
+
+    assert_nil unit2.next_unit(student)
+  end
+
+  test 'next_unit returns nil if not in a unit group' do
+    unit1 = create :unit, is_course: true
+
+    student = create :student
+
+    assert_nil unit1.next_unit(student)
+  end
+
   class MigratedScriptCopyTests < ActiveSupport::TestCase
     setup do
       Unit.any_instance.stubs(:write_script_json)

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -2118,6 +2118,7 @@ class UnitTest < ActiveSupport::TestCase
     create :unit_group_unit, unit_group: unit_group, script: unit1, position: 1
     create :unit_group_unit, unit_group: unit_group, script: unit2, position: 2
     unit1.reload
+    unit2.reload
 
     student = create :student
 
@@ -2130,6 +2131,8 @@ class UnitTest < ActiveSupport::TestCase
     unit_group = create :unit_group
     create :unit_group_unit, unit_group: unit_group, script: unit1, position: 1
     create :unit_group_unit, unit_group: unit_group, script: unit2, position: 2
+    unit1.reload
+    unit2.reload
 
     student = create :student
 


### PR DESCRIPTION
On self-paced PL curriculum, when finishing the last level in a unit, go to the next unit, if available. This change should only affect self-paced PL curriculum.

Long video but shows moving to the next unit, as well as progress being saved for the level (an issue that has come up in Zendesk a few times!). This screen capture is on my local levelbuilder account, but I tested on my local non-levelbuilder account as well.

https://github.com/code-dot-org/code-dot-org/assets/46464143/0e48a8ba-a79e-4def-9bdf-5c766463a4ea

I also tested on CSD 2023 and, if completing the last level of a unit, I am sent back to the current unit page, with the "You completed lesson X!" popup, the same behavior as production.