### PR TITLE
Make sure samples are loaded before re-queueing mid-playback

### DIFF
--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -75,7 +75,7 @@ export default class MusicPlayer {
   /**
    * Pre-load sounds for playback
    */
-  preloadSounds(
+  async preloadSounds(
     events: PlaybackEvent[],
     onLoadFinished?: LoadFinishedCallback
   ) {
@@ -88,7 +88,7 @@ export default class MusicPlayer {
       )
     );
 
-    this.samplePlayer.loadSounds(sampleIds, onLoadFinished);
+    return this.samplePlayer.loadSounds(sampleIds, onLoadFinished);
   }
 
   /**

--- a/apps/src/music/player/SamplePlayer.ts
+++ b/apps/src/music/player/SamplePlayer.ts
@@ -224,7 +224,7 @@ export default class SamplePlayer {
   }
 
   async loadSounds(sampleIds: string[], onLoadFinished?: LoadFinishedCallback) {
-    await this.soundCache.loadSounds(sampleIds, {
+    return this.soundCache.loadSounds(sampleIds, {
       updateLoadProgress: this.updateLoadProgress,
       onLoadFinished,
     });

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -352,13 +352,13 @@ class UnconnectedMusicView extends React.Component {
 
     const codeChanged = this.compileSong();
     if (codeChanged) {
-      this.executeCompiledSong();
-
-      // If code has changed mid-playback, clear and re-queue all events in the player
-      if (this.props.isPlaying) {
-        this.player.stopAllSoundsStillToPlay();
-        this.player.playEvents(this.sequencer.getPlaybackEvents());
-      }
+      this.executeCompiledSong().then(() => {
+        // If code has changed mid-playback, clear and re-queue all events in the player
+        if (this.props.isPlaying) {
+          this.player.stopAllSoundsStillToPlay();
+          this.player.playEvents(this.sequencer.getPlaybackEvents());
+        }
+      });
 
       this.analyticsReporter.onBlocksUpdated(
         this.musicBlocklyWorkspace.getAllBlocks()
@@ -453,7 +453,7 @@ class UnconnectedMusicView extends React.Component {
       orderedFunctions: this.sequencer.getOrderedFunctions(),
     });
 
-    this.player.preloadSounds(
+    return this.player.preloadSounds(
       [...this.sequencer.getPlaybackEvents(), ...allTriggerEvents],
       (loadTimeMs, soundsLoaded) => {
         // Report load time metrics if any sounds were loaded.


### PR DESCRIPTION
In switching to on-demand sound loading (https://github.com/code-dot-org/code-dot-org/pull/53441) I accidentally broke our ability to live reload sounds because we weren't waiting for sounds to be loaded in the cache before re-queueing events. This fixes the issue by waiting until the new sounds have been loaded in the cache before updating the player.

## Testing story

Tested locally on /projectbeats with non-triggered and triggered mid-playback updates.