### PR TITLE
stop storing versions as part of reject-comparing-older-main-json firehose event

### DIFF
--- a/dashboard/legacy/middleware/helpers/bucket_helper.rb
+++ b/dashboard/legacy/middleware/helpers/bucket_helper.rb
@@ -267,8 +267,6 @@ class BucketHelper
           # tab making this request. This is for diagnosing problems with writes from multiple browser
           # tabs.
           firstSaveTimestamp: timestamp,
-
-          versions: versions,
         }.to_json
       }
     )


### PR DESCRIPTION
Attempt to avoid large firehose records which break import into AWS. see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1705600196777669?thread_ts=1705518125.559239&cid=C0T0PNTM3) for context.

## Testing story

* manually verified versions are removed from the output locally
* also covered by a [unit test](https://github.com/code-dot-org/code-dot-org/blob/eeb5af340070511f7753a0dfc39e072984e1d061/dashboard/legacy/test/middleware/test_sources.rb#L305)