### PR TITLE
Disable oauth account linking for LTI users

### DIFF
--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -1,6 +1,7 @@
 - require '../shared/middleware/helpers/experiments'
 - require 'cpa'
 - require 'policies/child_account'
+- require 'policies/lti'
 - @page_title = t('activerecord.attributes.user.edit_header')
 - no_email = current_user.no_personal_email? || params[:noEmail] == 'true'
 
@@ -144,7 +145,7 @@
             = t('activerecord.attributes.user.ai_rubrics_disabled')
       %div= form.submit t('crud.update'), id: 'edit-ai-settings', class: 'btn btn-warning'
 
-- if current_user.migrated?
+- if current_user.migrated? && !(Policies::Lti.lti? current_user)
   -# Mount point for React ManageLinkedAccounts component.
   %div#manage-linked-accounts
 


### PR DESCRIPTION
Removes the div that houses the Manage Linked Accounts table if a user is LTI. This prevents any potential issues arising from connecting a personal oauth account to the school-owned LTI account.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-663)

## Testing story

Tested locally with an LTI user.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
