### PR TITLE
Moving to hoc_mode false

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -417,7 +417,7 @@ levelbuilder_mode:
 # make it easier to tell the difference
 use_local_header_color:
 
-default_hoc_mode: post-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_mode: false  # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''      # overridden by 'hoc_launch' DCDO param, except in :test
 
 # teacher_application_mode values: 'open', 'closing-soon', 'closed'

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -140,9 +140,6 @@ module Pd
       ARTIFICIAL_INTELLIGENCE_AND_MACHINE_LEARNING = 'Teaching Artificial Intelligence and Machine Learning'.freeze,
       PROBLEM_SOLVING_AND_COMPUTING = 'Teaching Problem Solving and Computing'.freeze,
       INTERACTIVE_ANIMATIONS_AND_GAMES = 'Teaching Interactive Animations and Games'.freeze,
-      TEACHING_CS_CONNECTIONS = 'Teaching CS Connections'.freeze,
-      CS_BASICS_FOR_K5_TEACHERS = 'Computer Science Basics for K-5 Teachers'.freeze,
-      TEACHING_DESIGN_PROCESS = 'Teaching Design Process'.freeze,
     ].freeze
 
     NOT_FUNDED_SUBJECTS = [

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -140,6 +140,8 @@ module Pd
       ARTIFICIAL_INTELLIGENCE_AND_MACHINE_LEARNING = 'Teaching Artificial Intelligence and Machine Learning'.freeze,
       PROBLEM_SOLVING_AND_COMPUTING = 'Teaching Problem Solving and Computing'.freeze,
       INTERACTIVE_ANIMATIONS_AND_GAMES = 'Teaching Interactive Animations and Games'.freeze,
+      TEACHING_CS_CONNECTIONS = 'Teaching CS Connections'.freeze,
+      CS_BASICS_FOR_K5_TEACHERS = 'Computer Science Basics for K-5 Teachers'.freeze,
     ].freeze
 
     NOT_FUNDED_SUBJECTS = [

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -142,6 +142,7 @@ module Pd
       INTERACTIVE_ANIMATIONS_AND_GAMES = 'Teaching Interactive Animations and Games'.freeze,
       TEACHING_CS_CONNECTIONS = 'Teaching CS Connections'.freeze,
       CS_BASICS_FOR_K5_TEACHERS = 'Computer Science Basics for K-5 Teachers'.freeze,
+      TEACHING_DESIGN_PROCESS = 'Teaching Design Process'.freeze,
     ].freeze
 
     NOT_FUNDED_SUBJECTS = [


### PR DESCRIPTION
This PR updates our test server to match what I'm about to flip the other environments' hoc_mode flag to!

Fun fact: this file has *never had a default hoc_mode = false. In the 5 year history of the file, we've always moved straight from post-hoc to pre-hoc. However, this year we are trying it out! Example of one of those old transitions [here](https://github.com/code-dot-org/code-dot-org/commit/00538d8d0637cfa9af4cc2221013fa4c9a3d01d5). 

## Links

- documentation: https://docs.google.com/document/d/1npRdcuOhOPGghHXkBZain_7ZvRrqvizAbwT1gwlAaK8/edit
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1304

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
