### PR TITLE
stop logging regional-partner-search-log events to firehose

### DIFF
--- a/dashboard/app/controllers/api/v1/regional_partners_controller.rb
+++ b/dashboard/app/controllers/api/v1/regional_partners_controller.rb
@@ -71,7 +71,8 @@ class Api::V1::RegionalPartnersController < ApplicationController
       {
         study: 'regional-partner-search-log',
         event: result,
-        data_string: zip_code,
+        # avoid overloading the data_string field with long zip codes
+        data_string: zip_code&.truncate(20),
         source_page_id: params[:source_page_id]
       }
     )

--- a/dashboard/app/controllers/api/v1/regional_partners_controller.rb
+++ b/dashboard/app/controllers/api/v1/regional_partners_controller.rb
@@ -53,29 +53,13 @@ class Api::V1::RegionalPartnersController < ApplicationController
 
     partner, state = RegionalPartner.find_by_zip(zip_code)
 
-    result = nil
-
     if partner
       render json: partner, serializer: Api::V1::Pd::RegionalPartnerSerializer
-      result = 'partner-found'
     elsif state
       render json: {error: WORKSHOP_SEARCH_ERRORS[:no_partner]}
-      result = 'no-partner'
     else
       render json: {error: WORKSHOP_SEARCH_ERRORS[:no_state]}
-      result = 'no-state'
     end
-
-    FirehoseClient.instance.put_record(
-      :analysis,
-      {
-        study: 'regional-partner-search-log',
-        event: result,
-        # avoid overloading the data_string field with long zip codes
-        data_string: zip_code&.truncate(20),
-        source_page_id: params[:source_page_id]
-      }
-    )
   end
 
   # Get the regional partner's cohort capacity for a specific role


### PR DESCRIPTION
removes `regional-partner-search-log` events from firehose because they were causing a problem by exceeding the size for the data_string field in firehose and we no longer need them anyway. (see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1705628598999289?thread_ts=1705518125.559239&cid=C0T0PNTM3))

## Testing story

existing test coverage indicates we didn't break the `find` action here: https://github.com/code-dot-org/code-dot-org/blob/b15fac4a11ac97bfbbb7bd2ff74111a27df9f5f2/dashboard/test/controllers/api/v1/regional_partners_controller_test.rb#L209