### PR TITLE
[Google Blockly] add horizontal scrollbar to workspaces

### DIFF
--- a/apps/src/blockly/addons/cdoMetricsManager.js
+++ b/apps/src/blockly/addons/cdoMetricsManager.js
@@ -6,6 +6,7 @@ export default class MetricsManager extends ScrollMetricsManager {
    */
   getPaddedContent_(viewMetrics, contentMetrics) {
     const contentBottom = contentMetrics.top + contentMetrics.height;
+    const contentRight = contentMetrics.left + contentMetrics.width;
 
     // Add extra vertical space beneath the last block
     const extraVerticalSpace = 100;
@@ -21,9 +22,20 @@ export default class MetricsManager extends ScrollMetricsManager {
       viewMetrics.height
     );
 
-    // No horizontal scroll
-    const right = viewMetrics.width;
+    const right = Math.max(contentRight, viewMetrics.width);
 
     return {top, left, bottom, right};
+  }
+
+  /**
+   * Returns whether the scroll area has fixed edges.
+   * Core Blockly doesn't have fixed edges when both the horizontal or vertical scrollbar are present.
+   * This keeps blocks from moving past the fixed left/top edges of our workspaces.
+   *
+   * @returns Whether the scroll area has fixed edges.
+   * @override
+   */
+  hasFixedEdges() {
+    return true;
   }
 }

--- a/apps/src/blockly/addons/cdoScrollbar.js
+++ b/apps/src/blockly/addons/cdoScrollbar.js
@@ -1,0 +1,27 @@
+/**
+ * Initializes the horizontal and vertical scrollbars in a workspace.
+ *
+ * @param {Object} workspace - The workspace object containing scrollbars and metrics.
+ * @param {Blockly.ScrollbarPair} workspace.scrollbar - A set of scrollbars.
+ * @param {Blockly.Scrollbar} workspace.scrollbar.hScroll - The horizontal scrollbar.
+ * @param {Blockly.Scrollbar} workspace.scrollbar.vScroll - The vertical scrollbar.
+ * @returns {void} This function does not return any value.
+ */
+export function initializeScrollbarPair(workspace) {
+  // In Core Blockly, pairs of scrollbars are always visible because the workspace
+  // is always larger than the viewport. See the Blockly Playground for an example.
+  // https://blockly-demo.appspot.com/static/tests/playground.html
+  // Only non-paired scrollbars can have their visibility toggled.
+  workspace.scrollbar.hScroll.pair = false;
+  workspace.scrollbar.vScroll.pair = false;
+
+  // When both scrollbars are present, Core Blockly would always show them.
+  // We can hide either scrollbar if it is not yet needed.
+  const metrics = workspace.getMetrics();
+  if (metrics.contentWidth < metrics.viewWidth) {
+    workspace.scrollbar.hScroll.setVisible(false);
+  }
+  if (metrics.contentHeight < metrics.viewHeight) {
+    workspace.scrollbar.vScroll.setVisible(false);
+  }
+}

--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -22,6 +22,7 @@ import {BLOCK_TYPES} from '../constants';
 import {frameSizes} from './cdoConstants';
 import CdoTrashcan from './cdoTrashcan';
 import {getAlphanumericId} from '@cdo/apps/utils';
+import {initializeScrollbarPair} from './cdoScrollbar';
 
 // This class creates the modal function editor, which is used by Sprite Lab and Artist.
 export default class FunctionEditor {
@@ -61,7 +62,7 @@ export default class FunctionEditor {
       move: {
         drag: false,
         scrollbars: {
-          horizontal: false,
+          horizontal: true,
           vertical: true,
         },
         wheel: true,
@@ -80,7 +81,7 @@ export default class FunctionEditor {
     });
     const scrollOptionsPlugin = new ScrollOptions(this.editorWorkspace);
     scrollOptionsPlugin.init();
-
+    initializeScrollbarPair(this.editorWorkspace);
     // Disable blocks that aren't attached. We don't want these to generate
     // code in the hidden workspace.
     this.editorWorkspace.addChangeListener(disableOrphans);

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -64,6 +64,7 @@ import {
   ObservableParameterModel,
 } from '@blockly/block-shareable-procedures';
 import {adjustCalloutsOnViewportChange, disableOrphans} from './eventHandlers';
+import {initializeScrollbarPair} from './addons/cdoScrollbar.js';
 
 const options = {
   contextMenu: true,
@@ -638,8 +639,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
         wheel: true,
         drag: true,
         scrollbars: {
+          horizontal: true,
           vertical: true,
-          horizontal: false,
         },
       },
       plugins: {
@@ -686,6 +687,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
       .getFlyout()
       ?.getWorkspace()
       ?.addChangeListener(adjustCalloutsOnViewportChange);
+
+    initializeScrollbarPair(workspace);
 
     document.dispatchEvent(
       utils.createEvent(Blockly.BlockSpace.EVENTS.MAIN_BLOCK_SPACE_CREATED)


### PR DESCRIPTION
Currently, horizontally scrolling a workspace is not supported in our Blockly labs. This leads to some frustrating "pushing" of blocks that can happen, especially with wide blocks and smaller screen sizes. For example:

Emily reported overlapping blocks in Outbreak:
**Before:**
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/4329892f-b53d-4fda-a556-25d75e5acce1)
**After**
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/c3f18021-84d4-45a7-8388-34d2bfd231dc)

Brendan reported procedure definitions getting pushed outside of their frames:
**Before:**
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/028a4d1b-429c-405b-abe8-bcc4bd6b40be)
**After:**
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/b56d3f1b-bd56-40bc-982a-9d1837464287)

In a [slack thread](https://codedotorg.slack.com/archives/C05DK21DAHK/p1699476749000309), @molly-moen offered some additional context:
> It’s not unreasonable for a block to be wider than the available space--for the wandering behavior, if I have my browser window around 3/4 sized on my 16" screen the block does not fit. This makes the end of a block un-editable and basically unviewable, because we can’t have a block that is half in the toolbox (if it’s undeletable it will snap back to the workspace, and if it’s deletable it will be deleted).

@amy-b agreed:
> taking away the action to scroll left-right feels wrong for the reason you mention, Molly. I'm with you that it's better to allow scrolling left-right when the code requires it for readability, especially because we allow editing of pre-made functions

It is worth noting that participants in this thread also signaled the importance of not relying on horizontal scrolling too much, including the potential for certain gestures to be conflated with issuing a browser a "back" command. Because of the significant crowding that can occur on a small workspace, this tradeoff appears to be worth it.

### Scrollbar Pairs in Core Blockly
Blockly makes some assumptions about when pairs of scrollbars are used that do not match our reality. For example, by visiting the [Blockly Playground](https://blockly-demo.appspot.com/static/tests/playground.html) you can observe:
* Both horizontal and vertical scrollbars are present
* The workspace is always larger than the viewable area

Because of these two points, Blockly assumes that this "pair" of scrollbars should always be visible if both are enabled. Note that `Blockly.ScrollbarPair` object includes two `Blockly.Scrollbar`s: `scrollbar.hScroll` and `scrollbar.vScroll`. Each of these is with `.pair = true` which prevents toggling the visibility of a scrollbar. (https://github.com/google/blockly/blob/1ba0e55e8a61f4228dfcc4d0eb18b7e38666dc6c/core/scrollbar.ts#L658-L665)

### Technical Changes
1. Set `horizontal: true` in scrollbars options when creating the main and function editor workspaces. This will tell Blockly that both scrollbars are needed. This is a standard supported option for inject calls.
2. Initialize the scrollbars so they are not treated as "paired". This allows toggling the visibility of an individual scrollbar when both are in use. This overrides the initial construction of the `Scrollbar` objects by the `ScrollbarPair` class.
3. Adjust the visibility of each scrollbar when the workspace is initially created. This prevents both scrollbars from always showing by default, based on Blockly's assumption that the workspace is larger than the view area. Blockly doesn't handle this for us because it assumes (and indeed forces) paired scrollbars to be visible.
4. Update the metrics manager so that the right edge is calculated based on the width of the block content, if larger than the workspace.
5. Override `hasFixedEdges()` to always return true. This prevents users from being able to drag blocks partially past the top/left edges, triggering a bump back in bounds when attempted.

As an alternative to 2-3 above, I initially considered adding a change listener to workspaces to handle toggling the scrollbar visibility. This function would need to run when Blockly finished loading, as well as at each block move and viewport change event. It was further grossified by needing to call `scrollbar.setVisibleInternal` to get around the `.pair` error.

At this time, Music Lab is excluded from these changes. If horizontal scrollbars are desired there, it should be a matter of updating the inject options and initializing the scrollbars here: 
https://github.com/code-dot-org/code-dot-org/blob/mike/add-horizontal-scroll/apps/src/music/blockly/MusicBlocklyWorkspace.js#L51

## Links

Jira: https://codedotorg.atlassian.net/browse/CT-201

## Testing story

I tested that blocks can be displayed outside the previous right-edge boundary. Blocks are no longer pushed to the left when the workspace is made smaller. The horizontal and vertical scrollbars each show and are hidden as expected based on the current workspace content.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
