### PR TITLE
[Google Blockly] Resize toolbox when browser is resized.

### DIFF
--- a/apps/src/blockly/eventHandlers.js
+++ b/apps/src/blockly/eventHandlers.js
@@ -102,7 +102,7 @@ export function reflowToolbox(event) {
     mainWorkspaceFlyout.reflow();
   }
   if (Blockly.functionEditor) {
-    const modalWorkspace = Blockly.functionEditor.editorWorkspace;
+    const modalWorkspace = Blockly.getFunctionEditorWorkspace();
     const modalWorkspaceFlyout = findFlyout(modalWorkspace);
     if (modalWorkspaceFlyout) {
       modalWorkspaceFlyout.reflow();

--- a/apps/src/blockly/eventHandlers.js
+++ b/apps/src/blockly/eventHandlers.js
@@ -2,6 +2,7 @@
 
 import {handleWorkspaceResizeOrScroll} from '@cdo/apps/code-studio/callouts';
 import {BLOCK_TYPES} from './constants';
+import {findFlyout} from './utils';
 
 // A custom version of Blockly's Events.disableOrphans. This makes a couple
 // changes to the original function.
@@ -90,5 +91,21 @@ function updateBlockEnabled(block) {
 export function adjustCalloutsOnViewportChange(event) {
   if (event.type === Blockly.Events.VIEWPORT_CHANGE) {
     handleWorkspaceResizeOrScroll();
+  }
+}
+
+// When the browser is resized, we need to re-adjust the width of any open flyout.
+export function reflowToolbox(event) {
+  const mainWorkspace = Blockly.getMainWorkspace();
+  const mainWorkspaceFlyout = findFlyout(mainWorkspace);
+  if (mainWorkspaceFlyout) {
+    mainWorkspaceFlyout.reflow();
+  }
+  if (Blockly.functionEditor) {
+    const modalWorkspace = Blockly.functionEditor.editorWorkspace;
+    const modalWorkspaceFlyout = findFlyout(modalWorkspace);
+    if (modalWorkspaceFlyout) {
+      modalWorkspaceFlyout.reflow();
+    }
   }
 }

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -63,7 +63,11 @@ import {
   ObservableProcedureModel,
   ObservableParameterModel,
 } from '@blockly/block-shareable-procedures';
-import {adjustCalloutsOnViewportChange, disableOrphans} from './eventHandlers';
+import {
+  adjustCalloutsOnViewportChange,
+  disableOrphans,
+  reflowToolbox,
+} from './eventHandlers';
 import {initializeScrollbarPair} from './addons/cdoScrollbar.js';
 
 const options = {
@@ -689,6 +693,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
       ?.addChangeListener(adjustCalloutsOnViewportChange);
 
     initializeScrollbarPair(workspace);
+
+    window.addEventListener('resize', reflowToolbox);
 
     document.dispatchEvent(
       utils.createEvent(Blockly.BlockSpace.EVENTS.MAIN_BLOCK_SPACE_CREATED)

--- a/apps/src/blockly/utils.js
+++ b/apps/src/blockly/utils.js
@@ -113,3 +113,23 @@ export function shouldSkipHiddenWorkspace(workspace) {
     Blockly.isToolboxMode
   );
 }
+
+/**
+ * Finds the flyout associated with a workspace.
+ * @param {Blockly.Workspace} workspace - The workspace to find the flyout for.
+ * @returns {Blockly.Flyout|null} The flyout associated with the workspace, or null if not found.
+ */
+export function findFlyout(workspace) {
+  if (!workspace) {
+    return null;
+  }
+  if (workspace.flyout) {
+    // Workspace has a single flyout (uncategorized toolbox)
+    return workspace.flyout;
+  }
+  if (workspace.toolbox_ && workspace.toolbox_.flyout_) {
+    // Workspace has a categorized toolbox with a flyout.
+    return workspace.toolbox_.flyout_;
+  }
+  return null;
+}


### PR DESCRIPTION
During the first Sprite Lab bug bash, @cnbrenci noticed that we were not resizing the toolbox when the browser gets resized: 

https://github.com/code-dot-org/code-dot-org/assets/43474485/82c5e266-d537-4ac9-9fc2-01e85fb3aec6

Core Blockly doesn't constrain the flyout width based on the size of the workspace or browser, but we do: https://github.com/code-dot-org/code-dot-org/blob/mike/resize-toolbox-with-view-area/apps/src/blockly/addons/cdoVerticalFlyout.js#L39
This customization is the reason we need to re-render things.

Calling `reflow()` on the improperly sized flyout fixes its width, so I added an event listener for a browser resize. The trickiest part was finding the flyouts, which vary depending on whether the workspace has a (categorized) `toolbox_` with a `flyout_` or just a (uncategorized) `flyout`.

Now the toolbox gets resized automatically:

https://github.com/code-dot-org/code-dot-org/assets/43474485/4a623054-caba-4fb8-b043-c96d43e84c03

While working on this, I discovered that the Function Editor is not constraining flyout width and therefore is evidently not using `CdoVerticalFlyout`. This branch includes a change that will also call `reflow()` on the function editor's flyouts should we wish to change that. https://codedotorg.atlassian.net/browse/CT-271

## Links

https://codedotorg.atlassian.net/browse/CT-202

## Testing story

Tested that flyouts now resize as expected on Chrome, Firefox, and Safari.

## Follow-up work

Ensure that the function editor is using CdoVerticalFlyout for its toolboxes. https://codedotorg.atlassian.net/browse/CT-271


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
