### PR TITLE
HoC - Replace hoc_mode false string with boolean

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/events/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events/index.haml
@@ -25,7 +25,7 @@ nav: resources_nav
 
 %h1=hoc_s(:hoc_events_heading)
 
-- if hoc_mode == "false"
+- if hoc_mode == false
   .clear-styles
     = view :off_season_interest_form
 - else

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -69,13 +69,13 @@ social:
       .text-wrapper.centered
         %p.body-two.no-margin-bottom
           =hoc_s(:hoc_homepage_registration_desc)
-        - if hoc_mode != "false"
+        - if hoc_mode != false
           %a.link-button{href: resolve_url("/events"), style: "margin-top: 2rem"}
             =hoc_s(:call_to_action_register_your_hoc)
 
   -# Off season interest form
   -# This is only shown when hoc_mode is false
-  - if hoc_mode == "false"
+  - if hoc_mode == false
     %section.no-padding-bottom
       .wrapper
         = view :off_season_interest_form


### PR DESCRIPTION
Replaces the `hoc_mode` `"false"` string with `false` booleans on https://hourofcode.com/ and https://hourofcode.com/events

**Related PR:** https://github.com/code-dot-org/code-dot-org/pull/55652