### PR TITLE
Accessible up/down arrows in instructions

### DIFF
--- a/apps/src/templates/instructions/ScrollButtons.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.jsx
@@ -127,9 +127,9 @@ class ScrollButtons extends React.Component {
         type="button"
         className={classNames(
           moduleStyles.up,
-          moduleStyles.minecraftButton,
           this.props.visible && moduleStyles.visible,
           centerItems && moduleStyles.upCenter,
+          moduleStyles.minecraftButton,
           'arrow'
         )}
         ref={c => {
@@ -151,11 +151,11 @@ class ScrollButtons extends React.Component {
         onClick={this.singleScrollUp}
         onMouseDown={this.continuousScrollStartUp}
         className={classNames(
-          moduleStyles.arrowGlyph,
-          moduleStyles.removeButtonStyles,
           moduleStyles.up,
           this.props.visible && moduleStyles.visible,
-          centerItems && moduleStyles.upCenter
+          centerItems && moduleStyles.upCenter,
+          moduleStyles.arrowGlyph,
+          moduleStyles.removeButtonStyles
         )}
       >
         <FontAwesome
@@ -170,9 +170,9 @@ class ScrollButtons extends React.Component {
         type="button"
         className={classNames(
           moduleStyles.down,
-          moduleStyles.minecraftButton,
           this.props.visible && moduleStyles.visible,
           centerItems && moduleStyles.downCenter,
+          moduleStyles.minecraftButton,
           'arrow'
         )}
         ref={c => {
@@ -191,12 +191,12 @@ class ScrollButtons extends React.Component {
           this.scrollDown = c;
         }}
         className={classNames(
-          'uitest-scroll-button-down',
-          moduleStyles.arrowGlyph,
-          moduleStyles.removeButtonStyles,
           moduleStyles.down,
           this.props.visible && moduleStyles.visible,
-          centerItems && moduleStyles.downCenter
+          centerItems && moduleStyles.downCenter,
+          moduleStyles.arrowGlyph,
+          moduleStyles.removeButtonStyles,
+          'uitest-scroll-button-down'
         )}
         key="scrollDown"
         onClick={this.singleScrollDown}

--- a/apps/src/templates/instructions/ScrollButtons.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.jsx
@@ -126,7 +126,6 @@ class ScrollButtons extends React.Component {
       <button
         type="button"
         className={classNames(
-          moduleStyles.all,
           moduleStyles.up,
           moduleStyles.minecraftButton,
           this.props.visible && moduleStyles.visible,
@@ -152,7 +151,6 @@ class ScrollButtons extends React.Component {
         onClick={this.singleScrollUp}
         onMouseDown={this.continuousScrollStartUp}
         className={classNames(
-          moduleStyles.all,
           moduleStyles.arrowGlyph,
           moduleStyles.up,
           this.props.visible && moduleStyles.visible,
@@ -170,12 +168,11 @@ class ScrollButtons extends React.Component {
       <button
         type="button"
         className={classNames(
-          'arrow',
-          moduleStyles.all,
           moduleStyles.down,
           moduleStyles.minecraftButton,
           this.props.visible && moduleStyles.visible,
-          centerItems && moduleStyles.downCenter
+          centerItems && moduleStyles.downCenter,
+          'arrow'
         )}
         ref={c => {
           this.scrollDown = c;
@@ -194,7 +191,6 @@ class ScrollButtons extends React.Component {
         }}
         className={classNames(
           'uitest-scroll-button-down',
-          moduleStyles.all,
           moduleStyles.arrowGlyph,
           moduleStyles.down,
           this.props.visible && moduleStyles.visible,
@@ -213,7 +209,10 @@ class ScrollButtons extends React.Component {
 
     return (
       showItems && (
-        <div style={{height: this.props.height, ...this.props.style}}>
+        <div
+          className={moduleStyles.container}
+          style={{height: this.props.height, ...this.props.style}}
+        >
           {upButton}
           {downButton}
         </div>

--- a/apps/src/templates/instructions/ScrollButtons.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.jsx
@@ -152,6 +152,7 @@ class ScrollButtons extends React.Component {
         onMouseDown={this.continuousScrollStartUp}
         className={classNames(
           moduleStyles.arrowGlyph,
+          moduleStyles.removeButtonStyles,
           moduleStyles.up,
           this.props.visible && moduleStyles.visible,
           centerItems && moduleStyles.upCenter
@@ -192,6 +193,7 @@ class ScrollButtons extends React.Component {
         className={classNames(
           'uitest-scroll-button-down',
           moduleStyles.arrowGlyph,
+          moduleStyles.removeButtonStyles,
           moduleStyles.down,
           this.props.visible && moduleStyles.visible,
           centerItems && moduleStyles.downCenter

--- a/apps/src/templates/instructions/ScrollButtons.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import classNames from 'classnames';
-import color from '../../util/color';
 import FontAwesome from '../../templates/FontAwesome';
 import moduleStyles from './scroll-buttons.module.scss';
 
@@ -200,27 +199,28 @@ class ScrollButtons extends React.Component {
         <img src="/blockly/media/1x1.gif" className="scroll-down-btn" alt="" />
       </button>
     ) : (
-      <div
+      <button
+        type="button"
         ref={c => {
           this.scrollDown = c;
         }}
-        className="uitest-scroll-button-down"
+        className={classNames(
+          'uitest-scroll-button-down',
+          moduleStyles.all,
+          moduleStyles.arrowGlyph,
+          moduleStyles.down,
+          this.props.visible && moduleStyles.visible,
+          centerItems && moduleStyles.downCenter
+        )}
         key="scrollDown"
         onClick={this.singleScrollDown}
         onMouseDown={this.scrollStartDown}
-        style={[
-          styles.all,
-          styles.arrowGlyph,
-          styles.down,
-          this.props.visible && styles.visible,
-          centerItems && styles.downCenter,
-        ]}
       >
         <FontAwesome
           icon="caret-down"
           style={{lineHeight: '22px', pointerEvents: 'none'}}
         />
-      </div>
+      </button>
     );
 
     return (
@@ -239,33 +239,6 @@ const styles = {
     position: 'absolute',
     transition: 'opacity 200ms',
     margin: 0,
-  },
-  arrowGlyph: {
-    fontSize: 50,
-    color: color.neutral_dark,
-    cursor: 'pointer',
-  },
-  up: {
-    opacity: 0,
-    top: '10px',
-    margin: '0 0 3px 0',
-    left: 25,
-    transform: 'translateX(-50%)',
-  },
-  visible: {
-    opacity: 1,
-  },
-  upCenter: {
-    left: '50%',
-  },
-  down: {
-    opacity: 0,
-    bottom: '10px',
-    right: 25,
-    transform: 'translateX(50%)',
-  },
-  downCenter: {
-    right: '50%',
   },
 };
 

--- a/apps/src/templates/instructions/ScrollButtons.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.jsx
@@ -53,12 +53,12 @@ class ScrollButtons extends React.Component {
     return scrollButtonsHeight + this.getMargin() * 2;
   }
 
-  scrollStartUp = () => {
-    this.scrollStart(DIRECTIONS.UP);
+  continuousScrollStartUp = () => {
+    this.continuousScrollStart(DIRECTIONS.UP);
   };
 
-  scrollStartDown = () => {
-    this.scrollStart(DIRECTIONS.DOWN);
+  continuousScrollStartDown = () => {
+    this.continuousScrollStart(DIRECTIONS.DOWN);
   };
 
   singleScrollUp = () => {
@@ -79,7 +79,7 @@ class ScrollButtons extends React.Component {
     scrollBy(contentContainer, initialScroll);
   }
 
-  scrollStart(dir) {
+  continuousScrollStart(dir) {
     // If mouse is held down for half a second, begin gradual continuous
     // scroll
     const contentContainer = this.props.getScrollTarget();
@@ -156,7 +156,7 @@ class ScrollButtons extends React.Component {
           this.scrollUp = c;
         }}
         key="scrollUp"
-        onMouseDown={this.scrollStartUp}
+        onMouseDown={this.continuousScrollStartUp}
         style={[styles.all, upStyle, minecraftButton]}
       >
         <img src="/blockly/media/1x1.gif" className="scroll-up-btn" alt="" />
@@ -169,7 +169,7 @@ class ScrollButtons extends React.Component {
         }}
         key="scrollUp"
         onClick={this.singleScrollUp}
-        onMouseDown={this.scrollStartUp}
+        onMouseDown={this.continuousScrollStartUp}
         className={classNames(
           moduleStyles.all,
           moduleStyles.arrowGlyph,
@@ -193,7 +193,7 @@ class ScrollButtons extends React.Component {
           this.scrollDown = c;
         }}
         key="scrollDown"
-        onMouseDown={this.scrollStartDown}
+        onMouseDown={this.continuousScrollStartDown}
         style={[styles.all, downStyle, minecraftButton]}
       >
         <img src="/blockly/media/1x1.gif" className="scroll-down-btn" alt="" />
@@ -214,7 +214,7 @@ class ScrollButtons extends React.Component {
         )}
         key="scrollDown"
         onClick={this.singleScrollDown}
-        onMouseDown={this.scrollStartDown}
+        onMouseDown={this.continuousScrollStartDown}
       >
         <FontAwesome
           icon="caret-down"

--- a/apps/src/templates/instructions/ScrollButtons.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import classNames from 'classnames';
 import FontAwesome from '../../templates/FontAwesome';
@@ -119,31 +118,6 @@ class ScrollButtons extends React.Component {
       ? this.props.height > 100
       : this.props.height > 60;
 
-    // check minecraft and remove
-    const upStyle = {
-      opacity: this.props.visible ? 1 : 0,
-      top: '10px',
-      margin: '0 0 3px 0',
-      left: centerItems ? '50%' : 25,
-      transform: 'translateX(-50%)',
-    };
-
-    // check minecraft and remove
-    const downStyle = {
-      opacity: this.props.visible ? 1 : 0,
-      bottom: '10px',
-      right: centerItems ? '50%' : 25,
-      transform: 'translateX(50%)',
-    };
-
-    const minecraftButton = {
-      width: 40,
-    };
-
-    const containerStyle = {
-      height: this.props.height,
-    };
-
     // for most tutorials, we have minimalist arrow elements. For
     // minecraft, we use a special button element to stylistically align
     // with the other buttons on the screen.
@@ -151,13 +125,20 @@ class ScrollButtons extends React.Component {
     const upButton = this.props.isMinecraft ? (
       <button
         type="button"
-        className="arrow"
+        className={classNames(
+          moduleStyles.all,
+          moduleStyles.up,
+          moduleStyles.minecraftButton,
+          this.props.visible && moduleStyles.visible,
+          centerItems && moduleStyles.upCenter,
+          'arrow'
+        )}
         ref={c => {
           this.scrollUp = c;
         }}
         key="scrollUp"
+        onClick={this.singleScrollUp}
         onMouseDown={this.continuousScrollStartUp}
-        style={[styles.all, upStyle, minecraftButton]}
       >
         <img src="/blockly/media/1x1.gif" className="scroll-up-btn" alt="" />
       </button>
@@ -188,13 +169,20 @@ class ScrollButtons extends React.Component {
     const downButton = this.props.isMinecraft ? (
       <button
         type="button"
-        className="arrow"
+        className={classNames(
+          'arrow',
+          moduleStyles.all,
+          moduleStyles.down,
+          moduleStyles.minecraftButton,
+          this.props.visible && moduleStyles.visible,
+          centerItems && moduleStyles.downCenter
+        )}
         ref={c => {
           this.scrollDown = c;
         }}
         key="scrollDown"
+        onClick={this.singleScrollDown}
         onMouseDown={this.continuousScrollStartDown}
-        style={[styles.all, downStyle, minecraftButton]}
       >
         <img src="/blockly/media/1x1.gif" className="scroll-down-btn" alt="" />
       </button>
@@ -225,7 +213,7 @@ class ScrollButtons extends React.Component {
 
     return (
       showItems && (
-        <div style={[containerStyle, this.props.style]}>
+        <div style={{height: this.props.height, ...this.props.style}}>
           {upButton}
           {downButton}
         </div>
@@ -234,12 +222,4 @@ class ScrollButtons extends React.Component {
   }
 }
 
-const styles = {
-  all: {
-    position: 'absolute',
-    transition: 'opacity 200ms',
-    margin: 0,
-  },
-};
-
-export default Radium(ScrollButtons);
+export default ScrollButtons;

--- a/apps/src/templates/instructions/ScrollButtons.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.jsx
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types';
 import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import classNames from 'classnames';
 import color from '../../util/color';
 import FontAwesome from '../../templates/FontAwesome';
+import moduleStyles from './scroll-buttons.module.scss';
 
 import {addMouseUpTouchEvent} from '../../dom';
 import {getOuterHeight, scrollBy} from './utils';
@@ -60,7 +62,15 @@ class ScrollButtons extends React.Component {
     this.scrollStart(DIRECTIONS.DOWN);
   };
 
-  scrollStart(dir) {
+  singleScrollUp = () => {
+    this.singleScroll(DIRECTIONS.UP);
+  };
+
+  singleScrollDown = () => {
+    this.singleScroll(DIRECTIONS.DOWN);
+  };
+
+  singleScroll(dir) {
     // initial scroll in response to button click
     const contentContainer = this.props.getScrollTarget();
     let initialScroll = SCROLL_BY;
@@ -68,9 +78,12 @@ class ScrollButtons extends React.Component {
       initialScroll *= -1;
     }
     scrollBy(contentContainer, initialScroll);
+  }
 
+  scrollStart(dir) {
     // If mouse is held down for half a second, begin gradual continuous
     // scroll
+    const contentContainer = this.props.getScrollTarget();
     this.scrollTimeout = setTimeout(
       function () {
         this.scrollInterval = setInterval(
@@ -107,7 +120,8 @@ class ScrollButtons extends React.Component {
       ? this.props.height > 100
       : this.props.height > 60;
 
-    let upStyle = {
+    // check minecraft and remove
+    const upStyle = {
       opacity: this.props.visible ? 1 : 0,
       top: '10px',
       margin: '0 0 3px 0',
@@ -115,6 +129,7 @@ class ScrollButtons extends React.Component {
       transform: 'translateX(-50%)',
     };
 
+    // check minecraft and remove
     const downStyle = {
       opacity: this.props.visible ? 1 : 0,
       bottom: '10px',
@@ -148,19 +163,27 @@ class ScrollButtons extends React.Component {
         <img src="/blockly/media/1x1.gif" className="scroll-up-btn" alt="" />
       </button>
     ) : (
-      <div
+      <button
+        type="button"
         ref={c => {
           this.scrollUp = c;
         }}
         key="scrollUp"
+        onClick={this.singleScrollUp}
         onMouseDown={this.scrollStartUp}
-        style={[styles.all, styles.arrowGlyph, upStyle]}
+        className={classNames(
+          moduleStyles.all,
+          moduleStyles.arrowGlyph,
+          moduleStyles.up,
+          this.props.visible && moduleStyles.visible,
+          centerItems && moduleStyles.upCenter
+        )}
       >
         <FontAwesome
           icon="caret-up"
           style={{lineHeight: '22px', pointerEvents: 'none'}}
         />
-      </div>
+      </button>
     );
 
     const downButton = this.props.isMinecraft ? (
@@ -183,8 +206,15 @@ class ScrollButtons extends React.Component {
         }}
         className="uitest-scroll-button-down"
         key="scrollDown"
+        onClick={this.singleScrollDown}
         onMouseDown={this.scrollStartDown}
-        style={[styles.all, styles.arrowGlyph, downStyle]}
+        style={[
+          styles.all,
+          styles.arrowGlyph,
+          styles.down,
+          this.props.visible && styles.visible,
+          centerItems && styles.downCenter,
+        ]}
       >
         <FontAwesome
           icon="caret-down"
@@ -214,6 +244,28 @@ const styles = {
     fontSize: 50,
     color: color.neutral_dark,
     cursor: 'pointer',
+  },
+  up: {
+    opacity: 0,
+    top: '10px',
+    margin: '0 0 3px 0',
+    left: 25,
+    transform: 'translateX(-50%)',
+  },
+  visible: {
+    opacity: 1,
+  },
+  upCenter: {
+    left: '50%',
+  },
+  down: {
+    opacity: 0,
+    bottom: '10px',
+    right: 25,
+    transform: 'translateX(50%)',
+  },
+  downCenter: {
+    right: '50%',
   },
 };
 

--- a/apps/src/templates/instructions/scroll-buttons.module.scss
+++ b/apps/src/templates/instructions/scroll-buttons.module.scss
@@ -7,9 +7,12 @@
   margin: 0;
 }
 
+.removeButtonStyles {
+  @include remove-button-styles;
+}
+
 .container {
   .up {
-    @include remove-button-styles;
     @extend %all;
     opacity: 0;
     top: 10px;
@@ -23,7 +26,6 @@
   }
 
   .down {
-    @include remove-button-styles;
     @extend %all;
     opacity: 0;
     bottom: 10px;

--- a/apps/src/templates/instructions/scroll-buttons.module.scss
+++ b/apps/src/templates/instructions/scroll-buttons.module.scss
@@ -42,3 +42,7 @@
 .downCenter {
   right: 50%;
 };
+
+.minecraftButton {
+  width: 40px;
+}

--- a/apps/src/templates/instructions/scroll-buttons.module.scss
+++ b/apps/src/templates/instructions/scroll-buttons.module.scss
@@ -1,48 +1,51 @@
 @import "color";
 @import '../../mixins.scss';
 
-.all {
+%all {
   position: absolute;
   transition: opacity 200ms;
   margin: 0;
 }
 
-.arrowGlyph {
-  font-size: 50px;
-  color: $neutral_dark;
-  cursor: pointer;
-}
+.container {
+  .up {
+    @include remove-button-styles;
+    @extend %all;
+    opacity: 0;
+    top: 10px;
+    margin: 0 0 3px 0;
+    left: 25px;
+    transform: translateX(-50%);
 
-.up {
-  @include remove-button-styles;
-  opacity: 0;
-  top: 10px;
-  margin: 0 0 3px 0;
-  left: 25px;
-  transform: translateX(-50%);
-}
+    &Center {
+      left: 50%;
+    }
+  }
 
-.down {
-  @include remove-button-styles;
-  opacity: 0;
-  bottom: 10px;
-  right: 25px;
-  transform: translateX(50%);
-}
+  .down {
+    @include remove-button-styles;
+    @extend %all;
+    opacity: 0;
+    bottom: 10px;
+    right: 25px;
+    transform: translateX(50%);
 
-.visible {
-  opacity: 1;
-};
+    &Center {
+      right: 50%;
+    }
+  }
 
-// move within center?
-.upCenter {
-  left: 50%;
-};
+  .arrowGlyph {
+    font-size: 50px;
+    color: $neutral_dark;
+    cursor: pointer;
+  }
 
-.downCenter {
-  right: 50%;
-};
+  .visible {
+    opacity: 1;
+  }
 
-.minecraftButton {
-  width: 40px;
+  .minecraftButton {
+    width: 40px;
+  }
 }

--- a/apps/src/templates/instructions/scroll-buttons.module.scss
+++ b/apps/src/templates/instructions/scroll-buttons.module.scss
@@ -1,0 +1,32 @@
+@import "color";
+@import '../../mixins.scss';
+
+.all {
+  position: absolute;
+  transition: opacity 200ms;
+  margin: 0;
+}
+
+.arrowGlyph {
+  font-size: 50px;
+  color: $neutral_dark;
+  cursor: pointer;
+}
+
+.up {
+  @include remove-button-styles;
+  opacity: 0;
+  top: 10px;
+  margin: 0 0 3px 0;
+  left: 25px;
+  transform: translateX(-50%);
+}
+
+.visible {
+  opacity: 1;
+};
+
+// move within center?
+.upCenter {
+  left: 50%;
+};

--- a/apps/src/templates/instructions/scroll-buttons.module.scss
+++ b/apps/src/templates/instructions/scroll-buttons.module.scss
@@ -22,6 +22,14 @@
   transform: translateX(-50%);
 }
 
+.down {
+  @include remove-button-styles;
+  opacity: 0;
+  bottom: 10px;
+  right: 25px;
+  transform: translateX(50%);
+}
+
 .visible {
   opacity: 1;
 };
@@ -29,4 +37,8 @@
 // move within center?
 .upCenter {
   left: 50%;
+};
+
+.downCenter {
+  right: 50%;
 };

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -237,9 +237,6 @@ button.arrow > img {
   opacity: 1;
   vertical-align: text-bottom;
 }
-button.arrow:focus {
-  outline-style: none;
-}
 button.arrow:disabled {
   border: 1px solid $neutral_dark20;
   background-color: $neutral_dark20;

--- a/apps/style/craft/style.scss
+++ b/apps/style/craft/style.scss
@@ -3,7 +3,7 @@
 $root: "/blockly/media/craft/"; //TODO: Parameterize for asset pipeline
 
 @import "color.scss";
-@import "../common";
+@import "../responsive-visualization";
 @import "font";
 
 $darkest-gray: #333;


### PR DESCRIPTION
Main intention here is to **make the up and down arrows in the instructions tab accessible (particularly in the Dance AI progression)**. There were a few changes required to do that (and generally make the `ScrollButtons` component accessible):

- **Separate out a single scroll movement** (now in `onClick`) from some logic that starts a continuous scroll if user holds mouse down for half a second (now in `onMouseDown`). The existing continuous scroll logic relies on a `mouseUp` event to stop the scroll, which never happens when you're using a keyboard.
- Two global changes to improve the tab navigation in Minecraft instructions, which use the same component as Dance (but different HTML elements): 
  - **remove the import of the whole `common.scss`** file in the Minecraft-specific scss file. Made debugging tricky as changes to `common.scss` didn't rebuild the Minecraft-specific style file. This type of import is discouraged by Sass, [docs here](https://sass-lang.com/documentation/at-rules/import/). I can't exactly tell why this import is here because of some lost git history [mentioned here](https://github.com/code-dot-org/code-dot-org/commit/11d15e948896b26eb591f273bf566f37c0fe1c41), but I do think that we include `common.css` on basically every page load [here](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/views/levels/_apps_dependencies.html.haml#L16), so I don't think we'll be losing anything?
  - **remove the `outline-style` override** applied to arrow buttons (in Minecraft as well as in other labs). Per the [documentation here,](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#focus_vs_focus-visible) I think that this was here to avoid an "ugly" outline being applied as you clicked buttons back in the day. Apparently browsers are now smart enough not to outline the button every time you click on one, and in this case this override was preventing the Minecraft buttons from being outlined when they were tabbed to (confusing!)
- Convert clickable divs into buttons.
- Remove Radium and move inline CSS to SCSS module.

https://github.com/code-dot-org/code-dot-org/assets/25372625/e59669fe-90af-4354-9ed5-7ed68dbccccf

## Links

- jira ticket: [LABS-202](https://codedotorg.atlassian.net/browse/LABS-202)

## Testing story

Tested manually on Minecraft (http://localhost-studio.code.org:3000/s/hero/lessons/1/levels/1) and Dance Party (http://localhost-studio.code.org:3000/s/dance-ai-2023/lessons/1/levels/10) that scroll behavior continued to function as it did previously. 

I tested on a touch device as well that using the up/down arrows continued to function as expected.

For the removal of the import of `common.scss` in Minecraft, I briefly looked at a few Minecraft levels (ones from the tutorials listed [here](https://code.org/minecraft)), and didn't see anything obviously wrong. I also looked at a couple of minecraft standalone project levels and had the same conclusion.

For the change to remove the `outline-style` override, I looked at some other places where we apply the arrow class to a button (eg, the arrow buttons in Sprite Lab), which looked fine.