### PR TITLE
Fix docker build by importing new mysql apt pub key

### DIFF
--- a/docker/dockerfiles/Dockerfile
+++ b/docker/dockerfiles/Dockerfile
@@ -148,6 +148,7 @@ RUN curl -sSLOJ https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb && \
     echo "mysql-apt-config mysql-apt-config/repo-codename select bionic" | /usr/bin/debconf-set-selections && \
     dpkg -i mysql-apt-config_0.8.22-1_all.deb || apt-get --fix-broken --yes install && \
     rm -rf mysql-apt-config_0.8.22-1_all.deb && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && \
     apt-get update && \
     apt-get install --yes libmysqlclient-dev mysql-client=5.7.42-1ubuntu18.04 mysql-server=5.7.42-1ubuntu18.04
 


### PR DESCRIPTION
It looks like our Dockerfile broke due to an outdated pubkey for the MySQL apt repo:
```
 > [primary-layer  4/18] RUN curl -sSLOJ https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb &&     echo "mysql-apt-config mysql-apt-config/select-server select mysql-5.7" | /usr/bin/debconf-set-selections &&     echo "mysql-apt-config mysql-apt-config/repo-codename select bionic" | /usr/bin/debconf-set-selections &&     dpkg -i mysql-apt-config_0.8.22-1_all.deb || apt-get --fix-broken --yes install &&     rm -rf mysql-apt-config_0.8.22-1_all.deb &&     apt-get update &&     apt-get install --yes libmysqlclient-dev mysql-client=5.7.42-1ubuntu18.04 mysql-server=5.7.42-1ubuntu18.04:                                                                                                                                             
1.548 Selecting previously unselected package mysql-apt-config.                                                                                                                         
1.561 (Reading database ... 30450 files and directories currently installed.)                                                                                                           
1.561 Preparing to unpack mysql-apt-config_0.8.22-1_all.deb ...                                                                                                                         
1.563 Unpacking mysql-apt-config (0.8.22-1) ...                                                                                                                                         
1.613 Setting up mysql-apt-config (0.8.22-1) ...                                                                                                                                        
2.671 Warning: apt-key should not be used in scripts (called from postinst maintainerscript of the package mysql-apt-config)                                                            
4.440 OK                                                                                                                                                                                
5.051 Get:1 http://repo.mysql.com/apt/ubuntu bionic InRelease [20.0 kB]                                                                                                                 
5.234 Hit:2 http://archive.ubuntu.com/ubuntu focal InRelease                                                                                                                            
5.234 Hit:3 http://security.ubuntu.com/ubuntu focal-security InRelease                                                                                                                  
5.358 Hit:4 http://archive.ubuntu.com/ubuntu focal-updates InRelease
5.487 Hit:5 http://archive.ubuntu.com/ubuntu focal-backports InRelease
5.940 Err:1 http://repo.mysql.com/apt/ubuntu bionic InRelease
5.940   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B7B3B788A8D3785C
9.798 Reading package lists...
10.73 W: GPG error: http://repo.mysql.com/apt/ubuntu bionic InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B7B3B788A8D3785C
10.73 E: The repository 'http://repo.mysql.com/apt/ubuntu bionic InRelease' is not signed.
```

Fix following suggestion on askubuntu: https://askubuntu.com/questions/1497140/how-to-fix-apt-update-after-to-upgrade-the-mysql-list-file