### PR TITLE
[Google Blockly] resize flyout for function editor workspace toolbox

### DIFF
--- a/apps/src/blockly/addons/cdoVerticalFlyout.js
+++ b/apps/src/blockly/addons/cdoVerticalFlyout.js
@@ -101,8 +101,4 @@ export default class VerticalFlyout extends GoogleBlockly.VerticalFlyout {
     const toolboxWidth = Blockly.cdoUtils.getToolboxWidth();
     document.getElementById('toolbox-header').style.width = toolboxWidth + 'px';
   }
-
-  test() {
-    console.log('cdoVerticalFlyout!');
-  }
 }

--- a/apps/src/blockly/addons/cdoVerticalFlyout.js
+++ b/apps/src/blockly/addons/cdoVerticalFlyout.js
@@ -30,18 +30,16 @@ export default class VerticalFlyout extends GoogleBlockly.VerticalFlyout {
 
     /* Begin CDO Customization */
     const mainWorkspace = Blockly.getMainWorkspace();
-    const hiddenDefinitionWorkspace = Blockly.getHiddenDefinitionWorkspace();
+    const functionEditorWorkspace = Blockly.getFunctionEditorWorkspace();
 
-    if (this.targetWorkspace.id === mainWorkspace?.id) {
+    if (
+      [mainWorkspace, functionEditorWorkspace].includes(this.targetWorkspace)
+    ) {
       // Constrain the main workspace flyout to not be wider than 40% of the total workspace space.
       flyoutWidth = Math.min(
         flyoutWidth,
         this.targetWorkspace.getMetricsManager().getSvgMetrics().width * 0.4
       );
-    } else if (this.targetWorkspace.id === hiddenDefinitionWorkspace?.id) {
-      // Before the modal editor workspace is opened, its svg metrics are unreliable.
-      // Assume the flyout should have the same width as the main workspace.
-      flyoutWidth = mainWorkspace?.getMetricsManager().getFlyoutMetrics().width;
     }
 
     /* End CDO Customization */
@@ -102,5 +100,9 @@ export default class VerticalFlyout extends GoogleBlockly.VerticalFlyout {
     this.reflowInternal_();
     const toolboxWidth = Blockly.cdoUtils.getToolboxWidth();
     document.getElementById('toolbox-header').style.width = toolboxWidth + 'px';
+  }
+
+  test() {
+    console.log('cdoVerticalFlyout!');
   }
 }

--- a/apps/src/blockly/addons/cdoVerticalFlyout.js
+++ b/apps/src/blockly/addons/cdoVerticalFlyout.js
@@ -35,10 +35,11 @@ export default class VerticalFlyout extends GoogleBlockly.VerticalFlyout {
     if (
       [mainWorkspace, functionEditorWorkspace].includes(this.targetWorkspace)
     ) {
-      // Constrain the main workspace flyout to not be wider than 40% of the total workspace space.
+      // Constrain the flyout to not be wider than 40% of the total main workspace space.
       flyoutWidth = Math.min(
         flyoutWidth,
-        this.targetWorkspace.getMetricsManager().getSvgMetrics().width * 0.4
+        // Before the modal editor workspace is opened, its svg metrics are unreliable.
+        mainWorkspace?.getMetricsManager().getSvgMetrics().width * 0.4
       );
     }
 


### PR DESCRIPTION
We had some bad logic in our customized vertical flyout that was causing us only to constrain the width of the toolbox of the main workspace. Now, we will do the same for the modal editor. On Friday, I had surmised that this was happening because we weren't using the right class, but that is not the case, fortunately. Note that users should never see the hidden definition workspace, so references to it were removed.

**Before:**
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/f5b489cc-5d08-45aa-bc04-dfd119ccaad9)


**After:**
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/6c7e9e16-fb03-453f-9166-616e48a2b75c)

You can observe that the Sprites category is now constrained to no more than 40% of the width of the workspace behind it. I also tested that the modal flyout was responsive to browser resizing, as would be expected after this PR:
- https://github.com/code-dot-org/code-dot-org/pull/55846

## Links

https://codedotorg.atlassian.net/browse/CT-271


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
