### PR TITLE
Add workshop notes to teacher enrollment reminder emails

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
@@ -8,6 +8,8 @@
     vertical-align: top;
   }
 
+= render partial: 'workshop_notes'
+
 - if @workshop.subject == Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
   %h3
     Before the Workshop

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_counselor.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_counselor.html.haml
@@ -10,6 +10,8 @@
 
 = render partial: 'workshop_logistics'
 
+= render partial: 'workshop_notes'
+
 = render partial: 'accessibility'
 
 = render partial: 'how_to_cancel'


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds the workshop notes (rendered from the `workshop_notes` partial) to all enrollment reminder emails, instead of them only being in the '[facilitator](https://github.com/code-dot-org/code-dot-org/blob/7fda0781812004138a2e7b61ba258aa0e14cdb87/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml#L8)' teacher enrollment reminder emails. This includes the base `teacher_enrollment_details`, and the `counselor` version.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [ACQ-610](https://codedotorg.atlassian.net/browse/ACQ-610)

