### PR TITLE
Refactor code.org top navigation

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/container-responsive-full-width.css
+++ b/pegasus/sites.v3/code.org/public/css/container-responsive-full-width.css
@@ -15,13 +15,6 @@
   allowing each section to be full-width.
 */
 
-/* Removes the gap between the top nav bar and page content if
-  there's a hero banner; if there's no hero banner, the section
-  element has top-padding that will add white space */
-#pageheader-wrapper #pageheader {
-  margin-bottom: 0 !important;
-}
-
 .container_responsive_full_width {
   width: 100%;
   padding: 0;

--- a/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
@@ -1,10 +1,5 @@
 @import 'color.scss', 'font.scss', 'breakpoints.scss';
 
-#pageheader-wrapper #pageheader {
-  position: relative;
-  z-index: 10;
-}
-
 // Code.org HoC homepage banner
 #bars {
   height: 450px;

--- a/pegasus/sites.v3/code.org/public/css/homepage.css
+++ b/pegasus/sites.v3/code.org/public/css/homepage.css
@@ -123,7 +123,7 @@ body.modal-open .supreme-container{
 
 #homepage #actions {
   position: relative;
-  padding: 20px;
+  padding: 4rem 2rem 5rem;
 }
 
 @media screen and (max-width: 970px) {
@@ -308,10 +308,6 @@ body.modal-open .supreme-container{
   color: var(--neutral_white) !important;
   font-family: var(--main-font) !important;
   text-decoration: underline !important;
-}
-
-#homepage .action_buttons {
-  margin-bottom: 60px;
 }
 
 #homepage #actions a {

--- a/pegasus/sites.v3/code.org/public/css/pl-hero-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/pl-hero-banner.scss
@@ -2,7 +2,7 @@
 
 .pl-banner-superhero.homepage {
   max-width: 1020px;
-  margin: 2em auto 5em;
+  margin: 1em auto;
 
   @media screen and (max-width: $width-md) {
     margin-top: 0;

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -24,6 +24,8 @@ style_min: true
 - if ["student", "teacher"].include?(user_type)
   - redirect CDO.studio_url('/home', CDO.default_scheme)
 
+= view :header
+
 #homepage.supreme-container
   = view :homepage_hero
 

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -429,6 +429,122 @@ td {
   }
 }
 
+/* Top navigation styles ------------------------ */
+nav.main {
+  background-color: #00adbc;
+  margin: 0;
+  padding: 0.25rem 1rem;
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: 3rem;
+}
+
+nav .left,
+nav .right {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+nav .left {
+  gap: 3rem;
+}
+
+nav .right {
+  gap: 0.5rem;
+  justify-content: end;
+}
+
+nav.main ul {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: start;
+  gap: 2rem;
+}
+
+nav.main ul li {
+  padding: 0;
+  text-indent: 0;
+  list-style: none;
+  color: var(--neutral_white);
+}
+
+nav.main ul li::before {
+  content: "";
+}
+
+nav.main ul li a {
+  color: var(--neutral_white);
+  text-decoration: none;
+  font-weight: var(--regular-font-weight);
+}
+
+nav.main img.logo {
+  width: 42px;
+}
+
+nav.main i.fa-fw {
+  line-height: 1;
+}
+
+nav.main .create_menu {
+  border: 2px solid;
+  margin: 0;
+  display: flex;
+  gap: 2px;
+}
+
+nav.main .create_menu i {
+  font-size: 1.5rem;
+  width: auto;
+}
+
+nav.main .create_menu i.create_menu_arrow_down {
+  margin-top: -3px;
+}
+
+nav.main .create_menu i.create_menu_arrow_up {
+  margin-top: -1px;
+}
+
+nav.main .button-signin {
+  font-size: 0.875rem;
+  padding: 7px 12px;
+  margin: 0;
+  border: 2px solid var(--neutral_white);
+  border-radius: 4px;
+  color: var(--neutral_white);
+  font-weight: var(--regular-font-weight);
+  text-decoration: none;
+}
+
+nav.main .help_button {
+  all: unset;
+}
+
+nav.main .help_button .help_icon {
+  padding: 0;
+  height: unset;
+}
+
+nav.main .help_button .help_contents {
+  right: 1rem;
+}
+
+nav.main #hamburger #hamburger-icon {
+  margin-top: -1px;
+}
+
+@media screen and (max-width: 1010px) {
+  .hide_on_tablet {
+    display: none;
+  }
+}
+
 /* Start carousel styles ------------------------ */
 .carousel-wrapper {
   position: relative;

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -481,6 +481,7 @@ nav.main ul li a {
   color: var(--neutral_white);
   text-decoration: none;
   font-weight: var(--regular-font-weight);
+  cursor: pointer;
 }
 
 nav.main ul li a:hover {

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -429,7 +429,7 @@ td {
   }
 }
 
-/* Top navigation styles ------------------------ */
+/* Start top navigation bar styles ------------------------ */
 nav.main {
   background-color: #00adbc;
   margin: 0;
@@ -483,6 +483,11 @@ nav.main ul li a {
   font-weight: var(--regular-font-weight);
 }
 
+nav.main ul li a:hover {
+  padding-bottom: 2px;
+  border-bottom: 2px solid var(--orange);
+}
+
 nav.main img.logo {
   width: 42px;
 }
@@ -504,7 +509,7 @@ nav.main .create_menu i {
 }
 
 nav.main .create_menu i.create_menu_arrow_down {
-  margin-top: -3px;
+  margin-top: -4px;
 }
 
 nav.main .create_menu i.create_menu_arrow_up {
@@ -540,7 +545,8 @@ nav.main #hamburger #hamburger-icon {
 }
 
 @media screen and (max-width: 1010px) {
-  .hide_on_tablet {
+  nav.main .create_menu,
+  nav.main .left ul {
     display: none;
   }
 }

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -529,7 +529,8 @@ nav.main .button-signin {
 }
 
 nav.main .help_button {
-  all: unset;
+  padding: 0;
+  height: unset;
 }
 
 nav.main .help_button .help_icon {
@@ -538,7 +539,7 @@ nav.main .help_button .help_icon {
 }
 
 nav.main .help_button .help_contents {
-  right: 1rem;
+  top: 46px;
 }
 
 nav.main #hamburger #hamburger-icon {

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -450,7 +450,7 @@ nav .right {
 }
 
 nav .left {
-  gap: 3rem;
+  gap: 2rem;
 }
 
 nav .right {

--- a/pegasus/sites.v3/code.org/views/header.haml
+++ b/pegasus/sites.v3/code.org/views/header.haml
@@ -27,11 +27,10 @@
   .left
     %a{href: current_user ? CDO.studio_url("/home") : CDO.code_org_url}
       %img.logo{src: '/images/logo.svg', alt: I18n.t(:code_org_logo_alt)}
-    .hide_on_tablet
-      %ul
-        - Hamburger.get_header_contents(header_contents_options).each do |entry|
-          %li
-            %a{id: entry[:id], href: entry[:url]}= entry[:title]
+    %ul
+      - Hamburger.get_header_contents(header_contents_options).each do |entry|
+        %li
+          %a{id: entry[:id], href: entry[:url]}= entry[:title]
   .right
     = view :sign_in_or_user
     = view :help_button, hamburger_options

--- a/pegasus/sites.v3/code.org/views/header.haml
+++ b/pegasus/sites.v3/code.org/views/header.haml
@@ -27,7 +27,7 @@
   .left
     %a{href: current_user ? CDO.studio_url("/home") : CDO.code_org_url}
       %img.logo{src: '/images/logo.svg', alt: I18n.t(:code_org_logo_alt)}
-    %ul
+    %ul#headerlinks
       - Hamburger.get_header_contents(header_contents_options).each do |entry|
         %li
           %a{id: entry[:id], href: entry[:url]}= entry[:title]

--- a/pegasus/sites.v3/code.org/views/header.haml
+++ b/pegasus/sites.v3/code.org/views/header.haml
@@ -21,44 +21,18 @@
 
   require 'cdo/hamburger'
 
-  # A note on the use of language_dir_class below:
-  #
-  # Ideally, Pegasus would have <head dir="rtl"> on all pages as the dashboard
-  # does.  It would even be helpful if it had it on pages that are localized.
-  # As it is, dir="rtl" is not featured anywhere.  To make the header look the
-  # same as on dashboard, when in an RTL language, we wrap the header in this
-  # locale_dir_class and use CSS to make the header's options display RTL when
-  # at desktop width.
-
-=inline_css 'header.css'
 =inline_css 'hamburger.css'
 
-#language_dir{class: language_dir_class}
-  #pageheader-wrapper
-    #pageheader
-      .content
-        #left
-          #logo-wrapper
-            - if current_user
-              %a.linktag#logo-signedin{:href=>CDO.studio_url("/home")}
-                %img#logo{:src=>'/images/logo.svg', alt: I18n.t(:code_org_logo_alt)}
-            - else
-              %a.linktag#logo-signedout{:href=>CDO.code_org_url}
-                %img#logo{:src=>'/images/logo.svg', alt: I18n.t(:code_org_logo_alt)}
-          #headerlinks.hide_on_tablet
-            - Hamburger.get_header_contents(header_contents_options).each do |entry|
-              %a.headerlink.linktag{id: entry[:id], href: entry[:url]}= entry[:title]
-
-        #right
-          #sign_in_or_user
-            =view :sign_in_or_user
-          = view :help_button, hamburger_options
-          = view :hamburger, hamburger_options
-
-      #clear{:style=>'clear:both'}
-
-      #loc.desktop-feature
-        -if banner = @header['banner']
-          =view banner
-
-#clear{:style=>'clear:both'}
+%nav.main
+  .left
+    %a{href: current_user ? CDO.studio_url("/home") : CDO.code_org_url}
+      %img.logo{src: '/images/logo.svg', alt: I18n.t(:code_org_logo_alt)}
+    .hide_on_tablet
+      %ul
+        - Hamburger.get_header_contents(header_contents_options).each do |entry|
+          %li
+            %a{id: entry[:id], href: entry[:url]}= entry[:title]
+  .right
+    = view :sign_in_or_user
+    = view :help_button, hamburger_options
+    = view :hamburger, hamburger_options

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -116,15 +116,6 @@
       -# Temp: for ai2020, heroes will show/hide responsively, so use widehero_do_not_hide
       .widehero_do_not_hide.lazyload{id: "fullwidth#{index}", "data-bg"=> "#{entry[:image]}", style: "background-position: #{entry[:centering]}", class: entry[:classname]}
 
-  #fullwidth
-    - if request.site == 'code.org'
-      = view :header
-    - else
-      #desktop-header.desktop-feature
-        = view :header
-      #mobile-header.mobile-headers.mobile-feature
-        = view :mobile_header_responsive
-
   - if show_single_hero
     - if num_columns == 3
       - extra_images = Homepage.get_outer_column_images(request)


### PR DESCRIPTION
Refactors the top nav on http://code.org to use modern HTML/CSS to improve accessibility and fix visual bugs:
- Moves the navigation out of the hero banner wrapper on the homepage to avoid overflow issues
  - Required some spacing updates to the homepage hero banners
- Fully responsive and hides the list of links and "Create" button on tablet and mobile 
- Works with LTR and RTL languages
- Works with screen readers and keyboard navigation

_Note:_ I only refactored the `header.haml` view and not any of the dropdowns or hamburger menus.

**Jira ticket:** [ACQ-1369](https://codedotorg.atlassian.net/browse/ACQ-1369)

----

## Desktop


https://github.com/code-dot-org/code-dot-org/assets/9256643/07466f9f-783a-4b98-aa12-a6e8a72270ae


## Tablet


https://github.com/code-dot-org/code-dot-org/assets/9256643/a7919044-2383-4232-8df1-b51239c04409


## Mobile


https://github.com/code-dot-org/code-dot-org/assets/9256643/0e740e14-a183-4a3d-8de8-4474f65144dd


## Keyboard navigation


https://github.com/code-dot-org/code-dot-org/assets/9256643/71d581b2-dc13-4bb7-be26-c899fae8db99


## Screen reader


https://github.com/code-dot-org/code-dot-org/assets/9256643/08c90d07-3faf-42c9-8719-361e031a4588

