### PR TITLE
Fix flaky sectionInstructorsController test

### DIFF
--- a/dashboard/test/controllers/api/v1/section_instructors_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/section_instructors_controller_test.rb
@@ -126,10 +126,13 @@ class Api::V1::SectionInstructorsControllerTest < ActionController::TestCase
   end
 
   test 'instructor cannot remove section owner' do
+    section = create(:section, user: @teacher, login_type: 'word')
+    si = section.instructors.first
+    create(:section_instructor, section: section, instructor: @teacher2, status: :active)
     sign_in @teacher2
-    delete :destroy, params: {id: @si2.id}
+    delete :destroy, params: {id: si.id}
     assert_response :forbidden
-    assert @si2.reload.deleted_at.nil?
+    assert si.reload.deleted_at.nil?
   end
 
   test 'instructor can remove themselves if not section owner' do


### PR DESCRIPTION
The test `instructor cannot remove section owner` is occasionally flaky. My guess is that this is because some other test is modifying one of the variables used in the test (either `@si2` or `@section2`). I can't find where this would be and there is NO REPRO. Therefore, out of an abundance of caution, I'm removing reliance on variables used in other tests and instead creating a section and section_instructor in the test.

This should hopefully be a noop that might fix an occasional flaky test. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[TEACH-817](https://codedotorg.atlassian.net/browse/TEACH-817)
[slack convo](https://codedotorg.slack.com/archives/C045UAX4WKH/p1705689720174729)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
