### PR TITLE
Music: don't show loading bar if there are no initial sounds to load

### DIFF
--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -76,6 +76,8 @@ const initialState: MusicState = {
   playbackEvents: [],
   orderedFunctions: [],
   lastMeasure: 0,
+  // Default to 1 (fully loaded). When loading a new sound, the progress will be set back to 0 before the load starts.
+  // This is to prevent the progress bar from showing if there are no sounds to load initially.
   soundLoadingProgress: 1,
   startingPlayheadPosition: 1,
   undoStatus: {

--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -76,7 +76,7 @@ const initialState: MusicState = {
   playbackEvents: [],
   orderedFunctions: [],
   lastMeasure: 0,
-  soundLoadingProgress: 0,
+  soundLoadingProgress: 1,
   startingPlayheadPosition: 1,
   undoStatus: {
     canUndo: false,


### PR DESCRIPTION
Currently if loading a new project with no sounds, the loading bar will stay on screen because loading progress is 0 and never gets updated. Change this to start progress at 1 which will hide the bar, because it will reset to 0 once there are sounds to load.

## Testing story

Tested locally