### PR TITLE
Music: enable playback keyboard shortcuts by default

### DIFF
--- a/apps/src/music/views/KeyHandler.tsx
+++ b/apps/src/music/views/KeyHandler.tsx
@@ -15,6 +15,7 @@ import {
 interface KeyHandlerProps {
   togglePlaying: () => void;
   playTrigger: (triggerId: string) => void;
+  uiShortcutsEnabled: boolean;
 }
 
 /**
@@ -24,6 +25,7 @@ interface KeyHandlerProps {
 const KeyHandler: React.FunctionComponent<KeyHandlerProps> = ({
   togglePlaying,
   playTrigger,
+  uiShortcutsEnabled,
 }) => {
   const analyticsReporter = useContext(AnalyticsContext);
   const dispatch = useDispatch();
@@ -54,25 +56,27 @@ const KeyHandler: React.FunctionComponent<KeyHandlerProps> = ({
       // keys are used for Blockly keyboard navigation: A, D, I, S, T, W, X
       // https://developers.google.com/blockly/guides/configure/web/keyboard-nav
       // Also avoid C and V that may be used in copy/paste shortcuts.
-      if (event.key === 'u') {
-        reportKeyPress('toggle-timeline-position');
-        dispatch(toggleTimelinePosition());
-      }
-      if (event.key === 'j') {
-        reportKeyPress('toggle-instructions');
-        dispatch(toggleInstructions());
-      }
-      if (event.key === 'n') {
-        reportKeyPress('advance-instructions-position');
-        dispatch(advanceInstructionsPosition());
-      }
-      if (event.key === 'h') {
-        reportKeyPress('toggle-headers');
-        dispatch(toggleHeaders());
-      }
-      if (event.key === 'b') {
-        reportKeyPress('toggle-beat-pad');
-        dispatch(toggleBeatPad());
+      if (uiShortcutsEnabled) {
+        if (event.key === 'u') {
+          reportKeyPress('toggle-timeline-position');
+          dispatch(toggleTimelinePosition());
+        }
+        if (event.key === 'j') {
+          reportKeyPress('toggle-instructions');
+          dispatch(toggleInstructions());
+        }
+        if (event.key === 'n') {
+          reportKeyPress('advance-instructions-position');
+          dispatch(advanceInstructionsPosition());
+        }
+        if (event.key === 'h') {
+          reportKeyPress('toggle-headers');
+          dispatch(toggleHeaders());
+        }
+        if (event.key === 'b') {
+          reportKeyPress('toggle-beat-pad');
+          dispatch(toggleBeatPad());
+        }
       }
       if (event.key === ',') {
         dispatch(moveStartPlayheadPositionBackward());
@@ -89,11 +93,14 @@ const KeyHandler: React.FunctionComponent<KeyHandlerProps> = ({
         togglePlaying();
       }
     },
-    [togglePlaying, playTrigger, reportKeyPress, dispatch]
+    [togglePlaying, playTrigger, reportKeyPress, dispatch, uiShortcutsEnabled]
   );
 
   useEffect(() => {
     document.body.addEventListener('keyup', handleKeyUp);
+    return () => {
+      document.body.removeEventListener('keyup', handleKeyUp);
+    };
   }, [handleKeyUp]);
 
   return null;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -657,12 +657,13 @@ class UnconnectedMusicView extends React.Component {
 
     return (
       <AnalyticsContext.Provider value={this.analyticsReporter}>
-        {AppConfig.getValue('keyboard-shortcuts-enabled') === 'true' && (
-          <KeyHandler
-            togglePlaying={this.togglePlaying}
-            playTrigger={this.playTrigger}
-          />
-        )}
+        <KeyHandler
+          togglePlaying={this.togglePlaying}
+          playTrigger={this.playTrigger}
+          uiShortcutsEnabled={
+            AppConfig.getValue('ui-keyboard-shortcuts-enabled') === 'true'
+          }
+        />
         <UpdateTimer
           getCurrentPlayheadPosition={this.getCurrentPlayheadPosition}
           updateHighlightedBlocks={this.updateHighlightedBlocks}

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -91,7 +91,7 @@ const optionsList = [
     ],
   },
   {
-    name: 'keyboard-shortcuts-enabled',
+    name: 'ui-keyboard-shortcuts-enabled',
     type: 'radio',
     values: [
       {value: 'false', description: 'Disable keyboard shortcuts.'},


### PR DESCRIPTION
Enable all playback related keyboard shortcuts by default (play/pause, triggers, skip forward/back). The UI-related keyboard shortcuts (toggle headers, toggle timeline position, etc) are still hidden behind a URL param which I renamed to `ui-keyboard-shortcuts-enabled` for clarity.

## Testing story

Tested locally with and without URL param.