### PR TITLE
Admin account deletion warning typo fix

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -62,7 +62,7 @@
   "addedToProjects": "Added",
   "addingToProjects": "Adding...",
   "adminAccountDeletionDialog_header": "Delete Admin Account",
-  "adminAccountDeletionDialog_body": "You are about delete an admin account. Are you sure you would like to continue?",
+  "adminAccountDeletionDialog_body": "You are about to delete an admin account. Are you sure you would like to continue?",
   "administrator": "Administrator",
   "administratorResourcesDescription": "View these resources to get started on expanding computer science opportunities.",
   "administratorResourcesHeading": "Expand computer science in your school or district",


### PR DESCRIPTION
Adds missing "to" for Admin account deletion warning.


- jira ticket: [here](https://codedotorg.atlassian.net/browse/P20-346)




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
