### PR TITLE
Music: restore missing level

### DIFF
--- a/dashboard/config/levels/custom/standalone_video/musiclab_intro_video_end.level
+++ b/dashboard/config/levels/custom/standalone_video/musiclab_intro_video_end.level
@@ -1,0 +1,24 @@
+<StandaloneVideo>
+  <config><![CDATA[{
+  "published": true,
+  "game_id": 54,
+  "created_at": "2024-01-09T03:30:49.000Z",
+  "level_num": "custom",
+  "user_id": 1196,
+  "properties": {
+    "encrypted": "false",
+    "video_key": "upload_sprites_backgrounds",
+    "instructions_important": "false",
+    "long_instructions": "Now you can upload your own sprites and backgrounds. Watch this video to learn how!",
+    "skip_dialog": true,
+    "skip_sound": true,
+    "background": "music-black",
+    "video_full_width": true,
+    "uses_lab2": true,
+    "background": "music-black"
+  },
+  "audit_log": "[{\"changed_at\":\"2024-01-09T03:30:49.939+00:00\",\"changed\":[\"cloned from \\\"musiclab_intro_video_start\\\"\"],\"cloned_from\":\"musiclab_intro_video_start\"},{\"changed_at\":\"2024-01-09 03:31:03 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2024-01-09 11:16:47 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"brendan+levelbuilder@code.org\"}]",
+  "level_concept_difficulty": {
+  }
+}]]></config>
+</StandaloneVideo>


### PR DESCRIPTION
This level is no longer used in the `music-intro-2024` script, but is still used in the `musiclab` script, so just restoring it for now to unblock the build.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/55758.
