### PR TITLE
Add close button and make it tab navigable to footer copyright popup

### DIFF
--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -179,7 +179,7 @@ export default class SmallFooter extends React.Component {
         top: 0,
         right: 0,
         padding: 0,
-        color: color.charcoal,
+        color: color.neutral_dark30,
         backgroundColor: color.background_gray,
         cursor: 'pointer',
         fontSize: 24,

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -262,7 +262,7 @@ export default class SmallFooter extends React.Component {
               )}
             />
             <Button
-              id="x-close"
+              id="x-close-copyright"
               onClick={() => this.setState({menuState: MenuState.MINIMIZED})}
               icon="fa-solid fa-xmark"
               style={styles.copyrightXClose}

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -13,6 +13,8 @@ import React from 'react';
 import debounce from 'lodash/debounce';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
+import Button from '../../templates/Button';
+import color from '../../util/color';
 import i18n from '@cdo/locale';
 
 const MenuState = {
@@ -172,6 +174,17 @@ export default class SmallFooter extends React.Component {
         maxWidth: '50%',
         minWidth: this.state.baseWidth,
       },
+      copyrightXClose: {
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        padding: 0,
+        color: color.charcoal,
+        backgroundColor: color.background_gray,
+        cursor: 'pointer',
+        fontSize: 24,
+        border: 'none',
+      },
       copyrightScrollArea: {
         maxHeight: this.props.phoneFooter ? 210 : undefined,
         marginBottom: this.state.baseHeight - 1,
@@ -247,6 +260,13 @@ export default class SmallFooter extends React.Component {
               markdown={decodeURIComponent(
                 this.props.copyrightStrings.trademark
               )}
+            />
+            <Button
+              id="x-close"
+              onClick={() => this.setState({menuState: MenuState.MINIMIZED})}
+              icon="fa-solid fa-xmark"
+              style={styles.copyrightXClose}
+              aria-label={i18n.closeDialog()}
             />
           </div>
         </div>


### PR DESCRIPTION
Adds a close button (that can be tab navigated to) to the footer copyright popup. I used similar close button parameters and styles as I did when adding a tab-navigable [close button in the BaseDialog](https://github.com/code-dot-org/code-dot-org/pull/55365/files#diff-8895ca710d673a6121a62c87c0a67db76135a91ab6ff7c1541d1990abf049eb0).

Previous look:
![prev_copyright](https://github.com/code-dot-org/code-dot-org/assets/56283563/9bb3aef9-7119-4607-a898-70194f09237d)

New look:
![new_copyright](https://github.com/code-dot-org/code-dot-org/assets/56283563/5a49e9d7-4563-495e-b908-862586c61fc9)

Demo of tab navigation (on the [/projects/applab](https://studio.code.org/projects/applab) page):
https://github.com/code-dot-org/code-dot-org/assets/56283563/e8a3bf7d-fa2b-4a47-a6bb-6c0632fb0631

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/A11Y-28)

## Testing story
Local testing.
