### PR TITLE
[Google Blockly] Add generator for text join block

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.js
@@ -12,6 +12,8 @@ export const blocks = {
     // which adds the plus/minus block UI.
     blockly.Blocks.text_join_simple = blockly.Blocks.text_join;
     blockly.JavaScript.text_join_simple = blockly.JavaScript.text_join;
+    const generator = Blockly.getGenerator();
+    generator.forBlock.text_join_simple = generator.forBlock.text_join;
   },
   mutationToDom() {
     var container = Blockly.utils.xml.createElement('mutation');

--- a/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.js
@@ -11,9 +11,8 @@ export const blocks = {
     // text_join is included with core Blockly. We register a custom text_join_mutator
     // which adds the plus/minus block UI.
     blockly.Blocks.text_join_simple = blockly.Blocks.text_join;
-    blockly.JavaScript.text_join_simple = blockly.JavaScript.text_join;
-    const generator = Blockly.getGenerator();
-    generator.forBlock.text_join_simple = generator.forBlock.text_join;
+    blockly.JavaScript.forBlock.text_join_simple =
+      blockly.JavaScript.forBlock.text_join;
   },
   mutationToDom() {
     var container = Blockly.utils.xml.createElement('mutation');


### PR DESCRIPTION
After the v10 upgrade we saw a bug where text join blocks could not generate code, which crashed the page. The fix for this is to use the new syntax `blockly.JavaScript.forBlock.text_join_simple` instead. 

## Links

- jira ticket: [CT-276](https://codedotorg.atlassian.net/browse/CT-276)


## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
