### PR TITLE
[Google Blockly] Fix costumes button being potentially cut off

### DIFF
--- a/apps/src/blockly/addons/cdoFieldImageDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldImageDropdown.js
@@ -49,8 +49,8 @@ export class CdoFieldImageDropdown extends FieldGridDropdown {
     if (this.buttons_) {
       // Force buttons to a new row by adding blank elements if needed.
       const numItems = this.menu_.menuItems.length;
-      const numInLastRow = numItems % this.columns_;
-      const numBlankToAdd = numInLastRow > 0 ? this.columns_ - numInLastRow : 0;
+      const numInLastRow = numItems % this.columns;
+      const numBlankToAdd = numInLastRow > 0 ? this.columns - numInLastRow : 0;
       for (let i = 0; i < numBlankToAdd; i++) {
         const item = document.createElement('div');
         item.style.width = this.imageWidth_ + 'px';


### PR DESCRIPTION
Due to a v10 field rename from `columns_` to `column_` our placement of the "Costumes" button in the costume dropdown was not going onto its own row. The fix was to update the field name in our code.

### Before
<img width="287" alt="Screenshot 2024-01-22 at 4 20 25 PM" src="https://github.com/code-dot-org/code-dot-org/assets/33666587/4d24f2f4-270e-487d-9b5c-46ddfdc485d2">


### After
<img width="287" alt="Screenshot 2024-01-22 at 4 19 23 PM" src="https://github.com/code-dot-org/code-dot-org/assets/33666587/79c1a2fe-3ac0-4433-8bee-0a89ee57fea0">


## Links

- jira ticket: [CT-273](https://codedotorg.atlassian.net/browse/CT-273)


## Testing story
Tested locally


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
