### PR TITLE
[Google Blockly] resize flyout workspace after setting flyout width

### DIFF
--- a/apps/src/blockly/addons/cdoVerticalFlyout.js
+++ b/apps/src/blockly/addons/cdoVerticalFlyout.js
@@ -89,6 +89,7 @@ export default class VerticalFlyout extends GoogleBlockly.VerticalFlyout {
 
       // Record the width for workspace metrics and .position.
       this.width_ = flyoutWidth;
+      Blockly.svgResize(this.workspace_);
       this.position();
       this.targetWorkspace.recordDragTargets();
     }

--- a/apps/src/blockly/addons/cdoVerticalFlyout.js
+++ b/apps/src/blockly/addons/cdoVerticalFlyout.js
@@ -6,9 +6,9 @@ export default class VerticalFlyout extends GoogleBlockly.VerticalFlyout {
    * This is copied almost entirely from
    * https://github.com/google/blockly/blob/master/core/flyout_vertical.js#L322
    * We override flyoutWidth to constrain it to be at most 40% of the total
-   * workspace space.
-   * Once https://github.com/google/blockly/issues/5684 is resolved, we can
-   * remove this duplicated code and use the API to set the max width of the flyout.
+   * workspace space. Later, we resize the flyout's workspace to fill this smaller container.
+   * This is necessary to ensure that the delete area doesn't extend into the main workspace.
+   * If Blockly adds an API to set the max width of the flyout, we can remove this override.
    **/
   reflowInternal_() {
     this.workspace_.scale = this.getFlyoutScale();
@@ -89,7 +89,11 @@ export default class VerticalFlyout extends GoogleBlockly.VerticalFlyout {
 
       // Record the width for workspace metrics and .position.
       this.width_ = flyoutWidth;
+
+      /* Begin CDO Customization */
       Blockly.svgResize(this.workspace_);
+      /* End CDO Customization */
+
       this.position();
       this.targetWorkspace.recordDragTargets();
     }


### PR DESCRIPTION
During the second Sprite Lab bug bash @onlinecsteacher noticed that blocks were unexpectedly getting deleted just by dragging them over parts of the main workspace. This was happening in places where the flyout, if uncropped, would have overlapped the main workspace. The underlying cause seems to be that the flyout itself was getting resized, but not the workspace it contains. This was meant that there was an invisible delete area partially covering the workspace.

![before](https://github.com/code-dot-org/code-dot-org/assets/43474485/fb7a9ba2-42f0-4cfa-b2ca-6847f54a2afa)

I discovered that the flyout workspace was reporting expected dimensions, but wasn't always being resized. One solution is to call `Blockly.svgResize` on the workspace.

Now a block can only be deleted by dragging it over the rendered flyout area, as expected:

![after2](https://github.com/code-dot-org/code-dot-org/assets/43474485/cb51490d-58d8-4f3f-909b-5bf637ad0a7b)

While updating comments, I removed a reference to a Blockly issue that is no longer being tracked since it has been closed: https://github.com/google/blockly/issues/5684

## Links

https://codedotorg.atlassian.net/browse/CT-272

## Testing story

Tested manually at `/s/csc-bookcovers-2023/lessons/3/levels/9?blocklyVersion=google`

I also checked for regressions in categorized toolboxes and the function editor using the Sprite Lab project level.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
