### PR TITLE
enable ai rubric eval on New-U3-2023-L24

### DIFF
--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -18,6 +18,7 @@ class EvaluateRubricJob < ApplicationJob
       'CSD U3 Sprites scene challenge_2023' => 'New-U3-2022-L10',
       'CSD web project animated review_2023' => 'New-U3-2022-L13',
       'CSD games sidescroll review_2023' => 'New-U3-2022-L20',
+      'CSD U3 collisions flyman bounceOff_2023' => 'New-U3-2023-L24',
     },
     'allthethings' => {
       'CSD U3 Sprites scene challenge_allthethings' => 'allthethings-lesson-48',


### PR DESCRIPTION
CSD Unit 3 Lesson 24 was one of the first lessons we tried to optimize accuracy on. This PR finally adds it to our closed pilot.

These are the accuracy scores I am seeing using rubric tester: [L24-94-percent.pdf](https://drive.google.com/file/d/1AsIqp-LpVVgUugeugAsLA8REWeRtPMsI/view?usp=sharing)
![Screenshot 2024-01-22 at 2 52 11 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/bce86034-4515-42ca-9027-43ec3ca6820b)

based on this, I've uploaded the following config to s3:
```
Dave-MBP:~/src/aiproxy (add-new-u3-l24)$ aws s3 ls s3://cdo-ai/teaching_assistant/lessons/New-U3-2023-L24/          
2024-01-22 16:11:43        323 confidence.json
2024-01-22 14:53:59        102 params.json
2024-01-22 16:11:34       5104 standard_rubric.csv
2024-01-22 06:12:46       3664 system_prompt.txt

Dave-MBP:~/src/aiproxy (add-new-u3-l24)$ aws s3 cp s3://cdo-ai/teaching_assistant/lessons/New-U3-2023-L24/confidence.json - | cat
{
  "Modularity - Multiple Sprites": "MEDIUM",
  "Algorithms and Control - Player Control Conditionals": "HIGH",
  "Algorithms and Control - Looping Conditionals": "MEDIUM",
  "Algorithms and Control - Interaction Conditionals & Collision Detection": "HIGH",
  "Optional “Stretch” Feature - Variables": "HIGH"
}

Dave-MBP:~/src/aiproxy (add-new-u3-l24)$ aws s3 cp s3://cdo-ai/teaching_assistant/lessons/New-U3-2023-L24/params.json - | cat
{
  "model": "gpt-4-0613",
  "remove-comments": "1",
  "num-responses": "3",
  "temperature": "0.1"
}
```
standard_rubric.csv and system_prompt.txt can be found in s3 or seen in the pdf above.

### done for this PR
* resolved issues with contractor grades in https://docs.google.com/spreadsheets/d/1dYZlZ-NgFwAIU4tIN3I53ffJrBVXyh8_BACJYahnJws/edit#gid=252038826
* did various accuracy work to get the accuracy scores high enough
* uploaded new files to s3 (see above)
* Angelina has updated the rubric in production in response to some clarifying questions, so now the AI rubric currently in S3 will match the latest rubric
* wrote this PR to enable TA on this lesson

## Testing story

Manually verified I can evaluate a student's work locally

## Deployment strategy

We've made a bunch of updates to the revised rubric as part of this work. I'm planning to hold off on deploying this change until the rubric has been updated.

## Future work

* Enable this lesson in rubric tester. https://github.com/code-dot-org/aiproxy/pull/40 
* add new lesson to regression test