### PR TITLE
 [Google Blockly] CT-279: Position blocks that have only x- or y-coordinate set

### DIFF
--- a/apps/src/blockly/addons/cdoSerializationHelpers.js
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.js
@@ -133,14 +133,15 @@ function adjustBlockPositions(blocks, workspace) {
     }
   });
 
+  const {defaultX, defaultY} = getDefaultLocation(workspace);
   blocksToPlace.forEach(block => {
     let {x, y} = block.getRelativeToSurfaceXY();
     // Only overwrite x/y if it is 0; otherwise, use the existing value
     // This allows for partial adjustments of user-defined positions
-    if (x === 0) {
+    if (x === defaultX) {
       x = getXCoordinate(block, workspace);
     }
-    if (y === 0) {
+    if (y === defaultY) {
       y = WORKSPACE_PADDING;
     }
 

--- a/apps/src/blockly/addons/cdoSerializationHelpers.js
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.js
@@ -126,7 +126,7 @@ function adjustBlockPositions(blocks, workspace) {
   let orderedColliders = [];
   let blocksToPlace = [];
   blocks.forEach(block => {
-    if (isBlockLocationUnset(block)) {
+    if (isBlockAtEdge(block)) {
       blocksToPlace.push(block);
     } else {
       insertCollider(orderedColliders, getCollider(block));
@@ -134,8 +134,15 @@ function adjustBlockPositions(blocks, workspace) {
   });
 
   blocksToPlace.forEach(block => {
-    let x = getXCoordinate(block, workspace);
-    let y = WORKSPACE_PADDING;
+    let {x, y} = block.getRelativeToSurfaceXY();
+    // Only overwrite x/y if it is 0; otherwise, use the existing value
+    // This allows for partial adjustments of user-defined positions
+    if (x === 0) {
+      x = getXCoordinate(block, workspace);
+    }
+    if (y === 0) {
+      y = WORKSPACE_PADDING;
+    }
 
     // Set initial position; collision area must be updated to account for new position
     // every time block is moved
@@ -224,14 +231,14 @@ export function isOverlapping(collider1, collider2) {
 }
 
 /**
- * Determines whether a block needs to be repositioned, based on its current position.
+ * Determines whether a block is positioned at the edge of the workspace.
  * @param {Blockly.Block} block - the block being considered
- * @returns {boolean} - true if the block is at the top corner of the workspace
+ * @returns {boolean} - true if the block is at the edge of the workspace
  */
-export function isBlockLocationUnset(block) {
+export function isBlockAtEdge(block) {
   const {defaultX, defaultY} = getDefaultLocation(block.workspace);
   const {x = 0, y = 0} = block.getRelativeToSurfaceXY();
-  return x === defaultX && y === defaultY;
+  return x === defaultX || y === defaultY;
 }
 
 export const getDefaultLocation = workspaceOverride => {

--- a/apps/src/blockly/addons/cdoSerializationHelpers.js
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.js
@@ -136,8 +136,9 @@ function adjustBlockPositions(blocks, workspace) {
   const {defaultX, defaultY} = getDefaultLocation(workspace);
   blocksToPlace.forEach(block => {
     let {x, y} = block.getRelativeToSurfaceXY();
-    // Only overwrite x/y if it is 0; otherwise, use the existing value
-    // This allows for partial adjustments of user-defined positions
+
+    // Don't overwrite x- (or y-) coordinate if it is set to something other than the default
+    // This retains partially positioned blocks (with either an x- or y-coordinate set)
     if (x === defaultX) {
       x = getXCoordinate(block, workspace);
     }

--- a/apps/test/unit/blockly/addons/cdoSerializationHelpersTest.js
+++ b/apps/test/unit/blockly/addons/cdoSerializationHelpersTest.js
@@ -167,7 +167,7 @@ describe('CdoSerializationHelpers', () => {
     const viewWidth = 515;
     const arbitraryCoordinates = {x: 20, y: 140};
     const defaultLTRCoordinates = {x: 0, y: 0};
-    const defaultRTLCoordinates = {x: 515, y: 0};
+    const defaultRTLCoordinates = {x: viewWidth, y: 0};
 
     let block, result;
     const workspaceLTR = {RTL: false, getMetrics: () => ({viewWidth})};

--- a/apps/test/unit/blockly/addons/cdoSerializationHelpersTest.js
+++ b/apps/test/unit/blockly/addons/cdoSerializationHelpersTest.js
@@ -3,7 +3,7 @@ import {
   addPositionsToState,
   getCombinedSerialization,
   insertCollider,
-  isBlockLocationUnset,
+  isBlockAtEdge,
   isOverlapping,
   appendProceduresToState,
   partitionJsonBlocksByType,
@@ -163,7 +163,7 @@ describe('CdoSerializationHelpers', () => {
     });
   });
 
-  describe('isBlockLocationUnset', () => {
+  describe('isBlockAtEdge', () => {
     const workspaceLTR = {RTL: false, getMetrics: () => ({viewWidth: 515})};
     const workspaceRTL = {RTL: true, getMetrics: () => ({viewWidth: 515})};
 
@@ -173,7 +173,7 @@ describe('CdoSerializationHelpers', () => {
         getRelativeToSurfaceXY: () => ({x: 0, y: 0}),
       };
 
-      const result = isBlockLocationUnset(block);
+      const result = isBlockAtEdge(block);
       expect(result).to.be.true;
     });
 
@@ -183,7 +183,7 @@ describe('CdoSerializationHelpers', () => {
         getRelativeToSurfaceXY: () => ({x: 20, y: 140}),
       };
 
-      const result = isBlockLocationUnset(block);
+      const result = isBlockAtEdge(block);
       expect(result).to.be.false;
     });
 
@@ -193,7 +193,7 @@ describe('CdoSerializationHelpers', () => {
         getRelativeToSurfaceXY: () => ({x: 515, y: 0}),
       };
 
-      const result = isBlockLocationUnset(block);
+      const result = isBlockAtEdge(block);
       expect(result).to.be.true;
     });
 
@@ -203,7 +203,7 @@ describe('CdoSerializationHelpers', () => {
         getRelativeToSurfaceXY: () => ({x: 495, y: 140}),
       };
 
-      const result = isBlockLocationUnset(block);
+      const result = isBlockAtEdge(block);
       expect(result).to.be.false;
     });
   });

--- a/apps/test/unit/blockly/addons/cdoSerializationHelpersTest.js
+++ b/apps/test/unit/blockly/addons/cdoSerializationHelpersTest.js
@@ -227,7 +227,7 @@ describe('CdoSerializationHelpers', () => {
 
     it('should return true for a block at either x=width or y=0 on a RTL workspace', () => {
       block = {
-        workspace: workspaceLTR,
+        workspace: workspaceRTL,
         getRelativeToSurfaceXY: () => ({
           x: defaultRTLCoordinates.x,
           y: arbitraryCoordinates.y,
@@ -237,7 +237,7 @@ describe('CdoSerializationHelpers', () => {
       expect(result).to.be.true;
 
       block = {
-        workspace: workspaceLTR,
+        workspace: workspaceRTL,
         getRelativeToSurfaceXY: () => ({
           x: arbitraryCoordinates.x,
           y: defaultRTLCoordinates.y,

--- a/apps/test/unit/blockly/addons/cdoSerializationHelpersTest.js
+++ b/apps/test/unit/blockly/addons/cdoSerializationHelpersTest.js
@@ -164,46 +164,96 @@ describe('CdoSerializationHelpers', () => {
   });
 
   describe('isBlockAtEdge', () => {
-    const workspaceLTR = {RTL: false, getMetrics: () => ({viewWidth: 515})};
-    const workspaceRTL = {RTL: true, getMetrics: () => ({viewWidth: 515})};
+    const viewWidth = 515;
+    const arbitraryCoordinates = {x: 20, y: 140};
+    const defaultLTRCoordinates = {x: 0, y: 0};
+    const defaultRTLCoordinates = {x: 515, y: 0};
 
-    it('should return true for a block at (0, 0) on an LTR workspace', () => {
-      const block = {
+    let block, result;
+    const workspaceLTR = {RTL: false, getMetrics: () => ({viewWidth})};
+    const workspaceRTL = {RTL: true, getMetrics: () => ({viewWidth})};
+
+    it('should return true for a block at (0, 0) on a LTR workspace', () => {
+      block = {
         workspace: workspaceLTR,
-        getRelativeToSurfaceXY: () => ({x: 0, y: 0}),
+        getRelativeToSurfaceXY: () => defaultLTRCoordinates,
       };
 
-      const result = isBlockAtEdge(block);
+      result = isBlockAtEdge(block);
       expect(result).to.be.true;
     });
 
-    it('should return false for a block at specific coordinates on an LTR workspace', () => {
-      const block = {
+    it('should return true for a block at either x=0 or y=0 on a LTR workspace', () => {
+      block = {
         workspace: workspaceLTR,
-        getRelativeToSurfaceXY: () => ({x: 20, y: 140}),
+        getRelativeToSurfaceXY: () => ({
+          x: defaultLTRCoordinates.x,
+          y: arbitraryCoordinates.y,
+        }),
+      };
+      result = isBlockAtEdge(block);
+      expect(result).to.be.true;
+
+      block = {
+        workspace: workspaceLTR,
+        getRelativeToSurfaceXY: () => ({
+          x: arbitraryCoordinates.x,
+          y: defaultLTRCoordinates.y,
+        }),
+      };
+      result = isBlockAtEdge(block);
+      expect(result).to.be.true;
+    });
+
+    it('should return false for a block at specific coordinates on a LTR workspace', () => {
+      block = {
+        workspace: workspaceLTR,
+        getRelativeToSurfaceXY: () => arbitraryCoordinates,
       };
 
-      const result = isBlockAtEdge(block);
+      result = isBlockAtEdge(block);
       expect(result).to.be.false;
     });
 
     it('should return true for a block at the top-right corner of an RTL workspace', () => {
-      const block = {
+      block = {
         workspace: workspaceRTL,
-        getRelativeToSurfaceXY: () => ({x: 515, y: 0}),
+        getRelativeToSurfaceXY: () => defaultRTLCoordinates,
       };
 
-      const result = isBlockAtEdge(block);
+      result = isBlockAtEdge(block);
+      expect(result).to.be.true;
+    });
+
+    it('should return true for a block at either x=width or y=0 on a RTL workspace', () => {
+      block = {
+        workspace: workspaceLTR,
+        getRelativeToSurfaceXY: () => ({
+          x: defaultRTLCoordinates.x,
+          y: arbitraryCoordinates.y,
+        }),
+      };
+      result = isBlockAtEdge(block);
+      expect(result).to.be.true;
+
+      block = {
+        workspace: workspaceLTR,
+        getRelativeToSurfaceXY: () => ({
+          x: arbitraryCoordinates.x,
+          y: defaultRTLCoordinates.y,
+        }),
+      };
+      result = isBlockAtEdge(block);
       expect(result).to.be.true;
     });
 
     it('should return false for a block at specific coordinates of an RTL workspace', () => {
-      const block = {
+      block = {
         workspace: workspaceRTL,
-        getRelativeToSurfaceXY: () => ({x: 495, y: 140}),
+        getRelativeToSurfaceXY: () => arbitraryCoordinates,
       };
 
-      const result = isBlockAtEdge(block);
+      result = isBlockAtEdge(block);
       expect(result).to.be.false;
     });
   });


### PR DESCRIPTION
Our original block positioning logic only detects and repositions when a block has neither an x _nor_ a y position set. Blocks frequently receive a specified x-position or a specified y-position (but not both), in which case we currently make the unspecifed coordinate the "default" thereby placing these blocks on the edge of the workspace. To adjust this, I modified `isBlockLocationUnset` to use an || conditional instead of an && conditional, to detect all blocks that touch any edges using `isBlockAtEdge`. Then, since `adjustBlockPositions` was previously assuming it needed to adjust _both_ the x- and the y-positions, I modified the logic only to adjust the coordinates with "default" initial values (`0` for LTR and workspace width for RTL).

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/CT-279

## Testing story

Before (LTR)
<img width="1088" alt="Screenshot 2024-01-22 at 10 12 23 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/04d7d889-da21-496d-aa98-7a5f5f10dc91">

Before (RTL)
<img width="1091" alt="Screenshot 2024-01-22 at 10 13 02 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/2872a141-6ed8-4a8f-8431-c0e5cb2d3c21">

After (LTR)
<img width="1491" alt="Screenshot 2024-01-23 at 9 51 01 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/eef70295-8d44-4947-9e21-1175a44f47c9">

After (RTL)
<img width="1507" alt="Screenshot 2024-01-23 at 9 52 46 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/13e5f387-f8a1-4e06-b082-2954ad4499dd">

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
