### PR TITLE
[Google Blockly] Re-render blocks when font size changes

### DIFF
--- a/apps/src/blockly/addons/contextMenu.js
+++ b/apps/src/blockly/addons/contextMenu.js
@@ -173,7 +173,7 @@ const registerDarkMode = function () {
       return MenuOptionStates.ENABLED;
     },
     callback: function (scope) {
-      const currentTheme = scope.workspace?.getTheme();
+      const currentTheme = scope.workspace.getTheme();
       const themeName =
         baseName(currentTheme.name) +
         (isDarkTheme(scope.workspace) ? '' : dark);
@@ -228,7 +228,7 @@ const registerTheme = function (name, label, index) {
       }
     },
     callback: function (scope) {
-      const currentTheme = scope.workspace?.getTheme();
+      const currentTheme = scope.workspace.getTheme();
       const themeName = name + (isDarkTheme(scope.workspace) ? dark : '');
       localStorage.setItem(BLOCKLY_THEME, themeName);
       setAllWorkspacesTheme(Blockly.themes[themeName], currentTheme);

--- a/apps/src/blockly/addons/contextMenu.js
+++ b/apps/src/blockly/addons/contextMenu.js
@@ -338,7 +338,17 @@ function setAllWorkspacesTheme(theme) {
   Blockly.Workspace.getAll().forEach(workspace => {
     // Headless workspaces do not have the ability to set the theme.
     if (typeof workspace.setTheme === 'function') {
+      const currentTheme = workspace.getTheme();
       workspace.setTheme(theme);
+      // Re-render blocks if the font size changed.
+      // Once https://github.com/google/blockly/issues/7782 is resolved,
+      // we should be able to remove this.
+      if (theme.fontStyle?.size !== currentTheme.fontStyle?.size) {
+        workspace.getAllBlocks().map(block => {
+          block.markDirty();
+          block.render();
+        });
+      }
     }
   });
 }

--- a/apps/src/blockly/addons/contextMenu.js
+++ b/apps/src/blockly/addons/contextMenu.js
@@ -173,11 +173,12 @@ const registerDarkMode = function () {
       return MenuOptionStates.ENABLED;
     },
     callback: function (scope) {
+      const currentTheme = scope.workspace?.getTheme();
       const themeName =
-        baseName(scope.workspace?.getTheme().name) +
+        baseName(currentTheme.name) +
         (isDarkTheme(scope.workspace) ? '' : dark);
       localStorage.setItem(BLOCKLY_THEME, themeName);
-      setAllWorkspacesTheme(Blockly.themes[themeName]);
+      setAllWorkspacesTheme(Blockly.themes[themeName], currentTheme);
     },
     scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.WORKSPACE,
     id: 'toggleDarkMode',
@@ -227,9 +228,10 @@ const registerTheme = function (name, label, index) {
       }
     },
     callback: function (scope) {
+      const currentTheme = scope.workspace?.getTheme();
       const themeName = name + (isDarkTheme(scope.workspace) ? dark : '');
       localStorage.setItem(BLOCKLY_THEME, themeName);
-      setAllWorkspacesTheme(Blockly.themes[themeName]);
+      setAllWorkspacesTheme(Blockly.themes[themeName], currentTheme);
     },
     scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.WORKSPACE,
     id: name + 'ThemeOption',
@@ -334,16 +336,15 @@ function baseName(themeName) {
   return themeName.replace(dark, '');
 }
 
-function setAllWorkspacesTheme(theme) {
+function setAllWorkspacesTheme(newTheme, previousTheme) {
   Blockly.Workspace.getAll().forEach(workspace => {
     // Headless workspaces do not have the ability to set the theme.
     if (typeof workspace.setTheme === 'function') {
-      const currentTheme = workspace.getTheme();
-      workspace.setTheme(theme);
+      workspace.setTheme(newTheme);
       // Re-render blocks if the font size changed.
       // Once https://github.com/google/blockly/issues/7782 is resolved,
       // we should be able to remove this.
-      if (theme.fontStyle?.size !== currentTheme.fontStyle?.size) {
+      if (newTheme.fontStyle?.size !== previousTheme.fontStyle?.size) {
         workspace.getAllBlocks().map(block => {
           block.markDirty();
           block.render();


### PR DESCRIPTION
During the second Sprite Lab bug bash, @samantha-code noticed that blocks were rendering incorrectly when switching to a high contrast theme.  This is reproducible on the Blockly Playground and appears to be due to a known v10 Blockly bug: https://github.com/google/blockly/issues/7782
This bug impacts all theme changes where the font size changes, so it can happen in either direction between our high contrast and other themes.
The workaround for this right now is to refresh the page after selecting a theme.

Until the above issue is resolved, one way we can work around it is to re-render blocks when changing themes. We only need to do this is the font size has changed. 

Initially, I attempted to just get the current theme in realtime as we set the new theme on each workspace. (https://github.com/code-dot-org/code-dot-org/pull/55909/commits/e81f716114ffaaf092cbc2d04c9b83ef35bbe851)
Unfortunately, this didn't quite work for flyouts because `getTheme()` was returning the theme that had already been set on the main workspace. Instead I need to pass in the current theme based on the workspace that hosted the context-menu click.

**Before** _(modern-> high contrast)_:
<img width="1187" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/f2e045aa-63ee-4589-b829-c009fe7d6d0d">
_(high contrast -> modern)_:
<img width="1188" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/ba5460b9-3456-41d3-a8ec-011896371ef9">

**After** _(modern-> high contrast)_:
<img width="1188" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/fa8ce738-2b7b-462e-b6af-b4fe752e5f3f">
_(high contrast -> modern)_:
<img width="1188" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/3ae4189b-ac11-4db1-8cbd-8712f14e82d6">


## Links

Jira: https://codedotorg.atlassian.net/browse/CT-282

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
