### PR TITLE
[Google Blockly] Fix: Costumes added from inside function editor are not usable

### DIFF
--- a/apps/src/blockly/addons/cdoFieldImageDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldImageDropdown.js
@@ -109,6 +109,36 @@ export class CdoFieldImageDropdown extends FieldGridDropdown {
       this.dropdownDispose_.bind(this)
     );
   }
+
+  /**
+   * @override
+   * Ensure that the input value is a valid language-neutral option.
+   * The only change we made from the parent method is to not use the cache,
+   * as the list of options can change.
+   *
+   * @param newValue The input value.
+   * @returns A valid language-neutral option, or null if invalid.
+   */
+  doClassValidation_(newValue) {
+    const options = this.getOptions(false); // false means do not use cache
+    const isValueValid = options.some(option => option[1] === newValue);
+
+    if (!isValueValid) {
+      if (this.sourceBlock_) {
+        console.warn(
+          "Cannot set the dropdown's value to an unavailable option." +
+            ' Block type: ' +
+            this.sourceBlock_.type +
+            ', Field name: ' +
+            this.name +
+            ', Value: ' +
+            newValue
+        );
+      }
+      return null;
+    }
+    return newValue;
+  }
 }
 
 export function fixMenuGenerator(menuGenerator, width, height) {

--- a/apps/src/blockly/addons/cdoFieldImageDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldImageDropdown.js
@@ -120,7 +120,10 @@ export class CdoFieldImageDropdown extends FieldGridDropdown {
    * @returns A valid language-neutral option, or null if invalid.
    */
   doClassValidation_(newValue) {
-    const options = this.getOptions(false); // false means do not use cache
+    /* Begin CDO Customization */
+    const options = this.getOptions(false); // false = do not use cache
+    /* End CDO Customization */
+
     const isValueValid = options.some(option => option[1] === newValue);
 
     if (!isValueValid) {


### PR DESCRIPTION
We found in our bug bash that already created function blocks cannot use new costumes. The fix for this is to override the `doClassValidation` method in `cdoFieldImageDropdown` to not cache the options list. Since this only occurs on changing the dropdown value, it felt safe to not use the cache here. In Sprite Lab, `FieldImageDropdown` is used for the background and costume pickers, which both can update dynamically. It looks like it may also be used for a couple blocks in flappy and bounce, but those blocks do not seem to be used in the "new project" for flappy and bounce.
 
## Links
- jira ticket: [CT-275](https://codedotorg.atlassian.net/browse/CT-275)

## Testing story
Tested locally that we can now use a new costume in a pre-existing costume picker in the function editor workspace.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
