### PR TITLE
Add title and description variables to resources_tabs.haml view

### DIFF
--- a/pegasus/sites.v3/code.org/public/curriculum/computer-vision.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/computer-vision.haml
@@ -47,7 +47,7 @@ theme: responsive_full_width
 %section.bg-neutral-light
   .wrapper
     .hide-tab
-      = view :"tabs_section/resources/resources_tabs"
+      = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/educate/csa.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csa.haml
@@ -56,7 +56,7 @@ theme: responsive_full_width
 
 %section.bg-neutral-light
   .wrapper
-    = view :"tabs_section/resources/resources_tabs"
+    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/educate/csc.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csc.haml
@@ -121,7 +121,7 @@ theme: responsive_full_width
 
 %section.bg-neutral-light
   .wrapper
-    = view :"tabs_section/resources/resources_tabs"
+    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/educate/csd/index.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csd/index.haml
@@ -100,7 +100,7 @@ theme: responsive_full_width
 
 %section.bg-neutral-light
   .wrapper
-    = view :"tabs_section/resources/resources_tabs"
+    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/educate/csf.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csf.haml
@@ -93,7 +93,7 @@ theme: responsive_full_width
 
 %section.bg-neutral-light
   .wrapper
-    = view :"tabs_section/resources/resources_tabs"
+    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/educate/csp.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csp.haml
@@ -57,7 +57,7 @@ theme: responsive_full_width
 
 %section.bg-neutral-light
   .wrapper
-    = view :"tabs_section/resources/resources_tabs"
+    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/teach.haml
+++ b/pegasus/sites.v3/code.org/public/teach.haml
@@ -108,7 +108,7 @@ theme: responsive_full_width
 
 %section.resources.bg-neutral-light
   .wrapper
-    = view :"tabs_section/resources/resources_tabs"
+    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
 
 %section.pl-offerings.centered
   .wrapper

--- a/pegasus/sites.v3/code.org/views/tabs_section/resources/resources_tabs.haml
+++ b/pegasus/sites.v3/code.org/views/tabs_section/resources/resources_tabs.haml
@@ -1,9 +1,10 @@
 -# Can only be used on rebranded pages that use the
 -# "design-system-pegasus.scss" stylesheet.
 
-%h2=hoc_s(:resources_tabs_heading)
+%h2
+  #{resources_heading}
 %p.desc
-  =hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
+  #{resources_desc}
 
 -# Shows tabs UI on desktop
 .tabs-section.resources-tabs.show-desktop


### PR DESCRIPTION
Creates heading and description variables for the Resources Tabs view so they can be changed on a page-by-page basis.

**Jira ticket:** [ACQ-1400](https://codedotorg.atlassian.net/browse/ACQ-1400)