### PR TITLE
Use a clearer key for new scholarship requirement and add it to application dashboard

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -818,6 +818,14 @@ export class DetailViewContents extends React.Component {
               ] || NA}
             </p>
           )}
+          {this.multiAnswerQuestionFields[key]['census'] && (
+            <p>
+              Data from Census:{' '}
+              {this.props.applicationData.school_stats[
+                this.multiAnswerQuestionFields[key]['census']
+              ] || NA}
+            </p>
+          )}
         </div>
       );
     } else {

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -1080,6 +1080,7 @@ module Pd::Application
       # consistent with the criteria.
       meets_scholarship_criteria_scores[:not_teaching_in_access_report] =
         Census::CensusSummary.find_by(school_id: school_id, school_year: census_year)&.does_teach? ? NO : YES
+      meets_scholarship_criteria_scores[:school_last_census_status] = Census::CensusSummary.find_by(school_id: school_id, school_year: census_year)&.does_teach? ? NO : YES
 
       update(
         response_scores: response_scores_hash.deep_merge(

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -1076,10 +1076,6 @@ module Pd::Application
 
       # Check if a school is not teaching CS according to the access report
       # If the school is not in the census_summaries table, treat that as not teaching
-      # This is a bit of a confusing double negative but I wanted to keep the YES/NO logic
-      # consistent with the criteria.
-      meets_scholarship_criteria_scores[:not_teaching_in_access_report] =
-        Census::CensusSummary.find_by(school_id: school_id, school_year: census_year)&.does_teach? ? NO : YES
       meets_scholarship_criteria_scores[:school_last_census_status] = Census::CensusSummary.find_by(school_id: school_id, school_year: census_year)&.does_teach? ? NO : YES
 
       update(

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -51,6 +51,10 @@ class School < ApplicationRecord
     school_stats_by_year.order(school_year: :desc).first
   end
 
+  def census_for_year(year)
+    census_summaries.find_by(school_year: year)
+  end
+
   # Determines if school meets Amazon Future Engineer criteria.
   # Eligible if the school is any of the following:
   # a) title I school,

--- a/dashboard/app/serializers/api/v1/pd/application_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/application_serializer.rb
@@ -187,7 +187,7 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
       title_i_status: stats.title_i_status,
       rural_status: yes_no_string(stats.rural_school?),
       school_type: school.school_type.try(:titleize),
-      school_last_census_status: school.census_for_year(object.census_year).teaches_cs,
+      school_last_census_status: school.census_for_year(object.census_year)&.teaches_cs,
       frl_eligible_percent: percent_string(stats.frl_eligible_total, stats.students_total),
       urm_percent: percent_string(urm_total, stats.students_total),
       students_total: stats.students_total,

--- a/dashboard/app/serializers/api/v1/pd/application_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/application_serializer.rb
@@ -187,6 +187,7 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
       title_i_status: stats.title_i_status,
       rural_status: yes_no_string(stats.rural_school?),
       school_type: school.school_type.try(:titleize),
+      school_last_census_status: school.census_for_year(object.census_year).teaches_cs,
       frl_eligible_percent: percent_string(stats.frl_eligible_total, stats.students_total),
       urm_percent: percent_string(urm_total, stats.students_total),
       students_total: stats.students_total,

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -554,7 +554,7 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: YES,
             underrepresented_minority_percent: YES,
-            not_teaching_in_access_report: YES,
+            school_last_census_status: YES,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -594,7 +594,7 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: YES,
             underrepresented_minority_percent: YES,
-            not_teaching_in_access_report: YES,
+            school_last_census_status: YES,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -638,7 +638,7 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: YES,
             underrepresented_minority_percent: YES,
-            not_teaching_in_access_report: YES,
+            school_last_census_status: YES,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -670,7 +670,7 @@ module Pd::Application
             previous_yearlong_cdo_pd: YES,
           },
           meets_scholarship_criteria_scores: {
-            not_teaching_in_access_report: YES,
+            school_last_census_status: YES,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -709,7 +709,7 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: NO,
             underrepresented_minority_percent: NO,
-            not_teaching_in_access_report: NO,
+            school_last_census_status: NO,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -749,7 +749,7 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: NO,
             underrepresented_minority_percent: NO,
-            not_teaching_in_access_report: NO,
+            school_last_census_status: NO,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -793,7 +793,7 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: NO,
             underrepresented_minority_percent: NO,
-            not_teaching_in_access_report: NO,
+            school_last_census_status: NO,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -948,22 +948,22 @@ module Pd::Application
     test 'meets_scholarship_criteria' do
       application = create :pd_teacher_application
       test_cases = [
-        {underrepresented_minority_percent: YES, free_lunch_percent: YES, not_teaching_in_access_report: YES, verdict: YES},
-        {underrepresented_minority_percent: YES, free_lunch_percent: YES, not_teaching_in_access_report: NO, verdict: YES},
-        {underrepresented_minority_percent: YES, free_lunch_percent: NO, not_teaching_in_access_report: YES, verdict: YES},
-        {underrepresented_minority_percent: NO, free_lunch_percent: YES, not_teaching_in_access_report: YES, verdict: YES},
-        {underrepresented_minority_percent: YES, free_lunch_percent: YES, not_teaching_in_access_report: nil, verdict: YES},
-        {underrepresented_minority_percent: YES, free_lunch_percent: nil, not_teaching_in_access_report: YES, verdict: YES},
-        {underrepresented_minority_percent: nil, free_lunch_percent: YES, not_teaching_in_access_report: YES, verdict: YES},
-        {underrepresented_minority_percent: YES, free_lunch_percent: NO, not_teaching_in_access_report: NO, verdict: YES},
-        {underrepresented_minority_percent: nil, free_lunch_percent: nil, not_teaching_in_access_report: nil, verdict: REVIEWING_INCOMPLETE},
-        {underrepresented_minority_percent: nil, free_lunch_percent: NO, not_teaching_in_access_report: NO, verdict: REVIEWING_INCOMPLETE},
-        {underrepresented_minority_percent: NO, free_lunch_percent: nil, not_teaching_in_access_report: NO, verdict: REVIEWING_INCOMPLETE},
-        {underrepresented_minority_percent: NO, free_lunch_percent: NO, not_teaching_in_access_report: NO, verdict: NO},
+        {underrepresented_minority_percent: YES, free_lunch_percent: YES, school_last_census_status: YES, verdict: YES},
+        {underrepresented_minority_percent: YES, free_lunch_percent: YES, school_last_census_status: NO, verdict: YES},
+        {underrepresented_minority_percent: YES, free_lunch_percent: NO, school_last_census_status: YES, verdict: YES},
+        {underrepresented_minority_percent: NO, free_lunch_percent: YES, school_last_census_status: YES, verdict: YES},
+        {underrepresented_minority_percent: YES, free_lunch_percent: YES, school_last_census_status: nil, verdict: YES},
+        {underrepresented_minority_percent: YES, free_lunch_percent: nil, school_last_census_status: YES, verdict: YES},
+        {underrepresented_minority_percent: nil, free_lunch_percent: YES, school_last_census_status: YES, verdict: YES},
+        {underrepresented_minority_percent: YES, free_lunch_percent: NO, school_last_census_status: NO, verdict: YES},
+        {underrepresented_minority_percent: nil, free_lunch_percent: nil, school_last_census_status: nil, verdict: REVIEWING_INCOMPLETE},
+        {underrepresented_minority_percent: nil, free_lunch_percent: NO, school_last_census_status: NO, verdict: REVIEWING_INCOMPLETE},
+        {underrepresented_minority_percent: NO, free_lunch_percent: nil, school_last_census_status: NO, verdict: REVIEWING_INCOMPLETE},
+        {underrepresented_minority_percent: NO, free_lunch_percent: NO, school_last_census_status: NO, verdict: NO},
       ]
 
       test_cases.each do |test_case|
-        input = test_case.slice(:underrepresented_minority_percent, :free_lunch_percent, :not_teaching_in_access_report)
+        input = test_case.slice(:underrepresented_minority_percent, :free_lunch_percent, :school_last_census_status)
         application.update(response_scores: {meets_scholarship_criteria_scores: input}.to_json)
 
         output = application.meets_scholarship_criteria

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -288,7 +288,6 @@ module Pd
       scholarship_questions: [
         :underrepresented_minority_percent,
         :free_lunch_percent,
-        :not_teaching_in_access_report,
         :school_last_census_status,
       ],
       criteria_score_questions_csd: [

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -123,6 +123,7 @@ module Pd
         title_i_status: 'Title I status',
         rural_status: 'Rural Status',
         school_type: 'School Type',
+        school_last_census_status: 'Last Census Status',
         total_student_enrollment: 'Total Student Enrollment',
         free_lunch_percent: 'Percent of students eligible to receive free/reduced lunch',
         underrepresented_minority_percent: 'Percent of students from underrepresented racial and ethnic groups',
@@ -247,6 +248,7 @@ module Pd
       title_i_status: {stats: :title_i_status},
       rural_status: {stats: :rural_status},
       school_type: {teacher: :school_type, stats: :school_type},
+      school_last_census_status: {census: :school_last_census_status},
       total_student_enrollment: {principal: :principal_total_enrollment, stats: :students_total},
       free_lunch_percent: {principal: :principal_free_lunch_percent, stats: :frl_eligible_percent},
       underrepresented_minority_percent: {principal: :principal_underrepresented_minority_percent, stats: :urm_percent},
@@ -278,6 +280,7 @@ module Pd
       # Scholarship requirements
       free_lunch_percent: YES_NO,
       underrepresented_minority_percent: YES_NO,
+      school_last_census_status: YES_NO,
     }
 
     # Need to explicitly list these for the shared constant generation to work.
@@ -286,6 +289,7 @@ module Pd
         :underrepresented_minority_percent,
         :free_lunch_percent,
         :not_teaching_in_access_report,
+        :school_last_census_status,
       ],
       criteria_score_questions_csd: [
         :csd_which_grades,


### PR DESCRIPTION
This PR:
- changes the key of the scholarship field for the census requirement. **This means I'll need to run `auto_score!` on all applications for this year after this PR hits production.** I'll explain below why I think this is a good option and what the alternative is.
- adds a row to the application dashboard showing this data

Row on application dashboard:
![Screenshot 2024-01-30 at 4 29 01 PM](https://github.com/code-dot-org/code-dot-org/assets/46464143/72b7140a-ad19-4b48-a074-685d892d63b0)

### Why change this key?

If I could go back six weeks and tell myself to implement it this way, I would. This key is clearer and more inline with the other keys for scholarship requirements, ie `underrepresented_minority_percent`, which describe what the requirement is then gives a yes/no "meets" value. It also makes the dashboard clearer.

However, I don't love changing data structure after a feature is live and I don't love having to run a command on all applications started, so I also prepped an alternative, which keeps this key the way it is in https://github.com/code-dot-org/code-dot-org/pull/55911. I'm very open to feedback on which is better.  