### PR TITLE
Fixing multi-day workshop date picker bug

### DIFF
--- a/apps/src/code-studio/assets/date_picker.scss
+++ b/apps/src/code-studio/assets/date_picker.scss
@@ -1,0 +1,3 @@
+.datePicker {
+    z-index: 10;
+  }

--- a/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.jsx
@@ -12,6 +12,7 @@ import {DATE_FORMAT} from '../workshopConstants';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {InputGroup, FormGroup, FormControl} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import 'react-datepicker/dist/react-datepicker.css';
+import '@cdo/apps/code-studio/assets/date_picker.scss';
 
 class DateInputWithIconUnwrapped extends React.Component {
   static propTypes = {
@@ -119,6 +120,7 @@ export default class DatePicker extends React.Component {
         startDate={this.props.startDate}
         endDate={this.props.endDate}
         disabled={this.props.readOnly}
+        popperClassName={'datePicker'}
       />
     );
   }


### PR DESCRIPTION
The built in date-picker styling has a z-index of 1, putting it behind the elements below. This pr adds a stylesheet to override the z-index as suggested in [this helpful github comment](https://github.com/Hacker0x01/react-datepicker/issues/1252#issuecomment-838978560) on the issue. 

Slack conversation from Sam who noticed it here: https://codedotorg.slack.com/archives/C04540KNGDQ/p1706029768340099

Before:
<img width="742" alt="Screenshot 2024-01-23 at 4 35 00 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/6082778c-67a0-457d-846e-83bfff861772">

After:
<img width="750" alt="Screenshot 2024-01-23 at 4 37 56 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/ae1a448c-ad42-42b0-8fa2-aac0947c68b1">

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1401

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
