### PR TITLE
remove trailing blank line in new Berksfile

### DIFF
--- a/cookbooks/cdo-github-access/Berksfile
+++ b/cookbooks/cdo-github-access/Berksfile
@@ -2,4 +2,3 @@ source 'https://supermarket.chef.io'
 
 metadata
 instance_eval File.read('../local_cookbooks.rb'), __FILE__
-


### PR DESCRIPTION
Caused a lint error in the staging build:

    cookbooks/cdo-github-access/Berksfile:5:1: C: [Correctable] Layout/TrailingEmptyLines: 1 trailing blank lines detected.

## Links

https://codedotorg.slack.com/archives/C03CK8E51/p1706069024357719

## Testing story

Ran `bundle exec rake lint` locally