### PR TITLE
Synchronize `TextToSpeech.sanitize` in multi-threaded operations

### DIFF
--- a/bin/i18n/resources/apps/text_to_speech/sync_out.rb
+++ b/bin/i18n/resources/apps/text_to_speech/sync_out.rb
@@ -114,7 +114,7 @@ module I18n
                   localized_message = localized_messages[message_key]
                   next unless localized_message
 
-                  tts_message_l10n = ::TextToSpeech.sanitize(localized_message)
+                  tts_message_l10n = mutex.synchronize {::TextToSpeech.sanitize(localized_message)}
                   tts_file_path = ::TextToSpeech.tts_path(localized_message, localized_message, locale: locale)
 
                   ::TextToSpeech.tts_upload_to_s3(tts_message_l10n, tts_file_path, METRIC_CONTEXT, locale: locale)

--- a/bin/i18n/resources/dashboard/text_to_speech/sync_out.rb
+++ b/bin/i18n/resources/dashboard/text_to_speech/sync_out.rb
@@ -48,17 +48,17 @@ module I18n
 
           def sanitize_tts(text)
             # Because the Redcarpet instance is not thread-safe (https://github.com/vmg/redcarpet/issues/570),
-            # sharing the Markdown formatter in multi-threaded operations may cause the error:
-            # "markdown.c:2897: sd_markdown_render: Assertion `md->work_bufs[BUFFER_BLOCK].size == 0' failed."
-            # more details here: https://www.redmine.org/issues/32563
+            # sharing the Redcarpet::Markdown formatter in multi-threaded operations may cause the error:
+            # "markdown.c:2897: sd_markdown_render: Assertion `md->work_bufs[BUFFER_BLOCK].size == 0' failed.".
+            # More details here: https://www.redmine.org/issues/32563
             mutex.synchronize {::TextToSpeech.sanitize(text || '')}
           end
 
           def squash(value)
             case value
             when String then value.gsub(/\s+/, '')
-            when Array then clean(value.join)
-            when Hash then clean(value.values)
+            when Array then squash(value.join)
+            when Hash then squash(value.values)
             else ''
             end
           end
@@ -68,7 +68,7 @@ module I18n
           end
 
           def upload_tts_short_instructions_l10n(level, locale)
-            tts_short_instructions_l10n = level.tts_short_instructions_text(locale: locale)
+            tts_short_instructions_l10n = mutex.synchronize {level.tts_short_instructions_text(locale: locale)}
             return if tts_short_instructions_l10n.empty?
 
             tts_short_instructions = sanitize_tts(level.short_instructions)
@@ -78,7 +78,7 @@ module I18n
           end
 
           def upload_tts_long_instructions_l10n(level, locale)
-            tts_long_instructions_l10n = level.tts_long_instructions_text(locale: locale)
+            tts_long_instructions_l10n = mutex.synchronize {level.tts_long_instructions_text(locale: locale)}
             return if tts_long_instructions_l10n.empty?
 
             tts_long_instructions = sanitize_tts(level.long_instructions)
@@ -88,7 +88,9 @@ module I18n
           end
 
           def upload_tts_authored_hints_l10n(level, locale)
-            localized_authored_hints = I18n.with_locale(locale) {level.localized_authored_hints}
+            localized_authored_hints = I18n.with_locale(locale) do
+              mutex.synchronize {level.localized_authored_hints}
+            end
             return unless localized_authored_hints
 
             original_hints = JSON.parse(level.authored_hints)


### PR DESCRIPTION
## Issue https://github.com/code-dot-org/code-dot-org/pull/55923
```bash
➜ bundle exec ./bin/i18n/resources/dashboard/text_to_speech/sync_out.rb

markdown.c:2897: sd_markdown_render: Assertion `md->work_bufs[BUFFER_BLOCK].size == 0' failed.
```
Because the `Redcarpet` instance is not thread-safe (https://github.com/vmg/redcarpet/issues/570),
sharing the `Redcarpet::Markdown` formatter in multi-threaded operations may cause the error.
More details here: https://www.redmine.org/issues/32563

https://github.com/code-dot-org/code-dot-org/blob/c857956c49202db4835318293c001ce3f1cfb81e/dashboard/app/models/concerns/text_to_speech.rb#L32

https://github.com/code-dot-org/code-dot-org/blob/c857956c49202db4835318293c001ce3f1cfb81e/dashboard/app/models/concerns/text_to_speech.rb#L112-L125