### PR TITLE
Fix moving to the next PL level when there is another level

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -176,7 +176,7 @@ class ScriptLevel < ApplicationRecord
         end
       end
     elsif script.pl_course?
-      build_script_level_path(level_to_follow) if level_to_follow
+      return build_script_level_path(level_to_follow) if level_to_follow
       next_unit = script.next_unit(user)
       next_unit ? script_path(next_unit) : script_completion_redirect(script)
     elsif bubble_choice? && !bubble_choice_parent

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -756,6 +756,28 @@ class ScriptLevelTest < ActiveSupport::TestCase
     assert_equal script_levels[1].path, script_levels[0].next_level_or_redirect_path_for_user(student)
   end
 
+  test 'next_level_or_redirect_path_for_user returns to next level if not end of lesson on a pl unit' do
+    unit1 = create :unit
+    unit2 = create :unit
+    unit1.stubs(:pl_course?).returns true
+    unit1.stubs(:next_unit).returns(unit2)
+
+    lesson_group = create(:lesson_group, script: unit1)
+    levels = [
+      create(:level),
+      create(:level)
+    ]
+
+    script_levels = levels.map.with_index(1) do |level, pos|
+      lesson = create(:lesson, script: unit1, absolute_position: pos, lesson_group: lesson_group)
+      create(:script_level, script: unit1, lesson: lesson, position: pos, chapter: pos, levels: [level])
+    end
+
+    student = create :student
+
+    assert_equal script_levels[1].path, script_levels[0].next_level_or_redirect_path_for_user(student)
+  end
+
   test 'next_level_or_redirect_path_for_user returns to next unit if at the end of the current self paced pl unit' do
     unit1 = create :unit
     unit2 = create :unit


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/code-dot-org/code-dot-org/pull/55805. As Turner correctly pointed out in [this Slack message](https://codedotorg.slack.com/archives/CFGAVL2CA/p1706055451573189?thread_ts=1706020913.469139&cid=CFGAVL2CA), I forgot a `return` before this value 🤦‍♀️ This fixes that and adds a test.