### PR TITLE
[Google Blockly] override findProcedureModel_ for behavior get blocks

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
@@ -6,6 +6,7 @@ import {convertXmlToJson} from '../../addons/cdoSerializationHelpers';
 import {behaviorDefMutator} from './mutators/behaviorDefMutator';
 import {behaviorGetMutator} from './mutators/behaviorGetMutator';
 import {BLOCK_TYPES} from '@cdo/apps/blockly/constants';
+import {behaviorCallerGetDefMixin} from './mixins/behaviorCallerGetDefMixin';
 
 /**
  * A dictionary of our custom procedure block definitions, used across labs.
@@ -90,6 +91,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedures_edit_button',
       'procedure_caller_serialize_name',
       'procedure_caller_get_def_mixin',
+      'behavior_caller_get_def_mixin',
       'procedure_caller_var_mixin',
       'procedure_caller_update_shape_mixin',
       'procedure_caller_context_menu_mixin',
@@ -174,6 +176,13 @@ GoogleBlockly.Extensions.register('on_behavior_def_change', function () {
 GoogleBlockly.Extensions.registerMutator(
   'behavior_get_mutator',
   behaviorGetMutator
+);
+
+// Using register instead of registerMixin to avoid triggering warnings about
+// overriding built-ins.
+GoogleBlockly.Extensions.register(
+  'behavior_caller_get_def_mixin',
+  behaviorCallerGetDefMixin
 );
 
 /**

--- a/apps/src/blockly/customBlocks/googleBlockly/mixins/behaviorCallerGetDefMixin.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mixins/behaviorCallerGetDefMixin.js
@@ -1,0 +1,57 @@
+// This mixin's function is copied and modified from
+// https://github.com/google/blockly-samples/blob/9a83a2c78a3e2a993942e96c4933dcbb3b2c79d7/plugins/block-shareable-procedures/src/blocks.ts#L832-L858
+// We need to override findProcedureModel_ so that it can find a match based
+// on behaviorId if there is no match by name. This is because a user might rename
+// a behavior for which there is a static behavior getter in the toolbox.
+
+import {BLOCK_TYPES} from '@cdo/apps/blockly/constants';
+
+export const behaviorCallerGetDefMixin = function () {
+  const mixin = {
+    /**
+     * Returns the procedure model tha was found.
+     *
+     * @param name The name of the procedure model to find.
+     * @param params The param names of the procedure model
+     *     to find.
+     * @returns The procedure model that was found.
+     * @override
+     */
+    findProcedureModel_(name, params = []) {
+      const workspace = this.getTargetWorkspace_();
+      let model = workspace
+        .getProcedureMap()
+        .getProcedures()
+        .find(proc => proc.getName() === name);
+
+      /* Begin CDO Customization */
+      // If we can't find a model normally, find one based on the behavior id.
+      if (!model && this.behaviorId) {
+        // All behavior definition blocks are on the hidden workspace.
+        const hiddenWorkspace = Blockly.getHiddenDefinitionWorkspace();
+        const definitionBlock = hiddenWorkspace
+          .getTopBlocks()
+          .filter(block => (block.type = BLOCK_TYPES.behaviorDefinition))
+          .find(block => block.behaviorId === this.behaviorId);
+        if (definitionBlock) {
+          model = definitionBlock.getProcedureModel();
+        }
+      }
+      /* End CDO Customization */
+      if (!model) return null;
+
+      const returnTypes = model.getReturnTypes();
+      const hasMatchingReturn = this.hasReturn_ ? returnTypes : !returnTypes;
+      if (!hasMatchingReturn) return null;
+
+      const hasMatchingParams = model
+        .getParameters()
+        .every((p, i) => p.getName() === params[i]);
+      if (!hasMatchingParams) return null;
+
+      return model;
+    },
+  };
+
+  this.mixin(mixin, true);
+};


### PR DESCRIPTION
During the second Sprite Lab [bug bash](https://docs.google.com/document/d/13lbU3SmQKohvFknyY5s0sMDhlllRa-Z3RtnDlHs95uI/edit), @samantha-code noticed that you could get toolbox blocks into a broken state by renaming a shared behavior. This would only happen if the behavior get block was explicitly set in the toolbox XML (as opposed to being auto-populated in the behaviors category.

**Repro**
1. Begin with a level like `/s/outbreak/lessons/1/levels/4?blocklyVersion=google` has the needed toolbox configuration.
2. Edit the "wandering" behavior being called on the main workspace and change its name.
3. Drag another behavior get block for "wandering" out of the toolbox.

You will see the following error:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/b50b5c14-86eb-4086-ba2c-5a8ebd2645e9)

This breaks things badly enough that the levels becomes unrecoverable on reload, as shown here:

https://github.com/code-dot-org/code-dot-org/assets/43474485/74d6036c-7bb1-4cd5-8b68-64373c1bfeef

**Explanation**

The first behavior get block is relabeled automatically, but the one in the toolbox is not. When a new behavior get block is added to the workspace, we attempt to find its procedure model by looking at the name. However, there is no longer a procedure with that name.

**Solutions:**

One potential solution I considered was to find and update any blocks in the toolbox XML whenever a behavior name was changed. This worked, but only until the page was refreshed. To address that, we'd have to not only re-traverse the toolbox XML tree at load time but also somehow have a map of old->new behavior names available.

A better solution seems to exist in overriding the `findProcedureModel_` method for this block type. If we can't find a matching procedure based on the name on the block, we can instead search for one based on the block's behavior id. If we find a behavior definition block (always on the hidden workspace) with a matching behavior id, we can infer that it would have the correct procedure model attached. As a bonus, configuring the model this way also automatically triggers an update of the block's name label - even if it's still in the flyout!


https://github.com/code-dot-org/code-dot-org/assets/43474485/41c4f927-6cb7-4f60-ae27-dd05b3e25f8e

## Links

Jira - https://codedotorg.atlassian.net/browse/CT-274

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
