### PR TITLE
Ceara/aitt 364 update rubric tabs

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2124,6 +2124,8 @@
   "rubricLevelTwoHeader": "Convincing Evidence",
   "rubricLevelFourHeader": "No Evidence",
   "rubricScores": "Rubric Scores",
+  "rubricTabStudent" : "Student Rubric",
+  "rubricTabClassManagement": "Class Management",
   "runAiAssessment": "Run AI Assessment for {studentName}",
   "runAiAssessmentAll": "Run AI Assessment for all unsubmitted",
   "runAiAssessmentDescription": "Manually run the AI Assessment if a student forgot to press Submit on their project",

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -12,6 +12,8 @@ import {
 } from './rubricShapes';
 import RubricContent from './RubricContent';
 import RubricSettings from './RubricSettings';
+import RubricTabButtons from './RubricTabButtons';
+import experiments from '@cdo/apps/util/experiments';
 
 const TAB_NAMES = {
   RUBRIC: 'rubric',
@@ -33,6 +35,10 @@ export default function RubricContainer({
 
   const [selectedTab, setSelectedTab] = useState(TAB_NAMES.RUBRIC);
   const [aiEvaluations, setAiEvaluations] = useState(null);
+
+  const tabSelectCallback = tabSelection => {
+    setSelectedTab(tabSelection);
+  };
 
   const fetchAiEvaluations = useCallback(() => {
     if (!!studentLevelInfo && teacherHasEnabledAi) {
@@ -74,21 +80,29 @@ export default function RubricContainer({
         [style.hiddenRubricContainer]: !open,
       })}
     >
-      <div className={style.rubricHeader}>
-        <div className={style.rubricHeaderLeftSide}>
-          <HeaderTab
-            text={i18n.rubric()}
-            isSelected={selectedTab === TAB_NAMES.RUBRIC}
-            onClick={() => setSelectedTab(TAB_NAMES.RUBRIC)}
-          />
-          {showSettings && (
+      <div
+        className={
+          experiments.isEnabled('ai-rubrics-redesign')
+            ? style.rubricHeaderRedesign
+            : style.rubricHeader
+        }
+      >
+        {!experiments.isEnabled('ai-rubrics-redesign') && (
+          <div className={style.rubricHeaderLeftSide}>
             <HeaderTab
-              text={i18n.settings()}
-              isSelected={selectedTab === TAB_NAMES.SETTINGS}
-              onClick={() => setSelectedTab(TAB_NAMES.SETTINGS)}
+              text={i18n.rubric()}
+              isSelected={selectedTab === TAB_NAMES.RUBRIC}
+              onClick={() => setSelectedTab(TAB_NAMES.RUBRIC)}
             />
-          )}
-        </div>
+            {showSettings && (
+              <HeaderTab
+                text={i18n.settings()}
+                isSelected={selectedTab === TAB_NAMES.SETTINGS}
+                onClick={() => setSelectedTab(TAB_NAMES.SETTINGS)}
+              />
+            )}
+          </div>
+        )}
         <div className={style.rubricHeaderRightSide}>
           <button
             type="button"
@@ -100,28 +114,42 @@ export default function RubricContainer({
         </div>
       </div>
 
-      <RubricContent
-        rubric={rubric}
-        studentLevelInfo={studentLevelInfo}
-        teacherHasEnabledAi={teacherHasEnabledAi}
-        canProvideFeedback={canProvideFeedback}
-        onLevelForEvaluation={onLevelForEvaluation}
-        reportingData={reportingData}
-        visible={selectedTab === TAB_NAMES.RUBRIC}
-        aiEvaluations={aiEvaluations}
-      />
-      {showSettings && (
-        <RubricSettings
-          canProvideFeedback={canProvideFeedback}
-          teacherHasEnabledAi={teacherHasEnabledAi}
-          studentUserId={studentLevelInfo && studentLevelInfo['user_id']}
-          visible={selectedTab === TAB_NAMES.SETTINGS}
-          refreshAiEvaluations={fetchAiEvaluations}
+      <div
+        className={classnames({
+          [style.fabBackground]: experiments.isEnabled('ai-rubrics-redesign'),
+        })}
+      >
+        {experiments.isEnabled('ai-rubrics-redesign') && (
+          <RubricTabButtons
+            tabSelectCallback={tabSelectCallback}
+            selectedTab={selectedTab}
+            showSettings={showSettings}
+          />
+        )}
+
+        <RubricContent
           rubric={rubric}
-          studentName={studentLevelInfo && studentLevelInfo.name}
-          sectionId={sectionId}
+          studentLevelInfo={studentLevelInfo}
+          teacherHasEnabledAi={teacherHasEnabledAi}
+          canProvideFeedback={canProvideFeedback}
+          onLevelForEvaluation={onLevelForEvaluation}
+          reportingData={reportingData}
+          visible={selectedTab === TAB_NAMES.RUBRIC}
+          aiEvaluations={aiEvaluations}
         />
-      )}
+        {showSettings && (
+          <RubricSettings
+            canProvideFeedback={canProvideFeedback}
+            teacherHasEnabledAi={teacherHasEnabledAi}
+            studentUserId={studentLevelInfo && studentLevelInfo['user_id']}
+            visible={selectedTab === TAB_NAMES.SETTINGS}
+            refreshAiEvaluations={fetchAiEvaluations}
+            rubric={rubric}
+            studentName={studentLevelInfo && studentLevelInfo.name}
+            sectionId={sectionId}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -136,10 +136,13 @@ export default function RubricContent({
 
   return (
     <div
-      className={classnames(style.rubricContent, {
-        [style.visibleRubricContent]: visible,
-        [style.hiddenRubricContent]: !visible,
-      })}
+      className={classnames(
+        {[style.rubricContent]: !experiments.isEnabled('ai-rubrics-redesign')},
+        {
+          [style.visibleRubricContent]: visible,
+          [style.hiddenRubricContent]: !visible,
+        }
+      )}
     >
       {infoText && <InfoAlert text={infoText} />}
       <div className={style.studentInfoGroup}>

--- a/apps/src/templates/rubrics/RubricSettings.jsx
+++ b/apps/src/templates/rubrics/RubricSettings.jsx
@@ -288,6 +288,7 @@ export default function RubricSettings({
   return (
     <div
       className={classnames(
+        'uitest-rubric-settings',
         {[style.settings]: !experiments.isEnabled('ai-rubrics-redesign')},
         {
           [style.settingsVisible]: visible,

--- a/apps/src/templates/rubrics/RubricSettings.jsx
+++ b/apps/src/templates/rubrics/RubricSettings.jsx
@@ -287,10 +287,13 @@ export default function RubricSettings({
 
   return (
     <div
-      className={classnames('uitest-rubric-settings', style.settings, {
-        [style.settingsVisible]: visible,
-        [style.settingsHidden]: !visible,
-      })}
+      className={classnames(
+        {[style.settings]: !experiments.isEnabled('ai-rubrics-redesign')},
+        {
+          [style.settingsVisible]: visible,
+          [style.settingsHidden]: !visible,
+        }
+      )}
     >
       {!experiments.isEnabled('ai-rubrics-redesign') && (
         <Heading2>{i18n.settings()}</Heading2>

--- a/apps/src/templates/rubrics/RubricTabButtons.jsx
+++ b/apps/src/templates/rubrics/RubricTabButtons.jsx
@@ -17,6 +17,7 @@ export default function RubricTabButtons({
   return (
     <div className={style.rubricTabGroup}>
       <SegmentedButtons
+        className="uitest-rubric-tab-buttons"
         selectedButtonValue={selectedTab}
         size="s"
         buttons={[

--- a/apps/src/templates/rubrics/RubricTabButtons.jsx
+++ b/apps/src/templates/rubrics/RubricTabButtons.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import style from './rubrics.module.scss';
+import i18n from '@cdo/locale';
+import SegmentedButtons from '@cdo/apps/componentLibrary/segmentedButtons/SegmentedButtons';
+
+export default function RubricTabButtons({
+  tabSelectCallback,
+  selectedTab,
+  showSettings,
+}) {
+  const TAB_NAMES = {
+    RUBRIC: 'rubric',
+    SETTINGS: 'settings',
+  };
+
+  return (
+    <div className={style.rubricTabGroup}>
+      <SegmentedButtons
+        selectedButtonValue={selectedTab}
+        size="s"
+        buttons={[
+          {label: i18n.rubricTabStudent(), value: TAB_NAMES.RUBRIC},
+          {
+            label: i18n.rubricTabClassManagement(),
+            value: TAB_NAMES.SETTINGS,
+            disabled: !showSettings,
+          },
+        ]}
+        onChange={value => tabSelectCallback(value)}
+      />
+    </div>
+  );
+}
+
+RubricTabButtons.propTypes = {
+  tabSelectCallback: PropTypes.func,
+  selectedTab: PropTypes.string,
+  showSettings: PropTypes.bool,
+};

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -170,6 +170,23 @@
   align-self: stretch;
 }
 
+.rubricHeaderRedesign {
+  border-radius: 4px 4px 0 0;
+  background: $neutral_dark;
+  color: $neutral_white;
+  // padding: 9px 15px 8px;
+
+  border-top: 2px solid $neutral_dark;
+  border-right: 2px solid $neutral_dark;
+  border-left: 2px solid $neutral_dark;
+
+  display: flex;
+  height: 40px;
+  justify-content: flex-end;
+  align-items: center;
+  align-self: stretch;
+}
+
 .rubricHeaderLeftSide {
   display: flex;
   gap: 4px;
@@ -735,5 +752,28 @@ i.infoAlertIcon {
   border-radius: 0.25rem;
   border: 1px solid #D4D5D7;
   background: $neutral_white;
+}
+
+.fabBackground {
+  width: 724px;
+  padding: 16px 16px 32px 16px;
+  gap: 16px;
+  border-radius: 0 0 4px 4px;
+  border-right: 2px solid $neutral_dark;
+  border-bottom: 2px solid $neutral_dark;
+  border-left: 2px solid $neutral_dark;
+  background: $neutral_white;
+  box-shadow: 4px 4px 6px 0 rgb(0 0 0 / 0.25);
+  height: 408px;
+
+  overflow-x: hidden;
+  overflow-y: auto;
+  h2 {
+    margin-bottom: 0;
+  }
+}
+
+.rubricTabGroup {
+  padding-bottom: 8px;
 }
 // End of rubrics redesign

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -4,6 +4,7 @@ import {mount, shallow} from 'enzyme';
 import sinon from 'sinon';
 import {act} from 'react-dom/test-utils';
 import RubricContainer from '@cdo/apps/templates/rubrics/RubricContainer';
+import experiments from '@cdo/apps/util/experiments';
 
 describe('RubricContainer', () => {
   const defaultRubric = {
@@ -79,5 +80,21 @@ describe('RubricContainer', () => {
     wrapper.find('HeaderTab').at(0).simulate('click');
     expect(wrapper.find('RubricContent').props().visible).to.be.true;
     expect(wrapper.find('RubricSettings').props().visible).to.be.false;
+  });
+
+  it('displays new RubricTabButtons prop when ai-rubrics-redesign experiment is enabled', () => {
+    experiments.setEnabled('ai-rubrics-redesign', true);
+    const wrapper = shallow(
+      <RubricContainer
+        rubric={defaultRubric}
+        studentLevelInfo={{}}
+        teacherHasEnabledAi={true}
+        currentLevelName={'test_level'}
+        reportingData={{}}
+        open
+      />
+    );
+    expect(wrapper.find('RubricTabButtons').length).to.equal(1);
+    experiments.setEnabled('ai-rubrics-redesign', false);
   });
 });

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -99,7 +99,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
     Then I see no difference for "floating action button icon"
 
     When I click selector "#ui-floatingActionButton"
-    And I wait until element ".uitest-rubric-header-tab:contains('Settings')" is visible
+    And I wait until element ".uitest-rubric-tab-buttons:contains('Class Management')" is visible
     And I wait until element "h6:contains(Code Quality)" is visible
     Then I see no difference for "rubric tab, Code Quality learning goal"
 
@@ -107,7 +107,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
     And I wait until element "h6:contains(Sprites)" is visible
     Then I see no difference for "rubric tab, Sprites learning goal"
 
-    When I click selector ".uitest-rubric-header-tab:contains('Settings')"
+    When I click selector "button:contains('Class Management')"
     And I wait until element ".uitest-rubric-settings" is visible
     And element ".uitest-run-ai-assessment" is disabled
     And element ".uitest-eval-status-text" is visible


### PR DESCRIPTION
This adds a RubricTabButtons component that's in RubricContainer and always displayed. The RubricTabButtons contains the buttons to switch tabs, and will (in a future PR) also contain the run AI button. 

This also adds a css style for the container size and background to be consistent across the settings and student rubric views (to follow the figma design doc)

All the changes are only in the ai-redesign experiment flag

<img width="765" alt="Screenshot 2024-01-24 at 1 12 55 PM" src="https://github.com/code-dot-org/code-dot-org/assets/7144482/9173f2c0-d179-4835-b594-283eaecb92ef">

<img width="765" alt="Screenshot 2024-01-24 at 1 14 23 PM" src="https://github.com/code-dot-org/code-dot-org/assets/7144482/8e0c6368-6ac5-467c-9562-7b7af88f4b98">


## Links

- jira ticket: https://codedotorg.atlassian.net/browse/AITT-364

## Testing story

Added a unit test to ensure the new component appears when the experiment flag is enabled


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
