### PR TITLE
Add keyboard shortcut for run button to labs

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -91,6 +91,7 @@ import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
 import {workspace_running_background, white} from '@cdo/apps/util/color';
 import WorkspaceAlert from '@cdo/apps/code-studio/components/WorkspaceAlert';
 import {closeWorkspaceAlert} from './code-studio/projectRedux';
+import KeyHandler from './util/KeyHandler';
 
 var copyrightStrings;
 
@@ -242,6 +243,11 @@ class StudioApp extends EventEmitter {
      * Stores the code at run. It's undefined if the code is not running.
      */
     this.executingCode = undefined;
+
+    /**
+     * Global key handler for the app.
+     */
+    this.keyHandler = new KeyHandler(document);
   }
 }
 /**
@@ -2097,6 +2103,13 @@ StudioApp.prototype.configureDom = function (config) {
   if (runButton && resetButton) {
     dom.addClickTouchEvent(runButton, _.bind(throttledRunClick, this));
     dom.addClickTouchEvent(resetButton, _.bind(this.resetButtonClick, this));
+    this.keyHandler.registerEvent(['Control', 'Enter'], () => {
+      if (this.isRunning()) {
+        this.resetButtonClick();
+      } else {
+        throttledRunClick();
+      }
+    });
   }
   var skipButton = container.querySelector('#skipButton');
   if (skipButton) {

--- a/apps/src/util/KeyHandler.js
+++ b/apps/src/util/KeyHandler.js
@@ -1,0 +1,47 @@
+/**
+ * A KeyHandler class that can listen for events with multiple keys pressed.
+ */
+class KeyHandler {
+  constructor(element) {
+    this.pressedKeyMap = {};
+    this.keyHandlers = [];
+
+    element.addEventListener('keydown', e => this.onKeyDown_(e.key));
+    element.addEventListener('keyup', e => this.onKeyUp_(e.key));
+  }
+
+  /**
+   * Register an event to be called when a set of keys are pressed.
+   *
+   * @param {String[]} keys the set of keys that trigger this event.
+   * @param {Function} callback function to call when the keys are pressed.
+   */
+  registerEvent(keys, callback) {
+    this.keyHandlers.push([keys, callback]);
+  }
+
+  onKeyDown_(key) {
+    // Ignore keys that we don't have mappings for
+    const keysToCheck = this.keyHandlers.map(([keys]) => keys).flat();
+    if (!keysToCheck.includes(key)) {
+      return;
+    }
+
+    this.pressedKeyMap[key] = true;
+    const pressedKeys = Object.keys(this.pressedKeyMap);
+    this.keyHandlers.forEach(([keys, callback]) => {
+      if (
+        keys.every(key => pressedKeys.includes(key)) &&
+        keys.length === pressedKeys.length
+      ) {
+        callback();
+      }
+    });
+  }
+
+  onKeyUp_(key) {
+    delete this.pressedKeyMap[key];
+  }
+}
+
+export default KeyHandler;


### PR DESCRIPTION
This adds a keyboard shortcut (**CTRL+Enter**) for the run/reset button, for nearly all labs. This is added at the Studio App level, so this will affect all labs that use StudioApp.js to manage the run/reset button. This should include every lab **except** Java Lab (has its own control buttons), Web Lab (doesn't have a run button), and Lab2 labs (just Music Lab for now, but which already has a separate keybinding for its Run/Stop button).

I initially wanted to just add this for App Lab to minimize the affected surface area, but due to how intertwined the run button logic is with legacy apps and Studio App, it felt cleaner to attach the listener there, rather than make a special case exception for App Lab.

## Links

https://codedotorg.atlassian.net/browse/LABS-290

## Testing story

Tested on: Sprite Lab, App Lab, Game Lab, Artist, Dance, Poetry, Bad Guys, Frozen, Flappy, Star Wars, Minecraft, PlayLab,  Bounce

Cassi Tested on Windows/Edge on all the projects above as well