### PR TITLE
Python Lab: lazy load pyodide

### DIFF
--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -13,7 +13,7 @@ async function loadPyodideAndPackages() {
 }
 
 let pyodideReadyPromise = null;
-export async function initializePyodide() {
+async function initializePyodide() {
   if (pyodideReadyPromise === null) {
     pyodideReadyPromise = loadPyodideAndPackages();
   }

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -12,11 +12,17 @@ async function loadPyodideAndPackages() {
   });
 }
 
-const pyodideReadyPromise = loadPyodideAndPackages();
+let pyodideReadyPromise = null;
+export async function initializePyodide() {
+  if (pyodideReadyPromise === null) {
+    pyodideReadyPromise = loadPyodideAndPackages();
+  }
+  await pyodideReadyPromise;
+}
 
 self.onmessage = async event => {
   // make sure loading is done
-  await pyodideReadyPromise;
+  await initializePyodide();
   const {id, python, ...context} = event.data;
   // The worker copies the context in its own "memory" (an object mapping name to values)
   for (const key of Object.keys(context)) {


### PR DESCRIPTION
I noticed that Music Lab was loading pyodide. This is because is [LabViewsRenderer](https://github.com/code-dot-org/code-dot-org/blob/ff0a7237d29434fb3deeb22d470de4150c718807/apps/src/lab2/views/LabViewsRenderer.tsx#L46) we create all possible lab views, and Python Lab immediately loads pyodide. To fix this, I have pyodide only load when the run button is clicked. This does make the first run of python slower, but since this is a prototype that is fine. Long term we can probably find a different proactive way to load pyodide.

## Testing story
Tested locally. Now Music Lab does not load pyodide, but Python lab does on run.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
