### PR TITLE
Create curriculum pathway view

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
+++ b/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
@@ -1,0 +1,129 @@
+$border-radius: 4px;
+$colors: (
+  "light": var(--brand_primary_light),
+  "medium": var(--brand_primary_medium),
+  "default": var(--brand_primary_default)
+);
+
+figure.curriculum-pathway {
+  background-color: var(--neutral_dark20);
+  border-radius: $border-radius;
+
+  .header {
+    background: var(--neutral_dark20);
+    border-radius: $border-radius $border-radius 0 0;
+    border-bottom: 1px solid var(--neutral_dark20);
+    text-align: center;
+    display: grid;
+    grid-template-columns: repeat(13, 1fr);
+    grid-template-rows: auto;
+    grid-column-gap: 1px;
+    grid-row-gap: 0;
+
+    .school.elementary { grid-area: 1 / 1 / 2 / 7; }
+    .school.middle { grid-area: 1 / 7 / 2 / 10; }
+    .school.high { grid-area: 1 / 10 / 2 / 14; }
+    .grade:nth-of-type(4) { grid-area: 2 / 1 / 3 / 2; }
+    .grade:nth-of-type(5) { grid-area: 2 / 2 / 3 / 3; }
+    .grade:nth-of-type(6) { grid-area: 2 / 3 / 3 / 4; }
+    .grade:nth-of-type(7) { grid-area: 2 / 4 / 3 / 5; }
+    .grade:nth-of-type(8) { grid-area: 2 / 5 / 3 / 6; }
+    .grade:nth-of-type(9) { grid-area: 2 / 6 / 3 / 7; }
+    .grade:nth-of-type(10) { grid-area: 2 / 7 / 3 / 8; }
+    .grade:nth-of-type(11) { grid-area: 2 / 8 / 3 / 9; }
+    .grade:nth-of-type(12) { grid-area: 2 / 9 / 3 / 10; }
+    .grade:nth-of-type(13) { grid-area: 2 / 10 / 3 / 11; }
+    .grade:nth-of-type(14) { grid-area: 2 / 11 / 3 / 12; }
+    .grade:nth-of-type(15) { grid-area: 2 / 12 / 3 / 13; }
+    .grade:nth-of-type(16) { grid-area: 2 / 13 / 3 / 14; }
+    .course.csf { grid-area: 3 / 1 / 4 / 7; }
+    .course.csc { grid-area: 4 / 4 / 5 / 7; }
+    .course.csd { grid-area: 5 / 7 / 6 / 12; }
+    .course.csp { grid-area: 6 / 10 / 7 / 14; }
+    .course.csa { grid-area: 7 / 11 / 8 / 14; }
+
+    p {
+      margin-bottom: 0;
+      line-height: 1;
+    }
+
+    .school {
+      background: var(--neutral_white);
+      border-bottom: 5px solid;
+      padding: 0.875rem;
+
+      p { font-weight: var(--semi-bold-font-weight); }
+      &.elementary { border-radius: $border-radius 0 0 0; }
+      &.high { border-radius: 0 $border-radius 0 0; }
+    }
+
+    .grade {
+      background-color: var(--neutral_white);
+      padding: 0.5rem;
+      height: 2rem;
+
+      p {
+        color: var(--neutral_dark70);
+        font-size: 0.875rem;
+      }
+    }
+  }
+
+  .body {
+    background-color: var(--neutral_dark20);
+    border-radius: 0 0 $border-radius $border-radius;
+    display: flex;
+    flex-direction: row;
+    gap: 1px;
+
+    & > div {
+      background-color: var(--neutral_light);
+      flex: 1;
+
+      &:first-of-type { border-radius: 0 0 0 $border-radius; }
+      &:last-of-type { border-radius: 0 0 $border-radius 0; }
+    }
+  }
+
+  .courses {
+    margin: 0.5rem 0;
+    display: grid;
+    grid-template-columns: repeat(13, 1fr);
+    grid-template-rows: repeat(5, 1fr);
+    grid-column-gap: 0px;
+    grid-row-gap: 0px;
+
+    .course.csf { grid-area: 1 / 1 / 2 / 7; }
+    .course.csc { grid-area: 2 / 4 / 3 / 7; }
+    .course.csd { grid-area: 3 / 7 / 4 / 12; }
+    .course.csp { grid-area: 4 / 10 / 5 / 14; }
+    .course.csa { grid-area: 5 / 11 / 6 / 14; }
+
+    .course {
+      background: white;
+      border-radius: 4px;
+      border: 1px solid var(--neutral_dark20);
+      border-top: 5px solid;
+      display: flex;
+      place-content: center;
+      height: fit-content;
+      margin: 0.25rem 0.75rem;
+      padding: 0.75rem 1rem;
+
+      p {
+        font-weight: var(--semi-bold-font-weight);
+        margin: 0;
+      }
+    }
+  }
+
+  // Creates border classes for each color band
+  @each $name, $color in $colors {
+    .border-bottom-primary-#{$name} {
+      border-bottom-color: $color !important;
+    }
+    .border-top-primary-#{$name} {
+      border-top-color: $color !important;
+    }
+  }
+}

--- a/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
+++ b/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
@@ -9,18 +9,17 @@ figure.curriculum-pathway {
   background-color: var(--neutral_light);
   border-radius: $border-radius;
   position: relative;
+  text-align: center;
 
   .header {
     position: relative;
     background: var(--neutral_dark20);
     border-radius: $border-radius $border-radius 0 0;
     border-bottom: 1px solid var(--neutral_dark20);
-    text-align: center;
     display: grid;
     grid-template-columns: repeat(13, 1fr);
     grid-template-rows: auto;
     grid-column-gap: 1px;
-    grid-row-gap: 0;
     z-index: 2;
 
     .school.elementary { grid-area: 1 / 1 / 2 / 7; }
@@ -39,11 +38,6 @@ figure.curriculum-pathway {
     .grade:nth-of-type(14) { grid-area: 2 / 11 / 3 / 12; }
     .grade:nth-of-type(15) { grid-area: 2 / 12 / 3 / 13; }
     .grade:nth-of-type(16) { grid-area: 2 / 13 / 3 / 14; }
-    .course.csf { grid-area: 3 / 1 / 4 / 7; }
-    .course.csc { grid-area: 4 / 4 / 5 / 7; }
-    .course.csd { grid-area: 5 / 7 / 6 / 12; }
-    .course.csp { grid-area: 6 / 10 / 7 / 14; }
-    .course.csa { grid-area: 7 / 11 / 8 / 14; }
 
     p {
       margin-bottom: 0;
@@ -83,7 +77,6 @@ figure.curriculum-pathway {
     grid-template-columns: repeat(13, 1fr);
     grid-template-rows: auto;
     grid-column-gap: 0px;
-    grid-row-gap: 0px;
     z-index: 1;
 
     .course.csf { grid-area: 1 / 1 / 2 / 7; }
@@ -126,7 +119,6 @@ figure.curriculum-pathway {
       p {
         font-weight: var(--semi-bold-font-weight);
         margin: 0;
-        text-align: center;
       }
     }
   }

--- a/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
+++ b/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
@@ -8,8 +8,10 @@ $colors: (
 figure.curriculum-pathway {
   background-color: var(--neutral_light);
   border-radius: $border-radius;
+  position: relative;
 
   .header {
+    position: relative;
     background: var(--neutral_dark20);
     border-radius: $border-radius $border-radius 0 0;
     border-bottom: 1px solid var(--neutral_dark20);
@@ -19,6 +21,7 @@ figure.curriculum-pathway {
     grid-template-rows: auto;
     grid-column-gap: 1px;
     grid-row-gap: 0;
+    z-index: 2;
 
     .school.elementary { grid-area: 1 / 1 / 2 / 7; }
     .school.middle { grid-area: 1 / 7 / 2 / 10; }
@@ -52,7 +55,11 @@ figure.curriculum-pathway {
       border-bottom: 5px solid;
       padding: 0.875rem;
 
-      p { font-weight: var(--semi-bold-font-weight); }
+      p {
+        font-weight: var(--semi-bold-font-weight);
+        font-size: 0.875rem;
+      }
+
       &.elementary { border-radius: $border-radius 0 0 0; }
       &.high { border-radius: 0 $border-radius 0 0; }
     }
@@ -69,29 +76,15 @@ figure.curriculum-pathway {
     }
   }
 
-  .body {
-    background-color: var(--neutral_dark20);
-    border-radius: 0 0 $border-radius $border-radius;
-    display: flex;
-    flex-direction: row;
-    gap: 1px;
-
-    & > div {
-      background-color: var(--neutral_light);
-      flex: 1;
-
-      &:first-of-type { border-radius: 0 0 0 $border-radius; }
-      &:last-of-type { border-radius: 0 0 $border-radius 0; }
-    }
-  }
-
   .courses {
-    margin: 0.5rem 0;
+    position: relative;
+    padding: 0.5rem 0;
     display: grid;
     grid-template-columns: repeat(13, 1fr);
     grid-template-rows: auto;
     grid-column-gap: 0px;
     grid-row-gap: 0px;
+    z-index: 1;
 
     .course.csf { grid-area: 1 / 1 / 2 / 7; }
     .course.csc { grid-area: 2 / 4 / 3 / 7; }
@@ -106,31 +99,56 @@ figure.curriculum-pathway {
       border-top: 5px solid;
       height: fit-content;
       margin: 0.25rem 0.75rem;
-      padding: 0.75rem 1rem;
+      padding: 0.65rem 1rem;
       transition: box-shadow 0.2s ease-in-out;
       display: flex;
       place-content: center;
       gap: 4px;
 
-      &:hover {
+      &:is(:hover, :focus) {
         box-shadow: 0 1px 6px var(--neutral_dark20);
 
         &:after {
+          color: var(--neutral_dark40);
           font: var(--fa-font-solid);
           content: "\f054";
-          color: var(--neutral_dark40);
           margin-top: 4px;
 
           html[dir="rtl"] & { content: "\f053"; }
         }
       }
 
+      &:focus {
+        outline: var(--brand_primary_default) solid 2px;
+        outline-offset: 2px;
+      }
 
       p {
         font-weight: var(--semi-bold-font-weight);
         margin: 0;
         text-align: center;
       }
+    }
+  }
+
+  .background {
+    position: absolute;
+    background-color: var(--neutral_dark20);
+    border-radius: $border-radius;
+    display: flex;
+    flex-direction: row;
+    gap: 1px;
+    top: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 0;
+
+    & > div {
+      background-color: var(--neutral_light);
+      flex: 1;
+
+      &:first-of-type { border-radius: $border-radius 0 0 $border-radius; }
+      &:last-of-type { border-radius: 0 $border-radius $border-radius 0; }
     }
   }
 

--- a/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
+++ b/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
@@ -6,7 +6,7 @@ $colors: (
 );
 
 figure.curriculum-pathway {
-  background-color: var(--neutral_dark20);
+  background-color: var(--neutral_light);
   border-radius: $border-radius;
 
   .header {
@@ -89,7 +89,7 @@ figure.curriculum-pathway {
     margin: 0.5rem 0;
     display: grid;
     grid-template-columns: repeat(13, 1fr);
-    grid-template-rows: repeat(5, 1fr);
+    grid-template-rows: auto;
     grid-column-gap: 0px;
     grid-row-gap: 0px;
 
@@ -99,20 +99,37 @@ figure.curriculum-pathway {
     .course.csp { grid-area: 4 / 10 / 5 / 14; }
     .course.csa { grid-area: 5 / 11 / 6 / 14; }
 
-    .course {
+    a.course {
       background: white;
       border-radius: 4px;
       border: 1px solid var(--neutral_dark20);
       border-top: 5px solid;
-      display: flex;
-      place-content: center;
       height: fit-content;
       margin: 0.25rem 0.75rem;
       padding: 0.75rem 1rem;
+      transition: box-shadow 0.2s ease-in-out;
+      display: flex;
+      place-content: center;
+      gap: 4px;
+
+      &:hover {
+        box-shadow: 0 1px 6px var(--neutral_dark20);
+
+        &:after {
+          font: var(--fa-font-solid);
+          content: "\f054";
+          color: var(--neutral_dark40);
+          margin-top: 4px;
+
+          html[dir="rtl"] & { content: "\f053"; }
+        }
+      }
+
 
       p {
         font-weight: var(--semi-bold-font-weight);
         margin: 0;
+        text-align: center;
       }
     }
   }

--- a/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
+++ b/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
@@ -43,30 +43,30 @@ figure.curriculum-pathway {
       margin-bottom: 0;
       line-height: 1;
     }
+  }
 
-    .school {
-      background: var(--neutral_white);
-      border-bottom: 5px solid;
-      padding: 0.875rem;
+  .school {
+    background: var(--neutral_white);
+    border-bottom: 5px solid;
+    padding: 0.875rem;
 
-      p {
-        font-weight: var(--semi-bold-font-weight);
-        font-size: 0.875rem;
-      }
-
-      &.elementary { border-radius: $border-radius 0 0 0; }
-      &.high { border-radius: 0 $border-radius 0 0; }
+    p {
+      font-weight: var(--semi-bold-font-weight);
+      font-size: 0.875rem;
     }
 
-    .grade {
-      background-color: var(--neutral_white);
-      padding: 0.5rem;
-      height: 2rem;
+    &.elementary { border-radius: $border-radius 0 0 0; }
+    &.high { border-radius: 0 $border-radius 0 0; }
+  }
 
-      p {
-        color: var(--neutral_dark70);
-        font-size: 0.875rem;
-      }
+  .grade {
+    background-color: var(--neutral_white);
+    padding: 0.5rem;
+    height: 2rem;
+
+    p {
+      color: var(--neutral_dark70);
+      font-size: 0.875rem;
     }
   }
 
@@ -114,6 +114,8 @@ figure.curriculum-pathway {
       &:focus {
         outline: var(--brand_primary_default) solid 2px;
         outline-offset: 2px;
+
+        &:not(:focus-visible) { outline: none; }
       }
 
       p {
@@ -151,6 +153,56 @@ figure.curriculum-pathway {
     }
     .border-top-primary-#{$name} {
       border-top-color: $color !important;
+    }
+  }
+
+  &.mobile { display: none; }
+
+  @media (max-width: 700px) {
+    &.desktop { display: none; }
+    &.mobile { display: block; }
+
+    background: none;
+
+    .school-wrapper {
+      background-color: var(--neutral_light);
+      border-radius: $border-radius;
+      margin-bottom: 1rem;
+      display: flex;
+      flex-direction: column;
+    }
+
+    p.heading-xs {
+      padding: 0.65rem;
+      background-color: var(--neutral_white);
+      border-bottom: 1px solid var(--neutral_dark20);
+      border-radius: $border-radius $border-radius 0 0;
+      font-weight: var(--regular-font-weight);
+    }
+
+    .courses {
+      display: block;
+      padding: 0;
+
+      a.course {
+        margin: 0.75rem;
+        text-align: initial;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+
+        &:is(:hover, :focus, :active):after { all: unset; }
+
+        p {
+          font-size: 0.875rem;
+
+          &.grades {
+            color: var(--neutral_dark70);
+            font-weight: var(--regular-font-weight);
+          }
+        }
+      }
     }
   }
 }

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -9,6 +9,7 @@
 :root {
   /* Colors */
   --brand_primary_light: #ABDFE5;
+  --brand_primary_medium: #7BC6CF;
   --brand_primary_default: #009EB0;
   --brand_primary_dark: #008291;
   --brand_secondary_light: #E0D1EC;

--- a/pegasus/sites.v3/code.org/views/curriculum_pathway.haml
+++ b/pegasus/sites.v3/code.org/views/curriculum_pathway.haml
@@ -3,49 +3,28 @@
 %figure.curriculum-pathway
   .header
     .school.elementary.border-bottom-primary-light
-      %p Elementary
+      %p=hoc_s(:grade_level_label_elementary)
     .school.middle.border-bottom-primary-medium
-      %p Middle
+      %p=hoc_s(:grade_level_label_middle)
     .school.high.border-bottom-primary-default
-      %p High
+      %p=hoc_s(:grade_level_label_high)
     .grade
       %p K
-    .grade
-      %p 1
-    .grade
-      %p 2
-    .grade
-      %p 3
-    .grade
-      %p 4
-    .grade
-      %p 5
-    .grade
-      %p 6
-    .grade
-      %p 7
-    .grade
-      %p 8
-    .grade
-      %p 9
-    .grade
-      %p 10
-    .grade
-      %p 11
-    .grade
-      %p 12
+    - (1..12).each do |grade|
+      .grade
+        %p= grade
 
   .courses
-    .course.csf.border-top-primary-light
-      %p CS Fundamentals
-    .course.csc.border-top-primary-light
-      %p CS Connections
-    .course.csd.border-top-primary-medium
-      %p CS Discoveries
-    .course.csp.border-top-primary-default
-      %p CS Principles
-    .course.csa.border-top-primary-default
-      %p AP® CSA
+    %a.course.csf.border-top-primary-light{href: "/csf"}
+      %p=hoc_s(:course_name_csf)
+    %a.course.csc.border-top-primary-light{href: "/csc"}
+      %p=hoc_s(:course_name_csc)
+    %a.course.csd.border-top-primary-medium{href: "/csd"}
+      %p=hoc_s(:course_name_csd)
+    %a.course.csp.border-top-primary-default{href: "/csp"}
+      %p=hoc_s(:course_name_csp)
+    %a.course.csa.border-top-primary-default{href: "/csa"}
+      %p=hoc_s(:course_name_csa)
 
   .body
     .div1

--- a/pegasus/sites.v3/code.org/views/curriculum_pathway.haml
+++ b/pegasus/sites.v3/code.org/views/curriculum_pathway.haml
@@ -1,6 +1,6 @@
 = inline_css "/generated/curriculum-pathway.css"
 
-%figure.curriculum-pathway
+%figure.curriculum-pathway.desktop
   .header
     .school.elementary.border-bottom-primary-light
       %p=hoc_s(:grade_level_label_elementary)
@@ -29,3 +29,47 @@
   .background
     - (1..13).each do |i|
       %div
+
+%figure.curriculum-pathway.mobile
+  .school-wrapper
+    %p.heading-xs.no-margin-bottom
+      =hoc_s(:grade_level_label_elementary)
+    .courses
+      %a.course.csf.border-top-primary-light{href: "/csf"}
+        %p=hoc_s(:course_name_csf)
+        %p.grades
+          =hoc_s(:module_label_grades)
+          =hoc_s(:module_grade_k_5)
+      %a.course.csc.border-top-primary-light{href: "/csc"}
+        %p=hoc_s(:course_name_csc)
+        %p.grades
+          =hoc_s(:module_label_grades)
+          =hoc_s(:module_grade_3_5)
+  .school-wrapper
+    %p.heading-xs.no-margin-bottom
+      =hoc_s(:grade_level_label_middle)
+    .courses
+      %a.course.csf.border-top-primary-medium{href: "/csd"}
+        %p=hoc_s(:course_name_csd)
+        %p.grades
+          =hoc_s(:module_label_grades)
+          =hoc_s(:module_grade_6_10)
+  .school-wrapper
+    %p.heading-xs.no-margin-bottom
+      =hoc_s(:grade_level_label_high)
+    .courses
+      %a.course.csf.border-top-primary-default{href: "/csd"}
+        %p=hoc_s(:course_name_csd)
+        %p.grades
+          =hoc_s(:module_label_grades)
+          =hoc_s(:module_grade_6_10)
+      %a.course.csf.border-top-primary-default{href: "/csp"}
+        %p=hoc_s(:course_name_csp)
+        %p.grades
+          =hoc_s(:module_label_grades)
+          =hoc_s(:module_grade_9_12)
+      %a.course.csc.border-top-primary-default{href: "/csa"}
+        %p=hoc_s(:course_name_csa)
+        %p.grades
+          =hoc_s(:module_label_grades)
+          =hoc_s(:module_grade_10_12)

--- a/pegasus/sites.v3/code.org/views/curriculum_pathway.haml
+++ b/pegasus/sites.v3/code.org/views/curriculum_pathway.haml
@@ -26,17 +26,6 @@
     %a.course.csa.border-top-primary-default{href: "/csa"}
       %p=hoc_s(:course_name_csa)
 
-  .body
-    .div1
-    .div2
-    .div3
-    .div4
-    .div5
-    .div6
-    .div7
-    .div8
-    .div9
-    .div10
-    .div11
-    .div12
-    .div13
+  .background
+    - (1..13).each do |i|
+      %div

--- a/pegasus/sites.v3/code.org/views/curriculum_pathway.haml
+++ b/pegasus/sites.v3/code.org/views/curriculum_pathway.haml
@@ -1,0 +1,63 @@
+= inline_css "/generated/curriculum-pathway.css"
+
+%figure.curriculum-pathway
+  .header
+    .school.elementary.border-bottom-primary-light
+      %p Elementary
+    .school.middle.border-bottom-primary-medium
+      %p Middle
+    .school.high.border-bottom-primary-default
+      %p High
+    .grade
+      %p K
+    .grade
+      %p 1
+    .grade
+      %p 2
+    .grade
+      %p 3
+    .grade
+      %p 4
+    .grade
+      %p 5
+    .grade
+      %p 6
+    .grade
+      %p 7
+    .grade
+      %p 8
+    .grade
+      %p 9
+    .grade
+      %p 10
+    .grade
+      %p 11
+    .grade
+      %p 12
+
+  .courses
+    .course.csf.border-top-primary-light
+      %p CS Fundamentals
+    .course.csc.border-top-primary-light
+      %p CS Connections
+    .course.csd.border-top-primary-medium
+      %p CS Discoveries
+    .course.csp.border-top-primary-default
+      %p CS Principles
+    .course.csa.border-top-primary-default
+      %p AP® CSA
+
+  .body
+    .div1
+    .div2
+    .div3
+    .div4
+    .div5
+    .div6
+    .div7
+    .div8
+    .div9
+    .div10
+    .div11
+    .div12
+    .div13

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -226,6 +226,12 @@
   volunteers_label: "Volunteers"
   virtual_events_label: "Virtual Events"
 
+  course_name_csf: "CS Fundamentals"
+  course_name_csc: "CS Connections"
+  course_name_csd: "CS Discoveries"
+  course_name_csp: "CS Principles"
+  course_name_csa: "AP® CSA"
+
   teacher_label_csf: "CS Fundamentals Teacher"
   teacher_label_csd: "CS Discoveries Teacher"
   teacher_label_csp: "CS Principles Teacher"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -632,6 +632,7 @@
   module_grade_6_10: "6-10"
   module_grade_7_12: "7-12"
   module_grade_9_12: "9-12"
+  module_grade_10_12: "10-12"
   module_grade_kindergarten: "Kindergarten"
   module_grade_grade_01: "Grade 1"
   module_grade_grade_02: "Grade 2"


### PR DESCRIPTION
Creates a `curriculum_pathway.haml` view for use throughout the code.org site. 
- Will be used on the new https://code.org/administrators page: https://github.com/code-dot-org/code-dot-org/pull/55895
- Fully responsive and accessible
- Works with LTR and RTL languages

**Jira ticket:** [ACQ-1405](https://codedotorg.atlassian.net/browse/ACQ-1405)

----

## Desktop

https://github.com/code-dot-org/code-dot-org/assets/9256643/3fffc935-0139-4310-9170-d29c804a65b8

### Keyboard Nav

https://github.com/code-dot-org/code-dot-org/assets/9256643/7718b5be-9845-4384-bb79-9f5cdd835e67

## Responsive

https://github.com/code-dot-org/code-dot-org/assets/9256643/e5db4463-e370-4d93-b5d6-0e61582f5627

## Mobile
<img width="300" alt="Screenshot 2024-01-25 at 12 43 33 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/233bc326-7c58-43a8-8ba7-f7780909f6bc">
