### PR TITLE
Add latency metric for progress-related API calls

### DIFF
--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -26,6 +26,7 @@ export function loadUnitProgress(scriptId, sectionId) {
   const state = getStore().getState().sectionProgress;
   const sectionData = getStore().getState().teacherSections.sections[sectionId];
   const students = getStore().getState().teacherSections.selectedStudents;
+  const startTime = new Date().getTime();
 
   // TODO: Save Standards data in a way that allows us
   // not to reload all data to get correct standards data
@@ -47,7 +48,7 @@ export function loadUnitProgress(scriptId, sectionId) {
     });
   }
 
-  let sectionProgress = {
+  const sectionProgress = {
     unitDataByUnit: {},
     studentLevelProgressByUnit: {},
     studentLessonProgressByUnit: {},
@@ -103,6 +104,7 @@ export function loadUnitProgress(scriptId, sectionId) {
     logToCloud.addPageAction(logToCloud.PageAction.LoadScriptProgressFinished, {
       sectionId,
       scriptId,
+      progressLatencyMs: new Date().getTime() - startTime,
     });
 
     sectionProgress.studentLessonProgressByUnit = {

--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -27,6 +27,8 @@ export function loadUnitProgress(scriptId, sectionId) {
   const sectionData = getStore().getState().teacherSections.sections[sectionId];
   const students = getStore().getState().teacherSections.selectedStudents;
   const startTime = new Date().getTime();
+  let progressLatencyMs = -1;
+  let structureLatencyMs = -1;
 
   // TODO: Save Standards data in a way that allows us
   // not to reload all data to get correct standards data
@@ -61,6 +63,7 @@ export function loadUnitProgress(scriptId, sectionId) {
   })
     .then(response => response.json())
     .then(scriptData => {
+      structureLatencyMs = new Date().getTime() - startTime;
       sectionProgress.unitDataByUnit = {
         [scriptId]: postProcessDataByScript(
           scriptData,
@@ -83,6 +86,7 @@ export function loadUnitProgress(scriptId, sectionId) {
     return fetch(url, {credentials: 'include'})
       .then(response => response.json())
       .then(data => {
+        progressLatencyMs = new Date().getTime() - startTime;
         sectionProgress.studentLevelProgressByUnit = {
           [scriptId]: {
             ...sectionProgress.studentLevelProgressByUnit[scriptId],
@@ -104,7 +108,8 @@ export function loadUnitProgress(scriptId, sectionId) {
     logToCloud.addPageAction(logToCloud.PageAction.LoadScriptProgressFinished, {
       sectionId,
       scriptId,
-      progressLatencyMs: new Date().getTime() - startTime,
+      progressLatencyMs,
+      structureLatencyMs,
     });
 
     sectionProgress.studentLessonProgressByUnit = {


### PR DESCRIPTION
Add a new latency variable to the object passed to NewRelic on completion of the section progress API calls. Our existing metrics measure against the initial page load time, which is often inaccurate in cases where the user switches to a new unit view some time after the initial page load.

## Links

[JIRA: TEACH-808](https://codedotorg.atlassian.net/browse/TEACH-808)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
