### PR TITLE
Set up Web Lab 2

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -199,7 +199,8 @@ export type AppName =
   | 'pythonlab'
   | 'spritelab'
   | 'standalone_video'
-  | 'panels';
+  | 'panels'
+  | 'weblab2';
 
 export type StandaloneAppName =
   | 'spritelab'

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -18,6 +18,7 @@ import moduleStyles from './lab-views-renderer.module.scss';
 import {DEFAULT_THEME, Theme, ThemeContext} from './ThemeWrapper';
 import PythonlabView from '@cdo/apps/pythonlab/PythonlabView';
 import PanelsView from '@cdo/apps/panels/PanelsView';
+import Weblab2View from '@cdo/apps/weblab2/Weblab2View';
 
 // Configuration for how a Lab should be rendered
 interface AppProperties {
@@ -72,6 +73,11 @@ const appsProperties: {[appName in AppName]?: AppProperties} = {
   panels: {
     backgroundMode: false,
     node: <PanelsView />,
+  },
+  weblab2: {
+    backgroundMode: false,
+    node: <Weblab2View />,
+    theme: Theme.LIGHT,
   },
 };
 

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -1,0 +1,8 @@
+// Weblab2 view
+import React from 'react';
+
+const Weblab2View: React.FunctionComponent = () => {
+  return <div>Welcome to Web lab 2!</div>;
+};
+
+export default Weblab2View;

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -60,7 +60,8 @@ class LevelsController < ApplicationController
     TextMatch,
     Unplugged,
     Vigenere,
-    Weblab
+    Weblab,
+    Weblab2
   ]
 
   # GET /levels
@@ -454,6 +455,8 @@ class LevelsController < ApplicationController
         @game = Game.pythonlab
       elsif @type_class == Panels
         @game = Game.panels
+      elsif @type_class == Weblab2
+        @game = Game.weblab2
       end
       @level = @type_class.new
       render :edit

--- a/dashboard/app/models/game.rb
+++ b/dashboard/app/models/game.rb
@@ -62,6 +62,7 @@ class Game < ApplicationRecord
   AICHAT = 'aichat'.freeze
   PYTHONLAB = 'pythonlab'.freeze
   PANELS = 'panels'.freeze
+  WEBLAB2 = 'weblab2'.freeze
 
   def self.bounce
     @@game_bounce ||= find_by_name("Bounce")
@@ -199,6 +200,10 @@ class Game < ApplicationRecord
     @@game_panels ||= find_by_name('Panels')
   end
 
+  def self.weblab2
+    @@game_weblab2 ||= find_by_name("Weblab2")
+  end
+
   def unplugged?
     app == UNPLUG
   end
@@ -245,7 +250,7 @@ class Game < ApplicationRecord
   end
 
   def uses_small_footer?
-    [NETSIM, APPLAB, TEXT_COMPRESSION, GAMELAB, WEBLAB, DANCE, FISH, AILAB, JAVALAB, AICHAT, PYTHONLAB].include? app
+    [NETSIM, APPLAB, TEXT_COMPRESSION, GAMELAB, WEBLAB, DANCE, FISH, AILAB, JAVALAB, AICHAT, PYTHONLAB, WEBLAB2].include? app
   end
 
   def no_footer?
@@ -357,6 +362,7 @@ class Game < ApplicationRecord
     Aichat:aichat
     Pythonlab:pythonlab
     Panels:panels
+    Weblab2:weblab2
   )
 
   def self.setup

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -342,6 +342,7 @@ class Level < ApplicationRecord
     'Unplugged', # no solutions
     'Vigenere', # widget
     'Weblab', # no ideal solution
+    'Weblab2', # no ideal solution
     'Widget', # widget
   ].freeze
   TYPES_WITH_IDEAL_LEVEL_SOURCE = %w(

--- a/dashboard/app/models/levels/weblab2.rb
+++ b/dashboard/app/models/levels/weblab2.rb
@@ -1,0 +1,49 @@
+# == Schema Information
+#
+# Table name: levels
+#
+#  id                    :integer          not null, primary key
+#  game_id               :integer
+#  name                  :string(255)      not null
+#  created_at            :datetime
+#  updated_at            :datetime
+#  level_num             :string(255)
+#  ideal_level_source_id :bigint           unsigned
+#  user_id               :integer
+#  properties            :text(4294967295)
+#  type                  :string(255)
+#  md5                   :string(255)
+#  published             :boolean          default(FALSE), not null
+#  notes                 :text(65535)
+#  audit_log             :text(65535)
+#
+# Indexes
+#
+#  index_levels_on_game_id    (game_id)
+#  index_levels_on_level_num  (level_num)
+#  index_levels_on_name       (name)
+#
+class Weblab2 < Level
+  serialized_attrs %w(
+    start_sources
+    hide_share_and_remix
+    is_project_level
+    encrypted_examples
+    submittable
+    validation_enabled
+  )
+
+  def self.create_from_level_builder(params, level_params)
+    create!(
+      level_params.merge(
+        user: params[:user],
+        game: Game.weblab2,
+        level_num: 'custom',
+      )
+    )
+  end
+
+  def uses_lab2?
+    true
+  end
+end

--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -46,6 +46,7 @@
     = render partial: 'levels/editors/music', locals: {f: f} if @level.is_a? Music
     = render partial: 'levels/editors/pythonlab', locals: {f: f} if @level.is_a? Pythonlab
     = render partial: 'levels/editors/panels', locals: {f: f} if @level.is_a? Panels
+    = render partial: 'levels/editors/weblab2', locals: {f: f} if @level.is_a? Weblab2
     -# Widgets
     = render partial: 'levels/editors/frequency_analysis', locals: {f: f} if @level.is_a? FrequencyAnalysis
     = render partial: 'levels/editors/netsim', locals: {f: f} if @level.is_a? NetSim

--- a/dashboard/app/views/levels/editors/_weblab2.html.haml
+++ b/dashboard/app/views/levels/editors/_weblab2.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'levels/editors/fields/weblab2_fields', locals: {f: f}
+
+= render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_weblab2_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_weblab2_fields.html.haml
@@ -1,0 +1,1 @@
+%h1 Web Lab 2 Fields

--- a/dashboard/app/views/levels/new.html.haml
+++ b/dashboard/app/views/levels/new.html.haml
@@ -63,6 +63,7 @@
   %li= link_to 'Build a Music Lab level', new_level_path(type: 'Music')
   %li= link_to 'Build a Python Lab level', new_level_path(type: 'Pythonlab')
   %li= link_to 'Build a Panels level', new_level_path(type: 'Panels')
+  %li= link_to 'Build a Web Lab 2 level', new_level_path(type: 'Weblab2')
 
 %h2 Algebra
 %ul

--- a/dashboard/config/levels/custom/Allthethings Weblab2 1.level
+++ b/dashboard/config/levels/custom/Allthethings Weblab2 1.level
@@ -1,0 +1,12 @@
+<Weblab2>
+  <config><![CDATA[{
+  "game_id": 74,
+  "created_at": "2024-01-24T23:52:56.000Z",
+  "level_num": "custom",
+  "user_id": 6959,
+  "properties": {
+    "encrypted": "false"
+  },
+  "published": true
+}]]></config>
+</Weblab2>

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -398,6 +398,8 @@ en:
               name: Dance Lab2
             lesson-53:
               name: Python Lab
+            lesson-54:
+              name: Web Lab 2
         algebraPD2b:
           title: Computer Science in Algebra PD
           description: 'Phase 2 Online: Blended Summer Study'

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2024-01-04 16:59:03 UTC",
+    "serialized_at": "2024-01-24 23:54:10 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -829,6 +829,21 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
+    },
+    {
+      "key": "lesson-54",
+      "name": "Web Lab 2",
+      "absolute_position": 54,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 51,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-54",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
     }
   ],
   "lesson_activities": [
@@ -1513,6 +1528,18 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
+    },
+    {
+      "key": "13a31209-c280-4f4d-8278-511b4f88ab7e",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "13a31209-c280-4f4d-8278-511b4f88ab7e",
+        "lesson.key": "lesson-54",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
     }
   ],
   "activity_sections": [
@@ -2044,6 +2071,16 @@
       "seeding_key": {
         "activity_section.key": "465bc905-13b5-487c-8fd6-8043676ee607",
         "lesson_activity.key": "5688685c-b8bf-4563-b285-04a9cce9bb6e"
+      }
+    },
+    {
+      "key": "b26e8309-b1a7-486a-9490-96d4ddd8b9aa",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "b26e8309-b1a7-486a-9490-96d4ddd8b9aa",
+        "lesson_activity.key": "13a31209-c280-4f4d-8278-511b4f88ab7e"
       }
     }
   ],
@@ -5367,6 +5404,9 @@
       "activity_section_position": 4,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "allthethings HOC Dance AI Customize"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6532,6 +6572,27 @@
       },
       "level_keys": [
         "Allthethings Python Lab 1"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Allthethings Weblab2 1"
+        ],
+        "lesson.key": "lesson-54",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "b26e8309-b1a7-486a-9490-96d4ddd8b9aa"
+      },
+      "level_keys": [
+        "Allthethings Weblab2 1"
       ]
     }
   ],
@@ -8868,6 +8929,18 @@
         "lesson_group.key": "",
         "script.name": "allthethings",
         "activity_section.key": "465bc905-13b5-487c-8fd6-8043676ee607"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Allthethings Weblab2 1",
+        "script_level.level_keys": [
+          "Allthethings Weblab2 1"
+        ],
+        "lesson.key": "lesson-54",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "b26e8309-b1a7-486a-9490-96d4ddd8b9aa"
       }
     }
   ],

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -1247,7 +1247,7 @@ class LevelTest < ActiveSupport::TestCase
       "GamelabJr", "Javalab", "Karel", "LevelGroup", "Map", "Match", "Maze", "Multi", "Music", "NetSim",
       "Odometer", "Panels", "Pixelation", "Poetry", "PublicKeyCryptography", "Pythonlab", "StandaloneVideo",
       "StarWarsGrid", "Studio", "TextCompression", "TextMatch", "Unplugged",
-      "Vigenere", "Weblab"
+      "Vigenere", "Weblab", "Weblab2"
     ]
     scripts = [
       "All scripts", "20-hour", "algebra", "artist", "course1", "course2",


### PR DESCRIPTION
Boilerplate to create a new lab, Web Lab 2. I followed the same strategy as [Python Lab](https://github.com/code-dot-org/code-dot-org/pull/55370). This sets up:

- The new game type and level type
- The basic levelbuilder plumbing to create a new Web Lab 2 file
- The plumbing for the frontend
- A new all the things lesson with a single "Web Lab 2" level

Right now a Web Lab 2 level just looks like this:
<img width="912" alt="Screenshot 2024-01-24 at 4 20 15 PM" src="https://github.com/code-dot-org/code-dot-org/assets/33666587/30a3ef31-c54c-4eaf-8a8c-59cb9fa8d0b3">

## Links
- jira ticket: [CT-286](https://codedotorg.atlassian.net/browse/CT-286)


## Testing story
Tested locally that the new lab type renders, and other labs are unaffected.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
