### PR TITLE
Pass user_type into Curriculum Catalog instead of is_teacher

### DIFF
--- a/apps/src/sites/studio/pages/curriculum_catalog/index.js
+++ b/apps/src/sites/studio/pages/curriculum_catalog/index.js
@@ -18,7 +18,7 @@ $(document).ready(function () {
     languageNativeName,
     sections,
     isSignedOut,
-    isTeacher,
+    userType,
     isInUS,
   } = catalogData;
 
@@ -36,7 +36,7 @@ $(document).ready(function () {
         isEnglish={isEnglish}
         languageNativeName={languageNativeName}
         isSignedOut={isSignedOut}
-        isTeacher={isTeacher}
+        userType={userType}
         isInUS={isInUS}
       />
     </Provider>,

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -19,7 +19,7 @@ const CurriculumCatalog = ({
   languageNativeName,
   isInUS,
   isSignedOut,
-  isTeacher,
+  userType,
   ...props
 }) => {
   const [filteredCurricula, setFilteredCurricula] = useState(curriculaData);
@@ -142,7 +142,7 @@ const CurriculumCatalog = ({
                   isInUS={isInUS}
                   availableResources={available_resources}
                   isSignedOut={isSignedOut}
-                  isTeacher={isTeacher}
+                  userType={userType}
                   {...props}
                 />
               )
@@ -212,7 +212,7 @@ CurriculumCatalog.propTypes = {
   languageNativeName: PropTypes.string.isRequired,
   isInUS: PropTypes.bool.isRequired,
   isSignedOut: PropTypes.bool.isRequired,
-  isTeacher: PropTypes.bool.isRequired,
+  userType: PropTypes.string,
 };
 
 export default CurriculumCatalog;

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -53,7 +53,7 @@ const CurriculumCatalogCard = ({
   isInUS,
   availableResources,
   isSignedOut,
-  isTeacher,
+  userType,
   ...props
 }) => (
   <CustomizableCurriculumCatalogCard
@@ -83,9 +83,9 @@ const CurriculumCatalogCard = ({
     imageAltText={imageAltText}
     translationIconTitle={i18n.courseInYourLanguage()}
     pathToCourse={`${
-      isSignedOut || isTeacher
-        ? pathToCourse + '?viewAs=Instructor'
-        : pathToCourse
+      userType === 'student'
+        ? pathToCourse
+        : pathToCourse + '?viewAs=Instructor'
     }`}
     onAssignSuccess={onAssignSuccess}
     deviceCompatibility={deviceCompatibility}
@@ -99,7 +99,7 @@ const CurriculumCatalogCard = ({
     isInUS={isInUS}
     availableResources={availableResources}
     isSignedOut={isSignedOut}
-    isTeacher={isTeacher}
+    userType={userType}
     {...props}
   />
 );
@@ -138,7 +138,7 @@ CurriculumCatalogCard.propTypes = {
   onQuickViewClick: PropTypes.func,
   isInUS: PropTypes.bool,
   availableResources: PropTypes.object,
-  isTeacher: PropTypes.bool.isRequired,
+  userType: PropTypes.string,
   isSignedOut: PropTypes.bool.isRequired,
 };
 
@@ -160,7 +160,7 @@ const CustomizableCurriculumCatalogCard = ({
   isEnglish,
   pathToCourse,
   sectionsForDropdown = [],
-  isTeacher,
+  userType,
   isSignedOut,
   onAssignSuccess,
   courseId,
@@ -177,6 +177,7 @@ const CustomizableCurriculumCatalogCard = ({
   ...props
 }) => {
   const [isAssignDialogOpen, setIsAssignDialogOpen] = useState(false);
+  const isTeacher = userType === 'teacher';
 
   const handleClickAssign = cardType => {
     setIsAssignDialogOpen(true);
@@ -331,7 +332,7 @@ const CustomizableCurriculumCatalogCard = ({
           imageAltText={imageAltText}
           availableResources={availableResources}
           isSignedOut={isSignedOut}
-          isTeacher={isTeacher}
+          userType={userType}
         />
       )}
     </div>
@@ -358,7 +359,7 @@ CustomizableCurriculumCatalogCard.propTypes = {
   scriptId: PropTypes.number,
   isStandAloneUnit: PropTypes.bool,
   sectionsForDropdown: PropTypes.arrayOf(sectionForDropdownShape).isRequired,
-  isTeacher: PropTypes.bool.isRequired,
+  userType: PropTypes.string,
   isSignedOut: PropTypes.bool.isRequired,
   onAssignSuccess: PropTypes.func,
   // for screenreaders

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -36,7 +36,7 @@ const ExpandedCurriculumCatalogCard = ({
   imageAltText,
   availableResources,
   isSignedOut,
-  isTeacher,
+  userType,
 }) => {
   const expandedCardRef = useRef(null);
   const iconData = {
@@ -53,6 +53,8 @@ const ExpandedCurriculumCatalogCard = ({
       color: style.circleXmark,
     },
   };
+
+  const isTeacher = userType === 'teacher';
 
   const devices = JSON.parse(deviceCompatibility);
 
@@ -297,7 +299,7 @@ ExpandedCurriculumCatalogCard.propTypes = {
   imageSrc: PropTypes.string,
   imageAltText: PropTypes.string,
   availableResources: PropTypes.object,
-  isTeacher: PropTypes.bool.isRequired,
+  userType: PropTypes.string,
   isSignedOut: PropTypes.bool.isRequired,
 };
 export default ExpandedCurriculumCatalogCard;

--- a/dashboard/app/controllers/curriculum_catalog_controller.rb
+++ b/dashboard/app/controllers/curriculum_catalog_controller.rb
@@ -9,7 +9,7 @@ class CurriculumCatalogController < ApplicationController
     @language_native_name = language_info[:native]
 
     @is_signed_out = current_user.nil?
-    @is_teacher = current_user&.teacher? || false
+    @user_type = current_user&.user_type
 
     if @is_teacher
       @sections_for_teacher = current_user.try {|u| u.sections.all.reject(&:hidden).map(&:summarize)}
@@ -21,7 +21,7 @@ class CurriculumCatalogController < ApplicationController
       languageEnglishName: @language_english_name,
       languageNativeName: @language_native_name,
       isSignedOut: @is_signed_out,
-      isTeacher: @is_teacher,
+      userType: @user_type,
       sections: @sections_for_teacher,
       isInUS: request.country.to_s.casecmp?('rd') || request.country.to_s.casecmp?('us')
     }


### PR DESCRIPTION
To prep for [this ticket](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1266) on updating the Curriculum Catalog card buttons for signed-in students, this PR passes in `user_type` rather than `isTeacher` for the Curriculum Catalog page since the changes will rely on knowing if the user is a student.

### Screenshots showing Curriculum Catalog still shows the right content to the right user type and signed in state
Student:
![student](https://github.com/code-dot-org/code-dot-org/assets/56283563/57d1e6ae-781a-4a21-b584-a22699193fbd)

Teacher:
![Teacher_view](https://github.com/code-dot-org/code-dot-org/assets/56283563/9594715a-60d2-44c9-9211-4a036ebf8009)

Signed-out (same as Teacher):
![signed_out](https://github.com/code-dot-org/code-dot-org/assets/56283563/bb708113-0962-4385-a3b9-1936fd8b047e)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1266)

## Testing story
Local testing.

## Follow-up work
Show 
