### PR TITLE
Revert "Revert "Firehose front end limit logging""

### DIFF
--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -294,8 +294,8 @@ class FirehoseClient {
 
 // Verifies that given data will not fail firehose batch
 function validateFirehoseDataSize(data) {
-  const json_size = new Blob([data.data_json]).size;
-  const string_size = new Blob([data.data_string]).size;
+  const json_size = new Blob([data?.data_json]).size;
+  const string_size = new Blob([data?.data_string]).size;
   if (json_size > maxDataJSONBytes) {
     logToCloud.logError(`data_json column too large (${json_size} bytes)`);
     return true;

--- a/apps/test/unit/lib/util/firehoseTest.js
+++ b/apps/test/unit/lib/util/firehoseTest.js
@@ -1,0 +1,43 @@
+import {stub} from 'sinon';
+import {expect} from '../../../util/reconfiguredChai';
+import {validateFirehoseDataSize} from '@cdo/apps/lib/util/firehose';
+import logToCloud from '@cdo/apps/logToCloud';
+
+describe('firehoseDataSize', () => {
+  const maxDataJSONBytes = 65500;
+  const maxDataStringBytes = 4095;
+
+  beforeEach(() => {
+    stub(logToCloud, 'logError');
+  });
+
+  afterEach(() => {
+    logToCloud.logError.restore();
+  });
+
+  it('checks json size to send newrelic error', () => {
+    const valid_record = {data_json: 'x'.repeat(maxDataJSONBytes - 1)};
+    expect(validateFirehoseDataSize(valid_record)).not.to.be.true;
+    expect(logToCloud.logError).not.to.be.called;
+
+    const invalid_record = {data_json: 'x'.repeat(maxDataJSONBytes + 1)};
+    expect(() => {
+      validateFirehoseDataSize(invalid_record);
+    }).not.to.throw();
+    expect(logToCloud.logError).to.be.calledOnce;
+    expect(validateFirehoseDataSize(invalid_record)).to.be.true;
+  });
+
+  it('checks string size to send newrelic error', () => {
+    const valid_record = {data_string: 'x'.repeat(maxDataStringBytes - 1)};
+    expect(validateFirehoseDataSize(valid_record)).not.to.be.true;
+    expect(logToCloud.logError).not.to.be.called;
+
+    const invalid_record = {data_string: 'x'.repeat(maxDataStringBytes + 1)};
+    expect(() => {
+      validateFirehoseDataSize(invalid_record);
+    }).not.to.throw();
+    expect(logToCloud.logError).to.be.calledOnce;
+    expect(validateFirehoseDataSize(invalid_record)).to.be.true;
+  });
+});

--- a/apps/test/unit/lib/util/firehoseTest.js
+++ b/apps/test/unit/lib/util/firehoseTest.js
@@ -40,4 +40,12 @@ describe('firehoseDataSize', () => {
     expect(logToCloud.logError).to.be.calledOnce;
     expect(validateFirehoseDataSize(invalid_record)).to.be.true;
   });
+
+  it('ensures validation does not fail empty and undefined cases', () => {
+    const null_record = {};
+    expect(validateFirehoseDataSize(null_record)).not.to.be.true;
+    expect(logToCloud.logError).not.to.be.called;
+    expect(validateFirehoseDataSize(undefined)).not.to.be.true;
+    expect(logToCloud.logError).not.to.be.called;
+  });
 });

--- a/apps/test/unit/utilsTest.js
+++ b/apps/test/unit/utilsTest.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import {stub} from 'sinon';
 import {assert, expect} from '../util/reconfiguredChai';
 import * as utils from '@cdo/apps/utils';
+
 const {
   isSubsequence,
   shallowCopy,


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#55973

The initial PR caused a spike in the JS error rate (DOTD pages above 4%, context in slack thread [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1706219185423979)). The error was "Cannot read properties of undefined (reading 'data_json')". This means we were sending firehose records with null data. I'm not sure how this happens, but I added a check for it and tests accordingly to prove that this will no longer create an error for the putRecord function.



Ticket: https://codedotorg.atlassian.net/browse/ACQ-1399