### PR TITLE
broaden db lint rules to include POSTE_DB and helper methods

### DIFF
--- a/dashboard/test/testing/poste_assertions.rb
+++ b/dashboard/test/testing/poste_assertions.rb
@@ -13,6 +13,8 @@ module PosteAssertions
     delivery_method = Poste2::DeliveryMethod.new
     delivery_id = delivery_method.deliver! mail
   ensure
+    # rubocop:disable CustomCops/PegasusDbUsage
     POSTE_DB[:poste_deliveries].where(id: delivery_id).delete if delivery_id
+    # rubocop:enable CustomCops/PegasusDbUsage
   end
 end

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -8,6 +8,7 @@ require 'mail'
 require 'openssl'
 require 'cdo/honeybadger'
 
+# rubocop:disable CustomCops/PegasusDbUsage
 module Poste
   def self.logger
     @@logger ||= $log
@@ -583,3 +584,4 @@ module Poste2
     end
   end
 end
+# rubocop:enable CustomCops/PegasusDbUsage

--- a/lib/test/test_deliverer.rb
+++ b/lib/test/test_deliverer.rb
@@ -36,8 +36,10 @@ class DelivererTest < Minitest::Test
     contact = Poste2.create_recipient(email, {ip_address: '5.6.7.8.'})
 
     # Sequel doesn't have a "find or create by", so we implement it manually
+    # rubocop:disable CustomCops/PegasusDbUsage
     message = POSTE_DB[:poste_messages].where(name: "dashboard").first
     message_id = message.nil? ? POSTE_DB[:poste_messages].insert({name: "dashboard"}) : message[:id]
+    # rubocop:enable CustomCops/PegasusDbUsage
 
     delivery = {
       id: 1,

--- a/pegasus/helper_modules/dashboard.rb
+++ b/pegasus/helper_modules/dashboard.rb
@@ -12,10 +12,6 @@ module Dashboard
     # rubocop:enable CustomCops/DashboardDbUsage
   end
 
-  def self.admin?(user_id)
-    !!db[:users][id: user_id, admin: true]
-  end
-
   class User
     # Wrap dashboard user row in this helper object.
     # You can use this, but it's preferred that clients call User.get(user_id).

--- a/pegasus/helper_modules/dashboard.rb
+++ b/pegasus/helper_modules/dashboard.rb
@@ -2,13 +2,14 @@
 # A set of utilities that provide access to the current user, their
 # authentication state, and other DASHBOARD_DB access.
 #
-# rubocop:disable CustomCops/DashboardDbUsage
 module Dashboard
   # Get the dashboard database
   # The static constant is wrapped here so it's easy to stub for tests.
   # @returns [Database]
   def self.db
+    # rubocop:disable CustomCops/DashboardDbUsage
     DASHBOARD_DB
+    # rubocop:enable CustomCops/DashboardDbUsage
   end
 
   class User
@@ -22,9 +23,11 @@ module Dashboard
     # @returns [User] for given user_id, or nil if not found in database
     def self.get(user_id)
       return nil if user_id.nil?
+      # rubocop:disable CustomCops/DashboardDbUsage
       row = Dashboard.db[:users].where(id: user_id, deleted_at: nil).first
       return nil unless row
       Dashboard::User.new(row)
+      # rubocop:enable CustomCops/DashboardDbUsage
     end
 
     def id
@@ -47,4 +50,3 @@ module Dashboard
     end
   end
 end
-# rubocop:enable CustomCops/DashboardDbUsage

--- a/pegasus/helper_modules/dashboard.rb
+++ b/pegasus/helper_modules/dashboard.rb
@@ -2,14 +2,13 @@
 # A set of utilities that provide access to the current user, their
 # authentication state, and other DASHBOARD_DB access.
 #
+# rubocop:disable CustomCops/DashboardDbUsage
 module Dashboard
   # Get the dashboard database
   # The static constant is wrapped here so it's easy to stub for tests.
   # @returns [Database]
   def self.db
-    # rubocop:disable CustomCops/DashboardDbUsage
     DASHBOARD_DB
-    # rubocop:enable CustomCops/DashboardDbUsage
   end
 
   class User
@@ -48,3 +47,4 @@ module Dashboard
     end
   end
 end
+# rubocop:enable CustomCops/DashboardDbUsage

--- a/pegasus/helpers.rb
+++ b/pegasus/helpers.rb
@@ -18,7 +18,9 @@ end
 
 def authentication_required!(url = request.url)
   dont_cache
+  # rubocop:disable CustomCops/DashboardDbUsage
   return if dashboard_user_helper
+  # rubocop:enable CustomCops/DashboardDbUsage
   redirect((request.scheme || 'http') + ':' + CDO.studio_url("/users/sign_in?user_return_to=#{url}"), 302)
 end
 

--- a/pegasus/helpers/email_preference_helpers.rb
+++ b/pegasus/helpers/email_preference_helpers.rb
@@ -4,6 +4,7 @@ require 'active_support/dependencies'
 require_dependency 'cdo/shared_constants/email_preference_constants'
 require_relative '../helper_modules/dashboard'
 
+# rubocop:disable CustomCops/DashboardDbUsage
 class EmailPreferenceHelper
   include EmailPreferenceConstants
 
@@ -56,3 +57,4 @@ class EmailPreferenceHelper
     return
   end
 end
+# rubocop:enable CustomCops/DashboardDbUsage

--- a/pegasus/helpers/email_preference_helpers.rb
+++ b/pegasus/helpers/email_preference_helpers.rb
@@ -4,7 +4,6 @@ require 'active_support/dependencies'
 require_dependency 'cdo/shared_constants/email_preference_constants'
 require_relative '../helper_modules/dashboard'
 
-# rubocop:disable CustomCops/DashboardDbUsage
 class EmailPreferenceHelper
   include EmailPreferenceConstants
 
@@ -26,6 +25,7 @@ class EmailPreferenceHelper
     # between the value of the opt_in column in the existing row and the new/input value.
     input_opt_in = opt_in
 
+    # rubocop:disable CustomCops/DashboardDbUsage
     existing_email_preference = Dashboard.db[:email_preferences].where(email: email).first
     if !existing_email_preference
       Dashboard.db[:email_preferences].insert(
@@ -53,8 +53,8 @@ class EmailPreferenceHelper
         }
       )
     end
+    # rubocop:enable CustomCops/DashboardDbUsage
     # This is a write-only helper method.  Don't return data to the caller.
     return
   end
 end
-# rubocop:enable CustomCops/DashboardDbUsage

--- a/pegasus/helpers/form_helpers.rb
+++ b/pegasus/helpers/form_helpers.rb
@@ -1,3 +1,4 @@
+# rubocop:disable CustomCops/DashboardDbUsage
 require 'digest/md5'
 require_relative '../../deployment'
 require lib_dir 'forms/pegasus_form_validation'
@@ -114,3 +115,4 @@ def update_form(kind, secret, updates)
   update_form.save_changes
   update_form
 end
+# rubocop:enable CustomCops/DashboardDbUsage

--- a/pegasus/helpers/form_helpers.rb
+++ b/pegasus/helpers/form_helpers.rb
@@ -1,4 +1,3 @@
-# rubocop:disable CustomCops/DashboardDbUsage
 require 'digest/md5'
 require_relative '../../deployment'
 require lib_dir 'forms/pegasus_form_validation'
@@ -28,10 +27,12 @@ end
 # TODO(asher): Fix this method, both the naming of it (to indicate the upsert behavior) and its
 # implementation (not overwriting various fields on update).
 def insert_or_upsert_form(kind, data, options = {})
+  # rubocop:disable CustomCops/DashboardDbUsage
   if dashboard_user
     data[:email_s] ||= dashboard_user[:email]
     data[:name_s] ||= dashboard_user[:name]
   end
+  # rubocop:enable CustomCops/DashboardDbUsage
 
   # The DB cannot store utf8mb4 characters so make sure they are all stripped out.
   data.each do |k, v|
@@ -56,7 +57,9 @@ def insert_or_upsert_form(kind, data, options = {})
     updated_ip: request.ip,
     hashed_email: Digest::MD5.hexdigest(normalized_email),
   }
+  # rubocop:disable CustomCops/DashboardDbUsage
   row[:user_id] = dashboard_user ? dashboard_user[:id] : data[:user_id_i]
+  # rubocop:enable CustomCops/DashboardDbUsage
 
   form_class = Object.const_get(kind)
   row[:source_id] = form_class.get_source_id(data) if form_class.respond_to? :get_source_id
@@ -90,10 +93,12 @@ end
 def update_form(kind, secret, updates)
   return nil unless (update_form = Form.find(kind: kind, secret: secret))
 
+  # rubocop:disable CustomCops/DashboardDbUsage
   if dashboard_user && !dashboard_user[:admin]
     updates[:email_s] ||= dashboard_user[:email]
     updates[:name_s] ||= dashboard_user[:name]
   end
+  # rubocop:enable CustomCops/DashboardDbUsage
 
   existing_data = JSON.parse update_form.data, symbolize_names: true
   form_data = JSON.parse updates[:data], symbolize_names: true if updates[:data]
@@ -103,7 +108,9 @@ def update_form(kind, secret, updates)
 
   normalized_email = merged_info[:email_s].to_s.strip.downcase if merged_info.key?(:email_s)
 
+  # rubocop:disable CustomCops/DashboardDbUsage
   update_form[:user_id] = dashboard_user[:id] if dashboard_user && !dashboard_user[:admin]
+  # rubocop:enable CustomCops/DashboardDbUsage
   update_form[:email] = normalized_email
   update_form[:name] = merged_info[:name_s].to_s.strip if merged_info.key?(:name_s)
   update_form[:data] = merged_info.to_json
@@ -115,4 +122,3 @@ def update_form(kind, secret, updates)
   update_form.save_changes
   update_form
 end
-# rubocop:enable CustomCops/DashboardDbUsage

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -219,8 +219,10 @@ class Documents < Sinatra::Base
   ['/private', '/private/*'].each do |uri|
     get_head_or_post uri do
       unless rack_env?(:development)
+        # rubocop:disable CustomCops/DashboardDbUsage
         not_authorized! unless dashboard_user_helper
         forbidden! unless dashboard_user_helper.admin?
+        # rubocop:enable CustomCops/DashboardDbUsage
       end
       pass
     end
@@ -318,7 +320,9 @@ class Documents < Sinatra::Base
     # TODO: Switch to using `dashboard_user_helper` everywhere and remove this
     def dashboard_user
       return nil if (id = dashboard_user_id).nil?
+      # rubocop:disable CustomCops/DashboardDbUsage
       @dashboard_user ||= Dashboard.db[:users][id: id]
+      # rubocop:enable CustomCops/DashboardDbUsage
     end
 
     # Get the current dashboard user wrapped in a helper
@@ -327,7 +331,9 @@ class Documents < Sinatra::Base
     # TODO: When we are using this everywhere, rename to just `dashboard_user`
     def dashboard_user_helper
       return nil if (id = dashboard_user_id).nil?
+      # rubocop:disable CustomCops/DashboardDbUsage
       @dashboard_user_helper ||= Dashboard::User.get(id)
+      # rubocop:enable CustomCops/DashboardDbUsage
     end
 
     # Get the current dashboard user ID

--- a/pegasus/routes/v2_forms_routes.rb
+++ b/pegasus/routes/v2_forms_routes.rb
@@ -14,6 +14,7 @@ post '/v2/forms/:kind' do |kind|
   end
 end
 
+# rubocop:disable CustomCops/DashboardDbUsage
 get '/v2/forms/:kind' do |kind|
   dont_cache
   results = []
@@ -25,6 +26,7 @@ get '/v2/forms/:kind' do |kind|
   content_type :json
   JSON.pretty_generate(results)
 end
+# rubocop:enable CustomCops/DashboardDbUsage
 
 get '/v2/forms/:kind/:secret' do |kind, secret|
   dont_cache
@@ -59,6 +61,7 @@ post '/v2/forms/:kind/:secret/update' do |kind, secret|
   call(env.merge('REQUEST_METHOD' => 'PATCH', 'PATH_INFO' => "/v2/forms/#{kind}/#{secret}"))
 end
 
+# rubocop:disable CustomCops/DashboardDbUsage
 post '/v2/forms/:kind/:secret/review' do |kind, secret|
   dont_cache
   hoc_year = DCDO.get("hoc_year", 2017)
@@ -83,6 +86,7 @@ post '/v2/forms/:kind/:secret/review' do |kind, secret|
   content_type :json
   ({review: review}).to_json
 end
+# rubocop:enable CustomCops/DashboardDbUsage
 
 get '/v2/forms/:parent_kind/:parent_secret/children/:kind' do |parent_kind, parent_secret, kind|
   dont_cache

--- a/pegasus/test/test_dashboard.rb
+++ b/pegasus/test/test_dashboard.rb
@@ -4,15 +4,16 @@ require_relative './test_helper'
 require_relative '../helper_modules/dashboard'
 require_relative 'fixtures/fake_dashboard'
 
-# rubocop:disable CustomCops/DashboardDbUsage
 class DashboardTest < Minitest::Test
   describe 'Dashboard::User' do
     before do
       FakeDashboard.use_fake_database
+      # rubocop:disable CustomCops/DashboardDbUsage
       @student = Dashboard::User.get(FakeDashboard::STUDENT[:id])
       @deleted_student = Dashboard::User.
         get(FakeDashboard::STUDENT_DELETED[:id])
       @teacher = Dashboard::User.get(FakeDashboard::TEACHER[:id])
+      # rubocop:enable CustomCops/DashboardDbUsage
     end
 
     describe 'to_hash' do
@@ -33,4 +34,3 @@ class DashboardTest < Minitest::Test
     end
   end
 end
-# rubocop:enable CustomCops/DashboardDbUsage

--- a/pegasus/test/test_dashboard.rb
+++ b/pegasus/test/test_dashboard.rb
@@ -4,6 +4,7 @@ require_relative './test_helper'
 require_relative '../helper_modules/dashboard'
 require_relative 'fixtures/fake_dashboard'
 
+# rubocop:disable CustomCops/DashboardDbUsage
 class DashboardTest < Minitest::Test
   describe 'Dashboard::User' do
     before do
@@ -32,3 +33,4 @@ class DashboardTest < Minitest::Test
     end
   end
 end
+# rubocop:enable CustomCops/DashboardDbUsage

--- a/pegasus/test/test_email_preference_helpers.rb
+++ b/pegasus/test/test_email_preference_helpers.rb
@@ -4,6 +4,7 @@ require_relative '../helpers/email_preference_helpers'
 require_relative 'sequel_test_case'
 require 'timecop'
 
+# rubocop:disable CustomCops/DashboardDbUsage
 class EmailPreferenceHelperTest < SequelTestCase
   def test_upsert_new_email_preference_with_valid_attributes_creates_email_preference
     EmailPreferenceHelper.upsert!(
@@ -186,3 +187,4 @@ class EmailPreferenceHelperTest < SequelTestCase
     refute_equal updated_email_preference[:form_kind], another_email_preference[:form_kind]
   end
 end
+# rubocop:enable CustomCops/DashboardDbUsage

--- a/shared/test/test_poste.rb
+++ b/shared/test/test_poste.rb
@@ -6,6 +6,7 @@ require 'mocha/mini_test'
 require 'cdo/poste'
 require 'digest/md5'
 
+# rubocop:disable CustomCops/PegasusDbUsage
 class PosteTest < SequelTestCase
   STUDENT_EMAIL = 'student@example.net'.freeze
   STUDENT_EMAIL_HASH = Digest::MD5.hexdigest(STUDENT_EMAIL).freeze
@@ -356,3 +357,4 @@ class Poste2Test < SequelTestCase
       POSTE_DB[:contacts].where(hashed_email: hashed_email).first[:created_ip]
   end
 end
+# rubocop:enable CustomCops/PegasusDbUsage

--- a/tools/customLinters/rubocop_dashboard_db_usage.rb
+++ b/tools/customLinters/rubocop_dashboard_db_usage.rb
@@ -1,14 +1,35 @@
 module CustomCops
-  # Custom cop that checks for use of DASHBOARD_DB outside of dashboard/ directory
+  # Custom cop that checks for use of dashboard DB outside of dashboard/ directory
   class DashboardDbUsage < RuboCop::Cop::Base
-    MSG = 'Do not use DASHBOARD_DB outside of dashboard/ directory.'
+    MSG = 'Do not access dashboard DB from outside of top-level dashboard/ directory.'
 
-    def_node_matcher :dashboard_db_usage?, <<-PATTERN
-      (const nil? :DASHBOARD_DB)
+    # Match DASHBOARD_DB or Dashboard::User
+    def_node_matcher :dashboard_db_const?, <<-PATTERN
+      {
+        (const nil? :DASHBOARD_DB)
+        (const (const nil? :Dashboard) :User)
+      }
     PATTERN
 
     def on_const(node)
-      if dashboard_db_usage?(node)
+      if dashboard_db_const?(node)
+        file_path = processed_source.buffer.name
+        unless file_path.include?('/dashboard/') || file_path.include?('/bin/')
+          add_offense(node, message: MSG)
+        end
+      end
+    end
+
+    # Match dashboard_user_helper, dashboard_user, current_user, or Dashboard.db
+    def_node_matcher :dashboard_db_method?, <<-PATTERN
+      {
+        (send nil? {:dashboard_user_helper :dashboard_user :current_user})
+        (send (const nil? :Dashboard) :db)
+      }
+    PATTERN
+
+    def on_send(node)
+      if dashboard_db_method?(node)
         file_path = processed_source.buffer.name
         unless file_path.include?('/dashboard/') || file_path.include?('/bin/')
           add_offense(node, message: MSG)

--- a/tools/customLinters/rubocop_dashboard_db_usage.rb
+++ b/tools/customLinters/rubocop_dashboard_db_usage.rb
@@ -1,7 +1,7 @@
 module CustomCops
   # Custom cop that checks for use of dashboard DB outside of dashboard/ directory
   class DashboardDbUsage < RuboCop::Cop::Base
-    MSG = 'Do not access dashboard DB from outside of top-level dashboard/ directory.'
+    MSG = 'Do not access dashboard DB from outside of top-level dashboard/ directory. For details, see: https://github.com/code-dot-org/code-dot-org/pull/55417'
 
     # Match DASHBOARD_DB or Dashboard::User
     def_node_matcher :dashboard_db_const?, <<-PATTERN

--- a/tools/customLinters/rubocop_dashboard_requires.rb
+++ b/tools/customLinters/rubocop_dashboard_requires.rb
@@ -2,7 +2,7 @@ module CustomCops
   # Custom cop that checks for require_relative references into the dashboard/ directory
   # from outside of dashboard/ directory
   class DashboardRequires < RuboCop::Cop::Base
-    MSG = 'Do not require dashboard code from outside of dashboard/ directory. For details, see: https://github.com/code-dot-org/code-dot-org/pull/55417'
+    MSG = 'Do not require dashboard code from outside of top-level dashboard/ directory. For details, see: https://github.com/code-dot-org/code-dot-org/pull/55417'
 
     def_node_matcher :require_relative_with_string?, <<-PATTERN
       (send nil? :require_relative (str $_))

--- a/tools/customLinters/rubocop_dashboard_requires.rb
+++ b/tools/customLinters/rubocop_dashboard_requires.rb
@@ -2,7 +2,7 @@ module CustomCops
   # Custom cop that checks for require_relative references into the dashboard/ directory
   # from outside of dashboard/ directory
   class DashboardRequires < RuboCop::Cop::Base
-    MSG = 'Do not require dashboard code from outside of dashboard/ directory.'
+    MSG = 'Do not require dashboard code from outside of dashboard/ directory. For details, see: https://github.com/code-dot-org/code-dot-org/pull/55417'
 
     def_node_matcher :require_relative_with_string?, <<-PATTERN
       (send nil? :require_relative (str $_))

--- a/tools/customLinters/rubocop_pegasus_db_usage.rb
+++ b/tools/customLinters/rubocop_pegasus_db_usage.rb
@@ -1,7 +1,7 @@
 module CustomCops
   # Custom cop that checks for use of pegasus DB outside of pegasus/ directory
   class PegasusDbUsage < RuboCop::Cop::Base
-    MSG = 'Do not access pegasus DB from outside of the top-level pegasus/ directory.'
+    MSG = 'Do not access pegasus DB from outside of the top-level pegasus/ directory. For details, see: https://github.com/code-dot-org/code-dot-org/pull/55417'
 
     def_node_matcher :pegasus_db_usage?, <<-PATTERN
       (const nil? {:PEGASUS_DB :POSTE_DB})

--- a/tools/customLinters/rubocop_pegasus_db_usage.rb
+++ b/tools/customLinters/rubocop_pegasus_db_usage.rb
@@ -1,10 +1,10 @@
 module CustomCops
-  # Custom cop that checks for use of PEGASUS_DB outside of pegasus/ directory
+  # Custom cop that checks for use of pegasus DB outside of pegasus/ directory
   class PegasusDbUsage < RuboCop::Cop::Base
-    MSG = 'Do not use PEGASUS_DB outside of pegasus/ directory.'
+    MSG = 'Do not access pegasus DB from outside of the top-level pegasus/ directory.'
 
     def_node_matcher :pegasus_db_usage?, <<-PATTERN
-      (const nil? :PEGASUS_DB)
+      (const nil? {:PEGASUS_DB :POSTE_DB})
     PATTERN
 
     def on_const(node)

--- a/tools/customLinters/rubocop_pegasus_requires.rb
+++ b/tools/customLinters/rubocop_pegasus_requires.rb
@@ -2,7 +2,7 @@ module CustomCops
   # Custom cop that checks for require_relative references into the pegasus/ directory
   # from outside of pegasus/ directory
   class PegasusRequires < RuboCop::Cop::Base
-    MSG = 'Do not require pegasus code from outside of pegasus/ directory. For details, see: https://github.com/code-dot-org/code-dot-org/pull/55417'
+    MSG = 'Do not require pegasus code from outside of top-level pegasus/ directory. For details, see: https://github.com/code-dot-org/code-dot-org/pull/55417'
 
     def_node_matcher :require_relative_with_string?, <<-PATTERN
       (send nil? :require_relative (str $_))

--- a/tools/customLinters/rubocop_pegasus_requires.rb
+++ b/tools/customLinters/rubocop_pegasus_requires.rb
@@ -2,7 +2,7 @@ module CustomCops
   # Custom cop that checks for require_relative references into the pegasus/ directory
   # from outside of pegasus/ directory
   class PegasusRequires < RuboCop::Cop::Base
-    MSG = 'Do not require pegasus code from outside of pegasus/ directory.'
+    MSG = 'Do not require pegasus code from outside of pegasus/ directory. For details, see: https://github.com/code-dot-org/code-dot-org/pull/55417'
 
     def_node_matcher :require_relative_with_string?, <<-PATTERN
       (send nil? :require_relative (str $_))


### PR DESCRIPTION
See https://github.com/code-dot-org/code-dot-org/pull/55417 for context. That PR added lint rules to prevent new direct references to DASHBOARD_DB from pegasus or to PEGASUS_DB from dashboard. This PR attempts to close a few loopholes by disallowing new usages of constants and helper methods which reference those DB constants indirectly, thus further reducing the surface area for ways that copying existing code patterns can lead to unwanted cross-service DB access.

## Testing story

* verified we are catching the new cases by updating the lint rules first, and then running rubocop to generate a to-do list of places to add exceptions
* code search to verify I didn't miss any cases (except for haml, see below)
* verified we are still catching the existing cases (DASHBOARD_DB, PEGASUS_DB) by temporarily introducing new violations and making sure they are still caught

## Follow-up work

rubocop is not currently enabled for haml, so some instances of the disallowed method names are still appearing in haml code: https://github.com/code-dot-org/code-dot-org/blob/e2415963eb142535f4158fb06b8c9f84180699e1/pegasus/sites.v3/code.org/views/header.haml#L28

follow-up work to address this here: https://github.com/code-dot-org/code-dot-org/pull/56053