### PR TITLE
Add perenual.com API for botanical data

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -99,6 +99,7 @@ class XhrProxyController < ApplicationController
     numbersapi.com
     open.mapquestapi.com
     opentdb.com
+    perenual.com
     pixabay.com
     pokeapi.co
     pro-api.coinmarketcap.com


### PR DESCRIPTION
This adds support for the perenual.com API for botanical data.

The documentation has been updated on levelbuilder, [here](https://levelbuilder-studio.code.org/docs/ide/applab/expressions/startWebRequest).  