### PR TITLE
Show deprecated message for newly deprecated songs

### DIFF
--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -16,6 +16,8 @@ const DEPRECATED_SONGS = [
   'ymca_villagepeople',
   'firework_katyperry',
   'showdaspoderosas_anitta',
+  'savagelove_jasonderulo',
+  'astronautintheocean_maskedwolf',
 ];
 
 /**


### PR DESCRIPTION
We deprecated a couple of songs at the beginning of this year in [this PR](https://github.com/code-dot-org/code-dot-org/pull/55669) -- adding them to the list of songs where we show the deprecation warning message (this message is being shown for a project with the Jason Derulo song selected):

<img width="1146" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/f768821e-2cef-4c3d-84eb-b9c55c019211">
