### PR TITLE
District page link cleanup

### DIFF
--- a/pegasus/sites.v3/code.org/public/district.redirect
+++ b/pegasus/sites.v3/code.org/public/district.redirect
@@ -1,2 +1,1 @@
-/administrators
-
+/districts

--- a/pegasus/sites.v3/code.org/public/educate/district/interest-form.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/district/interest-form.redirect
@@ -1,1 +1,1 @@
-/administrators
+/districts

--- a/pegasus/sites.v3/code.org/public/educate/district/k5-partnership.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/district/k5-partnership.redirect
@@ -1,1 +1,0 @@
-/administrators

--- a/pegasus/sites.v3/code.org/public/educate/district/k5-partnership.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/district/k5-partnership.redirect
@@ -1,0 +1,1 @@
+/districts

--- a/pegasus/sites.v3/code.org/public/educate/district/qualify.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/district/qualify.redirect
@@ -1,1 +1,0 @@
-https://code.org/administrators

--- a/pegasus/sites.v3/code.org/public/educate/district/qualify.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/district/qualify.redirect
@@ -1,0 +1,1 @@
+/districts

--- a/pegasus/sites.v3/code.org/public/educate/district/terms.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/district/terms.redirect
@@ -1,1 +1,0 @@
-https://code.org/administrators

--- a/pegasus/sites.v3/code.org/public/educate/district/terms.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/district/terms.redirect
@@ -1,0 +1,1 @@
+/districts


### PR DESCRIPTION
Cleans up and redirects some links in the `/district` folder based on this comment: https://github.com/code-dot-org/code-dot-org/pull/55895#issuecomment-1912570818

_Note:_ This list item from that comment is going to be populated with this new page: https://github.com/code-dot-org/code-dot-org/pull/55976
> code.org/district/partners should probably go to the new district recognition page

**Jira ticket:** [ACQ-1414](https://codedotorg.atlassian.net/browse/ACQ-1414)