### PR TITLE
Fix flaky Dance Party UI test

### DIFF
--- a/dashboard/test/ui/features/star_labs/dance/dance_party.feature
+++ b/dashboard/test/ui/features/star_labs/dance/dance_party.feature
@@ -84,10 +84,6 @@ Feature: Dance Party
     Then element "#runButton" is visible
     And element "#resetButton" is hidden
    
-    Then I click selector "#resetButton" once I see it
-    Then element "#runButton" is visible
-    And element "#resetButton" is hidden
-
     And I select the "How it Works (View Code)" small footer item to load a new page
     And I wait for the song selector to load
     And element "#song_selector" has value "cheapthrills_sia"

--- a/dashboard/test/ui/features/star_labs/dance/dance_party.feature
+++ b/dashboard/test/ui/features/star_labs/dance/dance_party.feature
@@ -68,9 +68,12 @@ Feature: Dance Party
 
     When I navigate to the shared version of my project
     And element ".signInOrAgeDialog" is hidden
-    # Tested level from Dance Party 2018 level 13 does not use visualization column preview.
-    # When level is shared, project level does use preview.
-    # First check run/reset buttons. This helps resolve test flakiness.
+    # We run/reset here once before checking the number of sprites below which helps
+    # resolve some not fully understood test flakiness related to Dance Party's "preview mode".
+    # The level used in this test (Dance Party 2018, level 13) does not use preview mode but
+    # when the level is shared via `project.getShareUrl`, the standalone Dance project level
+    # does use preview mode.
+
     Then I click selector "#runButton" once I see it
     Then I click selector "#resetButton" once I see it
     Then element "#runButton" is visible

--- a/dashboard/test/ui/features/star_labs/dance/dance_party.feature
+++ b/dashboard/test/ui/features/star_labs/dance/dance_party.feature
@@ -77,7 +77,7 @@ Feature: Dance Party
     And element "#resetButton" is hidden
 
     # Next check that correct number of sprites are displayed when program is run.
-    Then I click selector "#runButton" once I see it
+    Then I click selector "#runButton"
     Then I wait until element "#runButton" is not visible
     Then evaluate JavaScript expression "window.__DanceTestInterface.getSprites().length === 10"
     Then I click selector "#resetButton" once I see it

--- a/dashboard/test/ui/features/star_labs/dance/dance_party.feature
+++ b/dashboard/test/ui/features/star_labs/dance/dance_party.feature
@@ -70,20 +70,18 @@ Feature: Dance Party
     And element ".signInOrAgeDialog" is hidden
     # Tested level from Dance Party 2018 level 13 does not use visualization column preview.
     # When level is shared, project level does use preview.
-    # Click on run/reset once to resolve test flakiness.
+    # First check run/reset buttons. This helps resolve test flakiness.
     Then I click selector "#runButton" once I see it
-    Then I wait until element "#runButton" is not visible
     Then I click selector "#resetButton" once I see it
     Then element "#runButton" is visible
     And element "#resetButton" is hidden
 
+    # Next check that correct number of sprites are displayed when program is run.
     Then I click selector "#runButton" once I see it
     Then I wait until element "#runButton" is not visible
-    Then evaluate JavaScript expression "window.__DanceTestInterface.getSprites().length >= 10"
+    Then evaluate JavaScript expression "window.__DanceTestInterface.getSprites().length === 10"
     Then I click selector "#resetButton" once I see it
-    Then element "#runButton" is visible
-    And element "#resetButton" is hidden
-   
+
     And I select the "How it Works (View Code)" small footer item to load a new page
     And I wait for the song selector to load
     And element "#song_selector" has value "cheapthrills_sia"

--- a/dashboard/test/ui/features/star_labs/dance/dance_party.feature
+++ b/dashboard/test/ui/features/star_labs/dance/dance_party.feature
@@ -68,14 +68,22 @@ Feature: Dance Party
 
     When I navigate to the shared version of my project
     And element ".signInOrAgeDialog" is hidden
+    # Tested level from Dance Party 2018 level 13 does not use visualization column preview.
+    # When level is shared, project level does use preview.
+    # Click on run/reset once to resolve test flakiness.
     Then I click selector "#runButton" once I see it
     Then I wait until element "#runButton" is not visible
+    Then I click selector "#resetButton" once I see it
+    Then element "#runButton" is visible
+    And element "#resetButton" is hidden
 
-    # TODO: Fix flakiness. This test should assert that number of sprites is === to 10, not >= 10.
-    # Bug: In some automated tests, this nondeterministicaly displays doubles of the sprites. This
-    # Does not repro outside of automated testing.
+    Then I click selector "#runButton" once I see it
+    Then I wait until element "#runButton" is not visible
     Then evaluate JavaScript expression "window.__DanceTestInterface.getSprites().length >= 10"
-
+    Then I click selector "#resetButton" once I see it
+    Then element "#runButton" is visible
+    And element "#resetButton" is hidden
+   
     Then I click selector "#resetButton" once I see it
     Then element "#runButton" is visible
     And element "#resetButton" is hidden


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the `dance_party.feature` UI test to resolve the flakiness issue first reported [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1699578533080019) on Nov 9, 2023. Since this flakiness was blocking folks, https://github.com/code-dot-org/code-dot-org/pull/54876 skipped the problematic UI test scenario, and then https://github.com/code-dot-org/code-dot-org/pull/54874 updated it to check if the number of sprites displayed is `>= 10` instead of `=== 10`.
The issue was that when the project URL was in shared view, the number of sprites doubled (20 instead of 10).

![doubled](https://github.com/code-dot-org/code-dot-org/assets/107423305/32427268-1519-4e73-b06b-32e8ae6269ec)

In the Slack discussion, there was a suggestion that maybe we need to update the chrome version in testing environments. I tried updating to v109 [here](https://app.saucelabs.com/tests/1fe1f51791d742209b2c756f1eb52b37#51) but this did not resolve the doubling issue.

On the day the flakiness was first reported, https://github.com/code-dot-org/code-dot-org/pull/54792 was merged to `staging` which made updates to the `New Dance Lab Project.level` file including setting `uses_preview` to `true`.

In the 'Dance Party Share' scenario, the user first navigates to the project-backed level "http://studio.code.org/s/dance/lessons/1/levels/13". Then they copy the 'Share' url and navigate to the shared version of the project. It seems that since on the Dance Party level `uses_preview` is set to `false` while for Dance Party project  levels `uses_preview` is set to `true`, when the program is first run in 'share view' this incongruence sometimes results in the strange doubling of sprites. I am unsure why this happens in testing environments but is not able to be repro'd in other environments. Perhaps the call to [`window.__DanceTestInterface`](https://github.com/code-dot-org/code-dot-org/blob/a76eafdecf7e1054ae81805de0a9e3811150730e/apps/src/dance/Dance.js#L462) is a factor.

To fix the flakiness, I run and reset the program once. Then I run program again and test that the number of sprites displayed is correct.

## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-241)
[Slack discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1699578533080019)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
In /projects, Dance Party projects that have created sprites in the user program display thumbnail images of the preview of the project. If sprites are not created in the user program, then the default 'click to run' image is displayed.

![Screenshot 2024-01-27 at 6 36 33 PM](https://github.com/code-dot-org/code-dot-org/assets/107423305/ee100e0c-7c56-414d-9ca4-2cfa71d492ed)

![Screenshot 2024-01-27 at 6 36 40 PM](https://github.com/code-dot-org/code-dot-org/assets/107423305/0f79c7e1-5692-4d4e-8947-1aa656a21c4a)


 Now that we have the visualization column preview in Dance Party projects, I wonder if we should display the preview in ['share view'](https://github.com/code-dot-org/code-dot-org/blob/14169a2e5b32f111dd092de8011e6e183ee72c85/apps/src/dance/DanceVisualizationColumn.jsx#L111) instead of the default 'click to run' image. @samantha-code 

![Screenshot 2024-01-27 at 6 38 48 PM](https://github.com/code-dot-org/code-dot-org/assets/107423305/29fa26aa-4416-4833-8951-a2601da29f27)

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
