### PR TITLE
Update FAQ on engineering career page

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -9912,7 +9912,7 @@
   engineering_faq_answer_5_c_1: "We care deeply about each other."
   engineering_faq_answer_5_c_2: "When engineers are struggling with an issue, we step in and we help. One of our principles is that we are hard on problems, but kind to each other. We promote engineers regularly, but we don't prescribe over-engineered solutions just to support someone's promotion path. Instead, we invest in our engineers with a generous professional development budget and access to other learning opportunities."
   engineering_faq_answer_5_d_1: "We work hard, but we set clear boundaries."
-  engineering_faq_answer_5_d_2: "While we support students across the world, we hold ourselves accountable for clear boundaries between work and home life. We enjoy no-meetings Wednesdays, taking our PTO (5 weeks total, which includes an org-wide 2-week office closure at the end of the year aka Winter Break), half working day on Fridays during the summer aka Summer Fridays, and other generous benefits."
+  engineering_faq_answer_5_d_2: "While we support students across the world, we hold ourselves accountable for clear boundaries between work and home life. We enjoy no-meetings Wednesdays, 3 weeks of flexible paid time off, an additional org-wide 2-week office closure at the end of the year, and other generous benefits."
 
   careers_hero_title: "Careers"
   careers_hero_description: "Code.org is a nonprofit organization dedicated to expanding access to computer science in schools. We are especially focused on increasing participation among young women and underrepresented students."


### PR DESCRIPTION
Updates FAQ on our Engineering career page to remove the reference to summer Fridays. I'm very open to feedback on the text here -- I thought the previous version was a bit wordy and sounded a bit underwhelming without the summer Friday info. 