### PR TITLE
Replace old purple color with new purple color on code.org

### DIFF
--- a/pegasus/sites.v3/code.org/public/beyond/extended-learning.partial
+++ b/pegasus/sites.v3/code.org/public/beyond/extended-learning.partial
@@ -32,7 +32,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/csjourneys/stanford-online.png" alt="StanfordOnline logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="stanfordonline" href="https://www.edx.org/course/computer-science-101" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Computer Science 101</strong></h3></a>
+  <a class="linktag" id="stanfordonline" href="https://www.edx.org/course/computer-science-101" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Computer Science 101</strong></h3></a>
   <p><strong>Stanford University (via edX) | For university students | For beginners</strong></p>
   <p>CS101 is a self-paced course that teaches the essential ideas of Computer Science for a zero-prior-experience audience. In CS101, participants play and experiment with short bits of "computer code" to bring to life the power and limitations of computers. CS101 also provides a general background on computers today: what is a computer, what is hardware, what is software, what is the internet.</p>
   <p><i>Registration period: Rolling</i></p>
@@ -44,7 +44,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/csjourneys/udacity.png" alt="Udacity logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="udacity" href="https://www.udacity.com/course/introduction-to-python--ud1110" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Introduction to Python Programming</strong></h3></a>
+  <a class="linktag" id="udacity" href="https://www.udacity.com/course/introduction-to-python--ud1110" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Introduction to Python Programming</strong></h3></a>
   <p><strong>Udacity | For university students | For beginners</strong></p>
   <p>In this course, you'll learn the fundamentals of the Python programming language, along with programming best practices. You’ll learn to represent and store data using Python data types and variables, and use conditionals and loops to control the flow of your programs. You’ll harness the power of complex data structures like lists, sets, dictionaries, and tuples to store collections of related data. You’ll define and document your own custom functions, write scripts, and handle errors. Lastly, you’ll learn to find and use modules in the Python Standard Library and other third-party libraries.</p>
   <p><i>Registration period: Start anytime</i></p>
@@ -56,7 +56,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/csjourneys/harvard.png" alt="Harvard logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="harvard-cs50" href="https://www.edx.org/course/introduction-computer-science-harvardx-cs50x" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Harvard CS50</strong></h3></a>
+  <a class="linktag" id="harvard-cs50" href="https://www.edx.org/course/introduction-computer-science-harvardx-cs50x" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Harvard CS50</strong></h3></a>
   <p><strong>Harvard (via edX) | For university students | For beginners</strong></p>
   <p>CS50 is Harvard University's introduction to the intellectual enterprises of computer science and the art of programming. Topics include abstraction, algorithms, data structures, encapsulation, resource management, security, software engineering, and web development. Languages include C, Python, SQL, and JavaScript plus CSS and HTML. Problem sets inspired by real-world domains of biology, cryptography, finance, forensics, and gaming.</p>
   <p><i>Registration period: Rolling</i></p>
@@ -68,7 +68,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/khan_academy.png" alt="Khan Academy logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="khanacademy" href="https://www.khanacademy.org/computing/computer-programming" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Khan Academy Computer Programming courses</strong></h3></a>
+  <a class="linktag" id="khanacademy" href="https://www.khanacademy.org/computing/computer-programming" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Khan Academy Computer Programming courses</strong></h3></a>
   <p><strong>Khan Academy | For middle school and up | For beginners and advanced students</strong></p>
   <p>Learn programming languages like HTML, JavaScript and SQL. Make drawings, animations and webpages, and learn how to query and manage data.</p>
   <p><i>Registration period: Start anytime</i></p>
@@ -80,7 +80,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/odin-project.png" alt="The Odin Project logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="odin-project" href="https://www.theodinproject.com/home" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>The Odin Project</strong></h3></a>
+  <a class="linktag" id="odin-project" href="https://www.theodinproject.com/home" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>The Odin Project</strong></h3></a>
   <p><strong>The Odin Project | For high school and up | For beginners</strong></p>
   <p>The Odin Project provides a free open source coding curriculum that can be taken entirely online. Learn the foundations of web development, including HTML, CSS, JavaScript, and Ruby.</p>
   <p><i>Registration period: Start anytime</i></p>
@@ -92,7 +92,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/csjourneys/w3.png" alt="W3 Schools logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="w3schools" href="https://www.w3schools.com/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>W3 Schools</strong></h3></a>
+  <a class="linktag" id="w3schools" href="https://www.w3schools.com/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>W3 Schools</strong></h3></a>
   <p><strong>W3 Schools | For middle school and up | For beginners</strong></p>
   <p>Learn almost any programming language with these free, easy tutorials.</p>
   <p><i>Registration period: Start anytime</i></p>
@@ -113,7 +113,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/codeacademy.png" alt="Codecademy logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="codecademy" href="https://www.codecademy.com/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Codecademy</strong></h3></a>
+  <a class="linktag" id="codecademy" href="https://www.codecademy.com/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Codecademy</strong></h3></a>
   <p><strong>Codecademy | For high school and up | For beginners</strong></p>
   <p>Codecademy is an interactive learning platform used by tens of millions of students around the world. Our "Welcome to Codecademy" course is a great way to learn the basics of computer science using JavaScript. Sign up to create a free account and explore our many other free coding courses as well.</p>
   <p><i>Registration period: Start anytime</i></p>
@@ -125,7 +125,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/create-learn.png" alt="Create & Learn logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="create-learn" href="https://www.create-learn.us/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Create & Learn</strong></h3></a>
+  <a class="linktag" id="create-learn" href="https://www.create-learn.us/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Create & Learn</strong></h3></a>
   <p><strong>Create & Learn | For Grades 2 through 12 | For beginners</strong></p>
   <p>Live online computer science courses. Topics include coding, AI, data science, robotics, smart devices, coding for mobile, and digital design.</p>
   <p><i>Registration period: Rolling</i></p>
@@ -137,7 +137,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/linkedin-learning.png" alt="LinkedIn Learning logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="linkedin-learning" href="https://www.lynda.com/Developer-training-tutorials/50-0.html?utm_medium=ldc-partner&utm_source=SSPRC&utm_content=524&utm_campaign=CD14814&bid=524&aid=CD14814&opt=" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Developer Training and Tutorials</strong></h3></a>
+  <a class="linktag" id="linkedin-learning" href="https://www.lynda.com/Developer-training-tutorials/50-0.html?utm_medium=ldc-partner&utm_source=SSPRC&utm_content=524&utm_campaign=CD14814&bid=524&aid=CD14814&opt=" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Developer Training and Tutorials</strong></h3></a>
   <p><strong>LinkedIn Learning | For high school and up | For beginners</strong></p>
   <p>Learn how to code, create, and build web applications, from the foundations of object-oriented programming in C and C++, to how to write Java. Our developer tutorials can help you learn to develop and create mobile apps, work with PHP and MySQL databases, get started with the statistical processing language R, and much more.</p>
   <p><i>Registration period: Start anytime</i></p>
@@ -149,7 +149,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/educative.png" alt="Educative logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="educative" href="https://www.educative.io/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Educative.io</strong></h3></a>
+  <a class="linktag" id="educative" href="https://www.educative.io/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Educative.io</strong></h3></a>
   <p><strong>Educative.io | For high school and up | For beginners and advanced students</strong></p>
   <p>Hands-on, text-based courses that help you expand your skills in half the time, without the hassle of setup or lengthy videos. Get ready for your career in tech by exploring hundreds of our courses on topics like Coding Interview Preparation, Web Development, and top modern technologies like Cloud Computing, Containerization, and Machine Learning. Get started for FREE with our "From Scratch" Programming Language courses.</p>
   <p><i>Registration period: Start anytime</i></p>
@@ -161,7 +161,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/educode.png" alt="EduCode Academy logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="educode" href="https://educode.org/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>EduCode Academy</strong></h3></a>
+  <a class="linktag" id="educode" href="https://educode.org/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>EduCode Academy</strong></h3></a>
   <p><strong>EduCode Academy | For Grades 5-12 | For beginners and advanced students</strong></p>
   <p>Coding courses for kids, featuring real code, animated video micro-lessons, and gamified, relatable, real-world projects. Four learning paths are available: JavaScript Programming, Game Development, Web Development, and Data Science.</p>
   <p><i>Registration period: Start anytime</i></p>
@@ -173,7 +173,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/outlier.png" alt="Outlier.org logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="outlier" href="https://www.outlier.org/products/computer-science-i" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Computer Science I</strong></h3></a>
+  <a class="linktag" id="outlier" href="https://www.outlier.org/products/computer-science-i" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Computer Science I</strong></h3></a>
   <p><strong>Outlier.org | For Grades 9+ | For beginners and advanced students</strong></p>
   <p>In this groundbreaking, cinematic course taught by world-class instructors, you’ll learn about essential concepts in the Java programming language, and apply them as you analyze, write, and test real code. You’ll create your own Sudoku puzzle-solver, as well as a riveting survival game. From the basic “Hello, World!” program to recursion, you’ll develop practical skills for in-demand tech careers, such as debugging, error handling, and defensive programming. Plus, you’ll earn transferable college credits from the University of Pittsburgh, a top 50 global school.</p>
   <p><i>Registration period: Start anytime</i></p>
@@ -185,7 +185,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/udemy.png" alt="Udemy logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="udemy" href="https://www.udemy.com/courses/development/programming-languages/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Udemy</strong></h3></a>
+  <a class="linktag" id="udemy" href="https://www.udemy.com/courses/development/programming-languages/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Udemy</strong></h3></a>
   <p><strong>Udemy | For high school and up | For beginners</strong></p>
   <p>Whether you've never seen a line of code or you code for a living, Udemy has a course for you, taught by professional instructors.</p>
   <p><i>Registration period: Start anytime</i></p>

--- a/pegasus/sites.v3/code.org/public/beyond/extracurricular.partial
+++ b/pegasus/sites.v3/code.org/public/beyond/extracurricular.partial
@@ -33,7 +33,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/black_girls_code.png" alt="Black Girls CODE logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="bcg-hackathons" href="https://wearebgc.org/events/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Black Girls Code hackathons</strong></h3></a>
+  <a class="linktag" id="bcg-hackathons" href="https://wearebgc.org/events/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Black Girls Code hackathons</strong></h3></a>
   <p>Community oriented "girls only" hackathons for girls between the ages of 12 and 17. Students participate in creating solutions to social issues within their communities while they build their skills, confidence, experience and have lots of fun!</p>
   <p><i>Check event calendar for dates.</i></p>
 </div>
@@ -44,7 +44,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/congressional_app_challenge.png" alt="Congressional App Challenge logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="congr-app-challenge" href="https://www.congressionalappchallenge.us/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Congressional App Challenge</strong></h3></a>
+  <a class="linktag" id="congr-app-challenge" href="https://www.congressionalappchallenge.us/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Congressional App Challenge</strong></h3></a>
   <p>Middle and high school students create and submit original apps to their Members of Congress. Challenges are specific to congressional districts. Winning teams are recognized nationally and winning apps are put on display in the U.S. Capitol Building for one year.</p>
   <p><i>Applications due by November 1st, winners announced in December.</i></p>
 </div>
@@ -55,7 +55,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/coolest-projects.png" alt="Coolest Projects logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="coolest-project" href="https://online.coolestprojects.org/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Coolest Projects</strong></h3></a>
+  <a class="linktag" id="coolest-project" href="https://online.coolestprojects.org/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Coolest Projects</strong></h3></a>
   <p>Coolest Projects online is the world’s leading technology showcase for young people. Whether your project is a work in progress, a prototype, or completely finished, you can join in! Entry is free, and open to anyone up to the age of 18.</p>
   <p><i>Registration ends in early May.</i></p>
 </div>
@@ -66,7 +66,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/microsoft.png" alt="Microsoft logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="microsoft-imagine-cup" href="https://imaginecup.microsoft.com/en-us/junior" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Microsoft’s Imagine Cup Jr.</strong></h3></a>
+  <a class="linktag" id="microsoft-imagine-cup" href="https://imaginecup.microsoft.com/en-us/junior" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Microsoft’s Imagine Cup Jr.</strong></h3></a>
   <p>This global AI for Good challenge introduces students to Microsoft’s AI for Good initiatives, empowering them to solve a problem in the world with the power of AI.</p>
   <p><i>Submission deadline is mid-to-late May.</i></p>
 </div>
@@ -77,7 +77,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/nasa-adc.png" alt="Logo for NASA App Development Challenge">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="nasa-appdev" href="http://www.nasa.gov/education/appchallenge" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>NASA App Development Challenge</strong></h3></a>
+  <a class="linktag" id="nasa-appdev" href="http://www.nasa.gov/education/appchallenge" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>NASA App Development Challenge</strong></h3></a>
   <p>The NASA App Development Challenge (ADC) is a coding challenge in which NASA presents technical problems to middle and high school students seeking student contributions to future deep space exploration missions. By responding to the ADC, students take a part directly in the Artemis Generation endeavors to land American astronauts, including the first woman and first person of color on the Moon.</p>
   <p><i>Team registration closes September 28th.</i></p>
 </div>
@@ -88,7 +88,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/technovation.png" alt="Technovation logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="technovation" href="https://technovationchallenge.org/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Technovation Challenge</strong></h3></a>
+  <a class="linktag" id="technovation" href="https://technovationchallenge.org/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Technovation Challenge</strong></h3></a>
   <p>With the support of volunteer mentors, girls work in teams to code mobile apps that address real-world problems. Open to girls and young women ages 10-18.</p>
   <p><i>Register between October and March. Winners announced in late June or early July.</i></p>
 </div>
@@ -107,7 +107,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/coderdojo.png" alt="CoderDojo logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="coderdojo" href="https://coderdojo.com/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>CoderDojo</strong></h3></a>
+  <a class="linktag" id="coderdojo" href="https://coderdojo.com/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>CoderDojo</strong></h3></a>
   <p>A global network of free, volunteer-led, community-based programming clubs for young people. Anyone aged 7-17 can visit a Dojo where they can learn to code, build a website, create an app or a game, and explore technology in an informal, creative, and social environment.</p>
   <p><i>Join anytime.</i></p>
 </div>
@@ -118,7 +118,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/girls_who_code.png" alt="Girls Who Code logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="girlswhocode-clubs" href="https://girlswhocode.com/programs/clubs-program" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Girls Who Code</strong></h3></a>
+  <a class="linktag" id="girlswhocode-clubs" href="https://girlswhocode.com/programs/clubs-program" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Girls Who Code</strong></h3></a>
   <p>Clubs are free after-school programs for 3rd-5th and 6th-12th grade girls to join our sisterhood of supportive peers and role models using computer science to change the world. There are Clubs in all 50 states and applications are open year-round! Start a Club by visiting <a href="https://girlswhocode.com/clubsapply" target="_blank">girlswhocode.com/clubsapply</a> or find one to join in your local area at <a href="https://girlswhocode.com/locations" target="_blank">girlswhocode.com/locations</a></p>
   <p><i>Join anytime.</i></p>
 </div>
@@ -129,7 +129,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/google.png" alt="Google logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="google-codenext" href="https://codenext.withgoogle.com/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Google Code Next</strong></h3></a>
+  <a class="linktag" id="google-codenext" href="https://codenext.withgoogle.com/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Google Code Next</strong></h3></a>
   <p>Code Next is a free, computer science education program that meets Black and Hispanic/Latino high school students in their own communities and provides the skills and inspiration they need for long and rewarding careers in computer science-related fields. Learn computer science, plug in with a mentor, and work on impactful projects.</p>
   <p><i>Clubs run quarterly and last approximately 9 weeks.</i></p>
 </div>
@@ -140,7 +140,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/techgirlz.png" alt=" logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="techgirlz" href="https://www.techgirlz.org/techshopz/category/workshops/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Techgirlz Workshops</strong></h3></a>
+  <a class="linktag" id="techgirlz" href="https://www.techgirlz.org/techshopz/category/workshops/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Techgirlz Workshops</strong></h3></a>
   <p>TechShopz are free, hands-on technology workshops for middle school girls. There are 50 topics to choose including coding, movie editing, jewelry design, digital marketing, cybersecurity, and more!​</p>
   <p><i>View calendar for workshop dates.</i></p>
 </div>
@@ -158,7 +158,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/microsoft.png" alt="Microsoft logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="msft-digigirlz" href="https://www.microsoft.com/en-us/diversity/programs/digigirlz/default.aspx" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Digigirlz at Microsoft</strong></h3></a>
+  <a class="linktag" id="msft-digigirlz" href="https://www.microsoft.com/en-us/diversity/programs/digigirlz/default.aspx" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Digigirlz at Microsoft</strong></h3></a>
   <p>Middle and high school girls learn about careers in technology, connect with Microsoft employees, and participate in hands-on computer and technology workshops.</p>
   <p><i>Check calendar for dates.</i></p>
 </div>
@@ -169,7 +169,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/girls_who_code.png" alt="Girls Who Code logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="girlswhocode-immersion" href="https://girlswhocode.com/programs/summer-immersion-program" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Girls Who Code Summer Immersion</strong></h3></a>
+  <a class="linktag" id="girlswhocode-immersion" href="https://girlswhocode.com/programs/summer-immersion-program" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Girls Who Code Summer Immersion</strong></h3></a>
   <p>Girls Who Code's Summer Immersion Program is a 2-week opportunity available to rising sophomore, junior, and seniors. Participants learn the computer science skills they need to make an impact in their community while preparing for a career in tech. They will get exposure to tech jobs, meet women in tech careers, and join a supportive sisterhood of girls in tech. No prior computer science experience is required.</p>
   <p><i>Applications are open in the spring.</i></p>
 </div>
@@ -180,7 +180,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/google.png" alt="Google logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="google-cssi" href="https://buildyourfuture.withgoogle.com/programs/computer-science-summer-institute/#!?detail-content-tabby_activeEl=overview" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Google’s Computer Science Summer Institute</strong></h3></a>
+  <a class="linktag" id="google-cssi" href="https://buildyourfuture.withgoogle.com/programs/computer-science-summer-institute/#!?detail-content-tabby_activeEl=overview" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Google’s Computer Science Summer Institute</strong></h3></a>
   <p>At CSSI: Online, students will learn programming fundamentals directly from Google engineers, get an inside look at some of Google's most exciting technologies, and even design and develop their very own application with fellow participants that will be showcased to Googlers. Open to rising college freshmen.</p>
   <p><i>Applications are open in the spring.</i></p>
 </div>
@@ -191,7 +191,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/hack-the-hood.png" alt="Hack the Hood logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="hackthehood" href="https://www.hackthehood.org/programs" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Hack the Hood</strong></h3></a>
+  <a class="linktag" id="hackthehood" href="https://www.hackthehood.org/programs" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Hack the Hood</strong></h3></a>
   <p>Learn in-demand tech skills and launch your career with Hack the Hood’s immersion programs. For Black, Hispanic/Latino, and Indigenous learners aged 16-25.</p>
   <p><i>Program dates vary. Applications are open April-June.</i></p>
 </div>

--- a/pegasus/sites.v3/code.org/public/beyond/index.partial
+++ b/pegasus/sites.v3/code.org/public/beyond/index.partial
@@ -24,7 +24,7 @@ social:
   </a>
 </div>
 
-<div class="col-33" style="padding:15px; border-radius:15px; border:10px solid white; background-color:#7665a0; text-align:center">
+<div class="col-33" style="padding:15px; border-radius:15px; border:10px solid white; background-color:var(--brand_secondary_default); text-align:center">
   <a class="linktag" id="mentorships" href="/beyond/mentors-and-community" style="text-decoration:none" target="_blank">
   <h3 style="color:#ffffff; margin-top:12px"><strong>Mentorships and community</strong></h3>
   <img src="/images/csjourneys/mentorships.jpg" style="width:100%" alt="mentorships">

--- a/pegasus/sites.v3/code.org/public/beyond/internships.partial
+++ b/pegasus/sites.v3/code.org/public/beyond/internships.partial
@@ -33,7 +33,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/apprenti.png" alt="Apprenti logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="apprenti" href="https://apprenticareers.org/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Apprenti</strong></h3></a>
+  <a class="linktag" id="apprenti" href="https://apprenticareers.org/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Apprenti</strong></h3></a>
   <p>Technical training and year-long paid apprenticeships at tech companies for students looking for an alternative to college</p>
   <p><i>Application period: Rolling</i></p>
 </div>
@@ -44,7 +44,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/multiverse.png" alt="Multiverse.io logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="multiverse" href="https://www.multiverse.io/en-US/young-adults" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Multiverse.io</strong></h3></a>
+  <a class="linktag" id="multiverse" href="https://www.multiverse.io/en-US/young-adults" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Multiverse.io</strong></h3></a>
   <p>Paid CS apprenticeships at top companies and career development for students looking for an alternative to college</p>
   <p><i>Application period: Rolling</i></p>
 </div>
@@ -55,7 +55,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/npower.png" alt="NPower logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="npower" href="https://www.npower.org/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>NPower</strong></h3></a>
+  <a class="linktag" id="npower" href="https://www.npower.org/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>NPower</strong></h3></a>
   <p>Work-study program in select states for military veterans and students from underserved communities</p>
   <p><i>Application period: Rolling</i></p>
 </div>
@@ -66,7 +66,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/year-up.png" alt="Year Up logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="year-up" href="https://www.yearup.org/students" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Year Up</strong></h3></a>
+  <a class="linktag" id="year-up" href="https://www.yearup.org/students" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Year Up</strong></h3></a>
   <p>Year-long program includes six months of technical training and a six-month corporate internship</p>
   <p><i>Application period: Rolling</i></p>
 </div>
@@ -85,7 +85,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/code2040.png" alt="Code2040 logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="code2040" href="https://www.code2040.org/fellows-program" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Code2040 Fellows Program</strong></h3></a>
+  <a class="linktag" id="code2040" href="https://www.code2040.org/fellows-program" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Code2040 Fellows Program</strong></h3></a>
   <p>Summer internships at tech companies for Black and Hispanic/Latino college students</p>
   <p><i>Application period: June-July</i></p>
 </div>
@@ -96,7 +96,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/infosys-instep.png" alt="InStep from Infosys logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="infosys-instep" href="https://www.infosys.com/instep.html" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>InStep from Infosys</strong></h3></a>
+  <a class="linktag" id="infosys-instep" href="https://www.infosys.com/instep.html" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>InStep from Infosys</strong></h3></a>
   <p>Internships across the globe with opportunities spanning artificial intelligence, sustainability, big data, and more</p>
   <p><i>Application period: Year-round</i></p>
 </div>
@@ -107,7 +107,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/microsoft.png" alt="Microsoft logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="microsoft-internship-college" href="https://careers.microsoft.com/students/us/en/usuniversityinternship" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Microsoft internships</strong></h3></a>
+  <a class="linktag" id="microsoft-internship-college" href="https://careers.microsoft.com/students/us/en/usuniversityinternship" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Microsoft internships</strong></h3></a>
   <p>Paid internship opportunities in software engineering, UX design, data science, and more</p>
   <p><i>Application period: Varies</i></p>
 </div>
@@ -128,7 +128,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/genesys-works.png" alt="Genesys Works logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="genesys-works" href="https://genesysworks.org/for-students/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Genesys Works</strong></h3></a>
+  <a class="linktag" id="genesys-works" href="https://genesysworks.org/for-students/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Genesys Works</strong></h3></a>
   <p>Year-long program for high school students includes technical training and a paid corporate internship</p>
   <p><i>Application period: January-March</i></p>
 </div>
@@ -139,7 +139,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/microsoft.png" alt="Microsoft logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="microsoft-internship-highschool" href="https://careers.microsoft.com/students/us/en/ushighschoolprogram" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Microsoft internships for high school students</strong></h3></a>
+  <a class="linktag" id="microsoft-internship-highschool" href="https://careers.microsoft.com/students/us/en/ushighschoolprogram" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Microsoft internships for high school students</strong></h3></a>
   <p>On-the-job learning and opportunities to contribute to real-world technology projects at Microsoft</p>
   <p><i>Application period: Varies</i></p>
 </div>

--- a/pegasus/sites.v3/code.org/public/beyond/mentors-and-community.partial
+++ b/pegasus/sites.v3/code.org/public/beyond/mentors-and-community.partial
@@ -37,7 +37,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/aises.png" alt="AISES logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="aises" href="https://www.aises.org/students" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>American Indian Science & Engineering Society</strong></h3></a>
+  <a class="linktag" id="aises" href="https://www.aises.org/students" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>American Indian Science & Engineering Society</strong></h3></a>
   <p>Membership includes networking and career development opportunities, events, internship and scholarship opportunities, exclusive job board access, and a national conference. Membership is free for pre-college and college students.</p>
   <p><i>Application period: Join anytime</i></p>
 </div>
@@ -48,7 +48,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/natives-in-tech.png" alt="Natives in Tech logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="natives-in-tech" href="https://nativesintech.org/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Natives in Tech</strong></h3></a>
+  <a class="linktag" id="natives-in-tech" href="https://nativesintech.org/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Natives in Tech</strong></h3></a>
   <p>Online community, yearly conference, and opportunities to collaborate on projects.</p>
   <p><i>Application period: Join anytime</i></p>
 </div>
@@ -59,7 +59,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/natives-rising.png" alt="Natives Rising logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="natives-rising" href="http://www.joinnativesrising.com/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Natives Rising</strong></h3></a>
+  <a class="linktag" id="natives-rising" href="http://www.joinnativesrising.com/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Natives Rising</strong></h3></a>
   <p>Natives Rising promotes visibility of Native Americans in the tech industry, highlighting their accomplishments, and provides mentorship, job training, and networking opportunities for Native Americans interested in tech.</p>
   <p><i>Application period: Join anytime</i></p>
 </div>
@@ -77,7 +77,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/nsbe.png" alt="NSBE logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="nsbe" href="https://www.nsbe.org/membership/nsbe-jr-membership" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>National Society of Black Engineers</strong></h3></a>
+  <a class="linktag" id="nsbe" href="https://www.nsbe.org/membership/nsbe-jr-membership" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>National Society of Black Engineers</strong></h3></a>
   <p>Membership includes tutorial programs, group study sessions, high school/junior high outreach programs, technical seminars and workshops, a national communications network, banquets, an annual national convention, and more.</p>
   <p><i>Application period: Join anytime</i></p>
 </div>
@@ -88,7 +88,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/black_girls_code.png" alt="Black Girls CODE logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="blackgirlscode" href="https://wearebgc.org/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Black Girls CODE</strong></h3></a>
+  <a class="linktag" id="blackgirlscode" href="https://wearebgc.org/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Black Girls CODE</strong></h3></a>
   <p>Workshops and after-school programs for young girls of color. Operates in select states.</p>
   <p><i>Application period: Join anytime</i></p>
 </div>
@@ -106,7 +106,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/shpe.png" alt="SHPE logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="shpe" href="https://shpe.org/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Society of Hispanic Professionals</strong></h3></a>
+  <a class="linktag" id="shpe" href="https://shpe.org/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Society of Hispanic Professionals</strong></h3></a>
   <p>Membership includes events for students and professionals at all levels, access to cybersecurity courses and certifications, professional development webinars and courses, reading groups, and more.</p>
   <p><i>Application period: Join anytime</i></p>
 </div>
@@ -117,7 +117,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/technolochicas.png" alt="TECHNOlochicas logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="technolochicas" href="https://technolochicas.org/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>TECHNOLOchicas</strong></h3></a>
+  <a class="linktag" id="technolochicas" href="https://technolochicas.org/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>TECHNOLOchicas</strong></h3></a>
   <p>TECHNOLOchicas Ambassadors serve as role models in their communities to inspire the future generation of tech innovators.</p>
   <p><i>Application period: Join anytime</i></p>
 </div>
@@ -135,7 +135,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/girls_who_code.png" alt="Girls Who Code logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="girlswhocode-loops" href="https://girlswhocode.com/college-loops" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Girls Who Code College Loops</strong></h3></a>
+  <a class="linktag" id="girlswhocode-loops" href="https://girlswhocode.com/college-loops" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Girls Who Code College Loops</strong></h3></a>
   <p>College Loops are university-level networks for college-aged women interested in tech to support one another and help each other persist and succeed in the field. College Loops build belonging and community through weekly meetings during the school year. Find a College Loop near you by visiting <a href="https://girlswhocode.com/locations" target="_blank">girlswhocode.com/locations</a></p>
   <p><i>Application period: Join anytime</i></p>
 </div>
@@ -146,7 +146,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/rtc.png" alt="Rewriting the Code logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="rewritingthecode" href="https://rewritingthecode.org/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Rewriting the Code</strong></h3></a>
+  <a class="linktag" id="rewritingthecode" href="https://rewritingthecode.org/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Rewriting the Code</strong></h3></a>
   <p>The High School Bridge program connects rising college freshmen with a community of peers. Also includes technical training, career pathway exploration, and mentorships.</p>
   <p><i>Application period: April-May</i></p>
 </div>
@@ -157,7 +157,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/swe.png" alt="SWE logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="swe" href="https://swe.org/membership/benefits//" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Society of Women Engineers</strong></h3></a>
+  <a class="linktag" id="swe" href="https://swe.org/membership/benefits//" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Society of Women Engineers</strong></h3></a>
   <p>Membership includes training and development programs, networking opportunities, scholarships, and outreach and advocacy activities.</p>
   <p><i>Application period: Join anytime</i></p>
 </div>
@@ -168,7 +168,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/anitab.png" alt="AnitaB.org logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="systers" href="https://anitab.org/our-communities/systers/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Systers (AnitaB.org)</strong></h3></a>
+  <a class="linktag" id="systers" href="https://anitab.org/our-communities/systers/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Systers (AnitaB.org)</strong></h3></a>
   <p>Email community of women in technical computing roles. Members gain support by networking, sharing advice and experiences, and collaborating on various projects.</p>
   <p><i>Application period: Join anytime</i></p>
 </div>
@@ -186,7 +186,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/accesscomputing.png" alt="AccessComputing logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="accesscomputingteam" href="https://www.washington.edu/accesscomputing/accesscomputing-team-application" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>AccessComputing Team</strong></h3></a>
+  <a class="linktag" id="accesscomputingteam" href="https://www.washington.edu/accesscomputing/accesscomputing-team-application" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>AccessComputing Team</strong></h3></a>
   <p>Students with disabilities in computing fields can join the AccessComputing team.  Team members participate in an online mentoring community, learn about scholarship and internship opportunities, and are eligible to request funding for conference attendance, tutoring, and more.</p>
   <p><i>Application period: Join anytime</i></p>
 </div>
@@ -205,7 +205,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/association_for_computing_machinery.png" alt="ACM logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="acm" href="https://www.acm.org/membership/membership-benefits" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Association for Computing Machinery</strong></h3></a>
+  <a class="linktag" id="acm" href="https://www.acm.org/membership/membership-benefits" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Association for Computing Machinery</strong></h3></a>
   <p>ACM membership offers resources to help you shape the future – with lifelong learning programs, publications providing original research and practical content, special interest groups and local chapters to meet peers, delve deeper into technical areas, and leadership opportunities on stimulating projects.</p>
   <p><i>Application period: Join anytime</i></p>
 </div>
@@ -216,7 +216,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/codepath.png" alt="CodePath logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="codepath" href="https://codepath.org/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>CodePath.org</strong></h3></a>
+  <a class="linktag" id="codepath" href="https://codepath.org/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>CodePath.org</strong></h3></a>
   <p>CodePath transforms computer science education for women and underrepresented minorities across over 200 colleges and universities. By working closely with partners like Andreessen Horowitz, Cognizant, Facebook, Microsoft, and Walmart, we offer supplemental CS courses and career services to create successful pathways for students to enter and prosper in tech. To learn more, visit <a href="http://www.codepath.org/" target="_blank">www.codepath.org</a>.</p>
   <p><i>Application period: Varies</i></p>
 </div>
@@ -227,7 +227,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/ieee.png" alt="IEEE logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="ieee" href="https://students.ieee.org/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Institute of Electrical and Electronics Engineers</strong></h3></a>
+  <a class="linktag" id="ieee" href="https://students.ieee.org/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Institute of Electrical and Electronics Engineers</strong></h3></a>
   <p>Membership includes networking opportunities, job and internship opportunities, local events, and a national conference.</p>
   <p><i>Application period: Join anytime</i></p>
 </div>

--- a/pegasus/sites.v3/code.org/public/beyond/scholarships.partial
+++ b/pegasus/sites.v3/code.org/public/beyond/scholarships.partial
@@ -29,19 +29,19 @@ social:
   <h2 style="margin-top:10px; margin-bottom:0; color:#ffffff">Search for scholarships:</h2>
 </div>
 <div class="col-100" style="padding:25px; border: 1px solid var(--brand_primary_default); border-radius:0 0 15px 15px; border-top:none">
-<a class="linktag" id="careeronestop-scholar" href="https://www.careeronestop.org/toolkit/training/find-scholarships.aspx" target="_blank"><h3 style="color:#7665a0"><strong>CareerOneStop’s scholarship finder</strong></h3></a>
+<a class="linktag" id="careeronestop-scholar" href="https://www.careeronestop.org/toolkit/training/find-scholarships.aspx" target="_blank"><h3 style="color:var(--brand_secondary_default)"><strong>CareerOneStop’s scholarship finder</strong></h3></a>
 <p>Searchable database of college scholarships from the U.S. Department of Labor. Use keywords to search, or sort using filters.</p>
 
-<a class="linktag" id="niche-scholarships" href="https://www.niche.com/colleges/scholarships/" target="_blank"><h3 style="color:#7665a0"><strong>Niche’s scholarship finder</strong></h3></a>
+<a class="linktag" id="niche-scholarships" href="https://www.niche.com/colleges/scholarships/" target="_blank"><h3 style="color:var(--brand_secondary_default)"><strong>Niche’s scholarship finder</strong></h3></a>
 <p>Searchable database of college scholarships from Niche. Sort using filters.</p>
 
-<a class="linktag" id="college-scholarships" href="http://www.collegescholarships.org/financial-aid/" target="_blank"><h3 style="color:#7665a0"><strong>CollegeScholarships.org</strong></h3></a>
+<a class="linktag" id="college-scholarships" href="http://www.collegescholarships.org/financial-aid/" target="_blank"><h3 style="color:var(--brand_secondary_default)"><strong>CollegeScholarships.org</strong></h3></a>
 <p>Searchable database of college scholarships. Use keywords to search, or sort using filters.</p>
 
-<a class="linktag" id="cs-org-scholarships" href="https://www.computerscience.org/scholarships-overview/" target="_blank"><h3 style="color:#7665a0"><strong>ComputerScience.org</strong></h3></a>
+<a class="linktag" id="cs-org-scholarships" href="https://www.computerscience.org/scholarships-overview/" target="_blank"><h3 style="color:var(--brand_secondary_default)"><strong>ComputerScience.org</strong></h3></a>
 <p>Curated list of computer science scholarships.</p>
 
-<a class="linktag" id="scholarships-com" href="https://www.scholarships.com/financial-aid/college-scholarships/scholarships-by-major/computer-science-scholarships/" target="_blank"><h3 style="color:#7665a0"><strong>Scholarships.com</strong></h3></a>
+<a class="linktag" id="scholarships-com" href="https://www.scholarships.com/financial-aid/college-scholarships/scholarships-by-major/computer-science-scholarships/" target="_blank"><h3 style="color:var(--brand_secondary_default)"><strong>Scholarships.com</strong></h3></a>
 <p>Comprehensive list of computer science scholarships.</p>
 </div>
 
@@ -57,7 +57,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/afe.png" alt="Amazon Future Engineer logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="afe" href="https://www.amazonfutureengineer.com/scholarships?utm_campaign=Code%20.org&utm_medium=Scholarship&utm_source=US" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Amazon Future Engineer</strong></h3></a>
+  <a class="linktag" id="afe" href="https://www.amazonfutureengineer.com/scholarships?utm_campaign=Code%20.org&utm_medium=Scholarship&utm_source=US" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Amazon Future Engineer</strong></h3></a>
   <p>A serious 2-for-1 opportunity for students like you. $40,000 for college and a paid programming internship at Amazon for high school students from underserved and historically underrepresented backgrounds planning to major in CS.</p>
   <p><i>Application period: October 2-December 15</i></p>
 </div>
@@ -68,7 +68,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/natives-in-tech.png" alt="Natives in Tech logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="nucamp_nit" href="https://www.nucamp.co/scholarships/nativesintech" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Natives in Tech + Nucamp Scholarship</strong></h3></a>
+  <a class="linktag" id="nucamp_nit" href="https://www.nucamp.co/scholarships/nativesintech" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Natives in Tech + Nucamp Scholarship</strong></h3></a>
   <p>$50,000 scholarship fund to prepare and launch more Native technologists into high-demand coding careers. Beyond inclusion within Nucamp’s national network of coders, students will engage with Natives in Tech’s growing community for networking and support. Any verified member of a federally recognized tribal nation at least 18 years old is eligible for this scholarship.</p>
   <p><i>Application period: First come, first serve until fund is depleted</i></p>
 </div>
@@ -79,7 +79,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/aises.png" alt="AISES logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="aises-scholarships" href="https://www.aises.org/students/scholarships" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>American Indian Science and Engineering Society Scholarships</strong></h3></a>
+  <a class="linktag" id="aises-scholarships" href="https://www.aises.org/students/scholarships" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>American Indian Science and Engineering Society Scholarships</strong></h3></a>
   <p>AISES offers a number of scholarships that help students acquire skills and training that will help them meet the unique STEM needs of their communities. <i>Students must be members of AISES to apply.</i></p>
   <p><i>Application period: varies</i></p>
 </div>
@@ -90,7 +90,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/google.png" alt="Google logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="google-scholarships" href="https://buildyourfuture.withgoogle.com/scholarships/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Scholarships from Google</strong></h3></a>
+  <a class="linktag" id="google-scholarships" href="https://buildyourfuture.withgoogle.com/scholarships/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Scholarships from Google</strong></h3></a>
   <p>Google offers a number of scholarships to students that identify with groups historically excluded from the technology industry.</p>
   <p><i>Application period: varies</i></p>
 </div>
@@ -101,7 +101,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/beyond/swe.png" alt="SWE logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="swe-scholarships" href="https://swe.org/scholarships/" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Scholarships from Society of Women Engineers</strong></h3></a>
+  <a class="linktag" id="swe-scholarships" href="https://swe.org/scholarships/" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Scholarships from Society of Women Engineers</strong></h3></a>
   <p>SWE Scholarships support those who identify as a female/woman and are pursuing an ABET-accredited bachelor or graduate student program in preparation for careers in engineering, engineering technology and computer science globally.</p>
   <p><i>Application period: March-May for incoming college freshmen</i></p>
 </div>
@@ -112,7 +112,7 @@ social:
   <img style="width: 12%; float: left; margin-top: 1%; margin-right: 2%" src="/images/avatars/microsoft.png" alt="Microsoft logo">
 </a>
 <div style="width: 85%; float: left">
-  <a class="linktag" id="msft-bam-scholarships" href="https://www.microsoft.com/en-us/diversity/programs/blacks-scholarships.aspx" target="_blank"><h3 style="margin-top:0; color:#7665a0"><strong>Blacks at Microsoft Scholarship</strong></h3></a>
+  <a class="linktag" id="msft-bam-scholarships" href="https://www.microsoft.com/en-us/diversity/programs/blacks-scholarships.aspx" target="_blank"><h3 style="margin-top:0; color:var(--brand_secondary_default)"><strong>Blacks at Microsoft Scholarship</strong></h3></a>
   <p>The Blacks at Microsoft (BAM) group offers a number of scholarships to high school students of African descent planning on majoring in engineering, computer science, or business.</p>
   <p><i>Application period: November-March</i></p>
 </div>

--- a/pegasus/sites.v3/code.org/public/break.md.partial
+++ b/pegasus/sites.v3/code.org/public/break.md.partial
@@ -48,7 +48,7 @@ social:
 <div style="clear: both;"></div>
 <a id="activities"></a>
 
-<div style="background-color: #7665a0; margin-top:50px;"><h1 style="color: #FFFFFF; padding-top: 15px; padding-bottom: 15px; padding-left: 10px; padding-right: 10px;">Weekly Activities &amp; Past Episodes</h1></div>
+<div style="background-color: var(--brand_secondary_default); margin-top:50px;"><h1 style="color: #FFFFFF; padding-top: 15px; padding-bottom: 15px; padding-left: 10px; padding-right: 10px;">Weekly Activities &amp; Past Episodes</h1></div>
 <h2>Episode 1 - Algorithms with Hill Harper</h2>
 <div class="col-33" style="padding-right:20px;">
 <h4 style="background:var(--brand_primary_default);color:#ffffff; padding:8px;">Watch the 3/25 episode</h4>

--- a/pegasus/sites.v3/code.org/public/careers-with-cs/index.md.partial
+++ b/pegasus/sites.v3/code.org/public/careers-with-cs/index.md.partial
@@ -28,7 +28,7 @@ social:
   <a class="linktag" id="videos-nav" href="#videos" style="text-decoration:none"><p style="color:#ffffff; margin:0; text-decoration:none">Watch videos about different careers with CS</p></a>
 </div>
 
-<div class="col-25" style="padding:15px; border-radius:15px; border:10px solid white; background-color:#7665a0">
+<div class="col-25" style="padding:15px; border-radius:15px; border:10px solid white; background-color:var(--brand_secondary_default)">
   <a class="linktag" id="explore-nav" href="#explore" style="text-decoration:none"><p style="color:#ffffff; margin:0; text-decoration:none">Find a career that matches your interests</p>
 </div>
 

--- a/pegasus/sites.v3/code.org/public/csforgood.md.partial
+++ b/pegasus/sites.v3/code.org/public/csforgood.md.partial
@@ -93,7 +93,7 @@ social:
 
 <a href="https://code.org/oceans" target="_blank"><img src="/images/tutorials/hoc2019/oceans.png" style="width: 100%"></a>
 <br>
-<a href="https://code.org/oceans" target="_blank"><h3 style="color:#7665a0"><strong>AI for Oceans</strong></h3></a>
+<a href="https://code.org/oceans" target="_blank"><h3 style="color:var(--brand_secondary_default)"><strong>AI for Oceans</strong></h3></a>
 <p>Computer science is about so much more than coding! Learn about AI, machine learning, training data, and bias, while exploring ethical issues and how AI can be used to address world problems.</p>
 <p><i>From Code.org. For grades 3 and up.</i></p>
 
@@ -103,7 +103,7 @@ social:
 
 <a href="https://aka.ms/HourofCode2020" target="_blank"><img src="/images/tutorials/hoc2020/mee_empathy.jpg" style="width: 100%"></a>
 <br>
-<a href="https://aka.ms/HourofCode2020" target="_blank"><h3 style="color:#7665a0"><strong>A Minecraft Tale of Two Villages</strong></h3></a>
+<a href="https://aka.ms/HourofCode2020" target="_blank"><h3 style="color:var(--brand_secondary_default)"><strong>A Minecraft Tale of Two Villages</strong></h3></a>
 <p>Use the power of code to bring two villages together. Players will experience empathy and compassion for their neighbors, learn cooperation and inclusion, and embrace the diversity that makes us all uniquely special.</p>
 <p><i>From Minecraft Education. For grades 2 and up.</i></p>
 
@@ -113,7 +113,7 @@ social:
 
 <a href="https://csfirst.withgoogle.com/c/cs-first/en/cs-first-unplugged/cs-first-unplugged/introduction-to-cs-first-unplugged.html" target="_blank"><img src="/images/tutorials/hoc2020/csfirst_unplugged.png" style="width: 100%"></a>
 <br>
-<a href="https://csfirst.withgoogle.com/c/cs-first/en/cs-first-unplugged/cs-first-unplugged/introduction-to-cs-first-unplugged.html" target="_blank"><h3 style="color:#7665a0"><strong>CS First Unplugged</strong></h3></a>
+<a href="https://csfirst.withgoogle.com/c/cs-first/en/cs-first-unplugged/cs-first-unplugged/introduction-to-cs-first-unplugged.html" target="_blank"><h3 style="color:var(--brand_secondary_default)"><strong>CS First Unplugged</strong></h3></a>
 <p>No computer or internet? No problem. Try the CS First Unplugged activities to explore how computer science can solve problems like helping people stay connected while apart. "Plugged in" Scratch activities are available too!</p>
 <p><i>From Google. For grades 2 through 8.</i></p>
 

--- a/pegasus/sites.v3/code.org/public/csjourneys/nextsteps.md
+++ b/pegasus/sites.v3/code.org/public/csjourneys/nextsteps.md
@@ -75,7 +75,7 @@ social:
   </div>
   <div style="clear: both"></div>
 <br>
-  <div class="col-50" style="margin-bottom:10px; background-color: #7665a0; border-radius:25px; padding:25px; border:10px solid white">
+  <div class="col-50" style="margin-bottom:10px; background-color: var(--brand_secondary_default); border-radius:25px; padding:25px; border:10px solid white">
     <h3 style="color:#ffffff; margin-top:0">Before you watch:</h3>
     <ul style="color:#ffffff; margin-bottom:0">
         <li style="color:#ffffff">Give students time in class to <a href="https://code.org/careers-with-cs" target="_blank" style="color:#ffffff">explore career pathways</a> and encourage them to write down questions they have.</li><br>
@@ -138,7 +138,7 @@ social:
   </div>
   <div style="clear: both"></div>
 <br>
-<div class="col-50" style="margin-bottom:10px; background-color: #7665a0; border-radius:25px; padding:25px; border:10px solid white">
+<div class="col-50" style="margin-bottom:10px; background-color: var(--brand_secondary_default); border-radius:25px; padding:25px; border:10px solid white">
     <h3 style="color:#ffffff; margin-top:0">Before you watch:</h3>
     <ul style="color:#ffffff; margin-bottom:0">
         <li style="color:#ffffff">Have students think of which careers/majors they are interested in and write them down. If there’s time, encourage them to do a little research into that major or career.</li><br>
@@ -194,7 +194,7 @@ social:
   </div>
   <div style="clear: both"></div>
 <br>
-  <div class="col-50" style="margin-bottom:10px; background-color: #7665a0; border-radius:25px; padding:25px; border:10px solid white">
+  <div class="col-50" style="margin-bottom:10px; background-color: var(--brand_secondary_default); border-radius:25px; padding:25px; border:10px solid white">
     <h3 style="color:#ffffff; margin-top:0">Before you watch:</h3>
     <ul style="color:#ffffff; margin-bottom:0">
         <li style="color:#ffffff">Give students time in class to generate a list of goals for their future. These could be career goals (become an engineer, start a company), and/or personal goals (start a family, buy a house). The more specific their goals, the better.</li><br>
@@ -260,7 +260,7 @@ social:
   </div>
   <div style="clear: both"></div>
 <br>
-  <div class="col-50" style="margin-bottom:10px; background-color: #7665a0; border-radius:25px; padding:25px; border:10px solid white">
+  <div class="col-50" style="margin-bottom:10px; background-color: var(--brand_secondary_default); border-radius:25px; padding:25px; border:10px solid white">
     <h3 style="color:#ffffff; margin-top:0">Before you watch:</h3>
     <ul style="color:#ffffff; margin-bottom:0">
         <li style="color:#ffffff">Have students read through the responses to the question posed by another student on CareerVillage.org, “<a href="https://www.careervillage.org/questions/459689/is-it-possible-to-get-a-good-job-in-computer-science-without-a-strong-network" target="_blank" style="color:#ffffff">Is it possible to get a good job in Computer Science without a strong network?</a>” Have them write down some of the key answers that strike them, and then discuss as a class. If there’s time, give students an opportunity to explore more questions about networking on CareerVillage.org.</li><br>

--- a/pegasus/sites.v3/code.org/public/css/careers-greenhouse.scss
+++ b/pegasus/sites.v3/code.org/public/css/careers-greenhouse.scss
@@ -40,7 +40,7 @@
   margin-bottom: 18px;
 
   a {
-    color: #7665a0;
+    color: var(--brand_secondary_default);
     font-size: 14px;
   }
 }

--- a/pegasus/sites.v3/code.org/public/css/careers.css
+++ b/pegasus/sites.v3/code.org/public/css/careers.css
@@ -138,11 +138,11 @@
 }
 
 .careers__benefit--purple {
-  background: linear-gradient(90deg, #7665a0, #5f5988);
+  background: linear-gradient(90deg, var(--brand_secondary_default), #5f5988);
 }
 
 .careers__benefit__icon.careers__benefit--purple {
-  background: #7665a0;
+  background: var(--brand_secondary_default);
 }
 
 ul li:before {

--- a/pegasus/sites.v3/code.org/public/css/common.css
+++ b/pegasus/sites.v3/code.org/public/css/common.css
@@ -18,7 +18,7 @@
 }
 
 .solid-block-subheader {
-  color: #7665a0;
+  color: var(--brand_secondary_default);
   font-size: 18px;
   font-family: var(--main-font);
   font-weight: var(--bold-font-weight);

--- a/pegasus/sites.v3/code.org/public/css/highlights.css
+++ b/pegasus/sites.v3/code.org/public/css/highlights.css
@@ -55,7 +55,7 @@
 
 .learn-button {
   width: 100%;
-  background-color: #7665a0;
+  background-color: var(--brand_secondary_default);
   height: 30px;
   position: absolute;
   bottom: 0px;

--- a/pegasus/sites.v3/code.org/public/css/marketing.css
+++ b/pegasus/sites.v3/code.org/public/css/marketing.css
@@ -52,7 +52,7 @@ figure img{
 .callout-box {padding: 10px;margin-top: 30px;}
 .callout-box img {max-width:100%; vertical-align:middle;}
 
-.bp0 {background-color:#7665a0; color:#ffffff;}
+.bp0 {background-color:var(--brand_secondary_default); color:#ffffff;}
 .bp1 {background-color:#a69bc1;}
 .bp2 {background-color:#cfc9de;}
 .bp3 {background-color:#ebe8f1;}
@@ -127,7 +127,7 @@ h4.highlight {
 
 hr.bhm-border {  border:none;  height:5px;  background-image: url('../images/bhm/panafbars5.png');   background-repeat: repeat-x;}
 
-.bhm-heading {color:#7665a0; }
+.bhm-heading {color:var(--brand_secondary_default); }
 
 .blackstudentdata img {width:100%;}
 .blackstudentdata p {margin: 1em;}

--- a/pegasus/sites.v3/code.org/public/css/minecraft2018.css
+++ b/pegasus/sites.v3/code.org/public/css/minecraft2018.css
@@ -20,7 +20,7 @@
 
 .new-mc {
   color: white;
-  background-color: #7665a0;
+  background-color: var(--brand_secondary_default);
   width: 250px;
   margin: -10px;
   padding: 5px;

--- a/pegasus/sites.v3/code.org/public/css/mobile-footer.css
+++ b/pegasus/sites.v3/code.org/public/css/mobile-footer.css
@@ -66,7 +66,7 @@
 
 #non-en {
   height: 90px;
-  background-color: #7665a0
+  background-color: var(--brand_secondary_default)
 }
 
 #non-en .language-dropdown select {

--- a/pegasus/sites.v3/code.org/public/css/promote.css
+++ b/pegasus/sites.v3/code.org/public/css/promote.css
@@ -15,7 +15,7 @@ a.whitefooterlink {
 }
 
 #block a {
-  color: #7665a0;
+  color: var(--brand_secondary_default);
   text-decoration: none;
 }
 

--- a/pegasus/sites.v3/code.org/public/css/sports.css
+++ b/pegasus/sites.v3/code.org/public/css/sports.css
@@ -14,7 +14,7 @@
 }
 
 .tutorial-video {
-  background: #7665a0;
+  background: var(--brand_secondary_default);
   border-radius: 5px;
   width: 100%;
   height: 400px;

--- a/pegasus/sites.v3/code.org/public/css/state-facts-print.css
+++ b/pegasus/sites.v3/code.org/public/css/state-facts-print.css
@@ -19,7 +19,7 @@ body {
 }
 
 h1 {
-  color: #7665a0;
+  color: var(--brand_secondary_default);
   font-size: 32px;
   font-family: var(--main-font);
   font-weight: var(--semi-bold-font-weight);
@@ -50,7 +50,7 @@ h3 {
 }
 
 a {
-  color: #7665a0;
+  color: var(--brand_secondary_default);
   text-decoration: none;
   font-family: var(--main-font);
   font-weight: var(--semi-bold-font-weight);

--- a/pegasus/sites.v3/code.org/public/css/state-policy-landscape.css
+++ b/pegasus/sites.v3/code.org/public/css/state-policy-landscape.css
@@ -14,14 +14,14 @@
     padding-left:48px;
   }
   h1 {
-    color: #7665a0;
+    color: var(--brand_secondary_default);
     line-height: 36px;
   }
   h2 {
     color: var(--brand_primary_default);
   }
   a {
-    color: #7665a0;
+    color: var(--brand_secondary_default);
   }
   ul.link-bar {
     padding-left:0px;

--- a/pegasus/sites.v3/code.org/public/css/tools.css
+++ b/pegasus/sites.v3/code.org/public/css/tools.css
@@ -105,7 +105,7 @@ div[dir='rtl'] .tutorial-info-guide{
 }
 b.purple {
   font-size: 14px;
-  color: #7665a0;
+  color: var(--brand_secondary_default);
 }
 
 .pl-callout {

--- a/pegasus/sites.v3/code.org/public/css/widgets.css
+++ b/pegasus/sites.v3/code.org/public/css/widgets.css
@@ -1,5 +1,5 @@
 .block-header {
-  background-color: #7665a0;
+  background-color: var(--brand_secondary_default);
   color: white;
   height: 60px;
   padding-top: 10px;

--- a/pegasus/sites.v3/code.org/public/international/about.es-mx.md
+++ b/pegasus/sites.v3/code.org/public/international/about.es-mx.md
@@ -14,7 +14,7 @@ Code.org® es una organización sin fines de lucro dedicada a ampliar el acceso 
 
 [col-40]
 
-<div style="background-color:#7665a0;height:190px;padding:25px;display:flex;justify-content:center;flex-direction:column">
+<div style="background-color:var(--brand_secondary_default);height:190px;padding:25px;display:flex;justify-content:center;flex-direction:column">
 
   <font size="4" color="#FFFFFF"><b>Los cursos de Code.org son utilizados por decenas de millones de estudiantes y por un millón de profesores en todo el mundo.</b></font>
 

--- a/pegasus/sites.v3/code.org/public/professional-development-workshops/index.md.erb
+++ b/pegasus/sites.v3/code.org/public/professional-development-workshops/index.md.erb
@@ -63,7 +63,7 @@ Administrator Information: Share [this flyer](/files/csfadminbrochure2019.pdf) w
 
 ## Two workshop options to meet your needs
 
-<h3 style="color:#7665a0;font-weight:bold;">Never taught CS Fundamentals?</h3>
+<h3 style="color:var(--brand_secondary_default);font-weight:bold;">Never taught CS Fundamentals?</h3>
 
 <details>
   <summary style="color:var(--brand_primary_default)"><strong>Join us for the Intro workshop!</strong></summary>
@@ -86,7 +86,7 @@ Administrator Information: Share [this flyer](/files/csfadminbrochure2019.pdf) w
 <a href="#workshopmap">Register today!</a>
 
 <a name="deep-dive"></a>
-### <span style="color:#7665a0;font-weight:bold;">Already teaching CS Fundamentals?</span>
+### <span style="color:var(--brand_secondary_default);font-weight:bold;">Already teaching CS Fundamentals?</span>
 
 <details>
   <summary style="color:var(--brand_primary_default)"><strong>Join us for the Deep Dive workshop!</strong></summary>

--- a/pegasus/sites.v3/code.org/views/about_donors_image.haml
+++ b/pegasus/sites.v3/code.org/views/about_donors_image.haml
@@ -1,4 +1,4 @@
-%link{:href=>"/css/donors.css", :rel=>"stylesheet"} 
+%link{:href=>"/css/donors.css", :rel=>"stylesheet"}
 
 - size ||= "small"
 - columns = size == "large" ? 2 : 3
@@ -9,7 +9,7 @@
     - group.each do |supporter|
       - avatar_url = avatar_image(supporter[:name_s], 200)
       %td{class: "#{size}"}
-        %a{:href=>supporter[:url_s], :target=>"_blank", :style=>"color: #7665a0"}
+        %a{:href=>supporter[:url_s], :target=>"_blank", :style=>"color: var(--brand_secondary_default)"}
           - if supporter[:show_s] == "logo" || supporter[:show_s] == "both"
             %img{:src=>avatar_url, class: "#{size}-img"}
           - if supporter[:show_s] == "name" || supporter[:show_s] == "both"

--- a/pegasus/sites.v3/code.org/views/share_privacy.haml
+++ b/pegasus/sites.v3/code.org/views/share_privacy.haml
@@ -52,7 +52,7 @@
     background-position: center bottom;
   }
   .email-button, .print-button {
-    background-color: #7665a0;
+    background-color: var(--brand_secondary_default);
     color: white;
     text-decoration: none;
     display: inline-block;


### PR DESCRIPTION
Replaces the old purple color `#7665A0` with the updated purple color `#8C52BA` across the https://code.org site.

- Updated all instances with the `var(--brand_secondary_default)` variable
- The new purple is brighter and more saturated than the old purple
- Tested by checking each page locally

Jira ticket: [ACQ-1442](https://codedotorg.atlassian.net/browse/ACQ-1442)

----

| Before | After |
| ----- | ----- |
| <img width="834" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/6c1b16e9-af9a-49a3-afef-9dd5ab687a54"> | <img width="834" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/6710f82d-4316-4d92-b451-ad500963f407"> |