### PR TITLE
Storybook - Refactor date_picker.story.jsx

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
@@ -2,22 +2,48 @@ import React from 'react';
 import moment from 'moment';
 import DatePicker from './date_picker';
 import {action} from '@storybook/addon-actions';
+import {reduxStore} from '@cdo/storybook/decorators';
+import {Provider} from 'react-redux';
 
-export default storybook => {
-  return storybook
-    .storiesOf('DatePicker', module)
-    .addDecorator(story => (
-      // Currently the Bootstrap 3 styles required by React-Bootstrap are only applied inside div#workshop-container.
-      // This is to prevent conflicts with other parts of Code Studio using Bootstrap 2.
-      // See pd.scss. Without this container div it won't render properly.
-      <div id="workshop-container" style={{width: 300}}>
-        {story()}
-      </div>
-    ))
-    .add('Basic', () => (
-      <DatePicker date={moment()} onChange={action('changed')} />
-    ))
-    .add('Clearable', () => (
-      <DatePicker date={moment()} onChange={action('changed')} clearable />
-    ));
+export default {
+  title: 'WorkshopDashboard/DatePicker',
+  component: DatePicker,
 };
+
+const Template = args => (
+  <Provider store={reduxStore()}>
+    <DatePicker id="workshop-container" style="width: 300" {...args} />;
+  </Provider>
+);
+
+export const Basic = Template.bind({});
+Basic.args = {
+  date: moment(),
+  onChange: action('changed'),
+};
+
+export const Clearable = Template.bind({});
+Clearable.args = {
+  date: moment(),
+  onChange: action('changed'),
+  clearable: true,
+};
+
+// storybook => {
+//   return storybook
+//     .storiesOf('DatePicker', module)
+//     .addDecorator(story => (
+//       // Currently the Bootstrap 3 styles required by React-Bootstrap are only applied inside div#workshop-container.
+//       // This is to prevent conflicts with other parts of Code Studio using Bootstrap 2.
+//       // See pd.scss. Without this container div it won't render properly.
+//       <div id="workshop-container" style={{width: 300}}>
+//         {story()}
+//       </div>
+//     ))
+//     .add('Basic', () => (
+//       <DatePicker date={moment()} onChange={action('changed')} />
+//     ))
+//     .add('Clearable', () => (
+//       <DatePicker date={moment()} onChange={action('changed')} clearable />
+//     ));
+// };

--- a/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
@@ -12,6 +12,10 @@ export default {
 
 const Template = args => (
   <Provider store={reduxStore()}>
+    {/* Currently the Bootstrap 3 styles required by React-Bootstrap are
+    only applied inside div#workshop-container.
+    This is to prevent conflicts with other parts of Code Studio using Bootstrap 2.
+    See pd.scss. Without this container div it won't render properly. */}
     <div id="workshop-container" style={{width: 300}}>
       <DatePicker {...args} />
     </div>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
@@ -4,7 +4,7 @@ import DatePicker from './date_picker';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'WorkshopDashboard/DatePicker',
+  title: 'DatePicker',
   component: DatePicker,
 };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
@@ -12,7 +12,9 @@ export default {
 
 const Template = args => (
   <Provider store={reduxStore()}>
-    <DatePicker id="workshop-container" style="width: 300" {...args} />;
+    <div id="workshop-container" style={{width: 300}}>
+      <DatePicker {...args} />
+    </div>
   </Provider>
 );
 
@@ -28,22 +30,3 @@ Clearable.args = {
   onChange: action('changed'),
   clearable: true,
 };
-
-// storybook => {
-//   return storybook
-//     .storiesOf('DatePicker', module)
-//     .addDecorator(story => (
-//       // Currently the Bootstrap 3 styles required by React-Bootstrap are only applied inside div#workshop-container.
-//       // This is to prevent conflicts with other parts of Code Studio using Bootstrap 2.
-//       // See pd.scss. Without this container div it won't render properly.
-//       <div id="workshop-container" style={{width: 300}}>
-//         {story()}
-//       </div>
-//     ))
-//     .add('Basic', () => (
-//       <DatePicker date={moment()} onChange={action('changed')} />
-//     ))
-//     .add('Clearable', () => (
-//       <DatePicker date={moment()} onChange={action('changed')} clearable />
-//     ));
-// };

--- a/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import moment from 'moment';
 import DatePicker from './date_picker';
 import {action} from '@storybook/addon-actions';
-import {reduxStore} from '@cdo/storybook/decorators';
-import {Provider} from 'react-redux';
 
 export default {
   title: 'WorkshopDashboard/DatePicker',
@@ -11,15 +9,13 @@ export default {
 };
 
 const Template = args => (
-  <Provider store={reduxStore()}>
-    {/* Currently the Bootstrap 3 styles required by React-Bootstrap are
-    only applied inside div#workshop-container.
-    This is to prevent conflicts with other parts of Code Studio using Bootstrap 2.
-    See pd.scss. Without this container div it won't render properly. */}
-    <div id="workshop-container" style={{width: 300}}>
-      <DatePicker {...args} />
-    </div>
-  </Provider>
+  // Currently the Bootstrap 3 styles required by React-Bootstrap are
+  // only applied inside div#workshop-container.
+  // This is to prevent conflicts with other parts of Code Studio using Bootstrap 2.
+  // See pd.scss. Without this container div it won't render properly.
+  <div id="workshop-container" style={{width: 300}}>
+    <DatePicker {...args} />
+  </div>
 );
 
 export const Basic = Template.bind({});


### PR DESCRIPTION
Refactored the `DatePicker` component story.

| Basic | Clearable |
| ----- | ------ |
| <img width="338" alt="Basic" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/529aa2ce-053e-447b-8cca-7ec721b5ea9e"> | <img width="337" alt="Clearable" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/cbea37f2-61e1-4252-b9b4-64d6328ceae3"> |

The date picker functionality works, but the date doesn't change in the UI. The action is represented in the `Actions` section of the story; this may be because the date picker uses the [ReactDatePicker](https://www.npmjs.com/package/react-datepicker) library.

<img width="567" alt="Screenshot 2024-01-30 at 1 29 36 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/7d7ada44-49c7-41b6-b0cb-8cbd4966e19d">

----

**Jira ticket:** [ACQ-1433](https://codedotorg.atlassian.net/browse/ACQ-1433)