### PR TITLE
[Python Lab] Temporarily disable python running

### DIFF
--- a/apps/src/pythonlab/PythonEditor.tsx
+++ b/apps/src/pythonlab/PythonEditor.tsx
@@ -3,9 +3,14 @@ import {darkMode} from '@cdo/apps/lab2/views/components/editor/editorThemes';
 import {python} from '@codemirror/lang-python';
 import moduleStyles from './python-editor.module.scss';
 import {useDispatch, useSelector} from 'react-redux';
-import {PythonlabState, resetOutput, setCode} from './pythonlabRedux';
+import {
+  PythonlabState,
+  appendOutput,
+  resetOutput,
+  setCode,
+} from './pythonlabRedux';
 import Button from '@cdo/apps/templates/Button';
-import {runPythonCode} from './pyodideRunner';
+// import {runPythonCode} from './pyodideRunner';
 import {useFetch} from '@cdo/apps/util/useFetch';
 import CodeEditor from '@cdo/apps/lab2/views/components/editor/CodeEditor';
 
@@ -30,7 +35,9 @@ const PythonEditor: React.FunctionComponent = () => {
     const parsedData = data ? (data as PermissionResponse) : {permissions: []};
     // For now, restrict running python code to levelbuilders.
     if (parsedData.permissions.includes('levelbuilder')) {
-      runPythonCode(code);
+      dispatch(appendOutput('Simulating running code.'));
+      // TODO: re-enable once we fix iPad issues.
+      // runPythonCode(code);
     } else {
       alert('You do not have permission to run python code.');
     }

--- a/apps/src/pythonlab/PythonEditor.tsx
+++ b/apps/src/pythonlab/PythonEditor.tsx
@@ -37,6 +37,7 @@ const PythonEditor: React.FunctionComponent = () => {
     if (parsedData.permissions.includes('levelbuilder')) {
       dispatch(appendOutput('Simulating running code.'));
       // TODO: re-enable once we fix iPad issues.
+      // https://codedotorg.atlassian.net/browse/CT-299
       // runPythonCode(code);
     } else {
       alert('You do not have permission to run python code.');


### PR DESCRIPTION
We found an issue where old iOS versions would fail to load any lab2 level due to an issue with compatibility with Web Workers. While we figure this out I'm disabling running python in Python Lab, which gets rid of the Web Worker code from all lab2 labs. Now when you click the run button you get a generic message:
 
![Screenshot 2024-01-29 at 3 01 35 PM](https://github.com/code-dot-org/code-dot-org/assets/33666587/9da4454e-21f6-429d-9ee8-d37de36e010d)

## Links
- [slack thread](https://codedotorg.slack.com/archives/C05DK21DAHK/p1706502300666889)

## Testing story
Tested using the xcode simulator on iOS 15 and iPad 9th generation. Before this change, Music Lab did not load, after this change it did.

## Follow-up work
[CT-299](https://codedotorg.atlassian.net/browse/CT-299) outlines what we need to do to be able to re-enable pyodide. We also may want to look into finding a way to not load all lab2 lab views for every lab2 lab.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
