### PR TITLE
Update hover tooltip on levelbuilder 'Published State' to be useful

### DIFF
--- a/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -223,6 +223,7 @@ export default class CourseVersionPublishingEditor extends Component {
             curriculum. It also impacts what kinds of edits can be made, some of
             which can not be reversed without engineering assistance.
             <br />
+            <br />
             Click "More info" for more information.
           </HelpTip>
           <Link href="https://github.com/code-dot-org/code-dot-org/wiki/Updating-Publish-State-of-Scripts-or-Courses">

--- a/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -4,6 +4,7 @@ import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import color from '@cdo/apps/util/color';
 import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 import Button from '../../templates/Button';
+import Link from '@cdo/apps/componentLibrary/link/Link';
 
 export default class CourseVersionPublishingEditor extends Component {
   static propTypes = {
@@ -218,68 +219,15 @@ export default class CourseVersionPublishingEditor extends Component {
             ))}
           </select>
           <HelpTip>
-            <table>
-              <thead>
-                <tr>
-                  <th>Publish State</th>
-                  <th>Overview</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td style={styles.tableBorder}>In-Development</td>
-                  <td style={styles.tableBorder}>
-                    Only levelbuilder can see this course. Used for creating new
-                    content you don't want anyone to access.
-                  </td>
-                </tr>
-                <tr>
-                  <td style={styles.tableBorder}>Pilot</td>
-                  <td style={styles.tableBorder}>
-                    A limited set of teachers who are in a pilot experiment can
-                    see and assign the course.
-                  </td>
-                </tr>
-                <tr>
-                  <td style={styles.tableBorder}>Beta</td>
-                  <td style={styles.tableBorder}>
-                    Anyone who has the link can view the course and make
-                    progress on it. It is not assignable by teachers yet.
-                  </td>
-                </tr>
-                <tr>
-                  <td style={styles.tableBorder}>Preview</td>
-                  <td style={styles.tableBorder}>
-                    The course is now a choice in the dropdown that is
-                    assignable.
-                  </td>
-                </tr>
-                <tr>
-                  <td style={styles.tableBorder}>Stable</td>
-                  <td style={styles.tableBorder}>
-                    A course that is not changing. If it is the most recent
-                    course in your language it will be the recommended course.
-                  </td>
-                </tr>
-                <tr>
-                  <td style={styles.tableBorder}>Sunsetting</td>
-                  <td style={styles.tableBorder}>
-                    A course that is in the process of being deprecated.
-                  </td>
-                </tr>
-                <tr>
-                  <td style={styles.tableBorder}>Deprecated</td>
-                  <td style={styles.tableBorder}>
-                    A course that has been deprecated. <br />
-                    <br />
-                    For Deeper Learning Courses, deprecation prevents Peer
-                    Reviews conducted as part of this unit from being displayed
-                    in the admin-only Peer Review Dashboard.
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+            Making a change to this setting updates who can see and assign this
+            curriculum. It also impacts what kinds of edits can be made, some of
+            which can not be reversed without engineering assistance.
+            <br />
+            Click "More info" for more information.
           </HelpTip>
+          <Link href="https://github.com/code-dot-org/code-dot-org/wiki/Updating-Publish-State-of-Scripts-or-Courses">
+            More info
+          </Link>
         </label>
         {this.props.publishedState === PublishedState.pilot && (
           <label>

--- a/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -226,7 +226,10 @@ export default class CourseVersionPublishingEditor extends Component {
             <br />
             Click "More info" for more information.
           </HelpTip>
-          <Link href="https://github.com/code-dot-org/code-dot-org/wiki/Updating-Publish-State-of-Scripts-or-Courses">
+          <Link
+            href="https://github.com/code-dot-org/code-dot-org/wiki/Updating-Publish-State-of-Scripts-or-Courses"
+            openInNewTab={true}
+          >
             More info
           </Link>
         </label>


### PR DESCRIPTION
From [this](https://codedotorg.slack.com/archives/C045UAX4WKH/p1705978462415179) thread.

Old:
![image](https://github.com/code-dot-org/code-dot-org/assets/25193259/763fafc6-5c5d-493b-8bd7-67167deead3f)

New:
<img width="663" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25193259/4ed6d746-b130-4e6a-9f25-a43684e75338">

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
