### PR TITLE
Remove pegasus dependency from webpurify

### DIFF
--- a/lib/cdo/web_purify.rb
+++ b/lib/cdo/web_purify.rb
@@ -2,9 +2,6 @@ require 'net/http'
 require 'open-uri'
 require 'json'
 require 'dynamic_config/gatekeeper'
-# rubocop:disable CustomCops/PegasusRequires
-require_relative '../../pegasus/src/env'
-# rubocop:enable CustomCops/PegasusRequires
 
 module WebPurify
   # WebPurify limits us to 30,000 characters per request and 4 simultaneous requests per API key

--- a/lib/test/cdo/test_web_purify.rb
+++ b/lib/test/cdo/test_web_purify.rb
@@ -1,6 +1,5 @@
 require 'minitest/autorun'
 require_relative '../../../shared/test/test_helper'
-require_relative '../../cdo/pegasus'
 require_relative '../../cdo/web_purify'
 
 class WebPurifyTest < Minitest::Test


### PR DESCRIPTION
As part of the on-going effort to separate pegasus and dashboard, this PR removes the references to pegasus in web purify and the corresponding test. 

[X-TEAM 407](https://codedotorg.atlassian.net/browse/XTEAM-407)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
