### PR TITLE
[Google Blockly] stop vertically translating workspace SVG

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -78,8 +78,6 @@ const options = {
 const plugin = new CrossTabCopyPaste();
 plugin.init(options);
 
-const BLOCK_PADDING = 7; // Calculated from difference between block height and text height
-
 const INFINITE_LOOP_TRAP =
   '  executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}\n';
 
@@ -624,12 +622,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
     const bbox = svg.getBBox();
     svg.setAttribute('height', bbox.height + bbox.y);
     svg.setAttribute('width', bbox.width + bbox.x);
-    // Add a transform to center read-only blocks on their line
-    const notchHeight = workspace.getRenderer().getConstants().NOTCH_HEIGHT;
-    svg.setAttribute(
-      'style',
-      `transform: translate(0px, ${notchHeight + BLOCK_PADDING}px)`
-    );
     workspace.setTheme(theme);
     return workspace;
   };

--- a/apps/src/templates/codeDocs/ProgrammingExpressionOverview.jsx
+++ b/apps/src/templates/codeDocs/ProgrammingExpressionOverview.jsx
@@ -71,7 +71,6 @@ export default function ProgrammingExpressionOverview({
           title={programmingExpression.blockName}
           role="heading"
           aria-level="1"
-          style={{paddingBottom: 12}}
         />
       );
     }


### PR DESCRIPTION
During the second Sprite Lab [bug bash](https://docs.google.com/document/d/13lbU3SmQKohvFknyY5s0sMDhlllRa-Z3RtnDlHs95uI/edit#bookmark=id.7rtbitl36iar), @fisher-alice noticed that we were not putting enough space under blocks embedded in instructions and hints. Interestingly, we used to have the opposite problem which was causing the blocks to get cropped:
- https://github.com/code-dot-org/code-dot-org/pull/44004

The good news is that we no longer seem to have the original issue, whatever the cause may be. I've removed the translation and checked that things have improved in a whole bunch of places where we embed blocks

Level|Before|After
-|-|-
Hello World 6|<img width="517" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/00dfdb7a-f9d6-4752-8715-ac1ba993a39b">|<img width="465" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/7c60f91f-19c7-422b-be6c-c19514889167">
Hello World 6|<img width="393" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/798d37ec-7fd8-4583-858e-0518fc3e4423">|<img width="324" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/0147a957-14cd-4f00-a2ba-29f9e23fe328">
Hello World3|<img width="256" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/78372adc-19df-46f5-a2fc-9b45ac679d45">|<img width="258" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/b1e24981-deb6-4364-8456-385603edcb39">
Poetry 5.4|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/ed3eddcd-10ba-42a9-b9f3-38edbdb7cf4c)(cropped)|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/ee89ba4d-cabc-4d9b-8e99-d0cc2e5cfdb6)
Poetry 5.4|<img width="318" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/863ca8dc-3726-4df2-9dd3-9c78f05b2913">|<img width="329" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/81b09684-3e24-4ccc-8855-d632865f2845">
Dance 1.2|<img width="555" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/4b122894-52fb-4a0f-a289-c7435a973967">|<img width="558" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/6524a17c-c011-40dd-a2b1-bdacc0118a8d">
Docs|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/d77990c2-fb38-4ff6-aa17-9c9516d8c65a)|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/46cde82a-a218-4a1c-992a-181356b91e55)
n/a with https://github.com/code-dot-org/code-dot-org/pull/55985 and no SVG frame|![image (172)](https://github.com/code-dot-org/code-dot-org/assets/43474485/6b7630e0-c25a-4ca5-ad9b-228474493625)|<img width="252" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/31dc7b01-2958-4209-b70e-d913f4b98bc8">

The last row shows an instance of our `ProgrammingExpressionOverview` which we recently flipped to use Google Blockly for Sprite Lab docs. Now that the block is positioned correctly, we can remove some additional padding that was meant to compensate for the issue.

## Links

Jira - https://codedotorg.atlassian.net/browse/CT-281

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
