### PR TITLE
Add rack-cors gem and use it to remove one code.org/dashboardapi/* call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -353,4 +353,4 @@ gem 'crowdin-api', '~> 1.6.0'
 
 gem "delayed_job_active_record", "~> 4.1"
 
-gem 'rack-cors'
+gem 'rack-cors', '~> 2.0.1'

--- a/Gemfile
+++ b/Gemfile
@@ -352,3 +352,5 @@ gem 'cld'
 gem 'crowdin-api', '~> 1.6.0'
 
 gem "delayed_job_active_record", "~> 4.1"
+
+gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1055,7 +1055,7 @@ DEPENDENCIES
   puma_worker_killer
   pusher (~> 1.3.1)
   rack-cache
-  rack-cors
+  rack-cors (~> 2.0.1)
   rack-mini-profiler
   rack-ssl-enforcer
   rack_csrf

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -661,6 +661,8 @@ GEM
     rack (2.2.6.4)
     rack-cache (1.13.0)
       rack (>= 0.4)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
     rack-oauth2 (1.5.1)
@@ -1053,6 +1055,7 @@ DEPENDENCIES
   puma_worker_killer
   pusher (~> 1.3.1)
   rack-cache
+  rack-cors
   rack-mini-profiler
   rack-ssl-enforcer
   rack_csrf

--- a/apps/src/sites/code.org/pages/views/workshop_search.js
+++ b/apps/src/sites/code.org/pages/views/workshop_search.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import colors from '@cdo/apps/util/color';
+import getScriptData from '@cdo/apps/util/getScriptData';
 
 var map;
 
@@ -42,8 +43,9 @@ function initializeMapboxMap() {
 }
 
 function loadMapboxWorkshops() {
+  const studioUrl = getScriptData('studioUrl');
   const deepDiveOnly = $('#properties').attr('data-deep-dive-only');
-  let url = '/dashboardapi/v1/pd/k5workshops?geojson=1';
+  let url = `//${studioUrl}/dashboardapi/v1/pd/k5workshops?geojson=1`;
   if (deepDiveOnly !== undefined) {
     url += '&deep_dive_only=1';
   }

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -37,6 +37,13 @@ module Dashboard
     # added in Rails 6.0 (https://github.com/rails/rails/pull/32937)
     config.action_dispatch.use_cookies_with_metadata = false
 
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins CDO.pegasus_site_host
+        resource '/dashboardapi/*', headers: :any, methods: [:get]
+      end
+    end
+
     unless CDO.chef_managed
       # Only Chef-managed environments run an HTTP-cache service alongside the Rack app.
       # For other environments (development / CI), run the HTTP cache from Rack middleware.

--- a/dashboard/config/initializers/cors.rb
+++ b/dashboard/config/initializers/cors.rb
@@ -1,0 +1,6 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins CDO.pegasus_site_host
+    resource '/dashboardapi/*', headers: :any, methods: [:get]
+  end
+end

--- a/dashboard/config/initializers/cors.rb
+++ b/dashboard/config/initializers/cors.rb
@@ -1,6 +1,0 @@
-Rails.application.config.middleware.insert_before 0, Rack::Cors do
-  allow do
-    origins CDO.pegasus_site_host
-    resource '/dashboardapi/*', headers: :any, methods: [:get]
-  end
-end

--- a/pegasus/sites.v3/code.org/views/workshop_search.haml
+++ b/pegasus/sites.v3/code.org/views/workshop_search.haml
@@ -1,7 +1,7 @@
 - deep_dive_only ||= false
 
 - image_path = CDO.studio_url 'blockly/media/workshop_search/m', CDO.default_scheme
-%script{type: 'text/javascript', src: webpack_asset_path('js/code.org/views/workshop_search.js'), data: {workshopSearch: {'imagePath': image_path}.to_json} }
+%script{type: 'text/javascript', src: webpack_asset_path('js/code.org/views/workshop_search.js'), data: {studioUrl: CDO.dashboard_site_host.to_json} }
 
 %link{href:'https://api.mapbox.com/mapbox-gl-js/v1.12.0/mapbox-gl.css', rel:'stylesheet'}
 %script{src:'https://api.mapbox.com/mapbox-gl-js/v1.12.0/mapbox-gl.js'}


### PR DESCRIPTION
When looking for how to configure CORS for Rails applications, I kept running into references to the `rack-cors` gem ([here](https://www.stackhawk.com/blog/rails-cors-guide/), [here](https://stackoverflow.com/a/29751501), and [here](https://stackoverflow.com/a/29426455)). Set up was very easy (see [docs](https://github.com/cyu/rack-cors)) and it worked almost immediately. I've currently got it configured to only accept `GET` requests matching `/dashboardapi/*` from the `CDO.pegasus_site_host` origin. I erred on the side of more restrictive but I'm definitely open to feedback here.

The `rack-cors` gem is used by [119k repos on github](https://github.com/cyu/rack-cors/network/dependents) and was last committed to 3 months ago, so I feel reasonably comfortable adding it as a dependency. Definitely open to push back or discussion here!

## Testing Story

This PR also includes a corresponding change to remove the cross origin request on https://code.org/professional-development-workshops. There was a CORS error when I simply tried to call `http://localhost-studio.code.org/dashboardapi/v1/pd/k5workshops?geojson=1` but using this gem resolved the CORS error.

I also played with the configuration of the CORS rules a bit and confirmed they did block requests that didn't match. For example, I set the `resource` to `/dashboardapi/` (note the missing wildcard), which did not resolve the CORS error.
