### PR TITLE
Add delete user button to Admin UI

### DIFF
--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -59,6 +59,17 @@ class AdminUsersController < ApplicationController
     end
   end
 
+  def delete_user
+    user = User.find_by_id(params.require(:user_id))
+    if user
+      user.destroy
+      flash[:alert] = "User (ID: #{params[:user_id]}) Deleted!"
+    else
+      flash[:alert] = "User (ID: #{params[:user_id]}) not found or deleted"
+    end
+    redirect_to :find_students
+  end
+
   def undelete_user
     user = User.only_deleted.find_by_id(params[:user_id])
     if user

--- a/dashboard/app/views/admin_search/find_students.html.haml
+++ b/dashboard/app/views/admin_search/find_students.html.haml
@@ -43,7 +43,7 @@
   = paginate @users, total_pages: (@total_count / AdminSearchController::MAX_PAGE_SIZE.to_f).ceil
   %table.users
     %tr
-      - ['ID', 'Name', 'Email', 'Provider', 'Can Share?', 'Deleted At', 'Undelete'].each do |field|
+      - ['ID', 'Name', 'Email', 'Provider', 'Can Share?', 'Deleted At', 'Undelete', 'Delete'].each do |field|
         %th
           %span= field
     - @users.each do |user|
@@ -58,5 +58,12 @@
             %span= user[:deleted_at]
           %td
             =link_to 'Undelete User', undelete_user_path(user_id: user[:id]), method: :post, class: "btn", data: {confirm: "Are you sure?"}
+        - else
+          %td
+          %td
+          %td
+            =link_to delete_user_path(user_id: user[:id]), method: :post, class: "btn", data: {confirm: "Are you sure you want to DELETE this user?"} do
+              %i.fa.fa-trash
+              Delete User
 - else
   No users met the specified search criteria.

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -568,6 +568,7 @@ Dashboard::Application.routes.draw do
     post '/admin/account_repair', to: 'admin_users#account_repair',  as: 'account_repair'
     get '/admin/assume_identity', to: 'admin_users#assume_identity_form', as: 'assume_identity_form'
     post '/admin/assume_identity', to: 'admin_users#assume_identity', as: 'assume_identity'
+    post '/admin/delete_user', to: 'admin_users#delete_user', as: 'delete_user'
     post '/admin/undelete_user', to: 'admin_users#undelete_user', as: 'undelete_user'
     get '/admin/manual_pass', to: 'admin_users#manual_pass_form', as: 'manual_pass_form'
     post '/admin/manual_pass', to: 'admin_users#manual_pass', as: 'manual_pass'

--- a/dashboard/test/controllers/admin_users_controller_test.rb
+++ b/dashboard/test/controllers/admin_users_controller_test.rb
@@ -147,6 +147,21 @@ class AdminUsersControllerTest < ActionController::TestCase
     assert @deleted_student.deleted?
   end
 
+  test 'should delete a user' do
+    sign_in @admin
+    user_to_delete = create :student
+    post :delete_user, params: {user_id: user_to_delete.id}
+    assert user_to_delete.reload.deleted?
+  end
+
+  test 'should not delete a user if not an admin' do
+    sign_in @not_admin
+    user_to_delete = create :student
+    post :delete_user, params: {user_id: user_to_delete.id}
+    assert_response :forbidden
+    refute user_to_delete.reload.deleted?
+  end
+
   generate_admin_only_tests_for :manual_pass_form
 
   test 'manual_pass adds user_level with manual pass' do


### PR DESCRIPTION
Adds a delete button right next to the undelete button on the user search page for admins.

<img width="850" alt="Screenshot 2024-01-30 at 1 54 03 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/26c4dd71-95d0-48f3-a03d-9f93c616b47d">


## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-681)

## Testing story

```
bundle exec spring testunit test/controllers/admin_users_controller_test.rb
Running via Spring preloader in process 73243
Started with run options --seed 49308

  72/72: [==================================================] 100% Time: 00:00:33, Time: 00:00:33

Finished in 33.35322s
72 tests, 191 assertions, 0 failures, 0 errors, 0 skips
```

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
