### PR TITLE
Persist admin panel across pages linked to via the panel

### DIFF
--- a/dashboard/app/views/admin_nps/nps_form.html.haml
+++ b/dashboard/app/views/admin_nps/nps_form.html.haml
@@ -13,3 +13,5 @@
     %option{:value => "odd"} odd ID teachers
     %option{:value => "none"} no teachers
   %button.btn{type: 'submit', style: 'margin: 0px'}= "Save"
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/admin_reports/directory.html.haml
+++ b/dashboard/app/views/admin_reports/directory.html.haml
@@ -29,3 +29,5 @@
 
 %h3 NPS Surveys
 = link_to 'NPS Surveys', nps_form_path
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/admin_reports/level_completions.html.haml
+++ b/dashboard/app/views/admin_reports/level_completions.html.haml
@@ -34,3 +34,5 @@
   window.dashboard.levelCompletions.hideAndShowDomElements(
       #{ @is_sampled }, #{ params[:start_date].present? });
   window.dashboard.levelCompletions.populateTable(headers, data);
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/admin_search/find_students.html.haml
+++ b/dashboard/app/views/admin_search/find_students.html.haml
@@ -60,3 +60,5 @@
             =link_to 'Undelete User', undelete_user_path(user_id: user[:id]), method: :post, class: "btn", data: {confirm: "Are you sure?"}
 - else
   No users met the specified search criteria.
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/admin_search/lookup_section.html.haml
+++ b/dashboard/app/views/admin_search/lookup_section.html.haml
@@ -24,3 +24,5 @@
   - elsif @section
     %p= "Section code: #{@section.code}"
     %p{id: 'section_owner'}= "Owner: DELETED"
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/admin_search/pilots.html.haml
+++ b/dashboard/app/views/admin_search/pilots.html.haml
@@ -19,3 +19,5 @@
     = f.label 'Allow joining via url'
     = f.check_box :allow_joining_via_url
   = f.submit "Add Pilot", class: 'btn'
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/admin_users/account_repair_form.html.haml
+++ b/dashboard/app/views/admin_users/account_repair_form.html.haml
@@ -6,3 +6,5 @@
   = text_field_tag 'email', ''
   %br
   = submit_tag 'Fix!'
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/admin_users/assume_identity_form.html.haml
+++ b/dashboard/app/views/admin_users/assume_identity_form.html.haml
@@ -8,3 +8,5 @@
   = text_field_tag 'user_id', '', placeholder: 'id, email, or username', size: 80
   %br/
   = submit_tag 'Go!', data: {confirm: 'You really are going to be careful, right?'}
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/admin_users/permissions_form.html.haml
+++ b/dashboard/app/views/admin_users/permissions_form.html.haml
@@ -83,3 +83,5 @@
   %p
   %p Please enter each email on a new line
   = text_area_tag :emails, nil, class: 'form-control', rows: 5
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/admin_users/user_progress_form.html.haml
+++ b/dashboard/app/views/admin_users/user_progress_form.html.haml
@@ -54,3 +54,5 @@
           %td= format_time(user_script.assigned_at)
           %td= format_time(user_script.last_progress_at)
           %td= link_to 'Delete...', delete_progress_form_path(user_id: @target_user.id, script_id: user_script.script_id)
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/admin_users/user_projects_form.html.haml
+++ b/dashboard/app/views/admin_users/user_projects_form.html.haml
@@ -70,3 +70,5 @@
               = hidden_field_tag :user_id, @target_user.id
               = hidden_field_tag :channel, project["channel"]
               %button.btn{type: 'submit'}= "Restore"
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/devise/passwords/new.html.haml
+++ b/dashboard/app/views/devise/passwords/new.html.haml
@@ -13,3 +13,5 @@
       %button#forgotpassword-button.primary= t('password.reset_form.submit')
 :javascript
   $("#user_email").placeholder();
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/dynamic_config/gatekeeper_show.html.haml
+++ b/dashboard/app/views/dynamic_config/gatekeeper_show.html.haml
@@ -123,3 +123,5 @@
     $("#where-clauses").append(container);
     whereClauseCount += 1;
   }
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/videos/index.html.haml
+++ b/dashboard/app/views/videos/index.html.haml
@@ -26,3 +26,5 @@
         %td= link_to('Download', video.download)
         - if can? :update, video
           %td= link_to t('crud.edit'), edit_video_path(video)
+
+= render partial: 'home/admin'


### PR DESCRIPTION
CX prefers not to have to go back to the home page every time they need to access the admin panel. Often they may want to move from one admin page to another, or they might accidentally misclick on the menu and want to be able to go straight to another admin page without going back.

This adds the panel to the pages linked to from it.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-686)

## Testing story

Tested locally. Most of the pages are part of the admin controllers, which all require admin in order to access their routes. There are a few that aren't, such as the password reset and gatekeeper pages. The admin panel partial itself has a check for `admin?` though, so it doesn't show up if the logged-in user isn't an admin, just like on the homepage.

Only page I wasn't able to test locally was the Gatekeeper page. Anyone know what this page does?

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
