### PR TITLE
Music: dispose of workspace when leaving a music level

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -85,20 +85,21 @@ export default class MusicBlocklyWorkspace {
     Blockly.svgResize(this.workspace);
   }
 
-  hideFlyout() {
-    if (!this.workspace) {
-      return;
-    }
-
-    this.workspace.flyout.hide();
-  }
-
   hideChaff() {
     if (!this.workspace) {
       return;
     }
 
     this.workspace.hideChaff();
+  }
+
+  dispose() {
+    if (!this.workspace) {
+      return;
+    }
+
+    this.workspace.dispose();
+    this.workspace = null;
   }
 
   /**

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -85,14 +85,6 @@ export default class MusicBlocklyWorkspace {
     Blockly.svgResize(this.workspace);
   }
 
-  hideChaff() {
-    if (!this.workspace) {
-      return;
-    }
-
-    this.workspace.hideChaff();
-  }
-
   dispose() {
     if (!this.workspace) {
       return;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -202,7 +202,7 @@ class UnconnectedMusicView extends React.Component {
     }
 
     if (this.props.appName !== 'music') {
-      this.musicBlocklyWorkspace.hideFlyout();
+      this.musicBlocklyWorkspace.dispose();
     }
 
     if (

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -190,18 +190,18 @@ class UnconnectedMusicView extends React.Component {
     }
 
     // When changing levels, stop playback and reset the initial sounds loaded flag
-    // since a new set of sounds will be loaded on the next level.  Also clear
-    // the callout that's showing.
-    if (prevProps.currentLevelIndex !== this.props.currentLevelIndex) {
+    // since a new set of sounds will be loaded on the next level.  Also clear the
+    // callout that might be showing, and dispose of the Blockly workspace so that
+    // any lingering UI is removed.
+    if (
+      prevProps.currentLevelIndex !== this.props.currentLevelIndex &&
+      this.props.appName === 'music'
+    ) {
       this.stopSong();
       this.setState({
         hasLoadedInitialSounds: false,
       });
       this.props.clearCallout();
-      this.musicBlocklyWorkspace.hideChaff();
-    }
-
-    if (this.props.appName !== 'music') {
       this.musicBlocklyWorkspace.dispose();
     }
 


### PR DESCRIPTION
Dispose of the music Blockly workspace when leaving a music level. 

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/55959 and the discussion [here](https://github.com/code-dot-org/code-dot-org/pull/55959#discussion_r1471811656).  