### PR TITLE
Incubator: add link to music-intro-2024

### DIFF
--- a/apps/src/templates/studioHomepages/Incubator.jsx
+++ b/apps/src/templates/studioHomepages/Incubator.jsx
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import HeaderBanner from '../HeaderBanner';
 import {TwoColumnActionBlock} from '@cdo/apps/templates/studioHomepages/TwoColumnActionBlock';
+import Button from '@cdo/apps/templates/Button';
 
 class Incubator extends Component {
   render() {
@@ -43,8 +44,13 @@ class Incubator extends Component {
             }
             buttons={[
               {
+                url: '/s/music-intro-2024/reset',
+                text: 'Get started',
+              },
+              {
                 url: '/projectbeats',
-                text: 'Try it out!',
+                text: 'Skip to project',
+                color: Button.ButtonColor.white,
               },
             ]}
           />

--- a/apps/src/templates/studioHomepages/Incubator.jsx
+++ b/apps/src/templates/studioHomepages/Incubator.jsx
@@ -50,7 +50,7 @@ class Incubator extends Component {
               {
                 url: '/projectbeats',
                 text: 'Skip to project',
-                color: Button.ButtonColor.white,
+                color: Button.ButtonColor.neutralDark,
               },
             ]}
           />


### PR DESCRIPTION
This adds a link from the Project beats section of https://studio.code.org/incubator to the new intro script at https://studio.code.org/s/music-intro-2024.

<img width="1512" alt="Screenshot 2024-01-31 at 5 16 33 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/ca5d17ac-e10b-4caa-8cf4-3757ecb76604">

