### PR TITLE
Consolidate "prestorybook" step when starting Storybook

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -28,8 +28,7 @@
     "start:gamelab": "DEV=1 grunt dev --app=gamelab;",
     "start:craft": "DEV=1 grunt dev --app=craft --watch-notify;",
     "test-audio": "echo \"Open your browser to http://127.0.0.1:8080/test/audio/audio_test.html\" && http-server .",
-    "prestorybook": "curl -o build/package/css/application.css http://localhost-studio.code.org:3000/assets/application.css || curl -o build/package/css/application.css https://code-dot-org.github.io/cdo-styleguide/css/application.css; curl -o build/package/css/font-awesome.css http://localhost-studio.code.org:3000/assets/font-awesome.css",
-    "storybook": "STORYBOOK_STATIC_ASSETS=1 start-storybook -p 9001",
+    "storybook": "./script/start-storybook.sh",
     "storybook:deploy": "./script/deploy-storybook.sh"
   },
   "resolutions": {

--- a/apps/script/start-storybook.sh
+++ b/apps/script/start-storybook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+curl -o build/package/css/application.css http://localhost-studio.code.org:3000/assets/application.css || curl -o build/package/css/application.css https://code-dot-org.github.io/cdo-styleguide/css/application.css
+curl -o build/package/css/font-awesome.css http://localhost-studio.code.org:3000/assets/font-awesome.css
+STORYBOOK_STATIC_ASSETS=1 start-storybook -p 9001


### PR DESCRIPTION
[Yarn removed support for `pre` and `post` hooks in v2](https://github.com/yarnpkg/berry/issues/995#issuecomment-591414884), which we rely on when using storybook locally. 

[We recently moved to Yarn v3](https://github.com/code-dot-org/code-dot-org/pull/53684), which results in the `prestorybook` step not being run if you run `yarn storybook`. `npm run storybook` still ran the `prestorybook` step, but [we mostly recommend using `yarn` in our docs](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/README.md), so I thought it made sense to consolidate the `prestorybook` step into `storybook`.


## Testing story

I tested running `yarn storybook` locally and saw the `prestorybook` steps happening (curl-ing files), and didn't see any behavior difference in Storybook itself.