### PR TITLE
[ProgressV2] Add expandable choice level headers.

### DIFF
--- a/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
@@ -4,6 +4,7 @@ import styles from './progress-table-v2.module.scss';
 import classNames from 'classnames';
 import FontAwesome from '../FontAwesome';
 import i18n from '@cdo/locale';
+import LevelProgressHeader from './LevelProgressHeader';
 
 export default function ExpandedProgressColumnHeader({
   lesson,
@@ -39,15 +40,7 @@ export default function ExpandedProgressColumnHeader({
       </div>
       <div className={styles.expandedHeaderSecondRow}>
         {lesson.levels.map(level => (
-          <div
-            className={classNames(
-              styles.gridBox,
-              styles.expandedHeaderLevelCell
-            )}
-            key={lesson.id + '.' + level.bubbleText + '-h'}
-          >
-            {lesson.relative_position + '.' + level.bubbleText}
-          </div>
+          <LevelProgressHeader key={level.id} lesson={lesson} level={level} />
         ))}
       </div>
     </div>

--- a/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
@@ -12,7 +12,7 @@ export default function ExpandedProgressColumnHeader({
   expandedChoiceLevels,
   toggleExpandedChoiceLevel,
 }) {
-  // If there are only 2 levels, we only show the number so that the text fits the cell.
+  // If there are 2 or less levels, we only show the number so that the text fits the cell.
   const headerText =
     lesson.levels.length < 3 && expandedChoiceLevels.length === 0
       ? lesson.relative_position
@@ -23,6 +23,7 @@ export default function ExpandedProgressColumnHeader({
 
   // Manual width is necessary so that overflow text is hidden and lesson header exactly fits levels.
   // Add (numLevels + 1)px to account for borders.
+  // Also count expanded lessons and account for larger borders
   const width = React.useMemo(() => {
     const levelWidth = parseInt(styles.levelCellWidth);
     const lessonHeaderWidth = lesson.levels.reduce((acc, level) => {

--- a/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
@@ -9,6 +9,8 @@ import LevelProgressHeader from './LevelProgressHeader';
 export default function ExpandedProgressColumnHeader({
   lesson,
   removeExpandedLesson,
+  expandedChoiceLevels,
+  toggleExpandedChoiceLevel,
 }) {
   // If there are only 2 levels, we only show the number so that the text fits the cell.
   const headerText =
@@ -40,7 +42,13 @@ export default function ExpandedProgressColumnHeader({
       </div>
       <div className={styles.expandedHeaderSecondRow}>
         {lesson.levels.map(level => (
-          <LevelProgressHeader key={level.id} lesson={lesson} level={level} />
+          <LevelProgressHeader
+            key={level.id}
+            lesson={lesson}
+            level={level}
+            isLevelExpanded={expandedChoiceLevels.includes(level.id)}
+            toggleExpandedChoiceLevel={toggleExpandedChoiceLevel}
+          />
         ))}
       </div>
     </div>
@@ -50,4 +58,6 @@ export default function ExpandedProgressColumnHeader({
 ExpandedProgressColumnHeader.propTypes = {
   lesson: PropTypes.object.isRequired,
   removeExpandedLesson: PropTypes.func.isRequired,
+  expandedChoiceLevels: PropTypes.arrayOf(PropTypes.string).isRequired,
+  toggleExpandedChoiceLevel: PropTypes.func.isRequired,
 };

--- a/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './progress-table-v2.module.scss';
+import classNames from 'classnames';
+import FontAwesome from '../FontAwesome';
+import i18n from '@cdo/locale';
+
+export default function ExpandedProgressColumnHeader({
+  lesson,
+  removeExpandedLesson,
+}) {
+  // If there are only 2 levels, we only show the number so that the text fits the cell.
+  const headerText =
+    lesson.levels.length < 3
+      ? lesson.relative_position
+      : i18n.lessonNumbered({
+          lessonNumber: lesson.relative_position,
+          lessonName: lesson.name,
+        });
+
+  // Manual width is necessary so that overflow text is hidden and lesson header exactly fits levels.
+  // Add (numLevels + 1)px to account for borders.
+  const width =
+    lesson.levels.length * styles.levelCellWidth +
+    lesson.levels.length +
+    1 +
+    'px';
+
+  return (
+    <div className={styles.expandedHeader}>
+      <div
+        className={classNames(styles.gridBox, styles.expandedHeaderLessonCell)}
+        style={{width}}
+        onClick={() => removeExpandedLesson(lesson.id)}
+        aria-label={headerText}
+      >
+        <FontAwesome icon="caret-down" className={styles.expandedHeaderCaret} />
+        <div className={styles.expandedHeaderLessonText}>{headerText}</div>
+      </div>
+      <div className={styles.expandedHeaderSecondRow}>
+        {lesson.levels.map(level => (
+          <div
+            className={classNames(
+              styles.gridBox,
+              styles.expandedHeaderLevelCell
+            )}
+            key={lesson.id + '.' + level.bubbleText + '-h'}
+          >
+            {lesson.relative_position + '.' + level.bubbleText}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+ExpandedProgressColumnHeader.propTypes = {
+  lesson: PropTypes.object.isRequired,
+  removeExpandedLesson: PropTypes.func.isRequired,
+};

--- a/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
@@ -14,7 +14,7 @@ export default function ExpandedProgressColumnHeader({
 }) {
   // If there are only 2 levels, we only show the number so that the text fits the cell.
   const headerText =
-    lesson.levels.length < 3
+    lesson.levels.length < 3 && expandedChoiceLevels.length === 0
       ? lesson.relative_position
       : i18n.lessonNumbered({
           lessonNumber: lesson.relative_position,
@@ -23,11 +23,19 @@ export default function ExpandedProgressColumnHeader({
 
   // Manual width is necessary so that overflow text is hidden and lesson header exactly fits levels.
   // Add (numLevels + 1)px to account for borders.
-  const width =
-    lesson.levels.length * styles.levelCellWidth +
-    lesson.levels.length +
-    1 +
-    'px';
+  const width = React.useMemo(() => {
+    const levelWidth = parseInt(styles.levelCellWidth);
+    const lessonHeaderWidth = lesson.levels.reduce((acc, level) => {
+      if (
+        level.sublevels?.length > 0 &&
+        expandedChoiceLevels.includes(level.id)
+      ) {
+        return acc + ((level.sublevels.length + 1) * levelWidth + 3);
+      }
+      return acc + levelWidth + 1;
+    }, 0);
+    return lessonHeaderWidth + 1 + 'px';
+  }, [lesson, expandedChoiceLevels]);
 
   return (
     <div className={styles.expandedHeader}>

--- a/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
@@ -41,7 +41,11 @@ export default function ExpandedProgressColumnHeader({
   return (
     <div className={styles.expandedHeader}>
       <div
-        className={classNames(styles.gridBox, styles.expandedHeaderLessonCell)}
+        className={classNames(
+          styles.gridBox,
+          styles.expandedHeaderLessonCell,
+          styles.pointerMouse
+        )}
         style={{width}}
         onClick={() => removeExpandedLesson(lesson.id)}
         aria-label={headerText}

--- a/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
@@ -5,7 +5,7 @@ import {studentShape} from '../teacherDashboard/teacherSectionsRedux';
 import {studentLevelProgressType} from '../progress/progressTypes';
 import {connect} from 'react-redux';
 import LevelDataCell from './LevelDataCell';
-import ExpandedProgressColumnHeader from './ExpandedProgressColumnHeader';
+import ExpandedProgressColumnHeader from './ExpandedProgressColumnHeader.jsx';
 
 function ExpandedProgressDataColumn({
   lesson,
@@ -13,6 +13,17 @@ function ExpandedProgressDataColumn({
   sortedStudents,
   removeExpandedLesson,
 }) {
+  const [expandedChoiceLevels, setExpandedChoiceLevels] = React.useState([]);
+
+  const toggleExpandedChoiceLevel = levelId => {
+    //Todo: change to object
+    if (expandedChoiceLevels.includes(levelId)) {
+      setExpandedChoiceLevels(expandedChoiceLevels.filter(l => l !== levelId));
+    } else {
+      setExpandedChoiceLevels([...expandedChoiceLevels, levelId]);
+    }
+  };
+
   const progress = React.useMemo(
     () => (
       <div className={styles.expandedTable}>
@@ -43,6 +54,8 @@ function ExpandedProgressDataColumn({
       <ExpandedProgressColumnHeader
         lesson={lesson}
         removeExpandedLesson={removeExpandedLesson}
+        expandedChoiceLevels={expandedChoiceLevels}
+        toggleExpandedChoiceLevel={toggleExpandedChoiceLevel}
       />
       {progress}
     </div>

--- a/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
@@ -4,10 +4,8 @@ import styles from './progress-table-v2.module.scss';
 import {studentShape} from '../teacherDashboard/teacherSectionsRedux';
 import {studentLevelProgressType} from '../progress/progressTypes';
 import {connect} from 'react-redux';
-import classNames from 'classnames';
-import FontAwesome from '../FontAwesome';
 import LevelDataCell from './LevelDataCell';
-import i18n from '@cdo/locale';
+import ExpandedProgressColumnHeader from './ExpandedProgressColumnHeader.jsx';
 
 function ExpandedProgressDataColumn({
   lesson,
@@ -15,57 +13,6 @@ function ExpandedProgressDataColumn({
   sortedStudents,
   removeExpandedLesson,
 }) {
-  const header = React.useMemo(() => {
-    // If there are only 2 levels, we only show the number so that the text fits the cell.
-    const headerText =
-      lesson.levels.length < 3
-        ? lesson.relative_position
-        : i18n.lessonNumbered({
-            lessonNumber: lesson.relative_position,
-            lessonName: lesson.name,
-          });
-
-    // Manual width is necessary so that overflow text is hidden and lesson header exactly fits levels.
-    // Add (numLevels + 1)px to account for borders.
-    const width =
-      lesson.levels.length * styles.levelCellWidth +
-      lesson.levels.length +
-      1 +
-      'px';
-    return (
-      <div className={styles.expandedHeader}>
-        <div
-          className={classNames(
-            styles.gridBox,
-            styles.expandedHeaderLessonCell
-          )}
-          style={{width}}
-          onClick={() => removeExpandedLesson(lesson.id)}
-          aria-label={headerText}
-        >
-          <FontAwesome
-            icon="caret-down"
-            className={styles.expandedHeaderCaret}
-          />
-          <div className={styles.expandedHeaderLessonText}>{headerText}</div>
-        </div>
-        <div className={styles.expandedHeaderSecondRow}>
-          {lesson.levels.map(level => (
-            <div
-              className={classNames(
-                styles.gridBox,
-                styles.expandedHeaderLevelCell
-              )}
-              key={lesson.id + '.' + level.bubbleText + '-h'}
-            >
-              {lesson.relative_position + '.' + level.bubbleText}
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  }, [removeExpandedLesson, lesson]);
-
   const progress = React.useMemo(
     () => (
       <div className={styles.expandedTable}>
@@ -93,7 +40,10 @@ function ExpandedProgressDataColumn({
 
   return (
     <div key={lesson.id} className={styles.expandedColumn}>
-      {header}
+      <ExpandedProgressColumnHeader
+        lesson={lesson}
+        removeExpandedLesson={removeExpandedLesson}
+      />
       {progress}
     </div>
   );

--- a/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
@@ -5,7 +5,7 @@ import {studentShape} from '../teacherDashboard/teacherSectionsRedux';
 import {studentLevelProgressType} from '../progress/progressTypes';
 import {connect} from 'react-redux';
 import LevelDataCell from './LevelDataCell';
-import ExpandedProgressColumnHeader from './ExpandedProgressColumnHeader.jsx';
+import ExpandedProgressColumnHeader from './ExpandedProgressColumnHeader';
 
 function ExpandedProgressDataColumn({
   lesson,

--- a/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
@@ -15,11 +15,11 @@ function ExpandedProgressDataColumn({
 }) {
   const [expandedChoiceLevels, setExpandedChoiceLevels] = React.useState([]);
 
-  const toggleExpandedChoiceLevel = levelId => {
-    if (expandedChoiceLevels.includes(levelId)) {
-      setExpandedChoiceLevels(expandedChoiceLevels.filter(l => l !== levelId));
-    } else {
-      setExpandedChoiceLevels([...expandedChoiceLevels, levelId]);
+  const toggleExpandedChoiceLevel = level => {
+    if (expandedChoiceLevels.includes(level.id)) {
+      setExpandedChoiceLevels(expandedChoiceLevels.filter(l => l !== level.id));
+    } else if (level?.sublevels?.length > 0) {
+      setExpandedChoiceLevels([...expandedChoiceLevels, level.id]);
     }
   };
 

--- a/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
@@ -16,7 +16,6 @@ function ExpandedProgressDataColumn({
   const [expandedChoiceLevels, setExpandedChoiceLevels] = React.useState([]);
 
   const toggleExpandedChoiceLevel = levelId => {
-    //Todo: change to object
     if (expandedChoiceLevels.includes(levelId)) {
       setExpandedChoiceLevels(expandedChoiceLevels.filter(l => l !== levelId));
     } else {

--- a/apps/src/templates/sectionProgressV2/LessonProgressColumnHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LessonProgressColumnHeader.jsx
@@ -43,7 +43,11 @@ export default function LessonProgressColumnHeader({
   }
   return (
     <div
-      className={classNames(styles.gridBox, styles.lessonHeaderCell)}
+      className={classNames(
+        styles.gridBox,
+        styles.lessonHeaderCell,
+        styles.pointerMouse
+      )}
       onClick={() => addExpandedLesson(lesson.id)}
     >
       <FontAwesome icon="caret-right" className={styles.lessonHeaderCaret} />

--- a/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './progress-table-v2.module.scss';
+import classNames from 'classnames';
+import FontAwesome from '../FontAwesome';
+
+export default function ExpandedProgressColumnHeader({
+  lesson,
+  level,
+  isLevelExpanded,
+  toggleExpandedLevel,
+}) {
+  if (isLevelExpanded) {
+    <div
+      key={lesson.id + '.' + level.bubbleText + '-h'}
+      className={styles.expandedHeaderLevel}
+      onClick={onClick}
+    >
+      <div
+        className={classNames(styles.gridBox, styles.expandedHeaderLevelCell)}
+      >
+        {level.sublevels?.length > 0 && (
+          <FontAwesome
+            icon="caret-down"
+            className={styles.expandedHeaderLevelCaret}
+          />
+        )}
+        {lesson.relative_position + '.' + level.bubbleText}
+      </div>
+      {level.sublevels?.map(sublevel => (
+        <div
+          className={classNames(styles.gridBox, styles.expandedHeaderLevelCell)}
+          key={lesson.id + '.' + level.bubbleText + '-h-' + sublevel.letter}
+        >
+          {sublevel.letter}
+        </div>
+      ))}
+    </div>;
+  }
+
+  const onClick = () => {
+    if (level.sublevels?.length > 0) {
+      toggleExpandedLevel(lesson.id, level.id);
+    }
+  };
+
+  return (
+    <div
+      className={classNames(styles.gridBox, styles.expandedHeaderLevelCell)}
+      key={lesson.id + '.' + level.bubbleText + '-h'}
+      onClick={onClick}
+    >
+      {level.sublevels?.length > 0 && (
+        <FontAwesome
+          icon="caret-right"
+          className={styles.expandedHeaderLevelCaret}
+        />
+      )}
+      {lesson.relative_position + '.' + level.bubbleText}
+    </div>
+  );
+}
+
+ExpandedProgressColumnHeader.propTypes = {
+  lesson: PropTypes.object.isRequired,
+  level: PropTypes.object.isRequired,
+  isLevelExpanded: PropTypes.bool,
+  toggleExpandedLevel: PropTypes.func,
+};

--- a/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
@@ -10,18 +10,17 @@ export default function ExpandedProgressColumnHeader({
   isLevelExpanded,
   toggleExpandedChoiceLevel,
 }) {
-  const onClick = React.useCallback(() => {
-    if (level.sublevels?.length > 0) {
-      toggleExpandedChoiceLevel(level.id);
-    }
-  }, [level, toggleExpandedChoiceLevel]);
+  const isExpandable = level.sublevels?.length > 0;
 
   const expandedChoiceLevel = React.useCallback(
     () => (
       <div
         key={lesson.id + '.' + level.bubbleText + '-h'}
-        className={styles.expandedHeaderExpandedLevel}
-        onClick={onClick}
+        className={classNames(
+          styles.expandedHeaderExpandedLevel,
+          isExpandable && styles.pointerMouse
+        )}
+        onClick={() => toggleExpandedChoiceLevel(level)}
       >
         <div
           className={classNames(
@@ -49,15 +48,19 @@ export default function ExpandedProgressColumnHeader({
         ))}
       </div>
     ),
-    [lesson, level, onClick]
+    [lesson, level, isExpandable, toggleExpandedChoiceLevel]
   );
 
   const unexpandedLevel = React.useCallback(
     () => (
       <div
-        className={classNames(styles.gridBox, styles.expandedHeaderLevelCell)}
+        className={classNames(
+          styles.gridBox,
+          styles.expandedHeaderLevelCell,
+          isExpandable && styles.pointerMouse
+        )}
         key={lesson.id + '.' + level.bubbleText + '-h'}
-        onClick={onClick}
+        onClick={() => toggleExpandedChoiceLevel(level)}
       >
         {level.sublevels?.length > 0 && (
           <FontAwesome
@@ -68,7 +71,7 @@ export default function ExpandedProgressColumnHeader({
         {lesson.relative_position + '.' + level.bubbleText}
       </div>
     ),
-    [lesson, level, onClick]
+    [lesson, level, toggleExpandedChoiceLevel, isExpandable]
   );
 
   return level.sublevels?.length > 0 && isLevelExpanded

--- a/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
@@ -10,15 +10,14 @@ export default function ExpandedProgressColumnHeader({
   isLevelExpanded,
   toggleExpandedChoiceLevel,
 }) {
-  const onClick = () => {
+  const onClick = React.useCallback(() => {
     if (level.sublevels?.length > 0) {
       toggleExpandedChoiceLevel(level.id);
     }
-  };
+  }, [level, toggleExpandedChoiceLevel]);
 
-  // Todo: refactor into better optimized component, probably two functions with switch
-  if (level.sublevels?.length > 0 && isLevelExpanded) {
-    return (
+  const expandedChoiceLevel = React.useCallback(
+    () => (
       <div
         key={lesson.id + '.' + level.bubbleText + '-h'}
         className={styles.expandedHeaderExpandedLevel}
@@ -49,24 +48,32 @@ export default function ExpandedProgressColumnHeader({
           </div>
         ))}
       </div>
-    );
-  }
-
-  return (
-    <div
-      className={classNames(styles.gridBox, styles.expandedHeaderLevelCell)}
-      key={lesson.id + '.' + level.bubbleText + '-h'}
-      onClick={onClick}
-    >
-      {level.sublevels?.length > 0 && (
-        <FontAwesome
-          icon="caret-right"
-          className={styles.expandedHeaderLevelCaret}
-        />
-      )}
-      {lesson.relative_position + '.' + level.bubbleText}
-    </div>
+    ),
+    [lesson, level, onClick]
   );
+
+  const unexpandedLevel = React.useCallback(
+    () => (
+      <div
+        className={classNames(styles.gridBox, styles.expandedHeaderLevelCell)}
+        key={lesson.id + '.' + level.bubbleText + '-h'}
+        onClick={onClick}
+      >
+        {level.sublevels?.length > 0 && (
+          <FontAwesome
+            icon="caret-right"
+            className={styles.expandedHeaderLevelCaret}
+          />
+        )}
+        {lesson.relative_position + '.' + level.bubbleText}
+      </div>
+    ),
+    [lesson, level, onClick]
+  );
+
+  return level.sublevels?.length > 0 && isLevelExpanded
+    ? expandedChoiceLevel()
+    : unexpandedLevel();
 }
 
 ExpandedProgressColumnHeader.propTypes = {

--- a/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
@@ -8,41 +8,49 @@ export default function ExpandedProgressColumnHeader({
   lesson,
   level,
   isLevelExpanded,
-  toggleExpandedLevel,
+  toggleExpandedChoiceLevel,
 }) {
-  if (isLevelExpanded) {
-    <div
-      key={lesson.id + '.' + level.bubbleText + '-h'}
-      className={styles.expandedHeaderLevel}
-      onClick={onClick}
-    >
-      <div
-        className={classNames(styles.gridBox, styles.expandedHeaderLevelCell)}
-      >
-        {level.sublevels?.length > 0 && (
-          <FontAwesome
-            icon="caret-down"
-            className={styles.expandedHeaderLevelCaret}
-          />
-        )}
-        {lesson.relative_position + '.' + level.bubbleText}
-      </div>
-      {level.sublevels?.map(sublevel => (
-        <div
-          className={classNames(styles.gridBox, styles.expandedHeaderLevelCell)}
-          key={lesson.id + '.' + level.bubbleText + '-h-' + sublevel.letter}
-        >
-          {sublevel.letter}
-        </div>
-      ))}
-    </div>;
-  }
-
   const onClick = () => {
     if (level.sublevels?.length > 0) {
-      toggleExpandedLevel(lesson.id, level.id);
+      toggleExpandedChoiceLevel(level.id);
     }
   };
+
+  // Todo: refactor into better optimized component, probably two functions with switch
+  if (isLevelExpanded) {
+    return (
+      <div
+        key={lesson.id + '.' + level.bubbleText + '-h'}
+        className={styles.expandedHeaderLevel}
+        onClick={onClick}
+      >
+        <div
+          className={classNames(styles.gridBox, styles.expandedHeaderLevelCell)}
+        >
+          {level.sublevels?.length > 0 && (
+            <FontAwesome
+              icon="caret-down"
+              className={styles.expandedHeaderLevelCaret}
+            />
+          )}
+          {lesson.relative_position + '.' + level.bubbleText}
+        </div>
+        {level.sublevels?.map(sublevel => (
+          <div
+            className={classNames(
+              styles.gridBox,
+              styles.expandedHeaderLevelCell
+            )}
+            key={
+              lesson.id + '.' + level.bubbleText + '-h-' + sublevel.bubbleText
+            }
+          >
+            {sublevel.bubbleText}
+          </div>
+        ))}
+      </div>
+    );
+  }
 
   return (
     <div
@@ -65,5 +73,5 @@ ExpandedProgressColumnHeader.propTypes = {
   lesson: PropTypes.object.isRequired,
   level: PropTypes.object.isRequired,
   isLevelExpanded: PropTypes.bool,
-  toggleExpandedLevel: PropTypes.func,
+  toggleExpandedChoiceLevel: PropTypes.func,
 };

--- a/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
@@ -17,15 +17,18 @@ export default function ExpandedProgressColumnHeader({
   };
 
   // Todo: refactor into better optimized component, probably two functions with switch
-  if (isLevelExpanded) {
+  if (level.sublevels?.length > 0 && isLevelExpanded) {
     return (
       <div
         key={lesson.id + '.' + level.bubbleText + '-h'}
-        className={styles.expandedHeaderLevel}
+        className={styles.expandedHeaderExpandedLevel}
         onClick={onClick}
       >
         <div
-          className={classNames(styles.gridBox, styles.expandedHeaderLevelCell)}
+          className={classNames(
+            styles.expandedHeaderLevelCell,
+            styles.expandedHeaderExpandedLevelCell
+          )}
         >
           {level.sublevels?.length > 0 && (
             <FontAwesome
@@ -37,10 +40,7 @@ export default function ExpandedProgressColumnHeader({
         </div>
         {level.sublevels?.map(sublevel => (
           <div
-            className={classNames(
-              styles.gridBox,
-              styles.expandedHeaderLevelCell
-            )}
+            className={styles.expandedHeaderLevelCell}
             key={
               lesson.id + '.' + level.bubbleText + '-h-' + sublevel.bubbleText
             }

--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -170,10 +170,19 @@ $level-cell-width: 52px;
 
     &LevelCell {
       // If width is updated, must also update `LEVEL_HEADER_WIDTH` in ExpandedProgressDataColumn.jsx
-      min-width: 52px;
+      width: 52px;
       text-align: center;
       height: 32px;
       line-height: 32px;
+    }
+
+    &Level {
+      background-color: $light_primary_500;
+      color: $light_white;
+    }
+
+    &LevelCaret {
+      margin-inline-end: 4px;
     }
   }
   &Column {

--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -228,3 +228,7 @@ $level-cell-width: 52;
   min-width: 195px;
   margin-right: 12px;
 }
+
+.pointerMouse {
+  cursor: pointer;
+}

--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -179,6 +179,8 @@ $level-cell-width: 52px;
     &Level {
       background-color: $light_primary_500;
       color: $light_white;
+      display: flex;
+      flex-direction: row;
     }
 
     &LevelCaret {

--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -8,10 +8,10 @@
   flex-direction: row;
 }
 
-$level-cell-width: 52px;
+$level-cell-width: 52;
 
 :export {
-   c: $level-cell-width;
+   levelCellWidth: $level-cell-width;
 }
 
 .table {
@@ -56,7 +56,7 @@ $level-cell-width: 52px;
   }
   
   &Level {
-    width: $level-cell-width;
+    width: $level-cell-width + px;
     text-align: center;
     height: 47px;
     line-height: 47px;
@@ -165,7 +165,10 @@ $level-cell-width: 52px;
       display: flex;
       flex-direction: row;
       width: fit-content;
-      border-right: 1px solid $light_gray_200;
+
+      .expandedHeaderLevelCell:last-child {
+        border-right: 1px solid $light_gray_200;
+      }
     }
 
     &LevelCell {
@@ -176,11 +179,14 @@ $level-cell-width: 52px;
       line-height: 32px;
     }
 
-    &Level {
+    &ExpandedLevel {
       background-color: $light_primary_500;
       color: $light_white;
       display: flex;
       flex-direction: row;
+      border-right: 1px solid $light_gray_200;
+      border-left: 2px solid $light_gray_200;
+      border-top: 1px solid $light_gray_200;
     }
 
     &LevelCaret {

--- a/apps/test/unit/templates/sectionProgressV2/ExpandedProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ExpandedProgressDataColumnTest.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
 
 import {UnconnectedExpandedProgressDataColumn} from '@cdo/apps/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx';
 import LevelDataCell from '@cdo/apps/templates/sectionProgressV2/LevelDataCell.jsx';

--- a/apps/test/unit/templates/sectionProgressV2/ExpandedProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ExpandedProgressDataColumnTest.jsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
-import sinon from 'sinon';
 
 import {UnconnectedExpandedProgressDataColumn} from '@cdo/apps/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx';
 import LevelDataCell from '@cdo/apps/templates/sectionProgressV2/LevelDataCell.jsx';
+import ExpandedProgressColumnHeader from '@cdo/apps/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx';
 
 import {
   fakeLessonWithLevels,
   fakeStudentLevelProgress,
 } from '@cdo/apps/templates/progress/progressTestHelpers';
-import styles from '@cdo/apps/templates/sectionProgressV2/progress-table-v2.module.scss';
 
 const STUDENT_1 = {id: 1, name: 'Student 1', familyName: 'FamNameB'};
 const STUDENT_2 = {id: 2, name: 'Student 2', familyName: 'FamNameA'};
@@ -32,30 +31,11 @@ const setUp = overrideProps => {
 };
 
 describe('ExpandedProgressDataColumn', () => {
-  it('Shows header with lesson and all levels', () => {
-    const wrapper = setUp();
-
-    expect(wrapper.find(`.${styles.expandedHeaderLessonCell}`)).to.have.length(
-      1
-    );
-    expect(wrapper.find(`.${styles.expandedHeaderLevelCell}`)).to.have.length(
-      NUM_LEVELS
-    );
-  });
-
   it('Shows all levels for all students', () => {
     const wrapper = setUp();
+    expect(wrapper.find(ExpandedProgressColumnHeader)).to.have.length(1);
     expect(wrapper.find(LevelDataCell)).to.have.length(
       STUDENTS.length * NUM_LEVELS
     );
-  });
-
-  it('Un-expands on header click', () => {
-    const removeExpandedLesson = sinon.spy();
-    const wrapper = setUp({removeExpandedLesson: removeExpandedLesson});
-
-    wrapper.find(`.${styles.expandedHeaderLessonCell}`).simulate('click');
-
-    expect(removeExpandedLesson).to.have.been.calledOnceWith(LESSON.id);
   });
 });

--- a/apps/test/unit/templates/sectionProgressV2/ExpandedProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ExpandedProgressDataColumnTest.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
-import sinon from 'sinon';
 
 import {UnconnectedExpandedProgressDataColumn} from '@cdo/apps/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx';
 import LevelDataCell from '@cdo/apps/templates/sectionProgressV2/LevelDataCell.jsx';


### PR DESCRIPTION
Choice levels are extra expandable. This adds the expandable header. A follow up PR will add the expanded grid.

<img width="535" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25193259/12d501ed-b96b-41c3-8227-b0ee3eeee36e">
<img width="245" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25193259/714ecd68-c0b2-4e71-95cb-dd53e6c671e0">

Tests will come later. I want to try testing in RTL, but don't want that to clutter this PR

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
