### PR TITLE
Refactor FieldGroup storybook

### DIFF
--- a/apps/src/code-studio/pd/form_components/FieldGroup.story.jsx
+++ b/apps/src/code-studio/pd/form_components/FieldGroup.story.jsx
@@ -26,54 +26,57 @@ class TestWrapper extends React.Component {
     }
     return (
       <FieldGroup
-        id="full"
-        type="text"
-        label="this is a more full-featured example that errors if you type non-alpha characters"
+        id={this.props.id}
+        type={this.props.type}
+        componentClass={this.props.componentClass}
+        label={this.props.label}
         validationState={valid}
         onChange={this.handleChange}
         value={this.state.data}
         required={true}
-      />
+      >
+        {this.props.children}
+      </FieldGroup>
     );
   }
 }
 
 TestWrapper.propTypes = {
+  id: PropTypes.string.isRequired,
+  type: PropTypes.string,
+  componentClass: PropTypes.string,
+  label: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  children: PropTypes.arrayOf(PropTypes.node),
 };
 
-export default storybook => {
-  storybook.storiesOf('FormComponents/FieldGroup', module).addStoryTable([
-    {
-      name: 'basic example',
-      story: () => (
-        <FieldGroup
-          id="basic"
-          type="text"
-          label="this is a basic fieldgroup"
-          onChange={action('onChange')}
-        />
-      ),
-    },
-    {
-      name: 'dropdown with children',
-      story: () => (
-        <FieldGroup
-          id="dropdown"
-          componentClass="select"
-          label="a dropdown with children"
-          onChange={action('onChange')}
-        >
-          <option>Please Select One:</option>
-          <option value="first">One</option>
-          <option value="second">Two</option>
-          <option value="third">Three</option>
-        </FieldGroup>
-      ),
-    },
-    {
-      name: 'full-featured example',
-      story: () => <TestWrapper onChange={action('onChange')} />,
-    },
-  ]);
+export default {
+  title: 'FormComponents/FieldGroup',
+  component: FieldGroup,
+};
+
+const Template = args => <TestWrapper {...args} />;
+
+export const basicExample = Template.bind({});
+basicExample.args = {
+  id: 'basic',
+  type: 'text',
+  label: 'this is a basic fieldgroup',
+  onChange: action('onChange'),
+};
+
+export const dropdownWithChildren = Template.bind({});
+dropdownWithChildren.args = {
+  id: 'dropdown',
+  componentClass: 'select',
+  label: 'a dropdown with children',
+  onChange: action('onChange'),
+  children: (
+    <>
+      <option>Please Select One:</option>
+      <option value="first">One</option>
+      <option value="second">Two</option>
+      <option value="third">Three</option>
+    </>
+  ),
 };

--- a/apps/src/code-studio/pd/form_components/FieldGroup.story.jsx
+++ b/apps/src/code-studio/pd/form_components/FieldGroup.story.jsx
@@ -71,12 +71,16 @@ dropdownWithChildren.args = {
   componentClass: 'select',
   label: 'a dropdown with children',
   onChange: action('onChange'),
-  children: (
-    <>
-      <option>Please Select One:</option>
-      <option value="first">One</option>
-      <option value="second">Two</option>
-      <option value="third">Three</option>
-    </>
-  ),
+  children: [
+    <option key="title">Please Select One:</option>,
+    <option key="first" value="first">
+      One
+    </option>,
+    <option key="second" value="second">
+      Two
+    </option>,
+    <option key="third" value="third">
+      Three
+    </option>,
+  ],
 };


### PR DESCRIPTION
Refactors `FieldGroup.storybook.jsx`. Previously, there were 3 stories: 2 that render `FieldGroup` and 1 that renders a wrapper with an `onChange`. I just kept the wrapper and rendered that both times to keep it consistent (thus only needing to test the first two cases).

### Text field
![basic_fieldgroup](https://github.com/code-dot-org/code-dot-org/assets/56283563/cd48ecdf-f1cb-4cc5-98e3-20edfd84b0f5)

### Dropdown
![dropdown_with_children](https://github.com/code-dot-org/code-dot-org/assets/56283563/6a43314b-dffc-4a26-bda2-45e0a6dace0e)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1430)
Storybook spreadsheet: [here](https://docs.google.com/spreadsheets/d/1z8r10AcR0v3GimV_-28dJ6QaiaQ3CJoo9yXqa7U_bKs/edit#gid=0)

## Testing story
Tested locally on Storybook.
