### PR TITLE
Removing firehose logs for afe

### DIFF
--- a/apps/src/sites/code.org/pages/views/amazon_future_engineer_eligibility.js
+++ b/apps/src/sites/code.org/pages/views/amazon_future_engineer_eligibility.js
@@ -1,4 +1,3 @@
-import firehoseClient from '@cdo/apps/lib/util/firehose';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import $ from 'jquery';
@@ -25,10 +24,6 @@ function showAmazonFutureEngineerEligibility() {
       accountInformation = results;
     })
     .complete(() => {
-      firehoseClient.putRecord({
-        study: 'amazon-future-engineer-eligibility',
-        event: 'start',
-      });
       analyticsReporter.sendEvent(EVENTS.AFE_START);
 
       amazonFutureEngineerEligibilityElements.each(

--- a/apps/src/templates/DonorTeacherBanner.jsx
+++ b/apps/src/templates/DonorTeacherBanner.jsx
@@ -4,7 +4,6 @@ import React, {Component} from 'react';
 import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import fontConstants from '@cdo/apps/fontConstants';
-import {putRecord} from '../lib/util/firehose';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import color from '../util/color';
@@ -31,11 +30,6 @@ export default class DonorTeacherBanner extends Component {
 
   handleSubmit = event => {
     if (this.state.participate) {
-      putRecord({
-        study: 'afe-schools',
-        event: 'submit',
-        data_string: $('input[name="nces-id"]').val(),
-      });
       analyticsReporter.sendEvent(EVENTS.AFE_HOMEPAGE_BANNER_SUBMIT);
 
       // redirect to form on amazon-future-engineer page

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -1,4 +1,3 @@
-import firehoseClient from '@cdo/apps/lib/util/firehose';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import React from 'react';
@@ -14,27 +13,14 @@ const SIGN_IN_URL = studio(`/users/sign_in?${RETURN_TO}`);
 
 export default class AmazonFutureEngineerAccountConfirmation extends React.Component {
   signUpButtonPress = () => {
-    firehoseClient.putRecord(
-      {
-        study: 'amazon-future-engineer-eligibility',
-        event: 'sign_up_button_press',
-      },
-      {callback: () => (window.location = SIGN_UP_URL)}
-    );
     analyticsReporter.sendEvent(EVENTS.AFE_SIGN_UP_BUTTON_PRESS);
+    window.location = SIGN_UP_URL;
   };
 
   signInButtonPress = event => {
     event.preventDefault();
-
-    firehoseClient.putRecord(
-      {
-        study: 'amazon-future-engineer-eligibility',
-        event: 'sign_in_button_press',
-      },
-      {callback: () => (window.location = SIGN_IN_URL)}
-    );
     analyticsReporter.sendEvent(EVENTS.AFE_SIGN_IN_BUTTON_PRESS);
+    window.location = SIGN_IN_URL;
   };
 
   render() {

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -1,4 +1,3 @@
-import firehoseClient from '@cdo/apps/lib/util/firehose';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import React from 'react';
@@ -88,10 +87,6 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
   };
 
   submit = () => {
-    firehoseClient.putRecord({
-      study: 'amazon-future-engineer-eligibility',
-      event: 'submit_school_info',
-    });
     analyticsReporter.sendEvent(EVENTS.AFE_SUBMIT_SCHOOL_INFO);
 
     if (this.state.formData.schoolId === '-1') {
@@ -163,14 +158,8 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
     this.saveToSessionStorage();
 
     if (!isEligible) {
-      firehoseClient.putRecord(
-        {
-          study: 'amazon-future-engineer-eligibility',
-          event: 'ineligible',
-        },
-        {callback: () => (window.location = pegasus('/afe/start-codeorg'))}
-      );
       analyticsReporter.sendEvent(EVENTS.AFE_INELIGIBLE);
+      window.location = pegasus('/afe/start-codeorg');
     }
   }
 

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -1,4 +1,3 @@
-import firehoseClient from '@cdo/apps/lib/util/firehose';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import PropTypes from 'prop-types';
@@ -138,12 +137,6 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
       ...consentCSTA,
       ...roleCSTA,
     };
-
-    firehoseClient.putRecord({
-      study: 'amazon-future-engineer-eligibility',
-      event: 'continue',
-      data_json: JSON.stringify(submitData),
-    });
     analyticsReporter.sendEvent(EVENTS.AFE_CONTINUE, {
       submitData: JSON.stringify(submitData),
       isSignedIn: this.props.isSignedIn,


### PR DESCRIPTION
Removes all but one firehose call for afe! The submit call still happens in amazon_future_engineer_controller.rb. Any events that had a redirect on callback now redirect after the amplitude event is called.

I was able to test locally that these windlow.location calls still work, both from an ineligible school entry and a signed out submit (which redirects to account creation). 

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1373

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
