### PR TITLE
Refactor QuestionsTable storybook

### DIFF
--- a/apps/src/code-studio/pd/form_components/QuestionsTable.story.jsx
+++ b/apps/src/code-studio/pd/form_components/QuestionsTable.story.jsx
@@ -1,62 +1,54 @@
 import React from 'react';
 import QuestionsTable from './QuestionsTable';
-import reactBootstrapStoryDecorator from '../reactBootstrapStoryDecorator';
 import {action} from '@storybook/addon-actions';
 
-export default storybook => {
-  storybook
-    .storiesOf('FormComponents/QuestionsTable', module)
-    .addDecorator(reactBootstrapStoryDecorator)
-    .addStoryTable([
-      {
-        name: 'simple questions table',
-        story: () => (
-          <QuestionsTable
-            options={['this is cool', 'this is okay', 'this is useless']}
-            questions={[
-              {
-                label: 'what do you think of this component?',
-                name: 'thinkOfComponent',
-                required: true,
-              },
-              {
-                label: 'what do you think of this story?',
-                name: 'thinkOfStory',
-              },
-              {
-                label: 'what do you think of this question?',
-                name: 'thinkOfQuestion',
-              },
-            ]}
-          />
-        ),
-      },
-      {
-        name: 'controlled questions table',
-        story: () => (
-          <QuestionsTable
-            data={{
-              theOneThatIsSelected: 'first',
-            }}
-            errors={['theOneWithTheError']}
-            onChange={action('onChange')}
-            options={['first', 'second', 'third']}
-            questions={[
-              {
-                label: 'this one should have something selected',
-                name: 'theOneThatIsSelected',
-              },
-              {
-                label: 'this one should have an error',
-                name: 'theOneWithTheError',
-              },
-              {
-                label: 'this one should be plain',
-                name: 'theOtherOne',
-              },
-            ]}
-          />
-        ),
-      },
-    ]);
+export default {
+  title: 'FormComponents/QuestionsTable',
+  component: QuestionsTable,
+};
+
+const Template = args => <QuestionsTable {...args} />;
+
+const simpleQuestionsTable = Template.bind({});
+simpleQuestionsTable.args = {
+  options: ['this is cool', 'this is okay', 'this is useless'],
+  questions: [
+    {
+      label: 'what do you think of this component?',
+      name: 'thinkOfComponent',
+      required: true,
+    },
+    {
+      label: 'what do you think of this story?',
+      name: 'thinkOfStory',
+    },
+    {
+      label: 'what do you think of this question?',
+      name: 'thinkOfQuestion',
+    },
+  ],
+};
+
+const controlledQuestionsTable = Template.bind({});
+controlledQuestionsTable.args = {
+  data: {
+    theOneThatIsSelected: 'first',
+  },
+  errors: ['theOneWithTheError'],
+  onChange: action('onChange'),
+  options: ['first', 'second', 'third'],
+  questions: [
+    {
+      label: 'this one should have something selected',
+      name: 'theOneThatIsSelected',
+    },
+    {
+      label: 'this one should have an error',
+      name: 'theOneWithTheError',
+    },
+    {
+      label: 'this one should be plain',
+      name: 'theOtherOne',
+    },
+  ],
 };

--- a/apps/src/code-studio/pd/form_components/QuestionsTable.story.jsx
+++ b/apps/src/code-studio/pd/form_components/QuestionsTable.story.jsx
@@ -1,16 +1,57 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import QuestionsTable from './QuestionsTable';
 import {action} from '@storybook/addon-actions';
+
+class TestWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      data: this.props.data || {},
+    };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(newState) {
+    this.props.onChange(newState);
+    this.setState({
+      data: newState.full,
+    });
+  }
+
+  render() {
+    return (
+      <div id="application-container">
+        <QuestionsTable
+          data={this.state.data}
+          questions={this.props.questions}
+          options={this.props.options}
+          errors={this.props.errors}
+          onChange={this.handleChange}
+        />
+      </div>
+    );
+  }
+}
+
+TestWrapper.propTypes = {
+  data: PropTypes.object,
+  questions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  errors: PropTypes.arrayOf(PropTypes.string),
+  onChange: PropTypes.func.isRequired,
+};
 
 export default {
   title: 'FormComponents/QuestionsTable',
   component: QuestionsTable,
 };
 
-const Template = args => <QuestionsTable {...args} />;
+const Template = args => <TestWrapper {...args} />;
 
-const simpleQuestionsTable = Template.bind({});
+export const simpleQuestionsTable = Template.bind({});
 simpleQuestionsTable.args = {
+  onChange: action('onChange'),
   options: ['this is cool', 'this is okay', 'this is useless'],
   questions: [
     {
@@ -29,7 +70,7 @@ simpleQuestionsTable.args = {
   ],
 };
 
-const controlledQuestionsTable = Template.bind({});
+export const controlledQuestionsTable = Template.bind({});
 controlledQuestionsTable.args = {
   data: {
     theOneThatIsSelected: 'first',


### PR DESCRIPTION
Refactors the `QuestionsTable` storybook. The first one is a simple table of radio buttons that can be selected, and the second one shows off how its state can be set/updated (i.e. the first question is pre-set filled in, the second question has an error, and the third one is untouched).

### Simple table
![simple_example](https://github.com/code-dot-org/code-dot-org/assets/56283563/f98d3404-6958-4001-915e-4a385b2c5c4f)

### Controlled Questions table (how it looks before I make any changes)
![complicated_setup](https://github.com/code-dot-org/code-dot-org/assets/56283563/10507627-4aff-43d1-ac19-e7ee1f9d837d)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1430)
Storybook spreadsheet: [here](https://docs.google.com/spreadsheets/d/1z8r10AcR0v3GimV_-28dJ6QaiaQ3CJoo9yXqa7U_bKs/edit#gid=0)

## Testing story
Tested locally on Storybook.
