### PR TITLE
Fix Blockly comment block

### DIFF
--- a/apps/src/blocksCommon.js
+++ b/apps/src/blocksCommon.js
@@ -263,7 +263,7 @@ function installCommentBlock(blockly) {
   Blockly.customBlocks.defineNewBlockGenerator(
     blockly.JavaScript,
     'comment',
-    () => {
+    function () {
       var comment = this.getFieldValue('TEXT');
       return `// ${comment}\n`;
     }


### PR DESCRIPTION
We saw an issue where levels with a comment block were failing to load because `this.getFieldValue()` was not a function. This was due to using an arrow function instead of a regular function, which made `this` refer to `Window` rather than a block.

## Links
- [slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1706731653658989)
- [article on this in arrow functions](https://dmitripavlutin.com/differences-between-arrow-and-regular-functions/#1-this-value)

## Testing story
Tested locally that `/s/csc-starquilts-2023/lessons/3/levels/3` now loads.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
