### PR TITLE
Storybook - Refactor choice_responses.story.jsx

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.story.jsx
@@ -1,278 +1,242 @@
 import React from 'react';
 import ChoiceResponses from './choice_responses';
-import reactBootstrapStoryDecorator from '../../../reactBootstrapStoryDecorator';
 
-export default storybook => {
-  storybook
-    .storiesOf('Choice responses', module)
-    .addDecorator(reactBootstrapStoryDecorator)
-    .addStoryTable([
-      {
-        name: 'Choice responses without other',
-        story: () => (
-          <ChoiceResponses
-            question="What is your favorite pizza topping?"
-            answers={{
-              Peppers: 4,
-              Onions: 13,
-              Mushrooms: 2,
-              Olives: 2,
-              Sausage: 3,
-            }}
-            possibleAnswers={[
-              'Peppers',
-              'Onions',
-              'Mushrooms',
-              'Sausage',
-              'Olives',
-              'Pineapples',
-            ]}
-            answerType="selectText"
-          />
-        ),
-      },
-      {
-        name: 'Choice responses with others',
-        story: () => (
-          <ChoiceResponses
-            question={
-              'What is your favorite pizza topping? Please provide the topping if it is not listed here'
-            }
-            answers={{
-              Peppers: 4,
-              Onions: 13,
-              Mushrooms: 2,
-              Olives: 2,
-              Sausage: 3,
-              Corn: 1,
-              'Anything but pineapples lol': 1,
-              'Kalamata Olives specifically': 1,
-            }}
-            possibleAnswers={[
-              'Peppers',
-              'Onions',
-              'Mushrooms',
-              'Sausage',
-              'Olives',
-              'Pineapples',
-            ]}
-            otherText={'Other toppings'}
-            answerType="selectText"
-          />
-        ),
-      },
-      {
-        name: 'Choice selectValue response',
-        story: () => (
-          <ChoiceResponses
-            question={'What do you think about pineapples on pizza?'}
-            answers={{
-              1: 10,
-              2: 5,
-              3: 1,
-              4: 0,
-              5: 0,
-            }}
-            answerType="selectValue"
-            possibleAnswers={[
-              'Abhorrent',
-              'Not good',
-              'Ambivalent',
-              'Good',
-              'Delicious',
-            ]}
-          />
-        ),
-      },
-      {
-        name: 'Scale ratings',
-        story: () => (
-          <ChoiceResponses
-            question={'How do you feel about deep dish?'}
-            answers={{
-              1: 1,
-              4: 5,
-              5: 10,
-            }}
-            answerType="scale"
-            possibleAnswers={['1 - I hate it', '2', '3', '4', '5 - I love it']}
-          />
-        ),
-      },
-    ]);
+export default {
+  title: 'ChoiceResponses',
+  component: ChoiceResponses,
+};
 
-  storybook
-    .storiesOf('Choice per-facilitator responses', module)
-    .addDecorator(reactBootstrapStoryDecorator)
-    .addStoryTable([
-      {
-        name: 'Choice responses for only one facilitator',
-        story: () => (
-          <ChoiceResponses
-            question="What is your favorite pizza topping?"
-            perFacilitator={true}
-            answers={{
-              Tom: {
-                Peppers: 4,
-                Mushrooms: 2,
-                Olives: 2,
-                Sausage: 3,
-              },
-            }}
-            possibleAnswers={[
-              'Peppers',
-              'Onions',
-              'Mushrooms',
-              'Sausage',
-              'Olives',
-              'Pineapples',
-            ]}
-            answerType="selectText"
-          />
-        ),
-      },
-      {
-        name: 'Choice responses without other',
-        story: () => (
-          <ChoiceResponses
-            question="What is your favorite pizza topping?"
-            perFacilitator={true}
-            answers={{
-              Tom: {
-                Peppers: 4,
-                Mushrooms: 2,
-                Olives: 2,
-                Sausage: 3,
-              },
-              Dick: {
-                Peppers: 4,
-                Onions: 13,
-                Sausage: 3,
-              },
-              Harry: {
-                Pineapples: 5,
-                Onions: 5,
-              },
-            }}
-            possibleAnswers={[
-              'Peppers',
-              'Onions',
-              'Mushrooms',
-              'Sausage',
-              'Olives',
-              'Pineapples',
-            ]}
-            answerType="selectText"
-          />
-        ),
-      },
-      {
-        name: 'Choice responses with others',
-        story: () => (
-          <ChoiceResponses
-            question={
-              'What is your favorite pizza topping? Please provide the topping if it is not listed here'
-            }
-            perFacilitator={true}
-            answers={{
-              Tom: {
-                Peppers: 4,
-                Onions: 13,
-                Mushrooms: 2,
-                Olives: 2,
-                Sausage: 3,
-                Corn: 1,
-                'Anything but pineapples lol': 1,
-                'Kalamata Olives specifically': 1,
-              },
-              Dick: {
-                'Pepperoni and literally nothing else': 1,
-              },
-              Harry: {
-                Peppers: 16,
-                Onions: 17,
-                Mushrooms: 8,
-                Sausage: 16,
-                Olives: 12,
-                Pineapples: 14,
-              },
-            }}
-            possibleAnswers={[
-              'Peppers',
-              'Onions',
-              'Mushrooms',
-              'Sausage',
-              'Olives',
-              'Pineapples',
-            ]}
-            otherText={'Other toppings'}
-            answerType="selectText"
-          />
-        ),
-      },
-      {
-        name: 'Choice selectValue response',
-        story: () => (
-          <ChoiceResponses
-            question={'What do you think about pineapples on pizza?'}
-            perFacilitator={true}
-            answers={{
-              Tom: {
-                1: 10,
-                2: 5,
-                3: 1,
-              },
-              Dick: {
-                3: 1,
-                4: 5,
-                5: 10,
-              },
-              Harry: {
-                1: 1,
-                2: 1,
-                3: 1,
-                4: 1,
-                5: 1,
-              },
-            }}
-            answerType="selectValue"
-            possibleAnswers={[
-              'Abhorrent',
-              'Not good',
-              'Ambivalent',
-              'Good',
-              'Delicious',
-            ]}
-          />
-        ),
-      },
-      {
-        name: 'Scale ratings',
-        story: () => (
-          <ChoiceResponses
-            question={'How do you feel about deep dish?'}
-            perFacilitator={true}
-            answers={{
-              Tom: {
-                1: 10,
-                2: 5,
-                3: 1,
-              },
-              Dick: {
-                3: 1,
-                4: 5,
-                5: 10,
-              },
-              Harry: {
-                1: 1,
-                3: 1,
-                5: 1,
-              },
-            }}
-            answerType="scale"
-            possibleAnswers={['1 - I hate it', '2', '3', '4', '5 - I love it']}
-          />
-        ),
-      },
-    ]);
+const Template = args => (
+  <div id="application-container">
+    <ChoiceResponses {...args} />
+  </div>
+);
+
+export const ChoiceResponsesWithoutOther = Template.bind({});
+ChoiceResponsesWithoutOther.args = {
+  name: 'Choice responses without other',
+  question: 'What is your favorite pizza topping?',
+  answers: {
+    Peppers: 4,
+    Onions: 13,
+    Mushrooms: 2,
+    Olives: 2,
+    Sausage: 3,
+  },
+  possibleAnswers: [
+    'Peppers',
+    'Onions',
+    'Mushrooms',
+    'Sausage',
+    'Olives',
+    'Pineapples',
+  ],
+  answerType: 'selectText',
+};
+
+export const ChoiceResponsesWithOthers = Template.bind({});
+ChoiceResponsesWithOthers.args = {
+  name: 'Choice responses with others',
+  question:
+    'What is your favorite pizza topping? Please provide the topping if it is not listed here',
+  answers: {
+    Peppers: 4,
+    Onions: 13,
+    Mushrooms: 2,
+    Olives: 2,
+    Sausage: 3,
+    Corn: 1,
+    'Anything but pineapples lol': 1,
+    'Kalamata Olives specifically': 1,
+  },
+  possibleAnswers: [
+    'Peppers',
+    'Onions',
+    'Mushrooms',
+    'Sausage',
+    'Olives',
+    'Pineapples',
+  ],
+  otherText: 'Other toppings',
+  answerType: 'selectText',
+};
+
+export const ChoiceSelectValueResponse = Template.bind({});
+ChoiceSelectValueResponse.args = {
+  name: 'Choice selectValue response',
+  question: 'What do you think about pineapples on pizza?',
+  answers: {
+    1: 10,
+    2: 5,
+    3: 1,
+    4: 0,
+    5: 0,
+  },
+  answerType: 'selectValue',
+  possibleAnswers: ['Abhorrent', 'Not good', 'Ambivalent', 'Good', 'Delicious'],
+};
+
+export const ScaleRatings = Template.bind({});
+ScaleRatings.args = {
+  name: 'Scale ratings',
+  question: 'How do you feel about deep dish?',
+  answers: {
+    1: 1,
+    4: 5,
+    5: 10,
+  },
+  answerType: 'scale',
+  possibleAnswers: ['1 - I hate it', '2', '3', '4', '5 - I love it'],
+};
+
+export const ChoiceResponsesForOnlyOneFacilitator = Template.bind({});
+ChoiceResponsesForOnlyOneFacilitator.args = {
+  name: 'Choice responses for only one facilitator',
+  question: 'What is your favorite pizza topping?',
+  perFacilitator: true,
+  answers: {
+    Tom: {
+      Peppers: 4,
+      Mushrooms: 2,
+      Olives: 2,
+      Sausage: 3,
+    },
+  },
+  possibleAnswers: [
+    'Peppers',
+    'Onions',
+    'Mushrooms',
+    'Sausage',
+    'Olives',
+    'Pineapples',
+  ],
+  answerType: 'selectText',
+};
+
+export const ChoiceResponsesWithoutOtherPerFacilitator = Template.bind({});
+ChoiceResponsesWithoutOtherPerFacilitator.args = {
+  name: 'Choice responses without other per facilitator',
+  question: 'What is your favorite pizza topping?',
+  perFacilitator: true,
+  answers: {
+    Tom: {
+      Peppers: 4,
+      Mushrooms: 2,
+      Olives: 2,
+      Sausage: 3,
+    },
+    Dick: {
+      Peppers: 4,
+      Onions: 13,
+      Sausage: 3,
+    },
+    Harry: {
+      Pineapples: 5,
+      Onions: 5,
+    },
+  },
+  possibleAnswers: [
+    'Peppers',
+    'Onions',
+    'Mushrooms',
+    'Sausage',
+    'Olives',
+    'Pineapples',
+  ],
+  answerType: 'selectText',
+};
+
+export const ChoiceResponsesWithOthersPerFacilitator = Template.bind({});
+ChoiceResponsesWithOthersPerFacilitator.args = {
+  name: 'Choice responses with others',
+  question:
+    'What is your favorite pizza topping? Please provide the topping if it is not listed here',
+  perFacilitator: true,
+  answers: {
+    Tom: {
+      Peppers: 4,
+      Onions: 13,
+      Mushrooms: 2,
+      Olives: 2,
+      Sausage: 3,
+      Corn: 1,
+      'Anything but pineapples lol': 1,
+      'Kalamata Olives specifically': 1,
+    },
+    Dick: {
+      'Pepperoni and literally nothing else': 1,
+    },
+    Harry: {
+      Peppers: 16,
+      Onions: 17,
+      Mushrooms: 8,
+      Sausage: 16,
+      Olives: 12,
+      Pineapples: 14,
+    },
+  },
+  possibleAnswers: [
+    'Peppers',
+    'Onions',
+    'Mushrooms',
+    'Sausage',
+    'Olives',
+    'Pineapples',
+  ],
+  otherText: 'Other toppings',
+  answerType: 'selectText',
+};
+
+export const ChoiceSelectValueResponsePerFacilitator = Template.bind({});
+ChoiceSelectValueResponsePerFacilitator.args = {
+  name: 'Choice selectValue response',
+  question: 'What do you think about pineapples on pizza?',
+  perFacilitator: true,
+  answers: {
+    Tom: {
+      1: 10,
+      2: 5,
+      3: 1,
+    },
+    Dick: {
+      3: 1,
+      4: 5,
+      5: 10,
+    },
+    Harry: {
+      1: 1,
+      2: 1,
+      3: 1,
+      4: 1,
+      5: 1,
+    },
+  },
+  answerType: 'selectValue',
+  possibleAnswers: ['Abhorrent', 'Not good', 'Ambivalent', 'Good', 'Delicious'],
+};
+
+export const ScaleRatingsPerFacilitator = Template.bind({});
+ScaleRatingsPerFacilitator.args = {
+  name: 'Scale ratings',
+  question: 'How do you feel about deep dish?',
+  perFacilitator: true,
+  answers: {
+    Tom: {
+      1: 10,
+      2: 5,
+      3: 1,
+    },
+    Dick: {
+      3: 1,
+      4: 5,
+      5: 10,
+    },
+    Harry: {
+      1: 1,
+      3: 1,
+      5: 1,
+    },
+  },
+  answerType: 'scale',
+  possibleAnswers: ['1 - I hate it', '2', '3', '4', '5 - I love it'],
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.story.jsx
@@ -6,11 +6,7 @@ export default {
   component: ChoiceResponses,
 };
 
-const Template = args => (
-  <div id="application-container">
-    <ChoiceResponses {...args} />
-  </div>
-);
+const Template = args => <ChoiceResponses {...args} />;
 
 export const ChoiceResponsesWithoutOther = Template.bind({});
 ChoiceResponsesWithoutOther.args = {


### PR DESCRIPTION
Refactors the `ChoiceResponses` component story.

_Note:_ It looks like there were two `storybook` elements in the original story with duplicated constants: one with and without facilitators. I renamed the duplicate constants to include `PerFacilitator`, but if anyone knows of a cleaner way to do this with the new API let me know!

**Jira ticket:** [ACQ-1433](https://codedotorg.atlassian.net/browse/ACQ-1433)

----

https://github.com/code-dot-org/code-dot-org/assets/9256643/f9d17ca9-b573-4a1a-a5a2-eb1c31bb8a1c
