### PR TITLE
Add HelpTip for Announcement link field

### DIFF
--- a/apps/src/lib/levelbuilder/announcementsEditor/Announcement.jsx
+++ b/apps/src/lib/levelbuilder/announcementsEditor/Announcement.jsx
@@ -5,6 +5,7 @@ import {
   VisibilityType,
 } from '@cdo/apps/code-studio/announcementsRedux';
 import {NotificationType} from '@cdo/apps/templates/Notification';
+import HelpTip from '../../ui/HelpTip';
 
 export default class Announcement extends Component {
   static propTypes = {
@@ -38,6 +39,17 @@ export default class Announcement extends Component {
         </label>
         <label>
           Link
+          <HelpTip>
+            <p>
+              If linking to a studio.code.org, use the relative path, ie
+              "/projects".
+            </p>
+            <p>
+              {' '}
+              If linking to a code.org url, use the full path including
+              protocol, ie "https://code.org/about".
+            </p>
+          </HelpTip>
           <input
             value={announcement.link}
             style={inputStyle}

--- a/apps/src/lib/levelbuilder/announcementsEditor/Announcement.jsx
+++ b/apps/src/lib/levelbuilder/announcementsEditor/Announcement.jsx
@@ -5,7 +5,7 @@ import {
   VisibilityType,
 } from '@cdo/apps/code-studio/announcementsRedux';
 import {NotificationType} from '@cdo/apps/templates/Notification';
-import HelpTip from '../../ui/HelpTip';
+import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 
 export default class Announcement extends Component {
   static propTypes = {


### PR DESCRIPTION
We've had a couple issues where, when a link should go to our code.org site, it ends up going to a broken link. I don't fully understand why but when the link is `code.org/afe`, it sends the user to `studio.code.org/s/code.org/afe`. If `https://` is added in front of the link, it works.

This PR simply adds a HelpTip with this information, as it's a bit of a sharp corner. Definitely open to feedback on wording or whether folks think this is useful.


![Screenshot 2024-01-31 at 4 45 54 PM](https://github.com/code-dot-org/code-dot-org/assets/46464143/c5b72644-b454-46ea-9fa6-194f929d4770)

