### PR TITLE
Version csc-ecosystems for now as the unversioned link is broken

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/csc.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csc.haml
@@ -89,7 +89,8 @@ theme: responsive_full_width
           %img{src: "/images/csc-module-simulating-marine-ecosystem.png", alt: ""}
           %p=hoc_s(:module_desc_simulating_marine_ecosystem)
         .content-footer
-          %a.link-button{href: CDO.studio_url("/s/csc-ecosystems?viewAs=Instructor"), aria:{label: hoc_s(:aria_label_call_to_action_module_simulating_marine_ecosystem)}}
+          -# Because a unit exists called csc-ecosystems, we need to specify a year here 
+          %a.link-button{href: CDO.studio_url("/s/csc-ecosystems-2023?viewAs=Instructor"), aria:{label: hoc_s(:aria_label_call_to_action_module_simulating_marine_ecosystem)}}
             =hoc_s(:call_to_action_see_module_details)
       .action-block.action-block--one-col.flex-space-between
         .content-wrapper


### PR DESCRIPTION
Use a versioned link for csc-ecosystems for now. See [this thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1706807775711969). I think the long-term fix might end up being a bit complex so I want to get this out asap as it is currently broken on our site.

The context here is that a unit exists called `csc-ecosystems` but it's hidden for most users, so users will see a broken link instead of being redirected.