### PR TITLE
Update studio.code.org top nav to match code.org

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -225,7 +225,7 @@ img.video_thumbnail {
 
   @media screen and (max-width: 1010px) {
     .hide_on_tablet {
-      display: none;
+      display: none !important;
     }
   }
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -236,14 +236,18 @@ img.video_thumbnail {
   }
 
   .headerlinks {
-    margin-top: 12px;
+    margin-inline-start: 1rem;
+    display: flex;
+    justify-content: start;
+    align-items: center;
+    gap: 2rem;
 
     .headerlink {
       @include main-font-regular;
-      margin-left: 30px;
       font-size: 14px;
-      line-height: 22px;
+      line-height: 1;
       display: inline-block;
+      margin-top: -1px;
 
       &:link, &:visited {
         text-decoration: none;
@@ -251,6 +255,8 @@ img.video_thumbnail {
 
       &:hover, &:active {
         border-bottom: solid 2px $orange;
+        margin-top: 3px;
+        padding-bottom: 2px;
       }
     }
 
@@ -269,13 +275,14 @@ img.video_thumbnail {
     background-color: transparent;
     border: 2px solid $white;
     border-radius: 5px;
-    padding: 7px 14px;
+    padding: 7px 12px;
     font-size: 14px;
     line-height: 20px;
     box-sizing: border-box;
     float: left;
     cursor: pointer;
     white-space: nowrap;
+    margin-inline-start: 8px;
     a:hover {
       text-decoration: none;
       background-color: $orange;
@@ -321,14 +328,13 @@ img.video_thumbnail {
   }
 
   #hamburger {
-    padding-top: 4px;
-    padding-left: 16px;
+    padding: 4px 3px 0 11px;
   }
 
   .help_button {
     margin-top: 0;
-    padding-top: 4px;
-    padding-left: 16px;
+    padding-top: 3px;
+    padding-left: 11px;
 
     &:not(.user-is-tabbing) {
       outline: none;

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -527,6 +527,7 @@ nav.main .user_menu {
   margin: 0;
   display: flex;
   gap: 2px;
+  cursor: pointer;
 }
 
 nav.main .create_menu i,

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -549,6 +549,7 @@ nav.main .user_menu i.user_menu_arrow_up {
 nav.main .help_button {
   padding: 0;
   height: unset;
+  margin-inline-end: -6px;
 }
 
 nav.main .help_button .help_icon {
@@ -561,7 +562,8 @@ nav.main .help_button .help_contents {
 }
 
 nav.main #hamburger #hamburger-icon {
-  margin-top: -1px;
+  margin-top: -2px;
+  margin-inline-start: 6px;
 }
 
 @media screen and (max-width: 1010px) {

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -61,7 +61,7 @@
     right: 0;
     position: absolute;
     top: 55px;
-    background-color: $teal;
+    background-color: $light_primary_500;
     // We want the z-index to be greater than the teacher panel, which is currently 1021.
     // Teacher panel z-index is defined in teacher-panel.scss
     z-index: 1022;

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -239,7 +239,7 @@
   #hamburger-icon {
     padding: 10px 28px 16px 0;
     float: right;
-    margin-top: 8px;
+    margin-top: 7px;
     display: inline-block;
 
     %extend_burger {

--- a/shared/css/header.scss
+++ b/shared/css/header.scss
@@ -11,12 +11,12 @@
   padding-top: 0;
 
   .pageheader-translucent {
-    background-color: $teal !important;
+    background-color: $light_primary_500 !important;
   }
 
   #pageheader {
     width: 100%;
-    background-color: $teal;
+    background-color: $light_primary_500;
     height: 50px;
     margin: 0 0 40px 0;
 

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -23,15 +23,19 @@
   .user_menu_arrow_up,
   .create_menu_arrow_down,
   .create_menu_arrow_up {
-    font-size: 25px;
-    margin-top: -3px;
+    font-size: 1.5rem;
+    margin-top: -4px;
     .rtl & {
       float: left;
     }
     html[dir='rtl'] & {
       float: left;
-
     }
+  }
+
+  .user_menu_arrow_up,
+  .create_menu_arrow_up {
+    margin-top: -2px;
   }
 
   .user_options, .create_options {
@@ -121,7 +125,6 @@
     padding: 9px 0 16px 0;
     font-size: 26px;
     color: $white;
-    height: 25px;
     cursor: pointer;
     height: 20px;
     vertical-align: middle;


### PR DESCRIPTION
Updates the spacing on the [studio.code.org](https://studio.code.org) top nav to match the updated nav on [code.org](https://code.org) that was done in [this PR](https://github.com/code-dot-org/code-dot-org/pull/55873).

- The teal background color will be updated to the new teal when [this PR](https://github.com/code-dot-org/code-dot-org/pull/56183) goes live.
- There are a few neglible pixel differences due to different markup and stylesheets being used on code.org, but it's much closer to being identical than it was. 
- Tested locally on Chrome, Firefox, and Safari
- There are some minor spacing differences on tablet and mobile between studio.code.org and code.org due to the way studio.code.org is built (it doesn't appear to be optimized for responsive), but updating that is beyond the scope of this PR.

**Jira ticket:** [ACQ-1444](https://codedotorg.atlassian.net/browse/ACQ-1444) 

----

The following examples switch between http://localhost-studio.code.org:3000/home and http://localhost.code.org:3000/teach when **logged in:**

## Before

https://github.com/code-dot-org/code-dot-org/assets/9256643/aee0a546-44be-4217-a851-51827e70e3fd

## After

https://github.com/code-dot-org/code-dot-org/assets/9256643/56f3ac45-3797-4748-8d86-0b7858396042

----

The following examples switch between http://localhost-studio.code.org:3000/courses and http://localhost.code.org:3000/teach when **logged out:**

## Before

https://github.com/code-dot-org/code-dot-org/assets/9256643/43822210-f3c2-4529-9193-7a88c5879cb8

## After

https://github.com/code-dot-org/code-dot-org/assets/9256643/4e1f2461-a34c-4787-823a-d4136b5e297c


----

## Tablet

### Before 
<img width="677" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/36209df8-678e-4c27-be7f-0263c7f896f8">

### After
<img width="677" alt="Screenshot 2024-02-01 at 10 48 26 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/332ce31d-e4df-4f20-b664-9e6dfa095260">

## Mobile

### Before
<img width="431" alt="Screenshot 2024-02-01 at 10 49 43 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/93cc233e-cd3c-4cc5-9f1c-34d5c2998b76">

### After
<img width="431" alt="Screenshot 2024-02-01 at 10 49 36 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/854d7224-0c16-43dd-9cba-6d15c92455b6">


