### PR TITLE
Reorganize Storybook to use directory structure

### DIFF
--- a/apps/.storybook/preview.js
+++ b/apps/.storybook/preview.js
@@ -5,3 +5,15 @@ initializeRTL();
 
 //Stub jquery fileupload library function
 $.fn.fileupload = () => {};
+
+export const parameters = {
+  options: {
+    storySort: {
+      order: [
+        'DesignSystem',
+        'templates',
+        'code-studio',
+      ],
+    }
+  }
+};

--- a/apps/src/applab/ExternalRedirectDialog.story.jsx
+++ b/apps/src/applab/ExternalRedirectDialog.story.jsx
@@ -3,7 +3,6 @@ import {UnconnectedExternalRedirectDialog as ExternalRedirectDialog} from '@cdo/
 import {REDIRECT_RESPONSE} from './redux/applab';
 
 export default {
-  title: 'ExternalRedirectDialog',
   component: ExternalRedirectDialog,
 };
 

--- a/apps/src/applab/ImportProjectDialog.story.jsx
+++ b/apps/src/applab/ImportProjectDialog.story.jsx
@@ -3,7 +3,6 @@ import {ImportProjectDialog} from './ImportProjectDialog';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'ImportProjectDialog',
   component: ImportProjectDialog,
 };
 

--- a/apps/src/code-studio/components/AddAssetButtonRow.story.jsx
+++ b/apps/src/code-studio/components/AddAssetButtonRow.story.jsx
@@ -15,7 +15,6 @@ const mockApi = {
 };
 
 export default {
-  title: 'AddAssetButtonRow',
   component: AddAssetButtonRow,
 };
 

--- a/apps/src/code-studio/components/AssetThumbnail.story.jsx
+++ b/apps/src/code-studio/components/AssetThumbnail.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import AssetThumbnail from './AssetThumbnail';
 
 export default {
-  title: 'AssetThumbnail',
   component: AssetThumbnail,
 };
 

--- a/apps/src/code-studio/components/IconLibrary.story.jsx
+++ b/apps/src/code-studio/components/IconLibrary.story.jsx
@@ -3,7 +3,6 @@ import IconLibrary from './IconLibrary';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'IconLibrary',
   component: IconLibrary,
 };
 

--- a/apps/src/code-studio/components/ImagePicker.story.jsx
+++ b/apps/src/code-studio/components/ImagePicker.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ImagePicker from './ImagePicker';
 
 export default {
-  title: 'ImagePicker',
   component: ImagePicker,
 };
 

--- a/apps/src/code-studio/components/ShareAllowedDialog.story.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.story.jsx
@@ -9,7 +9,6 @@ import shareDialog from '@cdo/apps/code-studio/components/shareDialogRedux';
 import project from '@cdo/apps/code-studio/projectRedux';
 
 export default {
-  title: 'ShareAllowedDialog',
   component: ShareAllowedDialog,
 };
 

--- a/apps/src/code-studio/components/header/RetryProjectSaveDialog.story.jsx
+++ b/apps/src/code-studio/components/header/RetryProjectSaveDialog.story.jsx
@@ -4,7 +4,6 @@ import {projectUpdatedStatuses as statuses} from '../../projectRedux';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'RetryProjectSaveDialog',
   component: RetryProjectSaveDialog,
 };
 

--- a/apps/src/code-studio/components/lessonExtras/MazeThumbnail.story.jsx
+++ b/apps/src/code-studio/components/lessonExtras/MazeThumbnail.story.jsx
@@ -298,7 +298,6 @@ const harvesterMap = [
 ];
 
 export default {
-  title: 'MazeThumbnail',
   component: MazeThumbnail,
 };
 

--- a/apps/src/code-studio/components/playzone.story.jsx
+++ b/apps/src/code-studio/components/playzone.story.jsx
@@ -3,7 +3,6 @@ import PlayZone from './playzone';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'PlayZone',
   component: PlayZone,
 };
 

--- a/apps/src/code-studio/components/progress/LessonProgress.story.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.story.jsx
@@ -90,7 +90,6 @@ const bonus = {
 };
 
 export default {
-  title: 'LessonProgress',
   component: LessonProgress,
 };
 

--- a/apps/src/code-studio/components/progress/MiniViewTopRow.story.jsx
+++ b/apps/src/code-studio/components/progress/MiniViewTopRow.story.jsx
@@ -19,7 +19,6 @@ const initialState = {
 };
 
 export default {
-  title: 'MiniViewTopRow',
   component: MiniViewTopRow,
 };
 

--- a/apps/src/code-studio/components/progress/ResourcesDropdown.story.jsx
+++ b/apps/src/code-studio/components/progress/ResourcesDropdown.story.jsx
@@ -15,7 +15,6 @@ const migratedSampleResources = [
 ];
 
 export default {
-  title: 'ResourcesDropdown',
   component: ResourcesDropdown,
 };
 

--- a/apps/src/code-studio/pd/application_dashboard/cohort_view_table.story.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/cohort_view_table.story.jsx
@@ -3,7 +3,6 @@ import {CohortViewTable} from './cohort_view_table';
 import {WorkshopTypes} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 export default {
-  title: 'CohortViewTable',
   component: CohortViewTable,
 };
 

--- a/apps/src/code-studio/pd/form_components/ButtonList.story.jsx
+++ b/apps/src/code-studio/pd/form_components/ButtonList.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ButtonList from './ButtonList';
 
 export default {
-  title: 'ButtonList',
   component: ButtonList,
 };
 

--- a/apps/src/code-studio/pd/form_components/UsPhoneNumberInput.story.jsx
+++ b/apps/src/code-studio/pd/form_components/UsPhoneNumberInput.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import UsPhoneNumberInput from './UsPhoneNumberInput';
 
 export default {
-  title: 'UsPhoneNumberInput',
   component: UsPhoneNumberInput,
 };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.story.jsx
@@ -4,7 +4,6 @@ import DatePicker from './date_picker';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'DatePicker',
   component: DatePicker,
 };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/free_response_section.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/free_response_section.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import FreeResponseSection from './free_response_section';
 
 export default {
-  title: 'FreeResponseSection',
   component: FreeResponseSection,
 };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/question_averages_table.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/question_averages_table.story.jsx
@@ -15,7 +15,6 @@ const questions = [
 ];
 
 export default {
-  title: 'QuestionAveragesTable',
   component: QuestionAveragesTable,
 };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
@@ -3,7 +3,6 @@ import SurveyRollupTable from '../../components/survey_results/survey_rollup_tab
 import {COURSE_CSF} from '../../workshopConstants';
 
 export default {
-  title: 'SurveyRollupTable',
   component: SurveyRollupTable,
 };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/text_responses.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/text_responses.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import TextResponses from './text_responses';
 
 export default {
-  title: 'TextResponses',
   component: TextResponses,
 };
 

--- a/apps/src/code-studio/peer_reviews/PeerReviewLinkSection.story.jsx
+++ b/apps/src/code-studio/peer_reviews/PeerReviewLinkSection.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PeerReviewLinkSection from './PeerReviewLinkSection';
 
 export default {
-  title: 'PeerReviewLinkSection',
   component: PeerReviewLinkSection,
 };
 

--- a/apps/src/code-studio/peer_reviews/PeerReviewSubmissionData.story.jsx
+++ b/apps/src/code-studio/peer_reviews/PeerReviewSubmissionData.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PeerReviewSubmissionData from './PeerReviewSubmissionData';
 
 export default {
-  title: 'PeerReviewSubmissionData',
   component: PeerReviewSubmissionData,
 };
 

--- a/apps/src/componentLibrary/StylizedBaseDialog.story.jsx
+++ b/apps/src/componentLibrary/StylizedBaseDialog.story.jsx
@@ -3,7 +3,6 @@ import {action} from '@storybook/addon-actions';
 import StylizedBaseDialog from './StylizedBaseDialog';
 
 export default {
-  title: 'StylizedBaseDialog',
   component: StylizedBaseDialog,
 };
 

--- a/apps/src/componentLibrary/TabView.story.jsx
+++ b/apps/src/componentLibrary/TabView.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import TabView from './TabView';
 
 export default {
-  title: 'TabView',
   component: TabView,
 };
 

--- a/apps/src/componentLibrary/checkbox/Checkbox.story.tsx
+++ b/apps/src/componentLibrary/checkbox/Checkbox.story.tsx
@@ -4,7 +4,7 @@ import {Meta, Story} from '@storybook/react';
 import {ComponentSizeXSToL} from '@cdo/apps/componentLibrary/common/types';
 
 export default {
-  title: 'DesignSystem/Checkbox Component',
+  title: 'DesignSystem/Checkbox',
   component: Checkbox,
 } as Meta;
 

--- a/apps/src/componentLibrary/chips/Chips.story.tsx
+++ b/apps/src/componentLibrary/chips/Chips.story.tsx
@@ -4,7 +4,7 @@ import {Meta, Story} from '@storybook/react';
 import {Chips, ChipsProps} from './index';
 
 export default {
-  title: 'DesignSystem/Chips Component',
+  title: 'DesignSystem/Chips',
   component: Chips,
 } as Meta;
 

--- a/apps/src/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon.story.tsx
+++ b/apps/src/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon.story.tsx
@@ -3,7 +3,7 @@ import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from './index';
 import {Meta, Story} from '@storybook/react';
 
 export default {
-  title: 'DesignSystem/FontAwesomeV6Icon Component',
+  title: 'DesignSystem/FontAwesomeV6Icon',
   component: FontAwesomeV6Icon,
 } as Meta;
 

--- a/apps/src/componentLibrary/link/Link.story.tsx
+++ b/apps/src/componentLibrary/link/Link.story.tsx
@@ -3,7 +3,7 @@ import Link, {LinkProps} from './index';
 import {Meta, Story} from '@storybook/react';
 
 export default {
-  title: 'DesignSystem/Link Component',
+  title: 'DesignSystem/Link',
   component: Link,
 } as Meta;
 

--- a/apps/src/componentLibrary/radioButton/RadioButton.story.tsx
+++ b/apps/src/componentLibrary/radioButton/RadioButton.story.tsx
@@ -9,7 +9,7 @@ import {
 } from './index';
 
 export default {
-  title: 'DesignSystem/Radio Button Component',
+  title: 'DesignSystem/Radio Button',
   /**
    * Storybook Docs Generation doesn't work properly (as of 07.19.2023).
    * This workaround (component: Component.type instead of component: Component) is taken from

--- a/apps/src/componentLibrary/segmentedButtons/SegmentedButtons.story.tsx
+++ b/apps/src/componentLibrary/segmentedButtons/SegmentedButtons.story.tsx
@@ -3,7 +3,7 @@ import SegmentedButtons, {SegmentedButtonsProps} from './index';
 import {Meta, Story} from '@storybook/react';
 
 export default {
-  title: 'DesignSystem/Segmented Buttons Component',
+  title: 'DesignSystem/Segmented Buttons',
   component: SegmentedButtons,
 } as Meta;
 

--- a/apps/src/componentLibrary/simpleDropdown/SimpleDropdown.story.tsx
+++ b/apps/src/componentLibrary/simpleDropdown/SimpleDropdown.story.tsx
@@ -3,7 +3,7 @@ import SimpleDropdown, {SimpleDropdownProps} from './index';
 import {Meta, Story} from '@storybook/react';
 
 export default {
-  title: 'DesignSystem/Simple Dropdown Component',
+  title: 'DesignSystem/Simple Dropdown',
   component: SimpleDropdown,
 } as Meta;
 

--- a/apps/src/componentLibrary/tags/Tags.story.tsx
+++ b/apps/src/componentLibrary/tags/Tags.story.tsx
@@ -3,7 +3,7 @@ import Tags, {TagsProps} from './index';
 import {Meta, Story} from '@storybook/react';
 
 export default {
-  title: 'DesignSystem/Tags Component',
+  title: 'DesignSystem/Tags',
   component: Tags,
 } as Meta;
 

--- a/apps/src/componentLibrary/toggle/Toggle.story.tsx
+++ b/apps/src/componentLibrary/toggle/Toggle.story.tsx
@@ -4,7 +4,7 @@ import {Meta, Story} from '@storybook/react';
 import Toggle, {ToggleProps} from './index';
 
 export default {
-  title: 'DesignSystem/Toggle Component',
+  title: 'DesignSystem/Toggle',
   /**
    * Storybook Docs Generation doesn't work properly (as of 07.19.2023).
    * This workaround (component: Component.type instead of component: Component) is taken from

--- a/apps/src/componentLibrary/typography/Typography.story.jsx
+++ b/apps/src/componentLibrary/typography/Typography.story.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Typography from './index';
 
 export default {
-  title: 'DesignSystem/Typography Component',
+  title: 'DesignSystem/Typography',
   component: Typography,
 };
 

--- a/apps/src/lib/kits/maker/ui/MakerStatusOverlay.story.jsx
+++ b/apps/src/lib/kits/maker/ui/MakerStatusOverlay.story.jsx
@@ -16,7 +16,6 @@ const commonProps = {
 };
 
 export default {
-  title: 'MakerStatusOverlay',
   component: UnconnectedMakerStatusOverlay,
 };
 

--- a/apps/src/lib/levelbuilder/announcementsEditor/AnnouncementsEditor.story.jsx
+++ b/apps/src/lib/levelbuilder/announcementsEditor/AnnouncementsEditor.story.jsx
@@ -37,7 +37,6 @@ const inputStyle = {
 };
 
 export default {
-  title: 'AnnouncementsEditor',
   component: AnnouncementsEditor,
 };
 

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.story.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.story.jsx
@@ -20,7 +20,6 @@ import {
 import {allowConsoleWarnings} from '../../../../test/util/testUtils';
 
 export default {
-  title: 'ActivitiesEditor',
   component: ActivitiesEditor,
 };
 

--- a/apps/src/lib/levelbuilder/lesson-editor/LevelTokenDetails.story.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LevelTokenDetails.story.jsx
@@ -17,7 +17,6 @@ const defaultLevel = {
 };
 
 export default {
-  title: 'LevelTokenDetails',
   component: LevelTokenDetails,
 };
 

--- a/apps/src/lib/ui/ConfirmEnableMakerDialog.story.jsx
+++ b/apps/src/lib/ui/ConfirmEnableMakerDialog.story.jsx
@@ -3,7 +3,6 @@ import {ConfirmEnableMakerDialog} from './ConfirmEnableMakerDialog';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'ConfirmEnableMakerDialog',
   component: ConfirmEnableMakerDialog,
 };
 

--- a/apps/src/lib/ui/Headings.story.jsx
+++ b/apps/src/lib/ui/Headings.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {Heading1, Heading2, Heading3} from './Headings';
 
 export default {
-  title: 'Headings',
   // The component and subcomponents properties are somewhat invalid since all headings hold the
   // same weight here, but Storybook requires us to set the component property.
   component: Heading1,

--- a/apps/src/lib/ui/HelpTip.story.jsx
+++ b/apps/src/lib/ui/HelpTip.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import HelpTip from './HelpTip';
 
 export default {
-  title: 'HelpTip',
   component: HelpTip,
 };
 

--- a/apps/src/lib/ui/LtiSectionSyncDialog.story.jsx
+++ b/apps/src/lib/ui/LtiSectionSyncDialog.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import LtiSectionSyncDialog from '@cdo/apps/lib/ui/LtiSectionSyncDialog';
 
 export default {
-  title: 'LtiSectionSyncDialog',
   component: LtiSectionSyncDialog,
 };
 

--- a/apps/src/lib/ui/ParentLetter.story.jsx
+++ b/apps/src/lib/ui/ParentLetter.story.jsx
@@ -24,7 +24,6 @@ const sampleStudents = [
 ];
 
 export default {
-  title: 'ParentLetter',
   component: ParentLetter,
 };
 

--- a/apps/src/lib/ui/PopUpMenu.story.jsx
+++ b/apps/src/lib/ui/PopUpMenu.story.jsx
@@ -3,7 +3,6 @@ import {action} from '@storybook/addon-actions';
 import PopUpMenu from './PopUpMenu';
 
 export default {
-  title: 'PopUpMenu',
   component: PopUpMenu,
 };
 

--- a/apps/src/lib/ui/SchoolInfoConfirmationDialog.story.jsx
+++ b/apps/src/lib/ui/SchoolInfoConfirmationDialog.story.jsx
@@ -3,7 +3,6 @@ import SchoolInfoConfirmationDialog from './SchoolInfoConfirmationDialog';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'SchoolInfoConfirmationDialog',
   component: SchoolInfoConfirmationDialog,
 };
 

--- a/apps/src/lib/ui/SchoolInfoInterstitial.story.jsx
+++ b/apps/src/lib/ui/SchoolInfoInterstitial.story.jsx
@@ -3,7 +3,6 @@ import SchoolInfoInterstitial from './SchoolInfoInterstitial';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'SchoolInfoInterstitial',
   component: SchoolInfoInterstitial,
 };
 

--- a/apps/src/lib/ui/SyncOmniAuthSectionControl.story.jsx
+++ b/apps/src/lib/ui/SyncOmniAuthSectionControl.story.jsx
@@ -10,7 +10,6 @@ import {action} from '@storybook/addon-actions';
 import {SectionLoginType} from '@cdo/apps/util/sharedConstants';
 
 export default {
-  title: 'SyncOmniAuthSectionButton',
   component: SyncOmniAuthSectionButton,
 };
 

--- a/apps/src/lib/ui/ValidationStep.story.jsx
+++ b/apps/src/lib/ui/ValidationStep.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ValidationStep, {Status} from './ValidationStep';
 
 export default {
-  title: 'ValidationStep',
   component: ValidationStep,
 };
 

--- a/apps/src/lib/ui/accounts/AddParentEmailModal.story.jsx
+++ b/apps/src/lib/ui/accounts/AddParentEmailModal.story.jsx
@@ -8,7 +8,6 @@ const DEFAULT_PROPS = {
 };
 
 export default {
-  title: 'AddParentEmailModal',
   component: AddParentEmailModal,
 };
 

--- a/apps/src/lib/ui/accounts/ChangeEmailForm.story.jsx
+++ b/apps/src/lib/ui/accounts/ChangeEmailForm.story.jsx
@@ -21,7 +21,6 @@ const DEFAULT_PROPS = {
 };
 
 export default {
-  title: 'ChangeEmailForm',
   component: ChangeEmailForm,
 };
 

--- a/apps/src/lib/ui/accounts/ChangeEmailModal.story.jsx
+++ b/apps/src/lib/ui/accounts/ChangeEmailModal.story.jsx
@@ -9,7 +9,6 @@ const DEFAULT_PROPS = {
 };
 
 export default {
-  title: 'ChangeEmailModal',
   component: ChangeEmailModal,
 };
 

--- a/apps/src/lib/ui/accounts/ChangeUserTypeForm.story.jsx
+++ b/apps/src/lib/ui/accounts/ChangeUserTypeForm.story.jsx
@@ -17,7 +17,6 @@ const DEFAULT_PROPS = {
 };
 
 export default {
-  title: 'ChangeUserTypeForm',
   component: ChangeUserTypeForm,
 };
 

--- a/apps/src/lib/ui/accounts/ChangeUserTypeModal.story.jsx
+++ b/apps/src/lib/ui/accounts/ChangeUserTypeModal.story.jsx
@@ -8,7 +8,6 @@ const DEFAULT_PROPS = {
 };
 
 export default {
-  title: 'ChangeUserTypeModal',
   component: ChangeUserTypeModal,
 };
 

--- a/apps/src/lib/ui/accounts/DeleteAccountDialog.story.jsx
+++ b/apps/src/lib/ui/accounts/DeleteAccountDialog.story.jsx
@@ -22,7 +22,6 @@ const DEFAULT_PROPS = {
 };
 
 export default {
-  title: 'DeleteAccountDialog',
   component: DeleteAccountDialog,
 };
 

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.story.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.story.jsx
@@ -25,7 +25,6 @@ const mockAuthenticationOptions = {
 };
 
 export default {
-  title: 'ManageLinkedAccounts',
   component: ManageLinkedAccounts,
 };
 

--- a/apps/src/storage/dataBrowser/ConfirmDeleteButton.story.jsx
+++ b/apps/src/storage/dataBrowser/ConfirmDeleteButton.story.jsx
@@ -3,7 +3,6 @@ import ConfirmDeleteButton from './ConfirmDeleteButton';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'ConfirmDeleteButton',
   component: ConfirmDeleteButton,
 };
 

--- a/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.story.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.story.jsx
@@ -3,7 +3,6 @@ import CrossTabChart from './CrossTabChart';
 import _ from 'lodash';
 
 export default {
-  title: 'CrossTabChart',
   component: CrossTabChart,
 };
 

--- a/apps/src/templates/AssignButton.story.jsx
+++ b/apps/src/templates/AssignButton.story.jsx
@@ -4,7 +4,6 @@ import {UnconnectedAssignButton as AssignButton} from './AssignButton';
 import {fakeTeacherSectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/sectionAssignmentTestHelper';
 
 export default {
-  title: 'AssignButton',
   component: AssignButton,
 };
 

--- a/apps/src/templates/BaseDialog.story.jsx
+++ b/apps/src/templates/BaseDialog.story.jsx
@@ -10,7 +10,6 @@ const EXAMPLE_DIALOG_BODY = (
 
 // There isn't a clear abstraction for a template, so each is built separately
 export default {
-  title: 'BaseDialog',
   component: BaseDialog,
 };
 

--- a/apps/src/templates/Button.story.jsx
+++ b/apps/src/templates/Button.story.jsx
@@ -3,7 +3,6 @@ import Button from './Button';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'Button',
   component: Button,
 };
 

--- a/apps/src/templates/ChallengeDialog.story.jsx
+++ b/apps/src/templates/ChallengeDialog.story.jsx
@@ -9,7 +9,6 @@ import StudioWinAvatar from '@cdo/static/skins/studio/win_avatar.png';
 import SpriteLabAvatar from '@cdo/static/spritelab/avatar.png';
 
 export default {
-  title: 'ChallengeDialog',
   component: ChallengeDialog,
 };
 

--- a/apps/src/templates/CollapserIcon.story.jsx
+++ b/apps/src/templates/CollapserIcon.story.jsx
@@ -8,7 +8,6 @@ const styles = {
 };
 
 export default {
-  title: 'CollapserIcon',
   component: CollapserIcon,
 };
 

--- a/apps/src/templates/ContentContainer.story.jsx
+++ b/apps/src/templates/ContentContainer.story.jsx
@@ -5,7 +5,6 @@ import {Provider} from 'react-redux';
 import {reduxStore} from '@cdo/storybook/decorators';
 
 export default {
-  title: 'ContentContainer',
   component: ContentContainer,
 };
 

--- a/apps/src/templates/Dialog.story.jsx
+++ b/apps/src/templates/Dialog.story.jsx
@@ -13,7 +13,6 @@ import {action} from '@storybook/addon-actions';
 
 // There are so many different variations that making a template is not helpful
 export default {
-  title: 'Dialog',
   component: Dialog,
 };
 

--- a/apps/src/templates/DialogButtons.story.jsx
+++ b/apps/src/templates/DialogButtons.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import DialogButtons from './DialogButtons';
 
 export default {
-  title: 'DialogButtons',
   component: DialogButtons,
 };
 

--- a/apps/src/templates/DropdownButton.story.jsx
+++ b/apps/src/templates/DropdownButton.story.jsx
@@ -3,7 +3,6 @@ import DropdownButton from './DropdownButton';
 import Button from '@cdo/apps/templates/Button';
 
 export default {
-  title: 'DropdownButton',
   component: DropdownButton,
 };
 

--- a/apps/src/templates/FallbackPlayerCaptionDialogLink.story.jsx
+++ b/apps/src/templates/FallbackPlayerCaptionDialogLink.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import FallbackPlayerCaptionDialogLink from './FallbackPlayerCaptionDialogLink';
 
 export default {
-  title: 'FallbackPlayerCaptionDialogLink',
   component: FallbackPlayerCaptionDialogLink,
 };
 

--- a/apps/src/templates/GDPRDialog.story.jsx
+++ b/apps/src/templates/GDPRDialog.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import GDPRDialog from './GDPRDialog';
 
 export default {
-  title: 'GDPRDialog',
   component: GDPRDialog,
 };
 

--- a/apps/src/templates/InputPrompt.story.jsx
+++ b/apps/src/templates/InputPrompt.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import InputPrompt from './InputPrompt';
 
 export default {
-  title: 'InputPrompt',
   component: InputPrompt,
 };
 

--- a/apps/src/templates/LegacyButton.story.jsx
+++ b/apps/src/templates/LegacyButton.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import LegacyButton, {BUTTON_TYPES} from './LegacyButton';
 
 const defaultExport = {
-  title: 'LegacyButton',
   component: LegacyButton,
 };
 

--- a/apps/src/templates/Lightbulb.story.jsx
+++ b/apps/src/templates/Lightbulb.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Lightbulb from './Lightbulb';
 
 export default {
-  title: 'Lightbulb',
   component: Lightbulb,
 };
 

--- a/apps/src/templates/Meter.story.jsx
+++ b/apps/src/templates/Meter.story.jsx
@@ -3,7 +3,6 @@ import Meter from '@cdo/apps/templates/Meter';
 import color from '@cdo/apps/util/color';
 
 export default {
-  title: 'Meter',
   component: Meter,
 };
 

--- a/apps/src/templates/MultiCheckboxSelector.story.jsx
+++ b/apps/src/templates/MultiCheckboxSelector.story.jsx
@@ -25,7 +25,6 @@ ComplexItemComponent.propTypes = {
 };
 
 const defaultExport = {
-  title: 'Multi Checkbox Selector',
   component: MultiCheckboxSelector,
 };
 

--- a/apps/src/templates/Notification.story.jsx
+++ b/apps/src/templates/Notification.story.jsx
@@ -5,7 +5,6 @@ import Notification from './Notification';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'Notification',
   component: Notification,
 };
 

--- a/apps/src/templates/PaginationWrapper.story.jsx
+++ b/apps/src/templates/PaginationWrapper.story.jsx
@@ -18,7 +18,6 @@ class StorybookHarness extends React.Component {
 }
 
 export default {
-  title: 'PaginationWrapper',
   component: PaginationWrapper,
 };
 

--- a/apps/src/templates/PaneHeader.story.jsx
+++ b/apps/src/templates/PaneHeader.story.jsx
@@ -14,7 +14,6 @@ const styles = {
 };
 
 export default {
-  title: 'PaneHeader with PaneSections',
   component: PaneHeader,
 };
 

--- a/apps/src/templates/PendingButton.story.jsx
+++ b/apps/src/templates/PendingButton.story.jsx
@@ -4,7 +4,6 @@ import dataStyles from '../storage/dataBrowser/data-styles.module.scss';
 import classNames from 'classnames';
 
 export default {
-  title: 'PendingButton',
   component: PendingButton,
 };
 

--- a/apps/src/templates/ReCaptchaDialog.story.jsx
+++ b/apps/src/templates/ReCaptchaDialog.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReCaptchaDialog from './ReCaptchaDialog';
 
 export default {
-  title: 'ReCaptchaDialog',
   component: ReCaptchaDialog,
 };
 

--- a/apps/src/templates/SchoolInfoInputs.story.js
+++ b/apps/src/templates/SchoolInfoInputs.story.js
@@ -65,7 +65,6 @@ class SchoolInfoInputsWrapper extends Component {
 }
 
 export default {
-  title: 'SchoolInfoInputs',
   component: SchoolInfoInputs,
 };
 

--- a/apps/src/templates/SchoolTypeDropdown.story.js
+++ b/apps/src/templates/SchoolTypeDropdown.story.js
@@ -2,7 +2,6 @@ import React, {Component} from 'react';
 import SchoolTypeDropdown from './SchoolTypeDropdown';
 
 export default {
-  title: 'SchoolTypeDropdown',
   component: SchoolTypeDropdown,
 };
 

--- a/apps/src/templates/SearchBar.story.jsx
+++ b/apps/src/templates/SearchBar.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import SearchBar from './SearchBar';
 
 export default {
-  title: 'SearchBar',
   component: SearchBar,
 };
 

--- a/apps/src/templates/ShareWarningsDialog.story.jsx
+++ b/apps/src/templates/ShareWarningsDialog.story.jsx
@@ -3,7 +3,6 @@ import ShareWarningsDialog from './ShareWarningsDialog';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'ShareWarningsDialog',
   component: ShareWarningsDialog,
 };
 

--- a/apps/src/templates/SignInOrAgeDialog.story.jsx
+++ b/apps/src/templates/SignInOrAgeDialog.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {UnconnectedSignInOrAgeDialog as SignInOrAgeDialog} from './SignInOrAgeDialog';
 
 export default {
-  title: 'SignInOrAgeDialog',
   component: SignInOrAgeDialog,
 };
 

--- a/apps/src/templates/UnassignSectionButton.story.jsx
+++ b/apps/src/templates/UnassignSectionButton.story.jsx
@@ -6,7 +6,6 @@ import {fakeTeacherSectionsForDropdown} from '@cdo/apps/templates/teacherDashboa
 const assignedSection = fakeTeacherSectionsForDropdown[1];
 
 export default {
-  name: 'UnassignSectionButton',
   component: UnassignSectionButton,
 };
 

--- a/apps/src/templates/VerticalImageResourceCard.story.jsx
+++ b/apps/src/templates/VerticalImageResourceCard.story.jsx
@@ -21,7 +21,6 @@ const minecraftCard = {
 };
 
 export default {
-  title: 'VerticalImageResourceCard',
   component: VerticalImageResourceCard,
 };
 

--- a/apps/src/templates/VideoThumbnail.story.jsx
+++ b/apps/src/templates/VideoThumbnail.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import VideoThumbnail from './VideoThumbnail';
 
 export default {
-  title: 'VideoThumbnail',
   component: VideoThumbnail,
 };
 

--- a/apps/src/templates/certificates/petition/PetitionCallToAction.story.js
+++ b/apps/src/templates/certificates/petition/PetitionCallToAction.story.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PetitionCallToAction from '@cdo/apps/templates/certificates/petition/PetitionCallToAction';
 
 export default {
-  title: 'PetitionCallToAction',
   component: PetitionCallToAction,
 };
 

--- a/apps/src/templates/courseOverview/CourseScript.story.js
+++ b/apps/src/templates/courseOverview/CourseScript.story.js
@@ -6,7 +6,6 @@ import {reduxStore} from '../../../.storybook/decorators';
 import {Provider} from 'react-redux';
 
 export default {
-  title: 'CourseScript',
   component: CourseScript,
 };
 

--- a/apps/src/templates/courseRollupPages/CourseRollup.story.jsx
+++ b/apps/src/templates/courseRollupPages/CourseRollup.story.jsx
@@ -196,7 +196,6 @@ const defaultProps = {
 };
 
 export default {
-  title: 'CourseRollup',
   component: CourseRollup,
 };
 

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
@@ -5,7 +5,6 @@ import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSection
 import {configureStore} from '@reduxjs/toolkit';
 
 export default {
-  title: 'CurriculumCatalogCard',
   component: CurriculumCatalogCard,
 };
 

--- a/apps/src/templates/feedback/ParticipantFeedbackNotification.story.jsx
+++ b/apps/src/templates/feedback/ParticipantFeedbackNotification.story.jsx
@@ -5,7 +5,6 @@ import ParticipantFeedbackNotification from './ParticipantFeedbackNotification';
 import sinon from 'sinon';
 
 export default {
-  title: 'ParticipantFeedbackNotification',
   component: ParticipantFeedbackNotification,
 };
 

--- a/apps/src/templates/instructions/InstructionsCSF.story.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.story.jsx
@@ -15,7 +15,6 @@ import SmallStaticAvatar from '@cdo/static/skins/bee/small_static_avatar.png';
 import FailureAvatar from '@cdo/static/skins/bee/failure_avatar.png';
 
 export default {
-  title: 'InstructionsCSF',
   component: InstructionsCSF,
 };
 

--- a/apps/src/templates/instructions/ResourceLink.story.jsx
+++ b/apps/src/templates/instructions/ResourceLink.story.jsx
@@ -2,7 +2,6 @@ import ResourceLink from './ResourceLink';
 import React from 'react';
 
 export default {
-  title: 'ResourceLink',
   component: ResourceLink,
 };
 

--- a/apps/src/templates/instructions/ScrollButtons.story.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ScrollButtons from './ScrollButtons';
 
 export default {
-  title: 'ScrollButtons',
   component: ScrollButtons,
 };
 

--- a/apps/src/templates/instructions/TopInstructions.story.jsx
+++ b/apps/src/templates/instructions/TopInstructions.story.jsx
@@ -15,7 +15,6 @@ import SmallStaticAvatar from '@cdo/static/skins/bee/small_static_avatar.png';
 import FailureAvatar from '@cdo/static/skins/bee/failure_avatar.png';
 
 export default {
-  title: 'TopInstructions',
   component: TopInstructions,
 };
 

--- a/apps/src/templates/lessonOverview/LessonStandards.story.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.story.jsx
@@ -6,7 +6,6 @@ import {
 } from '../../../test/unit/templates/lessonOverview/sampleStandardsData.js';
 
 export default {
-  title: 'LessonStandards',
   component: LessonStandards,
 };
 

--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.story.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.story.jsx
@@ -127,7 +127,6 @@ const levelWithContainedLevel = {
 };
 
 export default {
-  title: 'LevelDetailsDialog',
   component: LevelDetailsDialog,
 };
 

--- a/apps/src/templates/policy_compliance/ChildAccountConsent.story.jsx
+++ b/apps/src/templates/policy_compliance/ChildAccountConsent.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ChildAccountConsent from './ChildAccountConsent';
 
 export default {
-  title: 'ChildAccountConsent',
   component: ChildAccountConsent,
 };
 

--- a/apps/src/templates/policy_compliance/LockoutLinkedAccounts.story.jsx
+++ b/apps/src/templates/policy_compliance/LockoutLinkedAccounts.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import LockoutLinkedAccounts from './LockoutLinkedAccounts';
 
 export default {
-  title: 'LockoutLinkedAccounts',
   component: LockoutLinkedAccounts,
 };
 

--- a/apps/src/templates/progress/DetailProgressTable.story.jsx
+++ b/apps/src/templates/progress/DetailProgressTable.story.jsx
@@ -10,7 +10,6 @@ import {
 } from './progressTestHelpers';
 
 export default {
-  title: 'DetailProgressTable',
   component: DetailProgressTable,
 };
 

--- a/apps/src/templates/progress/LessonGroup.story.jsx
+++ b/apps/src/templates/progress/LessonGroup.story.jsx
@@ -51,7 +51,6 @@ const groupedLesson = {
 };
 
 export default {
-  name: 'LessonGroup',
   compoent: LessonGroup,
 };
 

--- a/apps/src/templates/progress/ProgressBubble.story.jsx
+++ b/apps/src/templates/progress/ProgressBubble.story.jsx
@@ -5,7 +5,6 @@ import {LevelKind, LevelStatus} from '@cdo/apps/util/sharedConstants';
 const statuses = Object.values(LevelStatus);
 
 const defaultExport = {
-  title: 'ProgressBubble',
   component: ProgressBubble,
 };
 

--- a/apps/src/templates/progress/ProgressBubbleSet.story.jsx
+++ b/apps/src/templates/progress/ProgressBubbleSet.story.jsx
@@ -18,7 +18,6 @@ const levels = fakeLevels(5).map((level, index) => ({
 levels[0].isConceptLevel = true;
 
 export default {
-  title: 'ProgressBubbleSet',
   component: ProgressBubbleSet,
 };
 

--- a/apps/src/templates/progress/ProgressDetailToggle.story.jsx
+++ b/apps/src/templates/progress/ProgressDetailToggle.story.jsx
@@ -5,7 +5,6 @@ import {reduxStore} from '@cdo/storybook/decorators';
 import {Provider} from 'react-redux';
 
 export default {
-  title: 'ProgressDetailToggle',
   component: ProgressDetailToggle,
 };
 

--- a/apps/src/templates/progress/ProgressLegend.story.jsx
+++ b/apps/src/templates/progress/ProgressLegend.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ProgressLegend from './ProgressLegend';
 
 export default {
-  title: 'ProgressLegend',
   component: ProgressLegend,
 };
 

--- a/apps/src/templates/progress/ProgressLesson.story.jsx
+++ b/apps/src/templates/progress/ProgressLesson.story.jsx
@@ -11,7 +11,6 @@ import hiddenLesson from '@cdo/apps/code-studio/hiddenLessonRedux';
 import lessonLock from '@cdo/apps/code-studio/lessonLockRedux';
 
 export default {
-  title: 'ProgressLesson',
   component: ProgressLesson,
 };
 

--- a/apps/src/templates/progress/ProgressLessonContent.story.jsx
+++ b/apps/src/templates/progress/ProgressLessonContent.story.jsx
@@ -6,7 +6,6 @@ import {reduxStore} from '@cdo/storybook/decorators';
 import {Provider} from 'react-redux';
 
 export default {
-  title: 'ProgressLessonContent',
   component: ProgressLessonContent,
 };
 

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.story.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.story.jsx
@@ -156,7 +156,6 @@ const style = {
 };
 
 export default {
-  title: 'ProgressLessonTeacherInfo',
   component: ProgressLessonTeacherInfo,
 };
 

--- a/apps/src/templates/progress/ProgressLevelSet.story.jsx
+++ b/apps/src/templates/progress/ProgressLevelSet.story.jsx
@@ -6,7 +6,6 @@ import {reduxStore} from '@cdo/storybook/decorators';
 import {Provider} from 'react-redux';
 
 export default {
-  title: 'ProgressLevelSet',
   component: ProgressLevelSet,
 };
 

--- a/apps/src/templates/progress/ProgressPill.story.jsx
+++ b/apps/src/templates/progress/ProgressPill.story.jsx
@@ -3,7 +3,6 @@ import {UnconnectedProgressPill as ProgressPill} from './ProgressPill';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 export default {
-  title: 'ProgressPill',
   component: ProgressPill,
 };
 

--- a/apps/src/templates/progress/SummaryProgressTable.story.jsx
+++ b/apps/src/templates/progress/SummaryProgressTable.story.jsx
@@ -12,7 +12,6 @@ import {
 import {Provider} from 'react-redux';
 
 export default {
-  title: 'SummaryProgressTable',
   component: SummaryProgressTable,
 };
 

--- a/apps/src/templates/projects/FeaturedProjectsTable.story.jsx
+++ b/apps/src/templates/projects/FeaturedProjectsTable.story.jsx
@@ -21,6 +21,5 @@ FeaturedProjectTableArchive.args = {
 };
 
 export default {
-  title: 'FeaturedProjectsTable',
   component: FeaturedProjectsTable,
 };

--- a/apps/src/templates/projects/LibraryTable.story.jsx
+++ b/apps/src/templates/projects/LibraryTable.story.jsx
@@ -5,7 +5,6 @@ import {reduxStore} from '../../../.storybook/decorators';
 import {Provider} from 'react-redux';
 
 export default {
-  title: 'LibraryTable',
   component: LibraryTable,
 };
 

--- a/apps/src/templates/projects/NewProjectButtons.story.jsx
+++ b/apps/src/templates/projects/NewProjectButtons.story.jsx
@@ -31,6 +31,5 @@ MinecraftProjectButtons.args = {
 };
 
 export default {
-  title: 'NewProjectButtons',
   component: NewProjectButtons,
 };

--- a/apps/src/templates/projects/ProjectCard.story.jsx
+++ b/apps/src/templates/projects/ProjectCard.story.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ProjectCard from './ProjectCard';
 
-export default {title: 'ProjectCard', component: ProjectCard};
+export default {component: ProjectCard};
 
 const defaultData = {
   channel: 'abcdef',

--- a/apps/src/templates/projects/ProjectCardGrid.story.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.story.jsx
@@ -83,7 +83,6 @@ const createProjectsStore = function (galleryType) {
 };
 
 export default {
-  title: 'ProjectCardGrid',
   component: ProjectCardGrid,
 };
 

--- a/apps/src/templates/projects/ProjectWidget.story.jsx
+++ b/apps/src/templates/projects/ProjectWidget.story.jsx
@@ -5,7 +5,6 @@ import {reduxStore} from '../../../.storybook/decorators';
 import {Provider} from 'react-redux';
 
 export default {
-  title: 'ProjectWidget',
   component: ProjectWidget,
 };
 

--- a/apps/src/templates/projects/ProjectsList.story.jsx
+++ b/apps/src/templates/projects/ProjectsList.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ProjectsList from './ProjectsList';
 
 export default {
-  title: 'ProjectsList',
   component: ProjectsList,
 };
 

--- a/apps/src/templates/projects/deleteDialog/DeleteProjectDialog.story.jsx
+++ b/apps/src/templates/projects/deleteDialog/DeleteProjectDialog.story.jsx
@@ -5,7 +5,6 @@ import {reduxStore} from '../../../../.storybook/decorators';
 import {Provider} from 'react-redux';
 
 export default {
-  title: 'DeleteProjectDialog',
   component: DeleteProjectDialog,
 };
 

--- a/apps/src/templates/projects/publishDialog/PublishDialog.story.jsx
+++ b/apps/src/templates/projects/publishDialog/PublishDialog.story.jsx
@@ -26,6 +26,5 @@ DialogOpenPublishPending.args = {
 };
 
 export default {
-  title: 'PublishDialog',
   component: PublishDialog,
 };

--- a/apps/src/templates/rubrics/LearningGoal.story.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.story.jsx
@@ -3,7 +3,6 @@ import {RubricUnderstandingLevels} from '@cdo/apps/util/sharedConstants';
 import LearningGoal from './LearningGoal';
 
 export default {
-  title: 'LearningGoal',
   component: LearningGoal,
 };
 

--- a/apps/src/templates/rubrics/RubricContainer.story.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.story.jsx
@@ -3,7 +3,6 @@ import {RubricUnderstandingLevels} from '@cdo/apps/util/sharedConstants';
 import RubricContainer from './RubricContainer';
 
 export default {
-  title: 'RubricContainer',
   component: RubricContainer,
 };
 

--- a/apps/src/templates/sectionAssessments/FreeResponseDetailsDialog.story.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponseDetailsDialog.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {UnconnectedFreeResponseDetailsDialog as FreeResponseDetailsDialog} from '@cdo/apps/templates/sectionAssessments/FreeResponseDetailsDialog';
 
 export default {
-  title: 'FreeResponseDetailsDialog',
   component: FreeResponseDetailsDialog,
 };
 

--- a/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsTable.story.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsTable.story.jsx
@@ -7,7 +7,6 @@ import {
 } from './assessmentsTestHelpers';
 
 export default {
-  title: 'FreeResponsesAssessmentsTable',
   component: FreeResponsesAssessmentsTable,
 };
 

--- a/apps/src/templates/sectionAssessments/FreeResponsesSurveyTable.story.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponsesSurveyTable.story.jsx
@@ -3,7 +3,6 @@ import FreeResponsesSurveyTable from './FreeResponsesSurveyTable';
 import {surveyOne} from './assessmentsTestHelpers';
 
 export default {
-  title: 'FreeResponsesSurveyTable',
   component: FreeResponsesSurveyTable,
 };
 

--- a/apps/src/templates/sectionAssessments/MatchAssessmentsOverviewTable.story.jsx
+++ b/apps/src/templates/sectionAssessments/MatchAssessmentsOverviewTable.story.jsx
@@ -6,7 +6,6 @@ import {
 } from './assessmentsTestHelpers';
 
 export default {
-  title: 'MatchAssessmentsOverviewTable',
   component: UnconnectedMatchAssessmentsOverviewTable,
 };
 

--- a/apps/src/templates/sectionAssessments/MatchByStudentTable.story.jsx
+++ b/apps/src/templates/sectionAssessments/MatchByStudentTable.story.jsx
@@ -3,7 +3,6 @@ import MatchByStudentTable from './MatchByStudentTable';
 import {matchDataForSingleStudent} from './assessmentsTestHelpers';
 
 export default {
-  title: 'MatchByStudentTable',
   component: MatchByStudentTable,
 };
 

--- a/apps/src/templates/sectionAssessments/MatchDetailsDialog.story.jsx
+++ b/apps/src/templates/sectionAssessments/MatchDetailsDialog.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {UnconnectedMatchDetailsDialog as MatchDetailsDialog} from './MatchDetailsDialog';
 
 export default {
-  title: 'MatchDetailsDialog',
   component: MatchDetailsDialog,
 };
 

--- a/apps/src/templates/sectionAssessments/MultipleChoiceAssessmentsOverviewTable.story.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceAssessmentsOverviewTable.story.jsx
@@ -153,7 +153,6 @@ const multipleChoiceData = [
 ];
 
 export default {
-  name: 'MultipleChoiceAssessmentsOverviewTable',
   component: MultipleChoiceAssessmentsOverviewTable,
 };
 

--- a/apps/src/templates/sectionAssessments/MultipleChoiceByStudentTable.story.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceByStudentTable.story.jsx
@@ -6,7 +6,6 @@ import {
 } from './assessmentsTestHelpers';
 
 export default {
-  title: 'MultipleChoiceByStudentTable',
   component: MultipleChoiceByStudentTable,
 };
 

--- a/apps/src/templates/sectionAssessments/MultipleChoiceDetailsDialog.story.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceDetailsDialog.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {UnconnectedMultipleChoiceDetailsDialog as MultipleChoiceDetailsDialog} from './MultipleChoiceDetailsDialog';
 
 export default {
-  title: 'MultipleChoiceDetailsDialog',
   component: MultipleChoiceDetailsDialog,
 };
 

--- a/apps/src/templates/sectionAssessments/MultipleChoiceSurveyOverviewTable.story.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceSurveyOverviewTable.story.jsx
@@ -3,7 +3,6 @@ import MultipleChoiceSurveyOverviewTable from './MultipleChoiceSurveyOverviewTab
 import i18n from '@cdo/locale';
 
 export default {
-  title: 'MultipleChoiceSurveyOverviewTable',
   component: MultipleChoiceSurveyOverviewTable,
 };
 

--- a/apps/src/templates/sectionAssessments/PercentAnsweredCell.story.jsx
+++ b/apps/src/templates/sectionAssessments/PercentAnsweredCell.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PercentAnsweredCell from './PercentAnsweredCell';
 
 export default {
-  title: 'PercentAnsweredCell',
   component: PercentAnsweredCell,
 };
 

--- a/apps/src/templates/sectionProgress/ProgressBox.story.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ProgressBox from './ProgressBox';
 
 export default {
-  title: 'ProgressBox',
   component: ProgressBox,
 };
 

--- a/apps/src/templates/sectionProgress/SectionProgressToggle.story.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgressToggle.story.jsx
@@ -6,7 +6,6 @@ import {Provider} from 'react-redux';
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 
 export default {
-  title: 'SectionProgressToggle',
   component: SectionProgressToggle,
 };
 

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.story.jsx
@@ -39,7 +39,6 @@ const levelWithSublevels = fakeLevels(1)[0];
 levelWithSublevels.sublevels = sublevels;
 
 export default {
-  title: 'ProgressTableDetailCell',
   component: ProgressTableDetailCell,
 };
 

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.story.jsx
@@ -28,7 +28,6 @@ const wrapperStyle = {
 };
 
 const defaultExport = {
-  name: 'ProgressTableLevelBubble',
   component: ProgressTableLevelBubble,
 };
 

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.story.jsx
@@ -26,7 +26,6 @@ import currentUser from '@cdo/apps/templates/currentUserRedux';
 const INCLUDE_LARGE_STORIES = false;
 
 const defaultExport = {
-  title: 'ProgressTableView',
   component: ProgressTableView,
 };
 

--- a/apps/src/templates/sectionProgress/progressTables/SummaryViewLegend.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/SummaryViewLegend.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import SummaryViewLegend from './SummaryViewLegend';
 
 export default {
-  title: 'SummaryViewLegend',
   component: SummaryViewLegend,
 };
 

--- a/apps/src/templates/sectionProgress/standards/CreateStandardsReportDialog.story.jsx
+++ b/apps/src/templates/sectionProgress/standards/CreateStandardsReportDialog.story.jsx
@@ -8,7 +8,6 @@ import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgress
 import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 
 export default {
-  title: 'CreateStandardsReportDialog',
   component: CreateStandardsReportDialog,
 };
 

--- a/apps/src/templates/sectionProgress/standards/LessonStatusDialog.story.jsx
+++ b/apps/src/templates/sectionProgress/standards/LessonStatusDialog.story.jsx
@@ -9,7 +9,6 @@ import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSection
 import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 
 export default {
-  title: 'LessonStatusDialog',
   component: LessonStatusDialog,
 };
 

--- a/apps/src/templates/sectionProgress/standards/LessonStatusList.story.jsx
+++ b/apps/src/templates/sectionProgress/standards/LessonStatusList.story.jsx
@@ -31,7 +31,6 @@ const store = reduxStore(
 );
 
 export default {
-  title: 'LessonStatusList',
   component: LessonStatusList,
 };
 

--- a/apps/src/templates/sectionProgress/standards/StandardsIntroDialog.story.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsIntroDialog.story.jsx
@@ -3,7 +3,6 @@ import {UnconnectedStandardsIntroDialog as StandardsIntroDialog} from './Standar
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'StandardsIntroDialog',
   component: StandardsIntroDialog,
 };
 

--- a/apps/src/templates/sectionProgress/standards/StandardsProgressTable.story.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsProgressTable.story.jsx
@@ -9,7 +9,6 @@ import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import {reduxStore} from '@cdo/storybook/decorators';
 
 export default {
-  title: 'StandardsProgressTable',
   component: StandardsProgressTable,
 };
 

--- a/apps/src/templates/sessions/LockoutPanel.story.jsx
+++ b/apps/src/templates/sessions/LockoutPanel.story.jsx
@@ -4,7 +4,6 @@ import LockoutPanel from './LockoutPanel';
 const DAYS = 1000 * 60 * 60 * 24;
 
 export default {
-  title: 'LockoutPanel',
   component: LockoutPanel,
 };
 

--- a/apps/src/templates/studioHomepages/CourseBlocksWrapper.story.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocksWrapper.story.jsx
@@ -9,7 +9,6 @@ import {
 } from '@cdo/apps/util/courseBlockCardsConstants';
 
 export default {
-  title: 'CourseBlocksWrapper',
   component: CourseBlocksWrapper,
 };
 

--- a/apps/src/templates/studioHomepages/CourseCard.story.jsx
+++ b/apps/src/templates/studioHomepages/CourseCard.story.jsx
@@ -17,7 +17,6 @@ const examplePLCard = {
 };
 
 export default {
-  title: 'CourseCard',
   component: CourseCard,
 };
 

--- a/apps/src/templates/studioHomepages/ImageResourceCard.story.jsx
+++ b/apps/src/templates/studioHomepages/ImageResourceCard.story.jsx
@@ -4,7 +4,6 @@ import {Provider} from 'react-redux';
 import {reduxStore} from '@cdo/storybook/decorators';
 
 export default {
-  title: 'ImageResourceCard',
   component: ImageResourceCard,
 };
 

--- a/apps/src/templates/studioHomepages/JoinSection.story.jsx
+++ b/apps/src/templates/studioHomepages/JoinSection.story.jsx
@@ -3,7 +3,6 @@ import {UnconnectedJoinSection as JoinSection} from './JoinSection';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'JoinSection',
   component: JoinSection,
 };
 

--- a/apps/src/templates/studioHomepages/JoinSectionNotifications.story.jsx
+++ b/apps/src/templates/studioHomepages/JoinSectionNotifications.story.jsx
@@ -4,7 +4,6 @@ import {Provider} from 'react-redux';
 import {reduxStore} from '@cdo/storybook/decorators';
 
 export default {
-  title: 'JoinSectionNotifications',
   component: JoinSectionNotifications,
 };
 

--- a/apps/src/templates/studioHomepages/ParticipantSections.story.jsx
+++ b/apps/src/templates/studioHomepages/ParticipantSections.story.jsx
@@ -38,7 +38,6 @@ const sections = [
 ];
 
 export default {
-  title: 'ParticipantSections',
   component: ParticipantSections,
 };
 

--- a/apps/src/templates/studioHomepages/RecentCourses.story.jsx
+++ b/apps/src/templates/studioHomepages/RecentCourses.story.jsx
@@ -4,7 +4,6 @@ import {Provider} from 'react-redux';
 import {reduxStore} from '@cdo/storybook/decorators';
 
 export default {
-  title: 'RecentCourses',
   component: RecentCourses,
 };
 

--- a/apps/src/templates/studioHomepages/ResourceCard.story.jsx
+++ b/apps/src/templates/studioHomepages/ResourceCard.story.jsx
@@ -4,7 +4,6 @@ import {Provider} from 'react-redux';
 import {reduxStore} from '@cdo/storybook/decorators';
 
 export default {
-  title: 'ResourceCard',
   component: ResourceCard,
 };
 

--- a/apps/src/templates/studioHomepages/SectionsAsStudentTable.story.jsx
+++ b/apps/src/templates/studioHomepages/SectionsAsStudentTable.story.jsx
@@ -65,7 +65,6 @@ const sections = [
 ];
 
 export default {
-  title: 'SectionAsStudentTable',
   component: SectionsAsStudentTable,
 };
 

--- a/apps/src/templates/studioHomepages/SeeMoreCourses.story.jsx
+++ b/apps/src/templates/studioHomepages/SeeMoreCourses.story.jsx
@@ -24,7 +24,6 @@ const courses = [
 ];
 
 export default {
-  title: 'SeeMoreCourse',
   component: SeeMoreCourses,
 };
 

--- a/apps/src/templates/studioHomepages/SetUpCourses.story.jsx
+++ b/apps/src/templates/studioHomepages/SetUpCourses.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import SetUpCourses from './SetUpCourses';
 
 export default {
-  title: 'SetUpCourses',
   component: SetUpCourses,
 };
 

--- a/apps/src/templates/studioHomepages/SetUpSections.story.jsx
+++ b/apps/src/templates/studioHomepages/SetUpSections.story.jsx
@@ -5,7 +5,6 @@ import {reduxStore} from '@cdo/storybook/decorators';
 import {Provider} from 'react-redux';
 
 export default {
-  title: 'SetUpSections',
   component: SetUpSections,
 };
 

--- a/apps/src/templates/studioHomepages/TeacherHomepage.story.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.story.jsx
@@ -35,7 +35,6 @@ const serverCourses = [
 ];
 
 export default {
-  title: 'TeacherHomepage',
   component: TeacherHomepage,
 };
 

--- a/apps/src/templates/studioHomepages/TeacherResources.story.jsx
+++ b/apps/src/templates/studioHomepages/TeacherResources.story.jsx
@@ -4,7 +4,6 @@ import {Provider} from 'react-redux';
 import {reduxStore} from '@cdo/storybook/decorators';
 
 export default {
-  title: 'TeacherResources',
   component: TeacherResources,
 };
 

--- a/apps/src/templates/studioHomepages/TeacherSections.story.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.story.jsx
@@ -9,7 +9,6 @@ import teacherSections, {
 import TeacherSections from './TeacherSections';
 
 export default {
-  title: 'TeacherSections',
   component: TeacherSections,
 };
 

--- a/apps/src/templates/studioHomepages/TopCourse.story.jsx
+++ b/apps/src/templates/studioHomepages/TopCourse.story.jsx
@@ -4,7 +4,6 @@ import {Provider} from 'react-redux';
 import {reduxStore} from '@cdo/storybook/decorators';
 
 export default {
-  title: 'TopCourse',
   component: TopCourse,
 };
 

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.story.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.story.jsx
@@ -7,7 +7,6 @@ import {Provider} from 'react-redux';
 import {reduxStore} from '@cdo/storybook/decorators';
 
 export default {
-  title: 'TwoColumnActionBlock',
   component: TwoColumnActionBlock,
 };
 

--- a/apps/src/templates/tables/QuickActionsCell.story.jsx
+++ b/apps/src/templates/tables/QuickActionsCell.story.jsx
@@ -3,7 +3,6 @@ import QuickActionsCell from './QuickActionsCell';
 import PopUpMenu, {MenuBreak} from '@cdo/apps/lib/ui/PopUpMenu';
 
 export default {
-  title: 'QuickActionsCell',
   component: QuickActionsCell,
 };
 

--- a/apps/src/templates/teacherDashboard/AssignmentVersionSelector.story.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentVersionSelector.story.jsx
@@ -4,7 +4,6 @@ import AssignmentVersionSelector from './AssignmentVersionSelector';
 import {courseOfferings} from '@cdo/apps/templates/teacherDashboard/teacherDashboardTestHelpers';
 
 export default {
-  title: 'AssignmentVersionSelector',
   component: AssignmentVersionSelector,
 };
 

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.story.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.story.jsx
@@ -3,7 +3,6 @@ import {UnconnectedLoginTypePicker as LoginTypePicker} from './LoginTypePicker';
 import {action} from '@storybook/addon-actions';
 
 export default {
-  title: 'LoginTypePicker',
   component: LoginTypePicker,
 };
 

--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.story.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.story.jsx
@@ -6,7 +6,6 @@ import {reduxStore} from '@cdo/storybook/decorators';
 import teacherSections from './teacherSectionsRedux';
 
 export default {
-  title: 'SectionLoginInfo',
   component: SectionLoginInfo,
 };
 

--- a/apps/src/templates/teacherDashboard/TeacherSectionSelector.story.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherSectionSelector.story.jsx
@@ -4,7 +4,6 @@ import {action} from '@storybook/addon-actions';
 import {fakeTeacherSectionsForDropdown} from './sectionAssignmentTestHelper';
 
 export default {
-  title: 'TeacherSectionSelector',
   component: TeacherSectionSelector,
 };
 

--- a/apps/src/templates/textResponses/TextResponsesTable.story.jsx
+++ b/apps/src/templates/textResponses/TextResponsesTable.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import TextResponsesTable from './TextResponsesTable';
 
 export default {
-  title: 'TextResponsesTable',
   component: TextResponsesTable,
 };
 

--- a/apps/src/weblab/dialogs/DisallowedHtmlWarningDialog.story.js
+++ b/apps/src/weblab/dialogs/DisallowedHtmlWarningDialog.story.js
@@ -3,7 +3,6 @@ import {action} from '@storybook/addon-actions';
 import DisallowedHtmlWarningDialog from './DisallowedHtmlWarningDialog';
 
 export default {
-  title: 'DisallowedHtmlWarningDialog',
   component: DisallowedHtmlWarningDialog,
 };
 

--- a/apps/src/weblab/dialogs/FatalErrorDialog.story.js
+++ b/apps/src/weblab/dialogs/FatalErrorDialog.story.js
@@ -3,7 +3,6 @@ import {action} from '@storybook/addon-actions';
 import FatalErrorDialog from './FatalErrorDialog';
 
 export default {
-  title: 'FatalErrorDialog',
   component: FatalErrorDialog,
 };
 

--- a/apps/src/weblab/dialogs/ResetSuccessDialog.story.js
+++ b/apps/src/weblab/dialogs/ResetSuccessDialog.story.js
@@ -3,7 +3,6 @@ import {action} from '@storybook/addon-actions';
 import ResetSuccessDialog from './ResetSuccessDialog';
 
 export default {
-  title: 'ResetSuccessDialog',
   component: ResetSuccessDialog,
 };
 

--- a/apps/src/weblab/dialogs/UploadErrorDialog.story.js
+++ b/apps/src/weblab/dialogs/UploadErrorDialog.story.js
@@ -3,7 +3,6 @@ import {action} from '@storybook/addon-actions';
 import UploadErrorDialog from './UploadErrorDialog';
 
 export default {
-  title: 'UploadErrorDialog',
   component: UploadErrorDialog,
 };
 


### PR DESCRIPTION
Currently, when creating a new Storybook component, we include a `title` in the default export that typically matches the name of the component itself, something like:

```
export default {
  title: 'GDPRDialog',
  component: GDPRDialog,
};
```

According to Storybook, [this is an anti-pattern](https://github.com/storybookjs/eslint-plugin-storybook/blob/main/docs/rules/no-title-property-in-meta.md) -- this PR removes that property from (almost, see caveat below) all of our Storybook components.

Removing it gives us the goodness of using our directory structure to inform Storybook's structure. Admittedly, there's work to do in organizing our `apps` directory, but IMO this is easier to follow than what was here previously (an almost entirely unstructured organization of components), and any reorganization we do of `apps` will automagically be reflected in Storybook as well. It also alphabetizes everything automagically, which is nice!

I've also added some configuration that puts the new design system components @levadadenys has been working on at the top of Storybook, since I think of those as the first thing you'd want to see when opening it. The design system components still use the `title` property so it appears at the top level -- you can still include a `title` property in your component if you want to create a new top-level "root" node (as they call it in [Storybook docs](https://storybook.js.org/docs/6.5/writing-stories/naming-components-and-hierarchy#roots)) and override the default of using the directory structure.

The downside of this approach (IMO) is that there is more hierarchy, and this hierarchy reflects our `apps` hierarchy (see second screenshot), so you might not see a component that you might have stumbled across had it been at the root level like it was previously. I think the upside outweighs the downside, but open to other opinions.

| Before | After |
| - | - |
| <img width="219" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/14817a2f-8a68-4c9c-a932-9679a78e8aad"> | <img width="284" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/fb519cee-8f9d-4343-b4e1-778d7f1a5aef"> |
|(no equivalent, most components appear at the "root" level) | <img width="285" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/ceb628f8-3dd1-49ab-a152-1e5070da85ed"> |

## Testing story

Tested manually locally (see screenshots).

## Follow-up work

It might make sense to enable some linting that would prevent adding of a `title` property (like what's in the Storybook linter mentioned above)? But given our `apps` (dis)organization, I do like the idea of giving people the option to override, like what we do with design system components. Maybe a linting rule like "you must include a slash in the title if you want to include a title property"?