### PR TITLE
[Blockly] update math_random_int generators

### DIFF
--- a/apps/src/blockly/customBlocks/cdoBlockly/commonBlocks.js
+++ b/apps/src/blockly/customBlocks/cdoBlockly/commonBlocks.js
@@ -113,4 +113,45 @@ export const blocks = {
     generator[type] = generatorFunction;
   },
   addSerializationHooksToBlock() {},
+  mathRandomIntGenerator() {
+    // Random integer between [X] and [Y].
+    var argument0 =
+      Blockly.JavaScript.valueToCode(
+        this,
+        'FROM',
+        Blockly.JavaScript.ORDER_COMMA
+      ) || '0';
+    var argument1 =
+      Blockly.JavaScript.valueToCode(
+        this,
+        'TO',
+        Blockly.JavaScript.ORDER_COMMA
+      ) || '0';
+    if (!Blockly.JavaScript.definitions_['math_random_int']) {
+      var functionName = Blockly.JavaScript.variableDB_.getDistinctName(
+        'math_random_int',
+        Blockly.Generator.NAME_TYPE
+      );
+      Blockly.JavaScript.math_random_int.random_function = functionName;
+      var func = [];
+      func.push('function ' + functionName + '(a, b) {');
+      func.push('  if (a > b) {');
+      func.push('    // Swap a and b to ensure a is smaller.');
+      func.push('    var c = a;');
+      func.push('    a = b;');
+      func.push('    b = c;');
+      func.push('  }');
+      func.push('  return Math.floor(Math.random() * (b - a + 1) + a);');
+      func.push('}');
+      Blockly.JavaScript.definitions_['math_random_int'] = func.join('\n');
+    }
+    var code =
+      Blockly.JavaScript.math_random_int.random_function +
+      '(' +
+      argument0 +
+      ', ' +
+      argument1 +
+      ')';
+    return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+  },
 };

--- a/apps/src/blockly/customBlocks/cdoBlockly/commonBlocks.js
+++ b/apps/src/blockly/customBlocks/cdoBlockly/commonBlocks.js
@@ -2,6 +2,7 @@
  * Defines blocks useful in multiple blockly apps
  */
 var commonMsg = require('@cdo/locale');
+var blockly = require('@code-dot-org/blockly');
 
 export const blocks = {
   installJoinBlock(blockly) {
@@ -113,45 +114,5 @@ export const blocks = {
     generator[type] = generatorFunction;
   },
   addSerializationHooksToBlock() {},
-  mathRandomIntGenerator() {
-    // Random integer between [X] and [Y].
-    var argument0 =
-      Blockly.JavaScript.valueToCode(
-        this,
-        'FROM',
-        Blockly.JavaScript.ORDER_COMMA
-      ) || '0';
-    var argument1 =
-      Blockly.JavaScript.valueToCode(
-        this,
-        'TO',
-        Blockly.JavaScript.ORDER_COMMA
-      ) || '0';
-    if (!Blockly.JavaScript.definitions_['math_random_int']) {
-      var functionName = Blockly.JavaScript.variableDB_.getDistinctName(
-        'math_random_int',
-        Blockly.Generator.NAME_TYPE
-      );
-      Blockly.JavaScript.math_random_int.random_function = functionName;
-      var func = [];
-      func.push('function ' + functionName + '(a, b) {');
-      func.push('  if (a > b) {');
-      func.push('    // Swap a and b to ensure a is smaller.');
-      func.push('    var c = a;');
-      func.push('    a = b;');
-      func.push('    b = c;');
-      func.push('  }');
-      func.push('  return Math.floor(Math.random() * (b - a + 1) + a);');
-      func.push('}');
-      Blockly.JavaScript.definitions_['math_random_int'] = func.join('\n');
-    }
-    var code =
-      Blockly.JavaScript.math_random_int.random_function +
-      '(' +
-      argument0 +
-      ', ' +
-      argument1 +
-      ')';
-    return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
-  },
+  mathRandomIntGenerator: blockly.JavaScript.math_random_int,
 };

--- a/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.js
@@ -79,4 +79,27 @@ export const blocks = {
       block.loadExtraState = this.loadExtraState;
     }
   },
+  mathRandomIntGenerator(block, generator) {
+    // Random integer between [X] and [Y].
+    const argument0 =
+      generator.valueToCode(block, 'FROM', generator.ORDER_NONE) || '0';
+    const argument1 =
+      generator.valueToCode(block, 'TO', generator.ORDER_NONE) || '0';
+    const functionName = generator.provideFunction_(
+      'math_random_int',
+      `
+  function ${generator.FUNCTION_NAME_PLACEHOLDER_}(a, b) {
+    if (a > b) {
+      // Swap a and b to ensure a is smaller.
+      var c = a;
+      a = b;
+      b = c;
+    }
+    return Math.floor(Math.random() * (b - a + 1) + a);
+  }
+  `
+    );
+    const code = `${functionName}(${argument0}, ${argument1})`;
+    return [code, generator.ORDER_FUNCTION_CALL];
+  },
 };

--- a/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.js
@@ -79,6 +79,11 @@ export const blocks = {
       block.loadExtraState = this.loadExtraState;
     }
   },
+  // Copied and modified from core Blockly:
+  // https://github.com/google/blockly/blob/1ba0e55e8a61f4228dfcc4d0eb18b7e38666dc6c/generators/javascript/math.ts#L406-L429
+  // We need to override this generator in order to continue using the
+  // legacy function name from CDO Blockly. Other custom blocks in pools
+  // depend on the original name..
   mathRandomIntGenerator(block, generator) {
     // Random integer between [X] and [Y].
     const argument0 =
@@ -86,7 +91,7 @@ export const blocks = {
     const argument1 =
       generator.valueToCode(block, 'TO', generator.ORDER_NONE) || '0';
     const functionName = generator.provideFunction_(
-      'math_random_int',
+      'math_random_int', // Core Blockly uses 'mathRandomInt'
       `
   function ${generator.FUNCTION_NAME_PLACEHOLDER_}(a, b) {
     if (a > b) {

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -501,19 +501,27 @@ export default {
       },
       removeVar: Blockly.Blocks.variables_get.removeVar,
     };
-    generator.sprite_variables_get = function () {
-      return [
-        `{name: '${Blockly.JavaScript.translateVarName(
-          this.getFieldValue('VAR')
-        )}'}`,
-        Blockly.JavaScript.ORDER_ATOMIC,
-      ];
-    };
+    Blockly.customBlocks.defineNewBlockGenerator(
+      generator,
+      'sprite_variables_get',
+      function () {
+        return [
+          `{name: '${Blockly.JavaScript.translateVarName(
+            this.getFieldValue('VAR')
+          )}'}`,
+          Blockly.JavaScript.ORDER_ATOMIC,
+        ];
+      }
+    );
     Blockly.Variables.registerGetter(
       Blockly.BlockValueType.SPRITE,
       'sprite_variables_get'
     );
-
+    Blockly.customBlocks.defineNewBlockGenerator(
+      generator,
+      'math_random_int',
+      Blockly.customBlocks.mathRandomIntGenerator
+    );
     // NOTE: On the page where behaviors are created (the functions/#/edit page)
     // blockInstallOptions is undefined.
     if (


### PR DESCRIPTION
During yesterday's Sprite Lab "final checks", @ebeastlake noticed several levels where the start program wouldn't run and a workspace alert banner showed that the function `math_random_int` was undefined.

- https://studio.code.org/s/csc-ecosystems-2023/lessons/3/levels/2/sublevel/4 
- https://studio.code.org/s/csc-ecosystems-2023/lessons/3/levels/2/sublevel/2 
- https://studio.code.org/s/csc-ecosystems-2023/lessons/3/levels/2/sublevel/3  

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/a101454a-113a-454b-b7ec-5863fb88861f)

Some custom blocks from the CSC pools, such as [ecosystems_makeNumSpritesWithinRang](https://levelbuilder-studio.code.org/pools/ecosystems/blocks/ecosystems_makeNumSpritesWithinRange/edit) included calls to this function in their helper code:

```
function makeNumSpritesWithinRange(numSprites, costume, range){
  for (var count = 0; count < numSprites; count++) {
    makeNewSpriteAnon(costume, {
      x: math_random_int(range.x1, range.x2),
      y: 400 - math_random_int(range.y1, range.y2)
    });
  }
}
```

The reason `math_random_int` was `undefined` took some time to discover. One red herring is that several of Sprite Lab's helper libraries explicitly define `math_random_int`, but none of the libraries were included in the affected levels. Interestingly, levels with one of these libraries would work fine, but we couldn't just fix it by adding a library because that would introduce other undesired consequences.
By inspecting the final [code](https://github.com/code-dot-org/code-dot-org/blob/mike/math_random_int/apps/src/p5lab/P5Lab.js#L1125) that was being passed into the JSInterpreter, @molly-moen and I noticed that CDO Blockly had a function called `math_random_int` but Google Blockly had `mathRandomInt`. This is evidently because the block's generator function was renamed to use camelcase instead of snakecase at some point in mainline Blockly. If blocks of type `math_random_int` were used, they would generate valid but different JavaScript in each version of Blockly that we currently support. 

CDO Blockly:

https://github.com/code-dot-org/blockly/blob/v4.1.0/generators/javascript/math.js#L533-L573

Google Blockly:

https://github.com/google/blockly/blob/master/generators/javascript/math.ts#L406-L429

This means that the block was working just fine on its own. The problem is that we had other custom blocks that relied upon the legacy spelling of the function name. It's probably a bit a weird for one block to call a function that is supplied by another block's generator (as opposed to functions defined in the Sprite Lab library or helper libraries), but here we are.

The solution I found was to copy the new generator from mainline into our `customBlocks` file and simply change the string used to create the function name. I used the `newBlockGenerator` helper we recently created as the API for generators is different between CDO Blockly and v10+ Google Blockly. While I was here I also updated one other generator for seldom-used block that was defined nearby.

The custom CSC blocks now work as expected (as evidenced by the creation of lots of happy animal sprites)!

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/9d212dfc-35fa-4cf1-b806-27a377801aae)|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/d38e6ade-fa3e-4624-aeb1-4e5e58869958)|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/8203a28d-92e1-424c-9173-d358043b880b)
-|-|-


## Links

Jira -https://codedotorg.atlassian.net/browse/CT-310

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
