### PR TITLE
Skip Firefox Teacher Application UI test

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
@@ -141,7 +141,7 @@ Scenario: Teacher saves, re-opens, and submits an application
   And I complete Section 7 of the teacher PD application
   And I press the first "button[type='submit']" element
 
-@skip
+@no_firefox
 Scenario: Teacher starts a new csp application and submits it
   Given I create a teacher named "Severus"
   And I am on "http://studio.code.org/pd/application/teacher"

--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
@@ -141,6 +141,7 @@ Scenario: Teacher saves, re-opens, and submits an application
   And I complete Section 7 of the teacher PD application
   And I press the first "button[type='submit']" element
 
+@skip
 Scenario: Teacher starts a new csp application and submits it
   Given I create a teacher named "Severus"
   And I am on "http://studio.code.org/pd/application/teacher"


### PR DESCRIPTION
A [Teacher Application test](https://app.saucelabs.com/tests/589cbb83102e440b8bf57d8b6277543b#151) is failing on Firefox in a way that does not look like it's from an intentional change. It's currently blocking the test build so this PR skips the test on Firefox so we can investigate it.

## Links
Slack thread: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1706830888507409)
SauceLabs test fail: [here](https://app.saucelabs.com/tests/589cbb83102e440b8bf57d8b6277543b#151)
Jira ticket to track investigation: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64/backlog?selectedIssue=ACQ-1446)