### PR TITLE
Translated chevron storybook stories

### DIFF
--- a/apps/src/templates/SmallChevronLink.story.jsx
+++ b/apps/src/templates/SmallChevronLink.story.jsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import {SmallChevronLink} from './SmallChevronLink';
 
-export default storybook => {
-  return storybook.storiesOf('SmallChevronLink', module).addStoryTable([
-    {
-      name: 'Default',
-      description: 'Used throughout the site for navigation',
-      story: () => <SmallChevronLink href="/foo" text="View course" />,
-    },
-    {
-      name: 'Icon before text',
-      story: () => (
-        <SmallChevronLink href="/foo" text="View course" iconBefore />
-      ),
-    },
-  ]);
+export default {
+  title: 'SmallChevronLink',
+  component: SmallChevronLink,
+};
+
+const Template = args => (
+  <SmallChevronLink href="/foo" text="View course" {...args} />
+);
+
+export const Default = Template.bind({});
+
+export const IconBeforeText = Template.bind({});
+IconBeforeText.args = {
+  iconBefore: true,
 };

--- a/apps/src/templates/certificates/LargeChevronLink.story.jsx
+++ b/apps/src/templates/certificates/LargeChevronLink.story.jsx
@@ -1,22 +1,17 @@
 import React from 'react';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 import LargeChevronLink from './LargeChevronLink';
-import i18n from '@cdo/locale';
 
-export default storybook => {
-  return storybook
-    .storiesOf('LargeChevronLink', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'Large teal chevron link',
-        description: `Currently used on /congrats`,
-        story: () => (
-          <LargeChevronLink
-            link={'/foo'}
-            linkText={i18n.viewCourse()}
-            isRtl={false}
-          />
-        ),
-      },
-    ]);
+export default {
+  title: 'LargeChevronLink',
+  component: LargeChevronLink,
+};
+
+export const Default = () => {
+  return (
+    <Provider store={reduxStore()}>
+      <LargeChevronLink link="/foo" linkText="View course" isRtl={false} />
+    </Provider>
+  );
 };


### PR DESCRIPTION
Two small translations for the large and small chevron links. These were very straightforward and small, but don't have test coverage so I elected to keep them. 

Large chevron link:
<img width="328" alt="Screenshot 2024-02-01 at 4 20 44 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/1541cf9f-8f5c-44ee-b0d8-a889eca86e8a">

Small chevron link:
<img width="197" alt="Screenshot 2024-02-01 at 4 20 51 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/35e63bdd-b7ff-40fd-a630-150c7a8c6201">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
