### PR TITLE
Updated the Personal Projects Table storybook entry

### DIFF
--- a/apps/src/templates/projects/PersonalProjectsTable.story.jsx
+++ b/apps/src/templates/projects/PersonalProjectsTable.story.jsx
@@ -1,47 +1,34 @@
 import React from 'react';
 import {UnconnectedPersonalProjectsTable as PersonalProjectsTable} from './PersonalProjectsTable';
+import {stubFakePersonalProjectData} from './generateFakeProjects';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 import publishDialog from '@cdo/apps/templates/projects/publishDialog/publishDialogRedux';
 import deleteDialog from '@cdo/apps/templates/projects/deleteDialog/deleteProjectDialogRedux';
-import {stubFakePersonalProjectData} from './generateFakeProjects';
 
-const initialState = {
-  publishDialog: {
-    isOpen: false,
-    isPublishPending: false,
-  },
-  deleteDialog: {
-    isOpen: false,
-  },
+export default {
+  title: 'PersonalProjectsTable',
+  component: PersonalProjectsTable,
 };
 
-export default storybook => {
-  storybook
-    .storiesOf('Projects/PersonalProjectsTable', module)
-    .withReduxStore({publishDialog, deleteDialog}, initialState)
-    .addStoryTable([
-      {
-        name: 'Personal Project Table',
-        description: 'Table of personal projects',
-        story: () => (
-          <PersonalProjectsTable
-            personalProjectsList={stubFakePersonalProjectData}
-            isLoadingPersonalProjectsList={false}
-            isUserSignedIn={true}
-            canShare={true}
-          />
-        ),
-      },
-      {
-        name: 'Empty Personal Project Table',
-        description: 'Table when there are 0 personal projects',
-        story: () => (
-          <PersonalProjectsTable
-            personalProjectsList={[]}
-            isLoadingPersonalProjectsList={false}
-            isUserSignedIn={true}
-            canShare={true}
-          />
-        ),
-      },
-    ]);
+const Template = args => (
+  <Provider store={reduxStore({publishDialog, deleteDialog})}>
+    <PersonalProjectsTable {...args} />
+  </Provider>
+);
+
+export const WithProjects = Template.bind({});
+WithProjects.args = {
+  personalProjectsList: stubFakePersonalProjectData,
+  isLoadingPersonalProjectsList: false,
+  isUserSignedIn: true,
+  canShare: true,
+};
+
+export const WithoutProjects = Template.bind({});
+WithoutProjects.args = {
+  personalProjectsList: [],
+  isLoadingPersonalProjectsList: false,
+  isUserSignedIn: true,
+  canShare: true,
 };


### PR DESCRIPTION
This PR was originally here: https://github.com/code-dot-org/code-dot-org/pull/49133 - I found it while cleaning out old branches and PRs. Since the branch had diverged so far from staging, it was better to just recreate it. Here is the original description:

---

Updated the storybook entry for the PersonalProjectsTable story to work on the newer versions of Storybook.

We may want to consider deleting this one as it's not a reusable component. However, updating it was good practice and it now works, so keeping it around for now.