### PR TITLE
Music: More intro updates

### DIFF
--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -71,7 +71,7 @@
     }
 
     &.fadeInBlock {
-      animation: fade-out-block 1s;
+      animation: fade-out-block 0.5s;
     }
 
     .slowLoadContainer {

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -169,25 +169,27 @@ const PanelsView: React.FunctionComponent = () => {
             ? commonI18n.next()
             : commonI18n.continue()}
         </button>
-        <div id="panels-bubbles">
-          {Array.from(Array(levelPanels.panels.length).keys()).map(index => {
-            return (
-              <FontAwesome
-                key={index}
-                className={classNames(
-                  'icon',
-                  styles.bubble,
-                  index === currentPanel
-                    ? styles.bubbleCurrent
-                    : styles.bubbleNotCurrent
-                )}
-                title={undefined}
-                icon="circle"
-                onClick={() => handleBubbleClick(index)}
-              />
-            );
-          })}
-        </div>
+        {levelPanels.panels.length > 1 && (
+          <div id="panels-bubbles">
+            {Array.from(Array(levelPanels.panels.length).keys()).map(index => {
+              return (
+                <FontAwesome
+                  key={index}
+                  className={classNames(
+                    'icon',
+                    styles.bubble,
+                    index === currentPanel
+                      ? styles.bubbleCurrent
+                      : styles.bubbleNotCurrent
+                  )}
+                  title={undefined}
+                  icon="circle"
+                  onClick={() => handleBubbleClick(index)}
+                />
+              );
+            })}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/src/panels/panels.module.scss
+++ b/apps/src/panels/panels.module.scss
@@ -34,7 +34,7 @@
       background-size: cover;
       background-repeat: no-repeat;
       background-position: center;
-      animation: fade-in 1s;
+      animation: fade-in 0.5s;
     }
 
     .markdownText {
@@ -43,7 +43,7 @@
       width: 40%;
       position: absolute;
       padding: 20px;
-      animation: fade-in 2s;
+      animation: fade-in 1.5s;
 
       p {
         font-size: 16px;

--- a/apps/static/music/music-library.json
+++ b/apps/static/music/music-library.json
@@ -5,7 +5,6 @@
       "name": "All",
       "imageSrc": "all.png",
       "path": "all-by-type",
-      "defaultSound": "beats/groovy_alternate_beat",
       "folders": [
         {
           "name": "Piano",
@@ -1000,6 +999,53 @@
           ]
         },
         {
+          "name": "Drum Kit",
+          "path": "drums",
+          "type": "kit",
+          "sounds": [
+            {
+              "name": "Bass Drum",
+              "src": "sound_1",
+              "length": 0.0625
+            },
+            {
+              "name": "5nare",
+              "src": "sound_2",
+              "length": 0.0625
+            },
+            {
+              "name": "Closed Hi-hat",
+              "src": "sound_3",
+              "length": 0.0625
+            },
+            {
+              "name": "Open Hi-hat",
+              "src": "sound_4",
+              "length": 0.0625
+            },
+            {
+              "name": "Mid Tom",
+              "src": "sound_5",
+              "length": 0.0625
+            },
+            {
+              "name": "High Tom",
+              "src": "sound_6",
+              "length": 0.0625
+            },
+            {
+              "name": "Ride",
+              "src": "sound_7",
+              "length": 0.0625
+            },
+            {
+              "name": "Cymbal",
+              "src": "sound_8",
+              "length": 0.0625
+            }
+          ]
+        },
+        {
           "name": "Machine",
           "path": "machine",
           "type": "kit",
@@ -1048,14 +1094,14 @@
         },
         {
           "name": "Beats",
-          "subTitle": "Code.org",
           "path": "beats",
           "imageSrc": "thumbnail.png",
           "sounds": [
-            {
-              "src": "preview",
-              "preview": true
-            },
+            {"name": "Drum Kit Disco", "src": "drum_kit_disco", "length": 2, "type": "beat"},
+            {"name": "Drum Beat EDM", "src": "drum_beat_edm", "length": 2, "type": "beat"},
+            {"name": "Drum Beat Club", "src": "drum_beat_club", "length": 2, "type": "beat"},
+            {"name": "Drum Beat Knock", "src": "drum_beat_knock", "length": 2, "type": "beat"},
+            {"name": "Drum Kit Pop", "src": "drum_kit_pop", "length": 2, "type": "beat"},
             {
               "name": "Groovy Beat",
               "src": "groovy_beat",
@@ -1192,10 +1238,11 @@
         },
         {
           "name": "Bass",
-          "subTitle": "Code.org",
           "path": "bass",
           "imageSrc": "thumbnail.png",
           "sounds": [
+            {"name": "Bass Synth Glow Up", "src": "bass_synth_glow_up", "length": 2, "type": "bass"},
+            {"name": "Bass Home Steady", "src": "bass_home_steady", "length": 2, "type": "bass"},
             {
               "name": "Funky Bass",
               "src": "funky_bass",
@@ -1248,7 +1295,6 @@
         },
         {
           "name": "Leads",
-          "subTitle": "Code.org",
           "path": "leads",
           "imageSrc": "thumbnail.png",
           "sounds": [

--- a/dashboard/config/levels/custom/music/New Music Lab Project.level
+++ b/dashboard/config/levels/custom/music/New Music Lab Project.level
@@ -11,6 +11,7 @@
     "encrypted": "false",
     "background": "music-black",
     "level_data": {
+      "library": "will",
       "startSources": {
         "blocks": {
           "languageVersion": 0,

--- a/dashboard/config/levels/custom/music/New Music Lab Project.level
+++ b/dashboard/config/levels/custom/music/New Music Lab Project.level
@@ -11,7 +11,6 @@
     "encrypted": "false",
     "background": "music-black",
     "level_data": {
-      "library": "will",
       "startSources": {
         "blocks": {
           "languageVersion": 0,

--- a/dashboard/config/levels/custom/music/musiclab_intro_change_sound.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_change_sound.level
@@ -10,7 +10,6 @@
     "background": "music-black",
     "long_instructions": "####Change a Sound\n\nThere are tons of sounds you can choose from. Change up the beat!\n\nClick the [name](#clickable=play-sound-block-workspace) of the sound to select a new one.\n\nThen press [Run](#clickable=run-button).\n",
     "level_data": {
-      "library": "will",
       "startSources": {
         "blocks": {
           "languageVersion": 0,

--- a/dashboard/config/levels/custom/music/musiclab_intro_freeplay.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_freeplay.level
@@ -11,7 +11,6 @@
     "background": "music-black",
     "long_instructions": "####Free Play\n\nYou're ready to create!  Be sure to explore the blocks and the sounds.  There is a lot to explore and use to make an amazing track.",
     "level_data": {
-      "library": "will",
       "startSources": {
         "blocks": {
           "languageVersion": 0,

--- a/dashboard/config/levels/custom/music/musiclab_intro_function.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_function.level
@@ -10,7 +10,6 @@
     "background": "music-black",
     "long_instructions": "#### Functions\n\nYou can organize your music using functions.\n\nClick [Functions](#clickable=toolbox-first-row), then drag [bass](#clickable=toolbox-second-block) to [when run](#clickable=when-run-block), to play the content of the bass function.",
     "level_data": {
-      "library": "will",
       "startSources": {
         "blocks": {
           "languageVersion": 0,

--- a/dashboard/config/levels/custom/music/musiclab_intro_play_sound.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_play_sound.level
@@ -10,7 +10,6 @@
     "background": "music-black",
     "long_instructions": "####Play a Sound\n\nLet's play a new sound!\n\nDrag the [play](#clickable=play-sound-block) block and attach it to [when run](#clickable=when-run-block). Click the name of the sound if you want to select a new sound.\n\nThen press [Run](#clickable=run-button).",
     "level_data": {
-      "library": "will",
       "startSources": {
         "blocks": {
           "languageVersion": 0,

--- a/dashboard/config/levels/custom/music/musiclab_intro_play_together.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_play_together.level
@@ -10,7 +10,6 @@
     "background": "music-black",
     "long_instructions": "#### Play Together\n\nThis code currently plays a bass sound after a drum sound.\n\nBut you can also play them together at the same time.\n\nConnect [play together](#clickable=play-sounds-together-block) to [when run](#clickable=when-run-block).\n\nThen, move the two [play](#clickable=play-sound-block-workspace) blocks _into_ the [play together](#clickable=play-sounds-together-block-workspace) block.",
     "level_data": {
-      "library": "will",
       "startSources": {
         "blocks": {
           "languageVersion": 0,

--- a/dashboard/config/levels/custom/music/musiclab_intro_repeat.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_repeat.level
@@ -10,7 +10,6 @@
     "background": "music-black",
     "long_instructions": "#### Repeat\n\nSave effort and use code to repeat a sound.\n\nUse the [repeat](#clickable=repeat-block) block to play the same sound three times.",
     "level_data": {
-      "library": "will",
       "startSources": {
         "blocks": {
           "languageVersion": 0,
@@ -55,7 +54,7 @@
               "value": 2
             }
           ],
-          "message": "It's good that you've played two sounds.  Please play three."
+          "message": "It's good that you've played a sound twice.  Please play it three times."
         },
         {
           "conditions": [
@@ -64,7 +63,7 @@
               "value": 1
             }
           ],
-          "message": "You've played one sound.  Please play three by using the [repeat](#clickable=repeat-block) block."
+          "message": "You've played a sound once.  Please play it three times by using the [repeat](#clickable=repeat-block) block."
         },
         {
           "message": "Please play a sound three times.  Attached a [repeat](#clickable=repeat-block) block to [when run](#clickable=when-run-block). Then put a [play](#clickable=play-sound-block) block inside of it."

--- a/dashboard/config/levels/custom/music/musiclab_intro_trigger.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_trigger.level
@@ -10,7 +10,6 @@
     "background": "music-black",
     "long_instructions": "#### Play Live\n\nDid you know you can do a live performance?\n\nAttach a [play](#clickable=play-sound-block) block to the [triggered](#clickable=trigger-block-workspace) block.\n\nPress [Run](#clickable=run-button) and press [1](#clickable=trigger-button-1) to trigger the sound.",
     "level_data": {
-      "library": "will",
       "startSources": {
         "blocks": {
           "languageVersion": 0,

--- a/dashboard/config/levels/custom/panels/musiclab_intro_panels_function.level
+++ b/dashboard/config/levels/custom/panels/musiclab_intro_panels_function.level
@@ -10,18 +10,12 @@
     "level_data": {
       "panels": [
         {
-          "imageUrl": "https://images.code.org/0110f782ffc35dfd10584e068742e2b9-musiclab_intro_function_0.png",
-          "text": "Sometimes you'll want part of the mix to take up less room or be reusable in other parts of the mix. For instance, let's say you had a chorus in your track that looked like this."
+          "imageUrl": "https://images.code.org/e8cf0ed0263af03d3bed73749081b995-musiclab_intro_function_0.png",
+          "text": "A cool feature in **Project Beats** is that you can take a set of blocks and put them into your own block.  In coding, this is called making a **function**."
         },
         {
-          "imageUrl": "https://images.code.org/685a20f269ea8a53be4abcdc182fb7d7-musiclab_intro_function_1.png",
-          "text": "This green block from the **Functions** category lets you group the chorus together. You can name this whatever you want.",
-          "layout": "text-bottom-left"
-        },
-        {
-          "imageUrl": "https://images.code.org/211f25a646fdb1aa77259176fdb3cd36-musiclab_intro_function_2.png",
-          "text": "You'll then see a small block, with the name you chose, in the **Functions** category. This can be attached to the **when run** block to play your whole chorus in a single block. Let's try it out!",
-          "layout": "text-bottom-left"
+          "imageUrl": "https://images.code.org/79cffd279632872b91b162a1fe460e15-musiclab_intro_function_1.png",
+          "text": "You can \"call\" your new **function** by using the block with the matching name, like this."
         }
       ]
     }


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/55959.  This makes more updates to the `/s/music-intro-2024` experience:

- Lab2 level fade-ins are now twice as fast.
- Panel levels' panel image fade-ins are now twice as fast, too.
- After discovering that existing `/projectbeats` levels would continue using their existing music library, even if "start over" was used, we decided on a new strategy for now, which was to add some new sounds from the "will" library to our default library.  As of this change, none of the new levels use the "will" library any more, but instead will use the default library, albeit with 5 new beats sounds and 2 new bass sounds which are used by the levels.  We can add more sounds later, and consider the right way to use different music libraries, but for now this lets us rehearse gradually adding sounds to an existing library.
  - The library JSON is snapshotted here, and S3 has already been updated with the new sounds, thumbnail images, and JSON.
- The functions panels level has gone back to an earlier, simpler set of content.
- Panels levels no longer show bubbles at the bottom if there's only one panel.

### Playthrough

Here's a playthrough, beginning with the incubator link added in https://github.com/code-dot-org/code-dot-org/pull/56140:

https://github.com/code-dot-org/code-dot-org/assets/2205926/2e2423d3-3283-4f17-bd87-a27a18bc4110
