### PR TITLE
Update the teal color hex code on code.org

### DIFF
--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -10,7 +10,7 @@
   /* Colors */
   --brand_primary_light: #ABDFE5;
   --brand_primary_medium: #7BC6CF;
-  --brand_primary_default: #009EB0;
+  --brand_primary_default: #0093A4;
   --brand_primary_dark: #008291;
   --brand_secondary_light: #E0D1EC;
   --brand_secondary_default: #8C52BA;


### PR DESCRIPTION
Changes the `--brand_primary_default` variable HEX code from `#009EB0` to the latest brand teal `#0093A4` on https://code.org.

Updates the hex code from [this PR](https://github.com/code-dot-org/code-dot-org/pull/56069) — I found out the color changed again after doing this the first time 😅 Luckily I already swapped all of the instances of the teal with the `--brand_primary_default` variable so now this PR is only one teeny tiny change that'll update everything else that uses this variable automatically.

**Jira ticket:** [ACQ-1445](https://codedotorg.atlassian.net/browse/ACQ-1445)

----

## Before
<img width="988" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/6ae2a966-3002-45b0-87f5-25ac7df7751f">

## After
<img width="988" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/8850a168-e66f-4df8-b269-7da8e035ad94">

