### PR TITLE
Host `wjordan/*` gem forks on `code-dot-org/*`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'rails-controller-testing', '~> 1.0.5'
 
 # Compile Sprockets assets concurrently in `assets:precompile`.
 # Ref: https://github.com/rails/sprockets/pull/470
-gem 'sprockets', github: 'wjordan/sprockets', ref: 'concurrent_asset_bundle_3.x'
+gem 'sprockets', github: 'code-dot-org/sprockets', ref: 'concurrent_asset_bundle_3.x'
 gem 'sprockets-rails', '3.3.0'
 
 # provide `respond_to` methods
@@ -120,11 +120,11 @@ gem 'factory_bot_rails', '~> 6.2', group: [:development, :staging, :test, :adhoc
 gem 'open_uri_redirections', require: false
 
 # Ref: https://github.com/tmm1/gctools/pull/17
-gem 'gctools', github: 'wjordan/gctools', ref: 'ruby-2.5'
+gem 'gctools', github: 'code-dot-org/gctools', ref: 'ruby-2.5'
 # Optimizes copy-on-write memory usage with GC before web-application fork.
 gem 'nakayoshi_fork'
 # Ref: https://github.com/puma/puma/pull/1646
-gem 'puma', github: 'wjordan/puma', branch: 'debugging'
+gem 'puma', github: 'code-dot-org/puma', branch: 'debugging'
 gem 'puma_worker_killer'
 gem 'raindrops'
 
@@ -159,7 +159,7 @@ gem 'omniauth-google-oauth2', '~> 0.6.0'
 gem 'omniauth-microsoft_v2_auth', github: 'dooly-ai/omniauth-microsoft_v2_auth'
 # Ref: https://github.com/joel/omniauth-windowslive/pull/16
 # Ref: https://github.com/joel/omniauth-windowslive/pull/17
-gem 'omniauth-windowslive', '~> 0.0.11', github: 'wjordan/omniauth-windowslive', ref: 'cdo'
+gem 'omniauth-windowslive', '~> 0.0.11', github: 'code-dot-org/omniauth-windowslive', ref: 'cdo'
 
 # Resolve CVE 2015 9284
 # see: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284
@@ -251,7 +251,7 @@ end
 
 # Reduce volume of production logs
 # Ref: https://github.com/roidrage/lograge/pull/252
-gem 'lograge', github: 'wjordan/lograge', ref: 'debug_exceptions'
+gem 'lograge', github: 'code-dot-org/lograge', ref: 'debug_exceptions'
 
 # Enforce SSL
 gem 'rack-ssl-enforcer'
@@ -295,13 +295,13 @@ gem 'full-name-splitter', github: 'pahanix/full-name-splitter'
 gem 'rambling-trie', '>= 2.1.1'
 
 gem 'omniauth-openid'
-gem 'omniauth-openid-connect', github: 'wjordan/omniauth-openid-connect', ref: 'cdo'
+gem 'omniauth-openid-connect', github: 'code-dot-org/omniauth-openid-connect', ref: 'cdo'
 
 # Ref: https://github.com/toy/image_optim/pull/145
 # Also include sRGB color profile conversion.
-gem 'image_optim', github: 'wjordan/image_optim', ref: 'cdo'
+gem 'image_optim', github: 'code-dot-org/image_optim', ref: 'cdo'
 # Image-optimization tools and binaries.
-gem 'image_optim_pack', '~> 0.5.0', github: 'wjordan/image_optim_pack', ref: 'guetzli'
+gem 'image_optim_pack', '~> 0.5.0', github: 'code-dot-org/image_optim_pack', ref: 'guetzli'
 gem 'image_optim_rails', '~> 0.4.0'
 
 gem 'image_size', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,14 +48,14 @@ GIT
     full-name-splitter (0.1.2)
 
 GIT
-  remote: https://github.com/wjordan/gctools.git
+  remote: https://github.com/code-dot-org/-org/gctools.git
   revision: 729c6bbb32c4bcc2ebfed16543991e4d126f09cc
   ref: ruby-2.5
   specs:
     gctools (0.2.4)
 
 GIT
-  remote: https://github.com/wjordan/image_optim.git
+  remote: https://github.com/code-dot-org/image_optim.git
   revision: 939996f7ad102227c73b42bfda0058f9c66698aa
   ref: cdo
   specs:
@@ -67,7 +67,7 @@ GIT
       progress (~> 3.0, >= 3.0.1)
 
 GIT
-  remote: https://github.com/wjordan/image_optim_pack.git
+  remote: https://github.com/code-dot-org/image_optim_pack.git
   revision: 41e063908e1b038a852f18504dd52721aac5ea6a
   ref: guetzli
   specs:
@@ -76,7 +76,7 @@ GIT
       image_optim (~> 0.19)
 
 GIT
-  remote: https://github.com/wjordan/lograge.git
+  remote: https://github.com/code-dot-org/lograge.git
   revision: 1ef23fb6fe78e73e782e6393477a9953fb3f4515
   ref: debug_exceptions
   specs:
@@ -87,7 +87,7 @@ GIT
       request_store (~> 1.0)
 
 GIT
-  remote: https://github.com/wjordan/omniauth-openid-connect.git
+  remote: https://github.com/code-dot-org/omniauth-openid-connect.git
   revision: 2397b1415896e2639a7582a36e26c90b9211f99f
   ref: cdo
   specs:
@@ -97,7 +97,7 @@ GIT
       openid_connect (~> 1.0, >= 1.0.3)
 
 GIT
-  remote: https://github.com/wjordan/omniauth-windowslive.git
+  remote: https://github.com/code-dot-org/omniauth-windowslive.git
   revision: 68ece379fa4d79a49505454c52aaf9142cd2ed74
   ref: cdo
   specs:
@@ -106,14 +106,14 @@ GIT
       omniauth-oauth2 (~> 1.4)
 
 GIT
-  remote: https://github.com/wjordan/puma.git
+  remote: https://github.com/code-dot-org/puma.git
   revision: 29a576120b30c34db7706c062ddf9a046723789f
   branch: debugging
   specs:
     puma (3.12.0)
 
 GIT
-  remote: https://github.com/wjordan/sprockets.git
+  remote: https://github.com/code-dot-org/sprockets.git
   revision: 35caa45a78b739362b7db087b141f89e27d107c7
   ref: concurrent_asset_bundle_3.x
   specs:

--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -18,7 +18,7 @@
 proxysql_filename = 'proxysql_2.0.15-ubuntu18_amd64.deb'
 proxysql_file = "#{Chef::Config[:file_cache_path]}/#{proxysql_filename}"
 remote_file proxysql_file do
-  source "https://github.com/wjordan/proxysql/releases/download/v2.0.15-aurora_2.09_fix/#{proxysql_filename}"
+  source "https://github.com/code-dot-org/proxysql/releases/download/v2.0.15-aurora_2.09_fix/#{proxysql_filename}"
   checksum "29fe79e54bce0f532084bfd8e5a13a55f1f8530f92be8a0e7db847aefcb1762f"
 end
 dpkg_package('proxysql') do


### PR DESCRIPTION
1) Forked all `wjordan/*` repos referenced in Gemfile (etc) to `code-dot-org/*`
2) Set their default branch to the branch referenced by `Gemfile`
3) Updated `Gemfile` (and `cookbooks/cdo-mysql/recipes/proxy.rb`) to reference the `code-dot-org/` hosted equivalents.

Will hosted custom branches for 8 gems on their GitHub which are referenced in `code-dot-org/Gemfile`:
- wjordan/sprockets
- wjordan/gctools
- wjordan/puma
- wjordan/omniauth-windowslive
- wjordan/lograge
- wjordan/omniauth-openid-connect
- wjordan/image_optim
- wjordan/image_optim_pack

And additionally hosts a custom release of proxysql at wjordan/proxysql referenced by `cookbooks/cdo-mysql/recipes/proxy.rb`