### PR TITLE
Host `wjordan/*` gem forks on `code-dot-org/*`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'rails-controller-testing', '~> 1.0.5'
 
 # Compile Sprockets assets concurrently in `assets:precompile`.
 # Ref: https://github.com/rails/sprockets/pull/470
-gem 'sprockets', github: 'wjordan/sprockets', ref: 'concurrent_asset_bundle_3.x'
+gem 'sprockets', github: 'code-dot-org/sprockets', ref: 'concurrent_asset_bundle_3.x'
 gem 'sprockets-rails', '3.3.0'
 
 # provide `respond_to` methods
@@ -168,7 +168,7 @@ gem 'omniauth-google-oauth2', '~> 0.6.0'
 gem 'omniauth-microsoft_v2_auth', github: 'dooly-ai/omniauth-microsoft_v2_auth'
 # Ref: https://github.com/joel/omniauth-windowslive/pull/16
 # Ref: https://github.com/joel/omniauth-windowslive/pull/17
-gem 'omniauth-windowslive', '~> 0.0.11', github: 'wjordan/omniauth-windowslive', ref: 'cdo'
+gem 'omniauth-windowslive', '~> 0.0.11', github: 'code-dot-org/omniauth-windowslive', ref: 'cdo'
 
 # Resolve CVE 2015 9284
 # see: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284
@@ -254,7 +254,7 @@ end
 
 # Reduce volume of production logs
 # Ref: https://github.com/roidrage/lograge/pull/252
-gem 'lograge', github: 'wjordan/lograge', ref: 'debug_exceptions'
+gem 'lograge', github: 'code-dot-org/lograge', ref: 'debug_exceptions'
 
 # Enforce SSL
 gem 'rack-ssl-enforcer'
@@ -298,13 +298,13 @@ gem 'full-name-splitter', github: 'pahanix/full-name-splitter'
 gem 'rambling-trie', '>= 2.1.1'
 
 gem 'omniauth-openid'
-gem 'omniauth-openid-connect', github: 'wjordan/omniauth-openid-connect', ref: 'cdo'
+gem 'omniauth-openid-connect', github: 'code-dot-org/omniauth-openid-connect', ref: 'cdo'
 
 # Ref: https://github.com/toy/image_optim/pull/145
 # Also include sRGB color profile conversion.
-gem 'image_optim', github: 'wjordan/image_optim', ref: 'cdo'
+gem 'image_optim', github: 'code-dot-org/image_optim', ref: 'cdo'
 # Image-optimization tools and binaries.
-gem 'image_optim_pack', '~> 0.5.0', github: 'wjordan/image_optim_pack', ref: 'guetzli'
+gem 'image_optim_pack', '~> 0.5.0', github: 'code-dot-org/image_optim_pack', ref: 'guetzli'
 gem 'image_optim_rails', '~> 0.4.0'
 
 gem 'image_size', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,55 @@
 GIT
+  remote: https://github.com/code-dot-org/image_optim.git
+  revision: 939996f7ad102227c73b42bfda0058f9c66698aa
+  ref: cdo
+  specs:
+    image_optim (0.24.2)
+      exifr (~> 1.2, >= 1.2.2)
+      fspath (~> 3.0)
+      image_size (~> 1.5)
+      in_threads (~> 1.3)
+      progress (~> 3.0, >= 3.0.1)
+
+GIT
+  remote: https://github.com/code-dot-org/image_optim_pack.git
+  revision: 41e063908e1b038a852f18504dd52721aac5ea6a
+  ref: guetzli
+  specs:
+    image_optim_pack (0.5.0)
+      fspath (>= 2.1, < 4)
+      image_optim (~> 0.19)
+
+GIT
+  remote: https://github.com/code-dot-org/lograge.git
+  revision: 8d55ad595c0af229bb144bbe73c9e7404ce0b32c
+  ref: debug_exceptions
+  specs:
+    lograge (0.10.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
+
+GIT
+  remote: https://github.com/code-dot-org/omniauth-openid-connect.git
+  revision: 2397b1415896e2639a7582a36e26c90b9211f99f
+  ref: cdo
+  specs:
+    omniauth-openid-connect (0.2.2)
+      addressable (~> 2.3)
+      omniauth (~> 1.1)
+      openid_connect (~> 1.0, >= 1.0.3)
+
+GIT
+  remote: https://github.com/code-dot-org/omniauth-windowslive.git
+  revision: 68ece379fa4d79a49505454c52aaf9142cd2ed74
+  ref: cdo
+  specs:
+    omniauth-windowslive (0.0.11)
+      multi_json (>= 1.0.3)
+      omniauth-oauth2 (~> 1.4)
+
+GIT
   remote: https://github.com/code-dot-org/redis-slave-read.git
   revision: cfe1bd0f5cf65eee5b52560139cab133f22cb880
   ref: cfe1bd0f5cf65eee5b52560139cab133f22cb880
@@ -18,6 +69,15 @@ GIT
       sprockets (> 3.0)
       sprockets-rails
       tilt
+
+GIT
+  remote: https://github.com/code-dot-org/sprockets.git
+  revision: 35caa45a78b739362b7db087b141f89e27d107c7
+  ref: concurrent_asset_bundle_3.x
+  specs:
+    sprockets (3.7.1)
+      concurrent-ruby (~> 1.1)
+      rack (> 1, < 3)
 
 GIT
   remote: https://github.com/daynew/omniauth-clever.git
@@ -46,66 +106,6 @@ GIT
   revision: 316b4f3f4b1e5902dedc2a369d1d9052f042dd50
   specs:
     full-name-splitter (0.1.2)
-
-GIT
-  remote: https://github.com/wjordan/image_optim.git
-  revision: 939996f7ad102227c73b42bfda0058f9c66698aa
-  ref: cdo
-  specs:
-    image_optim (0.24.2)
-      exifr (~> 1.2, >= 1.2.2)
-      fspath (~> 3.0)
-      image_size (~> 1.5)
-      in_threads (~> 1.3)
-      progress (~> 3.0, >= 3.0.1)
-
-GIT
-  remote: https://github.com/wjordan/image_optim_pack.git
-  revision: 41e063908e1b038a852f18504dd52721aac5ea6a
-  ref: guetzli
-  specs:
-    image_optim_pack (0.5.0)
-      fspath (>= 2.1, < 4)
-      image_optim (~> 0.19)
-
-GIT
-  remote: https://github.com/wjordan/lograge.git
-  revision: 1ef23fb6fe78e73e782e6393477a9953fb3f4515
-  ref: debug_exceptions
-  specs:
-    lograge (0.10.0)
-      actionpack (>= 4)
-      activesupport (>= 4)
-      railties (>= 4)
-      request_store (~> 1.0)
-
-GIT
-  remote: https://github.com/wjordan/omniauth-openid-connect.git
-  revision: 2397b1415896e2639a7582a36e26c90b9211f99f
-  ref: cdo
-  specs:
-    omniauth-openid-connect (0.2.2)
-      addressable (~> 2.3)
-      omniauth (~> 1.1)
-      openid_connect (~> 1.0, >= 1.0.3)
-
-GIT
-  remote: https://github.com/wjordan/omniauth-windowslive.git
-  revision: 68ece379fa4d79a49505454c52aaf9142cd2ed74
-  ref: cdo
-  specs:
-    omniauth-windowslive (0.0.11)
-      multi_json (>= 1.0.3)
-      omniauth-oauth2 (~> 1.4)
-
-GIT
-  remote: https://github.com/wjordan/sprockets.git
-  revision: 35caa45a78b739362b7db087b141f89e27d107c7
-  ref: concurrent_asset_bundle_3.x
-  specs:
-    sprockets (3.7.1)
-      concurrent-ruby (~> 1.1)
-      rack (> 1, < 3)
 
 GEM
   remote: https://rubygems.org/
@@ -193,14 +193,14 @@ GEM
       activerecord (>= 4.2)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
-    aes_key_wrap (1.0.1)
+    aes_key_wrap (1.1.0)
     afm (0.2.2)
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
     ansi (1.5.0)
     ast (2.4.2)
-    attr_required (1.0.1)
+    attr_required (1.0.2)
     auto_strip_attributes (2.1.0)
       activerecord (>= 3.0)
     aws-eventstream (1.2.0)
@@ -270,7 +270,7 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
-    bindata (2.4.10)
+    bindata (2.5.0)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -483,7 +483,6 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       llhttp-ffi (~> 0.5.0)
-    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
@@ -508,10 +507,11 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (2.6.2)
-    json-jwt (1.10.0)
+    json-jwt (1.15.3.1)
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
+      httpclient
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
@@ -633,17 +633,17 @@ GEM
       time
       uri
     open_uri_redirections (0.2.1)
-    openid_connect (1.0.3)
+    openid_connect (1.4.2)
       activemodel
       attr_required (>= 1.0.0)
-      json (>= 1.4.3)
-      json-jwt (>= 1.5.0)
-      rack-oauth2 (>= 1.3.1)
-      swd (>= 1.0.0)
+      json-jwt (>= 1.15.0)
+      net-smtp
+      rack-oauth2 (~> 1.21)
+      swd (~> 1.3)
       tzinfo
       validate_email
       validate_url
-      webfinger (>= 1.0.1)
+      webfinger (~> 1.2)
     orm_adapter (0.5.0)
     os (1.1.4)
     parallel (1.23.0)
@@ -685,12 +685,12 @@ GEM
       rack (>= 2.0.0)
     rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
-    rack-oauth2 (1.5.1)
-      activesupport (>= 2.3)
-      attr_required (>= 0.0.5)
-      httpclient (>= 2.4)
-      multi_json (>= 1.3.6)
-      rack (>= 1.1)
+    rack-oauth2 (1.21.3)
+      activesupport
+      attr_required
+      httpclient
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
     rack-openid (1.3.1)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
@@ -748,7 +748,7 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
-    request_store (1.4.1)
+    request_store (1.6.0)
       rack (>= 1.4)
     require_all (2.0.0)
     rerun (0.14.0)
@@ -872,12 +872,10 @@ GEM
       user_agent_parser (~> 2.15.0)
     stringex (2.5.2)
     stringio (3.1.0)
-    swd (1.0.1)
+    swd (1.3.0)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
       httpclient (>= 2.4)
-      i18n
-      json (>= 1.4.3)
     sysexits (1.2.0)
     systemu (2.6.5)
     tableschema (1.0.4)
@@ -922,9 +920,9 @@ GEM
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
-    validate_url (1.0.2)
+    validate_url (1.0.15)
       activemodel (>= 3.0.0)
-      addressable
+      public_suffix
     validates_email_format_of (1.6.3)
       i18n
     vcr (3.0.3)
@@ -939,10 +937,9 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
-    webfinger (1.0.2)
+    webfinger (1.2.0)
       activesupport
       httpclient (>= 2.4)
-      multi_json
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)

--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -18,7 +18,7 @@
 proxysql_filename = 'proxysql_2.0.15-ubuntu18_amd64.deb'
 proxysql_file = "#{Chef::Config[:file_cache_path]}/#{proxysql_filename}"
 remote_file proxysql_file do
-  source "https://github.com/wjordan/proxysql/releases/download/v2.0.15-aurora_2.09_fix/#{proxysql_filename}"
+  source "https://github.com/code-dot-org/proxysql/releases/download/v2.0.15-aurora_2.09_fix/#{proxysql_filename}"
   checksum "29fe79e54bce0f532084bfd8e5a13a55f1f8530f92be8a0e7db847aefcb1762f"
   action :create_if_missing
 end


### PR DESCRIPTION
1) Forked all `wjordan/*` repos referenced in Gemfile (etc) to `code-dot-org/*`
2) Set their default branch to the branch referenced by `Gemfile`
3) Updated `Gemfile` (and `cookbooks/cdo-mysql/recipes/proxy.rb`) to reference the `code-dot-org/` hosted equivalents.

Will hosted custom branches for 8 gems on their GitHub which are referenced in `code-dot-org/Gemfile`:
- wjordan/sprockets
- wjordan/gctools
- wjordan/puma
- wjordan/omniauth-windowslive
- wjordan/lograge
- wjordan/omniauth-openid-connect
- wjordan/image_optim
- wjordan/image_optim_pack

And additionally hosts a custom release of proxysql at wjordan/proxysql referenced by `cookbooks/cdo-mysql/recipes/proxy.rb`