### PR TITLE
Add `bin/copy-pr` to re-open Git LFS mis-closed PRs

### DIFF
--- a/bin/copy-pr
+++ b/bin/copy-pr
@@ -1,0 +1,117 @@
+#!/usr/bin/env ruby
+
+# THIS SCRIPT SHOULD BE REMOVED ANYTIME AFTER MAR 1, 2024
+#
+# During our migration to use Git LFS:
+# https://github.com/code-dot-org/code-dot-org/issues/55759, many PRs were
+# auto-closed by GitHub (force push to staging rewriting history)
+# and cannot be re-opened. This script copies previous comments, 
+# and description frrm the old PR, and creates a new one.
+#
+# Usage: bin/copy-pr OLD_PR_NUMBER
+#
+# Example: bin/copy-pr 51637
+# Creates a PR like: https://github.com/code-dot-org/code-dot-org/pull/56273
+
+require 'json'
+require 'open3'
+
+def fetch_pr(pr_number)
+  json_fields = "title,body,headRefName,comments,url,reviews"
+  command = "gh pr view #{pr_number} --json #{json_fields}"
+  stdout, stderr, status = Open3.capture3(command)
+  abort("Error: #{stderr}") unless status.success?
+  JSON.parse(stdout, symbolize_names: true)
+end
+
+def comments_to_summary_text(comments)
+  comments_summary = comments.map do |comment|
+    "- **#{comment[:author][:login]}** [commented](#{comment[:url]}) - #{comment[:body].length > 500 ? "#{comment[:body][0..499]}... [more](#{comment[:url]})" : comment[:body].gsub(/\n/, ' ')}"
+  end
+  comments_summary.join("\n")
+end
+
+def reviews_to_summary_text(reviews)
+  reviews_summary = reviews.map do |review|
+    "- **#{review[:author][:login]} #{review[:state].downcase}** - #{review[:body].gsub(/\n/, ' ')}"
+  end
+  reviews_summary.join("\n")
+end
+
+def check_gh_is_installed
+  `which gh`
+  unless $?.success?
+    puts "We use the `gh` command from GitHub to create a new PR."
+    puts "`gh` not found, see installation instructions at:\nhttps://github.com/cli/cli#installation"
+    return false
+  end
+  true
+end
+
+def create_new_pr(old_pr)
+  branch = old_pr[:headRefName]
+  title = old_pr[:title].gsub("'", "\\\\'") # Escape single quotes in title
+  File.open("old-pr-description.txt", "w") { |file| file.write(old_pr[:body]) }
+  command = "gh pr create --base staging --head #{branch} --title '#{title}' --body-file old-pr-description.txt"
+  
+  puts "Running:\n#{command}\n"
+  puts
+  print "Create PR? [y/n]: "
+  answer = $stdin.gets.chomp.downcase
+  if answer == 'y'
+    stdout, stderr, status = Open3.capture3(command)
+    if status.success?
+      puts stdout
+      File.delete("old-pr-description.txt")
+      return stdout.split("\n").last.split('/').last
+    else
+      puts stderr
+      raise "Failed to create PR: #{stderr}"
+    end
+  end
+  nil
+end
+
+def add_old_pr_info_to(new_pr_number, old_pr)
+  old_pr_number = old_pr[:url].split('/').last
+  comment_body = "This PR is a continuation of ##{old_pr_number}, which was mis-closed by the Git LFS migration (#55759).\n\n" +
+                 "### Previous Comments:\n#{comments_to_summary_text(old_pr[:comments])}\n\n" +
+                 "### Previous Reviews:\n#{reviews_to_summary_text(old_pr[:reviews])}"
+  File.open("old-pr-info.txt", "w") { |file| file.write(comment_body) }
+  command = "gh pr comment #{new_pr_number} --body-file old-pr-info.txt"
+  puts
+  puts "Now we'll add a comment with the previous PRs comments and reviews"
+  puts "Adding previous comments (see old-pr-info.txt) with:\n#{command}\n"
+  stdout, stderr, status = Open3.capture3(command)
+  if status.success?
+    File.delete("old-pr-info.txt")
+    puts stdout
+  else
+    puts stderr
+    puts "\nWARNING: Failed to add old PR info: #{stderr}, you may want to manually add the contents of old-pr-info.txt to the PR as a new comment."
+  end
+end
+
+if check_gh_is_installed
+  unless ARGV.length == 1 && ARGV[0].match?(/^\d+$/)
+    puts "Creates a copy of PR OLD_PR_NUMBER which was mis-closed during the Git LFS migration"
+    puts
+    puts "Example: bin/copy-pr 51637"
+    puts "Creates a PR like: https://github.com/code-dot-org/code-dot-org/pull/56273"
+    exit(1)
+  end
+
+  pr_number = ARGV[0]
+  puts "Creating a copy of mis-closed PR ##{pr_number}"
+  puts
+  old_pr = fetch_pr(pr_number)
+  new_pr_number = create_new_pr(old_pr)
+  add_old_pr_info_to(new_pr_number, old_pr)
+  
+  # Open the new PR in the web browser
+  `gh pr view --web #{new_pr_number}`
+  
+  # Construct and print the new PR URL in bold
+  new_pr_url = "https://github.com/code-dot-org/code-dot-org/pull/#{new_pr_number}"
+  puts "\n\e[1mNew PR URL:\n#{new_pr_url}\e[0m"
+end


### PR DESCRIPTION
Makes a copy of a PR that was mis-closed by the LFS migration
THIS SCRIPT SHOULD BE REMOVED ANYTIME AFTER MAR 1, 2024

During our migration to use Git LFS:
https://github.com/code-dot-org/code-dot-org/issues/55759, many PRs were
auto-closed by GitHub (force push to staging rewriting history)
and cannot be re-opened. This script copies previous comments, 
and description frrm the old PR, and creates a new one.

Usage: bin/copy-pr OLD_PR_NUMBER

Example: bin/copy-pr 51637
Creates a PR like: https://github.com/code-dot-org/code-dot-org/pull/56273

Example output from running it:
```
➜  code-dot-org git:(staging) ✗ bin/copy-pr 51637
Creating a copy of mis-closed PR #51637

Running:
gh pr create --base staging --head seth/host-forks-on-cdo-github --title 'Host `wjordan/*` gem forks on `code-dot-org/*`' --body-file old-pr-description.txt

Create PR? [y/n]: y
https://github.com/code-dot-org/code-dot-org/pull/56273

Now we'll add a comment with the previous PRs comments and reviews
Adding previous comments (see old-pr-info.txt) with:
gh pr comment 56273 --body-file old-pr-info.txt
https://github.com/code-dot-org/code-dot-org/pull/56273#issuecomment-1926590461

New PR URL:
https://github.com/code-dot-org/code-dot-org/pull/56273
```
