### PR TITLE
Rubocop bin/copy-pr

### DIFF
--- a/bin/copy-pr
+++ b/bin/copy-pr
@@ -5,7 +5,7 @@
 # During our migration to use Git LFS:
 # https://github.com/code-dot-org/code-dot-org/issues/55759, many PRs were
 # auto-closed by GitHub (force push to staging rewriting history)
-# and cannot be re-opened. This script copies previous comments, 
+# and cannot be re-opened. This script copies previous comments,
 # and description frrm the old PR, and creates a new one.
 #
 # Usage: bin/copy-pr OLD_PR_NUMBER
@@ -26,14 +26,14 @@ end
 
 def comments_to_summary_text(comments)
   comments_summary = comments.map do |comment|
-    "- **#{comment[:author][:login]}** [commented](#{comment[:url]}) - #{comment[:body].length > 500 ? "#{comment[:body][0..499]}... [more](#{comment[:url]})" : comment[:body].gsub(/\n/, ' ')}"
+    "- **#{comment[:author][:login]}** [commented](#{comment[:url]}) - #{comment[:body].length > 500 ? "#{comment[:body][0..499]}... [more](#{comment[:url]})" : comment[:body].tr("\n", ' ')}"
   end
   comments_summary.join("\n")
 end
 
 def reviews_to_summary_text(reviews)
   reviews_summary = reviews.map do |review|
-    "- **#{review[:author][:login]} #{review[:state].downcase}** - #{review[:body].gsub(/\n/, ' ')}"
+    "- **#{review[:author][:login]} #{review[:state].downcase}** - #{review[:body].tr("\n", ' ')}"
   end
   reviews_summary.join("\n")
 end
@@ -51,9 +51,9 @@ end
 def create_new_pr(old_pr)
   branch = old_pr[:headRefName]
   title = old_pr[:title].gsub("'", "\\\\'") # Escape single quotes in title
-  File.open("old-pr-description.txt", "w") { |file| file.write(old_pr[:body]) }
+  File.write("old-pr-description.txt", old_pr[:body])
   command = "gh pr create --base staging --head #{branch} --title '#{title}' --body-file old-pr-description.txt"
-  
+
   puts "Running:\n#{command}\n"
   puts
   print "Create PR? [y/n]: "
@@ -75,9 +75,9 @@ end
 def add_old_pr_info_to(new_pr_number, old_pr)
   old_pr_number = old_pr[:url].split('/').last
   comment_body = "This PR is a continuation of ##{old_pr_number}, which was mis-closed by the Git LFS migration (#55759).\n\n" +
-                 "### Previous Comments:\n#{comments_to_summary_text(old_pr[:comments])}\n\n" +
-                 "### Previous Reviews:\n#{reviews_to_summary_text(old_pr[:reviews])}"
-  File.open("old-pr-info.txt", "w") { |file| file.write(comment_body) }
+    "### Previous Comments:\n#{comments_to_summary_text(old_pr[:comments])}\n\n" +
+    "### Previous Reviews:\n#{reviews_to_summary_text(old_pr[:reviews])}"
+  File.write("old-pr-info.txt", comment_body)
   command = "gh pr comment #{new_pr_number} --body-file old-pr-info.txt"
   puts
   puts "Now we'll add a comment with the previous PRs comments and reviews"
@@ -107,10 +107,10 @@ if check_gh_is_installed
   old_pr = fetch_pr(pr_number)
   new_pr_number = create_new_pr(old_pr)
   add_old_pr_info_to(new_pr_number, old_pr)
-  
+
   # Open the new PR in the web browser
   `gh pr view --web #{new_pr_number}`
-  
+
   # Construct and print the new PR URL in bold
   new_pr_url = "https://github.com/code-dot-org/code-dot-org/pull/#{new_pr_number}"
   puts "\n\e[1mNew PR URL:\n#{new_pr_url}\e[0m"

--- a/bin/copy-pr
+++ b/bin/copy-pr
@@ -26,7 +26,7 @@ end
 
 def comments_to_summary_text(comments)
   comments_summary = comments.map do |comment|
-    "- **#{comment[:author][:login]}** [commented](#{comment[:url]}) - #{comment[:body].length > 500 ? "#{comment[:body][0..499]}... [more](#{comment[:url]})" : comment[:body].tr("\n", ' ')}"
+    "- **#{comment[:author][:login]}** [commented](#{comment[:url]}) - #{comment[:body].tr("\n", ' ')}"
   end
   comments_summary.join("\n")
 end
@@ -74,8 +74,8 @@ end
 
 def add_old_pr_info_to(new_pr_number, old_pr)
   old_pr_number = old_pr[:url].split('/').last
-  comment_body = "This PR is a continuation of ##{old_pr_number}, which was mis-closed by the Git LFS migration (#55759).\n\n" +
-    "### Previous Comments:\n#{comments_to_summary_text(old_pr[:comments])}\n\n" +
+  comment_body = "This PR is a continuation of ##{old_pr_number}, which was mis-closed by the Git LFS migration (#55759).\n\n" \
+    "### Previous Comments:\n#{comments_to_summary_text(old_pr[:comments])}\n\n" \
     "### Previous Reviews:\n#{reviews_to_summary_text(old_pr[:reviews])}"
   File.write("old-pr-info.txt", comment_body)
   command = "gh pr comment #{new_pr_number} --body-file old-pr-info.txt"


### PR DESCRIPTION
For some reason git hooks didn't lint copy-pr, but it broke the build. Lint issues corrected by this PR.