### PR TITLE
Fix linter error

### DIFF
--- a/bin/copy-pr
+++ b/bin/copy-pr
@@ -113,7 +113,7 @@ if check_gh_is_installed
 
   puts "NOTE: Staging has drone.yml fixes and drone will not pass on your new PR until you merge staging into it. "
   puts
-  
+
   # Construct and print the new PR URL in bold
   new_pr_url = "https://github.com/code-dot-org/code-dot-org/pull/#{new_pr_number}"
   puts "\n\e[1mNew PR URL:\n#{new_pr_url}\e[0m"


### PR DESCRIPTION
I ensured my git hooks were still working before fixing this error. The git hooks accepted my commit after I removed the extra whitespace.