### PR TITLE
Edit username in Account Settings

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -533,7 +533,7 @@ class User < ApplicationRecord
 
   USERNAME_REGEX = /\A#{UserHelpers::USERNAME_ALLOWED_CHARACTERS.source}+\z/i
   validates_length_of :username, within: 5..20, allow_blank: true
-  validates_format_of :username, with: USERNAME_REGEX, on: :create, allow_blank: true
+  validates_format_of :username, with: USERNAME_REGEX, allow_blank: true
   validates_uniqueness_of :username, allow_blank: true, case_sensitive: false, on: :create, if: -> {errors.blank?}
   validates_uniqueness_of :username, case_sensitive: false, on: :update, if: -> {errors.blank? && username_changed?}
   validates_presence_of :username, if: :username_required?

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -44,7 +44,7 @@
   - if resource.username.present?
     .field
       = f.label :username, class: "label-bold"
-      = f.text_field :username, autofocus: false, maxlength: 20
+      = f.text_field :username, autofocus: false, maxlength: 20, minlength: 5
   - if f.object.can_edit_password? && f.object.encrypted_password.present?
     %div
       = f.label :password, maxlength: 255, class: "label-bold"

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -44,7 +44,7 @@
   - if resource.username.present?
     .field
       = f.label :username, class: "label-bold"
-      = f.object.username
+      = f.text_field :username, autofocus: false, maxlength: 20
   - if f.object.can_edit_password? && f.object.encrypted_password.present?
     %div
       = f.label :password, maxlength: 255, class: "label-bold"

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -147,7 +147,7 @@ class RegistrationsControllerTest < ActionController::TestCase
     assert_equal 'My School', student.school
   end
 
-  test "user cannot update on username to existing username" do
+  test "user cannot update username to existing username" do
     student = create(:student)
     new_student = create(:student)
 

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -147,6 +147,23 @@ class RegistrationsControllerTest < ActionController::TestCase
     assert_equal 'My School', student.school
   end
 
+  test "user cannot update on username to existing username" do
+    student = create(:student)
+    new_student = create(:student)
+
+    new_student.username = "newusername"
+    new_student.save
+
+    sign_in student
+    put :update, params: {
+      user: {
+        username: 'newusername',
+      }
+    }
+    assert_equal ["Username has already been taken"], assigns(:user).errors.full_messages
+    refute_equal 'newusername', student.reload.username
+  end
+
   test "parent_email: student can add a parent email without opt in" do
     student = create(:student)
     sign_in student


### PR DESCRIPTION
Allows users to edit their username within the Accounts Settings page. Adds a validation for `username` which checks if the username contains profanity.
<img width="707" alt="Screenshot 2024-02-01 at 10 47 37 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/77c65905-6e26-4f0a-bcef-56eed126d07e">
<img width="1082" alt="Screenshot 2024-02-01 at 11 46 03 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/a386c6cc-7531-4cb8-a0ea-0b435064594a">
<img width="761" alt="Screenshot 2024-02-06 at 2 46 39 PM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/ddde1b1a-c64a-464e-a5bc-b79de6584e2d">



## Links



- jira ticket: [here](https://codedotorg.atlassian.net/browse/P20-374)
Note: Mock ups in Jira contain the new styling which will be implemented in a different PR:
Slack thread for styling changes: [here](https://codedotorg.slack.com/archives/CFTFD6BPV/p1706810549232389)


## Follow-up work
Profanity check for usernames and display names.
Styling changes


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
