### PR TITLE
Removed duckduckgo api from allowed applab hostnames

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -38,7 +38,6 @@ class XhrProxyController < ApplicationController
     api.census.gov
     api.coinlayer.com
     api.datamuse.com
-    api.duckduckgo.com
     api.energidataservice.dk
     api.exchangeratesapi.io
     api.fda.gov


### PR DESCRIPTION
Due to concerns related to duckduckgo's API potentially returning offensive/inappropriate content as part of a discussion on a [Zendesk ticket ](https://codeorg.zendesk.com/agent/tickets/480645), we've decided to remove it from our applab's allowlist.