### PR TITLE
Music: only record Amplitude events on /projectbeats

### DIFF
--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -60,11 +60,11 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
   const onFeedbackClicked = () => {
     if (analyticsReporter) {
       analyticsReporter.onButtonClicked('feedback');
-      window.open(
-        'https://docs.google.com/forms/d/e/1FAIpQLScnUgehPPNjhSNIcCpRMcHFgtE72TlfTOh6GkER6aJ-FtIwTQ/viewform?usp=sf_link',
-        '_blank'
-      );
     }
+    window.open(
+      'https://docs.google.com/forms/d/e/1FAIpQLScnUgehPPNjhSNIcCpRMcHFgtE72TlfTOh6GkER6aJ-FtIwTQ/viewform?usp=sf_link',
+      '_blank'
+    );
   };
 
   return (

--- a/apps/src/music/views/ProjectBeats.tsx
+++ b/apps/src/music/views/ProjectBeats.tsx
@@ -9,7 +9,7 @@ import {Provider, useSelector} from 'react-redux';
 import MusicView from './MusicView';
 
 /**
- * Renders the "Project Beats" Music Lab experience, presented only on the Incubator page.
+ * Renders the "Project Beats" Music Lab experience, presented only on the /projectbeats page.
  * All other Music Lab experiences (script levels, single levels, standalone projects)
  * are presented via the Lab2 entrypoint.
  */
@@ -43,5 +43,5 @@ const DeferredMusicView: React.FunctionComponent = () => {
     return null;
   }
 
-  return <MusicView inIncubator={true} />;
+  return <MusicView onProjectBeats={true} />;
 };


### PR DESCRIPTION
As per product, we only want to record Amplitude analytics events when users are on the /projectbeats page (not in the intro script or any other levels). Updates MusicView to only record events when on /projectbeats. I also renamed the `inIncubator` prop to `onProjectBeats` for clarity, as technically the intro script also is accessible from within the incubator.