### PR TITLE
Disable new teacher popup for LTI

### DIFF
--- a/dashboard/app/helpers/initial_section_creation_interstitial_helper.rb
+++ b/dashboard/app/helpers/initial_section_creation_interstitial_helper.rb
@@ -1,9 +1,12 @@
+require 'policies/lti'
+
 module InitialSectionCreationInterstitialHelper
   # Determine whether or not to show the initial section creation interstitial popup to a user
   # This interstitial should be shown only to teachers on their first sign-in
   def self.show?(user)
     return false if user.nil?
     return false unless user.teacher?
+    return false if Policies::Lti.lti?(user)
 
     return user.sign_in_count <= 1
   end

--- a/dashboard/test/helpers/initial_section_creation_interstitial_helper_test.rb
+++ b/dashboard/test/helpers/initial_section_creation_interstitial_helper_test.rb
@@ -23,4 +23,11 @@ class InitialSectionCreationInterstitialHelperTest < ActiveSupport::TestCase
 
     assert InitialSectionCreationInterstitialHelper.show?(@teacher)
   end
+
+  test 'does not show the dialog if the teacher is an LTI user' do
+    @teacher = create :teacher, :with_lti_auth
+    @teacher.update(sign_in_count: 1)
+
+    refute InitialSectionCreationInterstitialHelper.show?(@teacher)
+  end
 end


### PR DESCRIPTION
Disables the popup for teachers logging in the first time, for LTI users. The popup was redundant since LTI users will be managing their sections in the LMS.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-676)

## Testing story

```
bundle exec spring testunit test/helpers/initial_section_creation_interstitial_helper_test.rb

Running via Spring preloader in process 14687
Started with run options --seed 54131

  4/4: [====================================================] 100% Time: 00:00:09, Time: 00:00:09

Finished in 9.76354s
4 tests, 5 assertions, 0 failures, 0 errors, 0 skips
```

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
