### PR TITLE
add without_deleted followers

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -490,7 +490,7 @@ class User < ApplicationRecord
 
   has_many :section_instructors, foreign_key: 'instructor_id', dependent: :destroy
   has_many :active_section_instructors, -> {where(status: :active)}, class_name: 'SectionInstructor', foreign_key: 'instructor_id'
-  has_many :sections_instructed, -> {without_deleted}, through: :active_section_instructors, source: :section
+  has_many :sections_instructed, -> {without_deleted.where(section_instructors: {deleted_at: nil})}, through: :active_section_instructors, source: :section
 
   # "sections" previously referred to what is now called :sections_owned.
   def sections

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -499,7 +499,7 @@ class User < ApplicationRecord
 
   # Relationships (sections/followers/students) from being a teacher.
   has_many :sections_owned, dependent: :destroy, class_name: 'Section'
-  has_many :followers, through: :sections_instructed
+  has_many :followers, -> {without_deleted}, through: :sections_instructed
   has_many :students, through: :followers, source: :student_user
 
   # Relationships (sections_as_students/followeds/teachers) from being a

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -5079,6 +5079,6 @@ class UserTest < ActiveSupport::TestCase
     section = create :section, teacher: teacher
     follower = create :follower, section: section, user: student
     follower.destroy
-    assert_empty student.reload.followers
+    assert_empty teacher.reload.followers
   end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -5081,4 +5081,13 @@ class UserTest < ActiveSupport::TestCase
     follower.destroy
     assert_empty teacher.reload.followers
   end
+
+  test 'does not return followers from formerly-instructed sections with deleted SectionInstructor in active status' do
+    student = create :student
+    teacher = create :teacher
+    section = create :section, teacher: teacher
+    SectionInstructor.where(section: section).destroy_all
+    create :follower, section: section, user: student
+    assert_empty teacher.reload.followers
+  end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -5075,9 +5075,10 @@ class UserTest < ActiveSupport::TestCase
 
   test "does not return deleted followers from the followers helper" do
     student = create :student
-    section = create :section
-    follower = create :follower, student_user_id: student.id, section_id: section.id
-    follower.delete
+    teacher = create :teacher
+    section = create :section, teacher: teacher
+    follower = create :follower, section: section, user: student
+    follower.destroy
     assert_empty student.reload.followers
   end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -5072,4 +5072,12 @@ class UserTest < ActiveSupport::TestCase
     student.save!
     assert_equal Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED, student.child_account_compliance_state
   end
+
+  test "does not return deleted followers from the followers helper" do
+    student = create :student
+    section = create :section
+    follower = create :follower, student_user_id: student.id, section_id: section.id
+    follower.delete
+    assert_empty student.reload.followers
+  end
 end


### PR DESCRIPTION
Bryan [reported on Slack](https://codedotorg.slack.com/archives/CFTFD6BPV/p1707176682739239) that the followers helper in the User model was returning deleted followers. For some reason, with this particular relation, we have to specify without_deleted to filter out Follower records with a deleted_at date.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
