### PR TITLE
Don't LFS dashboard/app/assets/stylesheets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,8 @@ dashboard/config/locales/** filter=lfs diff=lfs merge=lfs -text
 i18n/locales/** filter=lfs diff=lfs merge=lfs -text
 apps/static/** filter=lfs diff=lfs merge=lfs -text
 dashboard/app/assets/** filter=lfs diff=lfs merge=lfs -text
+dashboard/app/assets/stylesheets/** !text -filter -merge -diff
+dashboard/app/assets/javascripts/** !text -filter -merge -diff
 dashboard/public/** filter=lfs diff=lfs merge=lfs -text
 shared/images/** filter=lfs diff=lfs merge=lfs -text
 pegasus/sites.v3/** filter=lfs diff=lfs merge=lfs -text

--- a/dashboard/app/assets/javascripts/application.js.erb
+++ b/dashboard/app/assets/javascripts/application.js.erb
@@ -1,3 +1,39 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c241d2860287a2e845d7f0ba67b45420cf7f3a1bacae528d8e216387943d496
-size 1449
+// DEPRECATD: Do not add new javascript dependencies here. Instead, you should
+// add them to the apps package so they can be explicitly required/imported where
+// they are needed.
+
+// This is a manifest file that'll be compiled into application.js, which will include all the files
+// listed below.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// compiled file.
+//
+// Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
+// about supported directives.
+
+// Gem assets
+//= require jquery
+//= require jquery_ujs
+//= require jquery-ui
+// (Former location of video.js; reference while converting to code-studio.js)
+//= require bootstrap
+
+// Vendor assets
+//= require add2home
+//= require jquery.mask.min
+//= require jquery.placeholder
+//= require jquery.qtip.min
+//= require jquery.simulate
+//= require jquery.ui.touch-punch
+//= require jquery.overlaps
+
+// Shared assets
+//= require details-polyfill/jquery.details
+//= require details-polyfill/details-polyfill
+
+// window.dashboard is used to communicate between dashboard/apps in a variety
+// of places. In this case we want to make availale to our JS the url of the
+// pegasus portion of our site (i.e. http://code.org vs. http://studio.code.org)
+window.dashboard = window.dashboard || {};
+window.dashboard.CODE_ORG_URL = "<%= CDO.code_org_url %>";
+window.dashboard.rack_env = "<%= CDO.rack_env %>";

--- a/dashboard/app/assets/stylesheets/NpsSurveyBlock.scss
+++ b/dashboard/app/assets/stylesheets/NpsSurveyBlock.scss
@@ -1,3 +1,113 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9ff5b3846bedee19a50e64cb3c5235bcb81a1c18df226bbf5132aed4b43bddf
-size 2017
+// Style rules associated with the NpsSurveyBlock component
+@import "color";
+$box_shadow: rgba(255, 255, 255, 0.63);
+
+.nps-survey-root {
+  margin-top: 0;
+  color: $charcoal;
+  font-size: 25px;
+}
+
+.nps-survey-q-title {
+  padding-top: 10px;
+  font-size: 14px;
+}
+
+.nps-survey-row {
+  background-color: $table_header;
+}
+
+.nps-survey-q-rating-item {
+  display: inline-block;
+  font-size: 14px;
+  width: 32px;
+  height: 32px;
+  margin-right: 24px;
+  background-color: $white;
+  border-radius: 32px;
+  text-align: center;
+  line-height: 32px;
+  border: 1px solid $border_gray;
+}
+
+.nps-survey-rating-selected {
+  background-color: $teal;
+}
+
+.nps-survey-q-rating-item .sv-visuallyhidden {
+  display: none;
+}
+
+.nps-survey-rating-min {
+  position: absolute;
+  top: 45px;
+  width: 200px;
+  text-align: left;
+  left: 20px;
+  font-size: 14px;
+}
+
+.nps-survey-rating-max {
+  position: absolute;
+  top: 45px;
+  width: 200px;
+  text-align: right;
+  right: 220px;
+  font-size: 14px;
+}
+
+.nps-survey-rating-root {
+  height: 80px;
+  position: relative;
+  padding-top: 10px;
+  padding-bottom: 5px;
+  padding-left: 50px;
+
+  legend {
+    display: none;
+  }
+}
+
+.nps-survey-checkbox-material-decorator {
+  display: none;
+}
+
+.nps-survey-checkbox-item-control {
+  margin: 0 3px 3px 0 !important;
+}
+
+.nps-survey-top-error {
+  color: $bootstrap_error_text;
+  background-color: $bootstrap_error_background;
+  border: 1px solid $bootstrap_error_border;
+  border-radius: 4px;
+  padding: 10px;
+  font-size: 14px;
+}
+
+.nps-survey-submit-button {
+  font-size: 12px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: $border_gray;
+  border-radius: 3px;
+  white-space: nowrap;
+  color: $white;
+  background-color: $level_current;
+  font-weight: bold;
+  box-shadow: $box_shadow 0 2px 0 0 inset;
+  height: 34px;
+  padding-left: 24px;
+  padding-right: 24px;
+  line-height: 34px;
+  &:hover {
+    color: $level_current;
+    border-color: $level_current;
+    background-color: $white;
+  };
+}
+
+.nps-survey-comment {
+  width: 500px;
+  max-width: 700px;
+}

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1,3 +1,4180 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71209fb330cec501b38991e406d24de11d22a08cc17aebc9c592df7664fa0b35
-size 75268
+/*
+ * This is a manifest file that'll be compiled into application.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
+ * or vendor/assets/stylesheets of plugins, if any, can be referenced here using a relative path.
+ *
+ * You're free to add application-wide styles to this file and they'll appear at the top of the
+ * compiled file, but it's generally better to create a new file per style scope.
+ *
+ * Gem assets
+ *= require jquery-ui
+ *
+ * Vendor assets
+ *= require add2home
+ *= require jquery.qtip.min
+ *
+ * Application assets
+ *= require_self
+ *= require_directory .
+ *
+ * Shared
+ *= require barlow-semi-condensed-font
+ *= require metropolis-font
+ *= require user-menu
+ *= require buttons
+ *= require course-blocks
+ *= require details-polyfill
+ *= require warning-banner
+ */
+
+@import "color";
+@import "font";
+@import "mixins";
+@import "style-constants";
+
+// Bootstrap Variables
+$baseFontFamily: $main-font;
+$headingsFontWeight: $regular-font-weight;
+$btnPrimaryBackground: $orange;
+$btnPrimaryBackgroundHighlight: $orange;
+
+$selectUserTypeButtonBorderColor: #ccc;
+$selectUserTypeButtonBackgroundColor: #fff;
+$selectUserTypeButtonTextColor: #000;
+$selectUserTypeButtonBackgroundColorHover: #ddd;
+$selectUserTypeButtonTextColorHover: #000;
+$selectUserTypeButtonBackgroundColorSelected: #00adbc;
+$selectUserTypeButtonTextColorSelected: #fff;
+
+@import "bootstrap";
+
+p,pre,span {
+  @include selectable;
+}
+
+body {
+  -webkit-tap-highlight-color: transparent;
+  padding: 0;
+  font-style: normal;
+}
+
+body.pin_bottom {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+}
+
+body.oceans-blue {
+  background-color: $oceans_deep_blue;
+}
+
+body.music-black {
+  background-color: $dark_black;
+  overscroll-behavior: none;
+}
+
+h1 {
+  @include main-font-bold;
+  font-size: 32px;
+  color: $purple;
+}
+
+h2 {
+  margin: 25px 0 10px 0;
+  @include main-font-semi-bold;
+  font-size: 22px;
+  line-height: 30px;
+  color: $teal;
+}
+
+h3 {
+  font-size: 18px;
+}
+
+hr {
+  border-color: $teal;
+  border-bottom: none;
+}
+
+#classroom-sections hr {
+  border-color: $gray;
+}
+
+th {
+  background-color: $charcoal;
+  color: $white;
+  border: 1px solid $white;
+  text-align: left;
+  font-size: 120%;
+  @include main-font-semi-bold;
+  font-weight: normal;
+  padding: 5px;
+}
+
+strong {
+  @include main-font-bold;
+}
+
+em {
+  @include main-font-regular-italic;
+}
+
+strong em,
+em strong {
+  @include main-font-bold-italic;
+}
+
+a.video_link {
+  /* IE9 CSS hack */
+  max-width: 100%\9;
+}
+
+img.video_thumbnail {
+  width: 183px;
+}
+
+.center {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.clear {
+  clear: both;
+}
+
+.navbar {
+  margin-bottom: 30px;
+}
+
+.header-wrapper {
+  padding-top: 0;
+  min-height: 50px;
+  position: relative;
+  user-select: none;
+
+  .header {
+    position: absolute;
+    top: 0;
+    width: 100%;
+
+    padding-top: 0;
+    padding-bottom: 0;
+    height: 50px;
+    background-color: $teal;
+    color: $header_text;
+    a:link {
+      color: $header_text;
+    }
+    a:visited {
+      color: $header_text;
+    }
+
+    .small_font_on_tablet {
+      @media screen and (max-width: 1024px) {
+        font-size: 13px;
+      }
+    }
+
+    .header_left,
+    .header_right {
+      margin-top: 0;
+    }
+
+    .header_left {
+      left: 10px;
+    }
+
+    .header_middle {
+      top: 2px;
+    }
+
+    .header_logo {
+      width: 42px;
+      padding: 4px 16px;
+      margin-top: 0;
+    }
+  }
+
+  .project_info {
+    .header_text, .header_button {
+      float: left;
+    }
+    .project_name_wrapper .header_text {
+      float: left;
+      clear: left;
+    }
+  }
+
+  .header_text {
+    font-size: 16px;
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  @media screen and (min-width: 1011px) {
+    .show_on_tablet {
+      display: none;
+    }
+  }
+
+  @media screen and (max-width: 1010px) {
+    .hide_on_tablet {
+      display: none !important;
+    }
+  }
+
+  @media screen and (max-width: 1120px) {
+    .create_menu {
+      display: none !important;
+    }
+  }
+
+  .headerlinks {
+    margin-inline-start: 1rem;
+    display: flex;
+    justify-content: start;
+    align-items: center;
+    gap: 2rem;
+
+    .headerlink {
+      @include main-font-regular;
+      font-size: 14px;
+      line-height: 1;
+      display: inline-block;
+      margin-top: -1px;
+
+      &:link, &:visited {
+        text-decoration: none;
+      }
+
+      &:hover, &:active {
+        border-bottom: solid 2px $orange;
+        margin-top: 3px;
+        padding-bottom: 2px;
+      }
+    }
+
+    html[dir=rtl] & {
+      padding-right: 30px;
+    }
+  }
+
+  .header_button {
+    &.header_button_light {
+      background-color: $teal;
+    }
+    @include main-font-regular;
+    display: inline-block;
+    color: $white;
+    background-color: transparent;
+    border: 2px solid $white;
+    border-radius: 5px;
+    padding: 7px 12px;
+    font-size: 14px;
+    line-height: 20px;
+    box-sizing: border-box;
+    float: left;
+    cursor: pointer;
+    white-space: nowrap;
+    margin-inline-start: 8px;
+    a:hover {
+      text-decoration: none;
+      background-color: $orange;
+    }
+  }
+
+  .user_menu, .create_menu, .help_button {
+    margin-top: 6px;
+    .create_button, .display_name, .pairing_name {
+      html[dir=rtl] & {
+        float: right;
+        padding-left: 3px;
+      }
+    }
+
+    .pairing_icon {
+      display: inline-block;
+      float: left;
+      padding-right: 5px;
+      padding-top: 3px;
+    }
+
+    .user_options, .help_contents {
+      font-size: 14px;
+      line-height: 20px;
+    }
+  }
+
+  .button-signin {
+    text-decoration: none;
+  }
+
+  .project_updated_at {
+    font-size: 10px;
+    .project-save-error {
+      background-color: $dark_red;
+      padding: 0 5px;
+      margin-top: 2px;
+      font-size: 12px;
+      display: inline-block;
+      border-radius: 4px;
+    }
+  }
+
+  #hamburger {
+    padding: 4px 3px 0 11px;
+  }
+
+  .help_button {
+    margin-top: 0;
+    padding-top: 3px;
+    padding-left: 11px;
+
+    &:not(.user-is-tabbing) {
+      outline: none;
+    }
+  }
+
+  #signin_button .header_button {
+    margin-top: 6px;
+  }
+
+  #sign_in_or_user {
+    &.z_index_above_modal {
+      z-index: 1050;
+
+      // Usually transparent, so adding teal allows button to render in front
+      .header_user {
+        background-color: $teal;
+      }
+    }
+  }
+}
+
+.levelbuilder-header {
+  .header {
+    background-color: $purple;
+  }
+}
+
+.local-header {
+  .header {
+    background-color: $orange;
+  }
+}
+
+
+#language_dir.rtl #pageheader-wrapper {
+  .create_options {
+    direction: rtl;
+    .project_link {
+      padding: 0 4px 0 10px;
+    }
+    #view_all_projects {
+      padding-right: 10px;
+    }
+  }
+}
+
+#header-banner {
+  background-size: cover;
+  background-position: 90% 30%;
+  display: flex;
+  justify-content: center;
+
+  .bannerContent {
+    max-width: 60%;
+  }
+
+  /*
+    The banner background image leaves an open space for text on the left. Therefore, in Right-to-Left languages, the
+    banner needs to be flipped horizontally so the background image empty space is on the right.
+   */
+  html[dir=rtl] & {
+    transform: scaleX(-1);
+    /*
+      Since the whole banner was flipped horizontally, we need to un-flip all the content in the header. So the text and
+      layout is not backwards
+     */
+    .bannerContentContainer {
+      transform: scaleX(-1);
+    }
+  }
+
+  #projects-page & {
+    margin-bottom: 16px;
+  }
+}
+
+#header-banner-overflow {
+  margin: 16px;
+
+  .bannerContentButton {
+    // !important is used here to overwrite inline styles of button.
+    border-color: $neutral_dark !important;
+  }
+}
+
+#header-banner, #header-banner-overflow {
+  .children {
+    margin-top: 16px;
+  }
+}
+
+/* When we are using a dark theme in Google Blockly, we want the main Blockly area (inside #codeWorkspace)
+ * to have a 1px separation between it and the PaneHeader above it.
+*  */
+#codeWorkspace > .cdomoderndark-theme,
+#codeWorkspace > .cdohighcontrastdark-theme,
+#codeWorkspace > .cdoprotanopiadark-theme,
+#codeWorkspace > .cdodeuteranopiadark-theme,
+#codeWorkspace > .cdotritanopiadark-theme {
+  /* A small separation. */
+  margin-top: 1px;
+
+  /* Override the height in Google Blockly's .injectionDiv */
+  height: calc(100% - 1px);
+}
+
+.bannerContentContainer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  margin: 16px;
+}
+
+#courses-container {
+  #header-banner {
+    background-position: 75% 40%;
+  }
+
+  .announcements {
+    margin-top: 16px;
+  }
+
+  .contentContainer {
+    display: flex;
+    justify-content: center;
+    margin-top: 16px;
+
+    .content {
+      width: 100%;
+      margin: 0 16px;
+    }
+  }
+}
+
+.sign_in.show_only_on_mobile {
+  float: right;
+  margin-bottom: 10px;
+
+  @media screen and (min-device-width: 501px) {
+    display: none;
+  }
+}
+
+#betainfo {
+  position: absolute;
+  font-size: 10px;
+  top: -1px;
+  right: 33px;
+}
+
+.main {
+  padding: 10px;
+
+  a:link, a:visited, a:hover, a:active {
+    @include main-font-bold;
+    color: $brand_secondary_default;
+    background-color: transparent;
+    text-decoration: underline;
+  }
+  a:hover {
+    color: $brand_secondary_dark;
+    text-decoration: underline;
+  }
+
+  a:link, a:visited, a:active {
+    &:has(.visual-block) {
+      text-decoration: unset;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  a.fa:link, a.fa:visited, a.fa:hover, a.fa:active {
+    font-family: FontAwesome;
+  }
+}
+
+/* This styling helps to push the footer to the bottom of a page. */
+$footer_min_height: 236px;
+$footer_padding-top: 20px;
+$footer_fullheight: $footer_min_height + $footer_padding-top;
+html, body {
+  height: 100%;
+}
+.wrapper {
+  min-height: 100%;
+  margin-bottom: -$footer_fullheight;     /* This is the same as the height of .push. */
+  .legacy-share-view & {
+    position: relative;
+  }
+}
+.push {
+  height: $footer_fullheight;             /* This is the same as the height of .footer once its padding is included. */
+}
+.legacy-share-view .push {
+  display: none;
+}
+
+.footer {
+  min-height: $footer_min_height;
+  padding-top: $footer_padding-top;
+  font-size: 14px;
+  background-color: $darkest_gray;
+  color: $header_text;
+  a:link, a:visited, a:hover, a:active {
+    @include main-font-regular;
+    color: $white;
+    background-color: transparent;
+  }
+  a:hover {
+    text-decoration: underline;
+  }
+  .powered-by-aws {
+    width: 100%;
+    margin-top: 12px;
+  }
+  select {
+    width: auto;
+    font-size: 11px;
+    height: 18px;
+    margin-bottom: 4px;
+    }
+  .fineprint {
+    a:link, a:visited, a:hover, a:active {
+      @include main-font-semi-bold;
+    }
+  }
+  .dim {
+    display: inline-block;
+    opacity: 0.8;
+  }
+
+  .container {
+    html[dir=rtl] & {
+      float: right;
+    }
+
+    .row {
+      [class*="span"] {
+        html[dir=rtl] & {
+          float: right;
+          margin-right: 20px;
+          margin-left: 0;
+        }
+
+        a {
+          html[dir=rtl] & {
+            float: right;
+          }
+        }
+
+        div.dim {
+          html[dir=rtl] & {
+            float: right;
+            margin-left: 4px;
+            margin-right: 4px;
+          }
+        }
+      }
+    }
+
+  }
+}
+
+/* Styling that keeps the small footer consistent with other page elements */
+$codeApp-left-margin: 25px;
+$small-footer-horizontal-margin: 15px;
+$small-footer-standard-width: 400px;
+
+/* Shared styles so flyout looks like footer */
+.small-footer-base, #copyright-flyout, #more-menu {
+  background-color: $background_gray;
+  color: $dimgray;
+  font-size: 14px;
+  a {
+    @include main-font-semi-bold;
+    &:link {
+      color: $charcoal;
+      text-decoration: none;
+    }
+    &:visited {
+      color: $charcoal;
+      text-decoration: none;
+    }
+    &:hover {
+      color: $charcoal;
+      background-color: transparent;
+      text-decoration: none;
+    }
+    &:active {
+      color: $charcoal;
+      background-color: transparent;
+      text-decoration: none;
+    }
+  }
+
+  h4 {
+    color: $dimgray;
+  }
+
+  .dark & {
+    background-color: $dark-charcoal;
+    border: 0;
+    color: $light_gray;
+    justify-content: flex-end;
+    margin: 0;
+    a {
+      &:link {
+        color: $lightest_gray;
+      }
+      &:visited {
+        color: $lightest_gray;
+      }
+      &:hover {
+        color: $white;
+      }
+      &:active {
+        color: $white;
+      }
+    }
+
+    .more-link {
+      margin: 0 $small-footer-horizontal-margin;
+      background-color: $dark-charcoal;
+      border: 0;
+      color: $light_gray;
+      font-size: 14px;
+      padding: 0;
+      &:hover {
+        box-shadow: none;
+      }
+    }
+  }
+
+  @media screen and (max-width: 1150px) {
+    small {
+      font-size: 10px;
+    }
+  }
+}
+
+.small-footer-base {
+  position: absolute;
+  bottom: 0;
+  margin: 0 $codeApp-left-margin;
+  display: flex;
+  border-top: 1px solid $lighter_gray;
+  padding: 6px 0 3px 0;
+  width: 100%;
+  max-width: $small-footer-standard-width;
+
+  /*
+   * Used in @cdo/apps/src/StudioApp.js to resize #belowVisualization to
+   * fit between the visualization above and the .small-footer
+   */
+  margin-top: 5px;
+
+  select {
+    color: $charcoal;
+    width: 80px;
+    font-size: 11px;
+    height: 18px;
+    margin: 0;
+    line-height: 18px;
+    padding: 0;
+    border: 0;
+  }
+
+  .copyright-button, .i18n-dropdown-container, .globe-icon {
+    align-self: center;
+  }
+
+  .copyright-button {
+    margin: 0 10px;
+    button {
+      padding: 3px;
+      font-size: 16px;
+      line-height: 16px;
+      margin: 0;
+      border: 1px solid $lighter_gray;
+      background-color: $background-gray;
+    }
+  }
+
+  .globe-icon {
+    color: $charcoal;
+    font-size: 18px;
+    margin: 0 1px;
+  }
+
+  .i18n-dropdown-container {
+    display: flex;
+    border: 1px solid $lighter_gray;
+    border-radius: 4px;
+    background-color: $white;
+    padding: 0 0 0 4px;
+    margin: 0;
+  }
+
+  .i18n-dropdown-container:dir(rtl) {
+    padding: 0 4px 0 0;
+  }
+}
+
+/* Override footer position on some pages, but not published project views */
+#page-small-footer .small-footer-base {
+  position: fixed;
+  margin-top: 0;
+}
+
+
+#copyright-scroll-area {
+  overflow-y: auto;
+  padding: 0.8em;
+  border-bottom: 1px solid $lighter_gray;
+}
+
+.responsive-content-mobile-footer {
+  position: relative;
+
+  @media screen and (min-width: 970px) {
+    & {
+      display: none;
+    }
+  }
+}
+
+.responsive-content-desktop-footer {
+  @media screen and (max-width: 969px) {
+    & {
+      display: none;
+    }
+  }
+}
+
+#more-menu {
+  display: none;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  /* Prevent default unordered-list style */
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+
+  & > li > a {
+    display: block;
+    padding: 3px $small-footer-horizontal-margin 3px $codeApp-left-margin;
+    border-bottom: solid thin $lightest_gray;
+
+    &:hover {
+      background-color: $dark_charcoal;
+      color: $lightest_gray;
+      text-decoration: none;
+    }
+  }
+
+  .dark & {
+    & > li > a {
+      &:hover {
+        background-color: $lightest_gray;
+        color: $dark_charcoal;
+      }
+    }
+  }
+}
+
+.dark {
+  #copyright-flyout {
+    background-color: $dark-charcoal;
+  }
+  #copyright-scroll-area {
+    background-color: $dark-charcoal;
+  }
+  .small-footer-base {
+    font-size: 12px;
+  }
+}
+
+/* All three major components of .small-footer are stacked:
+   Need to have this reasonably, high since some of our elements (such as
+   applab editor) have higher values
+*/
+#more-menu {
+  z-index: 998;
+}
+#copyright-flyout {
+  z-index: 999;
+}
+.small-footer-base {
+  z-index: 1000;
+}
+
+#locale {
+  font-family: sans-serif;
+  height: 24px;
+}
+
+.oceans-blue .small-footer-base, .music-black .small-footer-base {
+  background-color: initial;
+  border-top: initial;
+}
+
+/* Custom styling for the locale & copyright buttons and the copyright flyout,
+ * for Music Lab.
+ */
+.music-black {
+  #page-small-footer {
+    user-select: none;
+
+    .small-footer-base {
+      margin-left: 10px;
+    }
+
+    .i18n-dropdown-container, .copyright-link {
+      height: 26px;
+      box-sizing: border-box;
+      border: solid 1px $neutral_dark40;
+    }
+
+    .copyright-button {
+      user-select: none;
+
+      .copyright-link {
+        width: 26px;
+      }
+    }
+
+    .i18n-dropdown-container, .globe-icon, #locale, .copyright-link {
+      background-color: initial;
+      color: $neutral_dark40;
+    }
+
+    #copyright-flyout {
+      border: solid 1px $neutral_dark40;
+      box-sizing: border-box;
+
+      h4, a:link {
+        color: $neutral_dark50;
+      }
+
+      img {
+        background-color: $neutral_light;
+        border-radius: 4px;
+        padding: 4px;
+        margin-bottom: 6px;
+      }
+    }
+
+    #copyright-flyout, #copyright-scroll-area {
+      background-color: $neutral_dark;
+      color: $neutral_light;
+    }
+  }
+}
+
+.header_separator {
+  padding-left: 2px;
+  margin-bottom: -18px;
+  margin-top: -8px;
+  margin-right: 2px;
+  height: 42px;
+  border-right: 1px solid $inset_color;
+  border-right-style: inset;
+  display: inline-block;
+}
+
+.user_options, .help_contents {
+  display: none;
+  a:link {
+    color: $black;
+  }
+  a:visited {
+    color: $black;
+  }
+  a:hover {
+    color: $white;
+    background-color: $dark_color;
+    text-decoration: none;
+  }
+  a:active {
+    color: $white;
+    background-color: $dark_color;
+  }
+  border: 1px solid $black;
+  color: $black;
+  padding: 10px;
+}
+
+.user_options .pairing_summary {
+  font-size: 0.8em;
+  line-height: 1.6em;
+}
+
+.full_container {
+  padding: 0 25px 25px 25px;
+}
+
+body.embedded_iframe {
+  .full_container {
+    padding-left: 0;
+  }
+}
+
+.responsive_full_container {
+  padding: 0 10px 10px 10px;
+}
+
+$default-modal-width: 640px;
+
+.modal {
+  @media screen and (max-height: 600px) {
+    max-height: 80vh;
+    overflow-y: auto;
+  }
+
+  a:hover:not(.btn) {
+    background-color: $white;
+  }
+
+  &#block-documentation-lightbox {
+    width: 80% !important;
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+  }
+
+  .markdown {
+    .modal-image {
+      margin-top: -100px;
+      float: left;
+      position: relative;
+    }
+  }
+}
+
+.auto-resize-scrollable {
+  &.modal {
+    position: absolute;
+    top: 50px; // top of the dialog
+
+    width: $default-modal-width;
+    margin-left: -($default-modal-width * 0.5);
+
+    // margin-bottom is reused in JavaScript to determine
+    // how close to get to the bottom of the viewport.
+    margin-bottom: 25px;
+
+    z-index: 1050;
+  }
+}
+
+.modal-body {
+  max-height: none;
+}
+
+.dash_modal {
+  width: $default-modal-width;
+  margin-left: -($default-modal-width * 0.5);
+}
+
+.dash_modal_body {
+  padding-right: 25px;
+}
+
+.btn#dataConfirmOK:hover {
+  color: $white;
+  background-color: $orange;
+}
+
+#videoTabContainer {
+  padding: 0;
+}
+
+#video {
+  border-width: 0;
+}
+
+.video-player {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+.vjs-tech:focus, .vjs-poster:focus {
+  outline: 0;
+}
+
+.video-player-rounded-corners {
+  border-radius: 10px;
+  border-width: 0;
+  overflow: hidden;
+}
+
+.video-player-full-width {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.video-content-full-width {
+  position: relative;
+  // Specifically supports 16x9 aspect ratio
+  padding-top: 56.25%;
+}
+
+.buttons-right-aligned {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: -44px;
+}
+
+.fallback-video-player-failed {
+  video, div {
+    visibility: hidden;
+  }
+  p {
+    font-size: 22px;
+    line-height: 26px;
+    padding: 5px;
+
+    a {
+      color: $white;
+    }
+  }
+}
+
+.video-modal {
+  z-index: 10000;
+  overflow: visible;
+
+  .ui-tabs {
+    height: 100%;
+    width: 100%;
+
+    video {
+      width: 100%;
+      max-height: 100%;
+    }
+  }
+}
+
+.header_left {
+  display: flex;
+  float: left;
+  z-index: 2;
+  flex-shrink: 0;
+  flex-grow: 0;
+}
+
+.header_left, .header_right {
+  margin-top: 5px;
+}
+
+.header_logo {
+  float: left;
+  z-index: 1;
+  margin-top: -24px;
+  padding-top: 14px;
+  min-width: 0;
+  max-width: 55px;
+  width: 55px;
+
+  a:hover {
+    background-color: transparent;
+  }
+}
+
+
+.project_info {
+  float: left;
+
+  .header_text, .header_button {
+    float: left;
+  }
+  .project_name_wrapper {
+    min-width: 160px;
+
+    html[dir=rtl] & {
+      padding-left: 5px;
+      padding-right: 5px;
+    }
+  }
+  .project_name_wrapper .header_text {
+    float: left;
+    clear: left;
+  }
+}
+
+.project_name {
+  max-width: 300px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  vertical-align: middle;
+}
+
+.project_save[disabled] {
+  background: $light_gray;
+}
+
+#project-share {
+
+  .export-button {
+    color: $dark_color;
+    cursor: pointer;
+    margin-top: 10px;
+    display: block;
+  }
+
+  .social-buttons a {
+    display: inline-block;
+    background: $purple;
+    color: $white;
+    border-radius: 5px;
+    margin-right: 8px;
+    font-size: larger;
+    &:hover, & {
+      text-decoration: none;
+    }
+
+    &:hover {
+      box-shadow: 2px 2px 5px $light_gray;
+    }
+
+    i {
+      border-radius: 5px;
+      width: 45px;
+      height: 45px;
+      line-height: 45px;
+      text-align: center;
+      vertical-align: middle;
+      font-size: 24pt;
+
+      &.fa-facebook {
+        background-color: $facebook_blue;
+      }
+      &.fa-twitter {
+        background-color: $twitter_blue;
+      }
+    }
+    span {
+      padding-right: 10px;
+    }
+  }
+}
+
+@keyframes header_fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.header_middle {
+  display: flex;
+  flex-shrink: 1;
+  flex-grow: 1;
+  min-width: 0;
+  float: left;
+
+  .header_button, .header_input {
+    margin-left: 10px;
+  }
+}
+
+.header_level_container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header_level {
+  font-size: 150%;
+  cursor: default;
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .progress_container {
+    overflow: hidden;
+  }
+}
+
+.unit_name_container {
+  overflow: hidden;
+  padding-right: 5px;
+}
+
+.header_right {
+  float: right;
+  margin-right: 13px;
+  flex-shrink: 0;
+  flex-grow: 0;
+  display: flex;
+  justify-content: flex-end;
+}
+
+#sign_in_or_user {
+  float: left;
+}
+
+input.header_input {
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 3px;
+}
+
+.header_user {
+  text-align: right;
+  margin-left: 6px;
+  margin-top: 6px;
+  height: 38px;
+}
+
+.header_popup {
+  position: absolute;
+  text-align: left;
+  // Set to have a 4 px gap with the bottom of the header
+  top: 48px;
+  right: 0;
+  left: 0;
+  margin: 0 auto;
+  // margin-bottom is reused in JavaScript to determine how close to get to the bottom of the viewport.
+  margin-bottom: 20px;
+  width: 635px;
+  border-color: $bkgnd_color;
+  border-top: 5px;
+  border-bottom: 5px;
+  border-radius: 6px;
+  z-index: 1050;
+  background-color: $white;
+  box-shadow: 0 0 10px $light_gray;
+  overflow: hidden;
+}
+
+.header_popup_scrollable {
+  max-height: 560px;
+  overflow-y: auto;
+}
+
+.header_popup_body {
+  position: relative;
+  display: block;
+  color: $charcoal;
+
+  .loading {
+    margin: 20px;
+    background: image-url("spinner-big.gif") no-repeat center center;
+  }
+}
+
+.header_finished_link {
+  display: inline-block;
+  font-size: 16px;
+  overflow: hidden;
+  padding-left: 5px;
+  box-sizing: border-box;
+
+  a {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.header_finished_link:hover {
+  background-color: transparent;
+  text-decoration: underline;
+}
+
+#alert {
+  color: $red;
+  font-size: 130%;
+  border-style: solid;
+  border-width: 2px;
+  padding: 5px;
+}
+
+.oceans-blue {
+  #codeApp {
+    .loading {
+      background: image-url("spinner-big-oceans-blue.gif") no-repeat center center;
+    }
+
+    .slow_load {
+      color: $white;
+    }
+  }
+}
+
+#codeApp {
+  position: relative;
+  margin: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+
+  .loading {
+    height: 520px;
+    background: image-url("spinner-big.gif") no-repeat center center;
+  }
+
+  .slow_load {
+    display: none;
+    text-align: center;
+    position: relative;
+    top: -230px;
+  }
+}
+
+body.iframe_embed_app_and_code {
+  background-color: transparent;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+
+  .full_container {
+    padding: 0;
+  }
+
+  #codeApp {
+    height: 100%;
+  }
+
+}
+
+#codeApp.pin_bottom {
+  position: absolute;
+  top: 60px;
+  left: 10px;
+  right: 10px;
+  bottom: 10px;
+
+  &.centered_embed {
+    position: relative;
+    top: 0;
+    left: auto;
+    right: auto;
+    margin-top: 10px;
+  }
+}
+
+.reference_area {
+  margin-top: 20px;
+  color: $neutral_dark;
+
+  .help_title {
+    @include main-font-bold;
+    font-size: 17.5px;
+    display: inline-block;
+  }
+
+  .solution_link {
+    font-size: 17.5px;
+    padding-bottom: 4px;
+  }
+
+  .video_link {
+    display: inline-block;
+    margin: 6px 0;
+    color: $brand_secondary_default;
+    text-decoration: underline;
+
+    &:hover {
+      color: $brand_secondary_dark;
+    }
+  }
+
+  .help_subtitle {
+    display: inline-block;
+  }
+}
+
+#notes-outer {
+  overflow-y: scroll;
+  padding: 0;
+}
+#notes {
+  .note {
+    padding-bottom: 10px;
+    p {
+      font-size: 20px;
+      line-height: 24px;
+      padding-right: 30px;
+      display: table-cell;
+    }
+    img {
+      float: left;
+      width: 450px;
+      height: auto;
+      padding-right: 30px;
+    }
+  }
+}
+
+// Tabs
+
+.video-modal {
+  .modal-body {
+    padding: 0;
+  }
+  .ui-tabs-nav {
+    background: $light_gray;
+
+    li {
+      border-top-right-radius: 4px;
+      border-top-left-radius: 4px;
+      border: 0;
+      background: transparent;
+      margin-bottom: 2px;
+
+      a {
+        background: $brand_secondary_default;
+        border: 2px solid $brand_secondary_default;
+        border-radius: 6px;
+        color: $neutral_white;
+        @include main-font-semi-bold;
+        cursor: pointer !important;
+
+        &:hover {
+          background-color: $brand_secondary_dark;
+          border-color: $brand_secondary_dark;
+          color: $neutral_white;
+        }
+        &:focus {
+          outline: 0;
+        }
+      }
+
+      html[dir=rtl] & {
+        float: right;
+      }
+    }
+
+    li.ui-state-active {
+      a {
+        background: $neutral_white;
+        color: $neutral_dark;
+        border: 2px solid $neutral_dark;
+
+        &:hover {
+          color: $neutral_dark;
+          background-color: $neutral_dark20;
+        }
+      }
+    }
+  }
+}
+
+@mixin close-button($cornerOffset) {
+  $startWidth: 61px;
+  $startHeight: 59px;
+  $growth: 3px;
+  $movement: 1px;
+
+  position: absolute;
+  cursor: pointer;
+  z-index: 10;
+  background: image-url("x_button.png") no-repeat center center;
+  background-size: 100% auto;
+
+  top: $cornerOffset;
+  right: $cornerOffset;
+  width: $startWidth;
+  height: $startHeight;
+  &:hover {
+    top: $cornerOffset - $movement;
+    right: $cornerOffset - $movement;
+    width: $startWidth + $growth;
+    height: $startHeight + $growth;
+  }
+
+  html[dir=rtl] &, .flip-x-close & {
+    right: auto;
+    left: $cornerOffset;
+  }
+  html[dir=rtl] &:hover, .flip-x-close &:hover {
+    right: auto;
+    left: $cornerOffset - $movement;
+  }
+
+  html[dir=rtl] .flip-x-close & {
+    right: auto;
+    left: $cornerOffset;
+  }
+
+  html[dir=rtl] .flip-x-close &:hover {
+    right: auto;
+    left: $cornerOffset - $movement;
+  }
+}
+
+.x-close {
+  @include close-button($cornerOffset: -20px);
+}
+
+.open-link {
+  $startWidth: 61px;
+  $startHeight: 59px;
+  $cornerOffset: -20px;
+  $growth: 3px;
+  $movement: 1px;
+
+  position: absolute;
+  cursor: pointer;
+  z-index: 1;
+  background: image-url("open_button.png") no-repeat center center;
+  background-size: 100% auto;
+
+  top: $cornerOffset;
+  right: -30px + $startWidth;
+  width: $startWidth;
+  height: $startHeight;
+  &:hover {
+    width: $startWidth + $growth;
+    height: $startHeight + $growth;
+  }
+}
+.open-link > a {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}
+
+.qtip-content {
+  font-size: 20px;
+  line-height: 28px;
+  color: $neutral_dark;
+  @include main-font-semi-bold;
+  padding-right: 25px;
+}
+
+html[dir=rtl] .qtip-content {
+  direction: rtl;
+  text-align: right;
+  padding-right: 9px;
+  padding-left: 25px;
+}
+
+.qtip-default {
+  background-color: $white;
+  color: $charcoal;
+  border: 1px solid $charcoal;
+  border-radius: 8px;
+  box-shadow: 5px 5px 5px $shadow;
+  padding: 10px;
+}
+
+.no-tip .qtip-tip {
+  visibility: hidden;
+}
+
+.cdo-qtips {
+  z-index: 1030 !important;
+}
+
+.tooltip-x-close.qtip-icon {
+  @include close-button($cornerOffset: -20px);
+}
+
+a.download-video {
+  z-index: 1;
+  cursor: pointer;
+  width: 40px;
+  height: 34px;
+  font-size: 28px;
+  background-color: $neutral_white;
+  color: $neutral_dark;
+  border: 2px solid $neutral_dark;
+  padding: 0;
+  line-height: 36px;
+
+  &:hover {
+    background: $neutral_dark20;
+  }
+
+  img {
+    width: 40px;
+    height: 41px;
+    margin-top: -3px;
+    margin-bottom: -2px;
+  }
+  img:hover {
+    width: 41px;
+    height: 42px;
+    margin-bottom: -3px;
+  }
+}
+
+.quiet_links {
+  a:link {
+    @include main-font-regular;
+  }
+}
+
+.fixed_width_cell {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-left: 5px;
+}
+
+#landingpage {
+  .row#continue {
+    background-color: $teal;
+    color: $white;
+    font-size: 24.5px;
+    padding: 5px 0;
+    #puzzle {
+      @include main-font-bold;
+    }
+    .btn {
+      height: 32px;
+      margin: 0 5px;
+    }
+  }
+
+  #welcome h2 {
+    font-size: 18px;
+  }
+
+  h3.whitetext {
+    a, a:link, a:hover, a:visited {
+      color: $white;
+      text-decoration: none;
+      cursor: pointer;
+    }
+  }
+
+  .row.navcontainer {
+    margin: 30px 0 10px -20px;
+    background-color: $lightest_gray;
+  }
+
+  ul.nav.nav-pills {
+    text-transform: uppercase;
+    padding: 10px;
+    li {
+      margin-right: 10px;
+    }
+
+    li.active a, li.active a:hover, li.active a:link {
+      background-color: $white;
+      color: $purple;
+      border: 2px solid $purple;
+    }
+    li a:hover, a:focus {
+      text-decoration: none;
+      background-color: $white;
+    }
+  }
+
+  #signup {
+    padding-top: 10px;
+    .medium-size-text {
+      font-size: 18px;
+      line-height: 30px;
+    }
+    #maintext {
+      text-align: left;
+      padding-left: 20px;
+      color: $charcoal;
+    }
+    #helptext {
+      text-align: right;
+      padding-right: 20px;
+      color: $light_gray;
+    }
+  }
+
+  #lesson {
+    #heading {
+      width: 700px;
+    }
+
+    /**
+     * betatext can be used to style a span directly, or betacontainer can be
+     * used on a node containing markdown to apply the beta styling to all
+     * **strong** nodes in the markdown
+     */
+    .betatext, .betacontainer strong {
+      background: $white;
+      color: $cyan;
+      padding: 2px 4px;
+      border: 1px solid $cyan;
+    }
+  }
+}
+
+.course_progress {
+  margin: 10px 0;
+}
+
+#signinsection {
+  ul.students, ul.pictures {
+    margin-left: 0;
+  }
+
+  ul.students li,
+  ul.pictures li {
+    list-style-type: none;
+    border: 1px solid $lighter_gray;
+    border-radius: 5px;
+    background-color: $lightest_gray;
+    float: left;
+    margin: 5px;
+    padding: 5px;
+    cursor: pointer;
+  }
+
+  ul.students li:hover,
+  ul.pictures li:hover {
+    background-color: $light_yellow;
+  }
+
+  ul.students li.selected,
+  ul.pictures li.selected {
+    background-color: $yellow;
+  }
+
+  #pairing_checkbox {
+    margin: 5px 0;
+    label {
+      font-size: 17.5px;
+    }
+    label, input {
+      margin: 5px;
+      display: inline-block;
+      vertical-align: middle;
+    }
+  }
+}
+
+.flex-container {
+  display: flex;
+  justify-content: space-between;
+}
+
+#change-password {
+  max-width: 600px;
+}
+
+#signin,
+#change-password {
+  $field-width: 310px;
+  $button-width: 324px;
+
+  min-width: 450px;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 2;
+
+  form {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .field {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    input[type=text], input[type=password] {
+      width: $field-width;
+      height: 40px;
+      padding: 0 6px;
+    }
+    input {
+      background-color: $neutral_light;
+    }
+
+    label {
+      color: $neutral_dark;
+      font-size: 1em;
+      max-width: 20%;
+      line-height: 1.2;
+      @include main-font-semi-bold;
+    }
+  }
+
+  .field-aligned {
+    width: $button-width;
+    align-self: flex-end;
+  }
+
+  #forgot-password {
+    color: $neutral_dark;
+    font-size: 1em;
+    line-height: 1.2;
+    @include main-font-semi-bold;
+  }
+
+  #password_field, #new_user {
+    margin-bottom: 0;
+  }
+
+  .password_help_link {
+    margin-bottom: 21px;
+  }
+
+  button {
+    align-self: flex-end;
+    background-color: $brand_secondary_default;
+    border: 2px solid $brand_secondary_default;
+    color: $neutral_white;
+    @include main-font-semi-bold;
+    margin: 5px 0;
+    width: $button-width;
+
+    &:hover {
+      background-color: $brand_secondary_dark;
+      border-color: $brand_secondary_dark;
+      box-shadow: none;
+    }
+
+    &:focus {
+      border-color: $brand_primary_default;
+    }
+
+    &:disabled {
+      color: $neutral_white;
+      border-color: $neutral_dark20;
+      background-color: $neutral_dark20;
+      @include box-shadow(none);
+      cursor: not-allowed;
+    }
+  }
+
+  .blue-button {
+    background-color: $blue;
+    border: 1px solid $blue;
+  }
+  .neutral-button {
+    background-color: $neutral_white;
+    border: 2px solid $neutral_dark;
+    color: $neutral_dark;
+
+    &:hover {
+      background-color: $neutral_dark10;
+      border-color: $neutral_dark;
+      box-shadow: none;
+    }
+
+    &:focus {
+      border-color: $brand_primary_default;
+    }
+
+    &:disabled {
+      color: $neutral_dark20;
+      border-color: $neutral_dark20;
+      background-color: $neutral_white;
+      @include box-shadow(none);
+      cursor: not-allowed;
+    }
+  }
+}
+
+#code_without_signing_in {
+  margin-top: 80px;
+  margin-bottom: 0;
+}
+
+#signup, #school-info-modal {
+  $signup-info-background: #f7f7f7;
+  $signup-info-border-color: #e5e5e5;
+
+  display: flex;
+  flex-wrap: wrap;
+
+  .header {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  #sign_up_errors {
+    background-color: $signup-info-background;
+    border: 1px solid $red;
+    flex-wrap: wrap;
+    width: 100%;
+    h4 {
+      margin: 0;
+    }
+  }
+
+  .padded-container {
+    padding: 20px;
+    display: flex;
+    flex-wrap: wrap;
+    .row {
+      flex-grow: 1;
+    }
+
+    .parent-email-field-input {
+      flex-grow: 1;
+    }
+  }
+
+  .oauth-links {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .more-details {
+    display: flex;
+    .more-details-text {
+      margin: 0 10px;
+    }
+  }
+
+  .signup {
+    margin: 20px 0;
+  }
+
+  .select-user-type-teacher-button, .select-user-type-student-button {
+    min-width: 225px;
+    min-height: 275px;
+    position: relative;
+    background-color: $selectUserTypeButtonBackgroundColor;
+    color: $selectUserTypeButtonTextColor;
+    border-radius: 15px;
+    border-color: $selectUserTypeButtonBorderColor;
+    display: flex;
+    flex-direction: column;
+
+    .user-type-name {
+      width: 100%;
+      text-align: center;
+      margin-top: 10px;
+    }
+
+    .user-type-desc {
+      text-align: start;
+      margin-top: 10px;
+      margin-left: 5px;
+      margin-right: 5px;
+    }
+
+    .user-type-abilities-unordered-list {
+      text-align: start;
+      width: 85%;
+      margin-inline-start: 10%;
+    }
+  }
+
+  #select-user-type-original {
+    display: flex;
+  }
+
+  #select-user-type-variant {
+    display: none;
+  }
+
+  .select-user-type-teacher-button:hover, .select-user-type-student-button:hover {
+    background-color: $selectUserTypeButtonBackgroundColorHover;
+    color: $selectUserTypeButtonTextColorHover;
+  }
+
+  .select-user-type-button-selected {
+    background-color: $selectUserTypeButtonBackgroundColorSelected;
+    color: $selectUserTypeButtonTextColorSelected;
+  }
+
+  .select-user-type-button-selected:hover {
+    background-color: $selectUserTypeButtonBackgroundColorSelected;
+    color: $selectUserTypeButtonTextColorSelected;
+  }
+
+  .finish-signup {
+    width: 800px;
+  }
+
+  .signup-header {
+    margin: 0;
+    flex-grow: 1;
+  }
+
+  .signup, .finish-signup {
+    .section-container {
+      padding: 10px;
+      flex-grow: 1;
+      background-color: $signup-info-background;
+      border: 1px solid $signup-info-border-color;
+
+      h5 {
+        font-weight: bold;
+      }
+
+      hr {
+        border: 1px solid $signup-info-border-color;
+      }
+    }
+
+    #school-info-inputs {
+      padding: 0;
+    }
+
+    .field-row {
+      display: flex;
+      align-items: center;
+    }
+
+    .field {
+      width: 600px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .field-sm {
+      width: 400px;
+    }
+
+    .field_with_errors {
+      display: flex;
+      flex-basis: 100%;
+      input, select {
+        border-color: $red;
+      }
+    }
+
+    .field_with_errors label {
+      color: $black;
+    }
+
+    .field_with_errors > input,
+    .field_with_errors > select {
+      background-color: $white;
+    }
+
+    .error {
+      color: $red;
+      font-style: italic;
+      margin: 0;
+    }
+
+    .padded {
+      padding-left: 10px;
+      max-width: 150px;
+    }
+
+    select {
+      height: 46px;
+      margin: 0;
+    }
+
+    #school-type {
+      height: 36px;
+    }
+
+    input[type=text], input[type=password], input[type=email] {
+      height: 36px;
+    }
+
+    input {
+      margin: 0;
+    }
+
+    input, select {
+      flex-grow: 1;
+    }
+
+    .row {
+      display: flex;
+      margin-bottom: 20px;
+
+      [class*=span] {
+        align-self: center;
+        display: flex;
+        .div {
+          align-self: center;
+          display: flex;
+        }
+      }
+
+      label {
+        margin: 0;
+      }
+
+      input[type=checkbox] {
+        flex-grow: 0;
+        align-self: center;
+        .field_with_errors {
+          flex-grow: 0;
+        }
+      }
+    }
+
+    #parent-email-section {
+      background-color: $signup-info-background;
+      border: 1px solid $signup-info-border-color;
+      flex-wrap: wrap;
+    }
+
+    .signup-field-label {
+      flex-wrap: wrap;
+
+      p {
+        margin: 0;
+      }
+    }
+
+    #signup-select-user-type-label {
+      width: 220px;
+    }
+
+    .parent-email-section-header {
+      margin-bottom: 0;
+      flex-grow: 1;
+    }
+
+    .parent-email-field {
+      margin-top: 20px;
+      margin-bottom: 0;
+      flex-grow: 1;
+    }
+
+    #teacher-name-label, #student-name-label, #teacher-email-label {
+      display: flex;
+      flex-basis: 100%;
+    }
+
+    .checkbox {
+      display: flex;
+      padding: 0;
+
+      label {
+        display: flex;
+      }
+
+      p, span {
+        margin: 0;
+        padding: 0 10px;
+        font-size: 14px;
+      }
+      .field_with_errors {
+        flex-basis: auto;
+      }
+    }
+
+    #email-preference-radio, #share-email-reg-part-preference-radio {
+      p {
+        margin: 0;
+      }
+    }
+
+    .radio {
+      padding: 0;
+      display: flex;
+      input[type=radio] {
+        margin-left: 0;
+        align-self: center;
+      }
+      input[type=radio], label {
+        flex-grow: 0;
+        margin-right: 5px;
+      }
+      .field_with_errors {
+        flex-basis: auto;
+      }
+    }
+
+    #school-type {
+      width: 370px !important;
+    }
+
+    .submit-section {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+    }
+
+    .submit {
+      background-color: $orange;
+      border: 1px solid $orange;
+      color: $white;
+      padding: 0 20px;
+      margin: 5px 0;
+      font-size: 18px;
+      height: 40px;
+      @include main-font-bold;
+    }
+
+    #forgot-password {
+      align-self: center;
+      font-style: italic;
+    }
+
+    .tos {
+      p {
+        font-size: 14px;
+        margin: 0;
+      }
+    }
+
+    #gdpr-section {
+      flex-wrap: wrap;
+      .checkbox {
+        label {
+          align-items: baseline;
+          input[type=checkbox] {
+            align-self: auto;
+          }
+        }
+      }
+      #gdpr-label {
+        margin: 0 10px;
+        span {
+          padding: 0;
+        }
+      }
+    }
+  }
+}
+
+.vertical-or {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 20px;
+  font-size: 16px;
+  font-weight: bolder;
+  color: $charcoal;
+
+  hr {
+    width: 1px;
+    height: 100%;
+    background-color: $light_gray;
+  }
+}
+
+.horizontal-or {
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 16px;
+  font-weight: bolder;
+  color: $charcoal;
+
+  hr {
+    width: 40%;
+    border-color: $light_gray;
+  }
+}
+
+// NEW STYLES FOR devise/shared/_new_links
+.devise-links {
+  flex-grow: 2;
+
+  form {
+    margin: 0;
+  }
+
+  .section-sign-in {
+    display: flex;
+    align-items: center;
+
+    input {
+      background-color: $neutral_light;
+    }
+
+    input[type=text] {
+      flex-grow: 2;
+      height: 40px;
+      padding-top: 0;
+      padding-bottom: 0;
+      margin: 0;
+    }
+
+    button {
+      @include main-font-semi-bold;
+      padding: 10px 20px;
+      margin-right: 0;
+      background-color: $brand_secondary_default;
+      border: 2px solid $brand_secondary_default;
+      color: $neutral_white;
+
+      &:hover {
+        background-color: $brand_secondary_dark;
+        border-color: $brand_secondary_dark;
+        box-shadow: none;
+      }
+      &:focus {
+        border-color: $brand_primary_default;
+      }
+
+      &:disabled {
+        color: $neutral_white;
+        border-color: $neutral_dark20;
+        background-color: $neutral_dark20;
+        @include box-shadow(none);
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  .oauth-sign-in {
+    @include main-font-semi-bold;
+    width: 100%;
+    margin: 5px 0;
+    color: $neutral_dark;
+    background-color: $neutral_white;
+    border: 2px solid $neutral_dark;
+    border-radius: 4px;
+    line-height: 18px;
+
+    &:hover {
+      background-color: $neutral_dark10;
+      box-shadow: none;
+    }
+
+    img {
+      opacity: unset;
+      float: left;
+      margin-left: 24px;
+    }
+
+    &:focus {
+      border-color: $brand_primary_default;
+    }
+
+    &:disabled {
+      color: $neutral_dark20;
+      border-color: $neutral_dark20;
+      background-color: $neutral_white;
+      @include box-shadow(none);
+      cursor: not-allowed;
+    }
+
+    &.with-google_oauth2 {
+      background-color: $google_brand_color;
+      border-color: $google_brand_color;
+      color: $neutral_white;
+    }
+
+    &.with-facebook {
+      background-color: $facebook_brand_color;
+      border-color: $facebook_brand_color;
+      color: $neutral_white;
+    }
+
+    &.with-microsoft_v2_auth {
+      background-color: $microsoft_brand_color;
+      border-color: $microsoft_brand_color;
+    }
+  }
+}
+
+#hoc_download {
+  color: $charcoal;
+  .capsule {
+    background-color: $lightest_gray;
+    border-radius: 10px;
+    margin-top: 16px;
+    margin-bottom: 16px;
+    padding-top: 20px;
+    padding-bottom: 28px;
+  }
+  .indent {
+    margin-left: 20px;
+  }
+}
+
+@mixin yTranslation($offset) {
+  -webkit-transform: translateY($offset);
+  -ms-transform: translateY($offset);
+  transform: translateY($offset);
+}
+
+/* overrides .unplugged for match levels in level groups */
+.level-group-content .unplugged.match {
+  width: auto;
+}
+
+.match {
+  .mainblock {
+    margin-left: 0;
+    .level-group-content & {
+      margin-left: 50px;
+    }
+  }
+  .column {
+    width: 260px;
+    float: left;
+    img {
+      position: relative;
+      top: 50%;
+      @include yTranslation(-50%);
+      height: auto;
+      width: auto;
+      max-height: 100%;
+      max-width: 100%;
+    }
+  }
+  .draggablecolumn {
+    cursor: default;
+    touch-action: none;
+    -ms-touch-action: none;
+  }
+  li {
+    padding-top: 1px;
+    padding-bottom: 1px;
+    background-color: $lighter_gray;
+    padding-left: 4px;
+    padding-right: 4px;
+    width: 220px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    border-style: solid;
+    border-color: transparent;
+    border-width: 6px;
+  }
+  .match_questions {
+    list-style-type: none;
+    margin-left: 0;
+    li {
+      background-color: $white;
+      border-color: $lighter_gray;
+    }
+  }
+  li {
+    text-align: center;
+  }
+  .match_slots {
+    list-style-type: none;
+    margin-left: 0;
+    .emptyslot {
+      background-color: $lightest_gray;
+      border-color: $lightest_gray;
+      .giantmark {
+        .text {
+          opacity: 0.8;
+          @include main-font-semi-bold;
+        }
+      }
+    }
+    .active {
+      border-style: dotted;
+      border-color: $light_yellow;
+    }
+    .active.emptyslot {
+      background-color: $lighter_yellow;
+    }
+  }
+  .question {
+    p {
+      font-size: 16px;
+      line-height: 24px;
+    }
+  }
+  .answer {
+    background-color: $white;
+    border-color: $lighter_cyan;
+  }
+  .answer.ui-draggable:hover {
+    border-color: $light_green;
+    cursor: move;
+  }
+  .match_answerdest {
+    width: 240px;
+  }
+  .answerlist {
+    h4 {
+      position: relative;
+      top: 25%;
+      @include yTranslation(-50%);
+    }
+  }
+  .match_answers {
+    list-style-type: none;
+    margin-left: 0;
+  }
+  .answerslot {
+    h4 {
+      position: relative;
+      top: 25%;
+      @include yTranslation(-50%);
+    }
+  }
+  .match_correctmarkscolumn {
+    width: 20px;
+    padding-right: 20px;
+  }
+  .match_correctmarks {
+    margin-left: 0;
+  }
+  .correctmark {
+    list-style-type: none;
+    margin-left: 0;
+    width: 30px;
+    padding-left: 0;
+    padding-right: 0;
+    background-color: transparent;
+  }
+}
+
+.level-group-number {
+  display: block;
+  font-size: 16px;
+  line-height: 24px;
+  float: left;
+  width: 30px;
+}
+
+.level-group-content {
+  overflow: hidden;
+
+  .external, .free-response {
+    margin-left: 0;
+  }
+}
+
+.text-match, .free-response, .peer-review {
+  p, label {
+    font-size: 16px;
+    line-height: 24px;
+  }
+  #markdown {
+    // By default, nothing in the page body is selectable.
+    // On text-match levels there may be a reason to paste part of the
+    // level markdown (the question) into the answer box, so we want it
+    // to be selectable.
+    @include selectable;
+  }
+}
+
+.external .content-level {
+  overflow: hidden;
+}
+
+.external-video-container {
+  margin-left: 93px;
+}
+
+.peer-review input[type=radio] {
+  margin: 0 3px 3px 5px;
+}
+
+.peer-review-content {
+  background: $white;
+  border: 1px solid $light_gray;
+  border-radius: 5px;
+  padding: 10px;
+  margin-bottom: 1em;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+  .peer-review-title {
+    margin: 0;
+  }
+  .peer-review-status {
+    font-size: 1em;
+  }
+  &.from-instructor {
+    border: 2px solid $cyan;
+
+    .peer-review-title {
+      color: $cyan;
+    }
+  }
+  &.outdated {
+    color: $charcoal;
+    &.from-instructor {
+      border: 2px solid $lighter_cyan;
+    }
+  }
+}
+
+.external-link-icon {
+  margin: 0 0.33em 0 20px;
+}
+
+.external-link-disclaimer {
+  padding: 20px;
+  margin: 40px 0 20px 0;
+  color: $dark_charcoal;
+  background-color: $lighter_gray;
+  font-size: 13px;
+  h2 {
+    font-size: 16px;
+    line-height: 1em;
+    margin: 0;
+    text-transform: uppercase;
+  }
+  strong {
+    display: block;
+    margin-bottom: 1em;
+  }
+}
+
+.container {
+  width: $content-width;
+}
+
+.container,
+.external,
+.text-match,
+.free-response,
+.standalone-video,
+.curriculum-reference,
+.multi,
+.match,
+.bubble-choice {
+  #markdown.teacher {
+    max-width: 1000px;
+    border: 5px solid $cyan;
+    background-color: $lightest_cyan;
+    border-radius: 5px;
+    margin: 10px auto;
+    .level-group-content & {
+      margin-left: 50px;
+    }
+    .content {
+      padding: 10px;
+    }
+    h3 {
+      padding: 5px;
+      font-size: 18px;
+      line-height: 18px;
+      @include main-font-bold;
+      color: $white;
+      background: $cyan;
+      margin: 0;
+    }
+    p {
+      font-size: 13px;
+    }
+  }
+
+  blockquote {
+    padding: 15px 20px;
+    background: $lightest_purple;
+    border: 0;
+    border-radius: 10px;
+    clear: both;
+    p {
+      margin-bottom: 10px;
+    }
+    h2:first-child {
+      margin-top: 5px;
+    }
+  }
+}
+
+.multi.contained, .contained.free-response {
+  margin: 20px;
+  max-width: 100%;
+  #markdown.teacher {
+    max-width: 100%;
+  }
+}
+
+.level-image {
+  width: 380px;
+  float: right;
+  margin: 20px 0 30px 30px;
+  transform: rotate(2deg);
+  box-shadow: 2px 2px 10px $shadow;
+  border: 1px solid $lighter_gray;
+}
+
+.curriculum-reference #iframe-loading.loading {
+  height: 200px;
+  background: image-url("spinner-big.gif") no-repeat center center;
+}
+
+.external, .free-response, .curriculum-reference {
+  max-width: 970px;
+  margin: auto;
+
+  &.left-aligned {
+    margin-left: 0;
+  }
+}
+
+.free-response .response {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.contained-level .free-response .response {
+  resize: vertical;
+}
+
+.standalone-video {
+  width: 853px;
+  margin: 10px auto 0 auto;
+
+  .video-link, .slides-link, #fallback-player-caption-dialog-link {
+    display: inline-block;
+  }
+
+  &-full-width {
+    width: unset;
+  }
+}
+
+.multi #markdown.teacher {
+  margin-left: 50px;
+  margin-right: 50px;
+  max-width: 100%;
+}
+
+.bubble-choice #markdown.teacher {
+  margin: 10px 0;
+}
+
+.multi.contained #markdown.teacher {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.text-match #markdown.teacher, .free-response #markdown.teacher {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+#free-response-upload {
+  overflow: hidden;
+}
+
+#current-script-levels, #all-levels {
+  min-height: 50px;
+  li {
+    list-style-type: none;
+  }
+}
+
+.blocklyMainBackground {
+  stroke: none;
+}
+
+#blockly-frame {
+  width: 70%;
+  height: 800px;
+}
+#script_name {
+  margin: 0 10px 0 0;
+}
+.edit_level {
+  .field {
+    margin-bottom: 10px;
+    border-top: 2px solid $lightest_gray;
+    padding-top: 10px;
+  }
+
+  #toolbox_name {
+    display: block;
+  }
+  .block-checkbox {
+    float: left;
+  }
+}
+
+.infobox {
+  background-color: $charcoal;
+  color: $white;
+  font-size: 13px;
+  padding-right: 10px;
+  @include main-font-regular;
+  padding: 10px;
+}
+
+.previousPageButton {
+  margin-right: 5px;
+}
+
+.buttons.submittable {
+  .submitButton, .unsubmitButton {
+    border-color: $purple;
+    background-color: $purple;
+    color: $white;
+    background-image: none;
+  }
+}
+
+.submitted_readonly {
+  background-color: $lightest_gray;
+}
+
+/* multiple choice */
+
+$information-phone-narrow: "only screen and  (max-width: 320px)";
+$information-phone-wide: "only screen and (min-width: 321px) and (max-width: 767px)";
+$information-tablet-tall: "only screen and (min-width: 768px) and (max-width: 1023px)";
+$information-desktop: "only screen and (min-width: 1024px)";
+
+.multi {
+  margin: auto;
+  h1 {
+    text-align: center;
+  }
+  p {
+    font-size: 16px;
+    line-height: 24px;
+  }
+  $multi-left-margin: 50px;
+
+  .answerbutton {
+    &.lock-answers {
+      pointer-events: none;
+      color: $light_gray;
+    }
+  }
+
+  &.contained {
+    h1 {
+      text-align: left;
+    }
+  }
+
+  // The tight layout is designed for a full-width layout that tends to
+  // vertically stack every element, rather than going for side-by-side elements.
+  &.tight {
+
+    // A piece of instructional content (image, text, markdown)
+    .question .content {
+      float: left;
+      clear: both;
+      @media #{$information-phone-narrow} {
+      }
+      @media #{$information-phone-wide} {
+      }
+      @media #{$information-tablet-tall} {
+        width: 55%;
+      }
+      @media #{$information-desktop} {
+        width: 55%;
+      }
+    }
+
+    // A plain-text question.
+    .multi-question {
+      float: left;
+      width: calc(100% - #{$multi-left-margin});
+      font-size: 16px;
+      line-height: 24px;
+    }
+
+    // The block of answers.
+    .answers {
+      float: left;
+      clear: both;
+      width: calc(100% - #{$multi-left-margin});
+      &.question-content-blank {
+        width: calc(100% - #{$multi-left-margin});
+      }
+    }
+
+    // A single answer button.
+    .answerbutton {
+      clear: both;
+      margin-left: $multi-left-margin;
+    }
+  }
+
+  // The default layout is designed to fit a single multi with a side-by-side
+  // layout when the screen is wide, and then stacking vertically for narrow
+  // devices.
+  &.default {
+
+    // The block containing all instructional content (image, text, markdown).
+    .question {
+      float: left;
+      @media #{$information-phone-narrow} {
+      }
+      @media #{$information-phone-wide} {
+      }
+      @media #{$information-tablet-tall} {
+        width: 35%;
+      }
+      @media #{$information-desktop} {
+        width: 35%;
+      }
+    }
+
+    // A plain-text question.
+    .multi-question {
+      float: left;
+      font-size: 16px;
+      line-height: 24px;
+
+      @media #{$information-tablet-tall} {
+        margin-left: $multi-left-margin;
+      }
+      @media #{$information-desktop} {
+        margin-left: $multi-left-margin;
+      }
+    }
+
+    // The block of answers.
+    .answers {
+      float: left;
+      margin-left: $multi-left-margin;
+      @media #{$information-phone-narrow} {
+      }
+      @media #{$information-phone-wide} {
+      }
+      @media #{$information-tablet-tall} {
+        width: 55%;
+      }
+      @media #{$information-desktop} {
+        width: 55%;
+      }
+      &.question-content-blank {
+        width: calc(100% - #{$multi-left-margin});
+      }
+    }
+
+    // A single answer button.
+    .answerbutton {
+      margin-top: 15px;
+      margin-right: 15px;
+      padding-left: 10px;
+      padding-right: 20px;
+      padding-top: 10px;
+      padding-bottom: 10px;
+    }
+  }
+
+  .mainblock {
+    margin-left: 0;
+    img {
+      max-height: 100%;
+    }
+  }
+  .item {
+    padding: 10px;
+    float: left;
+  }
+  input {
+    margin-top: 12px;
+  }
+  .answerbutton {
+    white-space: nowrap;
+  }
+  .item-radio {
+    display: inline-block;
+    float: left;
+    width: 32px;
+    text-align: right;
+    padding-right: 10px;
+    box-sizing: border-box;
+    @include yTranslation(-35%);
+  }
+  .item-mark {
+    display: inline-block;
+    text-align: left;
+    padding-right: 10px;
+    box-sizing: border-box;
+    font-size: 21px;
+    width: 30px;
+  }
+  .item-label {
+    display: inline-block;
+    text-align: left;
+    vertical-align: top;
+    white-space: normal;
+    .teacher & {
+      margin-right: 30px;
+    }
+    label {
+      font-size: 14px;
+    }
+  }
+  .item-answer-letter {
+    @include main-font-semi-bold;
+  }
+}
+
+$modal-image-width: 100px;
+$modal-image-margin-gap: 10px;
+$modal-no-icon-gap: 22px;
+
+.modal-content {
+  margin-left: $modal-image-width + $modal-image-margin-gap;
+  html[dir=rtl] & {
+    margin-left: 0;
+    margin-right: $modal-image-width + $modal-image-margin-gap;
+  }
+  &.no-modal-icon {
+    margin-left: $modal-no-icon-gap;
+  }
+
+  p, pre {
+    line-height: 27px;
+    font-size: 24px;
+    color: $neutral_dark;
+  }
+
+  pre {
+    color: $purple;
+  }
+
+  .congrats {
+    @include main-font-semi-bold;
+    font-size: 21px;
+    line-height: 27px;
+  }
+
+  .instructions2 {
+    font-size: 18px;
+    color: $charcoal;
+  }
+
+  .aniGif {
+    display: block;
+    margin: 0 auto 6px auto;
+    position: relative;
+    z-index: -1;
+  }
+
+  .feedback-image {
+    width: 180px;
+    height: auto;
+    margin: 0 15px 0 0;
+    float: left;
+    border: $light_gray;
+    border-style: solid;
+  }
+
+  .feedback-links {
+    margin-top: 15px;
+  }
+
+  .feedback-callout {
+    border: solid;
+    border-radius: 10px;
+    border-color: $red;
+
+    p {
+      margin: 15px;
+      color: $red;
+      padding-right: 20%;
+    }
+
+    .congrats {
+      font-size: 24px;
+      line-height: 27px;
+    }
+
+    .hint-header {
+      @include main-font-bold;
+    }
+
+    .hint-image {
+      float: right;
+      width: 20%;
+    }
+  }
+
+  .lines-of-code-message {
+    font-size: 20px;
+    line-height: normal;
+    margin: 0 0 8px 0;
+  }
+
+  .instructions-container {
+    .authored-hints {
+      p, pre {
+        font-size: 18px;
+        line-height: normal;
+        color: $charcoal;
+        margin: 0;
+      }
+    }
+  }
+}
+
+.dialog-title {
+  @include main-font-bold;
+}
+
+h5.dialog-title {
+  // TODO: [Phase 2] Remove when new typography will be done and used or replace with 1.25em
+  font-size: 20px;
+}
+
+#ok-button {
+  background-color: $orange;
+  border: 1px solid $orange;
+  color: $white;
+  min-width: 100px;
+}
+
+#again-button, #cancel-button {
+  background-color: $green;
+  color: $white;
+  margin-left: 0;
+  margin-right: 10px;
+}
+
+#continue-button {
+  background-color: $orange;
+  color: $white;
+  margin-left: 0;
+  margin-right: 10px;
+}
+
+.modal-image {
+  max-width: $modal-image-width;
+  max-height: 100px;
+  height: auto;
+  margin-top: -75px;
+  position: absolute;
+  html[dir=rtl] & {
+    float: right;
+    -webkit-transform: scaleX(-1);
+    -ms-transform: scaleX(-1);
+    transform: scaleX(-1);
+  }
+}
+.modal-header {
+  border: none;
+  height: 20px;
+}
+.modal-body {
+  height: 100%;
+  overflow: visible;
+}
+
+.modal-content.markdown-instructions-container {
+  margin-left: $modal-no-icon-gap;
+  margin-right: $modal-no-icon-gap;
+  /*margin-top: 10px;*/
+  margin-bottom: 15px;
+  float: left;
+  padding: 0 0 15px 0;
+  background-color: $white;
+  $outside-margin-side: 15px;
+  width: $default-modal-width - ($modal-no-icon-gap * 2) - ($outside-margin-side * 2);
+}
+
+.modal-content.instructions-container {
+  margin: 15px 10px 20px 20px;
+
+  button {
+    margin: 0;
+  }
+}
+
+.csf-top-instructions {
+  p {
+    margin: 5px 0;
+  }
+}
+
+.csf-top-instructions, .instructions-markdown {
+  p {
+    line-height: 25px;
+    font-size: 16px;
+    color: $black;
+  }
+
+  .secondary-instructions p {
+    font-size: 14px;
+    color: $charcoal;
+  }
+
+  strong {
+    @include main-font-semi-bold;
+  }
+}
+
+.instructions-markdown {
+  padding-top: 19px;
+
+  .instructor-image {
+    float: left;
+    padding-right: 10px;
+  }
+
+  .instructor-image-end {
+    float: right;
+    padding-left: 10px;
+  }
+}
+
+.dynamic-instructions-markdown {
+  p {
+    font-size: 16px;
+    line-height: 20px;
+  }
+}
+
+html[dir="rtl"] .instructions-markdown {
+  .instructor-image {
+    float: right;
+    padding-left: 10px;
+    padding-right: 0;
+  }
+
+  .instructor-image-end {
+    float: left;
+    padding-right: 10px;
+    padding-left: 0;
+  }
+}
+
+.markdown-level-header-text {
+  margin-left: $modal-image-width + $modal-image-margin-gap;
+  margin-top: 15px;
+  font-weight: normal;
+  line-height: 27px;
+  font-size: 24px;
+  color: $purple;
+
+  &.no-modal-icon {
+    margin-left: $modal-no-icon-gap;
+  }
+}
+
+#levelgroup-submit-incomplete-dialogcontent,
+#levelgroup-submit-complete-dialogcontent,
+#unsubmit-dialogcontent {
+  overflow: hidden;
+}
+
+#feedbackBlocks {
+  margin-left: 50px;
+  height: 100px;
+  border: none;
+}
+
+#feedbackButtons::after {
+  content: '';
+  display: inline-block;
+  width: 100%;
+}
+
+.farSide {
+  text-align: right;
+  html[dir=rtl] & {
+    text-align: left;
+  }
+}
+
+.exclamation-abuse {
+  a, a:hover {
+    color: $white;
+    text-decoration: underline;
+  }
+}
+
+/* Buttons from apps */
+
+button {
+  margin: 5px;
+  padding: 10px;
+  border-radius: 4px;
+  border: 1px solid $lightest_gray;
+  font-size: large;
+  background-color: $lightest_gray;
+  color: $black;
+}
+button.launch {
+  border: 1px solid $orange;
+  background-color: $orange;
+  color: $white;
+  font-size: large;
+  min-width: 96px;
+  margin-left: 0;
+  margin-right: 10px;
+  /* Can't use "text-align: start" due to IE. */
+  text-align: left;
+}
+html[dir="RTL"] button.launch {
+  text-align: right;
+}
+button.launch>img {
+  opacity: 1;
+  vertical-align: text-bottom;
+}
+button>img {
+  opacity: 0.6;
+  vertical-align: text-bottom;
+}
+button:hover>img {
+  opacity: 1;
+}
+button:active {
+  border: 1px solid $light_gray !important;
+}
+button.button-active-no-border:active {
+  // This class is needed for when we want to hide the border on
+  // an active button. (overriding button:active rule above)
+  border: none !important;
+}
+button:hover {
+  @include box-shadow(2px 2px 5px $shadow);
+}
+button.disabled, button[disabled=disabled] {
+  border: 1px solid $lighter_gray;
+  background-color: $lighter_gray;
+  @include box-shadow(none);
+}
+button.disabled:hover>img {
+  opacity: 0.6;
+}
+button.disabled {
+  display: none;
+}
+button.notext {
+  font-size: 10%;
+}
+
+@mixin bottom-shadow {
+  @include box-shadow(0 10px 13px -11px $black);
+}
+
+@mixin rounded-border {
+  border: 2px solid $light_gray;
+  box-sizing: border-box;
+  border-radius: 25px;
+}
+
+.example-image {
+  @include bottom-shadow;
+  @include rounded-border;
+}
+
+/*
+ * The following responsive styles are designed to match behavior
+ * with the vizualizationColumn styles
+ * defined in apps/style/common.scss, so that the columns in the
+ * header line up with the columns below them.
+ */
+
+$width: 400px;
+#visualizationColumnHeader {
+  max-width: $width;
+  float: left;
+}
+#visualizationEditorHeader {
+  margin-left: $width;
+  padding-left: 15px;
+}
+
+#visualizationEditor.responsive {
+  margin-left: $width;
+  padding-left: 15px;
+}
+
+@media screen and (min-width: 1101px) and (max-width: 1150px) {
+  $width: 350px;
+  #visualizationColumnHeader.responsive {
+    max-width: $width;
+  }
+  #visualizationEditorHeader.responsive {
+    margin-left: $width;
+  }
+  #visualizationEditor.responsive {
+    margin-left: $width;
+  }
+}
+
+@media screen and (min-width: 1051px) and (max-width: 1100px) {
+  $width: 300px;
+  #visualizationColumnHeader.responsive {
+    max-width: $width;
+  }
+  #visualizationEditorHeader.responsive {
+    margin-left: $width;
+  }
+  #visualizationEditor.responsive {
+    margin-left: $width;
+  }
+}
+
+@media screen and (min-width: 1001px) and (max-width: 1050px) {
+  $width: 250px;
+  #visualizationColumnHeader.responsive {
+    max-width: $width;
+  }
+  #visualizationEditorHeader.responsive {
+    margin-left: $width;
+  }
+  #visualizationEditor.responsive {
+    margin-left: $width;
+  }
+}
+
+@media screen and (max-width: 1000px) {
+  $width: 200px;
+  #visualizationColumnHeader.responsive {
+    max-width: $width;
+  }
+  #visualizationEditorHeader.responsive {
+    margin-left: $width;
+  }
+  #visualizationEditor.responsive {
+    margin-left: $width;
+  }
+}
+
+#main-logo {
+  padding: 10px 15px;
+  display: inline-block;
+  top: 10px;
+  left: 10px;
+  text-align: center;
+  font-size: 1.275em;
+  position: fixed;
+  z-index: 1000;
+
+  a {
+    color: $light_gray;
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  #logo-container {
+    padding: 4px;
+    background-color: $light_gray;
+    width: 60px;
+    border-radius: 0;
+    margin-bottom: 4px;
+  }
+}
+
+#environment_tag {
+  position: fixed;
+  top: 0;
+  right: 0;
+  color: $white;
+  background-color: $light_purple;
+  padding: 3px;
+  z-index: 100;
+  cursor: pointer;
+  box-shadow: 0 0 7px 2px $shadow;
+}
+
+#instructor_in_training_tag {
+  position: fixed;
+  top: 60px;
+  right: 0;
+  color: $white;
+  background-color: $teal;
+  padding: 3px;
+  z-index: 100;
+  cursor: pointer;
+  box-shadow: 0 0 7px 2px $shadow;
+}
+
+#assumed_identity_tag {
+  position: fixed;
+  top: 0;
+  right: 0;
+  color: $white;
+  background-color: $red;
+  padding: 3px;
+  z-index: 200;
+  box-shadow: 0 0 7px 2px $shadow;
+}
+
+#level-body {
+  height: 100%;
+}
+
+code {
+  color: $purple;
+}
+
+.instructions-markdown ul li, .instructions-markdown ol li {
+  font-size: 16px;
+  margin-bottom: 5px;
+  line-height: 1.2em;
+}
+
+#diversity_survey {
+  background-color: $background_gray;
+  color: $dark_charcoal;
+  overflow: hidden;
+
+  #surveythanks {
+    font-size: 14px;
+    padding: 20px;
+    color: $bootstrap_success_text;
+    background-color: $bootstrap_success_background;
+    border: solid 1px $bootstrap_success_border;
+    border-radius: 5px;
+  }
+
+  #surveybody {
+    border: solid 1px $purple;
+    border-radius: 5px;
+
+    #headingarea {
+      margin-top: 0;
+      background-color: $purple;
+      padding: 20px;
+      color: $white;
+
+      h2 {
+        color: $white;
+        font-size: 26px;
+        margin-bottom: 20px;
+      }
+
+      .subtext {
+        margin-left: 0;
+        font-size: 12px;
+
+        #privacylink {
+          color: $white;
+          text-decoration: underline;
+        }
+      }
+    }
+
+    #survey {
+      margin-bottom: 0;
+      padding: 20px;
+
+      .survey_questions {
+        width: 100%;
+
+        li {
+          font-size: 16px;
+        }
+
+        .dots {
+          padding-top: 10px;
+          padding-left: 20px;
+          padding-bottom: 20px;
+
+          #ethnicity_input {
+            width: 40px;
+            height: 24px;
+            font-size: 14px;
+            text-align: right;
+            margin: 6px;
+            margin-left: 10px;
+          }
+        }
+      }
+    }
+
+    #noanswer {
+      cursor: pointer;
+      border: none;
+      box-shadow: none;
+      @include main-font-semi-bold;
+      font-size: 100%;
+      color: $brand_secondary_default;
+      text-decoration: underline;
+      background-color: transparent;
+    }
+
+    #noanswer:hover {
+      color: $brand_secondary_dark;
+      text-decoration: underline;
+    }
+  }
+}
+
+.info-box-teal {
+  border: 1px solid $teal;
+  height: 46px;
+  margin-bottom: 10px;
+  .info-box-left {
+    float: left;
+    background-color: $teal;
+    height: 42px;
+    padding-top: 4px;
+  }
+  .info-box-right {
+    .info-box-message {
+      font-weight: bold;
+      color: $teal;
+    }
+    p {
+      margin-bottom: 0;
+    }
+    max-width: 400px;
+    float: left;
+    padding: 5px;
+  }
+}
+
+.breadcrumb-header {
+  margin-top: 10px;
+}
+
+#survey-submission-thankyou {
+  color: $purple;
+  font-size: 18px;
+}
+
+hr.danger {
+  border-color: $red;
+  border-width: medium;
+}
+
+h2.danger {
+  color: $red;
+}
+
+.account-page-section-break {
+  margin-top: 6em;
+}
+
+#change-user-type-status {
+  vertical-align: middle;
+}
+
+.label-bold {
+  font-weight: bold;
+  color: $dark_charcoal;
+}
+
+#donor-footer {
+  color: $white;
+  text-align: center;
+  padding: 30px 10px 36px 10px;
+
+  h1 {
+    @include main-font-semi-bold;
+    color: $white;
+    margin-bottom: 24px;
+    margin-top: 0;
+    font-size: 38px;
+  }
+
+  h3 {
+    @include main-font-semi-bold;
+    font-size: 20px;
+    line-height: normal;
+  }
+
+  p {
+    color: $white;
+    margin-bottom: 22px;
+    max-width: 720px;
+    display: inline-block;
+    font-size: 14px;
+  }
+
+  .logo {
+    max-width: 235px;
+    max-height: 128px;
+    display: inline-block;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-top: 20px;
+  }
+
+  .resources {
+    margin-top: 20px;
+  }
+
+  .learn-more {
+    color: $yellow;
+  }
+}
+
+.foorm-reset-font {
+  font-family: inherit !important;
+}
+
+.foorm-adjust-body {
+  border: none !important;
+}
+
+.foorm-adjust-header {
+  background-color: $white;
+  h3 {
+    @include main-font-semi-bold;
+    font-family: $main-font !important;
+    font-weight: $semi-bold-font-weight !important;
+    font-size: 22px !important;
+    line-height: 30px !important;
+    color: $teal !important;
+  }
+}
+
+.foorm-adjust-page-title {
+  @include main-font-semi-bold;
+  font-family: $main-font !important;
+  font-weight: $semi-bold-font-weight !important;
+  font-size: 22px !important;
+}
+
+.foorm-adjust-radio {
+  margin-top: -4px !important;
+}
+
+.foorm-adjust-checkbox {
+  margin-top: -4px !important;
+}
+
+.foorm-adjust-matrix {
+  table-layout: fixed;
+
+  th {
+    @include main-font-regular;
+    font-size: 12px;
+    text-align: center;
+    font-weight: $regular-font-weight !important;
+  }
+
+  @media (min-width: 601px) {
+    tr td:first-child {
+      width: 40%;
+    }
+
+    tr td:not(:first-child) {
+      text-align: center;
+    }
+  }
+
+  td {
+    min-width: 0 !important;
+  }
+}
+
+.foorm-adjust-rating {
+  text-align: center;
+}
+
+.foorm-adjust-row {
+  background-color: $white !important;
+  border-color: $white !important;
+}
+
+.foorm-button {
+  font-size: 100% !important;
+  padding-top: 10px !important;
+  padding-bottom: 10px !important;
+  padding-left: 20px !important;
+  padding-right: 20px !important;
+  border-radius: 5px !important;
+  background-color: $orange !important;
+}
+
+.foorm-button-left {
+  float: left !important;
+}
+
+.foorm-button-right {
+  float: right !important;
+}
+
+.foorm-survey-rating-question-sample {
+  width: 60%;
+  max-width: 600px;
+  margin: 0 auto 20px auto;
+  text-align: center;
+}
+
+.foorm-adjust-dropdown-height {
+  height: calc(2em + 10px) !important;
+}
+
+#parent-email-banner {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  overflow: hidden;
+  box-sizing: border-box;
+  padding: 14px 20px;
+  font-size: 16px;
+  line-height: 20px;
+  background-color: $purple;
+  text-align: center;
+  color: $white;
+  border-top: 1px solid $white;
+
+  z-index: 1030;
+
+  .banner-content {
+    max-width: 970px;
+    margin-left: auto;
+    margin-right: auto;
+
+    .text {
+      box-sizing: border-box;
+      text-align: left;
+      padding-right: 20px;
+
+      p {
+        font-size: 16px;
+        margin: auto;
+      }
+    }
+
+    .buttons {
+      box-sizing: border-box;
+      text-align: center;
+      margin: auto;
+
+      button {
+        margin-bottom: 0;
+        margin-right: 0;
+        margin-top: 0;
+        margin-left: 10px;
+        align-items: flex-start;
+        background-image: none;
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border-bottom-style: solid;
+        border-left-style: solid;
+        border-right-style: solid;
+        border-top-left-radius: 4px;
+        border-top-right-radius: 4px;
+        border-top-style: solid;
+        box-sizing: border-box;
+        color: $white;
+        cursor: pointer;
+        display: inline-block;
+        font-size: 14px;
+        font-weight: normal;
+        height: 35px;
+        letter-spacing: normal;
+        line-height: 20px;
+        padding-bottom: 6px;
+        padding-left: 12px;
+        padding-right: 12px;
+        padding-top: 6px;
+        text-align: center;
+        text-indent: 0;
+        text-transform: none;
+        vertical-align: middle;
+        white-space: nowrap;
+        word-spacing: 0;
+      }
+
+      #link_your_email {
+        @include main-font-regular;
+        font-family: $main-font !important;
+        background-color: $orange;
+        border-color: $orange;
+        border-image-source: none !important;
+        text-shadow: none !important;
+        border-width: 1px !important;
+      }
+
+      #not_now {
+        @include main-font-regular;
+        font-family: $main-font !important;
+        background-color: $light_purple;
+        border-color: $light_purple;
+        border-image-source: none !important;
+        text-shadow: none !important;
+        border-width: 1px !important;
+      }
+    }
+  }
+
+  /* desktop */
+  @media screen and (min-width: 971px) {
+    .text {
+      float: left;
+      width: 70%;
+    }
+    .buttons {
+      float: right;
+    }
+  }
+
+  /* mobile */
+  @media screen and (min-width: 0px) and (max-width: 970px) {
+    display: none;
+  }
+}
+
+// Some images must not be flipped over even in RTL
+html[dir=rtl] {
+  img[src="/blockly/media/skins/jigsaw/blocks.png"] {
+    -webkit-transform: none !important;
+    transform: none !important;
+  }
+}
+#add-parent-email {
+  #remove-parent-email-link {
+    color: $red;
+  }
+}
+
+.immersive-reader-button {
+  /* !important is used to override the default styling from the Microsoft immersive-reader-sdk */
+  background-color: $neutral_white !important;
+  float: right;
+  border: 2px solid $neutral_dark;
+  box-sizing: border-box;
+  height: 32px;
+  padding: 6px !important;
+
+  html[dir=rtl] & {
+    float: left;
+  }
+
+  &:hover {
+    background-color: $brand_primary_default !important;
+    border-color: $brand_primary_default;
+
+    /* The TTS buttons overlap this button, so make this button's z-index higher as a temp fix */
+    position: relative;
+    z-index: 1000;
+
+    img {
+      // paint native Microsoft icon full black and set it's color to $neutral_white
+      filter: brightness(0) saturate(100%) invert(100%) sepia(0%) saturate(0%) hue-rotate(111deg) brightness(101%) contrast(100%);
+    }
+  }
+
+  img {
+    // paint native Microsoft icon full black and set it's color to $neutral_dark
+    filter: brightness(0) saturate(100%) invert(15%) sepia(31%) saturate(359%) hue-rotate(169deg) brightness(94%) contrast(91%);
+  }
+}
+
+.immersive-reader-button-legacy-styles {
+  /* !important is used to override the default styling from the Microsoft immersive-reader-sdk */
+  background-color: $lightest_purple !important;
+  border-color: $lightest_purple;
+
+  &:hover {
+    background-color: $cyan !important;
+    border-radius: 4px !important;
+
+    /* The TTS buttons overlap this button, so make this button's z-index higher as a temp fix */
+  }
+}
+
+#mapbox-location-search-container {
+  .mapbox-location-search-container {
+    width: 100%;
+  }
+
+  .mapboxgl-ctrl-geocoder {
+    min-width: 100%;
+    z-index: 2;
+    box-shadow: none;
+    border: 1px solid $bootstrap_border_color;
+    font-family: inherit;
+    font-size: inherit;
+  }
+
+  input {
+    height: 36px;
+    margin: 0;
+    border: none;
+    padding: 0 34px;
+    &.readOnly {
+      width: 100%;
+    }
+  }
+
+  .mapboxgl-ctrl-geocoder--suggestion {
+    color: $default_text;
+    @include main-font-regular;
+  }
+}
+
+#reset-predict-progress-button {
+  display: 'inline-block';
+  font-size: 12;
+  @include main-font-regular;
+  border-width: '1px';
+  border-style: 'solid';
+  border-color: $border_gray;
+  border-bottom-left-radius: 3;
+  border-bottom-right-radius: 3;
+  border-top-left-radius: 3;
+  border-top-right-radius: 3;
+  text-decoration: 'none';
+  box-sizing: 'border-box';
+  overflow: 'hidden';
+  white-space: 'nowrap';
+  color: $white;
+  background-color: $red;
+  font-weight: 'bold';
+  box-shadow: 'inset 0 2px 0 0 rgba(255,255,255,0.40)';
+  &:hover:not(:disabled) {
+    box-shadow: 'none';
+    color: $red;
+    border-color: $red;
+    background-color: $white;
+    cursor: 'pointer';
+  }
+  &:disabled {
+    background-color: $lightest_red;
+    box-shadow: 'inset 0 2px 0 0 rgba(0,0,0,0.1)';
+  }
+}
+
+a {
+  &.design-system-btn {
+    &:link, &:visited, &:hover, &:active {
+      text-decoration: none;
+      border-radius: 4px;
+      @include main-font-semi-bold;
+      font-size: 1em !important;
+      padding: 10px 20px;
+      height: auto;
+      margin-right: 0;
+      background-color: $brand_secondary_default;
+      border: 2px solid $brand_secondary_default;
+      color: $neutral_white;
+      line-height: unset;
+
+      &:hover {
+        background-color: $brand_secondary_dark;
+        border-color: $brand_secondary_dark;
+        box-shadow: none;
+      }
+
+      &:focus {
+        border-color: $brand_primary_default;
+      }
+
+      &:disabled {
+        color: $neutral_white;
+        border-color: $neutral_dark20;
+        background-color: $neutral_dark20;
+        cursor: not-allowed;
+      }
+    }
+  }
+}
+
+#instructions {
+  .clickable-text {
+    cursor: pointer;
+  }
+}
+
+#lti-integration-portal {
+  $signup-info-background: #f7f7f7;
+  $signup-info-border-color: #e5e5e5;
+
+  display: flex;
+  flex-wrap: wrap;
+
+  .header {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .padded-container {
+    padding: 20px;
+    display: flex;
+    flex-wrap: wrap;
+    .row {
+      flex-grow: 1;
+    }
+  }
+
+  .lti-integration-form {
+    input[type=text], input[type=email] {
+      height: 36px;
+    }
+
+    input {
+      margin: 0;
+    }
+
+    input, select {
+      flex-grow: 1;
+    }
+
+    .row {
+      display: flex;
+      margin-bottom: 20px;
+
+      [class*=span] {
+        align-self: center;
+        display: flex;
+        .div {
+          align-self: center;
+          display: flex;
+        }
+      }
+
+      label {
+        margin: 0;
+      }
+    }
+    .lti-integration-field-label {
+      flex-wrap: wrap;
+
+      p {
+        margin: 0;
+      }
+    }
+  }
+
+  @mixin button {
+    background-image: none;
+    padding: 0 20px;
+    margin: 5px 0;
+    font-size: 18px;
+    height: 40px;
+    @include main-font-semi-bold;
+  }
+
+  @mixin purple-button {
+    @include button;
+    border-color: $purple;
+    background-color: $purple;
+    color: $white;
+  }
+
+  @mixin white-button {
+    @include button;
+    border-color: $black;
+    background-color: $white;
+    color: $black;
+  }
+
+  .lti-btn-purple {
+    @include purple-button;
+  }
+
+  .lti-btn-purple-right {
+    @include purple-button;
+    float: right;
+  }
+
+  .lti-btn-white {
+    @include white-button;
+  }
+}
+
+@import "NpsSurveyBlock";

--- a/dashboard/app/assets/stylesheets/errors.scss
+++ b/dashboard/app/assets/stylesheets/errors.scss
@@ -1,3 +1,104 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:03a9cc02d211351d43c503c69252fd0a84b536bfca4973347151be3b3bff1577
-size 2134
+@import "color";
+@import "font";
+
+.not-found-page {
+  body {
+    @include main-font-regular;
+    font-size: 14px;
+    line-height: 22px;
+    color: $dimgray;
+    margin: 0;
+  }
+
+  h1 {
+    @include main-font-bold;
+    color: $purple;
+    font-size: 28px;
+    margin-top: 50px;
+    margin-bottom: 30px;
+    line-height: 1.2em;
+  }
+
+  button {
+    @include main-font-regular;
+    -webkit-appearance: none;
+    -webkit-user-select: none;
+    -webkit-writing-mode: horizontal-tb;
+    align-items: flex-start;
+    background-color: $orange;
+    border-color: $orange;
+    background-image: none;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    border-image-outset: 0;
+    border-image-repeat: stretch;
+    border-image-slice: 100%;
+    border-image-source: none;
+    border-image-width: 1;
+    border-left-style: solid;
+    border-left-width: 1px;
+    border-right-style: solid;
+    border-right-width: 1px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-top-style: solid;
+    border-top-width: 1px;
+    box-sizing: border-box;
+    color: $white;
+    cursor: pointer;
+    display: inline-block;
+    font-size: 14px;
+    height: 34px;
+    letter-spacing: normal;
+    line-height: 20px;
+    margin-bottom: 0;
+    margin-left: 0;
+    margin-right: 0;
+    margin-top: 30px;
+    padding-bottom: 6px;
+    padding-left: 12px;
+    padding-right: 12px;
+    padding-top: 6px;
+    text-align: center;
+    text-indent: 0;
+    text-shadow: none;
+    text-transform: none;
+    vertical-align: middle;
+    white-space: nowrap;
+    word-spacing: 0;
+    writing-mode: lr-tb;
+  }
+
+  .error-image {
+    margin-top: 50px;
+  }
+
+  .error-parent {
+    text-align: center;
+  }
+
+  .error-child {
+    display: inline-block;
+    max-width: 300px;
+  }
+}
+
+.deprecated-course-page {
+  margin-bottom: 100px;
+
+  .deprecated-course-child {
+    display: inline-block;
+    max-width: 500px;
+  }
+
+  p {
+    @include main-font-bold;
+    color: $neutral_dark;
+    margin-top: 0;
+    margin-bottom: 30px;
+    font-size: 28px;
+    line-height: 1.2em;
+  }
+}

--- a/dashboard/app/assets/stylesheets/extra_links.scss
+++ b/dashboard/app/assets/stylesheets/extra_links.scss
@@ -1,3 +1,27 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:22abb2142280633b2afd3229ff11d71039caa9c798285cbdbe143d384cc87c21
-size 564
+@import "color";
+@import "font";
+@import "mixins";
+
+.extra-links {
+  @include selectable;
+  border: 2px solid $light_gray;
+  padding: 10px;
+  background: $lighter_gray;
+  position: fixed;
+  bottom: 27px; /* just above small footer */
+  left: 0;
+  h4 {
+    font-size: 14px;
+    @include main-font-bold;
+    margin: 0 0 5px 0;
+  }
+  opacity: 0.98;
+  color: $black;
+
+  /* don't take over the whole window*/
+  max-height: 50%;
+  /* only display scrollbars when needed */
+  overflow: auto;
+  /* admin box appears in front of the rest of the level */
+  z-index: 1000;
+}

--- a/dashboard/app/assets/stylesheets/interstitial.scss
+++ b/dashboard/app/assets/stylesheets/interstitial.scss
@@ -1,3 +1,168 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:16eedfdff437f0a6dc6ffbd8df8853c225022632dfad0eac0e2d2782e4f3a14f
-size 3132
+@import 'color';
+@import 'font';
+
+#terms-modal,
+#school-info-modal,
+#race-modal {
+  text-align: left;
+  top: 20px;
+}
+#terms-modal .modal-content,
+#school-info-modal .modal-content,
+#race-modal .modal-content {
+  margin: 0 20px;
+  padding: 0 15px;
+}
+#terms-modal .modal-content p,
+#school-info-modal .modal-content p,
+#race-modal .modal-content p {
+  font-size: 12px;
+  color: $default_text;
+}
+
+#race-modal .modal-content .custom-h2 {
+  margin-top: 20px;
+  margin-bottom: 10px;
+  font-size: 1.7em;
+}
+
+#race-modal .modal-content p {
+  font-size: 15px;
+  line-height: 20px;
+}
+
+#terms-modal .left,
+#school-info-modal .left,
+#race-modal .left {
+  float: left;
+}
+#terms-modal .right {
+  float: right;
+}
+#school-info-modal .right,
+#race-modal .right {
+  float: right;
+  margin-top: 20px;
+}
+#school-info-modal .full-width {
+  width: 100%;
+  padding-bottom: 20px;
+}
+#race-modal .full-width {
+  width: 100%;
+}
+#terms-modal .scroll-box {
+  height: 350px;
+  border: 1px solid $border_gray;
+  padding: 20px;
+  resize: vertical;
+  overflow: auto;
+  overflow-y: scroll;
+}
+#terms-modal label.terms {
+  font-size: inherit;
+  line-height: inherit;
+}
+#terms-modal .terms-text {
+  overflow: hidden;
+}
+
+#terms-modal .terms-checkbox {
+  margin: 0 5px 0 0;
+  float: left;
+}
+#race-modal .race-checkbox {
+  margin: 0 5px 0 0;
+}
+#terms-modal .primary-button,
+#school-info-modal .primary-button,
+#race-modal .primary-button {
+  background-color: $orange;
+  border: 1px solid $orange;
+  color: $white;
+  border-radius: 4px;
+  height: 34px;
+  text-shadow: none;
+  box-shadow: none;
+  background-image: none;
+  margin-top: 10px;
+}
+
+#race-modal .primary-button {
+  background-color: $brand_secondary_default;
+  border-color: $brand_secondary_default;
+  color: $neutral_white;
+  @include main-font-semi-bold;
+}
+
+#terms-modal .disabled-button {
+  background-color: $lighter_gray;
+  border-color: $lighter_gray;
+  color: $dark_charcoal;
+}
+
+#race-modal .disabled-button {
+  color: $neutral_white;
+  border-color: $neutral_dark20;
+  background-color: $neutral_dark20;
+  cursor: not-allowed;
+}
+#terms-modal .custom-h1,
+#race-modal .custom-h1 {
+  margin-top: 25px;
+}
+#race-modal h3 {
+  line-height: 24px;
+}
+#terms-modal .right-margin-5,
+#race-modal .right-margin-5 {
+  margin-right: 5px;
+}
+#race-modal .dismiss-link {
+  font-size: 14px;
+  @include main-font-regular;
+  line-height: 20px;
+}
+#school-info-modal .disabled,
+#race-modal .disabled {
+  color: $light-gray;
+}
+
+$almost_white: #eee;
+#school-info-modal .selectize-control .selectize-input.disabled {
+  opacity: 1;
+  background-color: $almost_white;
+}
+
+@media (max-width: 600px) {
+  #terms-modal, #race-modal, #school-info-modal {
+    width: 400px;
+    left: 70%;
+  }
+
+  #terms-modal .scroll-box {
+    height: 200px;
+  }
+}
+
+#implicit-terms-modal {
+  width: 600px;
+  text-align: left;
+  top: 20px;
+  padding: 20px;
+
+  #implicit_accept_terms_message {
+    font-size: 14px;
+    color: $default_text;
+    margin-left: 0;
+  }
+
+  #close_btn_go_to_account {
+    @include main-font-bold;
+    background-color: $orange;
+    border: 1px solid $orange;
+    color: $white;
+    margin: 25px 0 0 0;
+    padding: 10px 25px;
+  }
+}

--- a/dashboard/app/assets/stylesheets/level.scss
+++ b/dashboard/app/assets/stylesheets/level.scss
@@ -1,3 +1,37 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe8c8c2b16ff1676de0d07c68f2d7e641a2bb893d2cfe1b06ffaaf1a82295eaf
-size 538
+@import "mixins";
+
+li.level_name {
+  @include selectable;
+}
+
+.ani-gif-dropdown {
+  min-width: 450px;
+}
+
+.video-dropdown {
+  min-width: 450px;
+}
+
+// CSS tricks for preserving aspect ratio for iframe div
+.aspect-ratio iframe {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  // Fill parent.
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+.aspect-ratio {
+  width: 100%;
+  max-width: 400px;
+  display: flex;
+  position: relative;
+  min-width: 280px;
+}
+.aspect-ratio::after {
+  padding-top: 120.25%;
+  display: block;
+  content: '';
+}

--- a/dashboard/app/assets/stylesheets/levels/contract_match.scss
+++ b/dashboard/app/assets/stylesheets/levels/contract_match.scss
@@ -1,3 +1,71 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:574c7c2e9efac1ec85d4eef424bd898e9025f788423a3dee9b884ad4fef77dc7
-size 942
+@import 'color';
+
+.contract select {
+  color: $white;
+  background-color: $light_gray;
+  margin-top: 10px;
+}
+
+#functionNameText {
+  margin-top: 10px;
+}
+
+.domainItem {
+  height: 36px;
+  color: $white;
+  border-radius: 5px;
+  float: left;
+  margin-right: 5px;
+}
+
+#domainItemText {
+  margin-top: 10px;
+}
+
+.domainItem .domainItemText {
+  font-size: 16px;
+  padding: 10px;
+  color: $white;
+  overflow: hidden;
+}
+
+.contract .buttons {
+  margin-top: 8px;
+}
+
+#sectionTitle {
+  font-size: 20px;
+  margin-top: 11px;
+}
+
+#contractForm {
+  .ui-selectmenu-button {
+    margin-top: 13px;
+    margin-bottom: -13px;
+  }
+
+  .domain-add-button {
+    margin-left: 0;
+    margin-top: 13px;
+  }
+
+  .domain-x-button {
+    margin-top: 0;
+    margin-left: 10px;
+  }
+
+  margin-bottom: 20px;
+}
+
+.color-square-icon {
+  float: left;
+  width: 21px;
+  height: 19px;
+  margin-right: 7px;
+}
+
+.section-type-hint {
+  font-size: 12px;
+  color: $light_gray;
+  margin-top: 3px;
+}

--- a/dashboard/app/assets/stylesheets/levels/pixelation.scss
+++ b/dashboard/app/assets/stylesheets/levels/pixelation.scss
@@ -1,3 +1,141 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:271dc03edae18173c2296c4fde2e2311e9654be9e1e5fd90f6028efd4e39028b
-size 1784
+@import 'color';
+
+#external {
+  clear: both;
+}
+
+#visualization {
+  overflow: hidden;
+}
+
+#visualizationColumn {
+  width: 400px;
+  float: left;
+}
+
+#below_viz_instructions {
+  margin: 15px 0;
+  cursor: pointer;
+}
+
+.right {
+  float: right;
+}
+
+#save_image {
+  margin: 3px 10px 5px 0;
+}
+
+#actual_size_label {
+  margin-top: 9px;
+}
+
+#actual_size {
+  margin: 0;
+}
+
+#pixel_format {
+  color: $white;
+  background: $black;
+  font: bold 14pt monospace;
+  padding: 1px 7px;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+#pixel_format .r {
+  color: $red;
+}
+
+#pixel_format .g {
+  color: $highlight_green;
+}
+
+#pixel_format .b {
+  color: $default_blue;
+}
+
+#pixel_format .unknown {
+  color: $light_gray;
+}
+
+#pixel_data {
+  width: 100%;
+  height: 350px;
+  font-family: monospace;
+  box-sizing: border-box;
+  margin-top: 5px;
+}
+
+#file_format div {
+  padding: 3px 5px;
+  border: 1px solid $black;
+  max-width: 230px;
+  background: $white;
+}
+
+#file_format .byte {
+  border-bottom: 0;
+  width: 140px;
+}
+
+#image_controls {
+  margin-top: 10px;
+}
+
+#image_controls td {
+  white-space: nowrap;
+}
+
+#image_controls td:nth-child(2) {
+  padding: 0 5px;
+}
+
+#image_controls td:last-child {
+  width: 100%;
+}
+
+input[type=radio] {
+  margin: 0 3px;
+  vertical-align: baseline;
+}
+
+input[type=number] {
+  width: 50px;
+}
+
+input[type=range] {
+  width: 100%;
+}
+
+.label_group {
+  text-align: left;
+}
+
+.label_group label {
+  border: 1px solid $bootstrap_border_color;
+  display: inline-block;
+  padding: 5px 10px;
+}
+
+#file_format {
+  padding-bottom: 5px;
+  margin-bottom: 5px;
+}
+
+#file_format p {
+  margin-bottom: 0;
+}
+
+#file_format #file_format_title {
+  margin-top: 5px;
+  margin-bottom: 5px;
+  font-size: 14px;
+}
+
+#visualization {
+  margin-top: 6px;
+}

--- a/dashboard/app/assets/stylesheets/mixins.scss
+++ b/dashboard/app/assets/stylesheets/mixins.scss
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a1ad153ccead8c955cb50e77209628cbaa87d6fb7daa6c18feebbad812b36a48
-size 249
+@mixin unselectable {
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@mixin selectable {
+  -moz-user-select: text;
+  -webkit-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}

--- a/dashboard/app/assets/stylesheets/pairing.scss
+++ b/dashboard/app/assets/stylesheets/pairing.scss
@@ -1,3 +1,12 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b984cf51724c4de63c31f8cecbbb95cb1bbd04764d16d6aae6df219746030275
-size 185
+@import "color";
+
+#pairing {
+  .student {
+    color: $cyan;
+    padding: 10px;
+    border: 1px solid $cyan;
+    float: left;
+    border-radius: 5px;
+    margin: 10px 10px 10px 0;
+  }
+}

--- a/dashboard/app/assets/stylesheets/scaffolds.scss
+++ b/dashboard/app/assets/stylesheets/scaffolds.scss
@@ -1,3 +1,69 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08c401d52f88cc1bd9da13b8fece8ab87a9b8c507013483cef4594faea46b04c
-size 1012
+@import "color";
+
+body {
+  background-color: $white;
+  color: $default_text;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+p, ol, ul, td {
+  font-size: 13px;
+  line-height: 18px;
+}
+
+pre {
+  background-color: $lightest_gray;
+  padding: 10px;
+  font-size: 11px;
+}
+
+div {
+  &.field, &.actions {
+    margin-bottom: 10px;
+  }
+}
+
+#notice {
+  color: $realgreen;
+}
+
+.field_with_errors label {
+  color: $red;
+  display: inline-block;
+}
+
+.field_with_errors {
+  input, select {
+    background-color: $realyellow;
+    border-color: $red;
+  }
+}
+
+.field_with_errors_div {
+  background-color: $realyellow;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid $red;
+  padding: 7px;
+  padding-bottom: 0;
+  margin-bottom: 20px;
+  background-color: $white;
+  h2 {
+    text-align: left;
+    font-weight: bold;
+    padding: 0 0 0 15px;
+    font-size: 12px;
+    margin: -7px;
+    margin-bottom: 0;
+    background-color: $red;
+    color: $white;
+  }
+  ul li {
+    font-size: 12px;
+    list-style: square;
+    padding: 5px 0;
+  }
+}

--- a/dashboard/app/assets/stylesheets/teacher-panel.scss
+++ b/dashboard/app/assets/stylesheets/teacher-panel.scss
@@ -1,3 +1,76 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a96dce5ab3ab5fbad2ee4cf1fe7e52153041802e6a2d89138731ce0dfcea460
-size 1172
+@import "color";
+@import "font";
+
+.teacher-panel {
+  position: fixed;
+  top: 85px;
+  bottom: 20px;
+  right: 0;
+  width: 200px;
+  transition: right 0.5s;
+
+  background: $lightest_cyan;
+
+  opacity: 0.9;
+
+  border: 5px solid $cyan;
+  border-right: none;
+  border-radius: 10px 0 0 10px;
+
+  /* Must appear in front of <Overlay/>, whose z-index is 1020. */
+  z-index: 1021;
+
+  .hide-handle,
+  .show-handle {
+    cursor: pointer;
+    transition: right 0.5s;
+    position: absolute;
+    right: 200px;
+    top: 50%;
+    border-radius: 10px 0 0 10px;
+    color: $white;
+    background: $cyan;
+    height: 30px;
+    width: 25px;
+    i {
+      line-height: 30px;
+      padding-left: 5px;
+      font-size: 20px;
+    }
+  }
+
+  .hide-handle {
+    display: block;
+  }
+
+  .show-handle {
+    display: none;
+  }
+
+  h3 {
+    padding: 5px;
+    font-size: 18px;
+    @include main-font-bold;
+    color: $white;
+    background: $cyan;
+    margin: 0;
+  }
+
+  &.hidden {
+    right: -195px;
+    .hide-handle {
+      right: 200px;
+      display: none;
+    }
+    .show-handle {
+      right: 200px;
+      display: block;
+    }
+  }
+
+  select {
+    width: 190px;
+    display: block;
+    margin: 5px;
+  }
+}

--- a/dashboard/app/assets/stylesheets/trophy_sparkle.scss
+++ b/dashboard/app/assets/stylesheets/trophy_sparkle.scss
@@ -1,3 +1,39 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e88963504492a8a4cf77eca5462178783333c2df01dc9b90a6c7697e5cbdffe1
-size 520
+.sparkle {
+  position: absolute;
+  animation: loop 5s infinite linear;
+}
+.sparkle1 {
+  left: 251px;
+  top: 66px;
+  width: 20px;
+}
+.sparkle2 {
+  left: 281px;
+  top: 8px;
+  width: 30px;
+  animation-delay: 500ms;
+}
+.sparkle3 {
+  left: 286px;
+  top: 91px;
+  width: 25px;
+  animation-delay: 1000ms;
+}
+
+@keyframes loop {
+  0% {
+    transform: rotate(0deg);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  20% {
+    transform: rotate(200deg);
+    opacity: 0;
+  }
+  100% {
+    transform: rotate(360deg);
+    opacity: 0;
+  }
+}

--- a/dashboard/app/assets/stylesheets/unplugged.scss
+++ b/dashboard/app/assets/stylesheets/unplugged.scss
@@ -1,3 +1,44 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05c1bdaaccbf4dc235726f9c27a7f7f451c285e5cce439867a271e465885100e
-size 584
+@import "color";
+@import "mixins";
+
+.unplugged {
+  $page_width: 800px;
+
+  width: $page_width;
+  margin-left: auto;
+  margin-right: auto;
+
+  .video-section {
+    margin-top: 12px;
+
+    .video-container {
+      margin-top: 10px;
+      margin-bottom: 10px;
+    }
+  }
+
+  .pdf-button {
+    margin-right: 10px;
+  }
+
+  .lesson-plan {
+    margin-top: 40px;
+
+    .pdf-button {
+      margin-right: 0;
+      margin-top: 5px;
+    }
+  }
+
+  .coming-soon {
+    margin: 20px;
+    text-align: center;
+    font-size: 20px;
+  }
+
+  .video-download {
+    margin-bottom: 3px;
+  }
+
+  @include selectable;
+}


### PR DESCRIPTION
This PR excludes from Git LFS:
```
dashboard/app/assets/stylesheets/** !text -filter -merge -diff
dashboard/app/assets/javascripts/** !text -filter -merge -diff
```

We previously included `dashboard/app/assets/**` in LFS, but that directory includes `.scss` files and a `.js.erb` file.

We could have just made the LFS inclusion line only specifically add the `./assets/images` subdir, but for longevity of keeping binary files out of LFS, its better to cast a wide net. Its MUCH easier to migrate files OUT of LFS than rewrite history (like we just did, very painful).

To make this change I:
1. Edited .gitattributes to add exclusion lines
2. Used `git add --renormalize dashboard/app/assets` to get the previously-LFS files added as part of the commit