### PR TITLE
Support pagination for LTI NRPS calls

### DIFF
--- a/dashboard/lib/clients/lti_advantage_client.rb
+++ b/dashboard/lib/clients/lti_advantage_client.rb
@@ -11,7 +11,7 @@ class LtiAdvantageClient
   # The URL for the API will vary between LMS platforms, and is initially contained in the launch context.
   # See the LTI spec for details:
   # https://www.imsglobal.org/spec/lti-nrps/v2p0/
-  def get_context_membership(url, resource_link_id)
+  def get_context_membership(url, resource_link_id, page_limit = 100)
     options = {
       headers: {
         'Accept' => Policies::Lti::MEMBERSHIP_CONTAINER_CONTENT_TYPE,
@@ -19,32 +19,34 @@ class LtiAdvantageClient
       },
       query: {
         rlid: resource_link_id,
+        limit: page_limit,
       },
     }
-    res = HTTParty.get(url, options)
-    raise "Error getting context membership: #{res.code} #{res.body}" unless res[:code] == HTTP::Status::OK
-    parsed_res = JSON.parse(res, symbolize_names: true)
-    next_page = next_page_url(parsed_res)
+    res = make_request(url, options)
+    next_page = next_page_url(res[:headers])
+    parsed_res = res[:body]
     while next_page
-      current_page = JSON.parse(HTTParty.get(next_page, options), symbolize_names: true)
-      parsed_res[:members].concat(current_page[:members])
+      current_page = make_request(next_page, options)
+      parsed_res[:members].concat(current_page[:body][:members])
       return parsed_res unless parsed_res[:members].length <= Policies::Lti::MAX_COURSE_MEMBERSHIP
-      next_page = next_page_url(current_page)
+      next_page = next_page_url(current_page[:headers])
     end
     parsed_res
   end
 end
 
-private
-
 def make_request(url, options)
   res = HTTParty.get(url, options)
-  raise "Error getting context membership: #{res.code} #{res.body}" unless res[:code] == HTTP::Status::OK
-  res
+  raise "Error getting context membership: #{res.code} #{res.body}" unless res.code == HTTP::Status::OK
+  return {headers: res.headers, body: JSON.parse(res.body, symbolize_names: true)}
 end
 
-def next_page_url(nrps_response)
-  link_header = nrps_response.headers['link']
+private
+
+# Get the next page URL from the Link header in the response.
+# Returns nil if no next page is present.
+def next_page_url(headers)
+  link_header = headers&.[](:link)
   return nil unless link_header
 
   next_url = nil

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -53,7 +53,7 @@ class Policies::Lti
     },
   }
 
-  MAX_COURSE_MEMBERSHIP = 500
+  MAX_COURSE_MEMBERSHIP = 650
 
   def self.get_account_type(id_token)
     id_token[LTI_ROLES_KEY].each do |role|

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -53,6 +53,8 @@ class Policies::Lti
     },
   }
 
+  MAX_COURSE_MEMBERSHIP = 500
+
   def self.get_account_type(id_token)
     id_token[LTI_ROLES_KEY].each do |role|
       return User::TYPE_TEACHER if TEACHER_ROLES.include? role


### PR DESCRIPTION
This adds handling for large courses, where the full roster can't be returned in a single NRPS response. [LTI specifies](https://www.imsglobal.org/spec/lti-nrps/v2p0/#limit-query-parameter) that the tool can request a certain number of users to be returned, and the platform can optionally respect the limit parameter. If another page of users is present, the tool must include a link header with a url for the next page.

This PR adds

- Adds the limit param to our NRPS calls, defaulting to 100 to ensure we don't get a huge response if a platform doesn't have a reasonable limit implemented. Canvas maxes at 50, so we won't get more than 50 back for now.
- Checks for a next page link and calls it. Keeps calling for next pages until no next page link is included or we hit the max course size in the LTI policy.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-602)

## Testing story

Since uploading a large number of students to Canvas and force-enrolling them in a class requires uploading an SIS flatfile, I found that the easiest way to test locally was to lower the default page limit in `get_context_membership` to a very low number, like 2. Then, even with a relatively small course, you can get multiple pages. If you put some `puts` calls in, you can verify that you're making multiple calls with query params like `page=2`, `page=3`, etc.

Unit Tests:
```
bundle exec spring testunit test/lib/clients/lti_advantage_client_test.rb
Running via Spring preloader in process 42072
Started with run options --seed 13043

  3/3: [====================================================] 100% Time: 00:00:08
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
