### PR TITLE
Skip AI evaluation UI test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -1,4 +1,4 @@
-@no_firefox @no_mobile
+@skip
 # AI evaluation is stubbed out in UI tests via the /api/test/ai_proxy/assessment route.
 Feature: Evaluate student code against rubrics using AI
   Scenario: Student code is evaluated by AI when student submits project


### PR DESCRIPTION
Proposal to skip AI evaluation of student code UI tests -- took 4 manual reruns to pass in Chrome today:

https://codedotorg.slack.com/archives/C045UAX4WKH/p1707181960861349