### PR TITLE
Add Ability to Install MySQL 8.0 with Chef

### DIFF
--- a/cookbooks/cdo-mysql/attributes/default.rb
+++ b/cookbooks/cdo-mysql/attributes/default.rb
@@ -1,4 +1,5 @@
 default['cdo-mysql'] = {
+  target_version: '5.7',
   proxy: {
     # Enable ProxySQL on non-daemon app-servers by default.
     enabled: node['cdo-apps'] && !node['cdo-apps']['daemon'],

--- a/cookbooks/cdo-mysql/recipes/client.rb
+++ b/cookbooks/cdo-mysql/recipes/client.rb
@@ -1,11 +1,5 @@
 include_recipe 'cdo-mysql::repo'
 
-# We don't need to install a MySQL 5.7-specific libmysqlclient library,
-# since the 8.0 version distributed by default is backwards-compatible
-# all the way back to MySQL 5.5
 apt_package 'libmysqlclient-dev'
 
-# Pin to MySQL 5.7 until we're ready to update to MySQL 8
-apt_package 'mysql-client' do
-  version '5.7.42-1ubuntu18.04'
-end
+apt_package 'mysql-client'

--- a/cookbooks/cdo-mysql/recipes/client.rb
+++ b/cookbooks/cdo-mysql/recipes/client.rb
@@ -2,4 +2,10 @@ include_recipe 'cdo-mysql::repo'
 
 apt_package 'libmysqlclient-dev'
 
-apt_package 'mysql-client'
+apt_package 'mysql-client' do
+  if node['cdo-mysql']['target_version'] == '5.7'
+    version '5.7.42-1ubuntu18.04'
+  elsif node['cdo-mysql']['target_version'] == '8.0'
+    version '8.0.36-0ubuntu0.20.04.1'
+  end
+end

--- a/cookbooks/cdo-mysql/recipes/repo.rb
+++ b/cookbooks/cdo-mysql/recipes/repo.rb
@@ -1,17 +1,10 @@
 apt_repository 'mysql' do
   uri 'http://repo.mysql.com/apt/ubuntu'
+  distribution node['lsb']['codename']
+  components ['mysql-8.0']
 
-  # hardcode the distribution we target to Ubuntu 18 rather than whatever our
-  # current is, since that's the last LTS for which a MySQL 5.7 package was
-  # distributed. Once we update to MySQL 8+, this can be restored.
-  #distribution node['lsb']['codename']
-  distribution 'bionic'
-
-  # Pin to MySQL 5.7 until we're ready to update to MySQL 8
-  components ['mysql-5.7']
-
-  # https://dev.mysql.com/doc/refman/5.7/en/checking-gpg-signature.html
-  key 'B7B3B788A8D3785C'
+  # https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
+  key '3A79BD29'
   keyserver 'keyserver.ubuntu.com'
   retries 3
 end

--- a/cookbooks/cdo-mysql/recipes/repo.rb
+++ b/cookbooks/cdo-mysql/recipes/repo.rb
@@ -1,10 +1,26 @@
 apt_repository 'mysql' do
   uri 'http://repo.mysql.com/apt/ubuntu'
-  distribution node['lsb']['codename']
-  components ['mysql-8.0']
 
-  # https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
-  key '3A79BD29'
+  if node['cdo-mysql']['target_version'] == '5.7'
+    # hardcode the distribution we target to Ubuntu 18 rather than whatever our
+    # current is, since that's the last LTS for which a MySQL 5.7 package was
+    # distributed. Once we update to MySQL 8+, this can be restored.
+    #distribution node['lsb']['codename']
+    distribution 'bionic'
+
+    # Pin to MySQL 5.7 until we're ready to update to MySQL 8
+    components ['mysql-5.7']
+
+    # https://dev.mysql.com/doc/refman/5.7/en/checking-gpg-signature.html
+    key 'B7B3B788A8D3785C'
+  elsif node['cdo-mysql']['target_version'] == '8.0'
+    distribution node['lsb']['codename']
+    components ['mysql-8.0']
+
+    # https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
+    key '3A79BD29'
+  end
+
   keyserver 'keyserver.ubuntu.com'
   retries 3
 end

--- a/cookbooks/cdo-mysql/recipes/server.rb
+++ b/cookbooks/cdo-mysql/recipes/server.rb
@@ -2,8 +2,6 @@ include_recipe 'cdo-mysql::repo'
 
 apt_package 'mysql-server' do
   action :upgrade
-  # Pin to MySQL 5.7 until we're ready to update to MySQL 8
-  version '5.7.42-1ubuntu18.04'
   notifies :create, 'template[cdo.cnf]', :immediately
   notifies :start, 'service[mysql]', :immediately
   notifies :run, 'execute[mysql-upgrade]', :immediately
@@ -23,6 +21,7 @@ end
 
 # MySQL 5.7 Ubuntu package uses auth_socket plugin for local user by default.
 # Revert to mysql_native_password plugin to authenticate from non-root shell.
+# TODO: do we still need to do this on mysql8?
 execute 'mysql-user' do
   command <<~SH
     mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';"

--- a/cookbooks/cdo-mysql/recipes/server.rb
+++ b/cookbooks/cdo-mysql/recipes/server.rb
@@ -2,6 +2,13 @@ include_recipe 'cdo-mysql::repo'
 
 apt_package 'mysql-server' do
   action :upgrade
+
+  if node['cdo-mysql']['target_version'] == '5.7'
+    version '5.7.42-1ubuntu18.04'
+  elsif node['cdo-mysql']['target_version'] == '8.0'
+    version '8.0.36-0ubuntu0.20.04.1'
+  end
+
   notifies :create, 'template[cdo.cnf]', :immediately
   notifies :start, 'service[mysql]', :immediately
   notifies :run, 'execute[mysql-upgrade]', :immediately

--- a/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
+++ b/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
@@ -39,7 +39,7 @@ mysql_variables=
 
   # The server version with which the proxy will respond to the clients.
   # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-server_version
-  server_version="5.7.12-proxysql"
+  server_version="8.0.35-proxysql"
 
   # The user needs only USAGE privileges to connect, ping and check read_only.
   # The user needs also REPLICATION CLIENT if it needs to monitor replication lag.

--- a/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
+++ b/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
@@ -39,7 +39,7 @@ mysql_variables=
 
   # The server version with which the proxy will respond to the clients.
   # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-server_version
-  server_version="8.0.35-proxysql"
+  server_version="<%=node['cdo-mysql']['target_version'] == '5.7' ? '5.7.12-proxysql' : '8.0.36-proxysql'%>"
 
   # The user needs only USAGE privileges to connect, ping and check read_only.
   # The user needs also REPLICATION CLIENT if it needs to monitor replication lag.

--- a/cookbooks/cdo-mysql/test/cookbooks/test-mysql/recipes/readwrite.rb
+++ b/cookbooks/cdo-mysql/test/cookbooks/test-mysql/recipes/readwrite.rb
@@ -17,7 +17,7 @@ end
     bind_address '0.0.0.0'
     port endpoint.port
     initial_root_password endpoint.password
-    version '5.7'
+    version '8.0'
     action :create
   end
 

--- a/cookbooks/cdo-mysql/test/integration/default/serverspec/ruby_spec.rb
+++ b/cookbooks/cdo-mysql/test/integration/default/serverspec/ruby_spec.rb
@@ -17,6 +17,6 @@ describe 'mysql::default' do
     it {should be_running}
   end
 
-  version = '5.7'
+  version = '8.0'
   cmd 'echo "select version()" | mysql -u root -N', /^#{Regexp.escape(version)}/
 end

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -26,7 +26,7 @@ mysql_defaults: &mysql_defaults
   checkout_timeout: 3
 
   # `mysql_options` client options forwarded through the mysql2 adapter:
-  # See: https://dev.mysql.com/doc/refman/5.7/en/mysql-options.html
+  # See: https://dev.mysql.com/doc/c-api/8.0/en/mysql-options.html
 
   # `MYSQL_OPT_CONNECT_TIMEOUT`: The connect timeout in seconds.
   connect_timeout: 2

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -58,7 +58,7 @@ class ContactRollupsV2
     # Its default value is 1024, too short for the amount of data we need to concat.
     # @see:
     #   ContactRollupsProcessed.get_data_aggregation_query
-    #   https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_group_concat_max_len
+    #   https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_group_concat_max_len
     DASHBOARD_DB_WRITER.run('SET SESSION group_concat_max_len = 65535')
   end
 

--- a/pegasus/helper_modules/forms.rb
+++ b/pegasus/helper_modules/forms.rb
@@ -8,8 +8,9 @@ module Forms
   using CacheMethod
   FORMS = ::PEGASUS_DB[:forms]
 
-  # Converts a simple x.y JSON-attribute path to a MySQL 5.7 JSON expression using the inline-path operator.
-  # Ref: https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#operator_json-inline-path
+  # Converts a simple x.y JSON-attribute path to a MySQL JSON expression
+  # (available in MySQL 5.7.13 and later) using the inline-path operator.
+  # Ref: https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#operator_json-inline-path
   def self.json(path)
     column, attribute = path.split('.')
     "#{column}->>'$.#{attribute}'".lit

--- a/pegasus/helper_modules/hoc_event_review.rb
+++ b/pegasus/helper_modules/hoc_event_review.rb
@@ -5,8 +5,9 @@ module HocEventReview
   Sequel.extension :core_refinements
   using Sequel::CoreRefinements
 
-  # Converts a simple x.y JSON-attribute path to a MySQL 5.7 JSON expression using the inline-path operator.
-  # Ref: https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#operator_json-inline-path
+  # Converts a simple x.y JSON-attribute path to a MySQL JSON expression
+  # (available in MySQL 5.7.13 and later) using the inline-path operator.
+  # Ref: https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#operator_json-inline-path
   #
   # Because we use this method to initialize some constants, it must be
   # declared before the constants, in violation of the usual convention for

--- a/tools/hooks/scary_changes.rb
+++ b/tools/hooks/scary_changes.rb
@@ -107,7 +107,7 @@ class ScaryChangeDetector
         Making these types of changes on a large table (>10M rows) needs to be reviewed and
         tested with the Infrastructure team to avoid negatively impacting production database performance.
         The may cause MySQL to rebuild the entire table.
-        For more information see https://dev.mysql.com/doc/refman/5.7/en/innodb-online-ddl-operations.html#online-ddl-column-operations.
+        For more information see https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-column-operations-table
 
     EOS
   end


### PR DESCRIPTION
Make it possible to install MySQL 8.0 via cookbooks, although do not yet do so by default. Environments can be updated individually by overriding the `cdo-mysql` cookbook's `target_version` Chef attribute to `"8.0"`.

## Testing story

Tested on an adhoc that this change can be applied cleanly to a new environment without impact (ie, MySQL 5.7 is still installed by default). Then verified that updating the target version and rerunning `chef-client` will update MySQL to 8.0.

## Deployment strategy

This change should be safe to deploy as-is, since all of our managed servers are still running MySQL 5.7.

## Follow-up work

After merging, we can begin selectively updating environments to MySQL 8.0

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
