### PR TITLE
[Level builder] Display avail languages on script edit as check boxes instead of dropdown menu

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -30,6 +30,7 @@ import {
 import Button from '@cdo/apps/templates/Button';
 import Dialog from '@cdo/apps/templates/Dialog';
 import CourseTypeEditor from '@cdo/apps/lib/levelbuilder/course-editor/CourseTypeEditor';
+import MultiCheckboxSelector from '@cdo/apps/templates/MultiCheckboxSelector';
 
 /**
  * Component for editing units in unit_groups or stand alone courses
@@ -162,15 +163,8 @@ class UnitEditor extends React.Component {
     this.setState({supportedLocales: []});
   };
 
-  handleChangeSupportedLocales = e => {
-    var options = e.target.options;
-    var supportedLocales = [];
-    for (var i = 0, l = options.length; i < l; i++) {
-      if (options[i].selected) {
-        supportedLocales.push(options[i].value);
-      }
-    }
-    this.setState({supportedLocales});
+  handleChangeSupportedLocales = selectedOptions => {
+    this.setState({supportedLocales: selectedOptions});
   };
 
   handleFamilyNameChange = event => {
@@ -575,25 +569,22 @@ class UnitEditor extends React.Component {
             </HelpTip>
             <p>
               <span>
-                {'Select additional locales supported by this unit. Select '}
+                {'Select additional locales supported by this unit. Click '}
               </span>
               <a onClick={this.handleClearSupportedLocalesSelectClick}>none</a>
-              <span>{' or shift-click or cmd-click to select multiple.'}</span>
+              <span>{' to clear the selection.'}</span>
             </p>
-            <select
-              multiple
-              value={this.state.supportedLocales}
-              onChange={this.handleChangeSupportedLocales}
-            >
-              {this.state.locales
-                .filter(locale => !locale[1].startsWith('en'))
-                .map(locale => (
-                  <option key={locale[1]} value={locale[1]}>
-                    {locale[1]}
-                  </option>
-                ))}
-            </select>
           </label>
+          <MultiCheckboxSelector
+            noHeader={true}
+            items={this.state.locales
+              .filter(locale => !locale[1].startsWith('en'))
+              .map(locale => locale[1])}
+            selected={this.state.supportedLocales}
+            onChange={this.handleChangeSupportedLocales}
+          >
+            <LocaleItemComponent />
+          </MultiCheckboxSelector>
           {this.props.isLevelbuilder && (
             <label>
               Editor Experiment
@@ -1083,6 +1074,12 @@ class UnitEditor extends React.Component {
     );
   }
 }
+
+const LocaleItemComponent = function ({item}) {
+  return <strong>{item}</strong>;
+};
+
+LocaleItemComponent.propTypes = {item: PropTypes.string};
 
 const styles = {
   input: {

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -82,6 +82,7 @@ describe('UnitEditor', () => {
       initialInstructionType: InstructionType.teacher_led,
       initialInstructorAudience: InstructorAudience.teacher,
       initialParticipantAudience: ParticipantAudience.student,
+      initialSupportedLocales: [],
       hasCourse: false,
       scriptPath: '/s/test-unit',
       initialProfessionalLearningCourse: '',
@@ -165,12 +166,40 @@ describe('UnitEditor', () => {
       expect(wrapper.find('input').length).to.equal(24);
       expect(wrapper.find('input[type="checkbox"]').length).to.equal(11);
       expect(wrapper.find('textarea').length).to.equal(4);
-      expect(wrapper.find('select').length).to.equal(6);
+      expect(wrapper.find('select').length).to.equal(5);
       expect(wrapper.find('CollapsibleEditorSection').length).to.equal(10);
       expect(wrapper.find('SaveBar').length).to.equal(1);
       expect(wrapper.find('CourseTypeEditor').length).to.equal(1);
 
       expect(wrapper.find('UnitCard').length).to.equal(1);
+    });
+
+    it('locale selection is a multi select checkbox component with initial options selected', () => {
+      const wrapper = createWrapper({
+        initialLocales: [['Hindi', 'hi-IN'],['Tamil', 'ta-IN'],['Kannada', 'ka-IN'],['Bahasa', 'ms-MY']],
+        initialSupportedLocales: ['hi-IN', 'ta-IN']
+      });
+
+      expect(wrapper
+        .find('li')
+        .filterWhere(li =>
+          li.find('input[type="checkbox"]').length == 1 &&
+          li.find('strong').length == 1).length)
+      .to.equal(4);
+
+      expect(wrapper
+        .find('li')
+        .filterWhere(li =>
+          li.find('input[type="checkbox"]').length == 1 &&
+          li.find('strong').filterWhere(st => st.text() === "hi-IN").length == 1).length)
+      .to.equal(1);
+
+      expect(wrapper
+        .find('li')
+        .filterWhere(li =>
+          li.find('input[type="checkbox"]').length == 1 &&
+          li.find('strong').filterWhere(st => st.text() === "ta-IN").length == 1).length)
+      .to.equal(1);
     });
 
     it('disables changing student facing lesson plan checkbox when not allowed to make major curriculum changes', () => {

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -176,30 +176,46 @@ describe('UnitEditor', () => {
 
     it('locale selection is a multi select checkbox component with initial options selected', () => {
       const wrapper = createWrapper({
-        initialLocales: [['Hindi', 'hi-IN'],['Tamil', 'ta-IN'],['Kannada', 'ka-IN'],['Bahasa', 'ms-MY']],
-        initialSupportedLocales: ['hi-IN', 'ta-IN']
+        initialLocales: [
+          ['Hindi', 'hi-IN'],
+          ['Tamil', 'ta-IN'],
+          ['Kannada', 'ka-IN'],
+          ['Bahasa', 'ms-MY'],
+        ],
+        initialSupportedLocales: ['hi-IN', 'ta-IN'],
       });
 
-      expect(wrapper
-        .find('li')
-        .filterWhere(li =>
-          li.find('input[type="checkbox"]').length == 1 &&
-          li.find('strong').length == 1).length)
-      .to.equal(4);
+      expect(
+        wrapper
+          .find('li')
+          .filterWhere(
+            li =>
+              li.find('input[type="checkbox"]').length === 1 &&
+              li.find('strong').length === 1
+          ).length
+      ).to.equal(4);
 
-      expect(wrapper
-        .find('li')
-        .filterWhere(li =>
-          li.find('input[type="checkbox"]').length == 1 &&
-          li.find('strong').filterWhere(st => st.text() === "hi-IN").length == 1).length)
-      .to.equal(1);
+      expect(
+        wrapper
+          .find('li')
+          .filterWhere(
+            li =>
+              li.find('input[type="checkbox"]').length === 1 &&
+              li.find('strong').filterWhere(st => st.text() === 'hi-IN')
+                .length === 1
+          ).length
+      ).to.equal(1);
 
-      expect(wrapper
-        .find('li')
-        .filterWhere(li =>
-          li.find('input[type="checkbox"]').length == 1 &&
-          li.find('strong').filterWhere(st => st.text() === "ta-IN").length == 1).length)
-      .to.equal(1);
+      expect(
+        wrapper
+          .find('li')
+          .filterWhere(
+            li =>
+              li.find('input[type="checkbox"]').length === 1 &&
+              li.find('strong').filterWhere(st => st.text() === 'ta-IN')
+                .length === 1
+          ).length
+      ).to.equal(1);
     });
 
     it('disables changing student facing lesson plan checkbox when not allowed to make major curriculum changes', () => {


### PR DESCRIPTION
The script edit page in level builder has option to select the list of locales to be translated. The multi select element is updated in this PR to have check boxes instead of the current drop down list.

Current selection experience
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/b071f188-9bcc-4392-bd3b-da4a5eb4c2aa)

New selection experience with this PR
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/79d3b5c9-7621-45b6-a118-7c69037c79e1)

## Links

JIRA ticket https://codedotorg.atlassian.net/browse/TEACH-636?atlOrigin=eyJpIjoiN2FjMGFiN2I3Yzg4NDM1MWEyZmI4ZmVlYjJhNDYwNDUiLCJwIjoiaiJ9

## Testing story

Tested these cases manually
- Identify a course that is already supported in one lang which should be appropriately selected in the check box [Editing script '20-hour' - Code.org [development]](http://localhost-studio.code.org:3000/s/20-hour/edit)
- Identify a course that is already supported in more than one lang which should be appropriately selected in the check box [Editing script 'coursea-2017' - Code.org [development]](http://localhost-studio.code.org:3000/s/coursea-2017/edit)
- Selecting and saving one or more languages
- Deselecting and saving one or more languages
- Selecting some and deselecting a subset before saving
- Selecting and deselecting such that there is no change and try saving
- Clearing all selection through <none> link should work as expected 
  - Save 
  - exit without save
  - select one new lang and save
  - select multiple new langs and save

## Deployment strategy
Regular DTP

## Follow-up work
N/A

## Privacy
N/A

## Security
N/A

## Caching
N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
