### PR TITLE
Define drone cache bucket in code

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ steps:
   - name: restore-cache
     image: plugins/s3-cache
     settings:
-      endpoint: s3://code-dot-org-drone
+      endpoint: s3://cdo-ci-cache
       debug: true
       pull: true
       restore: true
@@ -78,7 +78,7 @@ steps:
       - name: rbenv
         path: /home/circleci/.rbenv
     settings:
-      endpoint: s3://code-dot-org-drone
+      endpoint: s3://cdo-ci-cache
       debug: true
       pull: true
       rebuild: true
@@ -139,7 +139,7 @@ steps:
   - name: restore-cache
     image: plugins/s3-cache
     settings:
-      endpoint: s3://code-dot-org-drone
+      endpoint: s3://cdo-ci-cache
       debug: true
       pull: true
       restore: true
@@ -189,7 +189,7 @@ steps:
       - name: rbenv
         path: /home/circleci/.rbenv
     settings:
-      endpoint: s3://code-dot-org-drone
+      endpoint: s3://cdo-ci-cache
       debug: true
       pull: true
       rebuild: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ steps:
   - name: restore-cache
     image: plugins/s3-cache
     settings:
-      endpoint: s3://cdo-ci-cache
+      endpoint: s3://cdo-drone
       debug: true
       pull: true
       restore: true
@@ -78,7 +78,7 @@ steps:
       - name: rbenv
         path: /home/circleci/.rbenv
     settings:
-      endpoint: s3://cdo-ci-cache
+      endpoint: s3://cdo-drone
       debug: true
       pull: true
       rebuild: true
@@ -139,7 +139,7 @@ steps:
   - name: restore-cache
     image: plugins/s3-cache
     settings:
-      endpoint: s3://cdo-ci-cache
+      endpoint: s3://cdo-drone
       debug: true
       pull: true
       restore: true
@@ -189,7 +189,7 @@ steps:
       - name: rbenv
         path: /home/circleci/.rbenv
     settings:
-      endpoint: s3://cdo-ci-cache
+      endpoint: s3://cdo-drone
       debug: true
       pull: true
       rebuild: true

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -269,7 +269,7 @@ Resources:
             -
               Name: DRONE_S3_BUCKET
               Value: code-dot-org
-              # TODO: change this to: !Ref CiCacheBucket
+              # TODO: change this to: !Ref DroneBucket
             -
               Name: DRONE_S3_PREFIX
               Value: /drone-build-logs/
@@ -509,26 +509,26 @@ Resources:
           CidrIp: 3.90.82.166/32
 
   # -------------------------
-  # Cache Bucket
+  # Drone Bucket for Cache and Logs
   # -------------------------
 
-  CiCacheBucket:
+  DroneBucket:
     Type: 'AWS::S3::Bucket'
     Properties:
-      BucketName: cdo-ci-cache
+      BucketName: cdo-drone
 
-  CiCacheBucketFullAccessPolicy:
+  DroneBucketFullAccessPolicy:
     Type: 'AWS::IAM::Policy'
     Properties:
-      PolicyName: CiCacheBucketFullAccessPolicy
+      PolicyName: DroneBucketFullAccessPolicy
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action: 's3:*'
             Resource:
-            - !Sub 'arn:aws:s3:::${CiCacheBucket}'
-            - !Sub 'arn:aws:s3:::${CiCacheBucket}/*'
+            - !Sub 'arn:aws:s3:::${DroneBucket}'
+            - !Sub 'arn:aws:s3:::${DroneBucket}/*'
             # TODO: remove references to old bucket once no longer used
             - 'arn:aws:s3:::code-dot-org'
             - 'arn:aws:s3:::code-dot-org/*'

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -269,6 +269,7 @@ Resources:
             -
               Name: DRONE_S3_BUCKET
               Value: code-dot-org
+              # TODO: change this to: !Ref CiCacheBucket
             -
               Name: DRONE_S3_PREFIX
               Value: /drone-build-logs/
@@ -506,3 +507,28 @@ Resources:
           FromPort: 22
           ToPort: 22
           CidrIp: 3.90.82.166/32
+
+  # -------------------------
+  # Cache Bucket
+  # -------------------------
+
+  CiCacheBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: cdo-ci-cache
+
+  CiCacheBucketFullAccessPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyName: CiCacheBucketFullAccessPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: 's3:*'
+            Resource:
+            - !Sub 'arn:aws:s3:::${CiCacheBucket}'
+            - !Sub 'arn:aws:s3:::${CiCacheBucket}/*'
+            # TODO: remove references to old bucket once no longer used
+            - 'arn:aws:s3:::code-dot-org'
+            - 'arn:aws:s3:::code-dot-org/*'


### PR DESCRIPTION
Defining the new bucket in code, and giving it a better name.

First I was going to go with `cdo-ci-cache`, but this bucket is also used for drone logs, so I went with `cdo-drone`, almost all the way back around to Seth's original name.

TODO:
- Add the policy created here to the manually created IAM roles (DroneWorker, DroneServer)
- Merge this into Seth's branch #56394
- Delete the other bucket he created.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
