### PR TITLE
Added copy conversation button to AI Tutor General Chat

### DIFF
--- a/apps/src/code-studio/components/aiTutor/copyButton.tsx
+++ b/apps/src/code-studio/components/aiTutor/copyButton.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {useSelector} from 'react-redux';
+
+import Button from '@cdo/apps/templates/Button';
+import copyToClipboard from '@cdo/apps/util/copyToClipboard';
+import {AITutorState} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
+
+const CopyButton: React.FunctionComponent = () => {
+  const storedMessages = useSelector(
+    (state: {aiTutor: AITutorState}) => state.aiTutor.chatMessages
+  );
+
+  const handleCopy = () => {
+    const textToCopy = storedMessages
+      .map(
+        message =>
+          `[${message.timestamp || 'XXXX-XX-XX XX:XX'} - ${message.role}] ${
+            message.chatMessageText
+          }`
+      )
+      .join('\n');
+    copyToClipboard(
+      textToCopy,
+      () => alert('Text copied to clipboard'),
+      () => {
+        console.error('Error in copying text');
+      }
+    );
+  };
+
+  return (
+    <Button
+      color={Button.ButtonColor.white}
+      icon={'clipboard'}
+      key="copy"
+      onClick={() => handleCopy()}
+      size={Button.ButtonSize.small}
+      text="Copy Conversation History"
+    />
+  );
+};
+
+export default CopyButton;

--- a/apps/src/code-studio/components/aiTutor/userChatMessageEditor.tsx
+++ b/apps/src/code-studio/components/aiTutor/userChatMessageEditor.tsx
@@ -7,6 +7,7 @@ import {
 } from '@cdo/apps/aiTutor/redux/aiTutorRedux';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {useSelector} from 'react-redux';
+import CopyButton from './copyButton';
 
 /**
  * Renders the AI Tutor user chat message editor component.
@@ -42,6 +43,7 @@ const UserChatMessageEditor = () => {
         color={Button.ButtonColor.brandSecondaryDefault}
         disabled={isWaitingForChatResponse}
       />
+      <CopyButton />
     </div>
   );
 };


### PR DESCRIPTION
Adding in a copy conversation button to the AI Tutor General Chat function in preparation for upcoming classroom visits.

![image](https://github.com/code-dot-org/code-dot-org/assets/95503833/1e88c426-a857-4551-9f2a-c705f50e8242)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CT-298](https://codedotorg.atlassian.net/browse/CT-298?atlOrigin=eyJpIjoiOWVkMzI0NmU1M2Q5NGMwOTg3YTc2Mjk2MGYwYjJmNmMiLCJwIjoiaiJ9)




## Deployment strategy

This is just for the purposes of pilot/playtesting and will need to be removed before any broader release.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

If we want to add this to the other two options (failing tests and code compilation), it will require more work to refactor how we are storing the chat history.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
