### PR TITLE
Always reporting language in GA

### DIFF
--- a/dashboard/app/helpers/locale_helper.rb
+++ b/dashboard/app/helpers/locale_helper.rb
@@ -1,3 +1,5 @@
+require_relative '../../lib/dashboard_languages'
+
 module LocaleHelper
   # Symbol of best valid locale code to be used for I18n.locale.
   def locale
@@ -42,25 +44,18 @@ module LocaleHelper
     options
   end
 
-  # Parses and ranks locale code strings from the Accept-Language header.
+  # Returns an Array of supported locale codes in dashboard.
   def accepted_locales
-    header = request.env.fetch('HTTP_X_VARNISH_ACCEPT_LANGUAGE', '')
-    begin
-      locale_codes = header.split(',').map do |entry|
-        locale, weight = entry.split(';')
-        weight = (weight || 'q=1').split('=')[1].to_f
-        [locale, weight]
-      end
-      locale_codes.sort_by {|_, weight| -weight}.map {|locale, _| locale.strip}
-    rescue
-      Logger.warn "Error parsing Accept-Language header: #{header}"
-      []
+    locale_codes = DashboardLanguages.table.select(:locale_s).map do |locale|
+      locale[:locale_s]
     end
+    locale_codes
   end
 
   # Strips regions off of accepted_locales.
   def accepted_languages
-    accepted_locales.map {|locale| locale.split('-')[0]}
+    accepted_languages = accepted_locales.map {|locale| locale.split('-')[0]}
+    accepted_languages.uniq
   end
 
   # Looks up a localized string driven by a database value.

--- a/dashboard/app/helpers/locale_helper.rb
+++ b/dashboard/app/helpers/locale_helper.rb
@@ -44,12 +44,9 @@ module LocaleHelper
     options
   end
 
-  # Returns an Array of supported locale codes in dashboard.
+  # Returns an Array of supported locale codes.
   def accepted_locales
-    locale_codes = DashboardLanguages.table.select(:locale_s).map do |locale|
-      locale[:locale_s]
-    end
-    locale_codes
+    I18n.available_locales.map(&:to_s)
   end
 
   # Strips regions off of accepted_locales.

--- a/dashboard/app/helpers/locale_helper.rb
+++ b/dashboard/app/helpers/locale_helper.rb
@@ -19,8 +19,8 @@ module LocaleHelper
   end
 
   # String representing the Locale code for the Blockly client code.
-  def js_locale
-    locale.to_s.downcase.tr('-', '_')
+  def js_locale(locale_code = locale)
+    locale_code.to_s.downcase.tr('-', '_')
   end
 
   def options_for_locale_select
@@ -44,12 +44,12 @@ module LocaleHelper
 
   # Returns an Array of supported locale codes.
   def accepted_locales
-    I18n.available_locales.map(&:to_s)
+    @accepted_locales ||= I18n.available_locales.map(&:to_s)
   end
 
   # Strips regions off of accepted_locales.
   def accepted_languages
-    accepted_locales.map(&method(:language)).uniq
+    @accepted_languages ||= accepted_locales.map(&method(:language)).uniq
   end
 
   # Looks up a localized string driven by a database value.

--- a/dashboard/app/helpers/locale_helper.rb
+++ b/dashboard/app/helpers/locale_helper.rb
@@ -1,5 +1,3 @@
-require_relative '../../lib/dashboard_languages'
-
 module LocaleHelper
   # Symbol of best valid locale code to be used for I18n.locale.
   def locale
@@ -16,8 +14,8 @@ module LocaleHelper
 
   # String representing the 2 letter language code.
   # Prefer full locale with region where possible.
-  def language
-    locale.to_s.split('-').first
+  def language(locale_code = locale)
+    locale_code.to_s.split('-').first
   end
 
   # String representing the Locale code for the Blockly client code.
@@ -51,8 +49,7 @@ module LocaleHelper
 
   # Strips regions off of accepted_locales.
   def accepted_languages
-    accepted_languages = accepted_locales.map {|locale| locale.split('-')[0]}
-    accepted_languages.uniq
+    accepted_locales.map(&method(:language)).uniq
   end
 
   # Looks up a localized string driven by a database value.

--- a/dashboard/app/views/layouts/_google_analytics.html.haml
+++ b/dashboard/app/views/layouts/_google_analytics.html.haml
@@ -1,7 +1,7 @@
 -# The following dimensions must match in order the custom dimension settings in our Google Analytics account.
 - selected_language_dim, age_dim, gender_dim, user_type_dim, env_dim, pixel_ratio, has_teacher = (1..7).map{|x|"dimension#{x}"}
 - dimensions = {}
-- dimensions[selected_language_dim] = language
+- dimensions[selected_language_dim] = language if language.present?
 - dimensions[env_dim] = Rails.env
 - if user_signed_in?
   - dimensions[age_dim] = current_user.age.to_s

--- a/dashboard/app/views/layouts/_google_analytics.html.haml
+++ b/dashboard/app/views/layouts/_google_analytics.html.haml
@@ -1,7 +1,7 @@
 -# The following dimensions must match in order the custom dimension settings in our Google Analytics account.
 - selected_language_dim, age_dim, gender_dim, user_type_dim, env_dim, pixel_ratio, has_teacher = (1..7).map{|x|"dimension#{x}"}
 - dimensions = {}
-- dimensions[selected_language_dim] = language if (accepted_languages.present? && accepted_languages.first != language)
+- dimensions[selected_language_dim] = language
 - dimensions[env_dim] = Rails.env
 - if user_signed_in?
   - dimensions[age_dim] = current_user.age.to_s

--- a/dashboard/app/views/layouts/_google_analytics.html.haml
+++ b/dashboard/app/views/layouts/_google_analytics.html.haml
@@ -1,7 +1,7 @@
 -# The following dimensions must match in order the custom dimension settings in our Google Analytics account.
 - selected_language_dim, age_dim, gender_dim, user_type_dim, env_dim, pixel_ratio, has_teacher = (1..7).map{|x|"dimension#{x}"}
 - dimensions = {}
-- dimensions[selected_language_dim] = language if language.present?
+- dimensions[selected_language_dim] = language if accepted_languages.include?(language)
 - dimensions[env_dim] = Rails.env
 - if user_signed_in?
   - dimensions[age_dim] = current_user.age.to_s


### PR DESCRIPTION
This PR does two things:
1. Removes a condition that prevents logging user language to Google Analytics in some cases.
2. Refactores the logic used in the `locale_helper` to provide accurately accepted locales and languages supported in our system.

Under the removed condition, a list of accepted languages is requested from the HTTP header using varnish in some legacy code:
https://github.com/code-dot-org/code-dot-org/blob/cfde1a3ef544cb8855949ef2d20abb64f18ebef7/dashboard/app/helpers/locale_helper.rb#L45-L59

The `ACCEPT_LANGUAGE` header looks as follows:
![Screenshot 2024-02-07 at 15 44 58](https://github.com/code-dot-org/code-dot-org/assets/66776217/e5adafa8-c466-4383-ac65-3cb2ad3dfa2c)

When the [locale language](https://github.com/code-dot-org/code-dot-org/blob/cfde1a3ef544cb8855949ef2d20abb64f18ebef7/dashboard/app/helpers/locale_helper.rb#L15-L19) coincides with the top language returned in the header, no value is assigned to the `selected_language_dim` resulting into a [(not set)](https://support.google.com/analytics/answer/13504892?hl=en#zippy=%2Cin-this-article) value in Google Analytics. 

By changing the logic, we are attempting to reduce or eliminate the number of (not set) values, decreasing the amount of noise in Google Analytics reporting data.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
