### PR TITLE
Drone: fix "error: pathspec '...' did not match"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,6 +41,7 @@ steps:
       # We should be in a cached git repo, but clone if the cache failed
       - "[ -d .git ] || (echo 'WARNING: get-cached-staging failed: checkout will be SLOW and LFS $$$!' && git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL .)"
       # Checkout our target branch (=the PR)
+      - git fetch origin $DRONE_SOURCE_BRANCH
       - git checkout $DRONE_SOURCE_BRANCH
       - git pull
       - git reset --hard $DRONE_COMMIT
@@ -150,13 +151,14 @@ steps:
       mount:
         - .
 
-  - name: clone
+  - name: checkout
     image: bitnami/git
     commands:
       - git lfs install --skip-repo
       # We should be in a cached git repo, but clone if the cache failed
       - "[ -d .git ] || (echo 'get-cached-staging failed: checkout will be SLOW and LFS $$$!' && git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL .)"
       # Checkout our target branch (the PR's branch).
+      - git fetch origin $DRONE_SOURCE_BRANCH
       - git checkout $DRONE_SOURCE_BRANCH
       - git pull
       - git reset --hard $DRONE_COMMIT
@@ -283,6 +285,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: edcddae91383f54d5a2d1923c6b7786dec279a44abb55b862040861505751df4
+hmac: c68da745b0729bc5215deffd72267d44c926668da805c930a06fdbd09a35be80
 
 ...


### PR DESCRIPTION
The issue occurs is your branch didn't exist when the staging clone was cached. A drone error occurs (from @davidsbailey ): 
<img width="760" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/af745378-89c0-4d56-85c0-3765b1779600">

The fix is to do a `git fetch` prior to checking out, to fetch refs that have been created since staging was cached.

The staging clone is cached to: https://s3.console.aws.amazon.com/s3/object/cdo-drone?region=us-west-2&bucketType=general[…]ode-dot-org/code-dot-org/staging/cache-staging-clone.tar (edited) 

### Testing

Because this was transient, needed a reliable 'manual' repro. Ran the following to both repro, and then go on to demonstrate the fix (add a git fetch):
```
+ git clone --branch staging https://github.com/code-dot-org/code-dot-org.git .
# In another repo, create and push a brand new branch from, say `seth/brand-new-branch`
+ git checkout seth/brand-new-branch
error: pathspec 'seth/brand-new-branch' did not match any file(s) known to git
# continuing on to now fix it...
+ git fetch origin seth/brand-new-branch
+ git checkout seth/brand-new-branch
branch 'seth/brand-new-branch' set up to track 'origin/seth/brand-new-branch'.
Switched to a new branch 'seth/brand-new-branch'
# success!
```

Testing the following are true:
Should have PASSED drone (fresh branch that has fix): https://drone.cdn-code.org/code-dot-org/code-dot-org/39896
Should have FAILED drone (fresh branch that has no fix): https://drone.cdn-code.org/code-dot-org/code-dot-org/39897