### PR TITLE
P20-688: Fix redaction of Dashboard/course_content

### DIFF
--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -16,25 +16,18 @@ module I18n
         class SyncIn < I18n::Utils::SyncInBase
           def process
             prepare_level_content
-            progress_bar.progress = 25
-
-            prepare_project_content
             progress_bar.progress = 50
 
+            prepare_project_content
+            progress_bar.progress = 75
+
             write_to_yml(VARIABLE_NAMES_TYPE, variable_strings)
-            progress_bar.progress = 65
+            progress_bar.progress = 90
 
             write_to_yml(PARAMETER_NAMES_TYPE, parameter_strings)
-            progress_bar.progress = 80
-
-            redact_level_content
           end
 
           private
-
-          def valid_source_file?(source_file_path)
-            !I18nScriptUtils.unit_directory_change?(I18N_SOURCE_DIR_PATH, source_file_path)
-          end
 
           def variable_strings
             @variable_strings ||= {}
@@ -342,7 +335,10 @@ module I18n
                 end
 
               source_file_path = File.join(script_i18n_directory, "#{script.name}.json")
-              I18nScriptUtils.write_json_file(source_file_path, script_strings) if valid_source_file?(source_file_path)
+              next if I18nScriptUtils.unit_directory_change?(I18N_SOURCE_DIR_PATH, source_file_path)
+
+              I18nScriptUtils.write_json_file(source_file_path, script_strings)
+              redact_json_file(source_file_path)
             end
 
             write_to_yml(BLOCK_CATEGORIES_TYPE, block_category_strings)
@@ -377,7 +373,8 @@ module I18n
 
             project_strings.delete_if {|_, value| value.blank?}
 
-            File.write(project_content_file, JSON.pretty_generate(project_strings))
+            I18nScriptUtils.write_json_file(project_content_file, project_strings)
+            redact_json_file(project_content_file)
           end
 
           def select_redactable(i18n_strings)
@@ -399,24 +396,19 @@ module I18n
             redactable.delete_if {|_k, v| v.blank?}
           end
 
-          def redact_level_content
-            Dir[File.join(I18N_SOURCE_DIR_PATH, '/**/*.json')].each do |source_path|
-              next unless valid_source_file?(source_path)
+          def redact_json_file(source_path)
+            source_data = JSON.load_file(source_path)
+            return if source_data.blank?
 
-              source_data = JSON.load_file(source_path)
-              next if source_data.blank?
+            redactable_data = source_data.map do |level_url, i18n_strings|
+              [level_url, select_redactable(i18n_strings)]
+            end.to_h
 
-              redactable_data = source_data.map do |level_url, i18n_strings|
-                [level_url, select_redactable(i18n_strings)]
-              end.to_h
+            backup_path = source_path.sub('source', 'original')
+            I18nScriptUtils.write_json_file(backup_path, redactable_data)
 
-              backup_path = source_path.sub('source', 'original')
-              FileUtils.mkdir_p(File.dirname(backup_path))
-              File.write(backup_path, JSON.pretty_generate(redactable_data))
-
-              redacted_data = RedactRestoreUtils.redact_data(redactable_data, REDACT_PLUGINS)
-              File.write(source_path, JSON.pretty_generate(source_data.deep_merge(redacted_data)))
-            end
+            redacted_data = RedactRestoreUtils.redact_data(redactable_data, REDACT_PLUGINS)
+            I18nScriptUtils.write_json_file(source_path, source_data.deep_merge(redacted_data))
           end
         end
       end

--- a/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
@@ -24,8 +24,6 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     I18n::Resources::Dashboard::CourseContent::SyncIn.any_instance.expects(:write_to_yml).with('variable_names', 'expected_variable_strings').in_sequence(execution_sequence)
     I18n::Resources::Dashboard::CourseContent::SyncIn.any_instance.expects(:write_to_yml).with('parameter_names', 'expected_parameter_strings').in_sequence(execution_sequence)
 
-    I18n::Resources::Dashboard::CourseContent::SyncIn.any_instance.expects(:redact_level_content).in_sequence(execution_sequence)
-
     I18n::Resources::Dashboard::CourseContent::SyncIn.perform
   end
 
@@ -33,7 +31,8 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
     exec_seq = sequence('execution')
 
-    expected_i18n_source_file_path = CDO.dir('i18n/locales/source/course_content/Hour of Code/hoc-script.json')
+    expected_i18n_source_dir_path = CDO.dir('i18n/locales/source/course_content')
+    expected_i18n_source_file_path = File.join(expected_i18n_source_dir_path, 'Hour of Code/hoc-script.json')
     expected_string_level_progression = 'expected_progression_string'
     expected_block_categories = {'expected_block_category_key' => 'expected_block_category_value'}
     expected_variable_names = {'expected_variable_name_key' => 'expected_variable_name_value'}
@@ -57,8 +56,9 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     I18nScriptUtils.expects(:get_level_url_key).with(script, level).in_sequence(exec_seq).returns('expected_level_url')
     sync_in_instance.expects(:get_i18n_strings).with(level).in_sequence(exec_seq).returns(expected_level_i18n_strings)
     Unit.expects(:unit_in_category?).with('hoc', script.name).in_sequence(exec_seq).returns(true)
-    sync_in_instance.expects(:valid_source_file?).with(expected_i18n_source_file_path).in_sequence(exec_seq).returns(true)
+    I18nScriptUtils.expects(:unit_directory_change?).with(expected_i18n_source_dir_path, expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
     I18nScriptUtils.expects(:write_json_file).with(expected_i18n_source_file_path, {'expected_level_url' => {'expected_script_string_key' => 'expected_script_string_value'}}).in_sequence(exec_seq)
+    sync_in_instance.expects(:redact_json_file).with(expected_i18n_source_file_path).in_sequence(exec_seq)
 
     sync_in_instance.expects(:write_to_yml).with('block_categories', expected_block_categories).in_sequence(exec_seq)
     sync_in_instance.expects(:write_to_yml).with('progressions', {expected_string_level_progression => expected_string_level_progression}).in_sequence(exec_seq)
@@ -73,7 +73,8 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
     exec_seq = sequence('execution')
 
-    expected_i18n_source_file_path = CDO.dir('i18n/locales/source/course_content/other/unversioned-script.json')
+    expected_i18n_source_dir_path = CDO.dir('i18n/locales/source/course_content')
+    expected_i18n_source_file_path = File.join(expected_i18n_source_dir_path, 'other/unversioned-script.json')
     expected_string_level_progression = 'expected_progression_string'
     expected_block_categories = {'expected_block_category_key' => 'expected_block_category_value'}
     expected_variable_names = {'expected_variable_name_key' => 'expected_variable_name_value'}
@@ -98,8 +99,9 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     sync_in_instance.expects(:get_i18n_strings).with(level).in_sequence(exec_seq).returns(expected_level_i18n_strings)
     Unit.expects(:unit_in_category?).with('hoc', script.name).in_sequence(exec_seq).returns(false)
     script.expects(:unversioned?).in_sequence(exec_seq).returns(true)
-    sync_in_instance.expects(:valid_source_file?).with(expected_i18n_source_file_path).in_sequence(exec_seq).returns(true)
+    I18nScriptUtils.expects(:unit_directory_change?).with(expected_i18n_source_dir_path, expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
     I18nScriptUtils.expects(:write_json_file).with(expected_i18n_source_file_path, {'expected_level_url' => {'expected_script_string_key' => 'expected_script_string_value'}}).in_sequence(exec_seq)
+    sync_in_instance.expects(:redact_json_file).with(expected_i18n_source_file_path).in_sequence(exec_seq)
 
     sync_in_instance.expects(:write_to_yml).with('block_categories', expected_block_categories).in_sequence(exec_seq)
     sync_in_instance.expects(:write_to_yml).with('progressions', {expected_string_level_progression => expected_string_level_progression}).in_sequence(exec_seq)
@@ -114,7 +116,8 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
     exec_seq = sequence('execution')
 
-    expected_i18n_source_file_path = CDO.dir('i18n/locales/source/course_content/expected_version_year/versioned-script.json')
+    expected_i18n_source_dir_path = CDO.dir('i18n/locales/source/course_content')
+    expected_i18n_source_file_path = File.join(expected_i18n_source_dir_path, 'expected_version_year/versioned-script.json')
     expected_string_level_progression = 'expected_progression_string'
     expected_block_categories = {'expected_block_category_key' => 'expected_block_category_value'}
     expected_variable_names = {'expected_variable_name_key' => 'expected_variable_name_value'}
@@ -139,8 +142,9 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     sync_in_instance.expects(:get_i18n_strings).with(level).in_sequence(exec_seq).returns(expected_level_i18n_strings)
     Unit.expects(:unit_in_category?).with('hoc', script.name).in_sequence(exec_seq).returns(false)
     script.expects(:unversioned?).in_sequence(exec_seq).returns(false)
-    sync_in_instance.expects(:valid_source_file?).with(expected_i18n_source_file_path).in_sequence(exec_seq).returns(true)
+    I18nScriptUtils.expects(:unit_directory_change?).with(expected_i18n_source_dir_path, expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
     I18nScriptUtils.expects(:write_json_file).with(expected_i18n_source_file_path, {'expected_level_url' => {'expected_script_string_key' => 'expected_script_string_value'}}).in_sequence(exec_seq)
+    sync_in_instance.expects(:redact_json_file).with(expected_i18n_source_file_path).in_sequence(exec_seq)
 
     sync_in_instance.expects(:write_to_yml).with('block_categories', expected_block_categories).in_sequence(exec_seq)
     sync_in_instance.expects(:write_to_yml).with('progressions', {expected_string_level_progression => expected_string_level_progression}).in_sequence(exec_seq)
@@ -155,7 +159,8 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
     exec_seq = sequence('execution')
 
-    expected_i18n_source_file_path = CDO.dir('i18n/locales/source/course_content/expected_version_year/versioned-script.json')
+    expected_i18n_source_dir_path = CDO.dir('i18n/locales/source/course_content')
+    expected_i18n_source_file_path = File.join(expected_i18n_source_dir_path, 'expected_version_year/versioned-script.json')
     expected_string_level_progression = 'expected_progression_string'
     expected_block_categories = {'expected_block_category_key' => 'expected_block_category_value'}
     expected_variable_names = {'expected_variable_name_key' => 'expected_variable_name_value'}
@@ -180,8 +185,9 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     sync_in_instance.expects(:get_i18n_strings).with(level).in_sequence(exec_seq).returns(expected_level_i18n_strings)
     Unit.expects(:unit_in_category?).with('hoc', script.name).in_sequence(exec_seq).returns(false)
     script.expects(:unversioned?).in_sequence(exec_seq).returns(false)
-    sync_in_instance.expects(:valid_source_file?).with(expected_i18n_source_file_path).in_sequence(exec_seq).returns(false)
+    I18nScriptUtils.expects(:unit_directory_change?).with(expected_i18n_source_dir_path, expected_i18n_source_file_path).in_sequence(exec_seq).returns(true)
     I18nScriptUtils.expects(:write_json_file).with(expected_i18n_source_file_path, {'expected_level_url' => {'expected_script_string_key' => 'expected_script_string_value'}}).never
+    sync_in_instance.expects(:redact_json_file).with(expected_i18n_source_file_path).never
 
     sync_in_instance.expects(:write_to_yml).with('block_categories', expected_block_categories).in_sequence(exec_seq)
     sync_in_instance.expects(:write_to_yml).with('progressions', {expected_string_level_progression => expected_string_level_progression}).in_sequence(exec_seq)
@@ -196,7 +202,8 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
     exec_seq = sequence('execution')
 
-    expected_i18n_source_file_path = CDO.dir('i18n/locales/source/course_content/expected_version_year/versioned-script.json')
+    expected_i18n_source_dir_path = CDO.dir('i18n/locales/source/course_content')
+    expected_i18n_source_file_path = File.join(expected_i18n_source_dir_path, 'expected_version_year/versioned-script.json')
     expected_string_level_progression = 'expected_progression_string'
     expected_block_categories = {'expected_block_category_key' => 'expected_block_category_value'}
     expected_variable_names = {'expected_variable_name_key' => 'expected_variable_name_value'}
@@ -221,8 +228,9 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     sync_in_instance.expects(:get_i18n_strings).with(level).never.returns(expected_level_i18n_strings)
     Unit.expects(:unit_in_category?).with('hoc', script.name).never.returns(false)
     script.expects(:unversioned?).never.returns(false)
-    sync_in_instance.expects(:valid_source_file?).with(expected_i18n_source_file_path).never.returns(true)
+    I18nScriptUtils.expects(:unit_directory_change?).with(expected_i18n_source_dir_path, expected_i18n_source_file_path).never.returns(false)
     I18nScriptUtils.expects(:write_json_file).with(expected_i18n_source_file_path, {'expected_level_url' => {'expected_script_string_key' => 'expected_script_string_value'}}).never
+    sync_in_instance.expects(:redact_json_file).with(expected_i18n_source_file_path).never
 
     sync_in_instance.expects(:write_to_yml).with('block_categories', {}).in_sequence(exec_seq)
     sync_in_instance.expects(:write_to_yml).with('progressions', {}).in_sequence(exec_seq)
@@ -240,6 +248,8 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
       sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
       level = FactoryBot.build(:level)
 
+      expected_i18n_source_dir_path = CDO.dir('i18n/locales/source/course_content')
+      expected_i18n_source_file_path = File.join(expected_i18n_source_dir_path, 'projects.json')
       expected_block_categories = {'expected_block_category_key' => 'expected_block_category_value'}
       expected_variable_names = {'expected_variable_name_key' => 'expected_variable_name_value'}
       expected_parameter_names = {'expected_parameter_name_key' => 'expected_parameter_name_value'}
@@ -252,10 +262,11 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
 
       Level.expects(:find_by_name).with('expected_project_name').in_sequence(exec_seq).returns(level)
       sync_in_instance.expects(:get_i18n_strings).with(level).in_sequence(exec_seq).returns(expected_project_i18n_strings)
-      File.expects(:write).with(
-        CDO.dir('i18n/locales/source/course_content/projects.json'),
-        %Q[{\n  "https://studio.code.org/p/expected_project_key": {\n    "expected_script_string_key": "expected_script_string_value"\n  }\n}]
+      I18nScriptUtils.expects(:write_json_file).with(
+        expected_i18n_source_file_path,
+        {'https://studio.code.org/p/expected_project_key' => {'expected_script_string_key' => 'expected_script_string_value'}}
       ).in_sequence(exec_seq)
+      sync_in_instance.expects(:redact_json_file).with(expected_i18n_source_file_path).in_sequence(exec_seq)
 
       sync_in_instance.send(:prepare_project_content)
 
@@ -285,6 +296,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
       sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
       level = FactoryBot.build(:level)
 
+      expected_i18n_source_file_path = CDO.dir('i18n/locales/source/course_content/projects.json')
       expected_block_categories = {'expected_block_category_key' => 'expected_block_category_value'}
       expected_variable_names = {'expected_variable_name_key' => 'expected_variable_name_value'}
       expected_parameter_names = {'expected_parameter_name_key' => 'expected_parameter_name_value'}
@@ -297,10 +309,8 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
 
       Level.expects(:find_by_name).with('expected_project_name').never.returns(level)
       sync_in_instance.expects(:get_i18n_strings).with(level).never.returns(expected_project_i18n_strings)
-      File.expects(:write).with(
-        CDO.dir('i18n/locales/source/course_content/projects.json'),
-        %Q[{\n  "https://studio.code.org/p/expected_project_key": {\n    "expected_script_string_key": "expected_script_string_value"\n  }\n}]
-      ).never
+      I18nScriptUtils.expects(:write_json_file).with(expected_i18n_source_file_path, {}).once
+      sync_in_instance.expects(:redact_json_file).with(expected_i18n_source_file_path).once
 
       sync_in_instance.send(:prepare_project_content)
 
@@ -660,35 +670,8 @@ describe I18n::Resources::Dashboard::CourseContent::SyncIn do
     FakeFS.with_fresh {test.call}
   end
 
-  describe '#valid_source_file?' do
-    let(:valid_source_file?) {described_instance.send(:valid_source_file?, i18n_source_file_path)}
-
-    let(:i18n_source_dir_path) {CDO.dir('i18n/locales/source/course_content')}
-    let(:i18n_source_file_path) {File.join(i18n_source_dir_path, 'expected_version_year/unit.json')}
-
-    let(:unit_directory_change?) {false}
-
-    before do
-      I18nScriptUtils.stubs(:unit_directory_change?).with(i18n_source_dir_path, i18n_source_file_path).returns(unit_directory_change?)
-    end
-
-    it 'returns true' do
-      _(valid_source_file?).must_equal true
-    end
-
-    context 'when the i18n source file directory of the unit is changed' do
-      let(:unit_directory_change?) {true}
-
-      it 'returns false' do
-        _(valid_source_file?).must_equal false
-      end
-    end
-  end
-
-  describe '#redact_level_content' do
-    let(:redact_level_content) {described_instance.send(:redact_level_content)}
-
-    let(:valid_source_file?) {true}
+  describe '#redact_json_file' do
+    let(:redact_json_file) {described_instance.send(:redact_json_file, i18n_source_file_path)}
 
     let(:i18n_original_file_path) {CDO.dir('i18n/locales/original/course_content/expected_version_year/unit.json')}
     let(:i18n_source_file_path) {CDO.dir('i18n/locales/source/course_content/expected_version_year/unit.json')}
@@ -704,32 +687,21 @@ describe I18n::Resources::Dashboard::CourseContent::SyncIn do
       FileUtils.mkdir_p File.dirname(i18n_source_file_path)
       File.write i18n_source_file_path, JSON.dump(i18n_source_file_data)
 
-      described_instance.stubs(:valid_source_file?).with(i18n_source_file_path).returns(valid_source_file?)
       described_instance.stubs(:select_redactable).with(i18n_data).returns(redactable_data[level_url])
       RedactRestoreUtils.stubs(:redact_data).with(redactable_data, %w[blockly]).returns(redacted_data)
     end
 
     it 'creates the i18n original file for restoration' do
-      redact_level_content
+      redact_json_file
 
       _(File.file?(i18n_original_file_path)).must_equal true
       _(JSON.load_file(i18n_original_file_path)).must_equal redactable_data
     end
 
     it 'redacts the i18n source file data' do
-      redact_level_content
+      redact_json_file
 
       _(JSON.load_file(i18n_source_file_path)).must_equal redacted_data
-    end
-
-    context 'when the i18n source file is invalid' do
-      let(:valid_source_file?) {false}
-
-      it 'does not redact the i18n source file data' do
-        redact_level_content
-
-        _(JSON.load_file(i18n_source_file_path)).must_equal i18n_source_file_data
-      end
     end
   end
 end


### PR DESCRIPTION
When we detect that a unit path has changed we skip the process of that file for translation because we need to manually delete the old file from Crowdin and the git repo first to avoid i18n strings duplication.
This PR fixes the bug where we were still redacting these skipped files.

- jira ticket: [P20-688](https://codedotorg.atlassian.net/browse/P20-688)

Related PRs:
- https://github.com/code-dot-org/code-dot-org/pull/33181
- https://github.com/code-dot-org/code-dot-org/pull/56358



Note: This fix requires manual updating of the corrupted `original` files on the `i18n server`:
- /i18n/locales/original/course_content/2023/dance-ai-2023.json
- /i18n/locales/original/course_content/other/K5-OnlinePD.json
- /i18n/locales/original/course_content/other/k5-onlinepd-2019.json
- /i18n/locales/original/course_content/other/kodea-pd-2021.json
- /i18n/locales/original/course_content/other/outbreak.json