### PR TITLE
Remove References to codecurricula.com

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -358,7 +358,7 @@ app_servers: {}
 rack_mini_profiler_enabled:
 https_development:
 default_scheme: '<%=(env == 'development') || ci ? 'http:' : 'https:'%>'
-allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net cuantrix.mx <%=pegasus_site_host%> <%=dashboard_site_host%> curriculum.code.org codecurricula.com https://*.lausd.iap.allhere.co
+allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net cuantrix.mx <%=pegasus_site_host%> <%=dashboard_site_host%> curriculum.code.org https://*.lausd.iap.allhere.co
 
 skip_locales:
 secret_pictures_csv:

--- a/pegasus/sites.v3/code.org/public/curriculumbuilder.moved
+++ b/pegasus/sites.v3/code.org/public/curriculumbuilder.moved
@@ -1,1 +1,0 @@
-http://codecurricula.com/


### PR DESCRIPTION
…application server logic.
`codecurricula.com` (a lesson plan authoring tool implemented in Django and hosted on Heroku) was replaced with features built directly in the dashboard “levelbuilder” curriculum authoring tool. Remove references to this defunct site from login within our web application servers.

## Testing story

This AWS Athena query on our HTTP logs show that there aren’t any HTTP requests to our learning platform referred via iframe nor referred via simple link from a site named `codecurricula.com` 

``` SQL
SELECT "cs-referer", count(*)
FROM cdo_access_logs.access_logs
WHERE -- The S3 Object key prefixes include the date and hour (UTC). Include this partition value to speed up queries.
      datehour LIKE '2024/02/%'
--      AND timestamp > CAST('2022-09-08 12:06:00.000' AS TIMESTAMP) AND timestamp < CAST('2022-09-08 12:12:00.000' AS TIMESTAMP)
  AND "cs-host" IN ('studio.code.org') -- CloudFront logs from multiple environments are streamed to this table.
  AND "cs-referer" LIKE '%codecurricula%'
GROUP BY "cs-referer"
ORDER BY count(*) DESC;
```

## Deployment strategy

Also manually delete the manually provisioned `codecurricula` `A` and `CNAME` DNS records in AWS Route 53 and also manually delete the manually provisioned `codecurricula.com` S3 Bucket which implemented an HTTP redirect via Static website hosting S3 functionality to the Heroku site.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
