### PR TITLE
Use DataStorageTable.columns in all controller methods instead of inferring from data

### DIFF
--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -234,19 +234,6 @@ function loadTableAndColumns({
   onRecordsChanged,
 }) {
   readRecords({tableName, isSharedTable}).then(records => {
-    console.log('Got a response from readRecords: ', records);
-
-    // We used to get columns by inferring them from the records:
-    //
-    // // FIXME: unfirebase, we are currently inferring the columns from the
-    // // data values, but based on our schema, we should be loading them
-    // // from DatablockStorageTables column columns.
-    // console.warn(
-    //   'FIXME DatablockStorage.subscribeToTable: onColumnsChanged is not yet implemented to load from the SQL table'
-    // );
-    // const columnNames = new Set(records.flatMap(record => Object.keys(record)));
-    // onColumnsChanged(Array.from(columnNames));
-
     getColumnsForTable(tableName).then(onColumnsChanged)
 
     // DataTableView.getTableJson() expects an array of JSON strings

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -364,11 +364,9 @@ DatablockStorage.renameColumn = function (
 ) {
   _fetch('rename_column', 'PUT', {
     table_name: tableName,
-    old_name: oldName,
-    new_name: newName,
+    old_column_name: oldName,
+    new_column_name: newName,
   }).then(onSuccess, onError);
-
-  throw 'Not implemented yet';
 };
 
 DatablockStorage.coerceColumn = function (

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -348,8 +348,6 @@ DatablockStorage.addColumn = function (
     table_name: tableName,
     column_name: columnName,
   }).then(onSuccess, onError);
-
-  throw 'Not implemented yet';
 };
 
 // Delete the column definition AND filters all rows to remove the offending JSON property

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -221,6 +221,12 @@ DatablockStorage.getTableNames = function () {
 
 // END DIFFERENCE BETWEEN FIREBASESTORAGE AND DATABLOCKSTORAGE //
 
+async function getColumnsForTable(tableName) {
+  const response = await _fetch('get_columns_for_table', 'GET', {table_name: tableName});
+  const json = await response.json();
+  return json;
+}
+
 function loadTableAndColumns({
   tableName,
   isSharedTable,
@@ -230,14 +236,18 @@ function loadTableAndColumns({
   readRecords({tableName, isSharedTable}).then(records => {
     console.log('Got a response from readRecords: ', records);
 
-    // FIXME: unfirebase, we are currently inferring the columns from the
-    // data values, but based on our schema, we should be loading them
-    // from DatablockStorageTables column columns.
-    console.warn(
-      'FIXME DatablockStorage.subscribeToTable: onColumnsChanged is not yet implemented to load from the SQL table'
-    );
-    const columnNames = new Set(records.flatMap(record => Object.keys(record)));
-    onColumnsChanged(Array.from(columnNames));
+    // We used to get columns by inferring them from the records:
+    //
+    // // FIXME: unfirebase, we are currently inferring the columns from the
+    // // data values, but based on our schema, we should be loading them
+    // // from DatablockStorageTables column columns.
+    // console.warn(
+    //   'FIXME DatablockStorage.subscribeToTable: onColumnsChanged is not yet implemented to load from the SQL table'
+    // );
+    // const columnNames = new Set(records.flatMap(record => Object.keys(record)));
+    // onColumnsChanged(Array.from(columnNames));
+
+    getColumnsForTable(tableName).then(onColumnsChanged)
 
     // DataTableView.getTableJson() expects an array of JSON strings
     // which it then parses as JSON, and then stringifies again 🙈
@@ -420,10 +430,7 @@ DatablockStorage.getLibraryManifest = function () {
 
 // returns an array of strings for each of the columns in the table
 DatablockStorage.getColumnsForTable = function (tableName, tableType) {
-  _fetch('get_columns_for_table', 'GET', {
-    table_name: tableName,
-  });
-  throw 'Not implemented yet';
+  return getColumnsForTable(tableName);
 };
 
 // @return {Promise<boolean>} whether the project channelID (configured at initFirebaseStorage) exists

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -46,9 +46,6 @@ class DatablockStorageController < ApplicationController
     table = DatablockStorageTable.where(channel_id: params[:channel_id], table_name: params[:table_name]).first_or_create
     table.create_records([record_json])
 
-    # FIXME: unfirebase, must check Table record to see if we should update the table.columns
-    # column based on this record_json's keys
-
     render json: record_json
   end
 
@@ -87,8 +84,11 @@ class DatablockStorageController < ApplicationController
   def update_record
     raise "record_json must be less than 4096 bytes" if params[:record_json].length > 4096
 
-    # FIXME: unfirebase, must check Table record to see if we should update the table.columns
-    # column based on this record_json's keys
+    # FIXME: datablock/use-column-defs
+    # When we update a record, we need to check the Table.columns field, and see if
+    # we need to add new columns that are contained in the records but not in  Table.columns yet
+    #
+    # Also, we should extract this logic and move it to DatablockStorageTable.update_record instead
 
     record = DatablockStorageRecord.find_by(channel_id: params[:channel_id], table_name: params[:table_name], record_id: params[:record_id])
     if record
@@ -129,7 +129,8 @@ class DatablockStorageController < ApplicationController
   def create_table
     table_name = params[:table_name]
     table = DatablockStorageTable.where(channel_id: params[:channel_id], table_name: table_name).first_or_create
-    # FIXME: unfirebase, what is the table already existed and had columns? Won't this overwrite them?
+    # FIXME: unfirebase, what if the table already existed and had columns? Won't this overwrite them?
+    # FIXME: datablock/use-column-defs look into this
     table.columns = '["id"]'
     table.save!
 

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -131,7 +131,7 @@ class DatablockStorageController < ApplicationController
     table = DatablockStorageTable.where(channel_id: params[:channel_id], table_name: table_name).first_or_create
     # FIXME: unfirebase, what if the table already existed and had columns? Won't this overwrite them?
     # FIXME: datablock/use-column-defs look into this
-    table.columns = '["id"]'
+    table.columns = ["id"]
     table.save!
 
     render json: true
@@ -156,10 +156,8 @@ class DatablockStorageController < ApplicationController
     column_name = params[:column_name]
 
     table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
-    columns = JSON.parse(table.columns)
-    unless columns.include? column_name
-      columns << column_name
-      table.columns = columns.to_json
+    unless table.columns.include? column_name
+      table.columns << column_name
       table.save!
     end
 
@@ -175,10 +173,8 @@ class DatablockStorageController < ApplicationController
     end
 
     table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
-    columns = JSON.parse(table.columns)
-    if columns.include? column_name
-      columns.delete column_name
-      table.columns = columns.to_json
+    if table.columns.include? column_name
+      table.columns.delete column_name
       table.save!
     end
 
@@ -190,7 +186,6 @@ class DatablockStorageController < ApplicationController
     new_column_name = params[:new_column_name]
 
     table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
-    columns = JSON.parse(table.columns)
 
     # First rename the column in all the JSON records
     DatablockStorageRecord.where(channel_id: params[:channel_id], table_name: params[:table_name]).each do |record|
@@ -199,8 +194,7 @@ class DatablockStorageController < ApplicationController
     end
 
     # Second rename the column in the table definition
-    columns = columns.map {|column| column == old_column_name ? new_column_name : column}
-    table.columns = columns.to_json
+    table.columns = table.columns.map {|column| column == old_column_name ? new_column_name : column}
     table.save!
 
     render json: true
@@ -268,7 +262,7 @@ class DatablockStorageController < ApplicationController
 
   def get_columns_for_table
     table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
-    render json: JSON.parse(table.columns)
+    render json: table.columns
   end
 
   # Returns true if validation checks pass

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -130,9 +130,6 @@ class DatablockStorageController < ApplicationController
   def create_table
     table_name = params[:table_name]
     table = DatablockStorageTable.where(channel_id: params[:channel_id], table_name: table_name).first_or_create
-    # FIXME: unfirebase, what if the table already existed and had columns? Won't this overwrite them?
-    # FIXME: datablock/use-column-defs look into this
-    table.columns = ["id"]
     table.save!
 
     render json: true

--- a/dashboard/app/models/datablock_storage_record.rb
+++ b/dashboard/app/models/datablock_storage_record.rb
@@ -13,4 +13,5 @@
 #
 class DatablockStorageRecord < ApplicationRecord
   self.primary_keys = :channel_id, :table_name, :record_id
+  belongs_to :table, class_name: 'DatablockStorageTable', foreign_key: [:channel_id, :table_name]
 end

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -12,6 +12,7 @@
 class DatablockStorageTable < ApplicationRecord
   self.primary_keys = :channel_id, :table_name
   has_many :records, class_name: 'DatablockStorageRecord', foreign_key: [:channel_id, :table_name]
+  after_initialize -> {self.columns ||= ['id']}, if: :new_record?
 
   def self.add_shared_table(channel_id, table_name)
     unless DatablockStorageTable.exists?(channel_id: "shared", table_name: table_name)

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -53,7 +53,7 @@ class DatablockStorageTable < ApplicationRecord
       end
 
       # Preserve the old column's order while adding any new columns
-      self.columns = columns + (cols_in_records - columns).to_a
+      self.columns += (cols_in_records - columns).to_a
       save!
     end
     # COMMIT;

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -20,6 +20,11 @@ class DatablockStorageTable < ApplicationRecord
   end
 
   def create_records(record_jsons)
+
+    # FIXME: datablock/use-column-defs
+    # When we create a record, we need to check the Table.columns field, and see if
+    # we need to add new columns that are contained in the records but not in  Table.columns yet
+
     # BEGIN;
     DatablockStorageRecord.transaction do
       # channel_id_quoted = Record.connection.quote(params[:channel_id])

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -11,6 +11,7 @@
 #
 class DatablockStorageTable < ApplicationRecord
   self.primary_keys = :channel_id, :table_name
+  has_many :records, class_name: 'DatablockStorageRecord', foreign_key: [:channel_id, :table_name]
 
   def self.add_shared_table(channel_id, table_name)
     unless DatablockStorageTable.exists?(channel_id: "shared", table_name: table_name)


### PR DESCRIPTION
We have a schema for defining columns, `DataStorageTable.columns`, but our current controller code is a mix of using this schema item, and inferring the column names from the actual records. This PR will switch us all the way over to using the columns schema.

Fixes https://github.com/code-dot-org/code-dot-org/issues/56463

