### PR TITLE
DatablockStorage: switch to fat models

### DIFF
--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -138,7 +138,9 @@ DatablockStorage.updateRecord = function (
     table_name: tableName,
     record_id: record.id,
     record_json: JSON.stringify(record),
-  }).then(onSuccess, onError);
+  }).then((record) => {
+    onSuccess(record, !!record)
+  }, onError);
 };
 
 /**

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -469,4 +469,8 @@ export function initDatablockStorage(config) {
   return DatablockStorage;
 }
 
+// FIXME: unfirebase, remove this before merging PR
+console.warn("Setting window.DatablockStorage for easier debugging, turn off before merging PR");
+window.DatablockStorage = DatablockStorage;
+
 export default DatablockStorage;

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -170,7 +170,7 @@ class DatablockStorageController < ApplicationController
 
   def get_columns_for_table
     table = find_table
-    render json: table.columns
+    render json: table.get_columns
   end
 
   # Returns true if validation checks pass

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -139,13 +139,9 @@ class DatablockStorageController < ApplicationController
   end
 
   def add_column
-    column_name = params[:column_name]
-
     table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
-    unless table.columns.include? column_name
-      table.columns << column_name
-      table.save!
-    end
+    table.add_column params[:column_name]
+    table.save!
 
     render json: true
   end

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -163,18 +163,9 @@ class DatablockStorageController < ApplicationController
   end
 
   def delete_column
-    column_name = params[:column_name]
-
-    DatablockStorageRecord.where(channel_id: params[:channel_id], table_name: params[:table_name]).each do |record|
-      record.record_json.delete(column_name)
-      record.save!
-    end
-
     table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
-    if table.columns.include? column_name
-      table.columns.delete column_name
-      table.save!
-    end
+    table.delete_column(params[:column_name])
+    table.save!
 
     render json: true
   end

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -175,9 +175,9 @@ class DatablockStorageController < ApplicationController
   end
 
   def import_csv
-    records = CSV.parse(params[:table_data_csv], headers: true).map(&:to_h)
     table = DatablockStorageTable.where(channel_id: params[:channel_id], table_name: params[:table_name]).first_or_create
-    table.create_records(records)
+    table.import_csv(params[:table_data_csv])
+    table.save!
 
     render json: true
   end

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -20,7 +20,7 @@ class DatablockStorageController < ApplicationController
   def set_key_value
     raise "value must be less than 4096 bytes" if params[:value].length > 4096
     value = JSON.parse params[:value]
-    DatablockStorageKvp.set_kvp(params[:channel_id], params[:key], value)
+    DatablockStorageKvp.set_kvp params[:channel_id], params[:key], value
     render json: {key: params[:key], value: value}
   end
 
@@ -44,7 +44,8 @@ class DatablockStorageController < ApplicationController
     record_json = JSON.parse params[:record_json]
 
     table = DatablockStorageTable.where(channel_id: params[:channel_id], table_name: params[:table_name]).first_or_create
-    table.create_records([record_json])
+    table.create_records [record_json]
+    table.save!
 
     render json: record_json
   end
@@ -85,7 +86,7 @@ class DatablockStorageController < ApplicationController
     raise "record_json must be less than 4096 bytes" if params[:record_json].length > 4096
 
     table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
-    record_json = table.update_record(params[:record_id], JSON.parse(params[:record_json]))
+    record_json = table.update_record params[:record_id], JSON.parse(params[:record_json])
     table.save!
 
     render json: record_json
@@ -148,7 +149,7 @@ class DatablockStorageController < ApplicationController
 
   def delete_column
     table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
-    table.delete_column(params[:column_name])
+    table.delete_column params[:column_name]
     table.save!
 
     render json: true
@@ -156,7 +157,7 @@ class DatablockStorageController < ApplicationController
 
   def rename_column
     table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
-    table.rename_column(params[:old_column_name], params[:new_column_name])
+    table.rename_column params[:old_column_name], params[:new_column_name]
     table.save!
 
     render json: true
@@ -164,7 +165,7 @@ class DatablockStorageController < ApplicationController
 
   def coerce_column
     table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
-    table.coerce_column(params[:column_name], params[:column_type])
+    table.coerce_column params[:column_name], params[:column_type]
     table.save!
 
     render json: true
@@ -172,7 +173,7 @@ class DatablockStorageController < ApplicationController
 
   def import_csv
     table = DatablockStorageTable.where(channel_id: params[:channel_id], table_name: params[:table_name]).first_or_create
-    table.import_csv(params[:table_data_csv])
+    table.import_csv params[:table_data_csv]
     table.save!
 
     render json: true
@@ -186,16 +187,16 @@ class DatablockStorageController < ApplicationController
   end
 
   def populate_tables
-    tables_json = JSON.parse(params[:tables_json])
+    tables_json = JSON.parse params[:tables_json]
     tables_json.each do |table_name, records|
       table = DatablockStorageTable.where(channel_id: params[:channel_id], table_name: table_name).first_or_create
-      table.create_records(records)
+      table.create_records records
     end
     render json: true
   end
 
   def populate_key_values
-    key_values_json = JSON.parse(params[:key_values_json])
+    key_values_json = JSON.parse params[:key_values_json]
     raise "key_values_json must be a hash" unless key_values_json.is_a? Hash
     DatablockStorageKvp.set_kvps(params[:channel_id], key_values_json)
     render json: true
@@ -225,7 +226,7 @@ class DatablockStorageController < ApplicationController
   end
 
   def add_shared_table
-    DatablockStorageTable.add_shared_table(params[:channel_id], params[:table_name])
+    DatablockStorageTable.add_shared_table params[:channel_id], params[:table_name]
   end
 
   private

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -166,31 +166,10 @@ class DatablockStorageController < ApplicationController
     render json: true
   end
 
-  def _coerce_type(value, column_type)
-    case column_type
-    when 'string'
-      value.to_s
-    when 'number'
-      value.to_f
-    when 'boolean'
-      value.to_b
-    end
-  end
-
   def coerce_column
-    table_name = params[:table_name]
-    column_name = params[:column_name]
-    column_type = params[:column_type]
-
-    unless ['string', 'number', 'boolean'].include? column_type
-      raise "column_type must be one of: string, number, boolean"
-    end
-
-    DatablockStorageRecord.where(channel_id: params[:channel_id], table_name: table_name).each do |record|
-      # column type is one of: string, number, boolean, date
-      record.record_json[column_name] = _coerce_type(record.record_json[column_name], column_type)
-      record.save!
-    end
+    table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
+    table.coerce_column(params[:column_name], params[:column_type])
+    table.save!
 
     render json: true
   end

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -180,19 +180,8 @@ class DatablockStorageController < ApplicationController
   end
 
   def rename_column
-    old_column_name = params[:old_column_name]
-    new_column_name = params[:new_column_name]
-
     table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
-
-    # First rename the column in all the JSON records
-    DatablockStorageRecord.where(channel_id: params[:channel_id], table_name: params[:table_name]).each do |record|
-      record.record_json[new_column_name] = record.record_json.delete(old_column_name)
-      record.save!
-    end
-
-    # Second rename the column in the table definition
-    table.columns = table.columns.map {|column| column == old_column_name ? new_column_name : column}
+    table.rename_column(params[:old_column_name], params[:new_column_name])
     table.save!
 
     render json: true

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -85,22 +85,10 @@ class DatablockStorageController < ApplicationController
     raise "record_json must be less than 4096 bytes" if params[:record_json].length > 4096
 
     table = DatablockStorageTable.find([params[:channel_id], params[:table_name]])
+    record_json = table.update_record(params[:record_id], JSON.parse(params[:record_json]))
+    table.save!
 
-    record = DatablockStorageRecord.find_by(channel_id: params[:channel_id], table_name: params[:table_name], record_id: params[:record_id])
-    if record
-      record_json = JSON.parse params[:record_json]
-      record_json['id'] = params[:record_id].to_i
-      record.record_json = record_json
-      record.save!
-
-      # update the table columns with any new JSON fields
-      table.columns += (record_json.keys.to_set - table.columns).to_a
-      table.save!
-
-      render json: record_json
-    else
-      render json: nil
-    end
+    render json: record_json
   end
 
   def delete_record

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -140,14 +140,6 @@ class DatablockStorageController < ApplicationController
     render json: true
   end
 
-  def import_csv
-    table = table_or_create
-    table.import_csv params[:table_data_csv]
-    table.save!
-
-    render json: true
-  end
-
   def delete_key_value
     key = params[:key]
     DatablockStorageKvp.where(channel_id: params[:channel_id], key: key).delete_all
@@ -157,10 +149,15 @@ class DatablockStorageController < ApplicationController
 
   def populate_tables
     tables_json = JSON.parse params[:tables_json]
-    tables_json.each do |table_name, records|
-      table = DatablockStorageTable.where(channel_id: params[:channel_id], table_name: table_name).first_or_create
-      table.create_records records
-    end
+    DatablockStorageTable.populate_tables params[:channel_id], tables_json
+    render json: true
+  end
+
+  def import_csv
+    table = table_or_create
+    table.import_csv params[:table_data_csv]
+    table.save!
+
     render json: true
   end
 

--- a/dashboard/app/models/datablock_storage_record.rb
+++ b/dashboard/app/models/datablock_storage_record.rb
@@ -13,5 +13,8 @@
 #
 class DatablockStorageRecord < ApplicationRecord
   self.primary_keys = :channel_id, :table_name, :record_id
-  belongs_to :table, class_name: 'DatablockStorageTable', foreign_key: [:channel_id, :table_name]
+
+  # Enabling this was adding an extra `SELECT `datablock_storage_tables`.*` query to update_record
+  # and we aren't using it, soooo...
+  # belongs_to :table, class_name: 'DatablockStorageTable', foreign_key: [:channel_id, :table_name]
 end

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -60,6 +60,20 @@ class DatablockStorageTable < ApplicationRecord
     # COMMIT;
   end
 
+  def update_record(record_id, record_json)
+    record = records.find_by(record_id: record_id)
+    return unless record
+
+    record_json['id'] = record_id.to_i
+    record.record_json = record_json
+    record.save!
+
+    # update the table columns with any new JSON fields
+    self.columns += (record_json.keys.to_set - columns).to_a
+
+    return record_json
+  end
+
   def delete_column(column_name)
     records.each do |record|
       record.record_json.delete(column_name)

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -50,7 +50,7 @@ class DatablockStorageTable < ApplicationRecord
   # end
 
   def read_records
-    # FIXME: is_shared_table, lookup that table and return its read_records instead
+    # FIXME: is_shared_table, read from shared_table
     return records
   end
 
@@ -118,6 +118,11 @@ class DatablockStorageTable < ApplicationRecord
   def import_csv(table_data_csv)
     records = CSV.parse(table_data_csv, headers: true).map(&:to_h)
     create_records(records)
+  end
+
+  def get_columns
+    # FIXME: is_shared_table, read from shared_table
+    return columns
   end
 
   def add_column(column_name)

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -79,6 +79,11 @@ class DatablockStorageTable < ApplicationRecord
     create_records(records)
   end
 
+  def add_column(column_name)
+    unless columns.include? column_name
+      self.columns << column_name
+    end
+  end
 
   def delete_column(column_name)
     records.each do |record|

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -21,6 +21,26 @@ class DatablockStorageTable < ApplicationRecord
     DatablockStorageTable.create!(channel_id: channel_id, table_name: table_name, is_shared_table: true)
   end
 
+  # This would require MySQL option MULTI_STATEMENTS set on the connection, which
+  # has lots of pitfalls and isn't particularly well supported with the mysql2 gem
+  # See: https://github.com/rails/rails/issues/31569
+  #
+  # def create_record_one_round_trip
+  #   channel_id_quoted = Record.connection.quote(params[:channel_id])
+  #   table_name_quoted = Record.connection.quote(params[:table_name])
+  #   json_quoted  = Record.connection.quote JSON.parse params[:json]
+  #   record_json = Record.find_by_sql(<<-SQL
+  #     BEGIN;
+  #       SELECT MIN(record_id) FROM #{Record.table_name} WHERE channel_id=#{channel_id_quoted} AND table_name=#{table_name_quoted} LIMIT 1 FOR UPDATE;
+  #       SELECT @id := IFNULL(MAX(record_id),0)+1 FROM #{Record.table_name} WHERE channel_id=#{channel_id_quoted} AND table_name=#{table_name_quoted};
+  #       INSERT INTO #{Record.table_name} VALUES (#{channel_id_quoted}, #{table_name_quoted}, @id, #{json_quoted}});
+  #     END;
+  #     SELECT * FROM #{Record.table_name} WHERE channel_id=#{channel_id_quoted} AND table_name=#{table_name_quoted} AND record_id=@id;
+  #   SQL)
+
+  #   render json: record_json
+  # end
+
   def create_records(record_jsons)
     # BEGIN;
     DatablockStorageRecord.transaction do

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -21,6 +21,14 @@ class DatablockStorageTable < ApplicationRecord
     DatablockStorageTable.create!(channel_id: channel_id, table_name: table_name, is_shared_table: true)
   end
 
+  def self.populate_tables(channel_id, tables_json)
+    tables_json.each do |table_name, records|
+      table = DatablockStorageTable.where(channel_id: channel_id, table_name: table_name).first_or_create
+      table.create_records records
+      table.save!
+    end
+  end
+
   # This would require MySQL option MULTI_STATEMENTS set on the connection, which
   # has lots of pitfalls and isn't particularly well supported with the mysql2 gem
   # See: https://github.com/rails/rails/issues/31569
@@ -108,8 +116,6 @@ class DatablockStorageTable < ApplicationRecord
   end
 
   def import_csv(table_data_csv)
-    # FIXME: is_shared_table, copy-on-write goes here
-
     records = CSV.parse(table_data_csv, headers: true).map(&:to_h)
     create_records(records)
   end

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -74,6 +74,12 @@ class DatablockStorageTable < ApplicationRecord
     return record_json
   end
 
+  def import_csv(table_data_csv)
+    records = CSV.parse(table_data_csv, headers: true).map(&:to_h)
+    create_records(records)
+  end
+
+
   def delete_column(column_name)
     records.each do |record|
       record.record_json.delete(column_name)

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -41,7 +41,14 @@ class DatablockStorageTable < ApplicationRecord
   #   render json: record_json
   # end
 
+  def read_records
+    # FIXME: is_shared_table, lookup that table and return its read_records instead
+    return records
+  end
+
   def create_records(record_jsons)
+    # FIXME: is_shared_table, copy-on-write goes here
+
     # BEGIN;
     DatablockStorageRecord.transaction do
       # channel_id_quoted = Record.connection.quote(params[:channel_id])
@@ -81,6 +88,8 @@ class DatablockStorageTable < ApplicationRecord
   end
 
   def update_record(record_id, record_json)
+    # FIXME: is_shared_table, copy-on-write goes here
+
     record = records.find_by(record_id: record_id)
     return unless record
 
@@ -94,18 +103,28 @@ class DatablockStorageTable < ApplicationRecord
     return record_json
   end
 
+  def delete_record(record_id)
+    records.find_by(record_id: record_id).delete
+  end
+
   def import_csv(table_data_csv)
+    # FIXME: is_shared_table, copy-on-write goes here
+
     records = CSV.parse(table_data_csv, headers: true).map(&:to_h)
     create_records(records)
   end
 
   def add_column(column_name)
+    # FIXME: is_shared_table, copy-on-write goes here
+
     unless columns.include? column_name
       self.columns << column_name
     end
   end
 
   def delete_column(column_name)
+    # FIXME: is_shared_table, copy-on-write goes here
+
     records.each do |record|
       record.record_json.delete(column_name)
     end
@@ -114,6 +133,8 @@ class DatablockStorageTable < ApplicationRecord
   end
 
   def rename_column(old_column_name, new_column_name)
+    # FIXME: is_shared_table, copy-on-write goes here
+
     # First rename the column in all the JSON records
     records.each do |record|
       record.record_json[new_column_name] = record.record_json.delete(old_column_name)
@@ -135,6 +156,8 @@ class DatablockStorageTable < ApplicationRecord
   end
 
   def coerce_column(column_name, column_type)
+    # FIXME: is_shared_table, copy-on-write goes here
+
     unless ['string', 'number', 'boolean'].include? column_type
       raise "column_type must be one of: string, number, boolean"
     end

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -60,6 +60,14 @@ class DatablockStorageTable < ApplicationRecord
     # COMMIT;
   end
 
+  def delete_column(column_name)
+    records.each do |record|
+      record.record_json.delete(column_name)
+    end
+
+    self.columns.delete column_name
+  end
+
   def rename_column(old_column_name, new_column_name)
     # First rename the column in all the JSON records
     records.each do |record|

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -91,4 +91,26 @@ class DatablockStorageTable < ApplicationRecord
     # Second rename the column in the table definition
     self.columns = columns.map {|column| column == old_column_name ? new_column_name : column}
   end
+
+  def _coerce_type(value, column_type)
+    case column_type
+    when 'string'
+      value.to_s
+    when 'number'
+      value.to_f
+    when 'boolean'
+      value.to_b
+    end
+  end
+
+  def coerce_column(column_name, column_type)
+    unless ['string', 'number', 'boolean'].include? column_type
+      raise "column_type must be one of: string, number, boolean"
+    end
+
+    records.each do |record|
+      # column type is one of: string, number, boolean, date
+      record.record_json[column_name] = _coerce_type(record.record_json[column_name], column_type)
+    end
+  end
 end


### PR DESCRIPTION
This PR refactors many fat methods on the DatablockStorageController to instead be located on the DatablockStorageTable model. This is important because it will permit us to do the shared table Copy-On-Write semantics inside the model, without the controller having to know about it.
