### PR TITLE
Redirected-Read and Copy-On-Write support makes Shared Tables Work

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -834,18 +834,24 @@ async function initDataTab(levelOptions) {
         if (!datasetInfo) {
           // We don't know what this table is, we should just skip it.
           console.warn(`unknown table ${table}`);
-        } else if (datasetInfo.current) {
-          Applab.storage.addCurrentTableToProject(
-            table,
-            () => console.log('success'),
-            outputError
-          );
         } else {
-          Applab.storage.copyStaticTable(
-            table,
-            () => console.log('success'),
-            outputError
-          );
+          if (isFirebaseStorage()) {
+            if (datasetInfo.current) {
+              Applab.storage.addCurrentTableToProject(
+                table,
+                () => console.log('success'),
+                outputError
+              );
+            } else {
+              Applab.storage.copyStaticTable(
+                table,
+                () => console.log('success'),
+                outputError
+              );
+            }
+          } else {
+            Applab.storage.addSharedTable(table);
+          }
         }
       });
     }

--- a/apps/src/storage/GetColumnParamPicker.jsx
+++ b/apps/src/storage/GetColumnParamPicker.jsx
@@ -5,6 +5,7 @@ import color from '../util/color';
 import {getStore} from '@cdo/apps/redux';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import fontConstants from '@cdo/apps/fontConstants';
+import { isFirebaseStorage } from './storage';
 
 export const ParamType = {
   TABLE: 'TABLE',
@@ -24,11 +25,10 @@ export default class GetColumnParamPicker extends React.Component {
   componentDidMount() {
     if (this.props.param === ParamType.COLUMN) {
       const reduxState = getStore().getState();
+      // Only firebase needs tableType, datablock storage checks on the backend
+      const tableType = isFirebaseStorage() ? reduxState.data.tableListMap[this.props.table] : undefined;
       Applab.storage
-        .getColumnsForTable(
-          this.props.table,
-          reduxState.data.tableListMap[this.props.table]
-        )
+        .getColumnsForTable(this.props.table, tableType)
         .then(columns => this.setState({columns: columns}));
     }
   }

--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -8,11 +8,12 @@ import SearchBar from '@cdo/apps/templates/SearchBar';
 import {getDatasetInfo} from './dataUtils';
 import msg from '@cdo/locale';
 import PreviewModal from './PreviewModal';
-import {storageBackend} from '../storage';
+import {isFirebaseStorage, storageBackend} from '../storage';
 import {WarningType} from '../constants';
 import experiments from '../../util/experiments';
 import _ from 'lodash';
 import style from './data-library-pane.module.scss';
+import { refreshCurrentDataView } from './loadDataForView';
 
 class DataLibraryPane extends React.Component {
   static propTypes = {
@@ -35,19 +36,24 @@ class DataLibraryPane extends React.Component {
   };
 
   importTable = datasetInfo => {
-    if (datasetInfo.current) {
-      storageBackend().addCurrentTableToProject(
-        // TODO: unfirebase
-        datasetInfo.name,
-        () => {},
-        this.onError
-      );
+    if (isFirebaseStorage()) {
+      if (datasetInfo.current) {
+        storageBackend().addCurrentTableToProject(
+          // TODO: unfirebase
+          datasetInfo.name,
+          () => {},
+          this.onError
+        );
+      } else {
+        storageBackend().copyStaticTable(
+          datasetInfo.name,
+          () => {},
+          this.onError
+        ); // TODO: unfirebase
+      }
     } else {
-      storageBackend().copyStaticTable(
-        datasetInfo.name,
-        () => {},
-        this.onError
-      ); // TODO: unfirebase
+      storageBackend().addSharedTable(datasetInfo.name);
+      refreshCurrentDataView();
     }
   };
 

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -346,8 +346,10 @@ DatablockStorage.getLibraryManifest = function () {
 };
 
 // returns an array of strings for each of the columns in the table
-DatablockStorage.getColumnsForTable = function (tableName, tableType) {
-  return getColumnsForTable(tableName);
+// Note this diverges a little from the F*rebase version, which takes a tableType param
+// which we do not need since we implement this on the backend.
+DatablockStorage.getColumnsForTable = function (tableName) {
+  return getColumnsForTable({tableName});
 };
 
 // @return {Promise<boolean>} whether the project channelID (configured at initF*rebaseStorage) exists

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -342,7 +342,52 @@ DatablockStorage.populateKeyValue = function (jsonData, onSuccess, onError) {
 
 // gets a list of all the shared or current tables available in the data browser
 DatablockStorage.getLibraryManifest = function () {
-  return getTableNames();
+  return getTableNames({isSharedTable: true}).then(tableNames => {
+    console.log('FOUND SHARED TABLES', tableNames);
+    // FIXME, unfirebase, we don't have this implemented yet
+    // see: issue on implementing the library manifest system here:
+    // https://github.com/code-dot-org/code-dot-org/issues/56472
+    const EXAMPLE_MANIFEST_FROM_FIREBASE = {
+      categories: [
+        {
+          datasets: [
+            '100 Birds of the World',
+            'Bee Colonies',
+            'Cats',
+            'Dogs',
+            'Endangered Species of Canada',
+            'Palmer Penguins',
+          ],
+          name: 'Animals',
+          published: true,
+        },
+      ],
+      tables: [
+        {
+          current: false,
+          description:
+            'Data and images about 100 different species of birds around the world',
+          docUrl: 'https://studio.code.org/data_docs/100-birds/',
+          name: '100 Birds of the World',
+          published: true,
+        },
+        {
+          current: true,
+          description:
+            'Live weather five-day forecast data for 100 cities. Updates daily with expected weather conditions.',
+          docUrl: 'https://studio.code.org/data_docs/daily-weather/',
+          lastUpdated: 1707480317000,
+          name: 'Daily Weather',
+          published: true,
+        },
+      ],
+    };
+    console.error(
+      'DatablockStorage.getLibraryManifest is NOT IMPLEMENTED YET, returning stock EXAMPLE_MANIFEST_FROM_FIREBASE:',
+      EXAMPLE_MANIFEST_FROM_FIREBASE
+    );
+    return EXAMPLE_MANIFEST_FROM_FIREBASE;
+  });
 };
 
 // returns an array of strings for each of the columns in the table
@@ -364,6 +409,10 @@ DatablockStorage.clearAllData = function (onSuccess, onError) {
 };
 
 // FIXME: unfirebase, remove this before merging PR
+//
+// See issue about implementing the library manifest system here:
+// https://github.com/code-dot-org/code-dot-org/issues/56472
+//
 // Current tables are live updated, the data is NOT copied into
 // the student project, instead a new type of f*rebase node is created
 // like /v3/channels/NZfs8i-ivpdJe_CXtPfHtOCssNIRTY1oKd5uXfSiuyI/current_tables/Daily Weather

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -372,7 +372,27 @@ DatablockStorage.clearAllData = function (onSuccess, onError) {
 //
 // Current tables can be found in https://console.firebase.google.com/project/cdo-v3-shared/database/cdo-v3-shared/data/~2Fv3~2Fchannels~2Fshared~2Fmetadata~2Fmanifest~2Ftables
 // where the table has `current: true` set in the manifest object
-DatablockStorage.addCurrentTableToProject = function (
+// DatablockStorage.addCurrentTableToProject = function (
+//   tableName,
+//   onSuccess,
+//   onError
+// ) {
+//   _fetch('add_shared_table', 'POST', {
+//     table_name: tableName,
+//   }).then(onSuccess, onError);
+// };
+//
+// Makes a project-local copy of one of the tables stored at /v3/channels/shared/storage/tables
+// DatablockStorage.copyStaticTable = function (tableName, onSuccess, onError) {
+//   // We don't differentiate between static and current shared tables
+//   // they are both just pointers to the 'shared' channel's tables.
+//   _fetch('add_shared_table', 'POST', {
+//     table_name: tableName,
+//   }).then(onSuccess, onError);
+// };
+
+// This is a new method for DatablockStorage which replaces the above APIs
+DatablockStorage.addSharedTable = function (
   tableName,
   onSuccess,
   onError

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -159,8 +159,10 @@ DatablockStorage.deleteRecord = function (
   }).then(onSuccess, onError);
 };
 
-async function getTableNames() {
-  const response = await _fetch('get_table_names', 'GET', {});
+async function getTableNames({isSharedTable = false}={}) {
+  const response = await _fetch('get_table_names', 'GET', {
+    is_shared_table: isSharedTable,
+  });
   return await response.json();
 }
 
@@ -169,8 +171,11 @@ DatablockStorage.getTableNames = function () {
   return getTableNames();
 };
 
-async function getColumnsForTable(tableName) {
-  const response = await _fetch('get_columns_for_table', 'GET', {table_name: tableName});
+async function getColumnsForTable({tableName,isSharedTable = false}) {
+  const response = await _fetch('get_columns_for_table', 'GET', {
+    table_name: tableName,
+    is_shared_table: isSharedTable,
+  });
   const json = await response.json();
   return json;
 }
@@ -182,7 +187,7 @@ function loadTableAndColumns({
   onRecordsChanged,
 }) {
   readRecords({tableName, isSharedTable}).then(records => {
-    getColumnsForTable(tableName).then(onColumnsChanged)
+    getColumnsForTable({tableName, isSharedTable}).then(onColumnsChanged)
 
     // DataTableView.getTableJson() expects an array of JSON strings
     // which it then parses as JSON, and then stringifies again 🙈

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -451,15 +451,6 @@ DatablockStorage.addSharedTable = function (
   }).then(onSuccess, onError);
 };
 
-// Makes a project-local copy of one of the tables stored at /v3/channels/shared/storage/tables
-DatablockStorage.copyStaticTable = function (tableName, onSuccess, onError) {
-  // We don't differentiate between static and current shared tables
-  // they are both just pointers to the 'shared' channel's tables.
-  _fetch('add_shared_table', 'POST', {
-    table_name: tableName,
-  }).then(onSuccess, onError);
-};
-
 /* TESTING RELATED FUNCTIONS */
 
 // Deletes the entire database for the project, including data and config

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -561,6 +561,7 @@ FirebaseStorage.resetForTesting = function () {
 //
 // Current tables can be found in https://console.firebase.google.com/project/cdo-v3-shared/database/cdo-v3-shared/data/~2Fv3~2Fchannels~2Fshared~2Fmetadata~2Fmanifest~2Ftables
 // where the table has `current: true` set in the manifest object
+// FIXME: unfirebase, this method is not found in DatablockStorage
 FirebaseStorage.addCurrentTableToProject = function (
   tableName,
   onSuccess,
@@ -578,6 +579,7 @@ FirebaseStorage.addCurrentTableToProject = function (
     .then(onSuccess, onError);
 };
 
+// FIXME: unfirebase, this method is not found in DatablockStorage
 FirebaseStorage.copyStaticTable = function (tableName, onSuccess, onError) {
   return enforceUniqueTableNames(tableName)
     .then(incrementRateLimitCounters)

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -216,7 +216,7 @@ class DatablockStorageController < ApplicationController
   end
 
   def find_table_or_shared_table
-    is_shared_table? ?
+    shared_table? ?
       DatablockStorageTable.find_shared_table(params[:table_name]) :
       find_table
   end

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -91,8 +91,11 @@ class DatablockStorageController < ApplicationController
   end
 
   def get_table_names
-    # SELECT DISTINCT table_name FROM datablock_storage_records WHERE channel_id='{params[:channel_id]}';
-    render json: DatablockStorageTable.where(channel_id: params[:channel_id]).pluck(:table_name)
+    table_names = is_shared_table? ?
+      DatablockStorageTable.get_shared_table_names :
+      DatablockStorageTable.get_table_names(params[:channel_id])
+
+    render json: table_names
   end
 
   def populate_tables

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -77,15 +77,15 @@ class DatablockStorageController < ApplicationController
   end
 
   def clear_table
-    table_name = params[:table_name]
-    DatablockStorageRecord.where(channel_id: params[:channel_id], table_name: table_name).delete_all
+    table = find_table
+    table.records.delete_all
+    table.save!
 
     render json: true
   end
 
   def delete_table
-    where_table.delete_all
-    DatablockStorageRecord.where(channel_id: params[:channel_id], table_name: params[:table_name]).delete_all
+    find_table.destroy
 
     render json: true
   end

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -92,7 +92,7 @@ class DatablockStorageController < ApplicationController
 
   def get_table_names
     # SELECT DISTINCT table_name FROM datablock_storage_records WHERE channel_id='{params[:channel_id]}';
-    render json: DatablockStorageRecord.where(channel_id: params[:channel_id]).select(:table_name).distinct.pluck(:table_name)
+    render json: DatablockStorageTable.where(channel_id: params[:channel_id]).pluck(:table_name)
   end
 
   def populate_tables

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -11,7 +11,11 @@
 #
 class DatablockStorageTable < ApplicationRecord
   self.primary_keys = :channel_id, :table_name
-  has_many :records, autosave: true, class_name: 'DatablockStorageRecord', foreign_key: [:channel_id, :table_name]
+  has_many :records, autosave: true,
+    class_name: 'DatablockStorageRecord',
+    foreign_key: [:channel_id, :table_name],
+    dependent: :delete_all
+
   after_initialize -> {self.columns ||= ['id']}, if: :new_record?
 
   def self.add_shared_table(channel_id, table_name)


### PR DESCRIPTION
This PR implements support for is_shared_table. It both redirects any read operations to the other table, and it makes a copy of the shared_table in the local context whenever a write operation is attempted.

With this PR in place, it is now possible to use shared tables (including both "static tables" and "current tables").

What's missing is a library system, see https://github.com/code-dot-org/code-dot-org/issues/56472 for ongoing work.

Fixes #56145