### PR TITLE
Clean up references to removed questions

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -90,13 +90,6 @@ const ATTENDED_CSF_COURSES_OPTIONS = {
   'Nope, I have never attended a CS Fundamentals workshop.': 'No',
 };
 
-const REPLACE_EXISTING_OPTIONS = [
-  'Yes, this course will replace an existing computer science course',
-  'No, this course will be added to the schedule in addition to an existing computer science course',
-  'No, this will be the only computer science course on the master schedule',
-  'I don’t know',
-];
-
 export default class EnrollForm extends React.Component {
   static propTypes = {
     user_id: PropTypes.number.isRequired,
@@ -271,7 +264,6 @@ export default class EnrollForm extends React.Component {
       attended_csf_intro_workshop:
         ATTENDED_CSF_COURSES_OPTIONS[this.state.attended_csf_intro_workshop],
       previous_courses: this.state.previous_courses,
-      replace_existing: this.state.replace_existing,
       csf_intro_intent: this.state.csf_intro_intent,
       csf_intro_other_factors: this.state.csf_intro_other_factors,
       years_teaching: this.state.years_teaching,
@@ -661,27 +653,6 @@ export default class EnrollForm extends React.Component {
               errorText={this.state.errors.previous_courses}
               type="check"
               columnCount={2}
-            />
-
-            <ButtonList
-              id="replace_existing"
-              key="replace_existing"
-              answers={REPLACE_EXISTING_OPTIONS}
-              groupName="replace_existing"
-              label="Will this course replace an existing computer science course in the master schedule?"
-              onChange={this.handleChange}
-              selectedItems={this.state.replace_existing}
-              validationState={
-                Object.prototype.hasOwnProperty.call(
-                  this.state.errors,
-                  'replace_existing'
-                )
-                  ? VALIDATION_STATE_ERROR
-                  : null
-              }
-              errorText={this.state.errors.replace_existing}
-              type="radio"
-              columnCount={1}
             />
           </div>
         )}

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
@@ -286,10 +286,6 @@ describe('Enroll Form', () => {
       refute(enrollForm.exists('#previous_courses'));
     });
 
-    it('does not display replace existing question', () => {
-      refute(enrollForm.exists('#replace_existing'));
-    });
-
     it('does not display intent question', () => {
       refute(enrollForm.exists({groupName: 'csf_intro_intent'}));
     });
@@ -321,10 +317,6 @@ describe('Enroll Form', () => {
 
     it('does display previous courses question', () => {
       assert(enrollForm.exists('#previous_courses'));
-    });
-
-    it('does display replace existing question', () => {
-      assert(enrollForm.exists('#replace_existing'));
     });
 
     it('submits when all required params are present', () => {
@@ -371,7 +363,7 @@ describe('Enroll Form', () => {
       });
     });
 
-    ['role', 'previous_courses', 'replace_existing'].forEach(question => {
+    ['role', 'previous_courses'].forEach(question => {
       it('displays questions not relevant for this workshop type', () => {
         refute(enrollForm.exists('#' + question));
       });

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -130,7 +130,6 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
       csf_course_experience: params[:csf_course_experience],
       csf_courses_planned: params[:csf_courses_planned],
       previous_courses: params[:previous_courses],
-      replace_existing: params[:replace_existing],
       csf_intro_intent: params[:csf_intro_intent],
       csf_intro_other_factors: params[:csf_intro_other_factors],
       # params only collected in CSP returning teachers workshop

--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -243,7 +243,6 @@ class TestController < ApplicationController
       csa_how_offer: 'As an AP course',
       csa_phone_screen: 'Yes',
       csa_already_know: 'Yes',
-      replace_existing: 'No, this course will be added to the schedule in addition to an existing computer science course',
       pay_fee: 'Yes, my school/district would be able to pay the full program fee.'
     }
   end

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -2,7 +2,7 @@ class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
   attributes :id, :first_name, :last_name, :email, :alternate_email, :application_id, :district_name, :school, :role,
     :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
     :csf_courses_planned, :user_id, :attended,
-    :pre_workshop_survey, :previous_courses, :replace_existing, :attendances,
+    :pre_workshop_survey, :previous_courses, :attendances,
     :scholarship_status, :enrolled_date, :years_teaching, :years_teaching_cs, :taught_ap_before, :planning_to_teach_ap
 
   def user_id

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -275,7 +275,6 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
       years_teaching: "30",
       years_teaching_cs: "10",
       previous_courses: "I don’t have experience teaching any of these courses",
-      replace_existing: "I don’t know",
       csf_intro_other_factors: "I want to learn computer science concepts.",
       taught_ap_before: "Yes, AP CS Principles or AP CS A",
       planning_to_teach_ap: "Yes"

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -411,7 +411,6 @@ FactoryBot.define do
     pay_fee {Pd::Application::TeacherApplication.options[:pay_fee].first}
     enough_course_hours {Pd::Application::TeacherApplication.options[:enough_course_hours].first}
     completing_on_behalf_of_someone_else {'No'}
-    replace_existing {'No, this course will be added to the schedule in addition to an existing computer science course'}
     will_teach {'Yes'}
 
     trait :csp do

--- a/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
+++ b/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
@@ -10,7 +10,7 @@ class Api::V1::Pd::WorkshopEnrollmentSerializerTest < ActionController::TestCase
       :id, :first_name, :last_name, :email, :alternate_email, :application_id, :district_name, :school, :role,
       :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
       :csf_courses_planned, :user_id, :attended,
-      :pre_workshop_survey, :previous_courses, :replace_existing, :attendances,
+      :pre_workshop_survey, :previous_courses, :attendances,
       :scholarship_status, :enrolled_date, :years_teaching, :years_teaching_cs,
       :taught_ap_before, :planning_to_teach_ap
     ]

--- a/lib/cdo/shared_constants/pd/principal_approval_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/principal_approval_application_constants.rb
@@ -11,7 +11,6 @@ module Pd
       other_with_text: 'Other:'.freeze,
       other_please_explain: 'Other (Please Explain):'.freeze,
       dont_know_explain: "I don't know (Please Explain):".freeze,
-      yes_replace_existing_course: 'Yes, it will replace an existing computer science course'.freeze
     }.freeze
 
     PAGE_LABELS = {

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -135,7 +135,6 @@ module Pd
         white_percent: 'Percent of student enrollment by race: White',
         other_races_percent: 'Percent of student enrollment by race: Other',
         principal_approval: "Do you approve of <Teacher Name> participating in Code.org's #{YEAR} Professional Learning Program?",
-        principal_schedule_confirmed: "Are you committed to including Computer Science <Program> on the master schedule in #{YEAR} if <Teacher Name> is accepted into the program?",
       }
     }.freeze
 
@@ -238,12 +237,7 @@ module Pd
       principal_role: {teacher: :principal_role, principal: :principal_response_role},
       principal_email: {teacher: :principal_email, principal: :principal_response_email},
 
-      replace_existing: {teacher: :replace_existing, principal: :principal_wont_replace_existing_course},
-
       pay_fee: {teacher: :pay_fee, principal: :principal_pay_fee},
-
-      contact_invoicing: {principal: :principal_contact_invoicing},
-      contact_invoicing_detail: {principal: :principal_contact_invoicing_detail},
 
       title_i_status: {stats: :title_i_status},
       rural_status: {stats: :rural_status},


### PR DESCRIPTION
In https://github.com/code-dot-org/code-dot-org/pull/55191 and https://github.com/code-dot-org/code-dot-org/pull/55240, we removed a handful of questions from the teacher application and admin form. One of those questions was whether or not this course would replace an existing course, but I missed removing it from the application dashboard.

I also removed some references to invoicing data as we also removed that.