### PR TITLE
[Google Blockly] override createDef_ for behavior getters

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
@@ -7,6 +7,7 @@ import {behaviorDefMutator} from './mutators/behaviorDefMutator';
 import {behaviorGetMutator} from './mutators/behaviorGetMutator';
 import {BLOCK_TYPES} from '@cdo/apps/blockly/constants';
 import {behaviorCallerGetDefMixin} from './mixins/behaviorCallerGetDefMixin';
+import {behaviorCreateDefMixin} from './mixins/behaviorCreateDefMixin';
 
 /**
  * A dictionary of our custom procedure block definitions, used across labs.
@@ -96,8 +97,9 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedure_caller_update_shape_mixin',
       'procedure_caller_context_menu_mixin',
       'procedure_caller_onchange_mixin',
-      'procedure_callernoreturn_get_def_block_mixin',
+      'behavior_caller_get_def_block_mixin',
       'modal_procedures_no_destroy',
+      'behavior_create_def_mixin',
     ],
     mutator: 'behavior_get_mutator',
   },
@@ -183,6 +185,21 @@ GoogleBlockly.Extensions.registerMutator(
 GoogleBlockly.Extensions.register(
   'behavior_caller_get_def_mixin',
   behaviorCallerGetDefMixin
+);
+GoogleBlockly.Extensions.register(
+  'behavior_create_def_mixin',
+  behaviorCreateDefMixin
+);
+
+// Used by createDef_ to create a new definition block for an orphaned call block.
+// We need to supply a specific block type used for behavior definitions.
+const procedureCallerNoReturnGetDefBlockMixin = {
+  hasReturn_: false,
+  defType_: BLOCK_TYPES.behaviorDefinition,
+};
+GoogleBlockly.Extensions.registerMixin(
+  'behavior_caller_get_def_block_mixin',
+  procedureCallerNoReturnGetDefBlockMixin
 );
 
 /**

--- a/apps/src/blockly/customBlocks/googleBlockly/mixins/behaviorCreateDefMixin.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mixins/behaviorCreateDefMixin.js
@@ -1,0 +1,50 @@
+// This mixin's function is copied and modified from
+// https://github.com/google/blockly-samples/blob/7954a8fff50e41fa7c0f891e957bf9ed616361d6/plugins/block-shareable-procedures/src/blocks.ts#L1312
+// We need to override createDef_ so that it correctly assigns a behavior id matching
+// the orphaned call block that triggered its creation.
+// This should only be needed if a user had previously deleted a definition
+// block but not its call blocks, which was possible with CDO Blockly.
+// References to behaviorId properties are customizations.
+import {getAlphanumericId} from '@cdo/apps/utils';
+
+export const behaviorCreateDefMixin = function () {
+  const mixin = {
+    /**
+     * Creates a procedure definition block with the given name and params,
+     * and returns the procedure model associated with it.
+     *
+     * @param name The name of the procedure to create.
+     * @param params The names of the parameters to create.
+     * @returns The procedure model associated with the new
+     *     procedure definition block.
+     */
+    createDef_(name, params = []) {
+      const xy = this.getRelativeToSurfaceXY();
+      const newName = Blockly.Procedures.findLegalName(name, this);
+      this.renameProcedure(name, newName);
+
+      if (!this.behaviorId) {
+        this.behaviorId = getAlphanumericId();
+      }
+
+      const blockDef = {
+        type: this.defType_,
+        x: xy.x + Blockly.config.snapRadius * (this.RTL ? -1 : 1),
+        y: xy.y + Blockly.config.snapRadius * 2,
+        extraState: {
+          behaviorId: this.behaviorId,
+          params: params.map(p => ({name: p})),
+        },
+        fields: {NAME: newName},
+      };
+      const block = Blockly.serialization.blocks.append(
+        blockDef,
+        this.getTargetWorkspace_(),
+        {recordUndo: true}
+      );
+      return block.getProcedureModel();
+    },
+  };
+
+  this.mixin(mixin, true);
+};

--- a/apps/src/blockly/customBlocks/googleBlockly/mixins/behaviorCreateDefMixin.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mixins/behaviorCreateDefMixin.js
@@ -22,10 +22,7 @@ export const behaviorCreateDefMixin = function () {
       const xy = this.getRelativeToSurfaceXY();
       const newName = Blockly.Procedures.findLegalName(name, this);
       this.renameProcedure(name, newName);
-
-      if (!this.behaviorId) {
-        this.behaviorId = getAlphanumericId();
-      }
+      this.behaviorId = getAlphanumericId();
 
       const blockDef = {
         type: this.defType_,


### PR DESCRIPTION
Google Blockly will delete all associated behavior getters when a definition block is deleted using the modal editor. However, CDO Blockly would not, which would leave projects in a broken state:
https://studio.code.org/projects/spritelab/aiGNkdPEAO6KmFbI41EjPblPg2_FDGqEQ-GLCVVgnkc/view?blocklyVersion=cdo

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/5f04ae21-4d4d-46ef-a55b-e6f70e9aae5a)

Google Blockly handles this situation by dynamically creating a definition block for the procedure. Unfortunately, due to a missing override it was creating a function definition:
https://studio.code.org/projects/spritelab/aiGNkdPEAO6KmFbI41EjPblPg2_FDGqEQ-GLCVVgnkc/view?blocklyVersion=google

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/816b294d-f1e9-4c29-aa6c-5277f7adf771)

Because the new function definition doesn't have a behaviorId, the code generated for it doesn't match. 

 To handle loading a project in this state, we can override the block's `defType_` property and `createDef_` function. Our version will create the correct type of block and assign it a matching behavior Id so it can generate code. 

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/00ff719a-b7f2-4423-a60e-48f2b1b64e30)

In this one scenario, we end up creating the behavior definition on the _main_ workspace, which isn't normally possible. The student can either carry on or delete any unwanted blocks. If the new code is saved and reloaded, the new definition block gets moved to the hidden definition workspace as expected.

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/4a8a8f0e-94a1-475b-bc48-5b9ecf6ac0b0)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
