### PR TITLE
[Google Blockly] add behavior id when deserializing xml

### DIFF
--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -312,7 +312,7 @@ export function addNameToBlockFunctionCallBlock(blockElement) {
  *
  * @param {Element} blockElement - The XML element for a single block.
  */
-function addMissingBehaviorId(blockElement) {
+export function addMissingBehaviorId(blockElement, trace = 'local') {
   const blockType = blockElement.getAttribute('type');
   if (blockType === BLOCK_TYPES.behaviorGet) {
     const behaviorNameField =

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -312,7 +312,7 @@ export function addNameToBlockFunctionCallBlock(blockElement) {
  *
  * @param {Element} blockElement - The XML element for a single block.
  */
-export function addMissingBehaviorId(blockElement, trace = 'local') {
+export function addMissingBehaviorId(blockElement) {
   const blockType = blockElement.getAttribute('type');
   if (blockType === BLOCK_TYPES.behaviorGet) {
     const behaviorNameField =

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorGetMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorGetMutator.js
@@ -8,7 +8,7 @@ export const behaviorGetMutator = {
   paramsFromSerializedState_: [],
 
   domToMutation: function (element) {
-    addMissingBehaviorId(element.parentElement, 'domToMutation');
+    addMissingBehaviorId(element.parentElement);
     const name = element.nextElementSibling.textContent;
     this.behaviorId = element.nextElementSibling.getAttribute('id');
     this.deserialize_(name, []);

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorGetMutator.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/behaviorGetMutator.js
@@ -1,3 +1,4 @@
+import {addMissingBehaviorId} from '@cdo/apps/blockly/addons/cdoXml';
 import {commonFunctions} from './commonProcedureCallerMutator';
 import GoogleBlockly from 'blockly/core';
 
@@ -7,6 +8,7 @@ export const behaviorGetMutator = {
   paramsFromSerializedState_: [],
 
   domToMutation: function (element) {
+    addMissingBehaviorId(element.parentElement, 'domToMutation');
     const name = element.nextElementSibling.textContent;
     this.behaviorId = element.nextElementSibling.getAttribute('id');
     this.deserialize_(name, []);


### PR DESCRIPTION
In old levels with behavior blocks explicitly set in toolbox XML with no behavior ids. We add them to project source XML if needed, but I overlooked uncategorized toolboxes with behaviors. This causes us to be unable to generated code at the `block.behaviorId` ends up being `null`:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/8a7a1af0-7466-45e1-ad66-57db05a4a093)

We can fix this easily by calling our existing helper to add behavior ids during deserialization. Now the toolbox blocks have behavior ids and can be used as normal:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/59d3da0e-242a-4d44-9841-22adecaf3153)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
