### PR TITLE
[Google Blockly] Process toolbox XML

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2841,7 +2841,13 @@ StudioApp.prototype.handleUsingBlockly_ = function (config) {
   // replace it with a full toolbox. I think some levels may depend on this
   // behavior. We want a way to specify no toolbox, which is <xml></xml>
   if (config.level.toolbox) {
-    var toolboxWithoutWhitespace = config.level.toolbox.replace(/\s/g, '');
+    // Update CDO Blockly XML so it is compatible with mainline Google Blockly
+    // (Nothing is changed if we are using CDO Blockly.)
+    config.level.toolbox = Blockly.cdoUtils.processToolboxXml(
+      config.level.toolbox
+    );
+
+    const toolboxWithoutWhitespace = config.level.toolbox.replace(/\s/g, '');
     if (
       toolboxWithoutWhitespace === '<xml></xml>' ||
       toolboxWithoutWhitespace === '<xml/>'

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -21,7 +21,10 @@ import {
 } from './cdoSerializationHelpers';
 import {parseElement as parseXmlElement} from '../../xml';
 import * as blockUtils from '../../block_utils';
-import {getProjectXml} from '@cdo/apps/blockly/addons/cdoXml';
+import {
+  getProjectXml,
+  processIndividualBlock,
+} from '@cdo/apps/blockly/addons/cdoXml';
 
 /**
  * Loads blocks to a workspace.
@@ -455,4 +458,31 @@ export function appendSharedFunctions(startBlocksSource, functionsXml) {
     startBlocks = JSON.stringify(stateToLoad);
   }
   return startBlocks;
+}
+/**
+ * Update the XML string representing toolbox data for compatibility with
+ * Google Blockly.
+ * This function potentially modifies each <block> element in the XML
+ * if there are unsupported attributes, missing mutators, etc.
+ * We also process block xml during domToBlockSpace, which is called to
+ * convert sources from XML to JSON.
+ *
+ * @param {string} toolboxString - The XML string representing toolbox data.
+ * @returns {string} The modified XML string after processing.
+ */
+export function processToolboxXml(toolboxString) {
+  const parser = new DOMParser();
+  const xmlDoc = parser.parseFromString(toolboxString, 'text/xml');
+  const xmlRoot = xmlDoc.documentElement;
+  const blocks = Array.from(xmlRoot.childNodes).filter(
+    node => node.nodeName === 'block'
+  );
+
+  blocks.forEach(block => {
+    processIndividualBlock(block);
+  });
+
+  // Convert the modified XML document back to a string
+  const modifiedXmlString = new XMLSerializer().serializeToString(xmlDoc);
+  return modifiedXmlString;
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -473,7 +473,6 @@ export function appendSharedFunctions(startBlocksSource, functionsXml) {
 export function processToolboxXml(toolboxString) {
   const parser = new DOMParser();
   const xmlDoc = parser.parseFromString(toolboxString, 'text/xml');
-  const xmlRoot = xmlDoc.documentElement;
   if (xmlDoc.querySelector('parsererror')) {
     throw new Error('Error parsing XML');
   }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -474,13 +474,12 @@ export function processToolboxXml(toolboxString) {
   const parser = new DOMParser();
   const xmlDoc = parser.parseFromString(toolboxString, 'text/xml');
   const xmlRoot = xmlDoc.documentElement;
-  const blocks = Array.from(xmlRoot.childNodes).filter(
-    node => node.nodeName === 'block'
-  );
+  if (xmlDoc.querySelector('parsererror')) {
+    throw new Error('Error parsing XML');
+  }
 
-  blocks.forEach(block => {
-    processIndividualBlock(block);
-  });
+  const blocks = xmlDoc.querySelectorAll('block');
+  blocks.forEach(processIndividualBlock);
 
   // Convert the modified XML document back to a string
   const modifiedXmlString = new XMLSerializer().serializeToString(xmlDoc);

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -398,7 +398,7 @@ function processBlockAndChildren(block) {
  * Perform any need manipulations for a given XML block element.
  * @param {Element} block - The XML element for a single block.
  */
-function processIndividualBlock(block) {
+export function processIndividualBlock(block) {
   addNameToBlockFunctionCallBlock(block);
   addMissingBehaviorId(block);
   addMutationToBehaviorBlocks(block);

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -356,6 +356,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
         return source;
       }
     },
+    processToolboxXml(toolbox) {
+      return toolbox;
+    },
   };
   blocklyWrapper.customBlocks = customBlocks;
 


### PR DESCRIPTION
After flipping Sprite Lab to mainline Blockly, we noticed some levels were having new issues due to XML behavior blocks in flyouts not being created as expected. Unfortunately, this is because we weren't processing toolbox block XML with the same rigor as sources (start blocks or saved student code).

For example, `unnamed` behavior blocks were showing up at https://studio.code.org/s/express-2018/lessons/35/levels/4?no_redirect=true
due to to XML like this:
```
<block type="gamelab_behavior_get">
  <title name="VAR">spinning right</title>
</block>
```
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/fad09d95-0bcf-484b-a5e1-bd4664bc6a0e)

We can fix this and other similar issues by treating our toolbox XML with the same care given to sources.
After processing the xml, it looks how we'd expect, including `userCreated` and `behaviorId` attributes:
```
<block type="gamelab_behavior_get">
  <mutation userCreated="false" behaviorId="spinning right"/>
  <title name="VAR" id="spinning right">spinning right</title>
</block>
```
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/633dcd17-7c97-4ee9-8218-07e852b2a085)

Conveniently, this should resolve other issues unrelated to the level shown above. For example, it also fixes an issue that was potentially going to be addressed with 
- https://github.com/code-dot-org/code-dot-org/pull/56478

For the level in the PR above, https://studio.code.org/s/express-2018/lessons/35/levels/4?no_redirect=true
we see that this branch fixes it too, but more cleanly. By updating the XML right away we don't need to rely on the mutator hooks to handle a missing behavior id.

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/78671ac5-ec6e-499a-bf74-2ee1150af4bf)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

If this PR is approved, I will close this branch: https://github.com/code-dot-org/code-dot-org/pull/56478

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
