### PR TITLE
Actually Use `head` Field in DOTD Script to Filter PRs

### DIFF
--- a/lib/cdo/github.rb
+++ b/lib/cdo/github.rb
@@ -6,7 +6,8 @@ require_relative '../../deployment'
 # This module serves as a thin wrapper around Octokit, itself a wrapper around
 # the GitHub API.
 module GitHub
-  REPO = "code-dot-org/code-dot-org".freeze
+  ORGANIZATION = 'code-dot-org'.freeze
+  REPO = "#{ORGANIZATION}/code-dot-org".freeze
   DASHBOARD_DB_DIR = 'dashboard/db/'.freeze
   PEGASUS_DB_DIR = 'pegasus/migrations/'.freeze
   STAGING_BRANCH = 'staging'.freeze
@@ -135,7 +136,10 @@ module GitHub
   #         and head, or a new PR if one didn't already exist.
   def self.find_or_create_pull_request(base:, head:, title:, body: nil)
     configure_octokit
-    existing_pull_requests = Octokit.pull_requests(REPO, {base: base, head: head})
+    # The "List pull requests" endpoint has special requirements for the `head` property.
+    # See https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests--parameters
+    formatted_head = "#{ORGANIZATION}:#{head}"
+    existing_pull_requests = Octokit.pull_requests(REPO, {base: base, head: formatted_head})
     return existing_pull_requests.first['number'] unless existing_pull_requests.empty?
 
     return create_pull_request(base: base, head: head, title: title, body: body)


### PR DESCRIPTION
Right now, we attempt to identify the DTP PR by filtering by both `base` and `head`. Unfortunately, the value we are currently passing for `head` is just the name of the branch, and this endpoint wants us to also include an organization identifier or it will ignore that value and filter only by `base`.

This hasn't been a problem before because it's usually the case that the only PR open against `production` is the DTP. But if, theoretically, we were to [have an open hotfix PR waiting to be reviewed when the DOTD runs DTP](https://codedotorg.slack.com/archives/C0T0PNTM3/p1707518933025489), then that hotfix PR would be incorrectly identified as the DTP PR.

## Links

- https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests--parameters

## Testing story


Tested a few `Octokit.pull_requests` calls manually:

```ruby
[development] dashboard > Octokit.pull_requests(GitHub::REPO, {base: 'staging', head: 'mysql-8-in-chef'}).count
=> 30
[development] dashboard > Octokit.pull_requests(GitHub::REPO, {base: 'staging'}).count
=> 30
[development] dashboard > Octokit.pull_requests(GitHub::REPO, {base: 'staging', head: 'dtp_candidate_92f7b0c9'}).count
=> 30
[development] dashboard > Octokit.pull_requests(GitHub::REPO, {base: 'staging', head: 'hamms:mysql-8-in-chef'}).count
=> 0
[development] dashboard > Octokit.pull_requests(GitHub::REPO, {base: 'staging', head: 'code-dot-org:mysql-8-in-chef'}).count
=> 1
[development] dashboard > Octokit.pull_requests(GitHub::REPO, {base: 'staging', head: 'code-dot-org:dtp_candidate_92f7b0c9'}).count
=> 0
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
