### PR TITLE
Removing iframe to cbsnews

### DIFF
--- a/pegasus/sites.v3/code.org/public/csforgood.md.partial
+++ b/pegasus/sites.v3/code.org/public/csforgood.md.partial
@@ -60,9 +60,6 @@ social:
 </ul>
 
 <h3><strong>We learn CS to connect with each other</strong></h3>
-
-<iframe src="https://www.cbsnews.com/video/students-sing-together-from-home-after-coronavirus-cancels-concert/" id="cbsNewsVideo" allowfullscreen allow="fullscreen" frameborder="0" width="325px" height="183px" style="float:right; margin-left:20px"></iframe>
-
 <p>From video chats and classes to apps that allow us to sing together remotely, people have built technical innovations that have kept us connected with some semblance of community through a global pandemic. And, we will continue to find ways to humanize technology to unite us.</p>
 <p>Have students watch this video (<a href="https://www.cbsnews.com/video/students-sing-together-from-home-after-coronavirus-cancels-concert/?intcid=CNM-00-10abd1h" target="_blank">link to original video at CBS News</a>) of students from Chino Valley Unified School District singing an a capella version of “Over the Rainbow” via video conference after covid-19 canceled their annual Choral Festival. Then have them work in pairs or groups to answer the questions below.</p>
 <p><i>Questions for discussion:</i></p>


### PR DESCRIPTION
On https://code.org/csforgood, we have an embedded iframe for a video hosted on cbsnews.com. This results in many cookies being added to the student's browser which we need to maintain a categorization for and try to block if the user doesn't want to be tracked. A much simpler solution is to remove the embedded video which is what this PR does.

## Testing
* Verified fix on http://localhost.code.org:3000/csforgood