### PR TITLE
Fix invalid dropdown condition

### DIFF
--- a/dashboard/config/levels/custom/spritelab/courseF_events_choice_pufferfish_2023.level
+++ b/dashboard/config/levels/custom/spritelab/courseF_events_choice_pufferfish_2023.level
@@ -811,7 +811,7 @@
             </value>
           </block>
           <block type="gamelab_keyPressed">
-            <title name="CONDITION">???</title>
+            <title name="CONDITION">when</title>
             <title name="KEY">"up"</title>
           </block>
         </category>


### PR DESCRIPTION
The `???` condition on the dropdown is invalid and does not work with google blockly.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Pulling a "when pressed` block from the toolbox in `/s/express-2023/lessons/7/levels/12` now does not stop code from generating.

## Follow-up work
Try to find a more robust workaround for this issue (i.e. in blockly code rather than fixing levels)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
