### PR TITLE
Support '???' dropdown value

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -741,10 +741,10 @@ const STANDARD_INPUT_TYPES = {
     generateCode(block, inputConfig) {
       let code = block.getFieldValue(inputConfig.name);
       if (
-        (inputConfig.type === Blockly.BlockValueType.STRING &&
-          !code.startsWith('"') &&
-          !code.startsWith("'")) ||
-        code === EMPTY_OPTION
+        (inputConfig.type === Blockly.BlockValueType.STRING ||
+          code === EMPTY_OPTION) &&
+        !code.startsWith('"') &&
+        !code.startsWith("'")
       ) {
         // Wraps the value in quotes, and escapes quotes/newlines
         code = JSON.stringify(code);

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import {styleTypes} from './blockly/themes/cdoBlockStyles.mjs';
 import xml from './xml';
 import MetricsReporter from './lib/metrics/MetricsReporter';
+import {EMPTY_OPTION} from './blockly/constants';
 
 const ATTRIBUTES_TO_CLEAN = ['uservisible', 'deletable', 'movable'];
 const DEFAULT_COLOR = [184, 1.0, 0.74];
@@ -740,9 +741,10 @@ const STANDARD_INPUT_TYPES = {
     generateCode(block, inputConfig) {
       let code = block.getFieldValue(inputConfig.name);
       if (
-        inputConfig.type === Blockly.BlockValueType.STRING &&
-        !code.startsWith('"') &&
-        !code.startsWith("'")
+        (inputConfig.type === Blockly.BlockValueType.STRING &&
+          !code.startsWith('"') &&
+          !code.startsWith("'")) ||
+        code === EMPTY_OPTION
       ) {
         // Wraps the value in quotes, and escapes quotes/newlines
         code = JSON.stringify(code);
@@ -1135,7 +1137,6 @@ exports.createJsWrapperBlockCreator = function (
             flyoutToggleButton
           );
         }
-        // Blockly.customBlocks.(this);
       },
     };
 

--- a/apps/src/blockly/addons/cdoFieldDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldDropdown.js
@@ -87,7 +87,7 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     if (newValue === EMPTY_OPTION) {
       this.value_ = newValue;
       this.isDirty_ = true;
-      this.selectedOption_ = [EMPTY_OPTION, ''];
+      this.selectedOption = [EMPTY_OPTION, ''];
     } else {
       super.doValueUpdate_(newValue);
     }


### PR DESCRIPTION
A user reported an error that was causing a blank play area in Express Course lesson 7: https://studio.code.org/s/express-2023/lessons/7/levels/12

To reproduce the error, open the Events toolbox category and drag out a `keyPressed` block.
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/fccc6957-ff08-4944-acf2-62dd82ba93c6)

```
SyntaxError: Unexpected token (386:11)
setProp(({costume: "blowfish_1"}), "scale", 50);
     
>>>  keyPressed(???, "up", function () {
       changePropBy(({costume: "blowfish_1"}), "scale", 25);
     });
```

Comparing with CDO Blockly, you get the same error but what you see in the block makes it easier to workaround. You'll notice that dropdown field's label also reads `???`

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/a3ee6219-db4b-4fbb-8a97-dfdac3c224f9)

### What is going on here?
There is a long-standing curriculum convention where a level designer would add `???` as an intentionally invalid default option for a dropdown field. It is thought that this set of symbols will stand out to students and encourage them to interact with the block, rather than trusting that the default value is probably fine. In fact, it looks we have thousands of levels that do this, both in and out of Sprite Lab:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/aeba8710-6d26-48e9-9981-55944a470704)

### What is the bug?
The bug that makes the new experience particularly confusing relates to field validators. Blockly's fields can check whether the selected option is valid based on its menu generator (gets valid options list). If it's not, Blockly rejects the option and re-selects the first valid option. Ordinarily, you'll see this logged as a warning when it happens. (For example, when you open the World category of the main project level, you'll see a warning like this relating to the `playSound` block.)
We actually began overriding the field's `doValueUpdate_` in September 2020 to allow for `???` as a special case: https://github.com/code-dot-org/code-dot-org/commit/442f071d9c64cd0041cecf523370b0924899e781
Unfortunately, we recently missed that `selectedOption_` was renamed to `selectedOption` with v10, so this broke.
Renaming the property to align to mainline fixes the bug. By removing the `_`, the block now shows `???` as expected. However, the project code still crashes with an unexpected token error.

### Improving the student experience
In the K-5 world, we try to avoid crashing whenever possible. This should include times when a student simply drags out a new block with default options (valid or not). While our `EMPTY_OPTION` value is the string `'???'`, when this gets added to generated code (also a long string), it ends up being simply `???`. In `block_utils.js,` we define generator logic for our custom dropdown field. If the input was set with a type (more on this later), we wrap the value in quotes.  Here we add a check to see if the field value is the string `'???'` (`EMPTY_OPTION`). If it is, we also wrap it in quotes. This generates valid code because the string `'???'` is not an invalid token. Are block functions, e.g. [`keyPressed`](https://github.com/code-dot-org/code-dot-org/blob/mike/support-dropdown-value/apps/src/p5lab/spritelab/commands/eventCommands.js#L25-L29) should already validate their arguments and fail gracefully for something unexpected.

```
  keyPressed(condition, key, callback) {
    if (condition === 'when' || condition === 'while') {
      this.addEvent(condition + 'press', {key: key}, callback);
    }
  },
```

Passing the string allows the code to "work", although in this case the block still won't _do_ anything until they select another option. This prevents the confusing blank play area problem. 

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/37e5c286-7bfa-43e1-bb3e-94ea31debfba)

This change actually improves the experience for CDO Blockly too, should we ever have need of that. (For example, if a Minecraft level used a ??? dropdown option in a block, it wouldn't cause an error any more. This is really just a point of interest as I can't find any levels like this.)

### About Input Config Types
If you look closely at the code changed, you'll notice `inputConfig.type === Blockly.BlockValueType.STRING`. You may be wondering why this check evaluates as false. In the case of the key pressed block, that's because the block's config file doesn't specify a type for that input. To be clear, the type being checked has nothing to do with the actual type of the field value, it's more about what the block is set up to expect. For example, we also have dropdown fields with number options that should not have their values wrapped in quotes. Of 170 custom blocks with dropdown fields, the vast majority have no type list. This probably doesn't cause a problem because the option values are usually already wrapped in quotes.

The `Poetry_addFrame` is one block that _does_ list a String type for the dropdown input, and so even with the EMPTY_OPTION check, it adds quotes around the ???:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/7ac6456c-2ba4-4ee7-a88a-c5670b081d66)

This presented me with two options:
- auditing 170 block config files to see which should have a String type added
- adding an extra check for `???`

Given the blocking nature of this bug, I've chosen the latter option for now.




## Links

ZenDesk: https://codeorg.zendesk.com/agent/tickets/485270
Slack:
- https://codedotorg.slack.com/archives/C05DK21DAHK/p1707523046744529
- https://codedotorg.slack.com/archives/C05DK21DAHK/p1707514252758899?thread_ts=1707508649.750439&cid=C05DK21DAHK

Example level: https://studio.code.org/s/express-2023/lessons/7/levels/12

## Testing story


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
