### PR TITLE
Revert "Fix invalid dropdown condition"

### DIFF
--- a/dashboard/config/levels/custom/spritelab/courseF_events_choice_pufferfish_2023.level
+++ b/dashboard/config/levels/custom/spritelab/courseF_events_choice_pufferfish_2023.level
@@ -811,7 +811,7 @@
             </value>
           </block>
           <block type="gamelab_keyPressed">
-            <title name="CONDITION">when</title>
+            <title name="CONDITION">???</title>
             <title name="KEY">"up"</title>
           </block>
         </category>


### PR DESCRIPTION
Reverts 
- code-dot-org/code-dot-org#56500

No longer needed due to 
- code-dot-org/code-dot-org/pull/56505

This level was originally designed to use `???` as the default dropdown value to encourage students to interact with the field. By fixing the bug we can maintain the original intended behavior.