### PR TITLE
[Google Blockly] Cleanup - use BLOCK_TYPES constant

### DIFF
--- a/apps/src/blockly/addons/cdoSerializationHelpers.js
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {WORKSPACE_PADDING, SETUP_TYPES} from '../constants';
+import {WORKSPACE_PADDING, SETUP_TYPES, BLOCK_TYPES} from '../constants';
 import {frameSizes} from './cdoConstants';
 import {shouldSkipHiddenWorkspace} from '../utils';
 
@@ -425,7 +425,7 @@ export function appendProceduresToState(projectState, proceduresState) {
 function blockExists(behaviorId, projectBlocks) {
   return projectBlocks.some(
     block =>
-      block.type === 'behavior_definition' &&
+      block.type === BLOCK_TYPES.behaviorDefinition &&
       block.extraState?.behaviorId === behaviorId
   );
 }

--- a/apps/src/blockly/customBlocks/cdoBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/cdoBlockly/spritelabBlocks.js
@@ -1,6 +1,6 @@
 // This file contains customizations to CDO Blockly Sprite Lab blocks.
 import i18n from '@cdo/locale';
-import {NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
+import {BLOCK_TYPES, NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
 
 export const blocks = {
   // Called by block_utils when creating Sprite Lab blocks with mini-toolboxes.
@@ -245,16 +245,18 @@ export const blocks = {
           getVars(category) {
             return {};
           },
-          callType_: 'gamelab_behavior_get',
+          callType_: BLOCK_TYPES.behaviorGet,
         },
       });
 
     generator.behavior_definition = generator.procedures_defnoreturn;
 
-    Blockly.Procedures.DEFINITION_BLOCK_TYPES.push('behavior_definition');
+    Blockly.Procedures.DEFINITION_BLOCK_TYPES.push(
+      BLOCK_TYPES.behaviorDefinition
+    );
     Blockly.Variables.registerGetter(
       Blockly.BlockValueType.BEHAVIOR,
-      'gamelab_behavior_get'
+      BLOCK_TYPES.behaviorGet
     );
 
     Blockly.Blocks.sprite_parameter_get = {
@@ -314,7 +316,7 @@ export const blocks = {
     const behaviors = [];
     Blockly.mainBlockSpace?.getTopBlocks().forEach(function (block) {
       if (
-        block.type === 'behavior_definition' &&
+        block.type === BLOCK_TYPES.behaviorGet &&
         block.getProcedureInfo()?.name &&
         block.getProcedureInfo()?.id
       ) {

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -138,7 +138,7 @@ GoogleBlockly.Extensions.register(
 GoogleBlockly.Extensions.register('procedure_def_mini_toolbox', function () {
   // TODO: Add comment block here after https://codedotorg.atlassian.net/browse/CT-121
   let miniToolboxBlocks = [];
-  if (this.type === 'behavior_definition') {
+  if (this.type === BLOCK_TYPES.behaviorDefinition) {
     miniToolboxBlocks.push('sprite_parameter_get');
   }
 
@@ -280,7 +280,7 @@ export function flyoutCategory(workspace, functionEditorOpen = false) {
   allFunctions.sort(nameComparator).forEach(({name, id}) => {
     blockList.push({
       kind: 'block',
-      type: 'procedures_callnoreturn',
+      type: BLOCK_TYPES.procedureCall,
       extraState: {
         name: name,
         id: id,


### PR DESCRIPTION
While troubleshooting another issue, I came across a few instances of string literals being used to reference some common block types. We can use our constant for this instead.