### PR TITLE
Error when creating a new Music Lab level

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_level_data.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_level_data.html.haml
@@ -3,4 +3,4 @@
 
 #level_data.in.collapse
   = f.label :level_data_label, 'Level data JSON'
-  = f.text_area :level_data, placeholder: 'Insert JSON Data', rows: 10, style: 'width: 90%', value: JSON.pretty_generate(@level.level_data)
+  = f.text_area :level_data, placeholder: 'Insert JSON Data', rows: 10, style: 'width: 90%', value: JSON.pretty_generate(@level.level_data || {})

--- a/dashboard/app/views/levels/editors/fields/_validations.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_validations.html.haml
@@ -5,4 +5,4 @@
 
 - content_for :body_scripts do
   %script{src: webpack_asset_path('js/levels/editors/fields/_validations.js'),
-        data: {validations: @level.level_data["validations"].to_json, levelname: @level.name, appname: @level.game&.app}}
+        data: {validations: (@level.properties.dig('level_data', 'validations') || []).to_json, levelname: @level.name, appname: @level.game&.app}}


### PR DESCRIPTION
Fixes an issue with creating new Music Lab levels in levelbuilder. When creating a level from scratch, the validations editor was throwing an error since there were no existing validations. Adds some defaults to prevent this.

## Links

https://codedotorg.atlassian.net/browse/LABS-502

## Testing story

Tested locally; was able to create and edit a new Music Lab level