### PR TITLE
Curriculum Catalog UI test waits for the home page and jquery to load when creating a new section

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -69,6 +69,8 @@ Feature: Curriculum Catalog Page
     Then I click selector "[aria-label='Assign AI for Oceans to your classroom']"
     And I wait until element "h3:contains(Create class section to assign a curriculum)" is visible
     Then I click selector "a:contains(Create Section)"
+    And I wait until current URL contains "/home"
+    And I wait for jquery to load
     And I wait until element "h3:contains(Create a new section)" is visible
 
   Scenario: Signed-in teacher with sections assigns and unassigns offerings to sections
@@ -216,6 +218,8 @@ Feature: Curriculum Catalog Page
     And I click selector "button:contains(Assign to class sections)"
     And I wait until element "h3:contains(Create class section to assign a curriculum)" is visible
     Then I click selector "a:contains(Create Section)"
+    And I wait until current URL contains "/home"
+    And I wait for jquery to load
     And I wait until element "h3:contains(Create a new section)" is visible
   
   @no_mobile


### PR DESCRIPTION
This PR updates the Curriculum Catalog UI test to wait for the home page and jquery to load when creating a new section. Before, this test was [failing on Firefox](https://cucumber-logs.s3.amazonaws.com/test/test/Firefox_acquisition_products_curriculum_catalog_output.html?versionId=_Q_UGp_K7UciVLj7PXMQATSO2HY21n1R) seemingly because `jquery` wasn't loaded yet. Now, following [this slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1678471188055309) about a similar issue and with waiting for the page to load, the test succeeds.

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1707768343717629)

## Testing story
First, we made this speculative change on the test server and reran the test (which [succeeded](https://codedotorg.slack.com/archives/C03CM903Y/p1707776136581179)). Bethany also locally opened Firefox and created a section through the curriculum catalog successfully.
