### PR TITLE
P20-706: Removes 'All' page, adds more page sizes, and adds CSV generation to permissions query page

### DIFF
--- a/dashboard/app/helpers/pd/page_helper.rb
+++ b/dashboard/app/helpers/pd/page_helper.rb
@@ -7,7 +7,7 @@ module Pd::PageHelper
   # @param collection_name [String] Name to be displayed in the page header, e.g. "Applications"
   # @param collection [ActiveRecord::Relation] collection of models with paging applied
   # @param permitted_params [Array<String, Symbol>] params to be preserved in paging urls
-  def page_header(collection_name, collection, permitted_params: [])
+  def page_header(collection_name, collection, permitted_params: [], extra_buttons: [])
     current_page = collection.current_page
 
     base_params = params.permit(permitted_params + [:page_size])
@@ -16,10 +16,10 @@ module Pd::PageHelper
       new_page_button('<', base_params.merge(page: current_page - 1), disabled: collection.first_page?),
       new_page_button('>', base_params.merge(page: current_page + 1), disabled: collection.last_page?),
       new_page_button('>>', base_params.merge(page: collection.total_pages), disabled: collection.last_page?)
-    ]
+    ] + extra_buttons
 
     page_size = params[:page_size] || collection.limit_value
-    page_size_buttons = %w(25 50 All).map do |page_size_option|
+    page_size_buttons = %w(25 50 100 500 1000 5000 10000).map do |page_size_option|
       new_page_size_button page_size_option, base_params
     end
 

--- a/dashboard/app/views/admin_users/permissions_form.html.haml
+++ b/dashboard/app/views/admin_users/permissions_form.html.haml
@@ -55,7 +55,8 @@
   %button.btn{type: 'submit'}
     %i.fa.fa-search
 -if @users_with_permission
-  = page_header 'users', @users_with_permission, permitted_params: [:permission]
+  - download_csv = link_to('Page as CSV', permissions_csv_path(params.permit([:permission, :page_size, :page, :search_term])), class: 'btn btn-default')
+  = page_header 'users', @users_with_permission, permitted_params: [:permission], extra_buttons: [download_csv]
   %table.table.table-hover.table-condensed.table-auto-width
     %thead
       %th ID

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -573,6 +573,7 @@ Dashboard::Application.routes.draw do
     get '/admin/manual_pass', to: 'admin_users#manual_pass_form', as: 'manual_pass_form'
     post '/admin/manual_pass', to: 'admin_users#manual_pass', as: 'manual_pass'
     get '/admin/permissions', to: 'admin_users#permissions_form', as: 'permissions_form'
+    get '/admin/permissions/csv', to: 'admin_users#permissions_csv', as: 'permissions_csv'
     post '/admin/grant_permission', to: 'admin_users#grant_permission', as: 'grant_permission'
     get '/admin/revoke_permission', to: 'admin_users#revoke_permission', as: 'revoke_permission'
     post '/admin/bulk_grant_permission', to: 'admin_users#bulk_grant_permission', as: 'bulk_grant_permission'


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Reported first in Slack: https://codedotorg.slack.com/archives/C04540KNGDQ/p1707240207180699

Essentially, we had a "All" button for the pagination... which failed due to the logic trying to use "All" as a number. However, it became clear that what they really needed was a larger pagination beyond 500. And they were working around it by manually forcing a page size of that magnitude.

Ultimately they want the data to create a CSV. Therefore, I asked if we could just... provide a download button.

This does the following:

* Removes the ill-advised "All" page option
* Adds page sizes in the thousands
* Adds a CSV download that will download a CSV representing the table on the current page

## Links

- jira ticket: [P20-706](https://codedotorg.atlassian.net/browse/P20-706)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
