### PR TITLE
Adding amplitude events for update school dialog

### DIFF
--- a/apps/src/lib/ui/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/lib/ui/SchoolInfoConfirmationDialog.jsx
@@ -73,6 +73,7 @@ class SchoolInfoConfirmationDialog extends Component {
   }
 
   closeModal = () => {
+    analyticsReporter.sendEvent(EVENTS.UPDATE_SCHOOL_INFO_DIALOG_CLOSED);
     this.setState({isOpen: false});
     this.props.onClose();
   };

--- a/apps/src/lib/ui/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/lib/ui/SchoolInfoConfirmationDialog.jsx
@@ -20,9 +20,11 @@ export const styles = {
     marginRight: '50%',
   },
   updateButton: {
+    marginTop: 20,
     marginLeft: 5,
   },
   updateButtonRTL: {
+    marginTop: 20,
     marginRight: 5,
   },
   intro: {
@@ -113,7 +115,6 @@ class SchoolInfoConfirmationDialog extends Component {
           </p>
         </div>
         <Button
-          __useDeprecatedTag
           style={isRTL ? styles.updateButtonRTL : styles.updateButton}
           text={i18n.schoolInfoDialogUpdate()}
           color={Button.ButtonColor.blue}
@@ -121,7 +122,6 @@ class SchoolInfoConfirmationDialog extends Component {
           id="update-button"
         />
         <Button
-          __useDeprecatedTag
           style={isRTL ? styles.buttonRTL : styles.button}
           text={i18n.yes()}
           color={Button.ButtonColor.brandSecondaryDefault}

--- a/apps/src/lib/ui/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/lib/ui/SchoolInfoConfirmationDialog.jsx
@@ -7,6 +7,8 @@ import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import {getStore} from '../../redux';
 import fontConstants from '@cdo/apps/fontConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 export const styles = {
   button: {
@@ -74,6 +76,7 @@ class SchoolInfoConfirmationDialog extends Component {
   };
 
   handleClickYes = () => {
+    analyticsReporter.sendEvent(EVENTS.CONFIRM_SCHOOL_CLICKED);
     const {authTokenName, authTokenValue} = this.props.scriptData;
     const formData = new FormData();
     formData.append(authTokenName, authTokenValue);
@@ -91,10 +94,12 @@ class SchoolInfoConfirmationDialog extends Component {
   };
 
   handleClickUpdate = () => {
+    analyticsReporter.sendEvent(EVENTS.UPDATE_SCHOOL_CLICKED);
     this.setState({showSchoolInterstitial: true});
   };
 
   renderInitialContent = () => {
+    analyticsReporter.sendEvent(EVENTS.UPDATE_SCHOOL_INFO_DIALOG_SHOWN);
     const {schoolName} = this.state;
     const isRTL = getStore().getState()?.isRtl;
     return (

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -11,6 +11,12 @@ const EVENTS = {
   ABANDON_SECTION_SETUP_SIGN_IN_EVENT: 'Abandon Section Setup Sign In',
   TEACHER_LOGIN_EVENT: 'Teacher Login',
 
+  // School Association
+  // Update School Info Dialog
+  UPDATE_SCHOOL_INFO_DIALOG_SHOWN: 'Update School Info Dialog Shown',
+  CONFIRM_SCHOOL_CLICKED: 'Confirm School Clicked',
+  UPDATE_SCHOOL_CLICKED: 'Update School Clicked',
+
   // Course/Unit info
   COURSE_OVERVIEW_PAGE_VISITED_BY_TEACHER_EVENT:
     'Course Overview Page Visited By Teacher',

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -14,6 +14,7 @@ const EVENTS = {
   // School Association
   // Update School Info Dialog
   UPDATE_SCHOOL_INFO_DIALOG_SHOWN: 'Update School Info Dialog Shown',
+  UPDATE_SCHOOL_INFO_DIALOG_CLOSED: 'Update School Info Dialog Closed',
   CONFIRM_SCHOOL_CLICKED: 'Confirm School Clicked',
   UPDATE_SCHOOL_CLICKED: 'Update School Clicked',
 

--- a/apps/test/unit/lib/ui/SchoolInfoConfirmationDialogTest.js
+++ b/apps/test/unit/lib/ui/SchoolInfoConfirmationDialogTest.js
@@ -115,7 +115,7 @@ describe('SchoolInfoConfirmationDialog', () => {
         const wrapperInstance = wrapper.instance();
         const handleClickYesSpy = sinon.spy(wrapperInstance, 'handleClickYes');
         wrapper.setState({showSchoolInterstitial: false});
-        wrapper.find('div#yes-button').simulate('click');
+        wrapper.find('#yes-button').simulate('click');
 
         expect(wrapperInstance.handleClickYes).to.have.been.called;
         await setTimeout(() => {}, 50);

--- a/apps/test/unit/lib/ui/SchoolInfoConfirmationDialogTest.js
+++ b/apps/test/unit/lib/ui/SchoolInfoConfirmationDialogTest.js
@@ -103,7 +103,7 @@ describe('SchoolInfoConfirmationDialog', () => {
         const wrapperInstance = wrapper.instance();
         sinon.spy(wrapperInstance, 'handleClickUpdate');
         wrapper.setState({showSchoolInterstitial: false});
-        wrapper.find('#update-button').simulate('click');
+        wrapper.find('button#update-button').simulate('click');
 
         expect(wrapperInstance.handleClickUpdate).to.have.been.called;
         await setTimeout(() => {}, 50);
@@ -115,7 +115,7 @@ describe('SchoolInfoConfirmationDialog', () => {
         const wrapperInstance = wrapper.instance();
         const handleClickYesSpy = sinon.spy(wrapperInstance, 'handleClickYes');
         wrapper.setState({showSchoolInterstitial: false});
-        wrapper.find('#yes-button').simulate('click');
+        wrapper.find('button#yes-button').simulate('click');
 
         expect(wrapperInstance.handleClickYes).to.have.been.called;
         await setTimeout(() => {}, 50);

--- a/apps/test/unit/lib/ui/SchoolInfoConfirmationDialogTest.js
+++ b/apps/test/unit/lib/ui/SchoolInfoConfirmationDialogTest.js
@@ -103,7 +103,7 @@ describe('SchoolInfoConfirmationDialog', () => {
         const wrapperInstance = wrapper.instance();
         sinon.spy(wrapperInstance, 'handleClickUpdate');
         wrapper.setState({showSchoolInterstitial: false});
-        wrapper.find('div#update-button').simulate('click');
+        wrapper.find('#update-button').simulate('click');
 
         expect(wrapperInstance.handleClickUpdate).to.have.been.called;
         await setTimeout(() => {}, 50);


### PR DESCRIPTION
Adds four amplitude events for the school info update dialog, as spelled out in product spec linked below, plus one added from PR feedback.

I also updated the a11y of this component to make it tab navigable by removing the __useDeprecatedTag. I had to update the styling of the update button: see before and after below. 
Shoutout to @wilkie who translated this Storybook last year, which made development here much much faster! So fun to see the fruits of that labor!

To be clear: this is only the first portion of Amplitude work: there is a dialog that follows this if a user presses 'update' that is not yet instrumented. 

<img width="815" alt="Screenshot 2024-02-12 at 6 57 03 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/18c0a74b-39f9-4847-bfc6-f0fb152b0617">
<img width="826" alt="Screenshot 2024-02-12 at 6 57 10 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/0dc5195d-ec63-4577-84c9-560fb3c2564a">
<img width="584" alt="Screenshot 2024-02-12 at 6 57 27 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/7e4e65cb-58fd-481a-b927-2aacc4bce45a">
<img width="484" alt="Screenshot 2024-02-13 at 9 32 39 AM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/46f0c20d-3a40-4ec8-94e4-28c0e9c2dbf5">


Before:
<img width="631" alt="Screenshot 2024-02-12 at 6 58 52 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/73188114-f8d4-4bcd-8e50-7d0f853f8cd3">

After (excuse the active blue outline on the 'x'- this was just me testing out tabnav):
<img width="645" alt="Screenshot 2024-02-12 at 7 03 53 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/c6bbf97c-1309-49a6-8a5a-bab1567a619f">

(This is how it looks RTL:)
<img width="600" alt="Screenshot 2024-02-12 at 7 05 50 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/68ad42b3-8552-40cc-b34f-1b7bad16ba1f">


## Links

- spec: https://docs.google.com/document/d/1P1RVtGDy4XbIs0t5hnHC3Li6ZDsCnjwMnOPMQqPXNyk/edit?pli=1#bookmark=id.y2xg1jxvnayj
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1466

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
