### PR TITLE
Per-project `appOptions.useDatablockStorage` stored in DB

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -422,10 +422,10 @@ Applab.init = function (config) {
   Applab.channelId = config.channel;
 
   if (!!config.useDatablockStorage) {
-    console.warn('Initializing DATABLOCK_STORAGE');
+    console.log('Initializing DATABLOCK_STORAGE');
     Applab.storage = initStorage(DATABLOCK_STORAGE, {});
   } else {
-    console.warn('Initializing FIREBASE_STORAGE');
+    console.log('Initializing FIREBASE_STORAGE');
     Applab.storage = initStorage(FIREBASE_STORAGE, {
       // TODO: unfirebase
       channelId: config.channel,

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -422,10 +422,10 @@ Applab.init = function (config) {
   Applab.channelId = config.channel;
 
   if (!!config.useDatablockStorage) {
-    console.log('Initializing DATABLOCK_STORAGE');
+    console.error('Initializing DATABLOCK_STORAGE');
     Applab.storage = initStorage(DATABLOCK_STORAGE, {});
   } else {
-    console.log('Initializing FIREBASE_STORAGE');
+    console.error('Initializing FIREBASE_STORAGE');
     Applab.storage = initStorage(FIREBASE_STORAGE, {
       // TODO: unfirebase
       channelId: config.channel,

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -421,14 +421,11 @@ Applab.init = function (config) {
   }
   Applab.channelId = config.channel;
 
-  function shouldUseDatablockStorage() {
-    // FIXME: unfirebase, how do we implement this?
-    return true;
-  }
-
-  if (shouldUseDatablockStorage()) {
+  if (!!config.useDatablockStorage) {
+    console.warn('Initializing DATABLOCK_STORAGE');
     Applab.storage = initStorage(DATABLOCK_STORAGE, {});
   } else {
+    console.warn('Initializing FIREBASE_STORAGE');
     Applab.storage = initStorage(FIREBASE_STORAGE, {
       // TODO: unfirebase
       channelId: config.channel,

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -583,8 +583,8 @@ module LevelsHelper
 
     if @level.game.use_datablock_storage?
       channel_id = params[:channel_id] || get_channel_for(@level, @script&.id, @user)
-      project = Project.find_by_channel_id(channel_id)
-      storage_options[:useDatablockStorage] = project&.use_datablock_storage || false
+      # TODO: post-firebase-cleanup, remove ProjectUseDatablockStorage once we reach 100% datablock storage
+      storage_options[:useDatablockStorage] = ProjectUseDatablockStorage.use_data_block_storage_for?(channel_id)
       unless storage_options[:useDatablockStorage]
         storage_options[:firebaseName] = CDO.firebase_name
         storage_options[:firebaseAuthToken] = firebase_auth_token

--- a/dashboard/app/models/game.rb
+++ b/dashboard/app/models/game.rb
@@ -266,7 +266,7 @@ class Game < ApplicationRecord
     !([NETSIM].include? app)
   end
 
-  def use_firebase? # TODO: unfirebase
+  def use_datablock_storage?
     [APPLAB, GAMELAB].include? app
   end
 

--- a/dashboard/app/models/project.rb
+++ b/dashboard/app/models/project.rb
@@ -15,7 +15,6 @@
 #  standalone              :boolean          default(TRUE)
 #  remix_parent_id         :integer
 #  skip_content_moderation :boolean
-#  use_datablock_storage   :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/dashboard/app/models/project.rb
+++ b/dashboard/app/models/project.rb
@@ -15,6 +15,7 @@
 #  standalone              :boolean          default(TRUE)
 #  remix_parent_id         :integer
 #  skip_content_moderation :boolean
+#  use_datablock_storage   :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/dashboard/app/models/project_use_datablock_storage.rb
+++ b/dashboard/app/models/project_use_datablock_storage.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: project_use_datablock_storages
+#
+#  id                    :bigint           not null, primary key
+#  project_id            :integer          not null
+#  use_datablock_storage :boolean          default(FALSE), not null
+#
+# Indexes
+#
+#  index_project_use_datablock_storages_on_project_id  (project_id)
+#
+class ProjectUseDatablockStorage < ApplicationRecord
+  # Should a given Project use datablock storage?
+  # This allows us to progressively migrate between Firebase
+  # and Datablock storage.
+  #
+  # TODO: post-firebase-cleanup, remove this table once 100%
+  # of projects are use_datablock_storage=true.
+  belongs_to :project
+
+  def self.use_data_block_storage_for?(channel_id)
+    project = Project.find_by_channel_id(channel_id)
+    find_by(project: project)&.use_datablock_storage || false
+  end
+end

--- a/dashboard/db/migrate/20240213025510_add_use_datablock_storage_to_projects.rb
+++ b/dashboard/db/migrate/20240213025510_add_use_datablock_storage_to_projects.rb
@@ -1,5 +1,0 @@
-class AddUseDatablockStorageToProjects < ActiveRecord::Migration[6.1]
-  def change
-    add_column :projects, :use_datablock_storage, :boolean, default: false, null: false
-  end
-end

--- a/dashboard/db/migrate/20240213025510_add_use_datablock_storage_to_projects.rb
+++ b/dashboard/db/migrate/20240213025510_add_use_datablock_storage_to_projects.rb
@@ -1,0 +1,5 @@
+class AddUseDatablockStorageToProjects < ActiveRecord::Migration[6.1]
+  def change
+    add_column :projects, :use_datablock_storage, :boolean, default: false, null: false
+  end
+end

--- a/dashboard/db/migrate/20240215100626_create_project_use_datablock_storages.rb
+++ b/dashboard/db/migrate/20240215100626_create_project_use_datablock_storages.rb
@@ -1,0 +1,8 @@
+class CreateProjectUseDatablockStorages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :project_use_datablock_storages do |t|
+      t.references :project, null: false, foreign_key: true, type: :integer, index: true
+      t.boolean :use_datablock_storage, default: false, null: false
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_22_193916) do
+ActiveRecord::Schema.define(version: 2024_02_13_025510) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1603,6 +1603,7 @@ ActiveRecord::Schema.define(version: 2024_01_22_193916) do
     t.boolean "standalone", default: true
     t.integer "remix_parent_id"
     t.boolean "skip_content_moderation"
+    t.boolean "use_datablock_storage", default: false, null: false
     t.index ["project_type"], name: "storage_apps_project_type_index", length: 191
     t.index ["published_at"], name: "storage_apps_published_at_index"
     t.index ["standalone"], name: "storage_apps_standalone_index"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_22_193916) do
+ActiveRecord::Schema.define(version: 2024_02_15_100626) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1590,6 +1590,12 @@ ActiveRecord::Schema.define(version: 2024_01_22_193916) do
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
   end
 
+  create_table "project_use_datablock_storages", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.boolean "use_datablock_storage", default: false, null: false
+    t.index ["project_id"], name: "index_project_use_datablock_storages_on_project_id"
+  end
+
   create_table "projects", id: :integer, charset: "utf8mb4", force: :cascade do |t|
     t.integer "storage_id"
     t.text "value", size: :medium
@@ -2375,6 +2381,7 @@ ActiveRecord::Schema.define(version: 2024_01_22_193916) do
   add_foreign_key "peer_reviews", "users", column: "submitter_id"
   add_foreign_key "plc_course_units", "scripts"
   add_foreign_key "plc_learning_modules", "stages"
+  add_foreign_key "project_use_datablock_storages", "projects"
   add_foreign_key "queued_account_purges", "users"
   add_foreign_key "rubric_ai_evaluations", "rubrics"
   add_foreign_key "rubric_ai_evaluations", "users"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_13_025510) do
+ActiveRecord::Schema.define(version: 2024_01_22_193916) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1603,7 +1603,6 @@ ActiveRecord::Schema.define(version: 2024_02_13_025510) do
     t.boolean "standalone", default: true
     t.integer "remix_parent_id"
     t.boolean "skip_content_moderation"
-    t.boolean "use_datablock_storage", default: false, null: false
     t.index ["project_type"], name: "storage_apps_project_type_index", length: 191
     t.index ["published_at"], name: "storage_apps_published_at_index"
     t.index ["standalone"], name: "storage_apps_standalone_index"

--- a/dashboard/db/schema_cache.yml
+++ b/dashboard/db/schema_cache.yml
@@ -4944,6 +4944,19 @@ columns:
     default_function:
     collation:
     comment:
+  projects_use_datablock_storage:
+  - *18
+  - !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
+    name: use_datablock_storage
+    sql_type_metadata: *23
+    'null': false
+    default: '0'
+    default_function:
+    collation:
+    comment:
+  - *30
+  - *9
+  - *10
   puzzle_ratings:
   - *5
   - *54
@@ -7664,6 +7677,7 @@ primary_keys:
   programming_methods: id
   project_commits: id
   projects: id
+  projects_use_datablock_storage: id
   puzzle_ratings: id
   queued_account_purges: id
   reference_guides: id
@@ -7857,6 +7871,7 @@ data_sources:
   programming_methods: true
   project_commits: true
   projects: true
+  projects_use_datablock_storage: true
   puzzle_ratings: true
   queued_account_purges: true
   reference_guides: true
@@ -11518,6 +11533,20 @@ indexes:
     type:
     using: :btree
     comment:
+  projects_use_datablock_storage:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: projects_use_datablock_storage
+    name: index_projects_use_datablock_storage_on_project_id
+    unique: false
+    columns:
+    - project_id
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using: :btree
+    comment:
   puzzle_ratings:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: puzzle_ratings
@@ -13134,7 +13163,7 @@ indexes:
     type: :fulltext
     using:
     comment:
-version: 20240122193916
+version: 20240215100626
 database_version: !ruby/object:ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
   version:
   - 5


### PR DESCRIPTION
1) Helps with progressive rollout of FirebaseStorage vs DatablockStorage.
2) Relevant to `APPLAB` and `GAMELAB`
3) Adds a new table `project_use_datablock_storages` with a `use_datablock_storage` column. This table should be removed by a follow-up PR after we've switched 100% to DatablockStorage.

Fixes https://github.com/code-dot-org/code-dot-org/issues/56534