### PR TITLE
Update Self-paced PL CSC broken URLs

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/csc.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csc.haml
@@ -134,7 +134,7 @@ theme: responsive_full_width
         %h3.heading-sm
           =hoc_s(:self_paced_pl_modules_heading)
         %p=hoc_s(:self_paced_pl_modules_desc)
-        %a.link-button{href: CDO.studio_url("/s/self-paced-pl-csc")}
+        %a.link-button{href: CDO.studio_url("/s/self-paced-pl-csc-2023")}
           =hoc_s(:call_to_action_start_modules)
 
 = view :section_divider_line

--- a/pegasus/sites.v3/code.org/views/faq_csc.haml
+++ b/pegasus/sites.v3/code.org/views/faq_csc.haml
@@ -6,7 +6,7 @@
   %p=hoc_s(:csc_page_faq_answer_02, markdown: :inline, locals: {cost_url: "/commitment"})
 %details
   %summary=hoc_s(:csc_page_faq_question_03)
-  %p=hoc_s(:csc_page_faq_answer_03, markdown: :inline, locals: {get_started_url: CDO.studio_url("/s/self-paced-pl-csc")})
+  %p=hoc_s(:csc_page_faq_answer_03, markdown: :inline, locals: {get_started_url: CDO.studio_url("/s/self-paced-pl-csc-2023")})
 %details
   %summary=hoc_s(:csc_page_faq_question_04)
   %p=hoc_s(:csc_page_faq_answer_04)

--- a/pegasus/sites.v3/code.org/views/self_paced_pl_modules_carousel.haml
+++ b/pegasus/sites.v3/code.org/views/self_paced_pl_modules_carousel.haml
@@ -30,7 +30,7 @@
       curriculum: hoc_s(:curriculum_name_csc_02),
       duration: hoc_s(:module_duration_2_hrs),
       prerequisites: hoc_s(:module_prerequisites_none),
-      url_primary: CDO.studio_url("/s/self-paced-pl-csc"),
+      url_primary: CDO.studio_url("/s/self-paced-pl-csc-2023"),
       url_secondary: "/educate/csc",
       aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_csc),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_csc),


### PR DESCRIPTION
Krystin [spotted](https://codedotorg.slack.com/archives/C04540KNGDQ/p1707851978128309) a broken link on the [CSC educate page](https://code.org/educate/csc#csc-modules) that sent the user to https://studio.code.org/s/self-paced-pl-csc. If the user is signed in, this redirects them automatically to https://studio.code.org/s/self-paced-pl-csc-2023. But if they're not signed in, then they see the sad bee. It seems that the url is just missing `-2023` so as a quick fix, this PR adds that to all uses of `/s/self-paced-pl-csc` to avoid any broken links.

## Links
Slack thread: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1707851978128309)

## Testing story
CSC page:
![csc_page](https://github.com/code-dot-org/code-dot-org/assets/56283563/164d46b2-8274-4be9-8f4c-26b3e5724887)

CSC faq:
![csc_faq](https://github.com/code-dot-org/code-dot-org/assets/56283563/b82f8eb8-4638-440c-9f42-34d09236cefa)

Professional learning page carousel:
![prof_learning_page](https://github.com/code-dot-org/code-dot-org/assets/56283563/0de80ed0-e2cc-4892-992f-cb1290514f53)

## Follow-up work
A more longterm fix that uses the most recent version rather than a hard-coded `-2023` will be trakced in [this Jira ticket](https://codedotorg.atlassian.net/browse/ACQ-1475).
