### PR TITLE
Add serialized_attr for LTI rostering opt-out

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -146,6 +146,7 @@ class User < ApplicationRecord
     ai_rubrics_disabled
     sort_by_family_name
     show_progress_table_v2
+    lti_roster_sync_enabled
   )
 
   attr_accessor(

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -98,4 +98,9 @@ class Policies::Lti
   def self.show_email_input?(user)
     user.teacher? && Policies::Lti.lti?(user)
   end
+
+  # Whether or not a roster sync can be performed for a user.
+  def self.roster_sync_enabled?(user)
+    user.teacher? && user.lti_roster_sync_enabled
+  end
 end


### PR DESCRIPTION
Adds a new serialized_attr to the user model for the roster sync opt-out setting. Also adds a helper to the LTI policy to check this field. This is prerequisite work for adding this setting to the account settings page and sync confirmation pop-up.

## Links

[Jira ticket](https://codedotorg.atlassian.net/browse/P20-703)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

[Adding toggle to Account Settings page](https://codedotorg.atlassian.net/browse/P20-705)
[Adding button to sync pop-up](https://codedotorg.atlassian.net/browse/P20-704)


## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
