### PR TITLE
Initial Music Mini Player Setup

### DIFF
--- a/apps/src/music/MiniPlayerView.tsx
+++ b/apps/src/music/MiniPlayerView.tsx
@@ -6,8 +6,6 @@ import Simple2Sequencer from './player/sequencer/Simple2Sequencer';
 import {RemoteSourcesStore, SourcesStore} from '../lab2/projects/SourcesStore';
 import {loadLibrary} from './utils/Loader';
 import MusicLibrary from './player/MusicLibrary';
-import {Triggers} from './constants';
-import {PlaybackEvent} from './player/interfaces/PlaybackEvent';
 import {setUpBlocklyForMusicLab} from './blockly/setup';
 import Lab2Registry from '../lab2/Lab2Registry';
 
@@ -55,17 +53,10 @@ const MiniPlayerView: React.FunctionComponent<MiniPlayerViewProps> = ({
     workspaceRef.current.compileSong({Sequencer: sequencerRef.current});
 
     // Execute compiled song
-
-    // *** NOTE: this below chunk of code (sequencing out all triggers and events) is
-    // somewhat copied from MusicView and could be factored out
-
     // Sequence out all possible trigger events to preload sounds if necessary.
-    const allTriggerEvents: PlaybackEvent[] = [];
-    Triggers.forEach(trigger => {
-      sequencerRef.current.clear();
-      workspaceRef.current.executeTrigger(trigger.id, 0);
-      allTriggerEvents.push(...sequencerRef.current.getPlaybackEvents());
-    });
+    sequencerRef.current.clear();
+    workspaceRef.current.executeAllTriggers();
+    const allTriggerEvents = sequencerRef.current.getPlaybackEvents();
 
     sequencerRef.current.clear();
     workspaceRef.current.executeCompiledSong();

--- a/apps/src/music/MiniPlayerView.tsx
+++ b/apps/src/music/MiniPlayerView.tsx
@@ -1,0 +1,104 @@
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {Channel} from '../lab2/types';
+import MusicPlayer from './player/MusicPlayer';
+import MusicBlocklyWorkspace from './blockly/MusicBlocklyWorkspace';
+import Simple2Sequencer from './player/sequencer/Simple2Sequencer';
+import {RemoteSourcesStore, SourcesStore} from '../lab2/projects/SourcesStore';
+import {loadLibrary} from './utils/Loader';
+import MusicLibrary from './player/MusicLibrary';
+import {Triggers} from './constants';
+import {PlaybackEvent} from './player/interfaces/PlaybackEvent';
+
+interface MiniPlayerViewProps {
+  projects: Channel[];
+  libraryName: string;
+}
+
+const MiniPlayerView: React.FunctionComponent<MiniPlayerViewProps> = ({
+  projects,
+  libraryName,
+}) => {
+  const playerRef = useRef<MusicPlayer>(new MusicPlayer());
+  const workspaceRef = useRef<MusicBlocklyWorkspace>(
+    new MusicBlocklyWorkspace()
+  );
+  const sequencerRef = useRef<Simple2Sequencer>(new Simple2Sequencer());
+  const sourcesStoreRef = useRef<SourcesStore>(new RemoteSourcesStore());
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Setup library and workspace on mount
+  const onMount = useCallback(async () => {
+    workspaceRef.current.initHeadless();
+    const library = await loadLibrary(libraryName);
+    MusicLibrary.setCurrent(library);
+    setIsLoading(false);
+  }, [libraryName]);
+
+  useEffect(() => {
+    onMount();
+  }, [onMount]);
+
+  // This is the main function that is called when a song is played in the mini player
+  // Loads code from the server, compiles the song, executes it to generate events,
+  // and then plays the events.
+  // Optimization: cache code and/or compiled song after played once.
+  const onPlaySong = useCallback(async (project: Channel) => {
+    // Load code
+    const code = await sourcesStoreRef.current.load(project.id);
+    workspaceRef.current.loadCode(JSON.parse(code.source));
+
+    // Compile song
+    workspaceRef.current.compileSong({Sequencer: sequencerRef.current});
+
+    // Execute compiled song
+
+    // *** NOTE: this below chunk of code (sequencing out all triggers and events) is
+    // somewhat copied from MusicView and could be factored out
+
+    // Sequence out all possible trigger events to preload sounds if necessary.
+    const allTriggerEvents: PlaybackEvent[] = [];
+    Triggers.forEach(trigger => {
+      sequencerRef.current.clear();
+      workspaceRef.current.executeTrigger(trigger.id, 0);
+      allTriggerEvents.push(...sequencerRef.current.getPlaybackEvents());
+    });
+
+    sequencerRef.current.clear();
+    workspaceRef.current.executeCompiledSong();
+
+    // Preload sounds in player
+    playerRef.current.preloadSounds(
+      [...allTriggerEvents, ...sequencerRef.current.getPlaybackEvents()],
+      () => {
+        // TODO: Metrics reporting if necessary
+      }
+    );
+
+    // Play sounds
+    playerRef.current.playSong(sequencerRef.current.getPlaybackEvents());
+  }, []);
+
+  // Some loading UI while we're fetching the library
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  // Bare bones render function to hook things together
+  return (
+    <div>
+      {projects.map(project => {
+        return (
+          <button
+            type="button"
+            key={project.id}
+            onClick={() => onPlaySong(project)}
+          >
+            Play! {project.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MiniPlayerView;

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -98,6 +98,10 @@ export default class MusicBlocklyWorkspace {
     this.headlessMode = false;
   }
 
+  /**
+   * Initialize the Blockly workspace in headless mode, with no UI.
+   * This is useful for instances where code needs to only be loaded and executed.
+   */
   initHeadless() {
     if (this.workspace) {
       this.workspace.dispose();

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -3,7 +3,7 @@ import {BlockTypes} from './blockTypes';
 import CdoDarkTheme from '@cdo/apps/blockly/themes/cdoDark';
 import {getToolbox} from './toolbox';
 import {getBlockMode} from '../appConfig';
-import {BlockMode} from '../constants';
+import {BlockMode, Triggers} from '../constants';
 import {
   FIELD_TRIGGER_START_NAME,
   TriggerStart,
@@ -314,7 +314,7 @@ export default class MusicBlocklyWorkspace {
 
   /**
    * Executes code for the specific trigger referenced by the ID. It is
-   * assumed that {@link executeSong()} has already been called and all event
+   * assumed that {@link compileSong()} has already been called and all event
    * hooks have already been generated, as triggers cannot be played until
    * the song has started.
    *
@@ -325,6 +325,12 @@ export default class MusicBlocklyWorkspace {
     if (hook) {
       this.callUserGeneratedCode(hook, [startPosition]);
     }
+  }
+
+  executeAllTriggers() {
+    Triggers.forEach(({id}) => {
+      this.executeTrigger(id, 0);
+    });
   }
 
   hasTrigger(id: string) {

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -327,9 +327,13 @@ export default class MusicBlocklyWorkspace {
     }
   }
 
-  executeAllTriggers() {
+  /**
+   * Executes code for all triggers in the workspace. Useful for assembling
+   * all events that could be potentially triggered for preloading sounds.
+   */
+  executeAllTriggers(startPosition = 0) {
     Triggers.forEach(({id}) => {
-      this.executeTrigger(id, 0);
+      this.executeTrigger(id, startPosition);
     });
   }
 

--- a/apps/src/music/player/sequencer/Simple2Sequencer.ts
+++ b/apps/src/music/player/sequencer/Simple2Sequencer.ts
@@ -38,7 +38,6 @@ export default class Simple2Sequencer extends Sequencer {
   private inTrigger: boolean;
 
   constructor(
-    private readonly library: MusicLibrary,
     private readonly metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter()
   ) {
     super();
@@ -201,8 +200,8 @@ export default class Simple2Sequencer extends Sequencer {
    * Play a sound at the current location.
    */
   playSound(id: string, blockId: string) {
-    const soundData = this.library.getSoundForId(id);
-    if (soundData === null) {
+    const soundData = MusicLibrary.getInstance()?.getSoundForId(id);
+    if (!soundData) {
       this.metricsReporter.logWarning('Could not find sound with ID: ' + id);
       return;
     }

--- a/apps/src/music/player/sequencer/Simple2Sequencer.ts
+++ b/apps/src/music/player/sequencer/Simple2Sequencer.ts
@@ -38,6 +38,7 @@ export default class Simple2Sequencer extends Sequencer {
   private inTrigger: boolean;
 
   constructor(
+    private readonly library = MusicLibrary.getInstance(),
     private readonly metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter()
   ) {
     super();
@@ -200,7 +201,7 @@ export default class Simple2Sequencer extends Sequencer {
    * Play a sound at the current location.
    */
   playSound(id: string, blockId: string) {
-    const soundData = MusicLibrary.getInstance()?.getSoundForId(id);
+    const soundData = this.library?.getSoundForId(id);
     if (!soundData) {
       this.metricsReporter.logWarning('Could not find sound with ID: ' + id);
       return;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -41,7 +41,7 @@ import {
 } from '@cdo/apps/lab2/lab2Redux';
 import Simple2Sequencer from '../player/sequencer/Simple2Sequencer';
 import MusicPlayerStubSequencer from '../player/sequencer/MusicPlayerStubSequencer';
-import {BlockMode, DEFAULT_LIBRARY, Triggers} from '../constants';
+import {BlockMode, DEFAULT_LIBRARY} from '../constants';
 import {Key} from '../utils/Notes';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {isEqual} from 'lodash';

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -468,12 +468,9 @@ class UnconnectedMusicView extends React.Component {
     this.props.clearOrderedFunctions();
 
     // Sequence out all possible trigger events to preload sounds if necessary.
-    const allTriggerEvents = [];
-    Triggers.forEach(trigger => {
-      this.sequencer.clear();
-      this.musicBlocklyWorkspace.executeTrigger(trigger.id, 0);
-      allTriggerEvents.push(...this.sequencer.getPlaybackEvents());
-    });
+    this.sequencer.clear();
+    this.musicBlocklyWorkspace.executeAllTriggers();
+    const allTriggerEvents = this.sequencer.getPlaybackEvents();
 
     this.sequencer.clear();
     this.musicBlocklyWorkspace.executeCompiledSong(this.playingTriggers);


### PR DESCRIPTION
Sets up a basic bare bones view of a "mini player" with most of the logic necessary to play a song given a list of channel IDs. This will be the basis of further work that @breville is doing to create the full mini player feature.

Also includes a few minor changes to other classes, namely allowing for our blockly workspace to be initialized in a "headless" mode (since we only need code execution capabilities for this), and tweaking Simple2Sequencer so we don't have to pass in the music library in the constructor.