### PR TITLE
Removing AFE submit page from the flow

### DIFF
--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -5,7 +5,7 @@ import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imp
 import {studio, pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import color from '@cdo/apps/util/color';
 
-const RETURN_TO = `user_return_to=${pegasus('/afe/submit')}`;
+const RETURN_TO = `user_return_to=${pegasus('/afe')}`;
 const SIGN_UP_URL = studio(
   `/users/sign_up?user[user_type]=teacher&${RETURN_TO}`
 );

--- a/pegasus/sites.v3/code.org/public/afe/submit.md.erb
+++ b/pegasus/sites.v3/code.org/public/afe/submit.md.erb
@@ -1,6 +1,0 @@
----
-title: Bring computer science to your classroom with Code.org and Amazon Future Engineer
-theme: responsive
----
-
-<%= view :amazon_future_engineer_eligibility %>


### PR DESCRIPTION
The existing submit page is largely empty, and just hosts the processing for submit after a user is directed to sign in or sign up, completes that action, and the afe submission begins. The page is a landing zone for a user whose info is still being submitted. If the request is successful, the user is redirected to /success.

Now, that work happens on the /afe page itself instead of its own /submit page.

See existing flow in figma here: https://www.figma.com/file/qEFj4WmsjOC5okiMMxLJXq/AFE-Updates-(Dec-2023)?type=design&node-id=1538-384&mode=design&t=W2aVyQ1n5pbKfOve-0

<img width="731" alt="Screenshot 2024-02-13 at 1 03 01 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/2674e3b4-3e28-48d3-a660-fc1039512653">


-> The request processes instead in place on the afe page:
<img width="1440" alt="Screenshot 2024-02-13 at 1 16 53 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/ffffd58d-4cbf-4dc2-9df3-39f4283a9b87">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1270

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
