### PR TITLE
Put padlock icons in lesson headers where appropriate

### DIFF
--- a/apps/src/templates/sectionProgressV2/LessonProgressColumnHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LessonProgressColumnHeader.jsx
@@ -63,5 +63,5 @@ export default function LessonProgressColumnHeader({
 LessonProgressColumnHeader.propTypes = {
   lesson: PropTypes.object.isRequired,
   addExpandedLesson: PropTypes.func.isRequired,
-  allLocked: PropTypes.bool.isRequired,
+  allLocked: PropTypes.bool,
 };

--- a/apps/src/templates/sectionProgressV2/LessonProgressColumnHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LessonProgressColumnHeader.jsx
@@ -6,13 +6,16 @@ import FontAwesome from '../FontAwesome';
 import {lessonHasLevels} from '../progress/progressHelpers';
 import skeletonizeContent from '@cdo/apps/componentLibrary/skeletonize-content.module.scss';
 
-const getUninteractiveLessonColumnHeader = lesson => {
+const getUninteractiveLessonColumnHeader = (lesson, allLocked) => {
   return (
     <div
       className={classNames(styles.gridBox, styles.lessonHeaderCell)}
       key={lesson.id}
     >
-      {lesson.relative_position}
+      {lesson.numberedLesson && lesson.relative_position}
+      {!lesson.numberedLesson && (
+        <FontAwesome icon={allLocked ? 'lock' : 'lock-open'} />
+      )}
     </div>
   );
 };
@@ -34,12 +37,13 @@ const getSkeletonLessonHeader = lessonId => (
 export default function LessonProgressColumnHeader({
   addExpandedLesson,
   lesson,
+  allLocked,
 }) {
   if (lesson.isFake) {
     return getSkeletonLessonHeader(lesson.id);
   }
-  if (!lessonHasLevels(lesson)) {
-    return getUninteractiveLessonColumnHeader(lesson);
+  if (!lessonHasLevels(lesson) || !lesson.numberedLesson) {
+    return getUninteractiveLessonColumnHeader(lesson, allLocked);
   }
   return (
     <div
@@ -59,4 +63,5 @@ export default function LessonProgressColumnHeader({
 LessonProgressColumnHeader.propTypes = {
   lesson: PropTypes.object.isRequired,
   addExpandedLesson: PropTypes.func.isRequired,
+  allLocked: PropTypes.bool.isRequired,
 };

--- a/apps/src/templates/sectionProgressV2/LessonProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/LessonProgressDataColumn.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './progress-table-v2.module.scss';
 import {studentShape} from '../teacherDashboard/teacherSectionsRedux';
-import {studentLessonProgressType} from '../progress/progressTypes';
+import {
+  studentLessonProgressType,
+  studentLevelProgressType,
+} from '../progress/progressTypes';
 import {connect} from 'react-redux';
 import LessonDataCell from './LessonDataCell';
 import LessonProgressColumnHeader from './LessonProgressColumnHeader';
@@ -10,14 +13,29 @@ import LessonProgressColumnHeader from './LessonProgressColumnHeader';
 function LessonProgressDataColumn({
   lesson,
   lessonProgressByStudent,
+  levelProgressByStudent,
   sortedStudents,
   addExpandedLesson,
 }) {
+  // For lockable lessons, check whether each level is locked for each student.
+  // Used to control locked/unlocked icon in lesson header.
+  const allLocked = React.useMemo(() => {
+    if (!lesson.lockable) {
+      return false;
+    }
+    return sortedStudents.every(student =>
+      lesson.levels.every(
+        level => levelProgressByStudent[student.id][level.id]?.locked
+      )
+    );
+  }, [sortedStudents, levelProgressByStudent, lesson]);
+
   return (
     <div className={styles.lessonColumn}>
       <LessonProgressColumnHeader
         lesson={lesson}
         addExpandedLesson={addExpandedLesson}
+        allLocked={allLocked}
       />
 
       <div className={styles.lessonDataColumn}>
@@ -42,6 +60,9 @@ LessonProgressDataColumn.propTypes = {
   lessonProgressByStudent: PropTypes.objectOf(
     PropTypes.objectOf(studentLessonProgressType)
   ).isRequired,
+  levelProgressByStudent: PropTypes.objectOf(
+    PropTypes.objectOf(studentLevelProgressType)
+  ).isRequired,
   lesson: PropTypes.object.isRequired,
   addExpandedLesson: PropTypes.func.isRequired,
 };
@@ -51,6 +72,10 @@ export const UnconnectedLessonProgressDataColumn = LessonProgressDataColumn;
 export default connect(state => ({
   lessonProgressByStudent:
     state.sectionProgress.studentLessonProgressByUnit[
+      state.unitSelection.scriptId
+    ],
+  levelProgressByStudent:
+    state.sectionProgress.studentLevelProgressByUnit[
       state.unitSelection.scriptId
     ],
 }))(LessonProgressDataColumn);

--- a/apps/test/unit/templates/sectionProgressV2/LessonProgressColumnHeaderTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/LessonProgressColumnHeaderTest.jsx
@@ -13,11 +13,12 @@ import {
   fakeLesson,
 } from '@cdo/apps/templates/progress/progressTestHelpers';
 
-const LESSON = fakeLessonWithLevels({}, 1);
+const LESSON = fakeLessonWithLevels({numberedLesson: true}, 1);
 
 const DEFAULT_PROPS = {
   lesson: LESSON,
   addExpandedLesson: () => {},
+  allLocked: true,
 };
 
 const setUp = overrideProps => {
@@ -35,9 +36,20 @@ describe('LessonProgressColumnHeader', () => {
   });
 
   it('Shows uninteractive if no levels in lesson', () => {
-    const wrapper = setUp({lesson: fakeLesson()});
+    const lesson = fakeLesson();
+    lesson.numberedLesson = true;
+    const wrapper = setUp({lesson});
 
     expect(wrapper.find(FontAwesome)).to.have.length(0);
+  });
+
+  it('Shows uninteractive if lockable lesson', () => {
+    const lesson = fakeLesson();
+    lesson.lockable = true;
+    const wrapper = setUp({lesson});
+
+    expect(wrapper.find(FontAwesome)).to.have.length(1);
+    expect(wrapper.findWhere(n => n.prop('icon') === 'lock')).to.have.length(1);
   });
 
   it('Shows lesson header and expands on click', () => {
@@ -45,6 +57,9 @@ describe('LessonProgressColumnHeader', () => {
     const wrapper = setUp({addExpandedLesson: addExpandedLesson});
 
     expect(wrapper.find(FontAwesome)).to.have.length(1);
+    expect(
+      wrapper.findWhere(n => n.prop('icon') === 'caret-right')
+    ).to.have.length(1);
     expect(wrapper.find(`.${styles.lessonHeaderCell}`)).to.have.length(1);
 
     wrapper.find(`.${styles.lessonHeaderCell}`).simulate('click');

--- a/apps/test/unit/templates/sectionProgressV2/LessonProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/LessonProgressDataColumnTest.jsx
@@ -15,6 +15,7 @@ const STUDENT_1 = {id: 1, name: 'Student 1', familyName: 'FamNameB'};
 const STUDENT_2 = {id: 2, name: 'Student 2', familyName: 'FamNameA'};
 const STUDENTS = [STUDENT_1, STUDENT_2];
 const LESSON = fakeLessonWithLevels({}, 1);
+const LEVEL = LESSON.levels[0];
 const LESSON_PROGRESS = {
   [STUDENT_1.id]: {
     [LESSON.id]: {
@@ -35,10 +36,29 @@ const LESSON_PROGRESS = {
     },
   },
 };
+const LEVEL_PROGRESS = {
+  [STUDENT_1.id]: {
+    [LEVEL.id]: {
+      locked: false,
+      status: 'perfect',
+      result: 100,
+      paired: true,
+    },
+  },
+  [STUDENT_2.id]: {
+    [LESSON.id]: {
+      locked: true,
+      status: 'not_tried',
+      result: 1,
+      paired: false,
+    },
+  },
+};
 
 const DEFAULT_PROPS = {
   lesson: LESSON,
   lessonProgressByStudent: LESSON_PROGRESS,
+  levelProgressByStudent: LEVEL_PROGRESS,
   sortedStudents: STUDENTS,
   addExpandedLesson: () => {},
 };


### PR DESCRIPTION
This change puts lock icons in the progress header for the non-numbered lessons: closed lock if the lesson is locked for all students in the section, open lock if the lesson is unlocked for any student in the section.

![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/35323f7a-b022-4ae2-97a7-5153c8223ad0)

![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/837be892-99af-461d-8638-ee325bd9875a)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[JIRA](https://codedotorg.atlassian.net/browse/TEACH-858)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
