### PR TITLE
[Google Blockly] simplify VARIABLE field values for toolbox

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -398,13 +398,21 @@ function simplifyBlockState(block, variableMap) {
   // Create a copy of the block so we can modify certain fields.
   const result = {...block};
 
-  // For VAR fields, look up the name of the variable to use instead of the id.
-  if (block.fields && block.fields.VAR) {
-    result.fields.VAR = {
-      name: variableMap[block.fields.VAR.id] || '',
-      type: '',
-    };
-  }
+  // For variable fields, look up the name of the variable to use instead of the id.
+  const variableFields = [
+    'VAR' /* most common */,
+    'VARIABLE' /* used in gamelab_changeVarBy */,
+  ];
+
+  variableFields.forEach(field => {
+    const fieldValue = block.fields?.[field];
+    if (fieldValue) {
+      result.fields[field] = {
+        name: variableMap[fieldValue.id] || '',
+        type: '',
+      };
+    }
+  });
 
   // Recursively check nested blocks.
   if (block.inputs) {


### PR DESCRIPTION
@ebeastlake noticed an error when trying to modify a toolbox with certain variable-related blocks:
```
variable_map.ts:186 Uncaught Error: Variable "i" is already in use and its id is "BY?TWU)X/R}36]#AMXP." 
which conflicts with the passed in id, "8c{g(FOfdV@:v^nWW=f[".
```
Toolbox Mode| Result in level
-|-
![Screenshot 2024-02-13 at 4 53 10 PM](https://github.com/code-dot-org/code-dot-org/assets/43474485/81a48dea-956a-4f1e-ae06-4ba0d5b07ec0)|![Screenshot 2024-02-13 at 4 53 50 PM](https://github.com/code-dot-org/code-dot-org/assets/43474485/26db29f2-cf20-4161-b1ca-fbda984d308a)


### Context
In Core Blockly, the blocks in the Variables category are auto-populated. On Code.org, we need to support a combination of auto-populated blocks and level-defined blocks in the XML. This was implemented for our Google Blockly labs here:
- https://github.com/code-dot-org/code-dot-org/pull/54302

Part of that work involves stripping unneeded block and variable ids before adding the level-defined blocks to the XML. (The ids show up in the first place because we convert the XML to JSON to make it compatible with the auto-populated blocks. We don't want random variable ids, because they might mismatch the defined variables on the main workspace's variable map, which would lead to the error shown above.) 
In that work, I had assumed we always used `VAR` for the field name. However, the `gamelab_changeVarBy` block uses `VARIABLE` (https://github.com/code-dot-org/code-dot-org/blob/mike/simplify-VARIABLE-field-values-for-toolbox/dashboard/config/blocks/GamelabJr/gamelab_changeVarBy.json#L14). Technically, this is supported as fields can have any name. Checking for both variants of the field name makes it so this block is properly simplified for the toolbox.

<img width="494" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/9c752bfc-4191-4216-a09b-932d64c95921">


## Links

https://codedotorg.atlassian.net/browse/CT-337

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
