### PR TITLE
Update ADMIN_PAGE_VISITED_EVENT amplitude event

### DIFF
--- a/pegasus/helpers/analytics_constants.rb
+++ b/pegasus/helpers/analytics_constants.rb
@@ -15,6 +15,7 @@ module AnalyticsConstants
     CSF_CURRICULUM_PAGE_VISITED_EVENT = 'CSF Curriculum Page Visited'.freeze,
     CSF_UNPLUGGED_PAGE_VISITED_EVENT = 'CSF Unplugged Page Visited'.freeze,
     CSP_CURRICULUM_PAGE_VISITED_EVENT = 'CSP Curriculum Page Visited'.freeze,
+    DISTRICT_PROGRAM_PAGE_VISITED_EVENT = 'District Program Page Visited'.freeze,
     DONATE_PAGE_VISITED_EVENT = 'Donate Page Visited'.freeze,
     HELP_US_PAGE_VISITED_EVENT = 'Help Us Page Visited'.freeze,
     PHYSICAL_COMPUTING_PAGE_VISITED_EVENT = 'Physical Computing Page Visited'.freeze,

--- a/pegasus/sites.v3/code.org/public/administrators.haml
+++ b/pegasus/sites.v3/code.org/public/administrators.haml
@@ -107,3 +107,5 @@ theme: responsive_full_width
     %p.centered
       =hoc_s(:admins_page_resources_desc)
     = view :"administrators/admins_additional_resources"
+
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::ADMIN_PAGE_VISITED_EVENT

--- a/pegasus/sites.v3/code.org/public/districts.haml
+++ b/pegasus/sites.v3/code.org/public/districts.haml
@@ -174,4 +174,4 @@ theme: responsive_full_width
           %a.link-button.has-external-link{href: "https://docs.google.com/document/d/102y3-j0uZBqSnqWHTiTbo81LyDUX2sZITYF9aHnZ_yc/edit#heading=h.9ub4frvyuqiy"} Learn more
   .clear
 
-= view :analytics_event_log_helper, event_name: AnalyticsConstants::ADMIN_PAGE_VISITED_EVENT
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::DISTRICT_PROGRAM_PAGE_VISITED_EVENT


### PR DESCRIPTION
We currently have an existing `ADMIN_PAGE_VISITED_EVENT` that fires on the [districts page](http://code.org/districts). This PR adds a “District Program Page Visited” event for [code.org/districts](http://code.org/districts) and moves the `ADMIN_PAGE_VISITED_EVENT` to [code.org/administrators](http://code.org/administrators).

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1465)
"District Program Page Visited" Amplitude event: [here](https://app.amplitude.com/data/code-org/Code.org%20Tracking%20Plan/events/main/latest/District%20Program%20Page%20Visited?view=All&tab=DETAILS&propertyValidityFilter=All%2520Properties)

## Testing story
Administrators page:
![Administrators page](https://github.com/code-dot-org/code-dot-org/assets/56283563/71a48529-2351-418b-ac9f-4412ca41c1f8)

Districts page:
![districts page](https://github.com/code-dot-org/code-dot-org/assets/56283563/84305cbd-e400-4539-8264-851df5cd9215)
