### PR TITLE
Show print certificate button on most units when user has completed them

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -45,7 +45,6 @@ class UnitOverviewTopRow extends React.Component {
     scriptResourcesPdfUrl: PropTypes.string,
     courseOfferingId: PropTypes.number,
     courseVersionId: PropTypes.number,
-    isProfessionalLearningCourse: PropTypes.bool,
     publishedState: PropTypes.oneOf(Object.values(PublishedState)),
     courseLink: PropTypes.string,
     participantAudience: PropTypes.string,
@@ -140,7 +139,6 @@ class UnitOverviewTopRow extends React.Component {
       hasPerLevelResults,
       courseOfferingId,
       courseVersionId,
-      isProfessionalLearningCourse,
       publishedState,
       participantAudience,
       isUnitWithLevels,
@@ -161,13 +159,6 @@ class UnitOverviewTopRow extends React.Component {
       unitProgress = IN_PROGRESS;
     }
 
-    /*
-     * We are turning off Printing Certificates for Professional Learning Courses
-     * until we can create a specialized certificate for PL courses.
-     * */
-    let completedProfessionalLearningCourse =
-      isProfessionalLearningCourse && unitProgress === COMPLETED;
-
     const displayPrintingOptionsDropwdown =
       pdfDropdownOptions.length > 0 &&
       publishedState !== PublishedState.pilot &&
@@ -177,7 +168,7 @@ class UnitOverviewTopRow extends React.Component {
       <div style={styles.buttonRow} className="unit-overview-top-row">
         {!deeperLearningCourse && viewAs === ViewType.Participant && (
           <div style={styles.buttonsInRow}>
-            {!completedProfessionalLearningCourse && isUnitWithLevels && (
+            {isUnitWithLevels && (
               <Button
                 __useDeprecatedTag
                 href={`/s/${scriptName}/next`}

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
@@ -26,7 +26,6 @@ const defaultProps = {
   isMigrated: false,
   unitCompleted: false,
   hasPerLevelResults: false,
-  isProfessionalLearningCourse: false,
   publishedState: 'stable',
   isUnitWithLevels: true,
 };
@@ -129,28 +128,6 @@ describe('UnitOverviewTopRow', () => {
         />
       )
     ).to.be.true;
-  });
-
-  it('does not render "Print Certificate" button for participant in professional learning course', () => {
-    const wrapper = shallow(
-      <UnitOverviewTopRow
-        {...defaultProps}
-        viewAs={ViewType.Participant}
-        unitCompleted={true}
-        isProfessionalLearningCourse={true}
-      />
-    );
-
-    expect(
-      wrapper.containsMatchingElement(
-        <Button
-          __useDeprecatedTag
-          href="/s/test-script/next"
-          text={i18n.printCertificate()}
-          size={Button.ButtonSize.large}
-        />
-      )
-    ).to.be.false;
   });
 
   it('renders SectionAssigner for instructor', () => {

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1466,7 +1466,7 @@ class Unit < ApplicationRecord
   def finish_url
     return hoc_finish_url if hoc?
     return csf_finish_url if csf?
-    nil
+    CDO.code_org_url "/congrats/#{name}"
   end
 
   # A unit that the general public can assign. Has been soft or


### PR DESCRIPTION
Adds a print certificate button for more units! I didn't change the logic of when we'd show this button -- it's still shown when we have a `UserScript` for the user and unit with a non-null `completed_at` value -- but this should show it on many more units!


https://github.com/code-dot-org/code-dot-org/assets/46464143/ed530bdb-b089-40bf-a384-bb41d266d730

