### PR TITLE
modified spacing in icon key

### DIFF
--- a/apps/src/templates/sectionProgressV2/LevelTypesBox.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelTypesBox.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import i18n from '@cdo/locale';
+import classNames from 'classnames';
 import LegendItem from './LegendItem';
 import {ITEM_TYPE} from './ItemType';
 import styles from './progress-table-legend.module.scss';
@@ -7,7 +8,7 @@ import {StrongText} from '@cdo/apps/componentLibrary/typography';
 
 export default function LevelTypesBox() {
   return (
-    <div className={styles.legend}>
+    <div className={classNames(styles.legend, styles.levelTypes)}>
       <StrongText className={styles.headerContainer}>
         {i18n.levelTypes()}
       </StrongText>

--- a/apps/src/templates/sectionProgressV2/progress-table-legend.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-legend.module.scss
@@ -32,7 +32,7 @@
 }
 
 .legend.levelTypes {
-  margin-right: 0px;
+  margin-right: 0;
 }
 
 .legendColumn {

--- a/apps/src/templates/sectionProgressV2/progress-table-legend.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-legend.module.scss
@@ -21,6 +21,7 @@
   display: inline-flex;
   flex-direction: column;
   white-space: nowrap;
+  margin-right: 16px;
 }
 
 .legend .headerContainer {
@@ -28,6 +29,10 @@
   padding: 8px 16px;
   border-bottom: 1px solid $light_gray_200;
   box-sizing: border-box;
+}
+
+.legend.levelTypes {
+  margin-right: 0px;
 }
 
 .legendColumn {
@@ -42,7 +47,7 @@
   display: flex;
   padding: 16px;
   align-items: flex-start;
-  gap: 40px;
+  gap: 28px;
 }
 
 .legendItem {
@@ -77,7 +82,7 @@
 }
 
 .feedbackGiven {
-background-image: url("data:image/svg+xml,%3Csvg viewBox='-1 1 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath id='Polygon 1' d='M19 1L19 15L5 1L19 1Z' fill='%23292F36'%3E%3C/path%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='-1 1 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath id='Polygon 1' d='M19 1L19 15L5 1L19 1Z' fill='%23292F36'%3E%3C/path%3E%3C/svg%3E");
   background-size: 20px;
   background-repeat: no-repeat;
   background-position: top right;


### PR DESCRIPTION
This adds spacing to the boxes on the legend.  Note that [Liam has been working on a PR](https://github.com/code-dot-org/code-dot-org/pull/56330) to change the width of the screen this component will be on.  Once that goes live, there will be enough space for all of the boxes - I had to modify that width in the developer console for the image below.  Since this is behind a DCDO flag, we are able to merge this before the screen width gets changed with Liam's PR.

Old look:
![image](https://github.com/code-dot-org/code-dot-org/assets/24883357/75436df8-741f-4164-9e69-92bc2fba139a)



New look:
<img width="886" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/14924772-9c49-47bd-9d64-198326f95c2d">


## Links
[Figma](https://www.figma.com/file/gCktlnafGYQSNJafD3FUgA/Progress-Tracking?node-id=2173%3A33166&mode=dev)
[Slack thread with Molly](https://codedotorg.slack.com/archives/C06ERUABG01/p1707837856028289)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[
Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-801)
## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
