### PR TITLE
replace crypto-js with browserify-crypto as crypto-js is no longer maintained

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -281,7 +281,7 @@
     "ace-builds": "^1.4.12",
     "blockly": "10.3.1",
     "chart.js": "^4.4.0",
-    "crypto-js": "^3.1.9-1",
+    "crypto-browserify": "^3.12.0",
     "dapjs": "^2.3.0",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "filesaver.js": "0.2.0",

--- a/apps/src/code-studio/hashEmail.js
+++ b/apps/src/code-studio/hashEmail.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import MD5 from 'crypto-js/md5';
+import {md5} from '../util/crypto';
 
 const EMAIL_REGEX = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 
@@ -21,7 +21,7 @@ export default function (options) {
 }
 
 export function hashEmail(cleartextEmail) {
-  return MD5(normalizeEmail(cleartextEmail)).toString();
+  return md5(normalizeEmail(cleartextEmail));
 }
 
 function normalizeEmail(rawEmail) {

--- a/apps/src/sites/studio/pages/shared/_check_admin.js
+++ b/apps/src/sites/studio/pages/shared/_check_admin.js
@@ -1,8 +1,8 @@
-import MD5 from 'crypto-js/md5';
 import getScriptData from '@cdo/apps/util/getScriptData';
+import {md5} from '@cdo/apps/util/crypto';
 
 const serverHOCSecret = getScriptData('checkadmin');
-const localHOCSecret = MD5(localStorage.getItem('hoc_secret')).toString();
+const localHOCSecret = md5(localStorage.getItem('hoc_secret'));
 if (localHOCSecret !== serverHOCSecret) {
   document.location = '/';
 }

--- a/apps/src/templates/instructions/InlineAudio.jsx
+++ b/apps/src/templates/instructions/InlineAudio.jsx
@@ -1,10 +1,10 @@
-import MD5 from 'crypto-js/md5';
 import PropTypes from 'prop-types';
 import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {connect} from 'react-redux';
 import trackEvent from '../../util/trackEvent';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import {md5} from '@cdo/apps/util/crypto';
 import moduleStyles from './inline-audio.module.scss';
 import classNames from 'classnames';
 import i18n from '@cdo/locale';
@@ -179,7 +179,7 @@ class InlineAudio extends React.Component {
       const voicePath = `${voice.VOICE}/${voice.SPEED}/${voice.SHAPE}`;
 
       const message = this.props.message.replace('"???"', 'the question marks');
-      const hash = MD5(message).toString();
+      const hash = md5(message);
       const contentPath = `${hash}/${encodeURIComponent(message)}.mp3`;
 
       return `${TTS_URL}/${voicePath}/${contentPath}`;

--- a/apps/src/util/crypto.ts
+++ b/apps/src/util/crypto.ts
@@ -1,0 +1,9 @@
+import crypto from 'crypto';
+
+export function md5(content: string): string {
+  const md5Hasher = crypto.createHash('md5');
+
+  md5Hasher.update(content);
+
+  return md5Hasher.digest('hex');
+}

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -1,11 +1,10 @@
 import $ from 'jquery';
 import Immutable from 'immutable';
-import MD5 from 'crypto-js/md5';
 import RGBColor from 'rgbcolor';
 import {Position} from './constants';
 import {dataURIFromURI} from './imageUtils';
 import './polyfills';
-
+import {md5} from './util/crypto';
 /**
  * Checks whether the given subsequence is truly a subsequence of the given sequence,
  * and whether the elements appear in the same order as the sequence.
@@ -883,7 +882,7 @@ export const findProfanity = (text, locale, authenticityToken = null) => {
  * @returns {string} A string representing an MD5 hash.
  */
 export function hashString(str) {
-  return MD5(str).toString();
+  return md5(str);
 }
 
 /*

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -135,7 +135,7 @@ const nodePolyfillConfig = {
       'process/browser': require.resolve('process/browser'),
       stream: require.resolve('stream-browserify'),
       timers: require.resolve('timers-browserify'),
-      crypto: false,
+      crypto: require.resolve('crypto-browserify'),
     },
   },
 };

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8198,7 +8198,7 @@ __metadata:
     codemirror: 5.5
     codemirror-spell-checker: ^1.1.2
     copy-webpack-plugin: ^9.0.1
-    crypto-js: ^3.1.9-1
+    crypto-browserify: ^3.12.0
     css-loader: ^6.2.0
     csv-parse: ^4.4.6
     dapjs: ^2.3.0
@@ -10531,7 +10531,7 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
-"crypto-browserify@npm:^3.11.0":
+"crypto-browserify@npm:^3.11.0, crypto-browserify@npm:^3.12.0":
   version: 3.12.0
   resolution: "crypto-browserify@npm:3.12.0"
   dependencies:
@@ -10547,13 +10547,6 @@ canvg@gabelerner/canvg:
     randombytes: ^2.0.0
     randomfill: ^1.0.3
   checksum: c1609af82605474262f3eaa07daa0b2140026bd264ab316d4bf1170272570dbe02f0c49e29407fe0d3634f96c507c27a19a6765fb856fed854a625f9d15618e2
-  languageName: node
-  linkType: hard
-
-"crypto-js@npm:^3.1.9-1":
-  version: 3.3.0
-  resolution: "crypto-js@npm:3.3.0"
-  checksum: 193923143a4784b2f974366068d96fe8280168fd3fef2bfea9551a5c3e32096f5a8fa49ff4eeb5bd0b9716d325618d38cfbe6125e359a4ef488fbca93e600824
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Previously, crypto-js was used solely for the md5 hashing function. Since node.js has a native crypto library, we can utilize the native md5 hasher. For browsers, a polyfill `browserify-crypto` can be used which is actively being maintained.

fixes dependabot moderate [Dependabot #434](https://github.com/code-dot-org/code-dot-org/security/dependabot/434) and critical  [Dependabot #486](https://github.com/code-dot-org/code-dot-org/security/dependabot/486)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

1. [crypto-js discontinued announcement](https://github.com/brix/crypto-js)
2. [crypto-browserify statement of active project status](https://github.com/browserify/crypto-browserify/issues/229)
3. [Dependabot #486](https://github.com/code-dot-org/code-dot-org/security/dependabot/486)
4. [Dependabot #434](https://github.com/code-dot-org/code-dot-org/security/dependabot/434)

## Testing story

I ran rake test and the UI tests. The following tests were run to ensure that the native md5 hasher is consistent with crypto-js:

```
apps/test/unit/templates/instructions/InlineAudioTest.js
apps/test/unit/templates/curriculumCatalog/curriculumCatalogExpandedCardTest.jsx
```

## Deployment strategy

## Follow-up work

No follow up necessary.

## Privacy

This does not change any user models or interact with privacy.

## Security

This addresses the discontinued crypto-js library by switching to an actively maintained and more mainline browserify library.

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
