### PR TITLE
Music: fix sequencer library lookup

### DIFF
--- a/apps/src/music/player/sequencer/Simple2Sequencer.ts
+++ b/apps/src/music/player/sequencer/Simple2Sequencer.ts
@@ -38,7 +38,6 @@ export default class Simple2Sequencer extends Sequencer {
   private inTrigger: boolean;
 
   constructor(
-    private readonly library = MusicLibrary.getInstance(),
     private readonly metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter()
   ) {
     super();
@@ -201,7 +200,7 @@ export default class Simple2Sequencer extends Sequencer {
    * Play a sound at the current location.
    */
   playSound(id: string, blockId: string) {
-    const soundData = this.library?.getSoundForId(id);
+    const soundData = MusicLibrary.getInstance()?.getSoundForId(id);
     if (!soundData) {
       this.metricsReporter.logWarning('Could not find sound with ID: ' + id);
       return;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -295,7 +295,7 @@ class UnconnectedMusicView extends React.Component {
     }
 
     if (getBlockMode() === BlockMode.SIMPLE2) {
-      this.sequencer = new Simple2Sequencer(this.library);
+      this.sequencer = new Simple2Sequencer();
     } else {
       this.sequencer = new MusicPlayerStubSequencer();
     }

--- a/apps/test/unit/music/player/sequencer/Simple2SequencerTest.ts
+++ b/apps/test/unit/music/player/sequencer/Simple2SequencerTest.ts
@@ -29,7 +29,7 @@ describe('Simple2Sequencer', () => {
     library.getSoundForId.returns(testSound);
     Sinon.stub(MusicLibrary, 'getInstance').returns(library);
 
-    sequencer = new Simple2Sequencer(library);
+    sequencer = new Simple2Sequencer();
   });
 
   afterEach(() => {

--- a/apps/test/unit/music/player/sequencer/Simple2SequencerTest.ts
+++ b/apps/test/unit/music/player/sequencer/Simple2SequencerTest.ts
@@ -27,8 +27,13 @@ describe('Simple2Sequencer', () => {
   beforeEach(() => {
     library = Sinon.createStubInstance(MusicLibrary);
     library.getSoundForId.returns(testSound);
+    Sinon.stub(MusicLibrary, 'getInstance').returns(library);
 
     sequencer = new Simple2Sequencer(library);
+  });
+
+  afterEach(() => {
+    Sinon.restore();
   });
 
   it('starts a new sequence at the given measure', () => {


### PR DESCRIPTION
Fix a minor bug I introduced in https://github.com/code-dot-org/code-dot-org/pull/56551. Instead of having a default parameter for the library in the constructor of Simple2Sequencer, we should just look it up directly when needed, as the library may be undefined when calling the constructor. Thanks Brendan for spotting this!

Note that this shouldn't have affected production because we were still passing in the library as an arg. Now however that the parameter has been fully removed, we no longer need to pass it in the constructor.

## Testing story

Tested locally on /projectbeats and gallery page with mini player.