### PR TITLE
Remove principal_schedule_confirmed from scoreable questions

### DIFF
--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -290,7 +290,6 @@ module Pd
         :committed,
         :previous_yearlong_cdo_pd,
         :principal_approval,
-        :principal_schedule_confirmed,
       ],
       criteria_score_questions_csp: [
         :csp_which_grades,
@@ -298,7 +297,6 @@ module Pd
         :committed,
         :previous_yearlong_cdo_pd,
         :principal_approval,
-        :principal_schedule_confirmed,
       ],
       criteria_score_questions_csa: [
         :csa_already_know,
@@ -308,7 +306,6 @@ module Pd
         :committed,
         :previous_yearlong_cdo_pd,
         :principal_approval,
-        :principal_schedule_confirmed,
       ]
     }
 


### PR DESCRIPTION
Applications that met all guidelines were seeing "Reviewing Incomplete" on the application dashboard. Looking at an application for each of CSD, CSP, and CSA, the issue was that `principal_schedule_confirmed` was still in `SCOREABLE_QUESTIONS` but removed in #55240. The applications I checked had all other fields set, so this is the only one that needed to be removed.