### PR TITLE
DRY up datablock_storage routes

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -423,7 +423,9 @@ Applab.init = function (config) {
 
   if (!!config.useDatablockStorage) {
     console.error('Initializing DATABLOCK_STORAGE');
-    Applab.storage = initStorage(DATABLOCK_STORAGE, {});
+    Applab.storage = initStorage(DATABLOCK_STORAGE, {
+      channelId: config.channel,
+    });
   } else {
     console.error('Initializing FIREBASE_STORAGE');
     Applab.storage = initStorage(FIREBASE_STORAGE, {

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 const DatablockStorage = {};
+let channelId = undefined;
 
 function getAuthToken() {
   const tokenDOM = document.querySelector('meta[name="csrf-token"]');
@@ -14,7 +15,7 @@ function urlFor(func_name) {
   // FIXME: this doesn't work for all URLs where this can be loaded from
   // e.g. http://localhost-studio.code.org:3000/projects/applab/Yp05MnSdVubn04tBoEZn_g/edit/
   // vs http://localhost-studio.code.org:3000/projects/applab/Yp05MnSdVubn04tBoEZn_g
-  return '../datablock_storage/' + func_name;
+  return `/datablock_storage/${channelId}/` + func_name;
 }
 
 function _fetch(path, method, params) {
@@ -465,7 +466,8 @@ DatablockStorage.resetForTesting = function () {
 
 DatablockStorage.resetRecordListener = function () {};
 
-export function initDatablockStorage(config) {
+export function initDatablockStorage({channelId: _channelId}) {
+  channelId = _channelId;
   return DatablockStorage;
 }
 

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -65,6 +65,8 @@ class DatablockStorageController < ApplicationController
 
   def add_shared_table
     DatablockStorageTable.add_shared_table @project_id, params[:table_name]
+
+    render json: true
   end
 
   def import_csv

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -226,48 +226,9 @@ Dashboard::Application.routes.draw do
     put '/featured_projects/:project_id/unfeature', to: 'featured_projects#unfeature'
     put '/featured_projects/:project_id/feature', to: 'featured_projects#feature'
 
-    SUPPORTS_DATABLOCK_STORAGE = ['applab', 'gamelab'].freeze
     resources :projects, path: '/projects/', only: [:index] do
       collection do
         ProjectsController::STANDALONE_PROJECTS.each do |key, _|
-          if SUPPORTS_DATABLOCK_STORAGE.include? key
-            # Datablock Storage: Debug View
-            get "/#{key}/:channel_id/datablock_storage", to: 'datablock_storage#index'
-
-            # Datablock Storage: Key-Value-Pair API
-            post "/#{key}/:channel_id/datablock_storage/set_key_value", to: 'datablock_storage#set_key_value'
-            get "/#{key}/:channel_id/datablock_storage/get_key_value", to: 'datablock_storage#get_key_value'
-            delete "/#{key}/:channel_id/datablock_storage/delete_key_value", to: 'datablock_storage#delete_key_value'
-            get "/#{key}/:channel_id/datablock_storage/get_key_values", to: 'datablock_storage#get_key_values'
-            put "/#{key}/:channel_id/datablock_storage/populate_key_values", to: 'datablock_storage#populate_key_values'
-
-            # Datablock Storage: Table API
-            post "/#{key}/:channel_id/datablock_storage/create_table", to: 'datablock_storage#create_table'
-            post "/#{key}/:channel_id/datablock_storage/add_shared_table", to: 'datablock_storage#add_shared_table'
-            post "/#{key}/:channel_id/datablock_storage/import_csv", to: 'datablock_storage#import_csv'
-            delete "/#{key}/:channel_id/datablock_storage/clear_table", to: 'datablock_storage#clear_table'
-            delete "/#{key}/:channel_id/datablock_storage/delete_table", to: 'datablock_storage#delete_table'
-            get "/#{key}/:channel_id/datablock_storage/get_table_names", to: 'datablock_storage#get_table_names'
-            put "/#{key}/:channel_id/datablock_storage/populate_tables", to: 'datablock_storage#populate_tables'
-
-            # Datablock Storage: Table Column API
-            post "/#{key}/:channel_id/datablock_storage/add_column", to: 'datablock_storage#add_column'
-            put "/#{key}/:channel_id/datablock_storage/rename_column", to: 'datablock_storage#rename_column'
-            put "/#{key}/:channel_id/datablock_storage/coerce_column", to: 'datablock_storage#coerce_column'
-            delete "/#{key}/:channel_id/datablock_storage/delete_column", to: 'datablock_storage#delete_column'
-            get "/#{key}/:channel_id/datablock_storage/get_columns_for_table", to: 'datablock_storage#get_columns_for_table'
-
-            # Datablock Storage: Table Record API
-            post "/#{key}/:channel_id/datablock_storage/create_record", to: 'datablock_storage#create_record'
-            get "/#{key}/:channel_id/datablock_storage/read_records", to: 'datablock_storage#read_records'
-            put "/#{key}/:channel_id/datablock_storage/update_record", to: 'datablock_storage#update_record'
-            delete "/#{key}/:channel_id/datablock_storage/delete_record", to: 'datablock_storage#delete_record'
-
-            # Datablock Storage: Channel API
-            get "/#{key}/:channel_id/datablock_storage/channel_exists", to: 'datablock_storage#channel_exists'
-            delete "/#{key}/:channel_id/datablock_storage/clear_all_data", to: 'datablock_storage#clear_all_data'
-          end
-
           get "/#{key}", to: 'projects#load', key: key.to_s, as: "#{key}_project"
           get "/#{key}/new", to: 'projects#create_new', key: key.to_s, as: "#{key}_project_create_new"
 
@@ -1143,5 +1104,42 @@ Dashboard::Application.routes.draw do
       'policy_compliance#child_account_consent'
     post '/policy_compliance/child_account_consent/', to:
       'policy_compliance#child_account_consent_request'
+
+    resources :datablock_storage, path: '/datablock_storage/:channel_id/', only: [:index] do
+      collection do
+        # Datablock Storage: Key-Value-Pair API
+        post :set_key_value
+        get :get_key_value
+        delete :delete_key_value
+        get :get_key_values
+        put :populate_key_values
+
+        # Datablock Storage: Table API
+        post :create_table
+        post :add_shared_table
+        post :import_csv
+        delete :clear_table
+        delete :delete_table
+        get :get_table_names
+        put :populate_tables
+
+        # Datablock Storage: Table Column API
+        post :add_column
+        put :rename_column
+        put :coerce_column
+        delete :delete_column
+        get :get_columns_for_table
+
+        # Datablock Storage: Table Record API
+        post :create_record
+        get :read_records
+        put :update_record
+        delete :delete_record
+
+        # Datablock Storage: Channel API
+        get :channel_exists
+        delete :clear_all_data
+      end
+    end
   end
 end


### PR DESCRIPTION
Our `routes.rb` entries were brittle (because they were project relative paths like `http://localhost-studio.code.org:3000/projects/applab/Yp05MnSdVubn04tBoEZn_g/datablock_storage/set_key_value`) and very verbose. This makes better use of rails routes.rb features to DRY them up, and uses the same path for all datablock_storage calls no matter which level type they came from.

This changes our routes.rb definitions from looking like:
```
            # Datablock Storage: Key-Value-Pair API
            post "/#{key}/:channel_id/datablock_storage/set_key_value", to: 'datablock_storage#set_key_value'
            get "/#{key}/:channel_id/datablock_storage/get_key_value", to: 'datablock_storage#get_key_value'
            delete "/#{key}/:channel_id/datablock_storage/delete_key_value", to: 'datablock_storage#delete_key_value'
            get "/#{key}/:channel_id/datablock_storage/get_key_values", to: 'datablock_storage#get_key_values'
            put "/#{key}/:channel_id/datablock_storage/populate_key_values", to: 'datablock_storage#populate_key_values'
```

To looking like:
```
        # Datablock Storage: Key-Value-Pair API
        post :set_key_value
        get :get_key_value
        delete :delete_key_value
        get :get_key_values
        put :populate_key_values
```

After this change, the datablock_storage browser debug UX is available at, e.g.:
http://localhost-studio.code.org:3000/datablock_storage/Yp05MnSdVubn04tBoEZn_g/

Individual methods are available at, e.g.:
http://localhost-studio.code.org:3000/datablock_storage/Yp05MnSdVubn04tBoEZn_g/get_table_names