### PR TITLE
Store "Data Library" info in `DatablockStorageLibraryManifest`

### DIFF
--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -346,54 +346,11 @@ DatablockStorage.populateKeyValue = function (jsonData, onSuccess, onError) {
   }).then(onSuccess, onError);
 };
 
-// gets a list of all the shared or current tables available in the data browser
+// fetch the library manifest used to populate the "Data Library" browser
+// see: datablock_storage_library_manifest.rb
 DatablockStorage.getLibraryManifest = function () {
-  return getTableNames({isSharedTable: true}).then(tableNames => {
-    console.log('FOUND SHARED TABLES', tableNames);
-    // FIXME, unfirebase, we don't have this implemented yet
-    // see: issue on implementing the library manifest system here:
-    // https://github.com/code-dot-org/code-dot-org/issues/56472
-    const EXAMPLE_MANIFEST_FROM_FIREBASE = {
-      categories: [
-        {
-          datasets: [
-            '100 Birds of the World',
-            'Bee Colonies',
-            'Cats',
-            'Dogs',
-            'Endangered Species of Canada',
-            'Palmer Penguins',
-          ],
-          name: 'Animals',
-          published: true,
-        },
-      ],
-      tables: [
-        {
-          current: false,
-          description:
-            'Data and images about 100 different species of birds around the world',
-          docUrl: 'https://studio.code.org/data_docs/100-birds/',
-          name: '100 Birds of the World',
-          published: true,
-        },
-        {
-          current: true,
-          description:
-            'Live weather five-day forecast data for 100 cities. Updates daily with expected weather conditions.',
-          docUrl: 'https://studio.code.org/data_docs/daily-weather/',
-          lastUpdated: 1707480317000,
-          name: 'Daily Weather',
-          published: true,
-        },
-      ],
-    };
-    console.error(
-      'DatablockStorage.getLibraryManifest is NOT IMPLEMENTED YET, returning stock EXAMPLE_MANIFEST_FROM_FIREBASE:',
-      EXAMPLE_MANIFEST_FROM_FIREBASE
-    );
-    return EXAMPLE_MANIFEST_FROM_FIREBASE;
-  });
+  return _fetch('get_library_manifest', 'GET')
+    .then(response => response.json());
 };
 
 // returns an array of strings for each of the columns in the table

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -10,6 +10,7 @@ class DatablockStorageController < ApplicationController
     @key_value_pairs = DatablockStorageKvp.where(project_id: @project_id)
     @records = DatablockStorageRecord.where(project_id: @project_id)
     @tables = DatablockStorageTable.where(project_id: @project_id)
+    @library_manifest = DatablockStorageLibraryManifest.instance.library_manifest
     puts "####################################################"
   end
 
@@ -186,6 +187,20 @@ class DatablockStorageController < ApplicationController
     table.delete_record params[:record_id]
     table.save!
     render json: nil
+  end
+
+  ##########################################################
+  #   Library Manifest API (shared table metadata)         #
+  ##########################################################
+
+  def get_library_manifest
+    render json: DatablockStorageLibraryManifest.instance.library_manifest
+  end
+
+  def set_library_manifest
+    library_manifest = JSON.parse params[:library_manifest]
+    DatablockStorageLibraryManifest.instance.update!(library_manifest: library_manifest)
+    render json: true
   end
 
   ##########################################################

--- a/dashboard/app/models/datablock_storage_library_manifest.rb
+++ b/dashboard/app/models/datablock_storage_library_manifest.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: datablock_storage_library_manifest
+#
+#  id               :bigint           not null, primary key
+#  library_manifest :json
+#  singleton_guard  :integer          not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  index_datablock_storage_library_manifest_on_singleton_guard  (singleton_guard) UNIQUE
+#
 # A one-row table storing a singleton JSON `library_manifest`` that
 # describes all Data Library datasets and categories:
 #

--- a/dashboard/app/models/datablock_storage_library_manifest.rb
+++ b/dashboard/app/models/datablock_storage_library_manifest.rb
@@ -12,6 +12,8 @@
 #
 #  index_datablock_storage_library_manifest_on_singleton_guard  (singleton_guard) UNIQUE
 #
+#
+#
 # A one-row table storing a singleton JSON `library_manifest`` that
 # describes all Data Library datasets and categories:
 #
@@ -42,11 +44,14 @@
 class DatablockStorageLibraryManifest < ApplicationRecord
   self.table_name = 'datablock_storage_library_manifest'
   
+  # DatablockStorageLibraryManifest is a singleton, only one-row allowed in the table
+  # with the unique `singleton_guard` value of 0
   validates_inclusion_of :singleton_guard, in: [0]
   validate :validate_library_manifest
 
   after_initialize :set_default_library_manifest, if: :new_record?
 
+  # DatablockStorageLibraryManifest.instance returns the singleton row
   def self.instance
     first_or_create!(singleton_guard: 0)
   end

--- a/dashboard/app/models/datablock_storage_library_manifest.rb
+++ b/dashboard/app/models/datablock_storage_library_manifest.rb
@@ -1,0 +1,62 @@
+# A one-row table storing a singleton JSON `library_manifest`` that
+# describes all Data Library datasets and categories:
+#
+# library_manifest = {
+#   categories: [
+#     {
+#       datasets: [
+#         '100 Birds of the World',
+#         'Cats',
+#         'Dogs',
+#       ],
+#       name: 'Animals',
+#       published: true,
+#     },
+#   ],
+#   tables: [
+#     {
+#       description:
+#         'Data and images about 100 different species of birds around the world',
+#       docUrl: 'https://studio.code.org/data_docs/100-birds/',
+#       name: '100 Birds of the World',
+#       published: true,
+#     },
+#   ],
+# };
+#
+# See: `DatasetController`(Ruby) and `DatablockStorage.getLibraryManifest` (JS)
+class DatablockStorageLibraryManifest < ApplicationRecord
+  self.table_name = 'datablock_storage_library_manifest'
+  
+  validates_inclusion_of :singleton_guard, in: [0]
+  validate :validate_library_manifest
+
+  after_initialize :set_default_library_manifest, if: :new_record?
+
+  def self.instance
+    first_or_create!(singleton_guard: 0)
+  end
+
+  validate :library_manifest
+
+private
+
+  def validate_library_manifest
+    unless library_manifest.is_a?(Hash)
+      errors.add(:library_manifest, "must be a JSON object")
+      return
+    end
+
+    unless library_manifest.key?('categories') && library_manifest['categories'].is_a?(Array)
+      errors.add(:library_manifest, "must have a 'categories' array")
+    end
+
+    unless library_manifest.key?('tables') && library_manifest['tables'].is_a?(Array)
+      errors.add(:library_manifest, "must have a 'tables' array")
+    end
+  end
+
+  def set_default_library_manifest
+    self.library_manifest ||= { 'categories' => [], 'tables' => [] }
+  end
+end

--- a/dashboard/app/views/datablock_storage/index.html.haml
+++ b/dashboard/app/views/datablock_storage/index.html.haml
@@ -169,3 +169,16 @@
 = form_tag "add_shared_table", :method => :post, :remote => false do
   = text_field_tag "table_name", "100 Birds of the World", placeholder: "table_name"
   = submit_tag "add_shared_table"
+
+%h2 Library Manifest
+
+%div= @library_manifest
+
+%h3 get_library_manifest
+= form_tag "get_library_manifest", :method => :get, :remote => false do
+  = submit_tag "get_library_manifest"
+
+%h3 set_library_manifest
+= form_tag "set_library_manifest", :method => :put, :remote => false do
+  = text_area_tag "library_manifest", '{"categories":[{"datasets":["100 Birds of the World"],"name":"Animals","published":true}],"tables":[{"current":false,"description":"Data and images about 100 different species of birds around the world","docUrl":"https://studio.code.org/data_docs/100-birds/","name":"100 Birds of the World","published":true}]}'
+  = submit_tag "set_library_manifest"

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1136,6 +1136,10 @@ Dashboard::Application.routes.draw do
         put :update_record
         delete :delete_record
 
+        # Datablock Storage: Library Manifest API (=shared table metadata)
+        get :get_library_manifest
+        put :set_library_manifest
+
         # Datablock Storage: Channel API
         get :channel_exists
         delete :clear_all_data

--- a/dashboard/db/migrate/20240216053618_create_datablock_storage_library_manifest.rb
+++ b/dashboard/db/migrate/20240216053618_create_datablock_storage_library_manifest.rb
@@ -1,0 +1,12 @@
+require 'firebase'
+
+class CreateDatablockStorageLibraryManifest < ActiveRecord::Migration[6.1]
+  def change
+    create_table :datablock_storage_library_manifest do |t|
+      t.json :library_manifest
+      t.integer :singleton_guard, null: false
+      t.timestamps
+    end
+    add_index :datablock_storage_library_manifest, :singleton_guard, unique: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_15_100626) do
+ActiveRecord::Schema.define(version: 2024_02_16_053618) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -439,6 +439,14 @@ ActiveRecord::Schema.define(version: 2024_02_15_100626) do
     t.integer "project_id", null: false
     t.string "key", limit: 768, null: false
     t.json "value"
+  end
+
+  create_table "datablock_storage_library_manifest", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+    t.json "library_manifest"
+    t.integer "singleton_guard", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["singleton_guard"], name: "index_datablock_storage_library_manifest_on_singleton_guard", unique: true
   end
 
   create_table "datablock_storage_records", primary_key: ["project_id", "table_name", "record_id"], charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
1. Implements a new singleton model: `DatablockStorageLibraryManifest`
2. Adds new DatablockStorageController methods: `get_library_manifest` and `set_library_manifest`
3. Uses `DatablockStorageController::get_library_manifest` to implement `DatablockStorage.getLibraryManifest` in JS
4. To prevent accidental erases, DatablockStorageLibraryManifest validates that set `library_manifest` JSON blobs contain at least a `categories` list and a `tables` list.

As per @cnbrenci 's comment in https://github.com/code-dot-org/code-dot-org/issues/56472#issuecomment-1947641827, we need a schema for storing "library manifest" type info: i.e. the data we'd have fetched in one json fetch in the past from https://console.firebase.google.com/project/cdo-v3-shared/database/cdo-v3-shared/data/~2Fv3~2Fchannels~2Fshared . 

We could have broken this into a more complex system, but because this data is only read and saved in a single "whole json glob" format, it seemed simplest to create a singleton (one-row) table with a `library_manifest` json value.

This also makes it mimic the existing Firebase semantics, which will make transitioning UX code like the dataset_controller.rb easier.