### PR TITLE
Update hover style on curriculum_pathway view

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
+++ b/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
@@ -98,16 +98,21 @@ figure.curriculum-pathway {
       place-content: center;
       gap: 4px;
 
+      &:after {
+        color: var(--neutral_dark20);
+        font: var(--fa-font-solid);
+        content: "\f054";
+        margin-top: 4px;
+        transition: color 0.2s ease-in-out;
+
+        html[dir="rtl"] & { content: "\f053"; }
+      }
+
       &:is(:hover, :focus) {
         box-shadow: 0 1px 6px var(--neutral_dark20);
 
         &:after {
           color: var(--neutral_dark40);
-          font: var(--fa-font-solid);
-          content: "\f054";
-          margin-top: 4px;
-
-          html[dir="rtl"] & { content: "\f053"; }
         }
       }
 


### PR DESCRIPTION
Adds the arrow to the static state on course elements on the `curriculum_pathway.haml` view, and gets darker on hover. This can be seen on https://code.org/administrators. Was updated based on feedback on [this comment](https://github.com/code-dot-org/code-dot-org/pull/55946#issuecomment-1912913976) on a previous PR.

**Jira ticket:** [ACQ-1441](https://codedotorg.atlassian.net/browse/ACQ-1441)

----

https://github.com/code-dot-org/code-dot-org/assets/9256643/b939af60-7710-43d1-a791-7c8f96ae827b