### PR TITLE
Always use Google Blockly for Sprite Lab

### DIFF
--- a/dashboard/app/models/levels/gamelab_jr.rb
+++ b/dashboard/app/models/levels/gamelab_jr.rb
@@ -183,9 +183,8 @@ class GamelabJr < Gamelab
     false
   end
 
-  # Use a DCDO flag here so we can flip Sprite Lab without a deploy
   def uses_google_blockly?
-    DCDO.get('sprite_lab_google_blockly', true)
+    true
   end
 
   def age_13_required?

--- a/dashboard/test/models/levels/gamelab_jr_test.rb
+++ b/dashboard/test/models/levels/gamelab_jr_test.rb
@@ -5,13 +5,7 @@ class GamelabJrTest < ActiveSupport::TestCase
     @gamelab_jr = GamelabJr.new
   end
 
-  test 'uses_google_blockly? returns true when DCDO flag is true' do
-    DCDO.stubs(:get).with('sprite_lab_google_blockly', true).returns(true)
+  test 'uses_google_blockly? returns true' do
     assert @gamelab_jr.uses_google_blockly?
-  end
-
-  test 'uses_google_blockly? returns false when DCDO flag is false' do
-    DCDO.stubs(:get).with('sprite_lab_google_blockly', true).returns(false)
-    refute @gamelab_jr.uses_google_blockly?
   end
 end


### PR DESCRIPTION
:tada:

After over a week of Sprite Lab running on Google Blockly via DCDO flag, we are ready to remove this additional check. From this point forwards, we will always need to use Google Blockly for Sprite Lab in order to continue supporting student progress after February 8, 2024.

Rather than remove the text file completely (created here: https://github.com/code-dot-org/code-dot-org/pull/55453/files), I opted to leave a simplified version as a secondary layer of protection against an accidental revert.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
