### PR TITLE
P20-628: Implement independent i18n sync-down of Apps resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,8 @@ npm-debug.log
 /bin/i18n/*_credentials.yml
 /bin/i18n/crowdin/etags/*testing_etags.json
 /bin/i18n/crowdin/etags/*test_etags.json
+/bin/i18n/crowdin/etags/**/*testing.json
+/bin/i18n/crowdin/etags/**/*test.json
 /bin/test/coverage
 /dashboard/config/newrelic.yml
 /dashboard/db/ui_test_data.*
@@ -96,6 +98,7 @@ npm-debug.log
 /pegasus/.sass-cache
 /pegasus/sites.v3/*/public/css/generated
 /tools/scripts/brokenLinkChecker/node_modules/
+/i18n/crowdin/*
 /i18n/locales/*/codeorg-markdown/
 /i18n/locales/*/curriculum_content/
 /i18n/locales/*/piskel/

--- a/Gemfile
+++ b/Gemfile
@@ -349,7 +349,7 @@ gem 'pry', '~> 0.14.0'
 # Google's Compact Language Detector
 gem 'cld'
 
-gem 'crowdin-api', '~> 1.6.0'
+gem 'crowdin-api', '~> 1.8.1'
 
 gem "delayed_job_active_record", "~> 4.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,9 +298,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    crowdin-api (1.6.0)
+    crowdin-api (1.8.1)
       open-uri (>= 0.1.0, < 0.2.0)
-      rest-client (>= 2.0.0, < 2.1.0)
+      rest-client (>= 2.0.0, < 2.2.0)
     css_parser (1.10.0)
       addressable
     cucumber (3.1.1)
@@ -972,7 +972,7 @@ DEPENDENCIES
   cld
   colorize
   composite_primary_keys (~> 13.0)
-  crowdin-api (~> 1.6.0)
+  crowdin-api (~> 1.8.1)
   cucumber
   daemons
   dalli

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -8,7 +8,9 @@ require 'psych'
 require 'ruby-progressbar'
 require 'parallel'
 
-I18N_LOCALES_DIR = 'i18n/locales'.freeze
+I18N_DIR = 'i18n'.freeze
+I18N_CROWDIN_DIR = File.join(I18N_DIR, 'crowdin').freeze
+I18N_LOCALES_DIR = File.join(I18N_DIR, 'locales').freeze
 I18N_SOURCE_DIR = File.join(I18N_LOCALES_DIR, 'source').freeze
 I18N_ORIGINAL_DIR = File.join(I18N_LOCALES_DIR, 'original').freeze
 
@@ -374,6 +376,10 @@ class I18nScriptUtils
     FileUtils.mkdir_p(to_dir)
     FileUtils.cp_r File.join(from_dir, '.'), to_dir
     FileUtils.rm_r(from_dir)
+  end
+
+  def self.crowdin_locale_dir(locale, *paths)
+    CDO.dir(I18N_CROWDIN_DIR, locale, *paths.compact)
   end
 
   def self.locale_dir(locale, *paths)

--- a/bin/i18n/resources/apps.rb
+++ b/bin/i18n/resources/apps.rb
@@ -15,6 +15,12 @@ module I18n
         Labs.sync_up(**opts)
       end
 
+      def self.sync_down(**opts)
+        Animations.sync_down(**opts)
+        ExternalSources.sync_down(**opts)
+        Labs.sync_down(**opts)
+      end
+
       def self.sync_out
         Animations.sync_out
         ExternalSources.sync_out

--- a/bin/i18n/resources/apps/animations.rb
+++ b/bin/i18n/resources/apps/animations.rb
@@ -16,6 +16,10 @@ module I18n
           SyncUp.perform(**opts)
         end
 
+        def self.sync_down(**opts)
+          SyncDown.perform(**opts)
+        end
+
         def self.sync_out
           SyncOut.perform
         end

--- a/bin/i18n/resources/apps/animations/sync_down.rb
+++ b/bin/i18n/resources/apps/animations/sync_down.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../i18n_script_utils'
+require_relative '../../../utils/sync_down_base'
+require_relative '../animations'
+
+module I18n
+  module Resources
+    module Apps
+      module Animations
+        class SyncDown < I18n::Utils::SyncDownBase
+          config.download_paths << DownloadPath.new(crowdin_src: DIR_NAME)
+        end
+      end
+    end
+  end
+end
+
+I18n::Resources::Apps::Animations::SyncDown.perform if __FILE__ == $0

--- a/bin/i18n/resources/apps/external_sources.rb
+++ b/bin/i18n/resources/apps/external_sources.rb
@@ -26,6 +26,10 @@ module I18n
           SyncUp.perform(**opts)
         end
 
+        def self.sync_down(**opts)
+          SyncDown.perform(**opts)
+        end
+
         def self.sync_out
           SyncOut.perform
         end

--- a/bin/i18n/resources/apps/external_sources/sync_down.rb
+++ b/bin/i18n/resources/apps/external_sources/sync_down.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../i18n_script_utils'
+require_relative '../../../utils/sync_down_base'
+require_relative '../external_sources'
+
+module I18n
+  module Resources
+    module Apps
+      module ExternalSources
+        class SyncDown < I18n::Utils::SyncDownBase
+          config.download_paths << DownloadPath.new(crowdin_src: BLOCKLY_CORE_DIR_NAME)
+          config.download_paths << DownloadPath.new(crowdin_src: DIR_NAME)
+        end
+      end
+    end
+  end
+end
+
+I18n::Resources::Apps::ExternalSources::SyncDown.perform if __FILE__ == $0

--- a/bin/i18n/resources/apps/labs.rb
+++ b/bin/i18n/resources/apps/labs.rb
@@ -19,6 +19,10 @@ module I18n
           SyncUp.perform(**opts)
         end
 
+        def self.sync_down(**opts)
+          SyncDown.perform(**opts)
+        end
+
         def self.sync_out
           SyncOut.perform
         end

--- a/bin/i18n/resources/apps/labs/sync_down.rb
+++ b/bin/i18n/resources/apps/labs/sync_down.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../i18n_script_utils'
+require_relative '../../../utils/sync_down_base'
+require_relative '../labs'
+
+module I18n
+  module Resources
+    module Apps
+      module Labs
+        class SyncDown < I18n::Utils::SyncDownBase
+          config.download_paths << DownloadPath.new(crowdin_src: DIR_NAME)
+        end
+      end
+    end
+  end
+end
+
+I18n::Resources::Apps::Labs::SyncDown.perform if __FILE__ == $0

--- a/bin/i18n/utils/crowdin_client.rb
+++ b/bin/i18n/utils/crowdin_client.rb
@@ -1,4 +1,6 @@
 require 'crowdin-api'
+require 'parallel'
+require 'open-uri'
 
 require_relative '../i18n_script_utils'
 
@@ -16,6 +18,7 @@ module I18n
         '429 Too Many Requests',
         '500 Internal Server Error',
         '503 Service Unavailable',
+        'Failed to open TCP connection',
       ].freeze # Request errors to retry
 
       # @param project [String] the Crowdin project name, one of the `CDO.crowdin_projects` keys
@@ -30,12 +33,22 @@ module I18n
         end
       end
 
+      # Retrieves the Crowdin project data
+      # @see https://developer.crowdin.com/api/v2/#operation/api.projects.get
+      #
+      # @param project_id [String] the Crowdin project ID
+      # @return [Hash] the Crowdin project data
+      def get_project(project_id = client.config.project_id)
+        request(:get_project, project_id)['data']
+      end
+
       # Creates the Crowdin directory for the given i18n source directory path
       # https://developer.crowdin.com/api/v2/#operation/api.projects.directories.post
       #
       # @param crowdin_dir_path [String] the absolute Crowdin source directory path, e.g "/course_content/2017"
       # return [Hash, nil] the created Crowdin source directory data
       def add_source_directory(crowdin_dir_path)
+        crowdin_dir_path = File.join('/', crowdin_dir_path)
         crowdin_dir_name = crowdin_source_name(crowdin_dir_path)
         return if crowdin_dir_name.empty?
 
@@ -51,6 +64,7 @@ module I18n
       # @param crowdin_dir_path [String] the absolute Crowdin source directory path, e.g "/course_content/2017"
       # @return [Hash, nil] the Crowdin source directory data
       def get_source_directory(crowdin_dir_path)
+        crowdin_dir_path = File.join('/', crowdin_dir_path)
         crowdin_dir_name = crowdin_source_name(crowdin_dir_path)
         return if crowdin_dir_name.empty?
 
@@ -76,6 +90,7 @@ module I18n
       # @param crowdin_file_path [String] the Crowdin source file path, e.g. "/course_content/2017/coursea-2017.json"
       # @return [Hash, nil] the Crowdin source file data
       def get_source_file(crowdin_file_path)
+        crowdin_file_path = File.join('/', crowdin_file_path)
         crowdin_file_name = crowdin_source_name(crowdin_file_path)
 
         request_offset = 0
@@ -92,6 +107,23 @@ module I18n
         end
 
         crowdin_file&.dig('data')
+      end
+
+      # Retrieves the Crowdin source files of the given Crowdin source directory path
+      # @see https://developer.crowdin.com/api/v2/#operation/api.projects.files.getMany
+      #
+      # @param crowdin_dir_path [String, nil] the absolute Crowdin source directory path, e.g "/course_content/2017"
+      # @param recursion [Boolean] whether to include files from subdirectories
+      # @return [Array<Hash>] the Crowdin source files data
+      def list_source_files(crowdin_dir_path = nil, recursion: true)
+        crowdin_dir_path = nil if crowdin_dir_path == '/'
+
+        if crowdin_dir_path
+          directory_id = get_source_directory(crowdin_dir_path)&.dig('id')
+          return [] unless directory_id
+        end
+
+        request(:fetch_all, :list_files, directoryId: directory_id, recursion: recursion).map {|file| file['data']}
       end
 
       # Uploads file to Crowdin Storage to obtain a unique `storageId` for adding it to the project later
@@ -144,20 +176,55 @@ module I18n
       # @yield [Hash] the uploaded Crowdin source file data
       # @return [Array<Hash>] the Crowdin source files data
       def upload_source_files(source_files, base_path:)
-        source_files_data = []
-
         mutex = Thread::Mutex.new
-        I18nScriptUtils.process_in_threads(source_files, in_threads: MAX_CONCURRENT_REQUESTS) do |source_file_path|
+        Parallel.map(source_files, in_threads: MAX_CONCURRENT_REQUESTS) do |source_file_path|
           crowdin_file_path = File.join File::SEPARATOR, source_file_path.delete_prefix(base_path)
           crowdin_dir_path = File.dirname(crowdin_file_path)
 
           source_file_data = upload_source_file(source_file_path, crowdin_dir_path)
 
           mutex.synchronize {yield source_file_data} if block_given?
-          mutex.synchronize {source_files_data << source_file_data}
-        end
 
-        source_files_data
+          source_file_data
+        end
+      end
+
+      # Builds the given Crowdin source file translations
+      # @see https://developer.crowdin.com/api/v2/#operation/api.projects.translations.builds.files.post
+      #
+      # @param source_file_id [Integer] the Crowdin source file ID
+      # @param language_id [String] the Crowdin language ID
+      # @param etag [String, nil] the ETag of the last translation build
+      # @return [String] the ETag of the current translation build
+      def download_translation(source_file_id, language_id, dest_path, etag: nil)
+        translation_build = request(
+          :build_project_file_translation,
+          source_file_id,
+          targetLanguageId: language_id,
+          eTag: etag
+        )
+        return etag if translation_build == 304 # no new translations since the last build
+
+        download_file(translation_build.dig('data', 'url'), dest_path)
+
+        translation_build.dig('data', 'etag')
+      rescue OpenURI::HTTPError => exception
+        attempt = (attempt || 0) + 1
+
+        if attempt <= REQUEST_RETRY_ATTEMPTS
+          sleep(REQUEST_RETRY_DELAY)
+          retry
+        else
+          exception.message << "\nProject:  #{project}"
+          exception.message << "\nSourceID: #{source_file_id}"
+          exception.message << "\nLangID:   #{language_id}"
+          exception.message << "\nDestPath: #{dest_path}"
+          exception.message << "\nEtag:     #{etag.inspect}"
+          exception.message << "\nResponse: #{translation_build.inspect}"
+          exception.message << "\nAttempt:  #{attempt}"
+
+          raise exception
+        end
       end
 
       private
@@ -237,6 +304,26 @@ module I18n
           exception.message << "\nProject:  #{project}"
           exception.message << "\nEndpoint: #{endpoint}"
           exception.message << "\nParams:   #{params.inspect}"
+          exception.message << "\nAttempt:  #{attempt}"
+
+          raise exception
+        end
+      end
+
+      def download_file(url, dest)
+        opened_uri = URI.parse(url).open
+        FileUtils.mkdir_p File.dirname(dest)
+        IO.copy_stream(opened_uri, dest)
+      rescue Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET => exception
+        attempt = (attempt || 0) + 1
+
+        if attempt <= REQUEST_RETRY_ATTEMPTS
+          sleep(REQUEST_RETRY_DELAY)
+          retry
+        else
+          exception.message << "\nProject:  #{project}"
+          exception.message << "\nURL:      #{url}"
+          exception.message << "\nDest:     #{dest}"
           exception.message << "\nAttempt:  #{attempt}"
 
           raise exception

--- a/bin/i18n/utils/sync_down_base.rb
+++ b/bin/i18n/utils/sync_down_base.rb
@@ -1,0 +1,131 @@
+require 'optparse'
+require 'parallel'
+
+require_relative '../i18n_script_utils'
+require_relative '../metrics'
+require_relative '../utils/crowdin_client'
+
+module I18n
+  module Utils
+    class SyncDownBase
+      Config = Struct.new :crowdin_project, :download_paths, keyword_init: true
+      DownloadPath = Struct.new :crowdin_src, :dest_subdir, keyword_init: true
+      Options = Struct.new :testing, keyword_init: true do
+        def initialize(testing: I18nScriptUtils::TESTING_BY_DEFAULT, **) super end
+      end
+
+      def self.config
+        @config ||= Config.new(
+          crowdin_project: 'codeorg',
+          download_paths: [],
+        )
+      end
+
+      def self.parse_options
+        options = Options.new
+
+        OptionParser.new do |opts|
+          opts.on('-t', '--testing', 'Run in testing mode') do
+            options[:testing] = true
+          end
+        end.parse!
+
+        options.to_h
+      end
+
+      # Sync-down an i18n resource.
+      #
+      # @param [Hash] options
+      # @option options [true, false] :testing Whether to run in testing mode
+      # @return [void]
+      def self.perform(options = parse_options)
+        sync_down = new(**options)
+
+        I18n::Metrics.report_runtime(sync_down.send(:resource_name), 'sync-down') do
+          sync_down.send(:perform)
+        end
+      end
+
+      protected
+
+      attr_reader :config, :options
+
+      def initialize(**options)
+        @config = self.class.config.freeze
+        @options = Options.new(**options).freeze
+      end
+
+      def perform
+        etags_path = CDO.dir('bin/i18n/crowdin/etags', "#{resource_name.underscore}.#{crowdin_project}.json")
+        etags = File.file?(etags_path) ? JSON.load_file(etags_path) : {}
+
+        config.download_paths.uniq.each do |download_path|
+          source_files = source_files(download_path[:crowdin_src])
+
+          progress_bar = I18nScriptUtils.create_progress_bar(
+            title: "#{self.class.name}[#{File.join(crowdin_project, download_path[:crowdin_src])}]",
+            total: cdo_languages.size * source_files.size,
+            format: '%t: |%W| %c/%C %a',
+          )
+
+          mutex = Thread::Mutex.new
+          Parallel.each(cdo_languages, in_threads: I18n::Utils::CrowdinClient::MAX_CONCURRENT_REQUESTS) do |language|
+            locale_etags = etags[language[:locale_s]] ||= {}
+
+            source_files.each do |source_file|
+              dest_path = I18nScriptUtils.crowdin_locale_dir(
+                language[:locale_s], download_path[:dest_subdir], source_file['path']
+              )
+
+              translation_etag = crowdin_client.download_translation(
+                source_file['id'], language[:crowdin_code_s], dest_path, etag: locale_etags[source_file['path']]
+              )
+
+              locale_etags[source_file['path']] = translation_etag
+            ensure
+              mutex.synchronize {progress_bar.increment}
+            end
+          end
+        end
+
+        I18nScriptUtils.write_json_file(etags_path, etags)
+      end
+
+      private
+
+      def resource_name
+        @resource_name ||= self.class.name[/^.*::(\w+::\w+)::SyncDown/, 1] || self.class.name
+      end
+
+      def crowdin_project
+        @crowdin_project ||=
+          if options.testing
+            # When testing, use a set of test Crowdin projects that mirrors our regular set of projects.
+            CDO.crowdin_project_test_mapping[config.crowdin_project]
+          else
+            config.crowdin_project
+          end
+      end
+
+      def crowdin_client
+        @crowdin_client ||= I18n::Utils::CrowdinClient.new(project: crowdin_project)
+      end
+
+      # CDO languages supported by the Crowdin project
+      def cdo_languages
+        @cdo_languages ||= begin
+          available_lang_ids = crowdin_client.get_project['targetLanguages'].map {|lang| lang['id']}
+          I18nScriptUtils.cdo_languages.select {|lang| available_lang_ids.include?(lang[:crowdin_code_s])}
+        end
+      end
+
+      def source_files(crowdin_src)
+        if crowdin_src.nil? || File.extname(crowdin_src).empty?
+          crowdin_client.list_source_files(crowdin_src)
+        else
+          [crowdin_client.get_source_file(crowdin_src)]
+        end
+      end
+    end
+  end
+end

--- a/bin/test/i18n/resources/apps/animation/test_sync_down.rb
+++ b/bin/test/i18n/resources/apps/animation/test_sync_down.rb
@@ -1,0 +1,11 @@
+require_relative '../../../../test_helper'
+require_relative '../../../../../i18n/resources/apps/animations/sync_down'
+
+describe I18n::Resources::Apps::Animations::SyncDown do
+  let(:described_class) {I18n::Resources::Apps::Animations::SyncDown}
+  let(:described_instance) {described_class.new}
+
+  it 'inherits from I18n::Utils::SyncDownBase' do
+    _(described_class.superclass).must_equal I18n::Utils::SyncDownBase
+  end
+end

--- a/bin/test/i18n/resources/apps/external_sources/test_sync_down.rb
+++ b/bin/test/i18n/resources/apps/external_sources/test_sync_down.rb
@@ -1,0 +1,11 @@
+require_relative '../../../../test_helper'
+require_relative '../../../../../i18n/resources/apps/external_sources/sync_down'
+
+describe I18n::Resources::Apps::ExternalSources::SyncDown do
+  let(:described_class) {I18n::Resources::Apps::ExternalSources::SyncDown}
+  let(:described_instance) {described_class.new}
+
+  it 'inherits from I18n::Utils::SyncDownBase' do
+    _(described_class.superclass).must_equal I18n::Utils::SyncDownBase
+  end
+end

--- a/bin/test/i18n/resources/apps/labs/test_sync_down.rb
+++ b/bin/test/i18n/resources/apps/labs/test_sync_down.rb
@@ -1,0 +1,11 @@
+require_relative '../../../../test_helper'
+require_relative '../../../../../i18n/resources/apps/labs/sync_down'
+
+describe I18n::Resources::Apps::Labs::SyncDown do
+  let(:described_class) {I18n::Resources::Apps::Labs::SyncDown}
+  let(:described_instance) {described_class.new}
+
+  it 'inherits from I18n::Utils::SyncDownBase' do
+    _(described_class.superclass).must_equal I18n::Utils::SyncDownBase
+  end
+end

--- a/bin/test/i18n/resources/apps/test_animations.rb
+++ b/bin/test/i18n/resources/apps/test_animations.rb
@@ -18,6 +18,13 @@ describe I18n::Resources::Apps::Animations do
     end
   end
 
+  describe '.sync_down' do
+    it 'sync-down Animations resource' do
+      described_class::SyncDown.expects(:perform).once
+      described_class.sync_down
+    end
+  end
+
   describe '.sync_out' do
     it 'sync-out Animations resource' do
       described_class::SyncOut.expects(:perform).once

--- a/bin/test/i18n/resources/apps/test_external_sources.rb
+++ b/bin/test/i18n/resources/apps/test_external_sources.rb
@@ -18,6 +18,13 @@ describe I18n::Resources::Apps::ExternalSources do
     end
   end
 
+  describe '.sync_down' do
+    it 'sync-down External Sources resource' do
+      described_class::SyncDown.expects(:perform).once
+      described_class.sync_down
+    end
+  end
+
   describe '.sync_out' do
     it 'sync-out External Sources resource' do
       described_class::SyncOut.expects(:perform).once

--- a/bin/test/i18n/resources/apps/test_labs.rb
+++ b/bin/test/i18n/resources/apps/test_labs.rb
@@ -18,6 +18,13 @@ describe I18n::Resources::Apps::Labs do
     end
   end
 
+  describe '.sync_down' do
+    it 'sync-down Labs (blockly-mooc) resource' do
+      described_class::SyncDown.expects(:perform).once
+      described_class.sync_down
+    end
+  end
+
   describe '.sync_out' do
     it 'sync-out Labs (blockly-mooc) resource' do
       described_class::SyncOut.expects(:perform).once

--- a/bin/test/i18n/resources/test_apps.rb
+++ b/bin/test/i18n/resources/test_apps.rb
@@ -28,6 +28,18 @@ describe I18n::Resources::Apps do
     end
   end
 
+  describe '.sync_down' do
+    it 'sync-down Apps resources' do
+      execution_sequence = sequence('execution')
+
+      described_class::Animations.expects(:sync_down).in_sequence(execution_sequence)
+      described_class::ExternalSources.expects(:sync_down).in_sequence(execution_sequence)
+      described_class::Labs.expects(:sync_down).in_sequence(execution_sequence)
+
+      described_class.sync_down
+    end
+  end
+
   describe '.sync_out' do
     it 'sync-out Apps resources' do
       execution_sequence = sequence('execution')

--- a/bin/test/i18n/test_i18n_script_utils.rb
+++ b/bin/test/i18n/test_i18n_script_utils.rb
@@ -468,4 +468,16 @@ describe I18nScriptUtils do
       end
     end
   end
+
+  describe '.crowdin_locale_dir' do
+    let(:crowdin_locale_dir) {I18nScriptUtils.crowdin_locale_dir(locale, subdir, file_path)}
+
+    let(:locale) {'uk-UA'}
+    let(:subdir) {nil}
+    let(:file_path) {'expected_file.json'}
+
+    it 'returns the correct Crowdin translation file path' do
+      _(crowdin_locale_dir).must_equal CDO.dir('i18n/crowdin', locale, file_path)
+    end
+  end
 end

--- a/bin/test/i18n/utils/test_crowdin_client.rb
+++ b/bin/test/i18n/utils/test_crowdin_client.rb
@@ -11,6 +11,7 @@ describe I18n::Utils::CrowdinClient do
 
   let(:api_token) {'expected_crowdin_api_token'}
   let(:client) {stub(:client)}
+  let(:client_config) {stub(:client_config)}
 
   around do |test|
     FakeFS.with_fresh {test.call}
@@ -19,14 +20,15 @@ describe I18n::Utils::CrowdinClient do
   before do
     CDO.stubs(:crowdin_projects).returns(cdo_crowdin_projects)
     I18nScriptUtils.stubs(:crowdin_creds).returns({'api_token' => api_token})
+    client_config.stubs(:project_id).returns(project_id)
+    client.stubs(:config).returns(client_config)
     Crowdin::Client.stubs(:new).returns(client)
   end
 
   describe '#initialize' do
     it 'defines `client` as Crowdin client instance' do
-      client_config = stub(:client_config)
-
       Crowdin::Client.expects(:new).yields(client_config).returns(client)
+
       client_config.expects(:api_token=).with(api_token).once
       client_config.expects(:project_id=).with(project_id).once
 
@@ -39,6 +41,38 @@ describe I18n::Utils::CrowdinClient do
       it 'raises "project is invalid" error' do
         actual_error = assert_raises(ArgumentError) {described_instance}
         assert_equal 'project is invalid', actual_error.message
+      end
+    end
+  end
+
+  describe '#get_project' do
+    let(:get_project) {described_instance.get_project}
+
+    it 'returns data of the project' do
+      expected_crowdin_project_data = {'id' => project_id}
+
+      described_instance.
+        expects(:request).
+        with(:get_project, project_id).
+        returns({'data' => expected_crowdin_project_data})
+
+      _(get_project).must_equal expected_crowdin_project_data
+    end
+
+    context 'when a project id is provided' do
+      let(:get_project) {described_instance.get_project(another_project_id)}
+
+      let(:another_project_id) {'another_project_id'}
+
+      it 'returns data of the provided project' do
+        another_crowdin_project_data = {'id' => another_project_id}
+
+        described_instance.
+          expects(:request).
+          with(:get_project, another_project_id).
+          returns({'data' => another_crowdin_project_data})
+
+        _(get_project).must_equal another_crowdin_project_data
       end
     end
   end
@@ -201,6 +235,63 @@ describe I18n::Utils::CrowdinClient do
     end
   end
 
+  describe '#list_source_files' do
+    let(:list_source_files) {described_instance.list_source_files}
+
+    let(:crowdin_dir_path) {'expected_crowdin_dir_path'}
+    let(:directory_id) {nil}
+    let(:recursion) {true}
+    let(:source_file_data) {'expected_source_file_data'}
+
+    before do
+      described_instance.
+        stubs(:request).
+        with(:fetch_all, :list_files, directoryId: directory_id, recursion: recursion).
+        returns([{'data' => source_file_data}])
+    end
+
+    it 'returns list of all project files data' do
+      described_instance.expects(:get_source_directory).never
+
+      _(list_source_files).must_equal [source_file_data]
+    end
+
+    context 'when provided `crowdin_dir_path` exists' do
+      let(:list_source_files) {described_instance.list_source_files(crowdin_dir_path)}
+      let(:directory_id) {'expected_directory_id'}
+
+      it 'returns list of all project files data in the provided directory' do
+        described_instance.
+          expects(:get_source_directory).
+          with(crowdin_dir_path).
+          returns({'id' => directory_id})
+
+        _(list_source_files).must_equal [source_file_data]
+      end
+    end
+
+    context 'when provided `crowdin_dir_path` does not exists' do
+      let(:list_source_files) {described_instance.list_source_files(crowdin_dir_path)}
+
+      it 'returns empty array' do
+        described_instance.expects(:get_source_directory).with(crowdin_dir_path).returns(nil)
+        described_instance.expects(:request).with(:fetch_all, :list_files, anything).never
+
+        _(list_source_files).must_equal []
+      end
+    end
+
+    context 'when `recursion` is false' do
+      let(:list_source_files) {described_instance.list_source_files(recursion: recursion)}
+
+      let(:recursion) {false}
+
+      it 'returns list of project files data in the root directory' do
+        _(list_source_files).must_equal [source_file_data]
+      end
+    end
+  end
+
   describe '#add_storage' do
     let(:add_storage) {described_instance.add_storage(file_path)}
 
@@ -320,6 +411,44 @@ describe I18n::Utils::CrowdinClient do
       end
 
       _(source_files_data).must_equal [expected_source_file_data]
+    end
+  end
+
+  describe '#download_translation' do
+    let(:download_translation) do
+      described_instance.download_translation(source_file_id, language_id, dest_path, etag: etag)
+    end
+
+    let(:source_file_id) {'expected_source_file_id'}
+    let(:language_id) {'expected_language_id'}
+    let(:dest_path) {'expected_dest_path'}
+    let(:etag) {'expected_etag'}
+
+    let(:translation_url) {'expected_translation_url'}
+    let(:translation_etag) {'expected_translation_etag'}
+    let(:translation_build) {{'data' => {'url' => translation_url, 'etag' => translation_etag}}}
+
+    before do
+      described_instance.
+        stubs(:request).
+        with(:build_project_file_translation, source_file_id, targetLanguageId: language_id, eTag: etag).
+        returns(translation_build)
+    end
+
+    it 'downloads translation for the given source file' do
+      described_instance.expects(:download_file).with(translation_url, dest_path)
+
+      _(download_translation).must_equal translation_etag
+    end
+
+    context 'when translation has no changes' do
+      let(:translation_build) {304}
+
+      it 'returns current etag' do
+        described_instance.expects(:download_file).never
+
+        _(download_translation).must_equal etag
+      end
     end
   end
 

--- a/bin/test/i18n/utils/test_sync_down_base.rb
+++ b/bin/test/i18n/utils/test_sync_down_base.rb
@@ -1,0 +1,328 @@
+require_relative '../../test_helper'
+require_relative '../../../i18n/utils/sync_down_base'
+
+describe I18n::Utils::SyncDownBase do
+  let(:described_class) {I18n::Utils::SyncDownBase}
+  let(:described_instance) {described_class.new}
+
+  around do |test|
+    FakeFS.with_fresh {test.call}
+  end
+
+  describe '.config' do
+    let(:config) {described_class.send(:config)}
+
+    describe '#crowdin_project' do
+      let(:crowdin_project) {config.crowdin_project}
+
+      it 'returns default Crowdin project' do
+        _(crowdin_project).must_equal 'codeorg'
+      end
+
+      context 'when new value is set' do
+        let(:described_class) do
+          Class.new(I18n::Utils::SyncDownBase) do
+            config.crowdin_project = 'new_crowdin_project'
+          end
+        end
+
+        it 'returns new value' do
+          _(crowdin_project).must_equal 'new_crowdin_project'
+        end
+      end
+    end
+
+    describe '#download_paths' do
+      let(:download_paths) {config.download_paths}
+
+      it 'returns empty array' do
+        _(download_paths).must_equal []
+      end
+
+      context 'when new value is pushed' do
+        let(:described_class) do
+          Class.new(I18n::Utils::SyncDownBase) do
+            config.download_paths << 'new_download_path'
+          end
+        end
+
+        it 'returns array with new value' do
+          _(download_paths).must_equal ['new_download_path']
+        end
+      end
+    end
+  end
+
+  describe '.parse_options' do
+    let(:parse_options) {described_class.parse_options}
+
+    it 'returns default options' do
+      _(parse_options).must_equal({testing: false})
+    end
+
+    describe ':testing' do
+      let(:option_testing) {parse_options[:testing]}
+
+      context 'when "-t" command line option is set' do
+        before do
+          ARGV << '-t'
+        end
+
+        it 'returns true' do
+          _(option_testing).must_equal true
+        end
+      end
+
+      context 'when "--testing" command line option is set' do
+        before do
+          ARGV << '--testing'
+        end
+
+        it 'returns true' do
+          _(option_testing).must_equal true
+        end
+      end
+    end
+  end
+
+  describe '.perform' do
+    let(:perform) {described_class.perform}
+
+    before do
+      I18n::Metrics.stubs(:report_runtime).yields(nil)
+    end
+
+    it 'creates new instance with command-line options and calls #perform' do
+      expected_options = {testing: true}
+      sync_down_instance = mock
+
+      described_class.expects(:parse_options).returns(expected_options)
+      described_class.expects(:new).with(**expected_options).returns(sync_down_instance)
+
+      sync_down_instance.expects(:resource_name).once
+      sync_down_instance.expects(:perform).once
+
+      perform
+    end
+
+    it 'calls report_runtime metrics with class name' do
+      I18n::Metrics.expects(:report_runtime).with(described_class.name, 'sync-down').once
+      perform
+    end
+
+    context 'when class name contains i18n resource name' do
+      module I18n
+        module Resources
+          module ResourceParent
+            module ResourceChild
+              class SyncDown < I18n::Utils::SyncDownBase
+              end
+            end
+          end
+        end
+      end
+
+      let(:described_class) {I18n::Resources::ResourceParent::ResourceChild::SyncDown}
+
+      it 'calls report_runtime metrics with i18n resource name' do
+        I18n::Metrics.expects(:report_runtime).with('ResourceParent::ResourceChild', 'sync-down').once
+        perform
+      end
+    end
+  end
+
+  describe '#perform' do
+    let(:perform) {described_instance.send(:perform)}
+
+    let(:crowdin_src) {'expected_source_file.json'}
+    let(:dest_subdir) {'expected_dest_subdir'}
+    let(:config) {stub(download_paths: [I18n::Utils::SyncDownBase::DownloadPath.new(crowdin_src: crowdin_src, dest_subdir: dest_subdir)])}
+
+    let(:resource_name) {'expected_resource_name'}
+    let(:crowdin_project) {'expected_crowdin_project'}
+
+    let(:source_file_id) {'expected_source_file_id'}
+    let(:source_file_path) {'expected_source_file_path'}
+    let(:source_file_data) {{'id' => source_file_id, 'path' => source_file_path}}
+
+    let(:crowdin_language_id) {'uk'}
+    let(:locale) {'uk-UA'}
+
+    let(:cdo_language) {{crowdin_code_s: crowdin_language_id, locale_s: locale}}
+    let(:crowdin_client) {stub(:crowdin_client)}
+
+    before do
+      described_instance.stubs(:config).returns(config)
+      described_instance.stubs(:resource_name).returns(resource_name)
+      described_instance.stubs(:crowdin_project).returns(crowdin_project)
+      described_instance.stubs(:crowdin_client).returns(crowdin_client)
+      described_instance.stubs(:cdo_languages).returns([cdo_language])
+      described_instance.stubs(:source_files).with(crowdin_src).returns([source_file_data])
+    end
+
+    it 'downloads the source file translation' do
+      expected_dest_path = CDO.dir('i18n/crowdin', locale, dest_subdir, source_file_path)
+
+      crowdin_client.
+        expects(:download_translation).
+        with(source_file_id, crowdin_language_id, expected_dest_path, etag: nil).
+        once
+
+      perform
+    end
+
+    describe 'translation etags saving' do
+      let(:old_translation_etag) {'old_translation_etag'}
+      let(:i18n_resource_etags_path) {CDO.dir('bin/i18n/crowdin/etags', "#{resource_name}.#{crowdin_project}.json")}
+
+      before do
+        FileUtils.mkdir_p File.dirname(i18n_resource_etags_path)
+        File.write i18n_resource_etags_path, JSON.dump({locale => {source_file_path => old_translation_etag}})
+      end
+
+      it 'saves new translation etags' do
+        expected_dest_path = CDO.dir('i18n/crowdin', locale, dest_subdir, source_file_path)
+        new_translation_etag = 'new_translation_etag'
+
+        crowdin_client.
+          stubs(:download_translation).
+          with(source_file_id, crowdin_language_id, expected_dest_path, etag: old_translation_etag).
+          returns(new_translation_etag)
+
+        perform
+
+        _(JSON.load_file(i18n_resource_etags_path)).must_equal({locale => {source_file_path => new_translation_etag}})
+      end
+    end
+
+    context 'when download source is a dir' do
+      let(:crowdin_src) {'/expected_source_dir'}
+      let(:dest_subdir) {nil}
+
+      it 'downloads the source file translation' do
+        expected_dest_path = CDO.dir('i18n/crowdin', locale, source_file_path)
+
+        crowdin_client.
+          expects(:download_translation).
+          with(source_file_id, crowdin_language_id, expected_dest_path, etag: nil).
+          once
+
+        perform
+      end
+    end
+  end
+
+  describe '#crowdin_project' do
+    let(:crowdin_project) {described_instance.send(:crowdin_project)}
+
+    let(:crowdin_prod_project) {'expected_crowdin_prod_project'}
+    let(:crowdin_test_project) {'expected_crowdin_test_project'}
+
+    let(:config) {stub(crowdin_project: crowdin_prod_project)}
+    let(:options) {stub(testing: is_testing)}
+
+    let(:is_testing) {false}
+
+    before do
+      CDO.stubs(:crowdin_project_test_mapping).returns({crowdin_prod_project => crowdin_test_project})
+      described_class.stubs(:config).returns(config)
+      described_instance.stubs(:options).returns(options)
+    end
+
+    it 'returns Crowdin project from config' do
+      _(crowdin_project).must_equal crowdin_prod_project
+    end
+
+    context 'when testing' do
+      let(:is_testing) {true}
+
+      it 'returns test Crowdin project from mapping' do
+        _(crowdin_project).must_equal crowdin_test_project
+      end
+    end
+  end
+
+  describe '#crowdin_client' do
+    let(:crowdin_client) {described_instance.send(:crowdin_client)}
+
+    let(:expected_crowdin_project) {'expected_crowdin_project'}
+
+    before do
+      described_instance.stubs(:crowdin_project).returns(expected_crowdin_project)
+    end
+
+    it 'returns I18n Crowdin client until instance' do
+      expected_i18n_utils_crowdin_client_instance = 'expected_i18n_utils_crowdin_client_instance'
+
+      I18n::Utils::CrowdinClient.
+        expects(:new).
+        with(project: expected_crowdin_project).
+        returns(expected_i18n_utils_crowdin_client_instance)
+
+      _(crowdin_client).must_equal expected_i18n_utils_crowdin_client_instance
+    end
+  end
+
+  describe '#cdo_languages' do
+    let(:cdo_languages) {described_instance.send(:cdo_languages)}
+
+    let(:crowdin_client) {stub(:crowdin_client)}
+
+    before do
+      described_instance.stubs(:crowdin_client).returns(crowdin_client)
+    end
+
+    it 'returns CDO languages supported by the Crowdin project' do
+      available_crowdin_lang_id = 'uk'
+
+      crowdin_client.expects(:get_project).returns('targetLanguages' => [{'id' => available_crowdin_lang_id}])
+
+      _(cdo_languages.first).must_be_instance_of CdoLanguages
+      _(cdo_languages.map {|lang| lang[:crowdin_code_s]}).must_equal [available_crowdin_lang_id]
+    end
+  end
+
+  describe '#source_files' do
+    let(:source_files) {described_instance.send(:source_files, crowdin_src)}
+
+    let(:crowdin_src) {nil}
+
+    let(:crowdin_client) {stub(:crowdin_client)}
+
+    before do
+      described_instance.stubs(:crowdin_client).returns(crowdin_client)
+    end
+
+    it 'returns data of all the source files in the root dir' do
+      source_files_data = ['expected_source_file_data']
+
+      crowdin_client.expects(:list_source_files).with(crowdin_src).returns(source_files_data)
+
+      _(source_files).must_equal source_files_data
+    end
+
+    context 'when the download source is a file' do
+      let(:crowdin_src) {'expected_crowdin_source_file.json'}
+
+      it 'returns source file data' do
+        source_file_data = 'expected_source_file_data'
+
+        crowdin_client.expects(:get_source_file).with(crowdin_src).returns(source_file_data)
+
+        _(source_files).must_equal [source_file_data]
+      end
+    end
+
+    context 'when the download source is a dir' do
+      let(:crowdin_src) {'/expected_crowdin_source_path'}
+
+      it 'returns data of all the source files in the dir' do
+        source_files_data = ['expected_source_file_data']
+
+        crowdin_client.expects(:list_source_files).with(crowdin_src).returns(source_files_data)
+
+        _(source_files).must_equal source_files_data
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. Created independent `sync-down` script for the `Apps/Animations` i18n resource.
2. Created independent `sync-down` script for the `Apps/ExternalSources` i18n resource.
3. Created independent `sync-down` script for the `Apps/Labs` i18n resource.
4. Sync-down translation files to the separate `i18n/crowdin` dir instead of `i18n/locales`.

- jira ticket: [P20-628](https://codedotorg.atlassian.net/browse/P20-628)

References:
- https://github.com/crowdin/crowdin-api-client-ruby/pull/69
- https://github.com/crowdin/crowdin-api-client-ruby/pull/70
- https://github.com/crowdin/crowdin-api-client-ruby/pull/75

