### PR TITLE
Add Amplitude API key to the user header for the "Create" menu events

### DIFF
--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -27,6 +27,8 @@
   cookie_key = environment_specific_cookie_name('_user_type')
   user_type = request.cookies[cookie_key]
 
+%script{data: {"amplitude-api-key": CDO.safe_amplitude_api_key}}
+
 - if show_create_menu
   .header_button.create_menu{id: "header_create_menu", tabindex: 0, role: "button"}
     %span.create_button


### PR DESCRIPTION
Currently on production there is a "missing API key" error on pegasus pages with the "Create" menu after this PR was merged to log click events on the menu. We've seen this issue before like in [this PR](https://github.com/code-dot-org/code-dot-org/pull/55309) so adding the Amplitude api-key should resolve this!

Error message:
![missing api key](https://github.com/code-dot-org/code-dot-org/assets/56283563/c225087b-6c21-4b57-b1c3-737300bd5e44)

## Links
PR this follows up: [here](https://github.com/code-dot-org/code-dot-org/pull/56319)

## Testing story
Tested locally to make sure there are no errors in the console and the Amplitude events still log as expected.

Pegasus:
![pegasus](https://github.com/code-dot-org/code-dot-org/assets/56283563/b92935e2-d680-4a7f-856b-baf16891fc54)

Dashboard:
![dashboard](https://github.com/code-dot-org/code-dot-org/assets/56283563/b2787a79-3d87-4266-9b5a-83902fada629)

## Followup work
I'm going to monitor staging and check that the staging Amplitude event counts increase once this PR hits staging to double check.
