### PR TITLE
feat(pegasus): enhance a11y for lightbox components

### DIFF
--- a/pegasus/sites.v3/code.org/views/display_language_lightbox.haml
+++ b/pegasus/sites.v3/code.org/views/display_language_lightbox.haml
@@ -37,7 +37,35 @@
       $.getJSON( "/v2/client-location", function( data ) {
         country_code = data['country_code'];
         if(country_code != 'US') {
-          $('#selectLanguage').modal('show')
+          $('#selectLanguage').modal('show');
+          $('#selectLanguage').on('shown.bs.modal', function () {
+            var focusableEls = $(this).find('a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select');
+            var firstFocusableEl = focusableEls.first()[0];
+            var lastFocusableEl = focusableEls.last()[0];
+            var KEYCODE_TAB = 9;
+
+            firstFocusableEl.focus();
+
+            $(this).on('keydown', function(e) {
+              var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
+
+              if (!isTabPressed) { 
+                return; 
+              }
+
+              if (e.shiftKey) {
+                if (document.activeElement === firstFocusableEl) {
+                  lastFocusableEl.focus();
+                  e.preventDefault();
+                }
+              } else {
+                if (document.activeElement === lastFocusableEl) {
+                  firstFocusableEl.focus();
+                  e.preventDefault();
+                }
+              }
+            });
+          });
         }
       });
       setCookie('_loc_notice', '1', 365)

--- a/pegasus/sites.v3/code.org/views/display_language_lightbox.haml
+++ b/pegasus/sites.v3/code.org/views/display_language_lightbox.haml
@@ -31,6 +31,42 @@
     return keyValue ? keyValue[2] : null;
   }
 
+  /**
+   * A focus trap is a common accessibility feature that ensures that the keyboard focus remains
+   * within a certain container (like a modal dialog), and does not move to other parts of the 
+   * page.
+  */
+  function focusTrap(modalId) {
+    return () => {
+      var focusableEls = $(modalId).find('a[href], button, textarea, input:not([disabled]), select');
+      var firstFocusableEl = focusableEls.first()[0];
+      var lastFocusableEl = focusableEls.last()[0];
+      var KEYCODE_TAB = 9;
+
+      firstFocusableEl.focus();
+
+      $(modalId).on('keydown', function(e) {
+        var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
+
+        if (!isTabPressed) { 
+          return; 
+        }
+
+        if (e.shiftKey) { // if shift key pressed for shift + tab combination
+          if (document.activeElement === firstFocusableEl) {
+            lastFocusableEl.focus();
+            e.preventDefault();
+          }
+        } else { // if tab key is pressed
+          if (document.activeElement === lastFocusableEl) { // if focused has reached to last item then focus first item after tab
+            firstFocusableEl.focus();
+            e.preventDefault();
+          }
+        }
+      });
+    }
+  }
+
   $( document ).ready(function() {
     already_shown = !!getCookie('_loc_notice');
     if(!already_shown) {
@@ -38,34 +74,7 @@
         country_code = data['country_code'];
         if(country_code != 'US') {
           $('#selectLanguage').modal('show');
-          $('#selectLanguage').on('shown.bs.modal', function () {
-            var focusableEls = $(this).find('a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select');
-            var firstFocusableEl = focusableEls.first()[0];
-            var lastFocusableEl = focusableEls.last()[0];
-            var KEYCODE_TAB = 9;
-
-            firstFocusableEl.focus();
-
-            $(this).on('keydown', function(e) {
-              var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
-
-              if (!isTabPressed) { 
-                return; 
-              }
-
-              if (e.shiftKey) {
-                if (document.activeElement === firstFocusableEl) {
-                  lastFocusableEl.focus();
-                  e.preventDefault();
-                }
-              } else {
-                if (document.activeElement === lastFocusableEl) {
-                  firstFocusableEl.focus();
-                  e.preventDefault();
-                }
-              }
-            });
-          });
+          $('#selectLanguage').on('shown.bs.modal', focusTrap('#selectLanguage'));
         }
       });
       setCookie('_loc_notice', '1', 365)

--- a/pegasus/sites.v3/code.org/views/display_language_lightbox.haml
+++ b/pegasus/sites.v3/code.org/views/display_language_lightbox.haml
@@ -1,4 +1,5 @@
 %script{:defer => "defer", type: "text/javascript", src: "/js/bootstrap.min.js"}
+%script{type: "text/javascript", src: "/shared/js/helpers.js"}
 
 %div{:class=>"modal fade", :id=>"selectLanguage"}
   %div{:class=>"modal-dialog", :width=>"500px"}
@@ -12,7 +13,7 @@
         %h4{:class=>"modal-title"}= I18n.t('select_language')
         =view :language
       %div{:class=>"modal-footer"}
-        %button{:type=>"button", :class=>"btn btn-primary", :"data-dismiss"=>"modal"}= I18n.t('submit')  
+        %button{:type=>"button", :class=>"btn btn-primary", :"data-dismiss"=>"modal"}= I18n.t('submit')
 
 :css
   .modal{
@@ -29,42 +30,6 @@
   function getCookie(key) {
     var keyValue = document.cookie.match('(^|;) ?' + key + '=([^;]*)(;|$)');
     return keyValue ? keyValue[2] : null;
-  }
-
-  /**
-   * A focus trap is a common accessibility feature that ensures that the keyboard focus remains
-   * within a certain container (like a modal dialog), and does not move to other parts of the 
-   * page.
-  */
-  function focusTrap(modalId) {
-    return () => {
-      var focusableEls = $(modalId).find('a[href], button, textarea, input:not([disabled]), select');
-      var firstFocusableEl = focusableEls.first()[0];
-      var lastFocusableEl = focusableEls.last()[0];
-      var KEYCODE_TAB = 9;
-
-      firstFocusableEl.focus();
-
-      $(modalId).on('keydown', function(e) {
-        var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
-
-        if (!isTabPressed) { 
-          return; 
-        }
-
-        if (e.shiftKey) { // if shift key pressed for shift + tab combination
-          if (document.activeElement === firstFocusableEl) {
-            lastFocusableEl.focus();
-            e.preventDefault();
-          }
-        } else { // if tab key is pressed
-          if (document.activeElement === lastFocusableEl) { // if focused has reached to last item then focus first item after tab
-            firstFocusableEl.focus();
-            e.preventDefault();
-          }
-        }
-      });
-    }
   }
 
   $( document ).ready(function() {

--- a/pegasus/sites.v3/code.org/views/display_video_lightbox.haml
+++ b/pegasus/sites.v3/code.org/views/display_video_lightbox.haml
@@ -24,6 +24,34 @@
   window["showVideo_#{id}"] = function()
   {
     $("#showVideo_#{id}").modal('show');
+    $("#showVideo_#{id}").on('shown.bs.modal', function () {
+      var focusableEls = $(this).find('a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select');
+      var firstFocusableEl = focusableEls.first()[0];
+      var lastFocusableEl = focusableEls.last()[0];
+      var KEYCODE_TAB = 9;
+
+      firstFocusableEl.focus();
+
+      $(this).on('keydown', function(e) {
+        var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
+
+        if (!isTabPressed) { 
+          return; 
+        }
+
+        if (e.shiftKey) {
+          if (document.activeElement === firstFocusableEl) {
+            lastFocusableEl.focus();
+            e.preventDefault();
+          }
+        } else {
+          if (document.activeElement === lastFocusableEl) {
+            firstFocusableEl.focus();
+            e.preventDefault();
+          }
+        }
+      });
+    });
     setupPopupWindows();
     window["playVideo_#{id}"](true);
 

--- a/pegasus/sites.v3/code.org/views/display_video_lightbox.haml
+++ b/pegasus/sites.v3/code.org/views/display_video_lightbox.haml
@@ -2,6 +2,7 @@
 - twitter ||= nil
 - download_filename ||= nil
 - download_path ||= nil
+%script{type: "text/javascript", src: "/shared/js/helpers.js"}
 
 .modal.fade{id: "showVideo_#{id}"}
   .modal-dialog.modal-lg
@@ -20,42 +21,6 @@
   }
 
 :javascript
-  /**
-   * A focus trap is a common accessibility feature that ensures that the keyboard focus remains
-   * within a certain container (like a modal dialog), and does not move to other parts of the 
-   * page.
-  */
-  function focusTrap(modalId) {
-    return () => {
-      var focusableEls = $(modalId).find('a[href], button, textarea, input:not([disabled]), select');
-      var firstFocusableEl = focusableEls.first()[0];
-      var lastFocusableEl = focusableEls.last()[0];
-      var KEYCODE_TAB = 9;
-
-      firstFocusableEl.focus();
-
-      $(modalId).on('keydown', function(e) {
-        var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
-
-        if (!isTabPressed) { 
-          return; 
-        }
-
-        if (e.shiftKey) { // if shift key pressed for shift + tab combination
-          if (document.activeElement === firstFocusableEl) {
-            lastFocusableEl.focus();
-            e.preventDefault();
-          }
-        } else { // if tab key is pressed
-          if (document.activeElement === lastFocusableEl) { // if focused has reached to last item then focus first item after tab
-            firstFocusableEl.focus();
-            e.preventDefault();
-          }
-        }
-      });
-    }
-  }
-
   window["showVideo_#{id}"] = function()
   {
     $("#showVideo_#{id}").modal('show');

--- a/pegasus/sites.v3/code.org/views/display_video_lightbox.haml
+++ b/pegasus/sites.v3/code.org/views/display_video_lightbox.haml
@@ -20,38 +20,46 @@
   }
 
 :javascript
-
-  window["showVideo_#{id}"] = function()
-  {
-    $("#showVideo_#{id}").modal('show');
-    $("#showVideo_#{id}").on('shown.bs.modal', function () {
-      var focusableEls = $(this).find('a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select');
+  /**
+   * A focus trap is a common accessibility feature that ensures that the keyboard focus remains
+   * within a certain container (like a modal dialog), and does not move to other parts of the 
+   * page.
+  */
+  function focusTrap(modalId) {
+    return () => {
+      var focusableEls = $(modalId).find('a[href], button, textarea, input:not([disabled]), select');
       var firstFocusableEl = focusableEls.first()[0];
       var lastFocusableEl = focusableEls.last()[0];
       var KEYCODE_TAB = 9;
 
       firstFocusableEl.focus();
 
-      $(this).on('keydown', function(e) {
+      $(modalId).on('keydown', function(e) {
         var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
 
         if (!isTabPressed) { 
           return; 
         }
 
-        if (e.shiftKey) {
+        if (e.shiftKey) { // if shift key pressed for shift + tab combination
           if (document.activeElement === firstFocusableEl) {
             lastFocusableEl.focus();
             e.preventDefault();
           }
-        } else {
-          if (document.activeElement === lastFocusableEl) {
+        } else { // if tab key is pressed
+          if (document.activeElement === lastFocusableEl) { // if focused has reached to last item then focus first item after tab
             firstFocusableEl.focus();
             e.preventDefault();
           }
         }
       });
-    });
+    }
+  }
+
+  window["showVideo_#{id}"] = function()
+  {
+    $("#showVideo_#{id}").modal('show');
+    $("#showVideo_#{id}").on('shown.bs.modal', focusTrap("#showVideo_#{id}"));
     setupPopupWindows();
     window["playVideo_#{id}"](true);
 

--- a/shared/js/helpers.js
+++ b/shared/js/helpers.js
@@ -9,3 +9,42 @@ function adjustScroll(destination) {
     1000
   );
 }
+
+/**
+ * A focus trap is a common accessibility feature that ensures that the keyboard focus remains
+ * within a certain container (like a modal dialog), and does not move to other parts of the
+ * page.
+ *
+ * @param {string} modalId The element ID of modal dialog container, e.g. * "#promotion-video-modal"
+ * @return {function} Function meant to be run once the given modal is visible.
+ */
+function focusTrap(modalId) {
+  return () => {
+    var focusableEls = $(modalId).find('a[href], button, textarea, input:not([disabled]), select');
+    var firstFocusableEl = focusableEls.first()[0];
+    var lastFocusableEl = focusableEls.last()[0];
+    var KEYCODE_TAB = 9;
+
+    firstFocusableEl.focus();
+
+    $(modalId).on('keydown', function(e) {
+      var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
+
+      if (!isTabPressed) {
+        return;
+      }
+
+      if (e.shiftKey) { // if shift key pressed for shift + tab combination
+        if (document.activeElement === firstFocusableEl) {
+          lastFocusableEl.focus();
+          e.preventDefault();
+        }
+      } else { // if tab key is pressed
+        if (document.activeElement === lastFocusableEl) { // if focused has reached to last item then focus first item after tab
+          firstFocusableEl.focus();
+          e.preventDefault();
+        }
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Description

- This fix traps the user's focus on the tabbable elements in the modal dialogs when they are shown.
- Previously, although the modal is accessible, the user has to tab through all of the focusable elements in the background of the modal to reach the modal.
- Currently, pressing `Tab` should immediately focus on the modal's elements and traps the user's focus in the modal.

## Acceptance tests

Reran the `rake test` command in the `pegasus` directory. No test failed.

Output from acceptance testing:

```bash
❯ RAILS_ENV=test bundle exec rake test:reset_dependencies
ERROR 1008 (HY000) at line 1: Can't drop database 'pegasus_test'; database doesn't exist
Finished db:drop (less than a minute)
Finished db:ensure_created (less than a minute)
#<Sequel::Mysql2::Database: "mysql2://root@localhost/pegasus_test" {:encoding=>"utf8mb4", :default_group=>"cdo", :test=>false, :max_connections=>4, :pool_timeout=>3, :reconnect=>true, :connect_timeout=>2, :read_timeout=>30, :write_timeout=>5}>
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Schema Version: 141
Finished db:version (less than a minute)
Finished db:migrate (less than a minute)
Finished db:recreate (less than a minute)
Finished seed:reset (8 minutes)
Finished test:reset_dependencies (less than a minute)
❯ bundle exec rake test
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Started with run options --seed 50142

WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
HocEventReview
  test_0002_can filter to unreviewed events                       PASS (0.43s)
  test_0006_can filter to state                                   PASS (0.01s)
  test_0003_can filter to special events                          PASS (0.01s)
  test_0008_only finds events with processed data                 PASS (0.02s)
  test_0004_finds event counts by country                         PASS (0.02s)
  test_0001_finds event counts by state                           PASS (0.02s)
  test_0005_finds event details                                   PASS (0.02s)
  test_0007_can filter to country                                 PASS (0.02s)

I18nHocRoutesTest
  test_hoc_partner_pages                                          PASS (0.00s)
  test_hoc_pages_for_all_locales                                  PASS (16.27s)

/api/dev/ routes::/api/dev/start-build
  test_0005_is allowed on adhoc                                   PASS (0.03s)
  test_0007_is forbidden with a missing token                     PASS (0.00s)
  test_0009_generates a start_build file if none exists           PASS (0.01s)
  test_0002_is forbidden on development environments              PASS (0.00s)
  test_0008_is forbidden with an incorrect token                  PASS (0.00s)
  test_0010_succeeds without action if start_build exists         PASS (0.01s)
  test_0003_is allowed on staging                                 PASS (0.01s)
  test_0004_is allowed on test                                    PASS (0.01s)
  test_0006_is allowed on levelbuilder                            PASS (0.01s)
  test_0001_is forbidden on production environments               PASS (0.00s)

HashTest
  test_to_query                                                   PASS (0.00s)
  test_slice_keys                                                 PASS (0.00s)

HamlTest
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_resources_videos                                           PASS (2.65s)

PegasusTest
`tidy` not found, skipping HTML validation.
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_render_pegasus_documents                                   PASS (74.61s)
Found 1621 Pegasus documents.
  test_pegasus_documents                                          PASS (0.12s)
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.

Educate Routes
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0001_redirects the weblab test page to code studio         PASS (0.24s)

insert_form_with_large_utf8
  test_0001_strips bad utf8 characeters on insert                 PASS (0.00s)

Poste Routes::GET /u/:id
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
  test_0002_unsubscribes existing contact                         PASS (0.36s)
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
  test_0001_unsubscribes new contact                              PASS (0.02s)
  test_0003_noops with 200 if bad poste_deliveries id             PASS (0.01s)

ArrayTest
  test_to_query                                                   PASS (0.00s)

volunteer_engineer_submission_2015
  test_0002_uses reverse chronological order                      PASS (0.03s)
  test_0001_returns local results                                 PASS (0.01s)

HocI18nTest
  test_interpolated_markdown                                      PASS (0.01s)
  test_markdown                                                   PASS (0.02s)
  test_inline_markdown                                            PASS (0.03s)
  test_html_escaped                                               PASS (0.01s)
  test_basic_functionality                                        PASS (0.01s)
  test_interpolation                                              PASS (0.02s)

HourOfCodeHelpersTest
  test_get_translated_language_names                              PASS (0.00s)
/home/felixng/.rbenv/versions/3.0.5/lib/ruby/gems/3.0.0/gems/honeybadger-4.12.1/lib/honeybadger/agent.rb:151: warning: deprecated Object#=~ is called on Integer; it always returns nil
** [Honeybadger] Unable to send error report: API key is missing. id=8227ef4b-1c80-443d-8b3a-4eef8fefa36e level=3 pid=3786
/home/felixng/.rbenv/versions/3.0.5/lib/ruby/gems/3.0.0/gems/honeybadger-4.12.1/lib/honeybadger/agent.rb:151: warning: deprecated Object#=~ is called on Integer; it always returns nil
** [Honeybadger] Unable to send error report: API key is missing. id=b8b80ded-360c-4f03-b00a-75bd15e4bb3b level=3 pid=3786
/home/felixng/.rbenv/versions/3.0.5/lib/ruby/gems/3.0.0/gems/honeybadger-4.12.1/lib/honeybadger/agent.rb:151: warning: deprecated Object#=~ is called on Integer; it always returns nil
** [Honeybadger] Unable to send error report: API key is missing. id=20ec33d8-dfd2-4020-b5f6-339709aed3de level=3 pid=3786
/home/felixng/.rbenv/versions/3.0.5/lib/ruby/gems/3.0.0/gems/honeybadger-4.12.1/lib/honeybadger/agent.rb:151: warning: deprecated Object#=~ is called on Integer; it always returns nil
** [Honeybadger] Unable to send error report: API key is missing. id=68217dce-98c7-4ff0-a3fc-779e1c1c301e level=3 pid=3786
  test_redirect_untrusted_proxy                                   PASS (0.78s)
  test_get_language_names_in_english                              PASS (0.00s)
  test_hourofcode_redirect                                        PASS (0.51s)

TextRenderTest
  test_markdown_brackets_to_div_classes                           PASS (0.00s)
  test_markdown_details_wrapped_in_divs                           PASS (0.00s)
  test_markdown                                                   PASS (0.00s)
  test_haml                                                       PASS (0.00s)
  test_erb                                                        PASS (0.00s)
  test_markdown_details_doesnt_chomp_trailing_bracket_tags        PASS (0.00s)
  test_yaml                                                       PASS (0.00s)

Form Routes::POST /forms/:kind/query
  test_0001_returns 400 for non-existent form kind                PASS (0.00s)

CurriculumCourse
  test_0004_should get empty array for units when no units        PASS (0.00s)
  test_0003_should verify directory existence                     PASS (0.01s)
  test_0002_should verify directory names                         PASS (0.00s)
  test_0001_should create with a type                             PASS (0.00s)
  test_0005_should get all lessons                                PASS (0.01s)

FileUtilityTest
  test_find_first_existing                                        PASS (0.00s)

ObjectTest
  test_nil_or_empty                                               PASS (0.00s)

Dashboard::User::to_hash
  test_0001_returns dashboard row.to_hash                         PASS (0.00s)

StaticModelsTest
  test_static_models                                              PASS (0.01s)

Poste Routes::GET /l/:id/:url
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0004_creates no poste_clicks row with a bad url id         PASS (0.25s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0003_creates no poste_clicks row with an undecryptable id  PASS (0.25s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0002_creates no poste_clicks row with a bad delivery id    PASS (0.25s)
  test_0001_creates poste_clicks row and redirects                PASS (0.01s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0005_creates no poste_clicks row with an undecodable url id PASS (0.26s)

PDFMergerTest
  test_merge_two_remote_pdfs                                      PASS (0.40s)
  test_reading_pdfs                                               PASS (0.04s)
  test_merge_two_local_pdfs                                       PASS (0.43s)
  test_merge_local_from_file                                      PASS (0.42s)
  test_merge_from_file                                            PASS (0.32s)
  test_merge_with_numbers                                         PASS (0.98s)

PropertiesTest
  test_get_when_key_exists                                        PASS (0.02s)
  test_set_with_new_values                                        PASS (0.12s)
  test_get_when_key_does_not_exist                                PASS (0.03s)
  test_delete_when_key_exists                                     PASS (0.03s)
  test_delete_when_key_does_not_exist                             PASS (0.03s)
  test_set_with_existing_value                                    PASS (0.02s)

Poste Routes::GET /o/:id
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0002_creates no poste_opens row with bad poste_deliveries id PASS (0.27s)
  test_0001_creates poste_opens row                               PASS (0.01s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0003_creates no poste_opens row with an undecryptable id   PASS (0.28s)

AnalyzeHocActivityHelperTest
  test_add_hashes_intersecting_keys                               PASS (0.00s)
  test_add_hashes_disjoint_keys                                   PASS (0.00s)

CurriculumCourse::with unit numbers
  test_0004_should determine whether lessons are in unit          PASS (0.00s)
  test_0003_should get lesson numbers when there are unit numbers PASS (0.00s)
  test_0002_should recognize that it has units                    PASS (0.00s)
  test_0001_should get units when has units                       PASS (0.00s)
  test_0005_should get all lessons                                PASS (0.04s)

GeocoderTest
  test_can_parse_result_with_empty_context_field                  PASS (0.01s)
  test_result_adapter                                             PASS (0.00s)
  test_finding_potential_addresses                                PASS (0.01s)
  test_with_errors                                                PASS (0.00s)
  test_freegeoip_overrides                                        PASS (0.00s)
  test_can_get_country_code_for_direct_country_searches           PASS (0.00s)
  test_localhost_lookup                                           PASS (0.00s)
  test_saucelabs_override                                         PASS (0.00s)

Poste Routes::GET /unsubscribe/:email
  test_0002_noops with 200 for non-existing contact               PASS (0.01s)
  test_0001_unsubscribes existing contact                         PASS (0.01s)

StringTest
  test_to_bool                                                    PASS (0.00s)
  test_multiply_concat                                            PASS (0.00s)
  test_include_one_of                                             PASS (0.00s)
  test_end_with                                                   PASS (0.00s)
  test_utf8_to_iso_8859                                           PASS (0.00s)

CSVTest
  test_cdo_donors_db                                              PASS (0.01s)
  test_cdo_donors_csv                                             PASS (0.00s)
  test_policy_columns_exist                                       PASS (0.01s)

TutorialsTest
  test_sort_by_popularity_cs_ed_week_org                          PASS (0.00s)
  test_tutorials_contents_immutable                               PASS (0.35s)
  test_sort_by_popularity_code_org                                PASS (0.00s)
  test_sort_by_popularity_hour_of_code_com                        PASS (0.00s)

MultipleExtnameFileUtilsTest
  test_find_with_extnames                                         PASS (0.00s)
  test_file_has_only_extnames                                     PASS (0.00s)
  test_file_has_any_extnames                                      PASS (0.00s)
  test_all_extnames                                               PASS (0.00s)
  test_find_with_extnames_only_subdirectory                       PASS (0.00s)

GraphicsTest
  test_process_image                                              PASS (16.79s)

/api/dev/ routes::api/dev/check-dts
  test_0004_ignores PRs against branches we dont care about       PASS (0.00s)
  test_0006_Sets the dts check to fail if DTS is no               PASS (0.00s)
  test_0003_ignores events we dont care about                     PASS (0.00s)
  test_0002_ignores actions we dont care about                    PASS (0.00s)
  test_0001_is forbidden on non-staging environments              PASS (0.01s)
  test_0005_Sets the dts check to pass if DTS is yes              PASS (0.00s)

Congrats Routes
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0001_shows a course-specific congrats page for appropriate courses PASS (0.76s)

Dashboard::User::get
  test_0002_does not return deleted students                      PASS (0.00s)
  test_0001_does return students                                  PASS (0.00s)

DelivererRenderTest
  test_deliverer_render_all                                       PASS (0.21s)

update_form
  test_0002_updates form                                          PASS (0.01s)
  test_0001_returns nil if form not found                         PASS (0.00s)

OptimizeTest
  test_optimize_image                                             PASS (0.37s)
  test_optimize_anigif                                            PASS (1.66s)
  test_gatekeeper_disable                                         PASS (0.01s)
  test_dcdo_pixel_max                                             PASS (0.00s)
  test_uncacheable                                                PASS (0.11s)

VolunteerFormsTest
  test_cached_localized_strings                                   PASS (0.00s)

/api/dev/ routes::api/dev/set-last-dtt-green
  test_0002_succeeds on test environment                          PASS (0.00s)
  test_0001_is forbidden on non-test environments                 PASS (0.01s)

RequestTest
  test_unknown_ip                                                 PASS (0.37s)
  test_shared_cookie_domain                                       PASS (0.00s)
  test_saucelabs_ip                                               PASS (0.00s)
  test_gdpr                                                       PASS (0.00s)
  test_x_forwarded_host                                           PASS (0.00s)

YamlTest
  test_markdown_no_front_matter                                   PASS (0.00s)
  test_cdo_yaml_load_file                                         PASS (0.00s)
  test_markdown_with_front_matter                                 PASS (0.00s)

insert_or_upsert_form
  test_0002_creates a forms_geos entry                            PASS (0.00s)
  test_0001_inserts a new form                                    PASS (0.00s)
  test_0003_updates an existing HOC signup form                   PASS (0.01s)

Forms
  test_0002_events_by_state                                       PASS (0.01s)
  test_0001_events_by_country                                     PASS (0.01s)
  test_0003_events_by_name                                        PASS (0.01s)

RouterTest
  test_localized_markdown_fallback                                PASS (0.29s)
  test_div_brackets                                               PASS (0.09s)
  test_markdown_partial                                           PASS (0.09s)
  test_not_found                                                  PASS (0.10s)
  test_index                                                      PASS (0.10s)
  test_no_erb_in_yaml                                             PASS (0.09s)
  test_markdown_partial_only_templates                            PASS (0.08s)
  test_haml_error                                                 PASS (0.09s)
  test_parsing_yaml_header                                        PASS (0.00s)
  test_syntax_error                                               PASS (0.10s)
  test_erb_error_body                                             PASS (0.11s)
  test_localized_markdown                                         PASS (0.11s)
  test_all_documents                                              PASS (0.00s)
  test_splat                                                      PASS (0.01s)
  test_view                                                       PASS (0.10s)

Form Routes::POST /forms/:kind
  test_0001_returns 400 for non-existent form kind                PASS (0.00s)

MinecraftCertificatesTest
  test_missing_minecraft_certificates                             PASS (0.06s)
  test_minecraft_certificates_present_in_csv                      PASS (0.04s)

EmailPreferenceHelperTest
  test_upsert_email_preference_that_is_already_opted_in_does_not_opt_out PASS (0.08s)
  test_upsert_email_preference_without_opt_in_does_not_create_email_preference PASS (0.00s)
  test_upsert_email_preference_with_invalid_email_does_not_create_email_preference PASS (0.00s)
  test_upsert_new_email_preference_with_valid_attributes_creates_email_preference PASS (0.01s)
  test_upsert_email_preference_with_invalid_source_does_not_create_email_preference PASS (0.00s)
  test_upsert_does_not_update_other_rows                          PASS (0.03s)
  test_upsert_email_preference_without_ip_address_does_not_create_email_preference PASS (0.00s)
  test_upsert_existing_email_preference_changes_existing_email_preference PASS (0.02s)

various supporting structs
  test_0001_should get created with right types                   PASS (0.00s)

GatekeeperTest
  test_gatekeeper_works_in_pegasus                                PASS (0.00s)

delete_form
  test_0002_returns false on bad secret                           PASS (0.00s)
  test_0001_deletes existing form                                 PASS (0.00s)

Homepage
  test_0002_banner with showInternationally true is seen only by users we know are outside the US PASS (0.00s)
  test_0004_banners for local testing are shown as if based in the US PASS (0.00s)
  test_0001_banner with showInternationally false is seen only by users in the US and with unknown country PASS (0.00s)
  test_0003_banner without showInternationally flag is seen by everyone PASS (0.00s)

SiteTest
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_new_relic_transactions                                     PASS (2.25s)
(haml):135: warning: File.exists? is deprecated; use File.exist? instead
(haml):135: warning: File.exists? is deprecated; use File.exist? instead
  test_get_list                                                   PASS (0.11s)
  test_post_allowlist                                             PASS (0.05s)

HOC Routes
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0001_redirects to tutorial via shortcode                   PASS (0.39s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0018_does not write at start of sessions not in sample     PASS (1.51s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0003_starts tutorial                                       PASS (1.01s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0008_redirects batch certificate page to code studio       PASS (0.35s)
  test_0005_starts given tutorial with png image                  PASS (0.08s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0015_starts and ends given tutorial, tracking company and tutorial, with hoc_activity_sample_weight 100 PASS (1.87s)
  test_0002_gets certificate info                                 PASS (0.00s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0012_preserves url params when redirecting congrats page   PASS (0.36s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0010_redirects sharecertificate page to code studio        PASS (0.36s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0020_handles negative sampling weight correctly            PASS (1.04s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0007_ends given tutorial, providing script ID to congrats page PASS (0.46s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0011_redirects vanilla congrats page to code studio        PASS (0.42s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0013_starts and ends given tutorial, tracking company and tutorial PASS (1.81s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0009_redirects blank certificate page to code studio       PASS (0.34s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0014_starts and ends given tutorial, tracking company and tutorial using cookie PASS (1.54s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0004_ends tutorial                                         PASS (0.36s)
  test_0021_records weight for tracking pixel in sample           PASS (0.19s)
  test_0022_does not write for start or end tracking pixel for session not in sample PASS (0.18s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0019_handles 0 sampling weight correctly                   PASS (1.06s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0016_starts and ends given tutorial, tracking time         PASS (1.50s)
  test_0006_ends given tutorial with png image                    PASS (0.09s)
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
  test_0017_respects sample weight and records weight for sessions in sample PASS (1.62s)

Finished in 167.70105s
208 tests, 964 assertions, 0 failures, 0 errors, 0 skips
```

## Before-after GIFs:

![video_before_sm](https://github.com/code-dot-org/code-dot-org/assets/75899581/2cb10075-4d43-4f69-b405-395f0d9ef34f)
![video_after_sm](https://github.com/code-dot-org/code-dot-org/assets/75899581/6fecc09c-72f5-4ffb-852e-b882de70957f)
![language_before_sm](https://github.com/code-dot-org/code-dot-org/assets/75899581/f1c8f7b0-b56f-4afd-943a-555244bf8668)
![language_after](https://github.com/code-dot-org/code-dot-org/assets/75899581/df1ddf15-a04f-4337-bc27-6c1bb724007c)
