### PR TITLE
Moving supported locales to its own collapsible section to avoid lot of scrolling

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -593,7 +593,7 @@ class UnitEditor extends React.Component {
             />
           </label>
         </CollapsibleEditorSection>
-        <CollapsibleEditorSection title="Supported locales" collapsed="true">
+        <CollapsibleEditorSection title="Supported locales" collapsed={true}>
           <p>
             <span>
               {'Select additional locales supported by this unit. Click '}

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -598,12 +598,15 @@ class UnitEditor extends React.Component {
             <span>
               {'Select additional locales supported by this unit. Click '}
             </span>
-            <a style={{cursor: "pointer"}} onClick={this.handleClearSupportedLocalesSelectClick}>none</a>
+            <a
+              style={{cursor: 'pointer'}}
+              onClick={this.handleClearSupportedLocalesSelectClick}
+            >
+              none
+            </a>
             <span>{' to clear the selection.'}</span>
           </p>
-          <p>
-              A list of other locales supported by this unit besides en-US.
-          </p>
+          <p>A list of other locales supported by this unit besides en-US.</p>
           <MultiCheckboxSelector
             noHeader={true}
             items={this.state.locales
@@ -615,7 +618,6 @@ class UnitEditor extends React.Component {
             <LocaleItemComponent />
           </MultiCheckboxSelector>
         </CollapsibleEditorSection>
-
 
         {this.props.hasCourse && (
           <CollapsibleEditorSection title="Course Type Settings">

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -560,31 +560,6 @@ class UnitEditor extends React.Component {
               }}
             />
           )}
-          <label>
-            Supported locales
-            <HelpTip>
-              <p>
-                A list of other locales supported by this unit besides en-US.
-              </p>
-            </HelpTip>
-            <p>
-              <span>
-                {'Select additional locales supported by this unit. Click '}
-              </span>
-              <a onClick={this.handleClearSupportedLocalesSelectClick}>none</a>
-              <span>{' to clear the selection.'}</span>
-            </p>
-          </label>
-          <MultiCheckboxSelector
-            noHeader={true}
-            items={this.state.locales
-              .filter(locale => !locale[1].startsWith('en'))
-              .map(locale => locale[1])}
-            selected={this.state.supportedLocales}
-            onChange={this.handleChangeSupportedLocales}
-          >
-            <LocaleItemComponent />
-          </MultiCheckboxSelector>
           {this.props.isLevelbuilder && (
             <label>
               Editor Experiment
@@ -618,6 +593,29 @@ class UnitEditor extends React.Component {
             />
           </label>
         </CollapsibleEditorSection>
+        <CollapsibleEditorSection title="Supported locales" collapsed="true">
+          <p>
+            <span>
+              {'Select additional locales supported by this unit. Click '}
+            </span>
+            <a style={{cursor: "pointer"}} onClick={this.handleClearSupportedLocalesSelectClick}>none</a>
+            <span>{' to clear the selection.'}</span>
+          </p>
+          <p>
+              A list of other locales supported by this unit besides en-US.
+          </p>
+          <MultiCheckboxSelector
+            noHeader={true}
+            items={this.state.locales
+              .filter(locale => !locale[1].startsWith('en'))
+              .map(locale => locale[1])}
+            selected={this.state.supportedLocales}
+            onChange={this.handleChangeSupportedLocales}
+          >
+            <LocaleItemComponent />
+          </MultiCheckboxSelector>
+        </CollapsibleEditorSection>
+
 
         {this.props.hasCourse && (
           <CollapsibleEditorSection title="Course Type Settings">

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -167,7 +167,7 @@ describe('UnitEditor', () => {
       expect(wrapper.find('input[type="checkbox"]').length).to.equal(11);
       expect(wrapper.find('textarea').length).to.equal(4);
       expect(wrapper.find('select').length).to.equal(5);
-      expect(wrapper.find('CollapsibleEditorSection').length).to.equal(10);
+      expect(wrapper.find('CollapsibleEditorSection').length).to.equal(11);
       expect(wrapper.find('SaveBar').length).to.equal(1);
       expect(wrapper.find('CourseTypeEditor').length).to.equal(1);
 


### PR DESCRIPTION
A follow up change to https://github.com/code-dot-org/code-dot-org/pull/56418 which changed the locale selection to a checkbox list from a dropdown list. This change was made because the dropdown list was very hard to multi select. Upon release we got feedback from curriculum team that the list of checkboxes is taking too much vertical space.

Fix: Moving the locale selection to its own collapsible section

Images of the checkbox list with the "Supported Locales" collapsed
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/36709d3d-ae3c-44ab-89f3-ede8220bdcfd)

Expanded
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/9b729dda-41f3-41d0-9197-9715967c6a8e)

## Links

N/A

## Testing story
- Quick manual validation
- Tests through drone

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
Regular DTP

## Follow-up work
None

## Privacy
N/A

## Security
N/A

## Caching
N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
