### PR TITLE
Hide arrow on mobile on curriculum_pathway.haml

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
+++ b/pegasus/sites.v3/code.org/public/css/curriculum-pathway.scss
@@ -105,6 +105,10 @@ figure.curriculum-pathway {
         margin-top: 4px;
         transition: color 0.2s ease-in-out;
 
+        @media screen and (max-width: 700px) {
+          display: none;
+        }
+
         html[dir="rtl"] & { content: "\f053"; }
       }
 


### PR DESCRIPTION
Hides the arrow on mobile on the curriculum pathway graphic seen on https://code.org/administrators that was added in this PR: https://github.com/code-dot-org/code-dot-org/pull/56627

| Before | After |
| ---- | ----- |
| <img width="420" alt="Screenshot 2024-02-16 at 5 38 48 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/013d891a-9e8a-4ca4-9578-dc26b507b414"> | <img width="420" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/a20d50d5-8f20-4b5e-9de9-b2f553bcc93e"> |

