### PR TITLE
Implement get_column 

### DIFF
--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -236,11 +236,13 @@ class DatablockStorageController < ApplicationController
   #   Project Use Datablock Storage API                    #
   ##########################################################
 
+  # TODO: post-firebase-cleanup, remove
   def use_datablock_storage
     ProjectUseDatablockStorage.set_data_block_storage_for!(params[:channel_id], true)
     render json: true
   end
 
+  # TODO: post-firebase-cleanup, remove
   def use_firebase_storage
     ProjectUseDatablockStorage.set_data_block_storage_for!(params[:channel_id], false)
     render json: true

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -11,6 +11,7 @@ class DatablockStorageController < ApplicationController
     @records = DatablockStorageRecord.where(project_id: @project_id)
     @tables = DatablockStorageTable.where(project_id: @project_id)
     @library_manifest = DatablockStorageLibraryManifest.instance.library_manifest
+    @storage_backend = ProjectUseDatablockStorage.use_data_block_storage_for?(params[:channel_id]) ? "Datablock Storage" : "Firebase"
     puts "####################################################"
   end
 
@@ -142,6 +143,12 @@ class DatablockStorageController < ApplicationController
     render json: true
   end
 
+  def get_column
+    table = find_table
+    column = table.get_column params[:column_name]
+    render json: column
+  end
+
   def get_columns_for_table
     table = find_table_or_shared_table
     render json: table.get_columns
@@ -225,6 +232,23 @@ class DatablockStorageController < ApplicationController
     render json: true
   end
 
+  ##########################################################
+  #   Project Use Datablock Storage API                    #
+  ##########################################################
+
+  def use_datablock_storage
+    ProjectUseDatablockStorage.set_data_block_storage_for!(params[:channel_id], true)
+    render json: true
+  end
+
+  def use_firebase_storage
+    ProjectUseDatablockStorage.set_data_block_storage_for!(params[:channel_id], false)
+    render json: true
+  end
+
+  ##########################################################
+  #   Private                                              #
+  ##########################################################
   private
 
   def shared_table?

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -159,6 +159,16 @@ class DatablockStorageTable < ApplicationRecord
     self.columns.delete column_name
   end
 
+  # TODO: What is the current behavior if the column doesn't exist?
+  # This will return Nil. What happens in AppLab today?
+  def get_column(column_name)
+    if columns.include? column_name
+      read_records.map do |record|
+        record.record_json[column_name]
+      end
+    end
+  end
+
   def rename_column(old_column_name, new_column_name)
     if_shared_table_copy_on_write
 

--- a/dashboard/app/models/project_use_datablock_storage.rb
+++ b/dashboard/app/models/project_use_datablock_storage.rb
@@ -23,4 +23,9 @@ class ProjectUseDatablockStorage < ApplicationRecord
     project = Project.find_by_channel_id(channel_id)
     find_by(project: project)&.use_datablock_storage || false
   end
+
+  def self.set_data_block_storage_for!(channel_id, use_datablock_storage)
+    project = Project.find_by_channel_id(channel_id)
+    find_or_create_by(project: project).update!(use_datablock_storage: ActiveRecord::Type::Boolean.new.cast(use_datablock_storage))
+  end
 end

--- a/dashboard/app/views/datablock_storage/index.html.haml
+++ b/dashboard/app/views/datablock_storage/index.html.haml
@@ -1,4 +1,4 @@
-%strong{:class => "code", :id => "message"} Hello,  #{@project.project_type}
+%strong{:class => "code", :id => "message"} This #{@project.project_type} project uses #{@storage_backend} as its backing store.
 
 %h2 Tables
 %table
@@ -113,6 +113,12 @@
   = text_area_tag "table_data_csv", "", placeholder: "table_data_csv"
   = submit_tag "import_csv"
 
+%h3 get_column
+= form_tag "get_column", :method => :get, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = text_field_tag "column_name", "", placeholder: "column_name"
+  = submit_tag "get_column"
+
 %h3 add_column
 = form_tag "add_column", :method => :post, :remote => false do
   = text_field_tag "table_name", "", placeholder: "table_name"
@@ -182,3 +188,9 @@
 = form_tag "set_library_manifest", :method => :put, :remote => false do
   = text_area_tag "library_manifest", '{"categories":[{"datasets":["100 Birds of the World"],"name":"Animals","published":true}],"tables":[{"current":false,"description":"Data and images about 100 different species of birds around the world","docUrl":"https://studio.code.org/data_docs/100-birds/","name":"100 Birds of the World","published":true}]}'
   = submit_tag "set_library_manifest"
+
+  %h3 switch storage backend
+= form_tag "use_datablock_storage", :method => :put, :remote => false do
+  = submit_tag "use_datablock_storage"
+= form_tag "use_firebase_storage", :method => :put, :remote => false do
+  = submit_tag "use_firebase_storage"

--- a/dashboard/app/views/datablock_storage/index.html.haml
+++ b/dashboard/app/views/datablock_storage/index.html.haml
@@ -1,5 +1,11 @@
 %strong{:class => "code", :id => "message"} This #{@project.project_type} project uses #{@storage_backend} as its backing store.
 
+%h3 switch storage backend
+= form_tag "use_datablock_storage", :method => :put, :remote => false do
+  = submit_tag "use_datablock_storage"
+= form_tag "use_firebase_storage", :method => :put, :remote => false do
+  = submit_tag "use_firebase_storage"
+
 %h2 Tables
 %table
   %tr
@@ -188,9 +194,3 @@
 = form_tag "set_library_manifest", :method => :put, :remote => false do
   = text_area_tag "library_manifest", '{"categories":[{"datasets":["100 Birds of the World"],"name":"Animals","published":true}],"tables":[{"current":false,"description":"Data and images about 100 different species of birds around the world","docUrl":"https://studio.code.org/data_docs/100-birds/","name":"100 Birds of the World","published":true}]}'
   = submit_tag "set_library_manifest"
-
-  %h3 switch storage backend
-= form_tag "use_datablock_storage", :method => :put, :remote => false do
-  = submit_tag "use_datablock_storage"
-= form_tag "use_firebase_storage", :method => :put, :remote => false do
-  = submit_tag "use_firebase_storage"

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1145,6 +1145,7 @@ Dashboard::Application.routes.draw do
         get :channel_exists
         delete :clear_all_data
 
+        # TODO: post-firebase-cleanup, remove
         # Project Use Datablock Storage API
         put :use_datablock_storage
         put :use_firebase_storage

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1128,6 +1128,7 @@ Dashboard::Application.routes.draw do
         put :rename_column
         put :coerce_column
         delete :delete_column
+        get :get_column
         get :get_columns_for_table
 
         # Datablock Storage: Table Record API
@@ -1143,6 +1144,10 @@ Dashboard::Application.routes.draw do
         # Datablock Storage: Channel API
         get :channel_exists
         delete :clear_all_data
+
+        # Project Use Datablock Storage API
+        put :use_datablock_storage
+        put :use_firebase_storage
       end
     end
   end


### PR DESCRIPTION
Implement get_column on the backend.

Implemented the ability to switch a project to datablock_storage and back to firebase. Keep in mind that when doing this switch, the data that exists in either storage system will stay the same. This would let us pretty easily test in a bug bash scenario without the need for a DCDO flag. Folks could make a new project, navigate to /datablock_storage/CHANNEL_ID/ and swap the storage for the project to test.  This might be especially interesting to swap over existing projects that are exclusively using stock tables, because you could switch the project over, import the tables needed for the project, and run the project.