### PR TITLE
Update links on Intl PL Partners page

### DIFF
--- a/pegasus/sites.v3/code.org/views/professional_learning/intl_pl_partners_list.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning/intl_pl_partners_list.haml
@@ -16,8 +16,8 @@
           %td=value[:description_t]
           %td
             - if value[:url_email_s]
-              %a{href: value[:url_email_s]}
+              %a{href: "mailto:#{value[:url_email_s]}"}
                 = value[:url_email_s]
             - if value[:url_site_s]
-              %a{href: value[:url_site_s]}
+              %a.has-external-link{href: value[:url_site_s], target: "_blank", rel: "noopener noreferrer"}
                 = value[:url_site_s]


### PR DESCRIPTION
Realized in the middle of the night I forgot to add `mailto:` links to the email links on https://code.org/professional-learning/international-partners so adding that, and also made the website urls open in a new tab. 

<img width="1099" alt="Screenshot 2024-02-17 at 6 46 25 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/31a69ff0-4718-4b73-aab5-0d1a01c89c38">
