### PR TITLE
AI Tutor: add index method for ai_tutor_interactions_controller and initial tests

### DIFF
--- a/dashboard/app/controllers/ai_tutor_interactions_controller.rb
+++ b/dashboard/app/controllers/ai_tutor_interactions_controller.rb
@@ -62,4 +62,14 @@ class AiTutorInteractionsController < ApplicationController
       version_id: version_id,
     }
   end
+
+  # GET /ai_tutor_interactions
+  def index
+    return render(status: :forbidden, json: {error: 'This user does not have access to AI Tutor chat messages'}) unless current_user.can_view_student_ai_chat_messages?
+    params.require([:sectionId])
+    section = Section.find(params[:sectionId])
+    return render(status: :not_found, json: {error: 'Section not found'}) unless section
+    return render(status: :forbidden, json: {error: 'This user does not own this section'}) unless current_user.sections.include?(section)
+    render json:  AiTutorInteraction.where(user_id: section.students.pluck(:id))
+  end
 end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -294,6 +294,10 @@ class Ability
         can :chat_completion, :openai_chat
         can :create, AiTutorInteraction, user_id: user.id
       end
+
+      if user.can_view_student_ai_chat_messages?
+        can :index, AiTutorInteraction
+      end
     end
 
     # Override UnitGroup, Unit, Lesson and ScriptLevel.

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1498,6 +1498,11 @@ class User < ApplicationRecord
       SingleUserExperiment.enabled?(user: self, experiment_name: AI_TUTOR_EXPERIMENT_NAME))
   end
 
+  def can_view_student_ai_chat_messages?
+    sections.any?(&:assigned_csa?) &&
+      SingleUserExperiment.enabled?(user: self, experiment_name: AI_TUTOR_EXPERIMENT_NAME)
+  end
+
   # Students
   def has_ai_tutor_access?
     !DCDO.get('ai-tutor-disabled', false) && (

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1100,7 +1100,7 @@ Dashboard::Application.routes.draw do
 
     post '/openai/chat_completion', to: 'openai_chat#chat_completion'
 
-    resources :ai_tutor_interactions, only: [:create]
+    resources :ai_tutor_interactions, only: [:create, :index]
 
     # Policy Compliance
     get '/policy_compliance/child_account_consent/', to:

--- a/dashboard/test/controllers/ai_tutor_interactions_controller_test.rb
+++ b/dashboard/test/controllers/ai_tutor_interactions_controller_test.rb
@@ -121,16 +121,18 @@ class AiTutorInteractionsControllerTest < ActionController::TestCase
     sign_in teacher
     User.any_instance.stubs(:can_view_student_ai_chat_messages?).returns(true)
     section = @student_with_ai_tutor_access.sections_as_student.first
-
+    num_ai_tutor_interactions = 3
+    num_ai_tutor_interactions.times do
+      create :ai_tutor_interaction, user: @student_with_ai_tutor_access
+    end
     get :index, params: {
       sectionId: section.id,
     }
     assert_response :success
 
-    # TODO: Make AiTutorInteractions factory, use it to make interactions for the student,
-    # then check that they are the interactions we expect
     response_json = JSON.parse(response.body)
-    pp response_json
+    assert response_json.length, num_ai_tutor_interactions
+    assert response_json.first["user_id"], @student_with_ai_tutor_access.id
   end
 
   test 'index returns forbidden for section not owned by teacher' do

--- a/dashboard/test/controllers/ai_tutor_interactions_controller_test.rb
+++ b/dashboard/test/controllers/ai_tutor_interactions_controller_test.rb
@@ -116,6 +116,48 @@ class AiTutorInteractionsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'index returns AI Tutor Interactions for section owned by teacher who can view chats' do
+    teacher = @student_with_ai_tutor_access.teachers.first
+    sign_in teacher
+    User.any_instance.stubs(:can_view_student_ai_chat_messages?).returns(true)
+    section = @student_with_ai_tutor_access.sections_as_student.first
+
+    get :index, params: {
+      sectionId: section.id,
+    }
+    assert_response :success
+
+    # TODO: Make AiTutorInteractions factory, use it to make interactions for the student,
+    # then check that they are the interactions we expect
+    response_json = JSON.parse(response.body)
+    pp response_json
+  end
+
+  test 'index returns forbidden for section not owned by teacher' do
+    teacher = @student_with_ai_tutor_access.teachers.first
+    sign_in teacher
+    User.any_instance.stubs(:can_view_student_ai_chat_messages?).returns(true)
+    random_section = create :section
+    refute teacher.sections.include?(random_section)
+
+    get :index, params: {
+      sectionId: random_section.id,
+    }
+    assert_response :forbidden
+  end
+
+  test 'index returns forbidden for teacher who can not view chats' do
+    teacher = @student_with_ai_tutor_access.teachers.first
+    sign_in teacher
+    User.any_instance.stubs(:can_view_student_ai_chat_messages?).returns(false)
+    section = @student_with_ai_tutor_access.sections_as_student.first
+
+    get :index, params: {
+      sectionId: section.id,
+    }
+    assert_response :forbidden
+  end
+
   private def stub_project_source_data(channel_id, code: 'fake-code', version_id: 'fake-version-id')
     fake_main_json = {source: code}.to_json
     fake_source_data = {

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -711,7 +711,7 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
       create :teacher_feedback, script: script, level: weblab_level, student: student, teacher: @teacher
     end
 
-    assert_queries 13 do
+    assert_queries 14 do
       get :section_feedback, params: {section_id: @section.id, script_id: script.id}
     end
 

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -147,7 +147,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, lesson_scores: [{lesson_id: lesson.id, score: score}]}
 
-    assert_queries 7 do
+    assert_queries 8 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
 
@@ -159,7 +159,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal section.students.count, 11
 
-    assert_queries 7 do
+    assert_queries 8 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
   end

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1149,7 +1149,7 @@ class ApiControllerTest < ActionController::TestCase
   test "should get progress for section with section script" do
     Unit.stubs(:should_cache?).returns true
 
-    assert_queries 7 do
+    assert_queries 8 do
       get :section_progress, params: {section_id: @flappy_section.id}
     end
     assert_response :success

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -60,7 +60,7 @@ class CoursesControllerTest < ActionController::TestCase
 
     test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 10
 
-    test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 3
+    test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 4
   end
 
   class CachedQueryCounts < ActionController::TestCase

--- a/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
@@ -45,7 +45,7 @@ class TeacherFeedbacksControllerTest < ActionController::TestCase
 
     assert_equal TeacherFeedback.all.count, 4
     sign_in student
-    assert_queries 19 do
+    assert_queries 20 do
       get :index
       assert_response :success
     end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1917,4 +1917,10 @@ FactoryBot.define do
     email {"foobar@example.com"}
     receives_marketing {true}
   end
+
+  factory :ai_tutor_interaction do
+    association :user
+    type {SharedConstants::AI_TUTOR_TYPES[:GENERAL_CHAT]}
+    status {SharedConstants::AI_TUTOR_INTERACTION_SAVE_STATUS[:OK]}
+  end
 end

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -20,7 +20,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level,
       level_source: create(:level_source, level: level)
 
-    assert_cached_queries(8) do
+    assert_cached_queries(9) do
       get script_lesson_script_level_path(
         script_id: script.name,
         lesson_position: 1,
@@ -65,7 +65,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     sl = create(:script, :with_levels, levels_count: 3).script_levels[2]
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
-    assert_cached_queries(8) do
+    assert_cached_queries(9) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id
@@ -81,7 +81,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     sl = create(:script, :with_levels, levels_count: 3).script_levels[2]
     params = {program: 'fake program', testResult: 0, result: 'false'}
 
-    assert_cached_queries(8) do
+    assert_cached_queries(9) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id
@@ -109,7 +109,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(script)
     sign_in student
 
-    assert_cached_queries(6) do
+    assert_cached_queries(7) do
       get "/s/#{script.name}"
       assert_response :success
     end
@@ -122,7 +122,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       assert_response :success
     end
 
-    assert_cached_queries(3) do
+    assert_cached_queries(4) do
       get "/api/v1/teacher_feedbacks/count?student_id=#{student.id}"
       assert_response :success
     end
@@ -152,7 +152,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(unit)
     sign_in student
 
-    assert_cached_queries(17) do
+    assert_cached_queries(18) do
       get "/s/#{unit.name}/lessons/1/levels/1"
       assert_response :success
     end
@@ -165,7 +165,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       assert_response :success
     end
 
-    assert_cached_queries(3) do
+    assert_cached_queries(4) do
       get "/levels/#{level.id}/get_rubric"
       assert_response :success
     end


### PR DESCRIPTION
One of the requirements for AI Tutor is that teachers be able to see the chat messages sent by students in their sections.  This PR sets up an `index` method in the `ai_tutor_interactions_controller` that returns all of the `AiTutorInteractions` for all of the students in a given section if the teacher requesting the interactions owns the section.  Also includes tests for the new index method to ensure the correct responses are returned. 

### Links
[CT-231](https://codedotorg.atlassian.net/browse/CT-231)
[AI Tutor Product Spec](https://docs.google.com/document/d/1rEWpIA6zXzevldiyi6DH-Pt4UU7uqPlWjTnUbz9uVLE/edit)

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
