### PR TITLE
[Sprite Lab] Preserve previous drawing style settings when making variable bubbles

### DIFF
--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -42,6 +42,7 @@ export function variableBubble(p5, x, y, text) {
   const textWidthValue = textWidth + 2 * padding;
   const textHeightValue = textSizeValue + 2 * padding;
 
+  p5.push();
   p5.fill(colors.darkest_gray);
   p5.stroke('white');
   p5.strokeWeight(3);
@@ -53,6 +54,7 @@ export function variableBubble(p5, x, y, text) {
   p5.textSize(textSizeValue);
   p5.textAlign(p5.CENTER, p5.CENTER);
   p5.text(text, x, y);
+  p5.pop();
 }
 
 /**


### PR DESCRIPTION
The new K5 blocks shipped at the end of last week. This morning I noticed a regression that only impacted animation frames where both a variable bubble and a speech bubble were being drawn. 

The cause of this is that the new variable button use a different `rectMode` style: https://p5js.org/reference/#/p5/rectMode

The solution is to call `push()` and `pop()` around the bubble's drawing commands. These allow us to change the style and transformation settings and later return to what you had. https://p5js.org/reference/#/p5/push

**Before:**
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/8b51692b-a5d6-4dd3-9a3d-b8a2e9bc52b9)

**After:**
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/c2a7e022-22a5-483a-8254-c8e56fb9b062)

Note that push and pop were already implemented for other draw utils, e.g. speech bubbles, multiline text, and validation bars.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
