### PR TITLE
Revert "Revert "Music: scroll timeline during playback""

### DIFF
--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -76,7 +76,11 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
     progressManager,
   ]);
 
-  usePlaybackUpdate(doPlaybackUpdate, () => progressManager?.resetValidation());
+  const resetValidation = useCallback(
+    () => progressManager?.resetValidation(),
+    [progressManager]
+  );
+  usePlaybackUpdate(doPlaybackUpdate, resetValidation);
 
   const onInstructionsTextClick = useCallback(
     (id: string) => {

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useContext, useEffect, useRef} from 'react';
+import React, {useCallback, useContext, useEffect} from 'react';
 import MusicValidator from '../progress/MusicValidator';
 import moduleStyles from './music-view.module.scss';
 import {
@@ -17,6 +17,7 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import Controls from './Controls';
 import Timeline from './Timeline';
 import {ProgressManagerContext} from '@cdo/apps/lab2/progress/ProgressContainer';
+import usePlaybackUpdate from './hooks/usePlaybackUpdate';
 
 interface MusicLabViewProps {
   blocklyDivId: string;
@@ -30,7 +31,6 @@ interface MusicLabViewProps {
   clearCode: () => void;
   validator: MusicValidator;
 }
-const UPDATE_RATE = 1000 / 30; // 30 times per second
 
 const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   blocklyDivId,
@@ -54,10 +54,8 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   const timelineAtTop = useAppSelector(state => state.music.timelineAtTop);
   const hideHeaders = useAppSelector(state => state.music.hideHeaders);
   const appName = useAppSelector(state => state.lab.levelProperties?.appName);
-  const isPlaying = useAppSelector(state => state.music.isPlaying);
 
   const progressManager = useContext(ProgressManagerContext);
-  const intervalId = useRef<number | undefined>(undefined);
 
   // Pass music validator to Progress Manager
   useEffect(() => {
@@ -78,21 +76,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
     progressManager,
   ]);
 
-  // Starts updates whenever playback is in progress, and stops updates
-  // when playback stops.
-  useEffect(() => {
-    if (isPlaying) {
-      if (intervalId.current !== undefined) {
-        window.clearInterval(intervalId.current);
-      }
-      // Reset validation before starting the update timer when playback starts.
-      progressManager?.resetValidation();
-      intervalId.current = window.setInterval(doPlaybackUpdate, UPDATE_RATE);
-    } else {
-      window.clearInterval(intervalId.current);
-      intervalId.current = undefined;
-    }
-  }, [isPlaying, doPlaybackUpdate, progressManager]);
+  usePlaybackUpdate(doPlaybackUpdate, () => progressManager?.resetValidation());
 
   const onInstructionsTextClick = useCallback(
     (id: string) => {

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -1,4 +1,4 @@
-import React, {MouseEvent, useCallback} from 'react';
+import React, {MouseEvent, useCallback, useRef} from 'react';
 import moduleStyles from './timeline.module.scss';
 import classNames from 'classnames';
 import TimelineSampleEvents from './TimelineSampleEvents';
@@ -12,12 +12,15 @@ import {
   setStartPlayheadPosition,
 } from '../redux/musicRedux';
 import {useMusicSelector} from './types';
+import usePlaybackUpdate from './hooks/usePlaybackUpdate';
 
 const barWidth = 60;
 // Leave some vertical space between each event block.
 const eventVerticalSpace = 2;
 // A little room on the left.
 const paddingOffset = 10;
+// Start scrolling the playhead when it's more than this percentage of the way across the timeline area.
+const playheadScrollThreshold = 0.75;
 
 const getEventHeight = (numUniqueRows: number, availableHeight = 110) => {
   // While we might not actually have this many rows to show,
@@ -53,6 +56,8 @@ const Timeline: React.FunctionComponent = () => {
     MIN_NUM_MEASURES,
     useMusicSelector(state => state.music.lastMeasure)
   );
+  const playheadRef = useRef<HTMLDivElement>(null);
+  const timelineRef = useRef<HTMLDivElement>(null);
 
   const positionToUse = isPlaying
     ? currentPlayheadPosition
@@ -105,11 +110,36 @@ const Timeline: React.FunctionComponent = () => {
     dispatch(clearSelectedBlockId());
   }, [dispatch]);
 
+  const scrollPlayheadForward = useCallback(() => {
+    if (!timelineRef.current || !playheadRef.current) {
+      return;
+    }
+
+    const playheadOffset =
+      playheadRef.current.getBoundingClientRect().left -
+      timelineRef.current.getBoundingClientRect().left;
+    const scrollThreshold =
+      timelineRef.current.clientWidth * playheadScrollThreshold;
+    if (playheadOffset > scrollThreshold) {
+      timelineRef.current.scrollBy(playheadOffset - scrollThreshold, 0);
+    }
+  }, [playheadRef]);
+
+  const scrollToPlayhead = useCallback(() => {
+    playheadRef.current?.scrollIntoView();
+  }, [playheadRef]);
+
+  usePlaybackUpdate(scrollPlayheadForward, scrollToPlayhead, scrollToPlayhead);
+
   return (
     <div
       id="timeline"
-      className={moduleStyles.timeline}
+      className={classNames(
+        moduleStyles.timeline,
+        isPlaying && moduleStyles.timelinePlaying
+      )}
       onClick={onTimelineClick}
+      ref={timelineRef}
     >
       <div
         id="timeline-measures-background"
@@ -169,6 +199,7 @@ const Timeline: React.FunctionComponent = () => {
             isPlaying && moduleStyles.playheadPlaying
           )}
           style={{left: paddingOffset + playHeadOffsetInPixels}}
+          ref={playheadRef}
         >
           &nbsp;
         </div>

--- a/apps/src/music/views/hooks/usePlaybackUpdate.ts
+++ b/apps/src/music/views/hooks/usePlaybackUpdate.ts
@@ -1,0 +1,33 @@
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useEffect, useRef} from 'react';
+
+const UPDATE_RATE = 1000 / 30; // 30 times per second
+
+/**
+ * A hook for performing updates during playback.
+ * @param doUpdate function to run every UPDATE_RATE milliseconds while playback is in progress.
+ * @param onPlay optional function to run when playback starts.
+ * @param onStop optional function to run when playback stops.
+ */
+export default function usePlaybackUpdate(
+  doUpdate: () => void,
+  onPlay?: () => void,
+  onStop?: () => void
+) {
+  const isPlaying = useAppSelector(state => state.music.isPlaying);
+  const intervalId = useRef<number | undefined>();
+
+  useEffect(() => {
+    if (isPlaying) {
+      onPlay?.();
+      if (intervalId.current !== undefined) {
+        window.clearInterval(intervalId.current);
+      }
+      intervalId.current = window.setInterval(doUpdate, UPDATE_RATE);
+    } else {
+      onStop?.();
+      window.clearInterval(intervalId.current);
+      intervalId.current = undefined;
+    }
+  }, [isPlaying, doUpdate, onPlay, onStop]);
+}

--- a/apps/src/music/views/timeline.module.scss
+++ b/apps/src/music/views/timeline.module.scss
@@ -12,6 +12,10 @@
   height: 100%;
   position: relative;
 
+  &Playing {
+    overflow-x: hidden;
+  }
+
   .fullWidthOverlay {
     height: 100%;
     position: absolute;


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#56643. Redo of https://github.com/code-dot-org/code-dot-org/pull/56584. I forgot to use `useCallback` causing an infinite render loop on levels with validation.`useCallback` strikes again 😎 

Tested on:
- /projectbeats
- /music-intro-2024
- /alltehthings
- /projects/music