### PR TITLE
Use block explicitly instead of block-passing a method object

### DIFF
--- a/dashboard/app/helpers/locale_helper.rb
+++ b/dashboard/app/helpers/locale_helper.rb
@@ -49,7 +49,9 @@ module LocaleHelper
 
   # Strips regions off of accepted_locales.
   def accepted_languages
-    @accepted_languages ||= accepted_locales.map(&method(:language)).uniq
+    @accepted_languages ||= accepted_locales.map do |locale|
+      language(locale)
+    end.uniq
   end
 
   # Looks up a localized string driven by a database value.


### PR DESCRIPTION
Test environment threw the following error after I merged [this PR](https://github.com/code-dot-org/code-dot-org/pull/56429):
```
dashboard/app/helpers/locale_helper.rb:52:50: C: Performance/MethodObjectAsBlock: Use block explicitly instead of block-passing a method object.
    @accepted_languages ||= accepted_locales.map(&method(:language)).uniq
```
This PR implements an explicit Block instead of passing a method to a block.
```
rubocop dashboard/app/helpers/locale_helper.rb                                                            git:(fix-rubocop-block-linting-error|…1 
Inspecting 1 file
.

1 file inspected, no offenses detected
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
