### PR TITLE
Add Amplitude events for Congrats and Certificates

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -142,9 +142,11 @@ const EVENTS = {
   VIDEO_PAUSED: 'Video Paused',
   VIDEO_ENDED: 'Video Played To Completion',
 
+  // congrats and certificates
   BATCH_CERTIFICATES_PAGE_VIEWED: 'Batch Certificates Page Viewed',
-  TEACHER_HOC_CONGRATS_PAGE_VISITED:
-    'Teacher Hour of Code Congrats Page Visited ',
+  TEACHER_VISITED_CONGRATS_PAGE: 'Teacher Visited Congrats Page',
+  CERTIFICATE_SHARED: 'Certificate Shared',
+  CERTIFICATE_PRINTED: 'Certificate Printed',
 
   // Coteacher
   COTEACHER_INVITE_SENT: 'Coteacher Invite Sent',

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -146,7 +146,7 @@ const EVENTS = {
   BATCH_CERTIFICATES_PAGE_VIEWED: 'Batch Certificates Page Viewed',
   TEACHER_VISITED_CONGRATS_PAGE: 'Teacher Visited Congrats Page',
   CERTIFICATE_SHARED: 'Certificate Shared',
-  CERTIFICATE_PRINTED: 'Certificate Printed',
+  CERTIFICATE_PRINT_PAGE_VISITED: 'Certificate Print Page Visited',
 
   // Coteacher
   COTEACHER_INVITE_SENT: 'Coteacher Invite Sent',

--- a/apps/src/sites/studio/pages/congrats/index.js
+++ b/apps/src/sites/studio/pages/congrats/index.js
@@ -43,7 +43,7 @@ $(document).ready(function () {
   const mcShareLink = tryGetLocalStorage('craftHeroShareLink', '');
 
   userType === 'teacher' &&
-    analyticsReporter.sendEvent(EVENTS.TEACHER_HOC_CONGRATS_PAGE_VISITED, {
+    analyticsReporter.sendEvent(EVENTS.TEACHER_VISITED_CONGRATS_PAGE, {
       isHocTutorial,
       isPlCourse,
       isK5PlCourse,

--- a/apps/src/sites/studio/pages/congrats/index.js
+++ b/apps/src/sites/studio/pages/congrats/index.js
@@ -43,7 +43,11 @@ $(document).ready(function () {
   const mcShareLink = tryGetLocalStorage('craftHeroShareLink', '');
 
   userType === 'teacher' &&
-    analyticsReporter.sendEvent(EVENTS.TEACHER_HOC_CONGRATS_PAGE_VISITED);
+    analyticsReporter.sendEvent(EVENTS.TEACHER_HOC_CONGRATS_PAGE_VISITED, {
+      isHocTutorial,
+      isPlCourse,
+      isK5PlCourse,
+    });
 
   ReactDOM.render(
     <Provider store={store}>

--- a/apps/src/sites/studio/pages/print_certificates/show.js
+++ b/apps/src/sites/studio/pages/print_certificates/show.js
@@ -1,0 +1,6 @@
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+
+$(() => {
+  analyticsReporter.sendEvent(EVENTS.CERTIFICATE_PRINT_PAGE_VISITED);
+});

--- a/apps/src/templates/certificates/SocialShare.jsx
+++ b/apps/src/templates/certificates/SocialShare.jsx
@@ -42,11 +42,6 @@ export default function SocialShare({
     window.dashboard?.popupWindow(e);
   };
 
-  const onPrint = () => {
-    analyticsReporter.sendEvent(EVENTS.CERTIFICATE_PRINTED);
-    return true;
-  };
-
   const facebookShareUrl = `https://www.facebook.com/sharer/sharer.php?${facebook}`;
   const twitterShareUrl = `https://twitter.com/share?${twitter}`;
   const linkedShareUrl = `https://www.linkedin.com/sharing/share-offsite/?${linkedin}`;
@@ -103,7 +98,7 @@ export default function SocialShare({
           </button>
         </a>
       )}
-      <a href={print} className="social-print-link" onClick={onPrint}>
+      <a href={print} className="social-print-link">
         <button type="button" style={styles.printButton}>
           <i className="fa fa-print" />
           {' ' + i18n.print()}

--- a/apps/src/templates/certificates/SocialShare.jsx
+++ b/apps/src/templates/certificates/SocialShare.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import testImageAccess from '@cdo/apps/code-studio/url_test';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 export default function SocialShare({
   facebook,
@@ -35,11 +37,19 @@ export default function SocialShare({
     );
   }, []);
 
+  const onShare = (e, platform) => {
+    analyticsReporter.sendEvent(EVENTS.CERTIFICATE_SHARED, {platform});
+    window.dashboard?.popupWindow(e);
+  };
+
+  const onPrint = () => {
+    analyticsReporter.sendEvent(EVENTS.CERTIFICATE_PRINTED);
+    return true;
+  };
+
   const facebookShareUrl = `https://www.facebook.com/sharer/sharer.php?${facebook}`;
   const twitterShareUrl = `https://twitter.com/share?${twitter}`;
   const linkedShareUrl = `https://www.linkedin.com/sharing/share-offsite/?${linkedin}`;
-
-  const dashboard = window.dashboard;
 
   return (
     <div>
@@ -49,7 +59,7 @@ export default function SocialShare({
           href={linkedShareUrl}
           target="_blank"
           rel="noopener noreferrer"
-          onClick={dashboard?.popupWindow}
+          onClick={e => onShare(e, 'linkedin')}
         >
           <button
             type="button"
@@ -66,7 +76,7 @@ export default function SocialShare({
           href={facebookShareUrl}
           target="_blank"
           rel="noopener noreferrer"
-          onClick={dashboard?.popupWindow}
+          onClick={e => onShare(e, 'facebook')}
         >
           <button
             type="button"
@@ -82,7 +92,7 @@ export default function SocialShare({
           href={twitterShareUrl}
           target="_blank"
           rel="noopener noreferrer"
-          onClick={dashboard?.popupWindow}
+          onClick={e => onShare(e, 'twitter')}
         >
           <button
             type="button"
@@ -93,7 +103,7 @@ export default function SocialShare({
           </button>
         </a>
       )}
-      <a href={print} className="social-print-link">
+      <a href={print} className="social-print-link" onClick={onPrint}>
         <button type="button" style={styles.printButton}>
           <i className="fa fa-print" />
           {' ' + i18n.print()}

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -44,6 +44,7 @@ const CODE_STUDIO_ENTRIES = {
   'musiclab/gallery': './src/sites/studio/pages/musiclab/gallery.js',
   'policy_compliance/child_account_consent': './src/sites/studio/pages/policy_compliance/child_account_consent.js',
   'print_certificates/batch': './src/sites/studio/pages/print_certificates/batch.js',
+  'print_certificates/show': './src/sites/studio/pages/print_certificates/show.js',
   'programming_classes/show': './src/sites/studio/pages/programming_classes/show.js',
   'programming_environments/index': './src/sites/studio/pages/programming_environments/index.js',
   'programming_environments/show': './src/sites/studio/pages/programming_environments/show.js',

--- a/dashboard/app/views/print_certificates/show.html.haml
+++ b/dashboard/app/views/print_certificates/show.html.haml
@@ -1,2 +1,4 @@
 - alt_text = @student_name ? "Certificate for #{@student_name}" : 'Certificate for Completion of One Hour of Code'
 %img{src: @certificate_image_url, alt: alt_text, width:"100%", style: "margin-top: 25px"}
+
+%script{src: webpack_asset_path('js/print_certificates/show.js')}


### PR DESCRIPTION
Adds Amplitude events for the congrats page. Details are in [the ticket](https://codedotorg.atlassian.net/browse/ACQ-1495), but I did decide to remove the event `TEACHER_HOC_CONGRATS_PAGE_VISITED`, which fired even when the curriculum wasn't HoC, and replace it with a more generic event `TEACHER_VISITED_CONGRATS_PAGE`, which fires whenever a teacher views the congrats page, with info about what the page is for. 

Example events:
```
[AMPLITUDE ANALYTICS EVENT]: Teacher Hour of Code Congrats Page Visited . Payload: {"payload":{"isHocTutorial":false,"isPlCourse":true,"isK5PlCourse":false}}
[AMPLITUDE ANALYTICS EVENT]: Certificate Shared. Payload: {"payload":{"platform":"twitter"}}
[AMPLITUDE ANALYTICS EVENT]: Certificate Printed. Payload: {}
```

