### PR TITLE
Fix "uninitialized constant CdoLanguages" on the test env

### DIFF
--- a/bin/test/i18n/utils/test_sync_down_base.rb
+++ b/bin/test/i18n/utils/test_sync_down_base.rb
@@ -277,7 +277,7 @@ describe I18n::Utils::SyncDownBase do
 
       crowdin_client.expects(:get_project).returns('targetLanguages' => [{'id' => available_crowdin_lang_id}])
 
-      _(cdo_languages.first).must_be_instance_of CdoLanguages
+      _(cdo_languages.first&.class&.name).must_equal 'CdoLanguages'
       _(cdo_languages.map {|lang| lang[:crowdin_code_s]}).must_equal [available_crowdin_lang_id]
     end
   end


### PR DESCRIPTION
### Error
```
I18n::Utils::SyncDownBase::#cdo_languages
  test_0001_returns CDO languages supported by the Crowdin projectERROR (0.00s)
Minitest::UnexpectedError:         NameError: uninitialized constant CdoLanguages
            /home/ubuntu/test/bin/test/i18n/utils/test_sync_down_base.rb:280:in `block (3 levels) in <top (required)>'
```