### PR TITLE
[Blockly] Use handleColorAndStyle for all non-migrated labs

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import {styleTypes} from './blockly/themes/cdoBlockStyles.mjs';
 import xml from './xml';
 import MetricsReporter from './lib/metrics/MetricsReporter';
-import {EMPTY_OPTION} from './blockly/constants';
+import {BlockColors, BlockStyles, EMPTY_OPTION} from './blockly/constants';
 
 const ATTRIBUTES_TO_CLEAN = ['uservisible', 'deletable', 'movable'];
 
@@ -166,7 +166,11 @@ exports.generateSimpleBlock = function (blockly, generator, options) {
     helpUrl: helpUrl,
     init: function () {
       // Note: has a fixed HSV.  Could make this customizable if need be
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       var input = this.appendEndRowInput();
       if (title) {
         input.appendField(title);

--- a/apps/src/blockly/addons/unknownBlock.js
+++ b/apps/src/blockly/addons/unknownBlock.js
@@ -1,8 +1,10 @@
+import {BlockColors} from '../constants';
+
 export const UNKNOWN_BLOCK = {
   unknownBlock: true,
   init: function () {
     // Unknown blocks use a hard-coded HSV color and are not compatible with themes.
-    Blockly.cdoUtils.handleColorAndStyle(this, [0, 0, 0.8]);
+    Blockly.cdoUtils.handleColorAndStyle(this, BlockColors.UNKNOWN);
     this.appendDummyInput().appendField('unknown block', 'NAME');
     this.setPreviousStatement(true);
     this.setNextStatement(true);

--- a/apps/src/blockly/addons/unknownBlock.js
+++ b/apps/src/blockly/addons/unknownBlock.js
@@ -1,7 +1,8 @@
 export const UNKNOWN_BLOCK = {
   unknownBlock: true,
   init: function () {
-    Blockly.cdoUtils.setHSV(this, 0, 0, 0.8);
+    // Unknown blocks use a hard-coded HSV color and are not compatible with themes.
+    Blockly.cdoUtils.handleColorAndStyle(this, [0, 0, 0.8]);
     this.appendDummyInput().appendField('unknown block', 'NAME');
     this.setPreviousStatement(true);
     this.setNextStatement(true);

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -27,6 +27,34 @@ export const Themes = {
   TRITANOPIA_DARK: 'cdotritanopiadark',
 };
 
+export enum BlockStyles {
+  DEFAULT = 'default',
+  SETUP = 'setup_blocks',
+  EVENT = 'event_blocks',
+  LOOP = 'loop_blocks',
+  LOGIC = 'logic_blocks',
+  PROCEDURE = 'procedure_blocks',
+  VARIABLE = 'variable_blocks',
+  MATH = 'math_blocks',
+  TEXT = 'text_blocks',
+  COLOR = 'colour_blocks',
+  BEHAVIOR = 'behavior_blocks',
+}
+
+export const BlockColors = {
+  DEFAULT: [184, 1.0, 0.74],
+  SETUP: [39, 1.0, 0.99],
+  EVENT: [140, 1.0, 0.74],
+  LOOP: [322, 0.9, 0.95],
+  LOGIC: [196, 1.0, 0.79],
+  PROCEDURE: [94, 0.84, 0.6],
+  VARIABLE: [312, 0.32, 0.62],
+  MATH: [258, 0.35, 0.62],
+  TEXT: [160, 0.45, 0.65],
+  COLOR: [10, 0.45, 0.65],
+  BEHAVIOR: [136, 0.84, 0.8],
+};
+
 export const Renderers = {
   GERAS: 'cdo_renderer_geras',
   THRASOS: 'cdo_renderer_thrasos',

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -53,6 +53,9 @@ export const BlockColors = {
   TEXT: [160, 0.45, 0.65],
   COLOR: [10, 0.45, 0.65],
   BEHAVIOR: [136, 0.84, 0.8],
+  // The colors below do not have a corresponding style and are incompatible with themes.
+  COMMENT: [0, 0, 0.6],
+  UNKNOWN: [0, 0, 0.8],
 };
 
 export const Renderers = {

--- a/apps/src/blockly/customBlocks/cdoBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/cdoBlockly/spritelabBlocks.js
@@ -1,6 +1,11 @@
 // This file contains customizations to CDO Blockly Sprite Lab blocks.
 import i18n from '@cdo/locale';
-import {BLOCK_TYPES, NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
+import {
+  BlockColors,
+  BlockStyles,
+  BLOCK_TYPES,
+  NO_OPTIONS_MESSAGE,
+} from '@cdo/apps/blockly/constants';
 
 export const blocks = {
   // Called by block_utils when creating Sprite Lab blocks with mini-toolboxes.
@@ -109,7 +114,11 @@ export const blocks = {
         // Must be marked EDITABLE so that cloned blocks share the same var name
         fieldLabel.EDITABLE = true;
         this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
-        Blockly.cdoUtils.setHSV(this, 136, 0.84, 0.8);
+        Blockly.cdoUtils.handleColorAndStyle(
+          this,
+          BlockColors.BEHAVIOR,
+          BlockStyles.BEHAVIOR
+        );
         const mainTitle = this.appendDummyInput()
           .appendField(fieldLabel, 'VAR')
           .appendField(Blockly.Msg.VARIABLES_GET_TAIL);

--- a/apps/src/blocksCommon.js
+++ b/apps/src/blocksCommon.js
@@ -2,6 +2,8 @@
  * Defines blocks useful in multiple blockly apps
  */
 var commonMsg = require('@cdo/locale');
+var BlockStyles = require('./blockly/constants').BlockStyles;
+var BlockColors = require('./blockly/constants').BlockColors;
 
 /**
  * Install extensions to Blockly's language and JavaScript generator
@@ -38,8 +40,11 @@ function installControlsRepeatSimplified(blockly, skin) {
     // Repeat n times (internal number) with simplified UI
     init: function () {
       this.setHelpUrl(blockly.Msg.CONTROLS_REPEAT_HELPURL);
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
-      this.setStyle('loop_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput()
         .appendField(
           blockly.Msg.CONTROLS_REPEAT_TITLE_REPEAT || commonMsg.repeat()
@@ -64,8 +69,11 @@ function installControlsRepeatSimplified(blockly, skin) {
     // Repeat n times (internal number) with simplified UI
     init: function () {
       this.setHelpUrl(blockly.Msg.CONTROLS_REPEAT_HELPURL);
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
-      this.setStyle('loop_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput()
         .appendField(
           blockly.Msg.CONTROLS_REPEAT_TITLE_REPEAT || commonMsg.repeat()
@@ -92,8 +100,11 @@ function installControlsRepeatDropdown(blockly) {
     // Repeat n times (internal number) with a customizable dropdown of # choices.
     init: function () {
       this.setHelpUrl(blockly.Msg.CONTROLS_REPEAT_HELPURL);
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
-      this.setStyle('loop_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput()
         .appendField(
           blockly.Msg.CONTROLS_REPEAT_TITLE_REPEAT || commonMsg.repeat()
@@ -123,8 +134,11 @@ function installNumberDropdown(blockly) {
     // Numeric value with a customizable dropdown.
     init: function () {
       this.setHelpUrl(blockly.Msg.MATH_NUMBER_HELPURL);
-      Blockly.cdoUtils.setHSV(this, 258, 0.35, 0.62);
-      this.setStyle('math_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.MATH,
+        BlockStyles.MATH
+      );
       this.appendDummyInput().appendField(new blockly.FieldDropdown(), 'NUM');
       this.setOutput(true, Blockly.BlockValueType.NUMBER);
       this.setTooltip(blockly.Msg.MATH_NUMBER_TOOLTIP);
@@ -138,7 +152,11 @@ function installPickOne(blockly) {
   blockly.Blocks.pick_one = {
     // Repeat n times (internal number).
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
 
       // Not localized as this is only used by level builders
       this.appendDummyInput().appendField(
@@ -161,7 +179,11 @@ function installCategory(blockly) {
   blockly.Blocks.category = {
     // Repeat n times (internal number).
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.setInputsInline(true);
 
       // Not localized as this is only used by level builders
@@ -183,7 +205,11 @@ function installCategory(blockly) {
   blockly.Blocks.custom_category = {
     // Repeat n times (internal number).
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.setInputsInline(true);
 
       var customDropdown = new blockly.FieldDropdown([
@@ -215,8 +241,11 @@ function installWhenRun(blockly, skin, isK1) {
     // Block to handle event where mouse is clicked
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 39, 1.0, 0.99);
-      this.setStyle('setup_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.SETUP,
+        BlockStyles.SETUP
+      );
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.whenRun())
@@ -250,7 +279,8 @@ function installJoinBlock(blockly) {
 function installCommentBlock(blockly) {
   blockly.Blocks.comment = {
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 0, 0, 0.6);
+      // Comment blocks use a hard-coded HSV color and are not compatible with themes.
+      Blockly.cdoUtils.handleColorAndStyle(this, [0, 0, 0.6]);
       this.appendDummyInput()
         .appendField(commonMsg.commentPrefix())
         .appendField(new Blockly.FieldTextInput(''), 'TEXT');

--- a/apps/src/blocksCommon.js
+++ b/apps/src/blocksCommon.js
@@ -280,7 +280,7 @@ function installCommentBlock(blockly) {
   blockly.Blocks.comment = {
     init: function () {
       // Comment blocks use a hard-coded HSV color and are not compatible with themes.
-      Blockly.cdoUtils.handleColorAndStyle(this, [0, 0, 0.6]);
+      Blockly.cdoUtils.handleColorAndStyle(this, BlockColors.COMMENT);
       this.appendDummyInput()
         .appendField(commonMsg.commentPrefix())
         .appendField(new Blockly.FieldTextInput(''), 'TEXT');

--- a/apps/src/craft/agent/blocks.js
+++ b/apps/src/craft/agent/blocks.js
@@ -1,5 +1,6 @@
 var i18n = require('../locale');
 import {blockTypesToDropdownOptions} from '../utils';
+import {BlockColors, BlockStyles} from '@cdo/apps/blockly/constants';
 
 var allBlocks = [
   'bedrock',
@@ -68,8 +69,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.craft_moveForward = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockMoveForward())
       );
@@ -85,8 +89,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.craft_moveBackward = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockMoveBackward())
       );
@@ -103,8 +110,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for turning left or right.
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
@@ -129,8 +139,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.craft_destroyBlock = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockDestroyBlock())
       );
@@ -151,8 +164,11 @@ exports.install = function (blockly, blockInstallOptions) {
       );
       var dropdown = new blockly.FieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
-      this.setStyle('logic_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        'logic_blocks'
+      );
       this.appendDummyInput()
         .appendField(i18n.blockIf())
         .appendField(dropdown, 'TYPE')
@@ -180,8 +196,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.craft_ifLavaAhead = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
-      this.setStyle('logic_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        'logic_blocks'
+      );
       this.appendDummyInput().appendField(i18n.blockIfLavaAhead());
       this.appendStatementInput('DO').appendField(i18n.blockWhileXAheadDo());
       this.setPreviousStatement(true);
@@ -209,8 +228,11 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdown = new blockly.FieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
 
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput()
         .appendField(i18n.blockPlaceXPlace())
         .appendField(dropdown, 'TYPE');
@@ -240,8 +262,11 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdown = new blockly.FieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
 
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput()
         .appendField(i18n.blockPlaceXPlace())
         .appendField(dropdown, 'TYPE')

--- a/apps/src/craft/designer/blocks.js
+++ b/apps/src/craft/designer/blocks.js
@@ -4,6 +4,7 @@ import {stripQuotes} from '../../utils';
 import _ from 'lodash';
 import {EventType} from '@code-dot-org/craft';
 import {BLOCK_NAME_TO_DISPLAY_TEXT} from '../utils';
+import {BlockColors, BlockStyles} from '@cdo/apps/blockly/constants';
 
 const ENTITY_INPUT_EXTRA_SPACING = 14;
 
@@ -176,8 +177,11 @@ export const install = (blockly, blockInstallOptions) => {
     // Block for turning left or right.
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
@@ -207,8 +211,11 @@ export const install = (blockly, blockInstallOptions) => {
     // Block for turning left or right.
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(
           blockly.Blocks.craft_entityTurn.ENTITY_DIRECTIONS
@@ -241,8 +248,11 @@ export const install = (blockly, blockInstallOptions) => {
     // Block for turning left or right.
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(
           blockly.Blocks.craft_entityTurnLR.ENTITY_DIRECTIONS
@@ -424,8 +434,11 @@ export const install = (blockly, blockInstallOptions) => {
     blockly.Blocks[`craft_${functionName}`] = {
       helpUrl: '',
       init: function () {
-        Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
-        this.setStyle('event_blocks');
+        Blockly.cdoUtils.handleColorAndStyle(
+          this,
+          BlockColors.EVENT,
+          BlockStyles.EVENT
+        );
         this.appendDummyInput().appendField(text);
         this.appendStatementInput('DO');
         this.setPreviousStatement(false);
@@ -469,9 +482,11 @@ export const install = (blockly, blockInstallOptions) => {
         if (doSort) {
           dropdownOptions = _.sortBy(dropdownOptions, 0);
         }
-
-        Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-        this.setStyle('default');
+        Blockly.cdoUtils.handleColorAndStyle(
+          this,
+          BlockColors.DEFAULT,
+          BlockStyles.DEFAULT
+        );
         this.appendDummyInput()
           .appendField(new blockly.FieldLabel(blockText))
           .appendField(dropdown, 'TYPE');
@@ -490,8 +505,11 @@ export const install = (blockly, blockInstallOptions) => {
     blockly.Blocks[`craft_${simpleFunctionName}`] = {
       helpUrl: '',
       init: function () {
-        Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-        this.setStyle('default');
+        Blockly.cdoUtils.handleColorAndStyle(
+          this,
+          BlockColors.DEFAULT,
+          BlockStyles.DEFAULT
+        );
         this.appendDummyInput().appendField(new blockly.FieldLabel(blockText));
         this.setPreviousStatement(true);
         this.setNextStatement(true);
@@ -516,8 +534,11 @@ export const install = (blockly, blockInstallOptions) => {
         const dropdown = new blockly.FieldDropdown(dropdownOptions);
         dropdown.setValue(dropdownOptions[0][1]);
 
-        Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-        this.setStyle('default');
+        Blockly.cdoUtils.handleColorAndStyle(
+          this,
+          BlockColors.DEFAULT,
+          BlockStyles.DEFAULT
+        );
         this.appendDummyInput()
           .appendField(new blockly.FieldLabel(blockText))
           .appendField(dropdown, 'TYPE');
@@ -572,8 +593,11 @@ export const install = (blockly, blockInstallOptions) => {
   blockly.Blocks.craft_forever = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
-      this.setStyle('loop_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput().appendField(i18n.forever());
       this.appendStatementInput('DO').appendField(i18n.blockWhileXAheadDo());
       this.setPreviousStatement(true);
@@ -588,8 +612,11 @@ export const install = (blockly, blockInstallOptions) => {
   blockly.Blocks.craft_repeatTimes = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
-      this.setStyle('loop_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput()
         .appendField(i18n.blockActionRepeat())
         .appendField(
@@ -614,8 +641,11 @@ export const install = (blockly, blockInstallOptions) => {
   blockly.Blocks.craft_repeatRandom = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
-      this.setStyle('loop_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput().appendField(i18n.blockActionRepeatRandom());
       this.appendStatementInput('DO').appendField(i18n.blockWhileXAheadDo());
       this.setPreviousStatement(true);
@@ -638,8 +668,11 @@ export const install = (blockly, blockInstallOptions) => {
       const dropdown = new blockly.FieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
 
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
-      this.setStyle('loop_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput()
         .appendField(i18n.blockActionRepeat())
         .appendField(dropdown, 'TIMES');
@@ -675,8 +708,11 @@ export const install = (blockly, blockInstallOptions) => {
       const locationDropdown = new blockly.FieldDropdown(locationOptions);
       locationDropdown.setValue(locationOptions[0][1]);
 
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockActionSpawn()))
         .appendField(entityTypeDropdown, 'TYPE')
@@ -704,8 +740,11 @@ export const install = (blockly, blockInstallOptions) => {
       );
       entityTypeDropdown.setValue(entityTypeDropdownOptions[0][1]);
 
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel('spawn'))
         .appendField(entityTypeDropdown, 'TYPE');
@@ -722,8 +761,11 @@ export const install = (blockly, blockInstallOptions) => {
   blockly.Blocks.craft_moveEntityNorth = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(new blockly.FieldLabel('move north'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -737,8 +779,11 @@ export const install = (blockly, blockInstallOptions) => {
   blockly.Blocks.craft_moveEntitySouth = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(new blockly.FieldLabel('move south'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -752,8 +797,11 @@ export const install = (blockly, blockInstallOptions) => {
   blockly.Blocks.craft_moveEntityEast = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(new blockly.FieldLabel('move east'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -767,8 +815,11 @@ export const install = (blockly, blockInstallOptions) => {
   blockly.Blocks.craft_moveEntityWest = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(new blockly.FieldLabel('move west'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -799,8 +850,11 @@ export const install = (blockly, blockInstallOptions) => {
       );
       dropdown.setValue(dropdownOptions[0][1]);
 
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput()
         .appendField(i18n.blockActionPlaySound())
         .appendField(dropdown, 'TYPE');
@@ -823,8 +877,11 @@ export const install = (blockly, blockInstallOptions) => {
       const dropdown = new blockly.FieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
 
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput()
         .appendField(i18n.blockActionAdd())
         .appendField(dropdown, 'SCORE')

--- a/apps/src/craft/simple/blocks.js
+++ b/apps/src/craft/simple/blocks.js
@@ -1,5 +1,6 @@
 var i18n = require('../locale');
 import {blockTypesToDropdownOptions} from '../utils';
+import {BlockColors, BlockStyles} from '@cdo/apps/blockly/constants';
 
 var allBlocks = [
   'bedrock',
@@ -67,8 +68,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.craft_moveForward = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockMoveForward())
       );
@@ -85,8 +89,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for turning left or right.
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
@@ -111,8 +118,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.craft_destroyBlock = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockDestroyBlock())
       );
@@ -128,8 +138,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.craft_shear = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockShear())
       );
@@ -150,8 +163,11 @@ exports.install = function (blockly, blockInstallOptions) {
       );
       var dropdown = new blockly.FieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
-      this.setStyle('logic_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput()
         .appendField(i18n.blockIf())
         .appendField(dropdown, 'TYPE')
@@ -179,8 +195,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.craft_ifLavaAhead = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
-      this.setStyle('logic_blocks');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(i18n.blockIfLavaAhead());
       this.appendStatementInput('DO').appendField(i18n.blockWhileXAheadDo());
       this.setPreviousStatement(true);
@@ -208,8 +227,11 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdown = new blockly.FieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
 
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput()
         .appendField(i18n.blockPlaceXPlace())
         .appendField(dropdown, 'TYPE');
@@ -226,8 +248,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.craft_placeTorch = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(i18n.blockPlaceTorch());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -241,8 +266,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.craft_plantCrop = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(i18n.blockPlantCrop());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -256,8 +284,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.craft_tillSoil = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(i18n.blockTillSoil());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -277,8 +308,11 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdown = new blockly.FieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
 
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
-      this.setStyle('default');
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput()
         .appendField(i18n.blockPlaceXAheadPlace())
         .appendField(dropdown, 'TYPE')

--- a/apps/src/dance/blockly/blocks.js
+++ b/apps/src/dance/blockly/blocks.js
@@ -205,7 +205,7 @@ export default {
         // Must be marked EDITABLE so that cloned blocks share the same var name
         fieldLabel.EDITABLE = true;
         this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
-        Blockly.cdoUtils.setHSV(this, 631, 0.84, 0.8);
+        Blockly.cdoUtils.handleColorAndStyle(this, [631, 0.84, 0.8]);
         const mainTitle = this.appendDummyInput()
           .appendField(fieldLabel, 'VAR')
           .appendField(Blockly.Msg.VARIABLES_GET_TAIL);

--- a/apps/src/dance/blockly/blocks.js
+++ b/apps/src/dance/blockly/blocks.js
@@ -1,5 +1,6 @@
 import i18n from '@cdo/locale';
 import CdoFieldDanceAi from '../ai/cdoFieldDanceAi';
+import {BlockColors, BlockStyles} from '@cdo/apps/blockly/constants';
 
 // This color palette is limited to colors which have different hues, therefore
 // it should not contain different shades of the same color such as
@@ -205,7 +206,11 @@ export default {
         // Must be marked EDITABLE so that cloned blocks share the same var name
         fieldLabel.EDITABLE = true;
         this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
-        Blockly.cdoUtils.handleColorAndStyle(this, [631, 0.84, 0.8]);
+        Blockly.cdoUtils.handleColorAndStyle(
+          this,
+          BlockColors.BEHAVIOR,
+          BlockStyles.BEHAVIOR
+        );
         const mainTitle = this.appendDummyInput()
           .appendField(fieldLabel, 'VAR')
           .appendField(Blockly.Msg.VARIABLES_GET_TAIL);

--- a/apps/src/jigsaw/blocks.js
+++ b/apps/src/jigsaw/blocks.js
@@ -244,7 +244,7 @@ function generateJigsawBlocksForLevel(blockly, skin, options) {
       helpUrl: '',
       init: function () {
         // Jigsaw blocks use a hard-coded HSV color and are not compatible with themes.
-        Blockly.cdoUtils.handleColorAndStyle(this, hsv);
+        Blockly.cdoUtils.handleColorAndStyle(this, HSV);
         this.appendDummyInput().appendField(
           new blockly.FieldImage(skin.blank, titleWidth, titleHeight)
         );

--- a/apps/src/jigsaw/blocks.js
+++ b/apps/src/jigsaw/blocks.js
@@ -205,7 +205,8 @@ function generateBlankBlock(blockly, skin, name, hsv, width, label) {
   blockly.Blocks[name] = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, ...hsv);
+      // Jigsaw blocks use a hard-coded HSV color and are not compatible with themes.
+      Blockly.cdoUtils.handleColorAndStyle(this, hsv);
       this.appendDummyInput()
         .appendField(new blockly.FieldImage(skin.blank, width, 54))
         .appendField(
@@ -242,7 +243,8 @@ function generateJigsawBlocksForLevel(blockly, skin, options) {
     blockly.Blocks[blockName] = {
       helpUrl: '',
       init: function () {
-        Blockly.cdoUtils.setHSV(this, ...HSV);
+        // Jigsaw blocks use a hard-coded HSV color and are not compatible with themes.
+        Blockly.cdoUtils.handleColorAndStyle(this, hsv);
         this.appendDummyInput().appendField(
           new blockly.FieldImage(skin.blank, titleWidth, titleHeight)
         );

--- a/apps/src/maze/beeBlocks.js
+++ b/apps/src/maze/beeBlocks.js
@@ -4,6 +4,8 @@
 
 var msg = require('./locale');
 var blockUtils = require('../block_utils');
+var BlockStyles = require('../blockly/constants').BlockStyles;
+var BlockColors = require('../blockly/constants').BlockColors;
 
 var OPERATORS = [
   ['=', '=='],
@@ -134,7 +136,11 @@ function addIfOnlyFlower(blockly, generator) {
   blockly.Blocks.bee_ifOnlyFlower = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(msg.atFlower());
       this.setInputsInline(true);
@@ -168,7 +174,11 @@ function addIfFlowerHive(blockly, generator) {
         [msg.atHoneycomb(), 'atHoneycomb'],
       ];
 
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(LOCATIONS),
@@ -207,7 +217,11 @@ function addIfElseFlowerHive(blockly, generator) {
         [msg.atHoneycomb(), 'atHoneycomb'],
       ];
 
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(LOCATIONS),
@@ -248,7 +262,11 @@ function addRepeatedActionBlock(
   blockly.Blocks[name] = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.interpolateMsg(
         blockMsg,
         ['NUM', 'Number', Blockly.ALIGN_RIGHT],
@@ -283,15 +301,27 @@ function addConditionalComparisonBlock(blockly, generator, name, type, arg1) {
       switch (type) {
         case 'if':
           conditionalMsg = msg.ifCode();
-          Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+          Blockly.cdoUtils.handleColorAndStyle(
+            this,
+            BlockColors.LOGIC,
+            BlockStyles.LOGIC
+          );
           break;
         case 'ifelse':
           conditionalMsg = msg.ifCode();
-          Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+          Blockly.cdoUtils.handleColorAndStyle(
+            this,
+            BlockColors.LOGIC,
+            BlockStyles.LOGIC
+          );
           break;
         case 'while':
           conditionalMsg = msg.whileMsg();
-          Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+          Blockly.cdoUtils.handleColorAndStyle(
+            this,
+            BlockColors.LOOP,
+            BlockStyles.LOOP
+          );
           break;
         default:
           throw 'Unexpected type for addConditionalComparisonBlock';

--- a/apps/src/maze/blocks.js
+++ b/apps/src/maze/blocks.js
@@ -25,6 +25,8 @@ var commonMsg = require('@cdo/locale');
 var mazeUtils = require('@code-dot-org/maze').utils;
 
 var blockUtils = require('../block_utils');
+var BlockStyles = require('../blockly/constants').BlockStyles;
+var BlockColors = require('../blockly/constants').BlockColors;
 
 var msg = require('./locale');
 
@@ -84,7 +86,11 @@ exports.install = function (blockly, blockInstallOptions) {
       return {
         helpUrl: '',
         init: function () {
-          Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+          Blockly.cdoUtils.handleColorAndStyle(
+            this,
+            BlockColors.DEFAULT,
+            BlockStyles.DEFAULT
+          );
           this.appendDummyInput()
             .appendField(
               new blockly.FieldLabel(directionConfig.letter, {
@@ -138,7 +144,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for moving forward/backward
     helpUrl: 'http://code.google.com/p/blockly/wiki/Move',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
@@ -164,7 +174,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for turning left or right.
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
@@ -190,7 +204,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for checking if there a path.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.setOutput(true, blockly.BlockValueType.NUMBER);
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
@@ -216,7 +234,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for 'if' conditional if there is a path.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
@@ -244,7 +266,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for 'if/else' conditional if there is a path.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
@@ -275,7 +301,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for 'if' conditional if there is a path.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
@@ -309,7 +339,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for 'if/else' conditional if there is a path.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
@@ -340,7 +374,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.maze_whileNotClear = {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Repeat',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
@@ -368,7 +406,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.maze_untilBlocked = {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Repeat',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput().appendField(msg.repeatUntilBlocked());
       this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
@@ -388,7 +430,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Do forever loop.
     helpUrl: 'http://code.google.com/p/blockly/wiki/Repeat',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput()
         .appendField(msg.repeatUntil())
         .appendField(new blockly.FieldImage(skin.maze_forever, 35, 35));
@@ -411,7 +457,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.maze_untilBlockedOrNotClear = {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Repeat',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'

--- a/apps/src/maze/collectorBlocks.js
+++ b/apps/src/maze/collectorBlocks.js
@@ -1,5 +1,7 @@
 var msg = require('./locale');
 var blockUtils = require('../block_utils');
+var BlockStyles = require('../blockly/constants').BlockStyles;
+var BlockColors = require('../blockly/constants').BlockColors;
 
 exports.install = function (blockly, blockInstallOptions) {
   var skin = blockInstallOptions.skin;
@@ -34,7 +36,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.collector_ifCollectible = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(
         msg.ifCode() + ' ' + msg.collectiblePresent()
       );
@@ -57,7 +63,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.collector_whileCollectible = {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Repeat',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput().appendField(
         msg.whileMsg() + ' ' + msg.collectiblePresent()
       );

--- a/apps/src/maze/harvesterBlocks.js
+++ b/apps/src/maze/harvesterBlocks.js
@@ -4,6 +4,8 @@
 
 var msg = require('./locale');
 var blockUtils = require('../block_utils');
+var BlockStyles = require('../blockly/constants').BlockStyles;
+var BlockColors = require('../blockly/constants').BlockColors;
 
 const CROPS = ['corn', 'pumpkin', 'lettuce'];
 
@@ -15,7 +17,11 @@ function addIfAtSpecificCropBlock(blockly, generator, crop) {
   blockly.Blocks[`harvester_ifAt${capitalizeFirstLetter(crop)}`] = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(
         [msg.ifCode(), msg.at(), msg[crop]()].join(' ')
       );
@@ -40,7 +46,11 @@ function addIfAtSpecificCropElseBlock(blockly, generator, crop) {
   blockly.Blocks[`harvester_ifAt${capitalizeFirstLetter(crop)}Else`] = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(
         [msg.ifCode(), msg.at(), msg[crop]()].join(' ')
       );
@@ -67,7 +77,11 @@ function addUntilAtSpecificCropBlock(blockly, generator, crop) {
   blockly.Blocks[`harvester_untilAt${capitalizeFirstLetter(crop)}`] = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput().appendField(
         [msg.repeatUntil(), msg.at(), msg[crop]()].join(' ')
       );
@@ -91,7 +105,11 @@ function addIfSpecificCropHasBlock(blockly, generator, crop) {
   blockly.Blocks[`harvester_ifHas${capitalizeFirstLetter(crop)}`] = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(
         [msg.ifCode(), msg[`has${crop}`]()].join(' ')
       );
@@ -116,7 +134,11 @@ function addIfSpecificCropHasElseBlock(blockly, generator, crop) {
   blockly.Blocks[`harvester_ifHas${capitalizeFirstLetter(crop)}Else`] = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(
         [msg.ifCode(), msg[`has${crop}`]()].join(' ')
       );
@@ -143,7 +165,11 @@ function addWhileSpecificCropHasBlock(blockly, generator, crop) {
   blockly.Blocks[`harvester_whileHas${capitalizeFirstLetter(crop)}`] = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput().appendField(
         [msg.whileMsg(), msg[`has${crop}`]()].join(' ')
       );
@@ -169,7 +195,11 @@ function addUntilSpecificCropHasBlock(blockly, generator, crop) {
   blockly.Blocks[`harvester_untilHas${capitalizeFirstLetter(crop)}`] = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput().appendField(
         [msg.repeatUntil(), msg[`has${crop}`]()].join(' ')
       );
@@ -231,7 +261,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.harvester_ifAtCrop = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField([msg.ifCode(), msg.at()].join(' '));
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(AT_OPTIONS),
@@ -254,7 +288,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.harvester_ifAtCropElse = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField([msg.ifCode(), msg.at()].join(' '));
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(AT_OPTIONS),
@@ -279,7 +317,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.harvester_untilAtCrop = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput().appendField(
         [msg.repeatUntil(), msg.at()].join(' ')
       );
@@ -305,7 +347,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.harvester_ifHasCrop = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(HAS_OPTIONS),
@@ -330,7 +376,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.harvester_ifHasCropElse = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(HAS_OPTIONS),
@@ -357,7 +407,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.harvester_whileHasCrop = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput().appendField(msg.whileMsg());
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(HAS_OPTIONS),
@@ -383,7 +437,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.harvester_untilHasCrop = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput().appendField(msg.repeatUntil());
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(HAS_OPTIONS),

--- a/apps/src/maze/planterBlocks.js
+++ b/apps/src/maze/planterBlocks.js
@@ -3,6 +3,8 @@
  */
 var msg = require('./locale');
 var blockUtils = require('../block_utils');
+var BlockStyles = require('../blockly/constants').BlockStyles;
+var BlockColors = require('../blockly/constants').BlockColors;
 
 exports.install = function (blockly, blockInstallOptions) {
   var generator = blockly.getGenerator();
@@ -20,7 +22,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.planter_ifAtSoil = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(
         [msg.ifCode(), msg.at(), msg.soil()].join(' ')
       );
@@ -41,7 +47,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.planter_ifAtSprout = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(
         [msg.ifCode(), msg.at(), msg.sprout()].join(' ')
       );

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -9,7 +9,7 @@ import i18n from '@cdo/locale';
 import spritelabMsg from '@cdo/spritelab/locale';
 import {parseSoundPathString} from '@cdo/apps/blockly/utils';
 import {spriteLabPointers} from '@cdo/apps/p5lab/spritelab/blockly/constants';
-import {BlockStyles, NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
+import {NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
 
 function animations(includeBackgrounds) {
   const animationList = getStore().getState().animationList;
@@ -505,7 +505,7 @@ export default {
           .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
         this.setStrictOutput(true, Blockly.BlockValueType.SPRITE);
         this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
-        this.setStyle(BlockStyles.BEHAVIOR);
+        this.setStyle('sprite_blocks');
       },
       getVars: function () {
         return Blockly.Variables.getVars.bind(this)(

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -9,7 +9,11 @@ import i18n from '@cdo/locale';
 import spritelabMsg from '@cdo/spritelab/locale';
 import {parseSoundPathString} from '@cdo/apps/blockly/utils';
 import {spriteLabPointers} from '@cdo/apps/p5lab/spritelab/blockly/constants';
-import {NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
+import {
+  BlockColors,
+  BlockStyles,
+  NO_OPTIONS_MESSAGE,
+} from '@cdo/apps/blockly/constants';
 
 function animations(includeBackgrounds) {
   const animationList = getStore().getState().animationList;
@@ -505,7 +509,7 @@ export default {
           .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
         this.setStrictOutput(true, Blockly.BlockValueType.SPRITE);
         this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
-        this.setStyle('sprite_blocks');
+        this.setStyle(BlockStyles.BEHAVIOR);
       },
       getVars: function () {
         return Blockly.Variables.getVars.bind(this)(

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -9,11 +9,7 @@ import i18n from '@cdo/locale';
 import spritelabMsg from '@cdo/spritelab/locale';
 import {parseSoundPathString} from '@cdo/apps/blockly/utils';
 import {spriteLabPointers} from '@cdo/apps/p5lab/spritelab/blockly/constants';
-import {
-  BlockColors,
-  BlockStyles,
-  NO_OPTIONS_MESSAGE,
-} from '@cdo/apps/blockly/constants';
+import {BlockStyles, NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
 
 function animations(includeBackgrounds) {
   const animationList = getStore().getState().animationList;

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -26,6 +26,7 @@ import {
   RANDOM_VALUE,
   VISIBLE_VALUE,
 } from './constants';
+import {BlockColors, BlockStyles} from '../blockly/constants';
 
 var msg = i18n;
 
@@ -269,7 +270,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when the Left arrow button is pressed.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.when())
@@ -289,7 +294,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when the Right arrow button is pressed.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.when())
@@ -309,7 +318,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when the Up arrow button is pressed.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.when())
@@ -329,7 +342,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when the Down arrow button is pressed.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.when())
@@ -349,7 +366,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when an arrow button is pressed.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
       this.appendDummyInput().appendField(commonMsg.when());
       if (isK1) {
         this.appendDummyInput().appendField(
@@ -389,7 +410,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle the repeating tick event while the game is running.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       if (isK1) {
         this.appendDummyInput().appendField(commonMsg.repeat());
         this.appendStatementInput('DO').appendField(
@@ -414,7 +439,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when sprite is clicked.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
       if (spriteCount > 1) {
         if (isK1) {
           this.appendDummyInput()
@@ -456,7 +485,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when sprite touches an item.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
       this.appendDummyInput().appendField(msg.whenTouchCharacter());
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -470,7 +503,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when sprite touches a wall.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
       this.appendDummyInput().appendField(msg.whenTouchObstacle());
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -484,7 +521,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when sprite touches a goal.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
       this.appendDummyInput().appendField(msg.whenTouchGoal());
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -498,7 +539,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when the primary sprite gets a character.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.VALUES),
         'VALUE'
@@ -527,7 +572,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when the primary sprite gets all characters.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
       this.appendDummyInput().appendField(msg.whenGetAllCharacters());
       this.setPreviousStatement(false);
       this.setInputsInline(true);
@@ -542,7 +591,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when the primary sprite gets all characters of a class.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.VALUES),
         'VALUE'
@@ -573,7 +626,11 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       var dropdown1;
       var dropdown2;
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
 
       if (isK1) {
         // NOTE: K1 block does not yet support projectile or edge collisions
@@ -639,7 +696,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_allowSpritesOutsidePlayspace = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown([
           [msg.allowActorsToLeaveThePlayspace(), 'true'],
@@ -664,7 +725,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for stopping the movement of a sprite.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       if (spriteCount > 1) {
         this.appendDummyInput().appendField(
           spriteNumberTextDropdown(msg.stopSpriteN),
@@ -684,7 +749,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for stopping the movement of a sprite.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
         .appendField(msg.stopSpriteN({spriteIndex: ''}));
@@ -716,7 +785,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for adding a character to the scene.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(msg.addCharacter());
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(skin.itemChoices),
@@ -748,7 +821,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting the activity type on a class of items.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(skin.activityChoices),
         'TYPE'
@@ -796,7 +873,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting item speed
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
 
       this.appendDummyInput().appendField(msg.setItemSpeedSet());
       this.appendDummyInput().appendField(
@@ -840,7 +921,11 @@ exports.install = function (blockly, blockInstallOptions) {
   addRegularAndParamsVersions(
     'throw',
     function (actorSelectDropdown) {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       appendActorSelect(this, actorSelectDropdown);
       this.appendDummyInput().appendField(msg.throwSprite());
       this.appendDummyInput().appendField(
@@ -904,7 +989,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for making a projectile bounce or disappear.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.VALUES),
         'VALUE'
@@ -951,7 +1040,11 @@ exports.install = function (blockly, blockInstallOptions) {
       );
 
       dropdown.setValue(this.VALUES[1][1]); // default to top-left
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       if (spriteCount > 1) {
         this.interpolateMsg(
           msg.setSpritePosition(),
@@ -995,7 +1088,11 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       var dropdown = new blockly.FieldDropdown(POSITION_VALUES);
       dropdown.setValue(POSITION_VALUES[1][1]); // default to top-left
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.interpolateMsg(
         msg.setSpritePosition(),
         () => {
@@ -1027,7 +1124,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for jumping a sprite to specific XY location.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       if (spriteCount > 1) {
         this.appendValueInput('SPRITE')
           .setCheck(blockly.BlockValueType.NUMBER)
@@ -1079,7 +1180,11 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       var dropdown = new blockly.FieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to top-left
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.interpolateMsg(
         msg.addGoalPosition(),
         () => {
@@ -1112,7 +1217,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_addGoalXY = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(msg.addGoal());
       this.appendDummyInput().appendField(msg.to());
       this.appendValueInput('XPOS').setCheck(blockly.BlockValueType.NUMBER);
@@ -1235,7 +1344,11 @@ exports.install = function (blockly, blockInstallOptions) {
       return {
         helpUrl: '',
         init: function () {
-          Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+          Blockly.cdoUtils.handleColorAndStyle(
+            this,
+            BlockColors.DEFAULT,
+            BlockStyles.DEFAULT
+          );
           this.appendDummyInput()
             .appendField(msg.moveSprite()) // move
             .appendField(new blockly.FieldImage(directionConfig.image)) // arrow
@@ -1301,7 +1414,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for moving one frame a time.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       if (spriteCount > 1) {
         if (isK1) {
           this.appendDummyInput()
@@ -1368,7 +1485,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for moving/gliding a specific distance.
     block.helpUrl = '';
     block.init = function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       if (options.sprite) {
         this.appendValueInput('SPRITE')
           .setCheck(blockly.BlockValueType.NUMBER)
@@ -1566,7 +1687,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for moving forward/backward
     helpUrl: 'http://code.google.com/p/blockly/wiki/Move',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
@@ -1592,7 +1717,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for turning left or right.
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
@@ -1637,7 +1766,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for playing sound.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.play())
@@ -1686,7 +1819,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for changing the score.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.score())
@@ -1725,7 +1862,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for adding points.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.VALUES),
         'VALUE'
@@ -1759,7 +1900,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for removing points.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.VALUES),
         'VALUE'
@@ -1792,7 +1937,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setScore = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.VARIABLE,
+        BlockStyles.VARIABLE
+      );
       this.appendValueInput('VALUE').appendField(msg.setScore());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -1813,7 +1962,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_getScore = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.VARIABLE,
+        BlockStyles.VARIABLE
+      );
       this.appendDummyInput().appendField(msg.score());
       this.setOutput(true, Blockly.BlockValueType.NUMBER);
       this.setTooltip(msg.getScoreTooltip());
@@ -1828,7 +1981,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for adding arbitrary number of points
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendValueInput('NUM')
         .setCheck(blockly.BlockValueType.NUMBER)
         .appendField(msg.add());
@@ -1855,7 +2012,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for adding arbitrary number of points
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendValueInput('NUM').appendField(msg.remove());
       this.appendDummyInput().appendField(msg.points());
 
@@ -1880,7 +2041,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting the score text.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendValueInput('TEXT').appendField(msg.setScoreText());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -1904,7 +2069,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for showing the protagonist's coordinates.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(msg.showCoordinates());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -1922,7 +2091,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting droid speed
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       var dropdown = new blockly.FieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[2][1]); // default to normal
       this.appendDummyInput().appendField(dropdown, 'VALUE');
@@ -1954,7 +2127,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting sprite speed
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
 
       if (spriteCount > 1) {
         if (isK1) {
@@ -1994,7 +2171,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting sprite speed
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
         .appendField(msg.setSpriteN({spriteIndex: ''}));
@@ -2055,7 +2236,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting sprite size
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
 
       if (spriteCount > 1) {
         this.appendDummyInput().appendField(
@@ -2081,7 +2266,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting sprite size
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
         .appendField(msg.setSpriteN({spriteIndex: ''}));
@@ -2154,7 +2343,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setSpritesWander = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       const dropdown = createSpriteGroupDropdown(msg.setEverySpriteNameWander);
       this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
@@ -2174,7 +2367,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setSpritesStop = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       const dropdown = createSpriteGroupDropdown(msg.stopEverySpriteName);
       this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
@@ -2194,7 +2391,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setSpritesChase = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       const dropdown = createSpriteGroupDropdown(
         msg.setEverySpriteNameChaseActor
       );
@@ -2218,7 +2419,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setSpritesFlee = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       const dropdown = createSpriteGroupDropdown(
         msg.setEverySpriteNameFleeActor
       );
@@ -2242,7 +2447,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setSpritesSpeed = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       const dropdown = createSpriteGroupDropdown(msg.setEverySpriteNameSpeed);
       this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.appendValueInput('SPEED').setCheck(blockly.BlockValueType.NUMBER);
@@ -2269,7 +2478,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setSpriteBehavior = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(msg.setActor());
       this.appendValueInput('SPRITE').setCheck(blockly.BlockValueType.NUMBER);
       let hasTargetInput = true;
@@ -2324,7 +2537,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // and sets a variable to the sprite in the group that was touched
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
 
       var dropdown1 = spriteNumberTextDropdown(msg.whenSpriteN);
       var endLabel = new Blockly.FieldLabel();
@@ -2365,7 +2582,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when a sprite collides with any sprite in a group
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 140, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.EVENT,
+        BlockStyles.EVENT
+      );
 
       var dropdown1 = spriteNumberTextDropdown(msg.whenSpriteN);
       var dropdown2 = createSpriteGroupDropdown(msg.collidesWithAnySpriteName);
@@ -2388,7 +2609,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setBackground = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.VARIABLE,
+        BlockStyles.VARIABLE
+      );
       this.VALUES = [];
 
       var dropdown;
@@ -2418,7 +2643,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setBackgroundParam = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.VARIABLE,
+        BlockStyles.VARIABLE
+      );
       this.VALUES = skin.backgroundChoices;
 
       this.appendDummyInput().appendField(msg.setBackground());
@@ -2454,7 +2683,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setMap = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.VARIABLE,
+        BlockStyles.VARIABLE
+      );
       // 'random' is a special value, don't put it in quotes
       this.VALUES = skin.mapChoices.map(opt => [
         opt[0],
@@ -2483,7 +2716,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setMapAndColor = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.VARIABLE,
+        BlockStyles.VARIABLE
+      );
       // 'random' is a special value, don't put it in quotes
       this.VALUES = skin.mapChoices.map(opt => [
         opt[0],
@@ -2525,7 +2762,11 @@ exports.install = function (blockly, blockInstallOptions) {
 
     block.helpUrl = '';
     block.init = function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(msg.showTitleScreen());
       if (options.params) {
         this.appendValueInput('TITLE')
@@ -2616,7 +2857,11 @@ exports.install = function (blockly, blockInstallOptions) {
     blockly.Blocks.studio_setSprite = {
       helpUrl: '',
       init: function () {
-        Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+        Blockly.cdoUtils.handleColorAndStyle(
+          this,
+          BlockColors.VARIABLE,
+          BlockStyles.VARIABLE
+        );
         var visibilityTextDropdown = new blockly.FieldDropdown(this.VALUES);
         visibilityTextDropdown.setValue(VISIBLE_VALUE); // default to visible
         this.appendDummyInput().appendField(visibilityTextDropdown, 'VALUE');
@@ -2646,7 +2891,11 @@ exports.install = function (blockly, blockInstallOptions) {
       init: function () {
         // shallow copy array:
         this.VALUES = [].concat(skin.spriteChoices);
-        Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+        Blockly.cdoUtils.handleColorAndStyle(
+          this,
+          BlockColors.VARIABLE,
+          BlockStyles.VARIABLE
+        );
         if (spriteCount > 1) {
           this.appendDummyInput().appendField(
             spriteNumberTextDropdown(msg.setSpriteN),
@@ -2683,7 +2932,11 @@ exports.install = function (blockly, blockInstallOptions) {
       // default to first item after random/hidden
       dropdown.setValue(skin.spriteChoices[2][1]);
 
-      Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.VARIABLE,
+        BlockStyles.VARIABLE
+      );
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
         .appendField(msg.setSpriteN({spriteIndex: ''}));
@@ -2698,7 +2951,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setSpriteParamValue = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.VARIABLE,
+        BlockStyles.VARIABLE
+      );
       if (spriteCount > 1) {
         this.appendDummyInput().appendField(
           spriteNumberTextDropdown(msg.setSpriteN),
@@ -2752,7 +3009,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setSpriteEmotion = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       if (spriteCount > 1) {
         if (isK1) {
           this.appendDummyInput()
@@ -2793,7 +3054,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_setSpriteEmotionParams = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
         .appendField(msg.setSpriteN({spriteIndex: ''}));
@@ -2846,7 +3111,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for waiting a specific amount of time.
     block.helpUrl = '';
     block.init = function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       if (options.time) {
         this.appendValueInput('SPRITE')
           .setCheck(blockly.BlockValueType.NUMBER)
@@ -2997,7 +3266,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for waiting a specific amount of time.
     block.helpUrl = '';
     block.init = function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       if (options.params) {
         this.appendDummyInput().appendField(msg.waitFor());
         this.appendValueInput('VALUE').setCheck(blockly.BlockValueType.NUMBER);
@@ -3072,7 +3345,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_endGame = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       var dropdown = new blockly.FieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[0][1]); // default to win
       this.appendDummyInput().appendField(dropdown, 'VALUE');
@@ -3362,7 +3639,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_vanishSprite = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
         .appendField(msg.vanishActorN({spriteIndex: ''}));
@@ -3474,7 +3755,11 @@ exports.install = function (blockly, blockInstallOptions) {
       var fieldLabel = new Blockly.FieldLabel(Blockly.Msg.VARIABLES_GET_ITEM);
       // Must be marked EDITABLE so that cloned blocks share the same var name
       fieldLabel.EDITABLE = true;
-      Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.VARIABLE,
+        BlockStyles.VARIABLE
+      );
       this.appendDummyInput().appendField(msg.ask());
       this.setInputsInline(true);
       this.appendDummyInput()
@@ -3535,7 +3820,11 @@ function installVanish(
   blockly.Blocks.studio_vanish = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       if (blockInstallOptions.isK1) {
         this.appendDummyInput()
           .appendField(msg.vanish())
@@ -3619,7 +3908,11 @@ function installConditionals(
   addIfAndIfElseVersions(
     'ifActorHasEmotion',
     function (actorSelectDropdown, includeElseStatement) {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(commonMsg.ifCode());
 
       appendActorSelect(this, actorSelectDropdown);
@@ -3696,7 +3989,11 @@ function installConditionals(
             ['\u2265', 'GTE'],
           ];
 
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(commonMsg.ifCode());
 
       appendActorSelect(this, actorSelectDropdown);
@@ -3767,7 +4064,11 @@ function installConditionals(
   addIfAndIfElseVersions(
     'ifActorIsVisible',
     function (actorSelectDropdown, includeElseStatement) {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(commonMsg.ifCode());
 
       appendActorSelect(this, actorSelectDropdown);
@@ -3819,7 +4120,11 @@ function installConditionals(
   addIfAndIfElseVersions(
     'ifActorIsSprite',
     function (actorSelectDropdown, includeElseStatement) {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendDummyInput().appendField(commonMsg.ifCode());
 
       appendActorSelect(this, actorSelectDropdown);

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -26,6 +26,9 @@ var Colours = require('./colours');
 var msg = require('./locale');
 var commonMsg = require('@cdo/locale');
 var customLevelBlocks = require('./customLevelBlocks');
+var BlockStyles = require('../blockly/constants').BlockStyles;
+var BlockColors = require('../blockly/constants').BlockColors;
+
 import {Position} from '../constants';
 
 const RANDOM_VALUE = 'RAND';
@@ -126,7 +129,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for moving forward or backward the internal number of pixels.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(MOVE_BY_DIRECTION_VALUES),
         'DIR'
@@ -151,7 +158,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for moving forward or backward the internal number of pixels.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(MOVE_BY_DIRECTION_VALUES),
         'DIR'
@@ -186,7 +197,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for turning either left or right from among a fixed set of angles.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
@@ -232,7 +247,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for turning left or right any number of degrees.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
@@ -256,7 +275,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for turning left or right any number of degrees.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
@@ -310,7 +333,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for turning either left or right from among a fixed set of angles.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
@@ -356,7 +383,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for turning left or right any number of degrees.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
@@ -380,7 +411,11 @@ exports.install = function (blockly, blockInstallOptions) {
     return {
       helpUrl: '',
       init: function () {
-        Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+        Blockly.cdoUtils.handleColorAndStyle(
+          this,
+          BlockColors.DEFAULT,
+          BlockStyles.DEFAULT
+        );
         this.setPreviousStatement(true);
         this.setInputsInline(true);
         this.setNextStatement(true);
@@ -477,7 +512,11 @@ exports.install = function (blockly, blockInstallOptions) {
     category: null, // Variables are handled specially.
     helpUrl: blockly.Msg.VARIABLES_GET_HELPURL,
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.VARIABLE,
+        BlockStyles.VARIABLE
+      );
       this.appendDummyInput()
         .appendField(blockly.Msg.VARIABLES_GET_TITLE)
         .appendField(new blockly.FieldLabel(msg.loopVariable()), 'VAR');
@@ -494,7 +533,11 @@ exports.install = function (blockly, blockInstallOptions) {
     category: null, // Variables are handled specially.
     helpUrl: blockly.Msg.VARIABLES_GET_HELPURL,
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.VARIABLE,
+        BlockStyles.VARIABLE
+      );
       this.appendDummyInput()
         .appendField(blockly.Msg.VARIABLES_GET_TITLE)
         .appendField(new blockly.FieldLabel(msg.lengthParameter()), 'VAR');
@@ -511,7 +554,11 @@ exports.install = function (blockly, blockInstallOptions) {
     category: null, // Variables are handled specially.
     helpUrl: blockly.Msg.VARIABLES_GET_HELPURL,
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 312, 0.32, 0.62);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.VARIABLE,
+        BlockStyles.VARIABLE
+      );
       this.appendDummyInput()
         .appendField(blockly.Msg.VARIABLES_GET_TITLE)
         .appendField(new blockly.FieldLabel('sides'), 'VAR');
@@ -528,7 +575,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.draw_a_square = {
     // Draw a square.
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 94, 0.84, 0.6);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.PROCEDURE,
+        BlockStyles.PROCEDURE
+      );
       this.appendDummyInput().appendField(msg.drawASquare());
       this.appendValueInput('VALUE')
         .setAlign(blockly.ALIGN_RIGHT)
@@ -562,7 +613,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.draw_a_snowman = {
     // Draw a circle in front of the turtle, ending up on the opposite side.
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 94, 0.84, 0.6);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.PROCEDURE,
+        BlockStyles.PROCEDURE
+      );
       this.appendDummyInput().appendField(msg.drawASnowman());
       this.appendValueInput('VALUE')
         .setAlign(blockly.ALIGN_RIGHT)
@@ -637,7 +692,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // For loop with hardcoded loop variable.
     helpUrl: blockly.Msg.CONTROLS_FOR_HELPURL,
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 322, 0.9, 0.95);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOOP,
+        BlockStyles.LOOP
+      );
       this.appendDummyInput()
         .appendField(blockly.Msg.CONTROLS_FOR_INPUT_WITH)
         .appendField(new blockly.FieldLabel(msg.loopVariable()), 'VAR');
@@ -689,7 +748,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for moving forward or backwards.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.interpolateMsg(
         msg.moveDirectionByPixels(),
         () => {
@@ -727,7 +790,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for moving forward or backwards.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.interpolateMsg(
         msg.jumpByDirection(),
         () => {
@@ -948,7 +1015,11 @@ exports.install = function (blockly, blockInstallOptions) {
       return {
         helpUrl: '',
         init: function () {
-          Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+          Blockly.cdoUtils.handleColorAndStyle(
+            this,
+            BlockColors.DEFAULT,
+            BlockStyles.DEFAULT
+          );
           var input = this.appendDummyInput();
           if (directionConfig.isJump) {
             input.appendField(commonMsg.jump());
@@ -1027,7 +1098,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // without drawing.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(JUMP_BY_DIRECTION_VALUES),
         'DIR'
@@ -1053,7 +1128,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // without drawing.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(JUMP_BY_DIRECTION_VALUES),
         'DIR'
@@ -1090,7 +1169,11 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       var dropdown = new blockly.FieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to top-left
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.interpolateMsg(
         msg.jumpToPosition(),
         () => {
@@ -1122,7 +1205,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for jumping to specified XY location.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.interpolateMsg(
         msg.jumpToOverDown(),
         () => {
@@ -1162,7 +1249,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for turning left or right.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.interpolateMsg(
         msg.turnDirection(),
         () => {
@@ -1210,7 +1301,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting the pen width.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendValueInput('WIDTH')
         .setCheck(blockly.BlockValueType.NUMBER)
         .appendField(msg.setWidth());
@@ -1232,7 +1327,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting the pen width.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.setInputsInline(true);
       this.appendDummyInput().appendField(msg.setWidth());
       this.appendDummyInput().appendField(
@@ -1255,7 +1354,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for pen up/down.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.STATE),
         'PEN'
@@ -1282,7 +1385,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting the colour.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.appendValueInput('COLOUR')
         .setCheck(blockly.BlockValueType.COLOUR)
         .appendField(msg.setColour());
@@ -1303,7 +1410,11 @@ exports.install = function (blockly, blockInstallOptions) {
         .appendField(msg.setAlpha());
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       this.setTooltip('');
     },
   };
@@ -1339,7 +1450,11 @@ exports.install = function (blockly, blockInstallOptions) {
         Colours.AQUAMARINE,
         Colours.PLUM,
       ];
-      Blockly.cdoUtils.setHSV(this, 196, 1.0, 0.79);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.LOGIC,
+        BlockStyles.LOGIC
+      );
       var colourField = new Blockly.FieldColourDropdown(colours, 45, 35);
       this.appendDummyInput()
         .appendField(msg.setColour())
@@ -1360,7 +1475,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block to handle event when an arrow button is pressed.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.appendDummyInput()
@@ -1384,7 +1503,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.up_big = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.appendDummyInput().appendField(
@@ -1407,7 +1530,11 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for changing turtle visiblity.
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.appendDummyInput().appendField(
@@ -1438,7 +1565,11 @@ exports.install = function (blockly, blockInstallOptions) {
     return {
       helpUrl: '',
       init: function () {
-        Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+        Blockly.cdoUtils.handleColorAndStyle(
+          this,
+          BlockColors.DEFAULT,
+          BlockStyles.DEFAULT
+        );
         var dropdown;
         var input = this.appendDummyInput();
         input.appendField(msg.drawSticker());
@@ -1633,7 +1764,11 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.turtle_setArtist = {
     helpUrl: '',
     init: function () {
-      Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.DEFAULT,
+        BlockStyles.DEFAULT
+      );
       var values = (skin.artistOptions || ['default']).map(artist => [
         msg.setCharacter({
           character: artist.charAt(0).toUpperCase() + artist.slice(1),


### PR DESCRIPTION
Relates to:
- https://github.com/code-dot-org/code-dot-org/pull/56589

As part of the work to standardize our approach to setting colors and styles onto blocks, a new util `handleColorAndStyle` was created for each Blockly wrapper. In Google Blockly, we prioritize styles as they are compatible with themes. CDO Blockly only support colors. In anticipation of migrating more labs to Google Blockly, we can use this new util wherever we would set a block color. In most cases, the HSV values used map smoothly to the default color for a support block style. As there were a ton of repeated HSV arrays, I created a constant to handle these. I also created an enum for the matching block styles.
In cases where a block color does not map to a style (e.g. Jigsaw, unknown/comment blocks) I left the HSV array as-is and didn't provide a style argument. 

I also left behind approximately 50 direct calls to `setHSV` in labs we no longer support (Calc/Eval and Minecraft Code Connection). Since we don't have plans to migrate these labs it didn't make sense to take time to assign styles to their blocks.

I tested this locally by opening one of each Blockly project type (as listed on the projects page), as well as spot-checking Maze and Jigsaw levels.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
