### PR TITLE
Follow ups to googleBlocklyWrapper TypeScript migration

### DIFF
--- a/apps/src/blockly/addons/cdoGenerator.js
+++ b/apps/src/blockly/addons/cdoGenerator.js
@@ -48,7 +48,7 @@ export default function initializeGenerator(blocklyWrapper) {
   ) {
     // Skip disabled block check for non-rendered workspaces. Non-rendered workspaces
     // do not have an unused concept.
-    if (block?.workspace?.rendered && block?.isDisabled()) {
+    if (block?.workspace?.rendered && !block?.isEnabled()) {
       return '';
     }
     return originalBlockToCode.call(

--- a/apps/src/blockly/customBlocks/cdoBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/cdoBlockly/spritelabBlocks.js
@@ -1,4 +1,5 @@
 // This file contains customizations to CDO Blockly Sprite Lab blocks.
+// When we are ready to remove support for CDO Blockly we can remove this file.
 import i18n from '@cdo/locale';
 import {BLOCK_TYPES, NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
 
@@ -233,8 +234,6 @@ export const blocks = {
       ];
     };
 
-    // This is only used by CDO Blockly. When we are ready to remove support
-    // for CDO Blockly we can remove this call.
     Blockly.Blocks.behavior_definition =
       Blockly.Block.createProcedureDefinitionBlock({
         initPostScript(block) {

--- a/apps/src/blockly/customBlocks/cdoBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/cdoBlockly/spritelabBlocks.js
@@ -233,6 +233,8 @@ export const blocks = {
       ];
     };
 
+    // This is only used by CDO Blockly. When we are ready to remove support
+    // for CDO Blockly we can remove this call.
     Blockly.Blocks.behavior_definition =
       Blockly.Block.createProcedureDefinitionBlock({
         initPostScript(block) {

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -458,18 +458,6 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   const extendedBlockSvg = blocklyWrapper.BlockSvg
     .prototype as ExtendedBlockSvg;
 
-  extendedBlockSvg.isDisabled = function () {
-    return !this.isEnabled();
-  };
-
-  extendedBlockSvg.getHexColour = function () {
-    // In cdo Blockly labs, getColour() returns a numerical hue value, while
-    // in newer Google Blockly it returns a hexademical color value string.
-    // This is only used for locationPicker blocks and can likely be deprecated
-    // once Sprite Lab is using Google Blockly.
-    return this.getColour();
-  };
-
   extendedBlockSvg.isVisible = function () {
     // TODO (eventually) - All Google Blockly blocks are currently visible.
     // This shouldn't be a problem until we convert other labs.

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -133,8 +133,6 @@ export type GoogleBlocklyInstance = typeof GoogleBlockly;
 // types and can cast to them when needed.
 
 export interface ExtendedBlockSvg extends BlockSvg {
-  isDisabled: () => boolean;
-  getHexColour: () => string;
   isVisible: () => boolean;
   isUserVisible: () => boolean;
 }

--- a/apps/src/dance/blockly/blocks.js
+++ b/apps/src/dance/blockly/blocks.js
@@ -314,23 +314,6 @@ export default {
       ];
     };
 
-    Blockly.Blocks.behavior_definition =
-      Blockly.Block.createProcedureDefinitionBlock({
-        initPostScript(block) {
-          block.setHSV(136, 0.84, 0.8);
-          block.parameterNames_ = ['this sprite'];
-          block.parameterTypes_ = [Blockly.BlockValueType.SPRITE];
-        },
-        overrides: {
-          getVars(category) {
-            return {
-              Behavior: [this.getFieldValue('NAME')],
-            };
-          },
-          callType_: 'gamelab_behavior_get',
-        },
-      });
-
     generator.behavior_definition = generator.procedures_defnoreturn;
 
     Blockly.Procedures.DEFINITION_BLOCK_TYPES.push('behavior_definition');
@@ -338,18 +321,6 @@ export default {
       Blockly.BlockValueType.BEHAVIOR,
       'gamelab_behavior_get'
     );
-    Blockly.Flyout.configure(Blockly.BlockValueType.BEHAVIOR, {
-      initialize(flyout, cursor) {
-        if (behaviorEditor && !behaviorEditor.isOpen()) {
-          flyout.addButtonToFlyout_(
-            cursor,
-            i18n.createBlocklyBehavior(),
-            behaviorEditor.openWithNewFunction.bind(behaviorEditor)
-          );
-        }
-      },
-      addDefaultVar: false,
-    });
     delete blockly.Blocks.procedures_defreturn;
     delete blockly.Blocks.procedures_ifreturn;
   },

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -547,6 +547,8 @@ export default {
       !blockInstallOptions.level ||
       blockInstallOptions.level.editBlocks !== TOOLBOX_EDIT_MODE
     ) {
+      // This is only used by CDO Blockly. When we are ready to remove support
+      // for CDO Blockly we can remove this call.
       Blockly.Flyout.configure(Blockly.BlockValueType.BEHAVIOR, {
         initialize(flyout, cursor) {
           if (behaviorEditor && !behaviorEditor.isOpen()) {


### PR DESCRIPTION
A few clean ups that we noticed from the `googleBlocklyWrapper` TypeScript migration:
- replace usage of `block.isDisabled` with `!block.isEnabled` (and remove custom `isDisabled` function)
- get rid of `block.getHexColour`, as it was not used
- get rid of Dance usage of `block.createProcedureDefinitionBlock` and `Flyout.configure`. These two functions have been empty functions in the google blockly wrapper, and since Dance has been on google blockly for over a year we can safely remove that usage. I kept the usage of these functions in Sprite Lab, and the empty functions in the wrapper, because removing them breaks cdo blockly Sprite Lab. Since we are early post-migration we don't want to fully break the cdo version yet (mostly for our own debugging purposes).

## Links
- jira ticket: [CT-343](https://codedotorg.atlassian.net/browse/CT-343)


## Testing story
Tested locally that Sprite Lab still behaves the same on CDO and Google Blockly, and Dance still behaves the same on Google Blockly.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
