### PR TITLE
AI Tutor: script to set ai_tutor_available to true for CSA levels

### DIFF
--- a/bin/oneoff/set_ai_tutor_available_for_csa_levels.rb
+++ b/bin/oneoff/set_ai_tutor_available_for_csa_levels.rb
@@ -1,0 +1,21 @@
+# This script finds all levels currently used in CSA scripts and sets the property
+# ai_tutor_available to true. Levelbuilders will have the ability to set ai_tutor_available
+# on a per level basis via the level edit page. Initially, we want to default ai_tutor_available to
+# true for CSA levels and false for levels in all other curricula.
+
+require_relative '../../dashboard/config/environment'
+require src_dir 'database'
+
+count_levels_updated = 0
+
+time_taken = Benchmark.realtime do
+  ActiveRecord::Base.transaction do
+    Level.includes(:script_levels).all.select {|level| level.script_levels.any? {|sl| sl.script.csa?}}.each do |csa_level|
+      csa_level.properties["ai_tutor_available"] = true
+      csa_level.save!
+      count_levels_updated += 1
+    end
+  end
+end
+
+puts "It took #{time_taken} seconds to set ai_tutor_available to true for #{count_levels_updated} CSA levels."


### PR DESCRIPTION
[CT-237](https://codedotorg.atlassian.net/browse/CT-237) partial 

One of the requirements for AI Tutor is that Levelbuilders should be able to enable/disable AI Tutor on a per level basis. We're setting up a toggle on the level edit page that will allow them to do this. In the meantime we want to programmatically bulk update all levels in CSA scripts to have AI Tutor "on" and levels in all other curricula to to have AI Tutor "off". This PR adds a script to set the `ai_tutor_available` property on CSA levels to `true`. 

I ran the script locally with the output "It took 118.82571599999937 seconds to set ai_tutor_available to true for 3139 CSA levels." and spot checked that CSA levels now have the expected property.  We have a huge number of levels, but < 2 min for the script to run _seems_ reasonable. **Are there any performance concerns?** 

The `ai_tutor_available` property is not yet being used to enable/disable AI Tutor, and AI Tutor is only seen by a handful of internal users and one trusted contract teacher during this phase of the project, so there shouldn't be any impact for regular users. 


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
