### PR TITLE
Added accessibility to multiple choice + close popup component

### DIFF
--- a/apps/src/code-studio/LegacyDialog.js
+++ b/apps/src/code-studio/LegacyDialog.js
@@ -66,7 +66,7 @@ var LegacyDialog = (module.exports = function (options) {
 
   var close = options.close === undefined ? true : options.close;
 
-  var closeLink = $('<div id="x-close"/>')
+  var closeLink = $('<button id="x-close"/>')
     .addClass('x-close')
     .attr('data-dismiss', 'modal');
   this.div = $('<div tabindex="-1"/>').addClass('modal');

--- a/apps/src/code-studio/callouts.js
+++ b/apps/src/code-studio/callouts.js
@@ -113,7 +113,7 @@ export function addCallouts(callouts) {
       content: {
         text: callout.localized_text,
         title: {
-          button: $('<div class="tooltip-x-close"/>'),
+          button: $('<button class="tooltip-x-close"/>'),
         },
       },
       style: {

--- a/apps/src/code-studio/levels/multi.js
+++ b/apps/src/code-studio/levels/multi.js
@@ -70,7 +70,9 @@ var Multi = function (
 };
 
 Multi.prototype.enableButton = function (enable) {
-  $('#' + this.id + ' .submitButton').attr('disabled', !enable);
+  var button = $('#' + this.id + ' .submitButton');
+  button.prop('disabled', !enable);
+  button.prop('tagName', 'BUTTON');
 };
 
 Multi.prototype.choiceClicked = function (button) {
@@ -160,22 +162,17 @@ Multi.prototype.ready = function () {
     }
   }
 
-  $('#' + this.id + ' .answerbutton').click(
-    $.proxy(function (event) {
-      this.choiceClicked($(event.currentTarget));
-    }, this)
-  );
+  $('#' + this.id + ' .answerbutton').on('click', event => {
+    this.choiceClicked($(event.currentTarget));
+  });
 
-  $('#' + this.id + ' #voteform img').on(
-    'dragstart',
-    $.proxy(function (event) {
-      // Prevent button images from being dragged, click the button instead.
-      var button = $(event.currentTarget).parent().parent().parent();
-      this.choiceClicked(button);
-      event.preventDefault();
-      event.stopPropagation();
-    }, this)
-  );
+  $('#' + this.id + ' #voteform img').on('dragstart', event => {
+    // Prevent button images from being dragged, click the button instead.
+    var button = $(event.currentTarget).parent().parent().parent();
+    this.choiceClicked(button);
+    event.preventDefault();
+    event.stopPropagation();
+  });
 
   this.enableButton(false);
 
@@ -198,11 +195,11 @@ Multi.prototype.ready = function () {
   }
 
   if (this.standalone) {
-    $('.submitButton').click($.proxy(this.submitButtonClick, this));
+    $('.submitButton').on('click', this.submitButtonClick.bind(this));
   } else {
     var resetButton = $('#reset-predict-progress-button');
     if (resetButton) {
-      resetButton.click(() => resetContainedLevel());
+      resetButton.on('click', () => resetContainedLevel());
     }
   }
 

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -372,7 +372,7 @@ export function showGenericQtip(targetElement, title, message, position) {
         <p>${message}</p>
       `,
         title: {
-          button: $('<div class="tooltip-x-close"/>'),
+          button: $('<button class="tooltip-x-close"/>'),
         },
       },
       position,

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1613,6 +1613,10 @@ html[dir=rtl] .qtip-content {
   @include close-button($cornerOffset: -20px);
 }
 
+.tooltip-x-close:focus {
+  border-color: $brand_primary_default;
+}
+
 a.download-video {
   z-index: 1;
   cursor: pointer;
@@ -3002,7 +3006,7 @@ $information-desktop: "only screen and (min-width: 1024px)";
   .item-mark {
     display: inline-block;
     text-align: left;
-    padding-right: 10px;
+    padding-right: 30px;
     box-sizing: border-box;
     font-size: 21px;
     width: 30px;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -4185,4 +4185,9 @@ a {
   }
 }
 
+// Globally override button hover styling applied by Bootstrap
+button:hover {
+  box-shadow: none;
+}
+
 @import "NpsSurveyBlock";

--- a/dashboard/app/views/levels/_curriculum_reference.haml
+++ b/dashboard/app/views/levels/_curriculum_reference.haml
@@ -10,5 +10,5 @@
     - else
       #iframe-loading.loading
       %iframe{id: 'curriculum-reference', width: '100%', frameborder: 0, src: level.href, onload: 'window.curriculumReference.onload()', style: "display: none;" }
-    %a.btn.btn-large.btn-primary.next-lesson.submitButton.pull-right= t('continue')
+    %button.btn.btn-large.btn-primary.next-lesson.submitButton.pull-right= t('continue')
   = render partial: 'levels/teacher_markdown', locals: {data: level.properties}

--- a/dashboard/app/views/levels/_dialog.html.haml
+++ b/dashboard/app/views/levels/_dialog.html.haml
@@ -4,21 +4,21 @@
 - unless app == 'external'
   .buttons{class: @level.properties['submittable'] == 'true' ? 'submittable' : nil}
     - if local_assigns[:previous_page_button]
-      %a.btn.btn-large.btn-primary.previousPageButton
+      %button.btn.btn-large.btn-primary.previousPageButton
         =t('previous_page')
     - if local_assigns[:next_level_link]
       -# In the case where a level cannot be retried, we dynamically hide the submit button and show this button
-      %a{href: local_assigns[:next_link_level], class: 'btn btn-large btn-primary next-lesson nextLevelButton', style: !!local_assigns[:show_next_page_link] ? nil : 'display:none'}
+      %button{href: local_assigns[:next_link_level], class: 'btn btn-large btn-primary next-lesson nextLevelButton', style: !!local_assigns[:show_next_page_link] ? nil : 'display:none'}
         =t('next_level')
     - if local_assigns[:next_page_button]
-      %a.btn.btn-large.btn-primary.nextPageButton
+      %button.btn.btn-large.btn-primary.nextPageButton
         =t('next_page')
     - else
-      %a.btn.btn-large.btn-primary.next-lesson.submitButton{style: !!local_assigns[:show_next_page_link] ? 'display:none' : nil}
+      %button.btn.btn-large.btn-primary.next-lesson.submitButton{style: !!local_assigns[:show_next_page_link] ? 'display:none' : nil}
         =t('submit')
       -# This button is unhidden in _dialog.js if the user has already submitted
       - if @level.properties['submittable'] && !Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)
-        %a.btn.btn-large.btn-primary.unsubmitButton{style: 'display: none'}
+        %button.btn.btn-large.btn-primary.unsubmitButton{style: 'display: none'}
           =t('unsubmit')
 .clear
 

--- a/dashboard/app/views/levels/_single_match.html.haml
+++ b/dashboard/app/views/levels/_single_match.html.haml
@@ -3,7 +3,7 @@
 
   - if standalone && !(level.properties['options'].try(:[], 'hide_submit'))
     .buttons
-      %a.btn.btn-large.btn-primary.next-lesson.submitButton
+      %button.btn.btn-large.btn-primary.next-lesson.submitButton
         =t('submit')
 
   %br/

--- a/dashboard/app/views/levels/_single_multi.html.haml
+++ b/dashboard/app/views/levels/_single_multi.html.haml
@@ -71,11 +71,11 @@
           - correct = include_multi_answers?(standalone) ? answer['correct'] : false
           - answer_class = "answerbutton " + (use_tight_layout ? "" : "btn")
           %div{class: answer_class, style: "display: inline-block; height: #{height}", correct: "#{correct}", index: "#{i}"}
-            .item-mark{id: "unchecked_#{i}"}
+            %button.item-mark{id: "unchecked_#{i}"}
               .fa{class: unchecked_class}
-            .item-mark{id: "checked_#{i}", style: 'display: none;'}
+            %button.item-mark{id: "checked_#{i}", style: 'display: none;'}
               .fa{class: checked_class}
-            .item-mark{id: "cross_#{i}", style: 'display: none;'}
+            %button.item-mark{id: "cross_#{i}", style: 'display: none;'}
               .fa{class: cross_class}
             %label.item-label.item-answer-letter{style: "height: #{height}"}
               ="#{multi_answer_characters[i]}. "

--- a/dashboard/app/views/levels/_single_multi.html.haml
+++ b/dashboard/app/views/levels/_single_multi.html.haml
@@ -69,13 +69,13 @@
         - data['answers'].each_with_index do |answer, i|
           -# When LevelGroup-hosted, with students (or teachers doing PD), set all answers false before rendering page.
           - correct = include_multi_answers?(standalone) ? answer['correct'] : false
-          - answer_class = "answerbutton " + (use_tight_layout ? "" : "btn")
-          %div{class: answer_class, style: "display: inline-block; height: #{height}", correct: "#{correct}", index: "#{i}"}
-            %button.item-mark{id: "unchecked_#{i}"}
+          - answer_class = "answerbutton " + (use_tight_layout ? "tight_layout" : "btn")
+          %button{class: answer_class, style: "display: inline-block; height: #{height}", correct: "#{correct}", index: "#{i}"}
+            .item-mark{id: "unchecked_#{i}"}
               .fa{class: unchecked_class}
-            %button.item-mark{id: "checked_#{i}", style: 'display: none;'}
+            .item-mark{id: "checked_#{i}", style: 'display: none;'}
               .fa{class: checked_class}
-            %button.item-mark{id: "cross_#{i}", style: 'display: none;'}
+            .item-mark{id: "cross_#{i}", style: 'display: none;'}
               .fa{class: cross_class}
             %label.item-label.item-answer-letter{style: "height: #{height}"}
               ="#{multi_answer_characters[i]}. "

--- a/dashboard/app/views/levels/_single_multi.html.haml
+++ b/dashboard/app/views/levels/_single_multi.html.haml
@@ -69,7 +69,7 @@
         - data['answers'].each_with_index do |answer, i|
           -# When LevelGroup-hosted, with students (or teachers doing PD), set all answers false before rendering page.
           - correct = include_multi_answers?(standalone) ? answer['correct'] : false
-          - answer_class = "answerbutton " + (use_tight_layout ? "tight_layout" : "btn")
+          - answer_class = "answerbutton " + (use_tight_layout ? "tight-layout" : "btn")
           %button{class: answer_class, style: "display: inline-block; height: #{height}", correct: "#{correct}", index: "#{i}"}
             .item-mark{id: "unchecked_#{i}"}
               .fa{class: unchecked_class}

--- a/dashboard/test/ui/features/step_definitions/callouts.rb
+++ b/dashboard/test/ui/features/step_definitions/callouts.rb
@@ -13,7 +13,7 @@ And(/^callout "([^"]*)" is hidden$/) do |callout_id|
 end
 
 And(/^I close callout "([^"]*)"$/) do |callout_id|
-  xpath = "(//*[contains(@class, 'cdo-qtips')])[#{callout_id.to_i + 1}]/div[3]"
+  xpath = "(//*[contains(@class, 'cdo-qtips')])[#{callout_id.to_i + 1}]/button"
   @button = @browser.find_element(:xpath, xpath)
   @button.click
   short_wait.until {!callout_visible?(callout_id)}

--- a/shared/css/buttons.scss
+++ b/shared/css/buttons.scss
@@ -22,6 +22,14 @@
   }
 }
 
+.tight-layout {
+  padding: 0;
+  margin: 0;
+  background-color: white;
+  border-color: white;
+  color: $dark_gray;
+}
+
 .primary {
   @include button-with-color($orange);
 }
@@ -35,3 +43,4 @@
 .secondary:hover {
   box-shadow: none;
 }
+


### PR DESCRIPTION
## Description

- This fix turns X-marks on the video popups tabbable and focusable from the start. The user can now use the keyboard to exit a video popup. (First gif)
- Instruction popups are focusable via `tab` + `shift` commands. (Second gif)
- The user can now tab through multiple-choice options and select them using the keyboard. (Third gif)

![Kapture 2024-01-23 at 13 39 39 (1)](https://github.com/code-dot-org/code-dot-org/assets/68515140/f2d40435-a362-4f16-a7df-ee8c2961b585)

![Kapture 2024-02-20 at 23 36 18](https://github.com/code-dot-org/code-dot-org/assets/68515140/129ea2d0-9dc8-4505-acd5-8de61700fc13)

![Kapture 2024-02-07 at 23 52 44](https://github.com/code-dot-org/code-dot-org/assets/68515140/6be55b5f-2fc3-49da-9363-697bda434750)


## Testing story

Reran the yarn test, yarn test:unit, and yarn test:integration commands. No test failed.

