### PR TITLE
DCDO flag `fraction_of_new_projects_use_datablock_storage` controls whether projects use_datablock_storage

### DIFF
--- a/dashboard/app/models/project.rb
+++ b/dashboard/app/models/project.rb
@@ -30,9 +30,6 @@ class Project < ApplicationRecord
   has_one :owner, class_name: 'User', through: :project_storage, source: :user
   has_one :channel_token
 
-  # TODO: post-firebase-cleanup, remove this once we switch 100% to datablock storage
-  after_create :set_use_datablock_storage
-
   # Finds a project by channel id. Like `find`, this method raises an
   # ActiveRecord::RecordNotFound error if the corresponding project cannot
   # be found.
@@ -77,19 +74,5 @@ class Project < ApplicationRecord
 
   def existed_long_enough_to_publish?
     Time.now > created_at + 30.minutes
-  end
-
-  private
-
-  def set_use_datablock_storage
-    puts "NEW IS NEW!!! in Project.set_use_datablock_storage()"
-    if ['applab', 'gamelab'].include? project_type
-      puts "creating new #{project_type}..."
-      ProjectUseDatablockStorage.find_or_create_by(project_id: id) do |storage|
-        fraction = DCDO.get('fraction_of_new_projects_use_datablock_storage', 0.0)
-        storage.use_datablock_storage = rand < fraction
-        puts "new #{project_type} Project #{id}: use_datablock_storage=#{storage.use_datablock_storage}"
-      end
-    end
   end
 end

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -50,6 +50,9 @@ class Projects
     }
     row[:id] = @table.insert(row)
 
+    # TODO: post-firebase-cleanup, remove this once we switch 100% to datablock storage
+    set_use_datablock_storage row[:id], project_type
+
     storage_encrypt_channel_id(row[:storage_id], row[:id])
   end
 
@@ -447,6 +450,16 @@ class Projects
   end
 
   private
+
+  # TODO: post-firebase-cleanup, remove this once we switch 100% to datablock storage
+  def set_use_datablock_storage(project_id, project_type)
+    if ['applab', 'gamelab'].include? project_type
+      ProjectUseDatablockStorage.find_or_create_by(project_id: project_id) do |storage|
+        fraction = DCDO.get('fraction_of_new_projects_use_datablock_storage', 0.0)
+        storage.use_datablock_storage = rand < fraction
+      end
+    end
+  end
 
   #
   # Discovering a channel's project type is a real mess.  We don't usually


### PR DESCRIPTION
Create a percentage of new applab/gamelab projects using datablock_storage instead of firebase. Percentage is controlled by a DCDO flag, default percentage is 0% (don't use datablock storage ever).

When creating a new project using `Projects.create` (note this is helpers/projects.rb, not the project.rb model), roll dice and compare to `DCDO.get('fraction_of_new_projects_use_datablock_storage', 0.0)`. If dice came up positive, set `ProjectUseDatablockStorage.use_datablock_storage=true`.

This can be set on a server using `bin/dashboard-console`, followed by restarting the server:
```
# 5% use datablock_storage
DCDO.set('fraction_of_new_projects_use_datablock_storage', 0.05)
```

Fixes https://github.com/code-dot-org/code-dot-org/issues/56625