### PR TITLE
Disable CSRF on DatablockStorageController

### DIFF
--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -6,7 +6,9 @@ let channelId = undefined;
 function getAuthToken() {
   const tokenDOM = document.querySelector('meta[name="csrf-token"]');
   if (!tokenDOM) {
-    throw new Error('Could not find CSRF token');
+    //throw new Error('Could not find CSRF token');
+    console.error('Could not find CSRF token');
+    return;
   }
   return tokenDOM.content;
 }
@@ -25,7 +27,7 @@ function _fetch(path, method, params) {
         '?' +
         new URLSearchParams({
           ...params,
-          authenticity_token: getAuthToken(),
+          //authenticity_token: getAuthToken(),
         }),
       {
         method: 'GET',
@@ -37,7 +39,7 @@ function _fetch(path, method, params) {
       body: JSON.stringify(params),
       headers: {
         'Content-Type': 'application/json',
-        'X-CSRF-TOKEN': getAuthToken(),
+        //'X-CSRF-TOKEN': getAuthToken(),
         'X-Requested-With': 'XMLHttpRequest',
       },
       credentials: 'same-origin',
@@ -335,7 +337,7 @@ DatablockStorage.deleteKeyValue = function (key, onSuccess, onError) {
  * @returns {Promise} which resolves when all table data has been written
  */
 DatablockStorage.populateTable = function (jsonData) {
-  _fetch('populate_tables', 'PUT', {
+  return _fetch('populate_tables', 'PUT', {
     tables_json: JSON.stringify(jsonData),
   });
 };

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -3,16 +3,6 @@ import _ from 'lodash';
 const DatablockStorage = {};
 let channelId = undefined;
 
-function getAuthToken() {
-  const tokenDOM = document.querySelector('meta[name="csrf-token"]');
-  if (!tokenDOM) {
-    //throw new Error('Could not find CSRF token');
-    console.error('Could not find CSRF token');
-    return;
-  }
-  return tokenDOM.content;
-}
-
 function urlFor(func_name) {
   // FIXME: this doesn't work for all URLs where this can be loaded from
   // e.g. http://localhost-studio.code.org:3000/projects/applab/Yp05MnSdVubn04tBoEZn_g/edit/
@@ -25,13 +15,8 @@ function _fetch(path, method, params) {
     return fetch(
       urlFor(path) +
         '?' +
-        new URLSearchParams({
-          ...params,
-          //authenticity_token: getAuthToken(),
-        }),
-      {
-        method: 'GET',
-      }
+        new URLSearchParams(params),
+      { method: 'GET' }
     );
   } else {
     return fetch(urlFor(path), {
@@ -39,7 +24,6 @@ function _fetch(path, method, params) {
       body: JSON.stringify(params),
       headers: {
         'Content-Type': 'application/json',
-        //'X-CSRF-TOKEN': getAuthToken(),
         'X-Requested-With': 'XMLHttpRequest',
       },
       credentials: 'same-origin',

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -1,6 +1,7 @@
 class DatablockStorageController < ApplicationController
   before_action :validate_channel_id
   before_action :authenticate_user!
+  skip_before_action :verify_authenticity_token
 
   ##########################################################
   #   Debug View                                           #
@@ -103,6 +104,8 @@ class DatablockStorageController < ApplicationController
 
   def populate_tables
     tables_json = JSON.parse params[:tables_json]
+    # FIXME: unfirebase - Why are json encoding a string that's already a json encoded object?
+    tables_json = JSON.parse tables_json unless tables_json.is_a? Hash
     DatablockStorageTable.populate_tables @project_id, tables_json
     render json: true
   end


### PR DESCRIPTION
We discovered that levels loaded via the ScriptLevelsController, like http://localhost-studio.code.org:3000/s/csp6-2024/lessons/3/levels/3/sublevel/1, do not have a CSRF token. The reason is that ScriptLevelsController page views are cached by Cloud Front, so any CSRF token would be inherently outdated after the first time the script_level is loaded (see: https://github.com/code-dot-org/code-dot-org/blob/d000de6ef9c6de403367f216c5440aad983f02e5/dashboard/app/controllers/script_levels_controller.rb#L570-L573).

Since we use DatablockStorageController from a number of CSP ScriptLevels, a consequence is that we must have a way to use DatablockStorageController _without_ a CSRF token.

While this removes a "defense in depth" strategy, disabling CSRF checking does not seem to open any major security holes as `DatablockStorageController` does not expose any data-modifying GET requests.

CSRF attacks should only be viable against GET requests, as it requires the student be tricked into clicking a link. Note that CSRF is not a data exfiltration technique (generally speaking, of course exploits could theoretically be chained), instead it allows an attacker who tricks a user into performing a get-request that modifies state in some undesirable way.

### Fixes to populateTable

The CSRF issue was discovered while testing levelbuilder features that call populateTable. In the process, we also discovered an fixed a couple unrelated bugs in populateTable:
1. DatablockStorage.populateTable from datablockStorage.js wasn't returning its promise
2. DatablockStorageController.populate_table required a second JSON parse inside the existing parse due to the (braindead) way that its called by the existing Applab codepath to seed levelbuilder data.