### PR TITLE
AI Tutor: hide AI Tutor navigation link not just content of tab 

### DIFF
--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -99,7 +99,7 @@ function TeacherDashboard({
             components using Connect/Redux. Library we could use to fix issue:
             https://github.com/supasate/connected-react-router */}
           <TeacherDashboardHeader />
-          <TeacherDashboardNavigation />
+          <TeacherDashboardNavigation showAITutorTab={showAITutorTab} />
         </div>
       )}
       <Switch>

--- a/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
@@ -126,7 +126,7 @@ export default class TeacherDashboardNavigation extends Component {
       teacherDashboardLinks.push({
         label: 'AI Tutor',
         url: TeacherDashboardPath.aiTutorChatMessages,
-      },)
+      });
     }
     const links = this.props.links || teacherDashboardLinks;
     const containerStyles = this.state.shouldScroll

--- a/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
@@ -44,10 +44,6 @@ const teacherDashboardLinks = [
     label: i18n.teacherTabManageStudents(),
     url: TeacherDashboardPath.manageStudents,
   },
-  {
-    label: 'AI Tutor',
-    url: TeacherDashboardPath.aiTutorChatMessages,
-  },
 ];
 
 const ListPosition = {
@@ -58,6 +54,7 @@ const ListPosition = {
 
 export default class TeacherDashboardNavigation extends Component {
   static propTypes = {
+    showAITutorTab: PropTypes.bool,
     links: PropTypes.arrayOf(
       PropTypes.shape({
         label: PropTypes.string.isRequired,
@@ -125,6 +122,12 @@ export default class TeacherDashboardNavigation extends Component {
 
   render() {
     const {listPosition, shouldScroll} = this.state;
+    if (this.props.showAITutorTab) {
+      teacherDashboardLinks.push({
+        label: 'AI Tutor',
+        url: TeacherDashboardPath.aiTutorChatMessages,
+      },)
+    }
     const links = this.props.links || teacherDashboardLinks;
     const containerStyles = this.state.shouldScroll
       ? {...styles.container, ...styles.scrollableContainer}


### PR DESCRIPTION
Follow up to #56665

This hides the link in the teacher dashboard navigation for AI Tutor when the teacher does not have access to AI Tutor chats. Previously, I was only hiding the contents of the tab, but the link was visible 😱 Hooray for[ eyes tests](https://eyes.applitools.com/app/test-results/00000251693819779456/00000251693819779339/steps/1?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor) catching this bug. 