### PR TITLE
P20-628: Refactor unit tests of `I18n::Utils::SyncDownBase#cdo_languages`

### DIFF
--- a/bin/test/i18n/utils/test_sync_down_base.rb
+++ b/bin/test/i18n/utils/test_sync_down_base.rb
@@ -262,26 +262,30 @@ describe I18n::Utils::SyncDownBase do
       _(crowdin_client).must_equal expected_i18n_utils_crowdin_client_instance
     end
   end
-  # This test fails in the test environment while passing locally and in Drone.
-  # For some reason, the test environment is not loading the CdoLanguages class.
-  # describe '#cdo_languages' do
-  #   let(:cdo_languages) {described_instance.send(:cdo_languages)}
-  #
-  #   let(:crowdin_client) {stub(:crowdin_client)}
-  #
-  #   before do
-  #     described_instance.stubs(:crowdin_client).returns(crowdin_client)
-  #   end
-  #
-  #   it 'returns CDO languages supported by the Crowdin project' do
-  #     available_crowdin_lang_id = 'uk'
-  #
-  #     crowdin_client.expects(:get_project).returns('targetLanguages' => [{'id' => available_crowdin_lang_id}])
-  #
-  #     _(cdo_languages.first&.class&.name).must_equal 'CdoLanguages'
-  #     _(cdo_languages.map {|lang| lang[:crowdin_code_s]}).must_equal [available_crowdin_lang_id]
-  #   end
-  # end
+
+  describe '#cdo_languages' do
+    let(:cdo_languages) {described_instance.send(:cdo_languages)}
+
+    let(:crowdin_client) {stub(:crowdin_client)}
+
+    before do
+      described_instance.stubs(:crowdin_client).returns(crowdin_client)
+    end
+
+    it 'returns CDO languages supported by the Crowdin project' do
+      available_crowdin_lang_id = 'uk'
+
+      crowdin_client.
+        expects(:get_project).
+        returns('targetLanguages' => [{'id' => available_crowdin_lang_id}])
+
+      I18nScriptUtils.
+        expects(:cdo_languages).
+        returns([{crowdin_code_s: 'unavailable_crowdin_lang_id'}, {crowdin_code_s: available_crowdin_lang_id}])
+
+      _(cdo_languages).must_equal [{crowdin_code_s: available_crowdin_lang_id}]
+    end
+  end
 
   describe '#source_files' do
     let(:source_files) {described_instance.send(:source_files, crowdin_src)}


### PR DESCRIPTION
### Issue (on the test env)
```
I18n::Utils::SyncDownBase::#cdo_languages
  test_0001_returns CDO languages supported by the Crowdin projectERROR (0.00s)
Minitest::UnexpectedError:         NameError: uninitialized constant CdoLanguages
            /home/ubuntu/test/bin/test/i18n/utils/test_sync_down_base.rb:280:in `block (3 levels) in <top (required)>'
```
- JIRA ticket: [P20-628](https://codedotorg.atlassian.net/browse/P20-628)
- https://github.com/code-dot-org/code-dot-org/pull/56680
- https://github.com/code-dot-org/code-dot-org/pull/56688