### PR TITLE
Flaky eyes test Teacher dashboard assessments tab survey submissions

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -236,8 +236,13 @@ When /^I wait until (?:element )?"([^"]*)" is (not )?checked$/ do |selector, neg
   wait_until {@browser.execute_script("return $(\"#{selector}\").is(':checked');") == negation.nil?}
 end
 
+def jquery_is_defined
+  "(typeof jQuery !== 'undefined') && ($ !== 'undefined')"
+end
+
 def jquery_is_element_visible(selector)
-  "return (typeof jQuery !== 'undefined') && $(#{selector.dump}).is(':visible') && $(#{selector.dump}).css('visibility') !== 'hidden';"
+  "return #{jquery_is_defined} &&" +
+  " $(#{selector.dump}).is(':visible') && $(#{selector.dump}).css('visibility') !== 'hidden';"
 end
 
 def jquery_is_element_displayed(selector)
@@ -960,7 +965,7 @@ end
 
 def wait_for_jquery
   wait_until do
-    @browser.execute_script("return (typeof jQuery !== 'undefined');")
+    @browser.execute_script("return #{jquery_is_defined};")
   rescue Selenium::WebDriver::Error::ScriptTimeoutError
     puts "execute_script timed out after 30 seconds, likely because this is \
 Safari and the browser was still on about:blank when wait_for_jquery \

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -241,8 +241,7 @@ def jquery_is_defined
 end
 
 def jquery_is_element_visible(selector)
-  "return #{jquery_is_defined} &&" +
-  " $(#{selector.dump}).is(':visible') && $(#{selector.dump}).css('visibility') !== 'hidden';"
+  "return #{jquery_is_defined} && $(#{selector.dump}).is(':visible') && $(#{selector.dump}).css('visibility') !== 'hidden';"
 end
 
 def jquery_is_element_displayed(selector)

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -236,12 +236,8 @@ When /^I wait until (?:element )?"([^"]*)" is (not )?checked$/ do |selector, neg
   wait_until {@browser.execute_script("return $(\"#{selector}\").is(':checked');") == negation.nil?}
 end
 
-def jquery_is_defined
-  "(typeof jQuery !== 'undefined') && ($ !== 'undefined')"
-end
-
 def jquery_is_element_visible(selector)
-  "return #{jquery_is_defined} && $(#{selector.dump}).is(':visible') && $(#{selector.dump}).css('visibility') !== 'hidden';"
+  "return $(#{selector.dump}).is(':visible') && $(#{selector.dump}).css('visibility') !== 'hidden';"
 end
 
 def jquery_is_element_displayed(selector)
@@ -964,7 +960,7 @@ end
 
 def wait_for_jquery
   wait_until do
-    @browser.execute_script("return #{jquery_is_defined};")
+    @browser.execute_script("return (typeof jQuery !== 'undefined');")
   rescue Selenium::WebDriver::Error::ScriptTimeoutError
     puts "execute_script timed out after 30 seconds, likely because this is \
 Safari and the browser was still on about:blank when wait_for_jquery \

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -237,7 +237,7 @@ When /^I wait until (?:element )?"([^"]*)" is (not )?checked$/ do |selector, neg
 end
 
 def jquery_is_element_visible(selector)
-  "return $(#{selector.dump}).is(':visible') && $(#{selector.dump}).css('visibility') !== 'hidden';"
+  "return (typeof jQuery !== 'undefined') && $(#{selector.dump}).is(':visible') && $(#{selector.dump}).css('visibility') !== 'hidden';"
 end
 
 def jquery_is_element_displayed(selector)

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2.feature
@@ -1,5 +1,5 @@
 @no_mobile
-@no_firefox
+
 Feature: Using the assessments tab in the teacher dashboard
 
   Scenario: Assessments tab survey submissions

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2.feature
@@ -35,7 +35,7 @@ Feature: Using the assessments tab in the teacher dashboard
     And I press "assignment-version-year"
     And I click selector ".assignment-version-title:contains('17-'18)" once I see it
     And I select the "CSP Student Post-Course Survey ('17-'18)" option in dropdown "uitest-secondary-assignment"
-    And I press the first "#uitest-save-section-changes" element
+    And I press the first "#uitest-save-section-changes" element to load a new page
     And I wait until element "#classroom-sections" is visible
 
     # Progress tab


### PR DESCRIPTION
Eyes test `Firefox_teacher_tools_teacher_dashboard_teacher_dashboard_assessments2_Assessments tab survey submissions` intermittently fails with `ReferenceError: $ is not defined` error when waiting for an element on teacher dashboard page.

### Root cause analysis:
Spot checked multiple failure examples (https://app.saucelabs.com/tests/770b726d37fe4e8d9c9be7d3ab95d017#308, https://app.saucelabs.com/tests/9b28115386bd480f8adfa517907b6a89#280) of this test in sauce labs and noticed the below pattern,

1. Checking for jQuery loaded `"return (typeof jQuery !== 'undefined');"` returns `true`
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/d50cf19c-1601-4741-9db1-20001d8c3757)

2. Checking for element visibility `"return $(\"#classroom-sections\").is(':visible') && $(\"#classroom-sections\").css('visibility') !== 'hidden';"` returns `false` (this happens 0 or more times)
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/9258e6cd-9f7c-4d6b-a1a2-493f71f0e94c)

3. Same call to check for element visibility throws error that jQuery isn't loaded. 
 ![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/a386228a-52ec-43b5-955e-4cf4448b38ba)

Looking at the screen shots for these steps, we see that when step #2 is executing, it is still in the section set up page and not transitioned to the dashboard. So, the jQuery load check isn't happening on the correct page leading to this issue.

### Fix
Wait for the new page to load after hitting save button.
 
## Links

JIRA https://codedotorg.atlassian.net/browse/TEACH-830?atlOrigin=eyJpIjoiZjUwZTc3NmRiNDVkNDNlMWExNDlmNDEzZGU4NDQ3ZGYiLCJwIjoiaiJ9

## Testing story

Validated the teacher dashboard test locally. Relying on drone to catch any issues this change causes on other tests.

## Deployment strategy
Regular DTP

## Follow-up work

None at this time. Curious if folks think we should follow up this change in other jQueries if this improves reliability

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
