### PR TITLE
[Google Blockly] Functions: fix destroy override; add doProcedureUpdate override

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.js
@@ -98,7 +98,6 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedure_caller_context_menu_mixin',
       'procedure_caller_onchange_mixin',
       'behavior_caller_get_def_block_mixin',
-      'modal_procedures_no_destroy',
       'behavior_create_def_mixin',
     ],
     mutator: 'behavior_get_mutator',

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.js
@@ -87,7 +87,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedure_caller_context_menu_mixin',
       'procedure_caller_onchange_mixin',
       'procedure_callernoreturn_get_def_block_mixin',
-      'procedure_call_heal_stack',
+      'procedure_call_do_update',
     ],
     mutator: 'procedure_caller_mutator',
   },
@@ -208,7 +208,9 @@ GoogleBlockly.Extensions.register('modal_procedures_no_destroy', function () {
 
 // Override the doProcedureUpdate function to heal the stack. Without this,
 // any child blocks connected to a call block would also get deleted.
-GoogleBlockly.Extensions.register('procedure_call_heal_stack', function () {
+// Copied directly from
+// https://github.com/BeksOmega/blockly-samples/blob/7954a8fff50e41fa7c0f891e957bf9ed616361d6/plugins/block-shareable-procedures/src/blocks.ts#L1068
+GoogleBlockly.Extensions.register('procedure_call_do_update', function () {
   const mixin = {
     /**
      * Updates the shape of this block to reflect the state of the data model.


### PR DESCRIPTION
Last month, @sanchitmalhotra126 [noticed](https://codedotorg.slack.com/archives/C05DK21DAHK/p1706554295359669) that if you delete a function definition from the main workspace an error was caused because we weren't disposing the associated call blocks. This was observed in Music Lab as well as Dance but can really happen in any level that doesn't use the modal function editor.

In Core Blockly, deleting a definition deletes any call blocks:
![2024-02-21 16-29-03 2024-02-21 16_29_15](https://github.com/code-dot-org/code-dot-org/assets/43474485/6b3a3b7d-aa74-4a8b-a827-ec03fca32272)

The reason we weren't doing the same was due to an override of the definition blocks' `destroy` function. We knew we needed to no-op this function for the modal function editor so that closing it wouldn't cause us to delete the shared procedures. What we missed is that we _should_ delete the procedures if we're on the main workspace, ie. when we're not using the modal editor.

One curious discovery while fixing this was that insertion markers (the gray block outlines that show where a real block is about to snap into place) also get this function. We don't want an automatic insertion marker deletion to trigger a procedure to get deleted either.

Once that logic was added, things were working mostly as expected, except that I discovered that the stack was not being "healed", ie. all child blocks were also getting disposed. (It's only a coincidence that @molly-moen had to fix the same issue for our modal editor's delete button: https://github.com/code-dot-org/code-dot-org/pull/56712/commits/25ebd30df5c4d35d2723ca759505f0d5dd9c14e3) What is strange about this is that the plugin assumes a different default behavior here compared with core. Notice that that a `healStack` boolean is not passed: 
https://github.com/BeksOmega/blockly-samples/blob/7954a8fff50e41fa7c0f891e957bf9ed616361d6/plugins/block-shareable-procedures/src/blocks.ts#L1068
You can see that regardless of which workspace, deleting the definition causes the children of the associated call block to be disposed.

![2024-02-21 16-38-29 2024-02-21 16_38_47](https://github.com/code-dot-org/code-dot-org/assets/43474485/cf28739c-1006-40a8-b374-f6e53a317a76)

We don't want this behavior, which unfortunately means we have to override `doProcedureUpdate` as well.

These changes are only needed for functions and not behaviors as behavior definitions should never show up on the primary workspace.
While testing this, I noticed a new crash when opening the behaviors category. The cause was that the modified destroy function was unnecessarily being added to behavior get blocks as well. (The error was because they didn't have an original `this.destroy` to store.) We don't ever need to no-op a function that shouldn't be there in the first place so I removed the mixin from those blocks.

## Links

Slack thread: https://codedotorg.slack.com/archives/C05DK21DAHK/p1706554295359669

Jira: https://codedotorg.atlassian.net/browse/CT-303

## Testing story

I tested that this is working as expected in a no-modal Sprite Lab level and in Music Lab. No regressions were observed using the modal editor in the Sprite Lab project level.

![2024-02-21 16-42-51 2024-02-21 16_45_09](https://github.com/code-dot-org/code-dot-org/assets/43474485/a44d192e-678b-490d-84ea-1faa0f533ad8)|![2024-02-21 16-44-53 2024-02-21 16_45_02](https://github.com/code-dot-org/code-dot-org/assets/43474485/c27c630b-ee59-45d9-8bd4-e6ad194dc9d7)
-|-


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
