### PR TITLE
Fix for ethnicity form submission

### DIFF
--- a/apps/src/sites/studio/pages/layouts/_race_interstitial.js
+++ b/apps/src/sites/studio/pages/layouts/_race_interstitial.js
@@ -39,7 +39,6 @@ $(document).ready(() => {
       type: 'POST',
       url: form.prop('action'),
       data: form.serialize(),
-      dataType: 'json',
       success: data => $('#race-modal').modal('hide'),
     });
   }
@@ -56,9 +55,7 @@ $(document).ready(() => {
     submitCheckboxData(editUser);
     $('#race-modal').modal('hide');
   });
-});
 
-$(document).ready(() => {
   $('#race-modal').modal('show');
   $('#closed-dialog-label').hide();
 });

--- a/apps/src/sites/studio/pages/layouts/_race_interstitial.js
+++ b/apps/src/sites/studio/pages/layouts/_race_interstitial.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 
 $(document).ready(() => {
-  var editUser = $('#edit_user');
+  var editUser = $('#edit_user_race');
   var raceCheckboxes = $('.race-checkbox');
 
   editUser.on('change', () => {

--- a/apps/src/sites/studio/pages/layouts/_race_interstitial.js
+++ b/apps/src/sites/studio/pages/layouts/_race_interstitial.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 
 $(document).ready(() => {
-  var editUser = $('#edit_user_race');
+  var editUser = $('#edit_user_race_form');
   var raceCheckboxes = $('.race-checkbox');
 
   editUser.on('change', () => {

--- a/dashboard/app/views/layouts/_race_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_race_interstitial.html.haml
@@ -5,7 +5,7 @@
 
       %p= t('race_interstitial.message')
       .left.full-width
-        = form_for(current_user, url: registration_url('user'), html: {id: 'edit_user_race'}) do |f|
+        = form_for(current_user, url: registration_url('user'), html: {id: 'edit_user_race_form'}) do |f|
           .form-group
             - Policies::Races::DISPLAY_RACES.map do |race|
               = f.label "races_#{race}" do

--- a/dashboard/app/views/layouts/_race_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_race_interstitial.html.haml
@@ -5,7 +5,7 @@
 
       %p= t('race_interstitial.message')
       .left.full-width
-        = form_for(current_user, url: registration_url('user'), html: {id: 'edit_user'}) do |f|
+        = form_for(current_user, url: registration_url('user'), html: {id: 'edit_user_race'}) do |f|
           .form-group
             - Policies::Races::DISPLAY_RACES.map do |race|
               = f.label "races_#{race}" do


### PR DESCRIPTION
The ethnicity response drop off investigation led to the following conclusions:
1. The form would not close when submitted, prompting students to click the 'Cancel' button which records a 'closed_dialog' or students would refresh the page which records 'null'.
2. When this pop-up was overlayed another pop-up with a form, the javascript for the form would not work because the same id is being used to identify both forms.

To fix Issue 1, there was a parser error on the response of the AJAX request. Since we don't make use of the response data itself, removing the dataType field, which expected json, resulted in a successful submission.
To fix issue 2, renaming the form id for the race form allowed for submission.

## Issue 1 Fix

https://github.com/code-dot-org/code-dot-org/assets/137838584/8e561693-6389-4e1b-9160-d9ba90f843a3

<img width="1412" alt="Screenshot 2024-02-22 at 11 14 03 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/385dc9c5-7492-49a6-b15b-556df46742ec">




## Issue 2: Submit button not enabled when selecting an ethnicity and there are forms overlayed:
<img width="951" alt="Screenshot 2024-02-22 at 9 25 43 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/df00d912-d9ce-4fd1-b15c-fbd067c66e2f">

## Issue 2: After changing the form id
<img width="747" alt="Screenshot 2024-02-22 at 9 28 08 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/c2769ddc-619a-4dfc-b6a1-c0917f460636">

## Links
- jira ticket: [here](https://codedotorg.atlassian.net/browse/P20-715)


## Testing story
Local

## Follow-up work



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
