### PR TITLE
Lab2: prevent clicks when loading

### DIFF
--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -68,6 +68,7 @@
 
     &.showingBlock {
       opacity: 1;
+      pointer-events: initial;
     }
 
     &.fadeInBlock {


### PR DESCRIPTION
Prevent clicks from reaching UI elements that are visually hidden (but still in existence) when loading a new Lab2 level.

Prior to this change, it was possible to rapidly click on a "Continue" button in Music Lab and, even though it was no longer visible after the first click, it would keep receiving clicks and jump to a new level.

With this change, the "fade overlay" `div` consumes those clicks while loading is happening.
