### PR TITLE
P20-630: Implement independent i18n sync-down of Pegasus resources

### DIFF
--- a/bin/i18n/resources/pegasus.rb
+++ b/bin/i18n/resources/pegasus.rb
@@ -3,6 +3,8 @@ require_relative '../i18n_script_utils'
 module I18n
   module Resources
     module Pegasus
+      DIR_NAME = 'pegasus'.freeze
+
       def self.sync_in
         HourOfCode.sync_in
         Markdown.sync_in
@@ -13,6 +15,12 @@ module I18n
         HourOfCode.sync_up(**opts)
         Markdown.sync_up(**opts)
         Mobile.sync_up(**opts)
+      end
+
+      def self.sync_down(**opts)
+        HourOfCode.sync_down(**opts)
+        Markdown.sync_down(**opts)
+        Mobile.sync_down(**opts)
       end
 
       def self.sync_out

--- a/bin/i18n/resources/pegasus/hourofcode.rb
+++ b/bin/i18n/resources/pegasus/hourofcode.rb
@@ -4,6 +4,7 @@ module I18n
   module Resources
     module Pegasus
       module HourOfCode
+        CROWDIN_PROJECT = 'hour-of-code'.freeze
         DIR_NAME = 'hourofcode'.freeze
         ORIGIN_I18N_FILE_NAME = 'en.yml'.freeze
         MARKDOWN_DIR_NAME = 'public'.freeze
@@ -19,6 +20,10 @@ module I18n
 
         def self.sync_up(**opts)
           SyncUp.perform(**opts)
+        end
+
+        def self.sync_down(**opts)
+          SyncDown.perform(**opts)
         end
 
         def self.sync_out

--- a/bin/i18n/resources/pegasus/hourofcode/sync_down.rb
+++ b/bin/i18n/resources/pegasus/hourofcode/sync_down.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../i18n_script_utils'
+require_relative '../../../utils/sync_down_base'
+require_relative '../hourofcode'
+
+module I18n
+  module Resources
+    module Pegasus
+      module HourOfCode
+        class SyncDown < I18n::Utils::SyncDownBase
+          config.crowdin_project = CROWDIN_PROJECT
+          config.download_paths << DownloadPath.new(dest_subdir: DIR_NAME)
+        end
+      end
+    end
+  end
+end
+
+I18n::Resources::Pegasus::HourOfCode::SyncDown.perform if __FILE__ == $0

--- a/bin/i18n/resources/pegasus/hourofcode/sync_up.rb
+++ b/bin/i18n/resources/pegasus/hourofcode/sync_up.rb
@@ -9,7 +9,7 @@ module I18n
     module Pegasus
       module HourOfCode
         class SyncUp < I18n::Utils::SyncUpBase
-          config.crowdin_project = 'hour-of-code'
+          config.crowdin_project = CROWDIN_PROJECT
           config.base_path = I18N_SOURCE_DIR_PATH
           config.source_paths << 'en.yml'
           config.source_paths << '**/*.md'

--- a/bin/i18n/resources/pegasus/markdown.rb
+++ b/bin/i18n/resources/pegasus/markdown.rb
@@ -4,6 +4,8 @@ module I18n
   module Resources
     module Pegasus
       module Markdown
+        CROWDIN_PROJECT = 'codeorg-markdown'.freeze
+        DIR_NAME = 'codeorg-markdown'.freeze
         PARTIAL_EXTNAME = '.partial'.freeze
         ORIGIN_DIR_PATH = CDO.dir('pegasus/sites.v3/code.org').freeze
         ORIGIN_I18N_DIR_PATH = File.join(ORIGIN_DIR_PATH, 'i18n').freeze
@@ -15,6 +17,10 @@ module I18n
 
         def self.sync_up(**opts)
           SyncUp.perform(**opts)
+        end
+
+        def self.sync_down(**opts)
+          SyncDown.perform(**opts)
         end
 
         def self.sync_out

--- a/bin/i18n/resources/pegasus/markdown/sync_down.rb
+++ b/bin/i18n/resources/pegasus/markdown/sync_down.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../i18n_script_utils'
+require_relative '../../../utils/sync_down_base'
+require_relative '../markdown'
+
+module I18n
+  module Resources
+    module Pegasus
+      module Markdown
+        class SyncDown < I18n::Utils::SyncDownBase
+          config.crowdin_project = CROWDIN_PROJECT
+          config.download_paths << DownloadPath.new(dest_subdir: DIR_NAME)
+        end
+      end
+    end
+  end
+end
+
+I18n::Resources::Pegasus::Markdown::SyncDown.perform if __FILE__ == $0

--- a/bin/i18n/resources/pegasus/markdown/sync_out.rb
+++ b/bin/i18n/resources/pegasus/markdown/sync_out.rb
@@ -12,8 +12,6 @@ module I18n
     module Pegasus
       module Markdown
         class SyncOut < I18n::Utils::SyncOutBase
-          DIR_NAME = 'codeorg-markdown'.freeze
-
           def process(language)
             crowdin_locale_dir = I18nScriptUtils.locale_dir(language[:crowdin_name_s], DIR_NAME)
             return unless File.directory?(crowdin_locale_dir)

--- a/bin/i18n/resources/pegasus/markdown/sync_up.rb
+++ b/bin/i18n/resources/pegasus/markdown/sync_up.rb
@@ -9,7 +9,7 @@ module I18n
     module Pegasus
       module Markdown
         class SyncUp < I18n::Utils::SyncUpBase
-          config.crowdin_project = 'codeorg-markdown'
+          config.crowdin_project = CROWDIN_PROJECT
           config.base_path = I18N_SOURCE_DIR_PATH
           config.source_paths << '**/*.md'
           config.ignore_paths << 'ai.md'

--- a/bin/i18n/resources/pegasus/mobile.rb
+++ b/bin/i18n/resources/pegasus/mobile.rb
@@ -1,15 +1,16 @@
 require_relative '../../i18n_script_utils'
+require_relative '../pegasus'
 
 module I18n
   module Resources
     module Pegasus
       module Mobile
-        DIR_NAME = 'pegasus'
         FILE_NAME = 'mobile.yml'
+        FILE_PATH = File.join(DIR_NAME, FILE_NAME).freeze
         ORIGIN_I18N_DIR_PATH = CDO.dir('pegasus/cache/i18n').freeze
 
         ORIGINAL_I18N_FILE_PATH = File.join(ORIGIN_I18N_DIR_PATH, 'en-US.yml').freeze
-        I18N_SOURCE_FILE_PATH = CDO.dir(I18N_SOURCE_DIR, DIR_NAME, FILE_NAME).freeze
+        I18N_SOURCE_FILE_PATH = CDO.dir(I18N_SOURCE_DIR, FILE_PATH).freeze
 
         def self.sync_in
           SyncIn.perform
@@ -17,6 +18,10 @@ module I18n
 
         def self.sync_up(**opts)
           SyncUp.perform(**opts)
+        end
+
+        def self.sync_down(**opts)
+          SyncDown.perform(**opts)
         end
 
         def self.sync_out

--- a/bin/i18n/resources/pegasus/mobile/sync_down.rb
+++ b/bin/i18n/resources/pegasus/mobile/sync_down.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../i18n_script_utils'
+require_relative '../../../utils/sync_down_base'
+require_relative '../mobile'
+
+module I18n
+  module Resources
+    module Pegasus
+      module Mobile
+        class SyncDown < I18n::Utils::SyncDownBase
+          config.download_paths << DownloadPath.new(crowdin_src: FILE_PATH)
+        end
+      end
+    end
+  end
+end
+
+I18n::Resources::Pegasus::Mobile::SyncDown.perform if __FILE__ == $0

--- a/bin/i18n/resources/pegasus/mobile/sync_out.rb
+++ b/bin/i18n/resources/pegasus/mobile/sync_out.rb
@@ -10,13 +10,13 @@ module I18n
       module Mobile
         class SyncOut < I18n::Utils::SyncOutBase
           def process(language)
-            crowdin_file_path = I18nScriptUtils.locale_dir(language[:crowdin_name_s], DIR_NAME, FILE_NAME)
-            return unless File.exist?(crowdin_file_path)
+            crowdin_file_path = I18nScriptUtils.locale_dir(language[:crowdin_name_s], FILE_PATH)
+            return unless File.file?(crowdin_file_path)
 
             pegasus_i18n_file_poth = File.join(ORIGIN_I18N_DIR_PATH, "#{language[:locale_s]}.yml")
             I18nScriptUtils.sanitize_file_and_write(crowdin_file_path, pegasus_i18n_file_poth)
 
-            I18nScriptUtils.move_file(crowdin_file_path, I18nScriptUtils.locale_dir(language[:locale_s], DIR_NAME, FILE_NAME))
+            I18nScriptUtils.move_file(crowdin_file_path, I18nScriptUtils.locale_dir(language[:locale_s], FILE_PATH))
           end
         end
       end

--- a/bin/i18n/utils/sync_down_base.rb
+++ b/bin/i18n/utils/sync_down_base.rb
@@ -63,7 +63,7 @@ module I18n
           source_files = source_files(download_path[:crowdin_src])
 
           progress_bar = I18nScriptUtils.create_progress_bar(
-            title: "#{self.class.name}[#{File.join(crowdin_project, download_path[:crowdin_src])}]",
+            title: "#{self.class.name}[#{File.join(crowdin_project, download_path[:crowdin_src].to_s)}]",
             total: cdo_languages.size * source_files.size,
             format: '%t: |%W| %c/%C %a',
           )

--- a/bin/test/i18n/resources/pegasus/houtofcode/test_sync_down.rb
+++ b/bin/test/i18n/resources/pegasus/houtofcode/test_sync_down.rb
@@ -1,0 +1,11 @@
+require_relative '../../../../test_helper'
+require_relative '../../../../../i18n/resources/apps/animations/sync_down'
+
+describe I18n::Resources::Apps::Animations::SyncDown do
+  let(:described_class) {I18n::Resources::Apps::Animations::SyncDown}
+  let(:described_instance) {described_class.new}
+
+  it 'inherits from I18n::Utils::SyncDownBase' do
+    _(described_class.superclass).must_equal I18n::Utils::SyncDownBase
+  end
+end

--- a/bin/test/i18n/resources/pegasus/houtofcode/test_sync_down.rb
+++ b/bin/test/i18n/resources/pegasus/houtofcode/test_sync_down.rb
@@ -1,8 +1,8 @@
 require_relative '../../../../test_helper'
-require_relative '../../../../../i18n/resources/apps/animations/sync_down'
+require_relative '../../../../../i18n/resources/pegasus/hourofcode/sync_down'
 
-describe I18n::Resources::Apps::Animations::SyncDown do
-  let(:described_class) {I18n::Resources::Apps::Animations::SyncDown}
+describe I18n::Resources::Pegasus::HourOfCode::SyncDown do
+  let(:described_class) {I18n::Resources::Pegasus::HourOfCode::SyncDown}
   let(:described_instance) {described_class.new}
 
   it 'inherits from I18n::Utils::SyncDownBase' do

--- a/bin/test/i18n/resources/pegasus/markdown/test_sync_down.rb
+++ b/bin/test/i18n/resources/pegasus/markdown/test_sync_down.rb
@@ -1,0 +1,11 @@
+require_relative '../../../../test_helper'
+require_relative '../../../../../i18n/resources/pegasus/hourofcode/sync_down'
+
+describe I18n::Resources::Pegasus::HourOfCode::SyncDown do
+  let(:described_class) {I18n::Resources::Pegasus::HourOfCode::SyncDown}
+  let(:described_instance) {described_class.new}
+
+  it 'inherits from I18n::Utils::SyncDownBase' do
+    _(described_class.superclass).must_equal I18n::Utils::SyncDownBase
+  end
+end

--- a/bin/test/i18n/resources/pegasus/markdown/test_sync_down.rb
+++ b/bin/test/i18n/resources/pegasus/markdown/test_sync_down.rb
@@ -1,8 +1,8 @@
 require_relative '../../../../test_helper'
-require_relative '../../../../../i18n/resources/pegasus/hourofcode/sync_down'
+require_relative '../../../../../i18n/resources/pegasus/markdown/sync_down'
 
-describe I18n::Resources::Pegasus::HourOfCode::SyncDown do
-  let(:described_class) {I18n::Resources::Pegasus::HourOfCode::SyncDown}
+describe I18n::Resources::Pegasus::Markdown::SyncDown do
+  let(:described_class) {I18n::Resources::Pegasus::Markdown::SyncDown}
   let(:described_instance) {described_class.new}
 
   it 'inherits from I18n::Utils::SyncDownBase' do

--- a/bin/test/i18n/resources/pegasus/mobile/test_sync_down.rb
+++ b/bin/test/i18n/resources/pegasus/mobile/test_sync_down.rb
@@ -1,0 +1,11 @@
+require_relative '../../../../test_helper'
+require_relative '../../../../../i18n/resources/pegasus/markdown/sync_down'
+
+describe I18n::Resources::Pegasus::Markdown::SyncDown do
+  let(:described_class) {I18n::Resources::Pegasus::Markdown::SyncDown}
+  let(:described_instance) {described_class.new}
+
+  it 'inherits from I18n::Utils::SyncDownBase' do
+    _(described_class.superclass).must_equal I18n::Utils::SyncDownBase
+  end
+end

--- a/bin/test/i18n/resources/pegasus/mobile/test_sync_down.rb
+++ b/bin/test/i18n/resources/pegasus/mobile/test_sync_down.rb
@@ -1,8 +1,8 @@
 require_relative '../../../../test_helper'
-require_relative '../../../../../i18n/resources/pegasus/markdown/sync_down'
+require_relative '../../../../../i18n/resources/pegasus/mobile/sync_down'
 
-describe I18n::Resources::Pegasus::Markdown::SyncDown do
-  let(:described_class) {I18n::Resources::Pegasus::Markdown::SyncDown}
+describe I18n::Resources::Pegasus::Mobile::SyncDown do
+  let(:described_class) {I18n::Resources::Pegasus::Mobile::SyncDown}
   let(:described_instance) {described_class.new}
 
   it 'inherits from I18n::Utils::SyncDownBase' do

--- a/bin/test/i18n/resources/pegasus/test_hourofcode.rb
+++ b/bin/test/i18n/resources/pegasus/test_hourofcode.rb
@@ -18,6 +18,13 @@ describe I18n::Resources::Pegasus::HourOfCode do
     end
   end
 
+  describe '.sync_down' do
+    it 'sync-down HourOfCode resource' do
+      described_class::SyncDown.expects(:perform).once
+      described_class.sync_down
+    end
+  end
+
   describe '.sync_out' do
     it 'sync-out HourOfCode resource' do
       described_class::SyncOut.expects(:perform).once

--- a/bin/test/i18n/resources/pegasus/test_markdown.rb
+++ b/bin/test/i18n/resources/pegasus/test_markdown.rb
@@ -18,6 +18,13 @@ describe I18n::Resources::Pegasus::Markdown do
     end
   end
 
+  describe '.sync_down' do
+    it 'sync-down Markdown resource' do
+      described_class::SyncDown.expects(:perform).once
+      described_class.sync_down
+    end
+  end
+
   describe '.sync_out' do
     it 'sync-out Markdown resource' do
       described_class::SyncOut.expects(:perform).once

--- a/bin/test/i18n/resources/pegasus/test_mobile.rb
+++ b/bin/test/i18n/resources/pegasus/test_mobile.rb
@@ -18,6 +18,13 @@ describe I18n::Resources::Pegasus::Mobile do
     end
   end
 
+  describe '.sync_down' do
+    it 'sync-down Mobile resource' do
+      described_class::SyncDown.expects(:perform).once
+      described_class.sync_down
+    end
+  end
+
   describe '.sync_out' do
     it 'sync-out Mobile resource' do
       described_class::SyncOut.expects(:perform).once

--- a/bin/test/i18n/resources/test_pegasus.rb
+++ b/bin/test/i18n/resources/test_pegasus.rb
@@ -28,6 +28,18 @@ describe I18n::Resources::Pegasus do
     end
   end
 
+  describe '.sync_down' do
+    it 'sync-down Pegasus resources' do
+      execution_sequence = sequence('execution')
+
+      described_class::HourOfCode.expects(:sync_down).in_sequence(execution_sequence)
+      described_class::Markdown.expects(:sync_down).in_sequence(execution_sequence)
+      described_class::Mobile.expects(:sync_down).in_sequence(execution_sequence)
+
+      described_class.sync_down
+    end
+  end
+
   describe '.sync_out' do
     it 'sync-out Pegasus resources' do
       execution_sequence = sequence('execution')


### PR DESCRIPTION
1. [Created the `Pegasus/HourOfCode` i18n sync-down script](https://github.com/code-dot-org/code-dot-org/commit/b1e490306c6875edd0db3167b618bfb6f8b92550)
2. [Created the `Pegasus/Markdown` i18n sync-down script](https://github.com/code-dot-org/code-dot-org/commit/77e1953c59747d77ae35de800ee24d3f8d21af3d)
3. [Created the `Pegasus/Mobile` i18n sync-down script](https://github.com/code-dot-org/code-dot-org/commit/ecbf48279d42f15c10afa86707bf9f39c5e4b3cf)

- JIRA ticket: [P20-630](https://codedotorg.atlassian.net/browse/P20-630)
- https://github.com/code-dot-org/code-dot-org/pull/56630
- https://github.com/code-dot-org/code-dot-org/pull/56671