### PR TITLE
[Google Blockly] Migrate renderer code to typescript

### DIFF
--- a/apps/src/blockly/addons/cdoConnectionChecker.ts
+++ b/apps/src/blockly/addons/cdoConnectionChecker.ts
@@ -1,4 +1,4 @@
-import GoogleBlockly from 'blockly/core';
+import GoogleBlockly, {Connection} from 'blockly/core';
 import {customConnectionBlockTypes} from './cdoConstants';
 
 /**
@@ -21,7 +21,7 @@ export default class CdoConnectionChecker extends GoogleBlockly.ConnectionChecke
    * @param b Connection to compare against.
    * @returns True if the connections share a type.
    */
-  doTypeChecks(a, b) {
+  doTypeChecks(a: Connection, b: Connection) {
     const checkArrayOne = a.getCheck(); // An array of strings or null
     const checkArrayTwo = b.getCheck(); // An array of strings or null
 

--- a/apps/src/blockly/addons/cdoConstantsProvider.ts
+++ b/apps/src/blockly/addons/cdoConstantsProvider.ts
@@ -1,8 +1,12 @@
-import GoogleBlockly from 'blockly/core';
+import GoogleBlockly, {Connection} from 'blockly/core';
 import {customConnectionBlockTypes} from './cdoConstants';
+import {PuzzleTab} from 'blockly/core/renderers/common/constants';
 
 export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
   .ConstantProvider {
+  private RECT_INPUT_OUTPUT: PuzzleTab | undefined;
+  private TRI_INPUT_OUTPUT: PuzzleTab | undefined;
+  private ROUND_INPUT_OUTPUT: PuzzleTab | undefined;
   /**
    * Get an object with connection shape and sizing information based on the
    * type of the connection.
@@ -11,7 +15,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
    * @returns The shape object for the connection.
    * @override
    */
-  shapeFor(connection) {
+  shapeFor(connection: Connection) {
     const blockTypeShapeMap = {
       [customConnectionBlockTypes.SPRITE]: this.TRI_INPUT_OUTPUT,
       [customConnectionBlockTypes.BEHAVIOR]: this.ROUND_INPUT_OUTPUT,
@@ -22,13 +26,16 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     // For connections that are customized (sprite, behavior, location), there is
     // one value type that is accepted so we assign connectorType to the first
     // element in the list.
-    const connectorType = connection.check ? connection.check[0] : null;
+    const connectionCheck = connection.getCheck();
+    const connectorType = connectionCheck ? connectionCheck[0] : null;
     switch (connection.type) {
       case GoogleBlockly.ConnectionType.INPUT_VALUE:
       case GoogleBlockly.ConnectionType.OUTPUT_VALUE:
         // PUZZLE_TAB is the default shape for the connector if the value type is not
         // included in `blockTypeShapeMap`
-        return blockTypeShapeMap[connectorType] || this.PUZZLE_TAB;
+        return (
+          (connectorType && blockTypeShapeMap[connectorType]) || this.PUZZLE_TAB
+        );
       case GoogleBlockly.ConnectionType.PREVIOUS_STATEMENT:
       case GoogleBlockly.ConnectionType.NEXT_STATEMENT:
         return this.NOTCH;
@@ -45,7 +52,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
      * Since input and output connections share the same shape you can
      * define a function to generate the path for both.
      */
-    function makeMainPath(up) {
+    function makeMainPath(up: number) {
       return GoogleBlockly.utils.svgPaths.line([
         GoogleBlockly.utils.svgPaths.point(-width, (-1 * up * height) / 2),
         GoogleBlockly.utils.svgPaths.point(width, (-1 * up * height) / 2),
@@ -56,6 +63,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     const pathDown = makeMainPath(-1);
 
     return {
+      type: 1,
       width: width,
       height: height,
       pathDown: pathDown,
@@ -71,7 +79,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
      * Since input and output connections share the same shape you can
      * define a function to generate the path for both.
      */
-    function makeMainPath(up) {
+    function makeMainPath(up: number) {
       return GoogleBlockly.utils.svgPaths.line([
         GoogleBlockly.utils.svgPaths.point(-width, 0),
         GoogleBlockly.utils.svgPaths.point(0, -1 * up * height),
@@ -83,6 +91,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     const pathDown = makeMainPath(-1);
 
     return {
+      type: 1,
       width: width,
       height: height,
       pathDown: pathDown,
@@ -93,7 +102,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
   makeRoundInputConn() {
     const width = this.TAB_WIDTH;
     const height = this.TAB_HEIGHT;
-    function makeMainPath(up) {
+    function makeMainPath(up: number) {
       // Definition of curve function at https://github.com/google/blockly/blob/2bbb3aa1fcc1cc2df1a75bfbdefa42ab56182872/core/utils/svg_paths.ts#L26-L40
       const path = GoogleBlockly.utils.svgPaths.curve('c', [
         -width * 1.5 + ', 0 ',
@@ -107,6 +116,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     const pathDown = makeMainPath(-1);
 
     return {
+      type: 1,
       width: width,
       height: height,
       pathDown: pathDown,

--- a/apps/src/blockly/addons/cdoConstantsProvider.ts
+++ b/apps/src/blockly/addons/cdoConstantsProvider.ts
@@ -8,12 +8,13 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
   private TRI_INPUT_OUTPUT: PuzzleTab | undefined;
   private ROUND_INPUT_OUTPUT: PuzzleTab | undefined;
 
-  // Blockly enforces a 'type' property on the shape object.
-  // This can be any number. Blockly currently uses 1 and 2, so we'll use 10, 11, 12.
-  private CUSTOM_SHAPE_TYPE = {
-    RECT_INPUT_OUTPUT: 10,
-    TRI_INPUT_OUTPUT: 11,
-    ROUND_INPUT_OUTPUT: 12,
+  // Override the shapes constant to include the new shapes
+  override SHAPES = {
+    PUZZLE: 1,
+    NOTCH: 2,
+    RECTANGLE: 3,
+    TRIANGLE: 4,
+    ROUND: 5,
   };
 
   /**
@@ -72,7 +73,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     const pathDown = makeMainPath(-1);
 
     return {
-      type: this.CUSTOM_SHAPE_TYPE.TRI_INPUT_OUTPUT,
+      type: this.SHAPES.TRIANGLE,
       width: width,
       height: height,
       pathDown: pathDown,
@@ -100,7 +101,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     const pathDown = makeMainPath(-1);
 
     return {
-      type: this.CUSTOM_SHAPE_TYPE.RECT_INPUT_OUTPUT,
+      type: this.SHAPES.RECTANGLE,
       width: width,
       height: height,
       pathDown: pathDown,
@@ -125,7 +126,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     const pathDown = makeMainPath(-1);
 
     return {
-      type: this.CUSTOM_SHAPE_TYPE.ROUND_INPUT_OUTPUT,
+      type: this.SHAPES.ROUND,
       width: width,
       height: height,
       pathDown: pathDown,

--- a/apps/src/blockly/addons/cdoConstantsProvider.ts
+++ b/apps/src/blockly/addons/cdoConstantsProvider.ts
@@ -8,6 +8,14 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
   private TRI_INPUT_OUTPUT: PuzzleTab | undefined;
   private ROUND_INPUT_OUTPUT: PuzzleTab | undefined;
 
+  // Blockly enforces a 'type' property on the shape object.
+  // This can be any number. Blockly currently uses 1 and 2, so we'll use 10, 11, 12.
+  private CUSTOM_SHAPE_TYPE = {
+    RECT_INPUT_OUTPUT: 10,
+    TRI_INPUT_OUTPUT: 11,
+    ROUND_INPUT_OUTPUT: 12,
+  };
+
   /**
    * Get an object with connection shape and sizing information based on the
    * type of the connection.
@@ -64,7 +72,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     const pathDown = makeMainPath(-1);
 
     return {
-      type: this.SHAPES.PUZZLE,
+      type: this.CUSTOM_SHAPE_TYPE.TRI_INPUT_OUTPUT,
       width: width,
       height: height,
       pathDown: pathDown,
@@ -92,7 +100,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     const pathDown = makeMainPath(-1);
 
     return {
-      type: this.SHAPES.PUZZLE,
+      type: this.CUSTOM_SHAPE_TYPE.RECT_INPUT_OUTPUT,
       width: width,
       height: height,
       pathDown: pathDown,
@@ -117,7 +125,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     const pathDown = makeMainPath(-1);
 
     return {
-      type: this.SHAPES.PUZZLE,
+      type: this.CUSTOM_SHAPE_TYPE.ROUND_INPUT_OUTPUT,
       width: width,
       height: height,
       pathDown: pathDown,

--- a/apps/src/blockly/addons/cdoConstantsProvider.ts
+++ b/apps/src/blockly/addons/cdoConstantsProvider.ts
@@ -8,7 +8,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
   private TRI_INPUT_OUTPUT: PuzzleTab | undefined;
   private ROUND_INPUT_OUTPUT: PuzzleTab | undefined;
 
-  // Override the shapes constant to include the new shapes
+  // Override the shapes constant to include the custom shapes.
   override SHAPES = {
     PUZZLE: 1,
     NOTCH: 2,

--- a/apps/src/blockly/addons/cdoConstantsProvider.ts
+++ b/apps/src/blockly/addons/cdoConstantsProvider.ts
@@ -7,6 +7,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
   private RECT_INPUT_OUTPUT: PuzzleTab | undefined;
   private TRI_INPUT_OUTPUT: PuzzleTab | undefined;
   private ROUND_INPUT_OUTPUT: PuzzleTab | undefined;
+
   /**
    * Get an object with connection shape and sizing information based on the
    * type of the connection.
@@ -63,7 +64,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     const pathDown = makeMainPath(-1);
 
     return {
-      type: 1,
+      type: this.SHAPES.PUZZLE,
       width: width,
       height: height,
       pathDown: pathDown,
@@ -91,7 +92,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     const pathDown = makeMainPath(-1);
 
     return {
-      type: 1,
+      type: this.SHAPES.PUZZLE,
       width: width,
       height: height,
       pathDown: pathDown,
@@ -116,7 +117,7 @@ export default class CdoConstantsProvider extends GoogleBlockly.blockRendering
     const pathDown = makeMainPath(-1);
 
     return {
-      type: 1,
+      type: this.SHAPES.PUZZLE,
       width: width,
       height: height,
       pathDown: pathDown,

--- a/apps/src/blockly/addons/cdoPathObjectGeras.ts
+++ b/apps/src/blockly/addons/cdoPathObjectGeras.ts
@@ -1,16 +1,15 @@
 import GoogleBlockly from 'blockly/core';
 
-export default class CdoPathObject extends GoogleBlockly.blockRendering
-  .PathObject {
+export default class CdoPathObjectGeras extends GoogleBlockly.geras.PathObject {
   // The built-in function also adds a cross-hatch fill pattern to disabled blocks, which we don't want.
   // Overrriding the function here so we can just set the class but not add the fill pattern.
-  updateDisabled_(disabled) {
+  updateDisabled_(disabled: boolean) {
     this.setClass_('blocklyDisabled', disabled);
   }
 
   // The built-in function adds a light filter over the whole block. We want to match our old
   // behavior where highlighting the block adds the same yellow outline as selecting.
-  updateHighlighted(highlighted) {
+  updateHighlighted(highlighted: boolean) {
     this.setClass_('blocklySelected', highlighted);
   }
 }

--- a/apps/src/blockly/addons/cdoPathObjectThrasos.ts
+++ b/apps/src/blockly/addons/cdoPathObjectThrasos.ts
@@ -1,15 +1,16 @@
 import GoogleBlockly from 'blockly/core';
 
-export default class CdoPathObjectGeras extends GoogleBlockly.geras.PathObject {
+export default class CdoPathObject extends GoogleBlockly.blockRendering
+  .PathObject {
   // The built-in function also adds a cross-hatch fill pattern to disabled blocks, which we don't want.
   // Overrriding the function here so we can just set the class but not add the fill pattern.
-  updateDisabled_(disabled) {
+  updateDisabled_(disabled: boolean) {
     this.setClass_('blocklyDisabled', disabled);
   }
 
   // The built-in function adds a light filter over the whole block. We want to match our old
   // behavior where highlighting the block adds the same yellow outline as selecting.
-  updateHighlighted(highlighted) {
+  updateHighlighted(highlighted: boolean) {
     this.setClass_('blocklySelected', highlighted);
   }
 }

--- a/apps/src/blockly/addons/cdoPathObjectZelos.ts
+++ b/apps/src/blockly/addons/cdoPathObjectZelos.ts
@@ -3,13 +3,13 @@ import GoogleBlockly from 'blockly/core';
 export default class CdoPathObjectZelos extends GoogleBlockly.zelos.PathObject {
   // The built-in function also adds a cross-hatch fill pattern to disabled blocks, which we don't want.
   // Overrriding the function here so we can just set the class but not add the fill pattern.
-  updateDisabled_(disabled) {
+  updateDisabled_(disabled: boolean) {
     this.setClass_('blocklyDisabled', disabled);
   }
 
   // The built-in function adds a light filter over the whole block. We want to match our old
   // behavior where highlighting the block adds the same yellow outline as selecting.
-  updateHighlighted(highlighted) {
+  updateHighlighted(highlighted: boolean) {
     this.setClass_('blocklySelected', highlighted);
   }
 }

--- a/apps/src/blockly/addons/cdoRendererGeras.ts
+++ b/apps/src/blockly/addons/cdoRendererGeras.ts
@@ -1,5 +1,6 @@
 import GoogleBlockly from 'blockly/core';
 import CdoPathObject from './cdoPathObjectGeras';
+import {BlockStyle} from 'blockly/core/theme';
 
 export default class CdoRendererGeras extends GoogleBlockly.geras.Renderer {
   /**
@@ -7,7 +8,11 @@ export default class CdoRendererGeras extends GoogleBlockly.geras.Renderer {
    * Use our PathObject class instead of the default. Our PathObject has
    * different styles for highlighted and disabled blocks than the geras default.
    */
-  makePathObject(root, style) {
-    return new CdoPathObject(root, style, this.getConstants());
+  makePathObject(root: SVGElement, style: BlockStyle) {
+    return new CdoPathObject(
+      root,
+      style,
+      this.getConstants() as GoogleBlockly.geras.ConstantProvider
+    );
   }
 }

--- a/apps/src/blockly/addons/cdoRendererThrasos.ts
+++ b/apps/src/blockly/addons/cdoRendererThrasos.ts
@@ -1,6 +1,7 @@
 import GoogleBlockly from 'blockly/core';
 import CdoPathObject from './cdoPathObjectThrasos';
 import CdoConstantsProvider from './cdoConstantsProvider';
+import {BlockStyle} from 'blockly/core/theme';
 
 export default class CdoRendererThrasosBase extends GoogleBlockly.thrasos
   .Renderer {
@@ -9,7 +10,7 @@ export default class CdoRendererThrasosBase extends GoogleBlockly.thrasos
    * Use our PathObject class instead of the default. Our PathObject has
    * different styles for highlighted and disabled blocks than the geras default.
    */
-  makePathObject(root, style) {
+  makePathObject(root: SVGElement, style: BlockStyle) {
     return new CdoPathObject(root, style, this.getConstants());
   }
 

--- a/apps/src/blockly/addons/cdoRendererZelos.ts
+++ b/apps/src/blockly/addons/cdoRendererZelos.ts
@@ -1,5 +1,6 @@
 import GoogleBlockly from 'blockly/core';
 import CdoPathObject from './cdoPathObjectZelos';
+import {BlockStyle} from 'blockly/core/theme';
 
 export default class CdoRendererZelos extends GoogleBlockly.zelos.Renderer {
   /**
@@ -7,7 +8,7 @@ export default class CdoRendererZelos extends GoogleBlockly.zelos.Renderer {
    * Use our PathObject class instead of the default. Our PathObject has
    * different styles for highlighted and disabled blocks than the geras default.
    */
-  makePathObject(root, style) {
+  makePathObject(root: SVGElement, style: BlockStyle) {
     return new CdoPathObject(root, style, this.getConstants());
   }
 }

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -56,7 +56,7 @@ import {Themes, Renderers} from './constants';
 import {flyoutCategory as functionsFlyoutCategory} from './customBlocks/googleBlockly/proceduresBlocks';
 import {flyoutCategory as variablesFlyoutCategory} from './customBlocks/googleBlockly/variableBlocks';
 import {flyoutCategory as behaviorsFlyoutCategory} from './customBlocks/googleBlockly/behaviorBlocks';
-import CdoBlockSerializer from './addons/cdoBlockSerializer';
+import CdoBlockSerializer from './addons/cdoBlockSerializer.js';
 import customBlocks from './customBlocks/googleBlockly/index.js';
 import CdoFieldImage from './addons/cdoFieldImage';
 import {getPointerBlockImageUrl} from './addons/cdoSpritePointer';

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -56,7 +56,7 @@ import {Themes, Renderers} from './constants';
 import {flyoutCategory as functionsFlyoutCategory} from './customBlocks/googleBlockly/proceduresBlocks';
 import {flyoutCategory as variablesFlyoutCategory} from './customBlocks/googleBlockly/variableBlocks';
 import {flyoutCategory as behaviorsFlyoutCategory} from './customBlocks/googleBlockly/behaviorBlocks';
-import CdoBlockSerializer from './addons/cdoBlockSerializer.js';
+import CdoBlockSerializer from './addons/cdoBlockSerializer';
 import customBlocks from './customBlocks/googleBlockly/index.js';
 import CdoFieldImage from './addons/cdoFieldImage';
 import {getPointerBlockImageUrl} from './addons/cdoSpritePointer';


### PR DESCRIPTION
Migrate our renderer-related files to TypeScript. This was mostly straightforward adding types and null checks. Our custom constant provider was not returning a `type` for its custom shapes, which I synced with the Blockly team about. It seems like `type` is not used anywhere, but to make TypeScript happy they recommended overriding the parent `SHAPES` object to add new shape types.

## Links
- jira ticket: [CT-335](https://codedotorg.atlassian.net/browse/CT-335)

## Testing story
Tested that blocks and connections still render correctly. The only real code change was in the constants provider, so I ensured all our connections still have the correct shapes and shadows when connecting.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
