### PR TITLE
chore(deps): bump @code-dot-org/redactable-markdown to 0.9.4 in bin/i18n

### DIFF
--- a/bin/i18n/package-lock.json
+++ b/bin/i18n/package-lock.json
@@ -5,24 +5,24 @@
   "packages": {
     "": {
       "dependencies": {
-        "@code-dot-org/redactable-markdown": "0.9.3",
+        "@code-dot-org/redactable-markdown": "0.9.4",
         "@code-dot-org/remark-plugins": "^1.3.0"
       }
     },
     "node_modules/@code-dot-org/redactable-markdown": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@code-dot-org/redactable-markdown/-/redactable-markdown-0.9.3.tgz",
-      "integrity": "sha512-sEZT+0uMT5JZgaKCExeMmH3SOm3mLS113eXlOLkFP4BsIHHQ7nIEYUw5W/R9JDwiTrn8TNAu37bum4Hvhnz9tA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@code-dot-org/redactable-markdown/-/redactable-markdown-0.9.4.tgz",
+      "integrity": "sha512-a8n93w48JpKjxlJ0veINXn9A5+0PfC3/+0czLeI0UBAIzu5jcqY+EIlsNtivA6bpis44wXJc8nX/zA3KzPo0tQ==",
       "dependencies": {
         "@code-dot-org/remark-plugins": "1.2.4",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.8",
         "remark-html": "^9.0.0",
         "remark-parse": "^6.0.0",
         "remark-redactable": "2.0.2",
         "remark-stringify": "^6.0.0",
         "unified": "^7.0.0",
         "unist-util-select": "^2.0.2",
-        "xtend": "^4.0.1"
+        "xtend": "^4.0.2"
       },
       "bin": {
         "normalize": "src/bin/normalize.js",
@@ -394,9 +394,12 @@
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/not": {
       "version": "0.1.0",

--- a/bin/i18n/package.json
+++ b/bin/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@code-dot-org/redactable-markdown": "0.9.3",
+    "@code-dot-org/redactable-markdown": "0.9.4",
     "@code-dot-org/remark-plugins": "^1.3.0"
   }
 }


### PR DESCRIPTION
This change will fix the bin/i18n [dependabot security issues](https://github.com/code-dot-org/code-dot-org/security/dependabot?q=is%3Aopen+manifest%3Abin%2Fi18n%2Fpackage-lock.json) by upgrading its dependencies.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested the changes with Mario and pulled and redacted the changes in i18n properly.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

This will be deployed as part of the i18n pull process.

## Follow-up work

No follow up work as this addresses the critical dependabot issues.

## Privacy

No privacy related changes were introduced.

## Security

Addresses [dependabot security issues](https://github.com/code-dot-org/code-dot-org/security/dependabot?q=is%3Aopen+manifest%3Abin%2Fi18n%2Fpackage-lock.json) 

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
