### PR TITLE
Fixes storybook errors

### DIFF
--- a/apps/webpackStorybook.config.js
+++ b/apps/webpackStorybook.config.js
@@ -32,6 +32,9 @@ function storybookConfig(sbConfig) {
     plugins: [
       ...sbConfig.plugins,
       new webpack.ProvidePlugin({React: 'react'}),
+      new webpack.ProvidePlugin({
+        Buffer: ['buffer', 'Buffer'],
+      }),
       new webpack.DefinePlugin({
         IN_UNIT_TEST: JSON.stringify(false),
         IN_STORYBOOK: JSON.stringify(true),


### PR DESCRIPTION
It looks like the update to our crypo configuration caused >150 of our storybook stories to fail, all with the error "Buffer is not defined". After a quick google search, I found [this workaround](https://github.com/storybookjs/storybook/issues/17344) and added the Buffer configuration directly to our storybook webpack configuration. After rebuilding storybook, the errors went away and the missing stories came back! 

## Links

- spec: []()
- jira ticket: []()

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
