### PR TITLE
Don't logout chrome browsers on close

### DIFF
--- a/dashboard/config/initializers/session_store.rb
+++ b/dashboard/config/initializers/session_store.rb
@@ -3,4 +3,5 @@ session_cookie_key = environment_specific_cookie_name('_learn_session')
 Dashboard::Application.config.session_store :cookie_store,
   key: session_cookie_key,
   secure: !CDO.no_https_store && (!Rails.env.development? || CDO.https_development),
-  domain: :all
+  domain: :all,
+  expire_after: 200.days # don't expire in the same school year


### PR DESCRIPTION
We discovered Chrome browsers are logged out of studio.code.org every time they are closed. This does not appear to be true for Firefox and Edge, and is not the expected or desired behavior. See issue #56774 for details.

I immediately suspected this issue: https://developer.chrome.com/blog/cookie-max-age-expires. TL;DR: if you set a cookie expiration date over 400 days, Chrome will expire your cookie every time the browser is fully closed (like a session cookie).

Editing our primary cookie in session_store.rb produced the desired behavior: Chrome now preserved logins after I restarted the browser.

However, this behavior is confusing because:
1. Naively I would expect session_store.rb to be a "per session" cookie. However, since we're using it to store /everything/ not just session data, perhaps there's another place where we're setting it to be a general "everything while I'm logged in" cookie? This is actually quite common in a modern context, I believe session cookies have fallen out of vogue for storing "rails session" like values.
2. We also have some usage and configuration of a separate auth cookie in user.rb, but I cannot find it actually working or being created on any browser. I think this is historical cruft. (more to come on this)

I don't have much more time to spend on this, but despite the ambiguity, it may be worth merging this PR because:
1. It works on Firefox, Edge and Chrome
2. Gives the desired behavior on Chrome
3. Its a major student impact if we have Chrome browsers requesting login every time they are opened.
4. If we don't fix it soon, odds are it will get forgotten again. This is a very important UX detail that's not visible in a screenshot.

@dancodedotorg @dju90 