### PR TITLE
Show multiple certificates on Unit Group congrats page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1725,6 +1725,7 @@
   "no": "No",
   "pdNotApplicable": "Not applicable",
   "noAssessments": "It looks like there are no multi-question assessments or surveys in this course. Instead, you can measure the students’ progress using the 'Progress' tab. If you are interested in giving your students additional assessments, you can find recommended questions and areas in the lesson plans.",
+  "noCertificateReturnToCourse": "You must complete the course to earn a certificate. [Return to the course]({curriculumUrl}) and keep working.",
   "noClassroomsFound": "No classrooms found.",
   "noColumnsInTable": "We couldn't find any columns in \"{table}\". Make sure this table is imported in your project.",
   "noCurriculumSearchResultsBody": "None of our curricula match your exact criteria, but many of our offerings are flexible! Try broadening your search or consider building a custom curriculum from our more modular options (e.g. teaching two quarter-long curricula for a semester).",

--- a/apps/src/sites/studio/pages/congrats/index.js
+++ b/apps/src/sites/studio/pages/congrats/index.js
@@ -27,6 +27,7 @@ $(document).ready(function () {
   // Extras tutorial if we have problems during Hour of Code.
   const hideDancePartyFollowUp = congratsData.hide_dance_followup;
   const certificateData = congratsData.certificate_data;
+  const curriculumUrl = congratsData.curriculum_url;
   const isHocTutorial = congratsData.is_hoc_tutorial;
   const isPlCourse = congratsData.is_pl_course;
   const isK5PlCourse = congratsData.is_k5_pl_course;
@@ -67,6 +68,7 @@ $(document).ready(function () {
         nextCourseScriptName={nextCourseScriptName}
         nextCourseTitle={nextCourseTitle}
         nextCourseDesc={nextCourseDesc}
+        curriculumUrl={curriculumUrl}
       />
     </Provider>,
     document.getElementById('congrats-container')

--- a/apps/src/sites/studio/pages/congrats/index.js
+++ b/apps/src/sites/studio/pages/congrats/index.js
@@ -26,6 +26,7 @@ $(document).ready(function () {
   // Allows us to conditionally hide the promotional card for the Dance Party
   // Extras tutorial if we have problems during Hour of Code.
   const hideDancePartyFollowUp = congratsData.hide_dance_followup;
+  const certificateData = congratsData.certificate_data;
   const isHocTutorial = congratsData.is_hoc_tutorial;
   const isPlCourse = congratsData.is_pl_course;
   const isK5PlCourse = congratsData.is_k5_pl_course;
@@ -59,6 +60,7 @@ $(document).ready(function () {
         randomDonorTwitter={randomDonorTwitter}
         randomDonorName={randomDonorName}
         hideDancePartyFollowUp={hideDancePartyFollowUp}
+        certificateData={certificateData}
         isHocTutorial={isHocTutorial}
         isPlCourse={isPlCourse}
         isK5PlCourse={isK5PlCourse}

--- a/apps/src/sites/studio/pages/congrats/index.js
+++ b/apps/src/sites/studio/pages/congrats/index.js
@@ -46,7 +46,7 @@ $(document).ready(function () {
       isHocTutorial,
       isPlCourse,
       isK5PlCourse,
-      courseNames: [courseName],
+      courseNames: certificateData.map(data => data.courseName),
     });
 
   ReactDOM.render(

--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -119,6 +119,7 @@ function Certificate(props) {
 
   const swiperRef = useRef(null);
 
+  const [currentCertificateIndex, setCurrentImageIndex] = useState(0);
   useEffect(() => {
     if (swiperRef.current) {
       const swiperParams = {
@@ -145,30 +146,17 @@ function Certificate(props) {
       };
       Object.assign(swiperRef.current, swiperParams);
       swiperRef.current.initialize();
+
+      swiperRef.current.addEventListener('swiperslidechange', e => {
+        const [swiper] = e.detail;
+        setCurrentImageIndex(swiper.activeIndex);
+      });
     }
   }, []);
 
-  const [currentCertificateIndex, setCurrentImageIndex] = useState(0);
-  useEffect(() => {
-    // listen for Swiper events using addEventListener
-    swiperRef.current.addEventListener('swiperprogress', e => {
-      const [swiper, progress] = e.detail;
-      console.log(swiper, progress);
-      console.log(swiper.activeIndex);
-    });
-
-    swiperRef.current.addEventListener('swiperslidechange', e => {
-      const [swiper] = e.detail;
-      /*console.log('slide changed', e);
-      console.log(swiper, progress);
-      console.log(swiper.activeIndex);
- */
-      console.log('Swiper slide changed to active index' + swiper.activeIndex);
-      setCurrentImageIndex(swiper.activeIndex);
-    });
-  }, []);
-
   const courseName = certificateData[currentCertificateIndex]?.courseName;
+  const coursePath =
+    certificateData[currentCertificateIndex]?.coursePath || `s/${courseName}`;
 
   const externalCertificateShareLink =
     getExternalCertificateSharePath(courseName);
@@ -204,18 +192,12 @@ function Certificate(props) {
         </Heading1>
       </div>
       {courseName && (
-        <LargeChevronLink
-          link={`/s/${courseName}`}
-          linkText={i18n.backToActivity()}
-        />
+        <LargeChevronLink link={coursePath} linkText={i18n.backToActivity()} />
       )}
       <div className={style.certificateContainer}>
         <div
           id="uitest-certificate"
-          style={{
-            width: '50%',
-            display: 'flex',
-          }}
+          className={style.certificateImageContainer}
         >
           {
             <BackToFrontConfetti

--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {connect} from 'react-redux';
 import $ from 'jquery';
 import BackToFrontConfetti from '../BackToFrontConfetti';
@@ -16,6 +16,19 @@ import {
   Heading2,
   Heading3,
 } from '@cdo/apps/componentLibrary/typography';
+import {register} from 'swiper/element/bundle';
+register();
+
+/*import {Swiper, SwiperSlide} from 'swiper/react';
+import {Navigation, Pagination, Scrollbar, A11y} from 'swiper/modules';
+import 'swiper/scss';
+//import 'swiper/css';
+import 'swiper/scss/navigation';
+import {use} from 'chai';
+import {init} from '@cdo/apps/assetManagement/assetPrefix';
+import testImageAccess from '@cdo/apps/code-studio/url_test';
+//import 'swiper/scss/pagination';
+//import 'swiper/css/a11y';*/
 
 /**
  * Without this, we get an error on the server "invalid byte sequence in UTF-8".
@@ -86,10 +99,10 @@ function Certificate(props) {
     return urlSafeData;
   };
 
-  const getCertificateImagePath = () => {
+  /*const getCertificateImagePath = tutorial => {
     const filename = getEncodedParams();
     return `/certificate_images/${filename}.jpg`;
-  };
+  };*/
 
   const getPrintPath = () => {
     const encoded = getEncodedParams();
@@ -142,6 +155,37 @@ function Certificate(props) {
 
   const print = getPrintPath();
 
+  const swiperRef = useRef(null);
+
+  useEffect(() => {
+    if (swiperRef.current) {
+      const swiperParams = {
+        autoHeight: true,
+        pagination: {
+          clickable: true,
+        },
+        spaceBetween: 24,
+        slidesPerView: 1,
+        slidesPerGroup: 1,
+        breakpoints: {
+          640: {
+            autoHeight: false,
+          },
+        },
+        injectStyles: [
+          `
+            :host .swiper-pagination {
+              position: relative;
+              margin-top: 2rem;
+            }
+            `,
+        ],
+      };
+      Object.assign(swiperRef.current, swiperParams);
+      swiperRef.current.initialize();
+    }
+  }, []);
+
   return (
     <div className={style.container}>
       <div className={style.headerContainer}>
@@ -156,18 +200,32 @@ function Certificate(props) {
         />
       )}
       <div className={style.certificateContainer}>
-        <div id="uitest-certificate" className={certificateStyle}>
-          <BackToFrontConfetti
-            active={personalized}
-            className={style.confetti}
-          />
-          <a href={certificateShareLink}>
-            {
-              // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-              // Verify or update this alt-text as necessary
-            }
-            <img src={imgSrc} alt="" />
-          </a>
+        <div
+          id="uitest-certificate"
+          style={{
+            width: '50%',
+            display: 'flex',
+          }}
+        >
+          {
+            <BackToFrontConfetti
+              active={personalized}
+              className={style.confetti}
+            />
+          }
+          <swiper-container ref={swiperRef} class={style.swiperContainer}>
+            {initialCertificateImageUrls.map(imgUrl => (
+              <swiper-slide key={imgUrl} class={style.swiperSlide}>
+                <a href={certificateShareLink}>
+                  {
+                    // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
+                    // Verify or update this alt-text as necessary
+                  }
+                  <img src={imgUrl} alt="" style={{width: 470}} />
+                </a>
+              </swiper-slide>
+            ))}
+          </swiper-container>
         </div>
         <div className={`${certificateStyle} ${style.inputContainer}`}>
           {tutorial && !personalized && (

--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -9,7 +9,7 @@ import {
   Heading3,
   Heading4,
 } from '@cdo/apps/componentLibrary/typography';
-
+import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
 import selfPacedPlBanner from '@cdo/static/selfPacedPlBanner.png';
 import facilitatorLedPlBanner from '@cdo/static/facilitatorLedPlBanner.png';
 
@@ -61,6 +61,7 @@ export default function Congrats(props) {
     nextCourseScriptName,
     nextCourseTitle,
     nextCourseDesc,
+    curriculumUrl,
   } = props;
 
   const teacherCourses = [
@@ -354,23 +355,37 @@ export default function Congrats(props) {
     }
   };
 
+  console.log(certificateData);
   return (
     <div className={style.wrapper}>
-      <div className={style.certificateContainer}>
-        <Certificate
-          tutorial={tutorial}
-          certificateId={certificateId}
-          randomDonorTwitter={randomDonorTwitter}
-          randomDonorName={randomDonorName}
-          under13={under13}
-          certificateData={certificateData}
-          isHocTutorial={isHocTutorial}
-          isPlCourse={isPlCourse}
-        >
-          {renderExtraCertificateLinks(language, tutorial)}
-        </Certificate>
-      </div>
-      {renderRecommendedOptions()}
+      {certificateData.length > 0 && (
+        <>
+          <div className={style.certificateContainer}>
+            <Certificate
+              tutorial={tutorial}
+              certificateId={certificateId}
+              randomDonorTwitter={randomDonorTwitter}
+              randomDonorName={randomDonorName}
+              under13={under13}
+              certificateData={certificateData}
+              isHocTutorial={isHocTutorial}
+              isPlCourse={isPlCourse}
+            >
+              {renderExtraCertificateLinks(language, tutorial)}
+            </Certificate>
+          </div>
+          {renderRecommendedOptions()}
+        </>
+      )}
+      {certificateData.length === 0 && (
+        <div>
+          <Heading3>
+            <InlineMarkdown
+              markdown={i18n.noCertificateReturnToCourse({curriculumUrl})}
+            />
+          </Heading3>
+        </div>
+      )}
     </div>
   );
 }
@@ -384,6 +399,7 @@ Congrats.propTypes = {
   randomDonorTwitter: PropTypes.string,
   randomDonorName: PropTypes.string,
   certificateData: PropTypes.arrayOf(PropTypes.object).isRequired,
+  curriculumUrl: PropTypes.string,
   isHocTutorial: PropTypes.bool,
   isPlCourse: PropTypes.bool,
   isK5PlCourse: PropTypes.bool,

--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -54,6 +54,7 @@ export default function Congrats(props) {
     language,
     randomDonorTwitter,
     randomDonorName,
+    certificateData,
     isHocTutorial,
     isPlCourse,
     isK5PlCourse,
@@ -362,6 +363,7 @@ export default function Congrats(props) {
           randomDonorTwitter={randomDonorTwitter}
           randomDonorName={randomDonorName}
           under13={under13}
+          certificateData={certificateData}
           isHocTutorial={isHocTutorial}
           isPlCourse={isPlCourse}
         >
@@ -381,6 +383,7 @@ Congrats.propTypes = {
   language: PropTypes.string.isRequired,
   randomDonorTwitter: PropTypes.string,
   randomDonorName: PropTypes.string,
+  certificateData: PropTypes.arrayOf(PropTypes.object).isRequired,
   isHocTutorial: PropTypes.bool,
   isPlCourse: PropTypes.bool,
   isK5PlCourse: PropTypes.bool,

--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -355,7 +355,6 @@ export default function Congrats(props) {
     }
   };
 
-  console.log(certificateData);
   return (
     <div className={style.wrapper}>
       {certificateData.length > 0 && (

--- a/apps/src/templates/certificates/Congrats.story.jsx
+++ b/apps/src/templates/certificates/Congrats.story.jsx
@@ -11,7 +11,12 @@ export default {
 const Template = args => (
   <Provider store={reduxStore()}>
     <Congrats
-      initialCertificateImageUrl={'/images/placeholder-hoc-image.jpg'}
+      certificateData={[
+        {
+          courseName: 'dance',
+          coursePath: '/s/dance',
+        },
+      ]}
       language="en"
       tutorial="other"
       isHocTutorial={true}

--- a/apps/src/templates/certificates/congrats.module.scss
+++ b/apps/src/templates/certificates/congrats.module.scss
@@ -28,6 +28,7 @@
 .container {
   margin-bottom: 50px;
   float: left;
+  width: 100%;
 }
 
 .mobileHeading {
@@ -70,4 +71,23 @@
 
 .inputButtonContainer {
   display: flex;
+}
+
+.swiperContainer {
+  display: flex;
+  width: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  //max-height: 100vh;
+  min-height: 0;
+  min-width: 0;
+}
+
+.swiperSlide {
+  width: auto;
+  flex-shrink: 0;
+  display: block;
+  height: 100%;
+  max-height: 100%;
+  max-width: 100%;
 }

--- a/apps/src/templates/certificates/congrats.module.scss
+++ b/apps/src/templates/certificates/congrats.module.scss
@@ -78,7 +78,6 @@
   width: 100%;
   max-width: 100%;
   max-height: 100%;
-  //max-height: 100vh;
   min-height: 0;
   min-width: 0;
 }

--- a/apps/src/templates/certificates/congrats.module.scss
+++ b/apps/src/templates/certificates/congrats.module.scss
@@ -21,6 +21,11 @@
   width: 100%;
 }
 
+.certificateImageContainer {
+  display: flex;
+  width: 50%;
+}
+
 .heading {
   width: 100%;
 }

--- a/apps/test/unit/templates/certificates/CertificateTest.js
+++ b/apps/test/unit/templates/certificates/CertificateTest.js
@@ -54,12 +54,13 @@ describe('Certificate', () => {
         JSON.stringify(data),
       ]);
 
-      const initialCertificateImageUrl =
-        'https://code.org/images/placeholder-hoc-image.jpg';
       const wrapper = wrapperWithParams({
-        tutorial: 'dance',
+        certificateData: [
+          {
+            courseName: 'dance',
+          },
+        ],
         certificateId: 'sessionId',
-        initialCertificateImageUrl,
         isHocTutorial: true,
       });
       let image = wrapper.find('#uitest-certificate img');
@@ -95,12 +96,13 @@ describe('Certificate', () => {
     });
 
     it('passes down full urls to SocialShare', () => {
-      const initialCertificateImageUrl =
-        'https://code.org/images/placeholder-hoc-image.jpg';
       const wrapper = wrapperWithParams({
-        tutorial: 'dance',
+        certificateData: [
+          {
+            courseName: 'dance',
+          },
+        ],
         certificateId: 'sessionId',
-        initialCertificateImageUrl,
         isHocTutorial: true,
       });
       const socialShare = wrapper.find('SocialShare');

--- a/apps/test/unit/templates/certificates/CertificateTest.js
+++ b/apps/test/unit/templates/certificates/CertificateTest.js
@@ -110,4 +110,27 @@ describe('Certificate', () => {
       expect(socialShare.props().twitter).to.include('studio.code.org');
     });
   });
+
+  it('renders swiper for multiple certificates', () => {
+    const wrapper = wrapperWithParams({
+      certificateData: [
+        {
+          courseName: 'csd1-2023',
+          coursePath: '/s/csd1-2023',
+        },
+        {
+          courseName: 'csd2-2023',
+          coursePath: '/s/csd2-2023',
+        },
+      ],
+      certificateId: 'sessionId',
+      isHocTutorial: false,
+    });
+    expect(wrapper.find('swiper-container').exists()).to.be.true;
+    expect(wrapper.find('swiper-slide').length).to.equal(2);
+
+    expect(wrapper.find('LargeChevronLink').props().link).to.equal(
+      '/s/csd1-2023'
+    );
+  });
 });

--- a/apps/test/unit/templates/certificates/CongratsTest.js
+++ b/apps/test/unit/templates/certificates/CongratsTest.js
@@ -7,22 +7,27 @@ import GraduateToNextLevel from '@cdo/apps/templates/certificates/GraduateToNext
 
 describe('Congrats', () => {
   const userTypes = ['signedOut', 'teacher', 'student'];
-  const initialCertificateImageUrl = '/images/placeholder-hoc-image.jpg';
+  const certificateData = [
+    {
+      courseName: 'dance',
+    },
+  ];
+
   const defaultProps = {
     language: 'en',
-    initialCertificateImageUrl,
+    certificateData,
     isHocTutorial: false,
   };
 
   const hocProps = {
     language: 'en',
-    initialCertificateImageUrl,
+    certificateData,
     isHocTutorial: true,
   };
 
   const plProps = {
     language: 'en',
-    initialCertificateImageUrl,
+    certificateData,
     isHocTutorial: false,
     isPlCourse: true,
     userType: 'teacher',

--- a/apps/test/unit/templates/certificates/CongratsTest.js
+++ b/apps/test/unit/templates/certificates/CongratsTest.js
@@ -134,4 +134,20 @@ describe('Congrats', () => {
     expect(wrapper.find('a[href="https://code.org/apply"]').exists()).to.be
       .true;
   });
+
+  it('renders a message when there is no certificateData', () => {
+    const wrapper = shallow(
+      <Congrats
+        {...plProps}
+        certificateData={[]}
+        curriculumUrl="/s/self-paced-pl3-2023"
+      />
+    );
+    expect(wrapper.find('InlineMarkdown').props().markdown).to.include(
+      'You must complete the course to earn a certificate.'
+    );
+    expect(wrapper.find('InlineMarkdown').props().markdown).to.include(
+      '/s/self-paced-pl3-2023'
+    );
+  });
 });

--- a/dashboard/app/controllers/certificate_images_controller.rb
+++ b/dashboard/app/controllers/certificate_images_controller.rb
@@ -15,7 +15,6 @@ class CertificateImagesController < ApplicationController
 
     begin
       data = JSON.parse(Base64.urlsafe_decode64(filename))
-      puts filename, data.inspect
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       return render status: :bad_request, json: {message: 'invalid base64'}
     end

--- a/dashboard/app/controllers/certificate_images_controller.rb
+++ b/dashboard/app/controllers/certificate_images_controller.rb
@@ -15,6 +15,7 @@ class CertificateImagesController < ApplicationController
 
     begin
       data = JSON.parse(Base64.urlsafe_decode64(filename))
+      puts filename, data.inspect
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       return render status: :bad_request, json: {message: 'invalid base64'}
     end

--- a/dashboard/app/controllers/congrats_controller.rb
+++ b/dashboard/app/controllers/congrats_controller.rb
@@ -20,8 +20,24 @@ class CongratsController < ApplicationController
           else
             completed_units.map {|unit| certificate_image_url(nil, unit.name, nil)}
           end
+        @certificate_data =
+          if completed_units.empty? || completed_units.length == units.length
+            [{
+              courseName: course_name
+            }]
+          else
+            completed_units.map do |unit|
+              {
+                courseName: unit.name
+              }
+            end
+          end
+
       else
         @certificate_image_urls = [certificate_image_url(nil, course_name, nil)]
+        @certificate_data = [{
+          courseName: course_name
+        }]
       end
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       return render status: :bad_request, json: {message: 'invalid base64'}

--- a/dashboard/app/controllers/congrats_controller.rb
+++ b/dashboard/app/controllers/congrats_controller.rb
@@ -15,8 +15,8 @@ class CongratsController < ApplicationController
     end
 
     course_name = 'hourofcode' if course_name.blank?
-
     curriculum = CurriculumHelper.find_matching_unit_or_unit_group(course_name)
+
     if curriculum.is_a?(UnitGroup)
       @curriculum_url = course_path(curriculum)
       units = curriculum.units_for_user(current_user)
@@ -35,7 +35,13 @@ class CongratsController < ApplicationController
             }
           end
         end
-
+    elsif curriculum.nil?
+      # This occurs when the user completes a third party tutorial
+      @curriculum_url = script_path('hourofcode')
+      @certificate_data = [{
+        courseName: course_name,
+        coursePath: @curriculum_url,
+      }]
     else
       @curriculum_url = script_path(curriculum)
       # The order of this conditional is important. During HoC, we generally want to avoid

--- a/dashboard/app/controllers/congrats_controller.rb
+++ b/dashboard/app/controllers/congrats_controller.rb
@@ -9,13 +9,13 @@ class CongratsController < ApplicationController
     @random_donor_twitter = DashboardCdoDonor.get_random_donor_twitter
     @random_donor_name = DashboardCdoDonor.get_random_donor_name
     begin
-      course_name = params[:s] && Base64.urlsafe_decode64(params[:s])
+      @course_name = params[:s] && Base64.urlsafe_decode64(params[:s])
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       return render status: :bad_request, json: {message: 'invalid base64'}
     end
 
-    course_name = 'hourofcode' if course_name.blank?
-    curriculum = CurriculumHelper.find_matching_unit_or_unit_group(course_name)
+    @course_name = 'hourofcode' if @course_name.blank?
+    curriculum = CurriculumHelper.find_matching_unit_or_unit_group(@course_name)
 
     if curriculum.is_a?(UnitGroup)
       @curriculum_url = course_path(curriculum)
@@ -24,7 +24,7 @@ class CongratsController < ApplicationController
       @certificate_data =
         if completed_units.length == units.length
           [{
-            courseName: course_name,
+            courseName: @course_name,
             coursePath: course_path(curriculum),
           }]
         else
@@ -39,7 +39,7 @@ class CongratsController < ApplicationController
       # This occurs when the user completes a third party tutorial
       @curriculum_url = script_path('hourofcode')
       @certificate_data = [{
-        courseName: course_name,
+        courseName: @course_name,
         coursePath: @curriculum_url,
       }]
     else
@@ -49,7 +49,8 @@ class CongratsController < ApplicationController
       @certificate_data =
         if curriculum&.hoc? || UserScript.where(user: current_user, script: curriculum).where.not(completed_at: nil).exists?
           [{
-            courseName: course_name
+            courseName: @course_name,
+            coursePath: @curriculum_url,
           }]
         else
           []

--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -345,4 +345,11 @@ class TestController < ApplicationController
     EvaluateRubricJob.new.validate_ai_config
     render plain: 'OK'
   end
+
+  def complete_unit
+    unit_name = params.require(:unit_name)
+    unit = Unit.find_by!(name: unit_name)
+    UserScript.create!(user: current_user, script: unit, completed_at: Time.now)
+    head :ok
+  end
 end

--- a/dashboard/app/helpers/certificates_helper.rb
+++ b/dashboard/app/helpers/certificates_helper.rb
@@ -5,14 +5,17 @@ module CertificatesHelper
       course: course,
       donor: donor
     }.compact
+    puts opts.inspect
     Base64.urlsafe_encode64(opts.to_json)
   end
 
   def certificate_image_url(name, course, donor)
+    puts "getting certificate image url for #{name}, #{course}, #{donor}"
     return CDO.code_org_url('/images/hour_of_code_certificate.jpg') if course.blank?
     is_prefilled = CertificateImage.prefilled_title_course?(course)
     return CDO.code_org_url("/images/#{CertificateImage.certificate_template_for(course)}") if is_prefilled && !name
     encoded = encode_params(name, course, donor)
+    puts "encoded: #{encoded}"
     "/certificate_images/#{encoded}.jpg"
   end
 

--- a/dashboard/app/helpers/certificates_helper.rb
+++ b/dashboard/app/helpers/certificates_helper.rb
@@ -5,17 +5,14 @@ module CertificatesHelper
       course: course,
       donor: donor
     }.compact
-    puts opts.inspect
     Base64.urlsafe_encode64(opts.to_json)
   end
 
   def certificate_image_url(name, course, donor)
-    puts "getting certificate image url for #{name}, #{course}, #{donor}"
     return CDO.code_org_url('/images/hour_of_code_certificate.jpg') if course.blank?
     is_prefilled = CertificateImage.prefilled_title_course?(course)
     return CDO.code_org_url("/images/#{CertificateImage.certificate_template_for(course)}") if is_prefilled && !name
     encoded = encode_params(name, course, donor)
-    puts "encoded: #{encoded}"
     "/certificate_images/#{encoded}.jpg"
   end
 

--- a/dashboard/app/views/congrats/index.html.haml
+++ b/dashboard/app/views/congrats/index.html.haml
@@ -9,6 +9,7 @@
   congrats_data[:next_course_description] = @next_course_description
   congrats_data[:hide_dance_followup] = DCDO.get("hide_dance_followup", false)
   congrats_data[:certificate_data] = @certificate_data
+  congrats_data[:curriculum_url] = @curriculum_url
   congrats_data[:is_hoc_tutorial] = @is_hoc_tutorial
   congrats_data[:is_pl_course] = @is_pl_course
   congrats_data[:is_k5_pl_course] = @is_k5_pl_course

--- a/dashboard/app/views/congrats/index.html.haml
+++ b/dashboard/app/views/congrats/index.html.haml
@@ -8,6 +8,7 @@
   congrats_data[:next_course_title] = @next_course_title
   congrats_data[:next_course_description] = @next_course_description
   congrats_data[:hide_dance_followup] = DCDO.get("hide_dance_followup", false)
+  congrats_data[:certificate_data] = @certificate_data
   congrats_data[:is_hoc_tutorial] = @is_hoc_tutorial
   congrats_data[:is_pl_course] = @is_pl_course
   congrats_data[:is_k5_pl_course] = @is_k5_pl_course

--- a/dashboard/test/controllers/congrats_controller_test.rb
+++ b/dashboard/test/controllers/congrats_controller_test.rb
@@ -1,0 +1,129 @@
+require 'test_helper'
+
+class CongratsControllerTest < ActionController::TestCase
+  test "shows congrats page for HoC course" do
+    hoc_unit = create(:hoc_script)
+    get :index, params: {s: Base64.urlsafe_encode64(hoc_unit.name)}
+    assert_response :success
+
+    assert assigns(:is_hoc_tutorial)
+    refute assigns(:is_pl_course)
+
+    certificate_data = assigns(:certificate_data)
+    assert_equal 1, certificate_data.length
+    assert_equal hoc_unit.name, certificate_data[0][:courseName]
+  end
+
+  test "cached query test for hoc course" do
+    hoc_unit = create(:hoc_script)
+
+    Unit.stubs(:should_cache?).returns(true)
+
+    assert_cached_queries(0) do
+      get :index, params: {s: Base64.urlsafe_encode64(hoc_unit.name)}
+      assert_response :success
+    end
+  end
+
+  test "shows congrats page for unknown course" do
+    get :index, params: {s: Base64.urlsafe_encode64('2p-activity')}
+    assert_response :success
+
+    assert assigns(:is_hoc_tutorial)
+    refute assigns(:is_pl_course)
+
+    certificate_data = assigns(:certificate_data)
+    assert_equal 1, certificate_data.length
+    assert_equal '2p-activity', certificate_data[0][:courseName]
+  end
+
+  test "shows congrats page for PL unit with completion" do
+    teacher = create :teacher
+    sign_in teacher
+
+    pl_unit = create(:pl_unit, :is_course)
+    CourseOffering.add_course_offering(pl_unit)
+    create :user_script, user: teacher, script: pl_unit, completed_at: Time.now
+
+    get :index, params: {s: Base64.urlsafe_encode64(pl_unit.name)}
+    assert_response :success
+
+    refute assigns(:is_hoc_tutorial)
+    assert assigns(:is_pl_course)
+
+    certificate_data = assigns(:certificate_data)
+    assert_equal 1, certificate_data.length
+    assert_equal pl_unit.name, certificate_data[0][:courseName]
+  end
+
+  test "no certificate for PL unit without completion" do
+    teacher = create :teacher
+    sign_in teacher
+
+    pl_unit = create(:pl_unit, :is_course)
+    CourseOffering.add_course_offering(pl_unit)
+    assert_nil UserScript.find_by(user: teacher, script: pl_unit)
+
+    get :index, params: {s: Base64.urlsafe_encode64(pl_unit.name)}
+    assert_response :success
+
+    refute assigns(:is_hoc_tutorial)
+    assert assigns(:is_pl_course)
+
+    certificate_data = assigns(:certificate_data)
+    assert_equal 0, certificate_data.length
+  end
+
+  test "shows multiple certificates for unit group with partial completion" do
+    student = create :student
+    sign_in student
+
+    course_version = create :course_version, :with_unit_group
+    unit_group = course_version.content_root
+
+    unit1 = create :unit
+    create :unit_group_unit, unit_group: unit_group, script: unit1, position: 1
+    unit2 = create :unit
+    create :unit_group_unit, unit_group: unit_group, script: unit2, position: 2
+    unit3 = create :unit
+    create :unit_group_unit, unit_group: unit_group, script: unit3, position: 3
+
+    create :user_script, user: student, script: unit1, completed_at: Time.now
+    create :user_script, user: student, script: unit2, completed_at: Time.now
+    assert_nil UserScript.find_by(user: student, script: unit3)
+
+    get :index, params: {s: Base64.urlsafe_encode64(unit_group.name)}
+    assert_response :success
+
+    certificate_data = assigns(:certificate_data)
+    assert_equal 2, certificate_data.length
+    assert_equal unit1.name, certificate_data[0][:courseName]
+    assert_equal unit2.name, certificate_data[1][:courseName]
+  end
+
+  test "shows one certificate for fully completed unit group" do
+    student = create :student
+    sign_in student
+
+    course_version = create :course_version, :with_unit_group
+    unit_group = course_version.content_root
+
+    unit1 = create :unit
+    create :unit_group_unit, unit_group: unit_group, script: unit1, position: 1
+    unit2 = create :unit
+    create :unit_group_unit, unit_group: unit_group, script: unit2, position: 2
+    unit3 = create :unit
+    create :unit_group_unit, unit_group: unit_group, script: unit3, position: 3
+
+    create :user_script, user: student, script: unit1, completed_at: Time.now
+    create :user_script, user: student, script: unit2, completed_at: Time.now
+    create :user_script, user: student, script: unit3, completed_at: Time.now
+
+    get :index, params: {s: Base64.urlsafe_encode64(unit_group.name)}
+    assert_response :success
+
+    certificate_data = assigns(:certificate_data)
+    assert_equal 1, certificate_data.length
+    assert_equal unit_group.name, certificate_data[0][:courseName]
+  end
+end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -985,9 +985,14 @@ FactoryBot.define do
     end
 
     factory :hoc_script do
+      is_course {true}
+      sequence(:version_year) {|n| "bogus-hoc-version-year-#{n}"}
+      sequence(:family_name) {|n| "bogus-hoc-family-name-#{n}"}
       after(:create) do |hoc_script|
         hoc_script.curriculum_umbrella = Curriculum::SharedCourseConstants::CURRICULUM_UMBRELLA.HOC
         hoc_script.save!
+        course_offering = CourseOffering.add_course_offering(hoc_script)
+        course_offering.update!(category: 'hoc')
       end
     end
 

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -102,8 +102,11 @@ Scenario: Oceans uncustomized dashboard certificate pages
   And I close my eyes
 
 Scenario: Course A 2017 uncustomized dashboard certificate pages
-  Given I am on "http://studio.code.org/congrats"
-  And I wait until element "#uitest-certificate" is visible
+  Given I create a student named "Student1"
+  And I sign in as "Student1"
+  And I complete unit coursea-2017
+  And I am on "http://studio.code.org/congrats"
+  Then I wait until element "#uitest-certificate" is visible
 
   When I am on "http://code.org/congrats/coursea-2017"
   And I wait until current URL contains "http://studio.code.org/congrats"

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -184,20 +184,6 @@ Scenario: congrats certificate pages
   And I wait for 2 seconds
   And I see no difference for "customized oceans certificate"
 
-  When I am on "http://code.org/congrats/coursea-2017"
-  And I wait until current URL contains "http://studio.code.org/congrats"
-  And I wait to see element with ID "uitest-certificate"
-  And element "#uitest-certificate" is visible
-  And I wait for image "#uitest-certificate img" to load
-  And I wait for 2 seconds
-  And I see no difference for "uncustomized Course A 2017 certificate"
-
-  When I type "Robo Códer" into "#name"
-  And I press "button:contains(Submit)" using jQuery
-  And I wait to see element with ID "uitest-thanks"
-  And I wait for 2 seconds
-  And I see no difference for "customized Course A 2017 certificate"
-
   When I am on "http://code.org/congrats/accelerated"
   And I wait until current URL contains "http://studio.code.org/congrats"
   And I wait to see element with ID "uitest-certificate"
@@ -211,5 +197,22 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-thanks"
   And I wait for 2 seconds
   And I see no difference for "customized 20-hour certificate"
+
+  Given I create a student named "Student1"
+  And I sign in as "Student1"
+  And I complete unit coursea-2017
+  When I am on "http://code.org/congrats/coursea-2017"
+  And I wait until current URL contains "http://studio.code.org/congrats"
+  And I wait to see element with ID "uitest-certificate"
+  And element "#uitest-certificate" is visible
+  And I wait for image "#uitest-certificate img" to load
+  And I wait for 2 seconds
+  And I see no difference for "uncustomized Course A 2017 certificate"
+
+  When I type "Robo Códer" into "#name"
+  And I press "button:contains(Submit)" using jQuery
+  And I wait to see element with ID "uitest-thanks"
+  And I wait for 2 seconds
+  And I see no difference for "customized Course A 2017 certificate"
 
   And I close my eyes

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -124,3 +124,11 @@ Then(/^check that level (\d+) on this lesson is not done$/) do |level|
   undone = @browser.execute_script("return $('a[href$=\"level/#{level}\"].other_level').hasClass('level_undone')")
   undone
 end
+
+And(/^I complete unit (.+)/) do |unit_name|
+  browser_request(
+    url: '/api/test/complete_unit',
+    method: 'POST',
+    body: {unit_name: unit_name}
+  )
+end


### PR DESCRIPTION
This ended up being a doozy of a PR! It does a few things:
- Checks progress before showing certificates for non-HoC courses. If a course name is not given or we have no curriculum associated with that course name, we show a certificate
  - note: I didn't want to increase the number of queries this route does for HoC courses, so the order of some of the conditionals is important. I added a test to enforce this.
- For the congrats page for a unit group:
  - If the user has completed all units, shows a certificate for the unit group
  - If the user has completed some but not all units, shows a certificate for each completed unit
  - If the user has completed no units, shows a page telling them to return to the curriculum
  - note: I did not handle the HoC case here as we have no HoC unit groups. 


Video for multiple certificates:


https://github.com/code-dot-org/code-dot-org/assets/46464143/a7ba699b-33d7-4b4b-82fd-73122ac28597


Message to users to complete units:

![Screenshot 2024-02-29 at 3 26 50 PM](https://github.com/code-dot-org/code-dot-org/assets/46464143/1d350442-3010-43a0-a14a-692a1f258f63)


## Links

[figma](https://www.figma.com/file/sZ6d1uhJWFksJ6j3Fnmbnc/PL-Flow-Improvements?node-id=1958%3A10514&mode=dev)

## Testing story

- local testing
- relying on existing testing. There is significant existing UI test coverage


## Follow-up work

- [add arrows to the carousel](https://codedotorg.atlassian.net/browse/ACQ-1557)
- [updating alt text](https://codedotorg.atlassian.net/browse/ACQ-1554)
- [fixing component widths](https://codedotorg.atlassian.net/browse/ACQ-1553)



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
