### PR TITLE
Removed unused is-hotkey package that was considered for use in code review feature

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -232,7 +232,6 @@
     "html2canvas": "^0.5.0-beta4",
     "htmlhint": "^1.1.4",
     "immutable": "3.8.1",
-    "is-hotkey": "^0.2.0",
     "isolate-react": "^2.3.0",
     "jquery": "1.12.1",
     "jquery-ui": "^1.12.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8287,7 +8287,6 @@ __metadata:
     htmlhint: ^1.1.4
     http-server: ^0.9.0
     immutable: 3.8.1
-    is-hotkey: ^0.2.0
     isolate-react: ^2.3.0
     istanbul-instrumenter-loader: ^3.0.1
     jquery: 1.12.1
@@ -17314,13 +17313,6 @@ es6-shim@latest:
   version: 0.1.8
   resolution: "is-hotkey@npm:0.1.8"
   checksum: 793d0cccaf804583d8f4b835e040d4b6a74cb3f8d4094cb8188ed7cc86e6edf8f650fc80fabd4309e6c29938f5b0e9a17b45504b29dbf92735ef8d780d613aa0
-  languageName: node
-  linkType: hard
-
-"is-hotkey@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "is-hotkey@npm:0.2.0"
-  checksum: 97d295cfd8c3eb2c9b218daee5bff0ddaf47210930e3eb1eff36d2e6ad74854028203c640f35ea2d183d0cba94ac4c4bcd291925bc3a343d8a4c7d2c5ab3e2a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clearing out some unused packages from our package.json.

It looks like is-hotkey was considered for use in the code review feature, but the usage was never merged. 

PR where the it was added to the package.json: https://github.com/code-dot-org/code-dot-org/pull/46839

Added in this commit: https://github.com/code-dot-org/code-dot-org/pull/46817/commits/bf89fbb240a37117d60295f40efc27173c0a50f3
Usage was later removed in this commit (same PR) https://github.com/code-dot-org/code-dot-org/pull/46817/commits/55812bc43f36a5356fe71ec4dca1c959b3ec9684

This was found using [depcheck](https://www.npmjs.com/package/depcheck)