### PR TITLE
Add new initiative options to better classify self-pace vs facilitator led scripts.

### DIFF
--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -58,7 +58,11 @@ module Curriculum
         CSP_virtual_pl: 'CSP Virtual PL',
         CSD_virtual_pl: 'CSD Virtual PL',
         CSA_virtual_pl: 'CSA Virtual PL',
-        student_self_paced: 'Student Self Paced Courses'
+        student_self_paced: 'Student Self Paced Courses',
+        pd_workshop_activity_csf: 'PD Workshop Activity CSF',
+        pd_workshop_activity_csd: 'PD Workshop Activity CSD',
+        pd_workshop_activity_csp: 'PD Workshop Activity CSP',
+        pd_workshop_activity_csa: 'PD Workshop Activity CSA'
       }
     ).freeze
 


### PR DESCRIPTION
RED uses [Code.org](http://code.org/) initiative field on Levelbuilder to track the success of investments.  Currently self paced async and facilitator-led scripts have the same initiative.  With the new focus on custom workshops, we would like for these scripts to have different names.

Older commits where new initiatives were added
https://github.com/code-dot-org/code-dot-org/commit/9b0b708d30ad8520d6d52fe4575ce154b253aa0c
https://github.com/code-dot-org/code-dot-org/commit/212ce1aff5f76e041b5644c004d9ed8dc7876a91

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-844?atlOrigin=eyJpIjoiZWEwMmJjOTkwYjg5NDgzMzg0ODk3MzgxM2Y0NjdkZTMiLCJwIjoiaiJ9

## Testing story

Validated locally by rebuilding dashboard and apps to see the new options showing up in levelbuilder
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/a2a56094-699e-46e4-b71f-b7b5b51a472c)

## Deployment strategy
Regular DTP

## Follow-up work
There is a list of scripts that need to be backfilled to use the new initiative options. The list is attached to the JIRA task and will use the same to track the follow up work.

## Privacy
N/A

## Security
N/A

## Caching
N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
