### PR TITLE
Removed unused web-streams-polyfill package

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -326,7 +326,6 @@
     "video.js": "7.6.6",
     "vm-browserify": "^1.1.2",
     "vmsg": "^0.3.6",
-    "web-streams-polyfill": "^3.1.0",
     "wgxpath": "^1.2.0",
     "whatwg-fetch": "^2.0.3"
   },

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8446,7 +8446,6 @@ __metadata:
     video.js: 7.6.6
     vm-browserify: ^1.1.2
     vmsg: ^0.3.6
-    web-streams-polyfill: ^3.1.0
     webpack: ^5.74.0
     webpack-bundle-analyzer: ^4.4.2
     webpack-cli: ^5.1.4
@@ -29748,13 +29747,6 @@ temporal@latest:
   version: 1.1.2
   resolution: "web-namespaces@npm:1.1.2"
   checksum: 28741ad0ddf755697b2f58cc4c41482145a23a7109e918b39fa94ad64dc5ee45103406cb46c3d0a0c42232fcedc0cee6e51109e3f3de1367688d453dd9326e1f
-  languageName: node
-  linkType: hard
-
-"web-streams-polyfill@npm:^3.1.0":
-  version: 3.2.1
-  resolution: "web-streams-polyfill@npm:3.2.1"
-  checksum: b119c78574b6d65935e35098c2afdcd752b84268e18746606af149e3c424e15621b6f1ff0b42b2676dc012fc4f0d313f964b41a4b5031e525faa03997457da02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clearing out some unused packages from our package.json.

From what I can tell, the web-streams-polyfill package was a candidate for polyfilling some lost functionality when we upgraded from Webpack 4 to Webpack 5. However, I _think_ we got that functionality via stream-browserify instead. Maddie left some great notes when she did this work: https://github.com/code-dot-org/code-dot-org/pull/48105. @snickell and @bencodeorg, I could definitely use a hand checking my assumptions on this one if you get the chance.

This was found using [depcheck](https://www.npmjs.com/package/depcheck)