### PR TITLE
Removed explicit import of react-typist

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -291,7 +291,6 @@
     "react-tether": "^1.0.4",
     "react-tooltip": "^3.2.7",
     "react-transition-group": "2.9.0",
-    "react-typist": "^2.0.5",
     "react-virtualized": "^9.18.5",
     "react-virtualized-select": "^3.0.1",
     "react-with-context": "^2.0.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8392,7 +8392,6 @@ __metadata:
     react-tether: ^1.0.4
     react-tooltip: ^3.2.7
     react-transition-group: 2.9.0
-    react-typist: ^2.0.5
     react-virtualized: ^9.18.5
     react-virtualized-select: ^3.0.1
     react-with-context: ^2.0.0


### PR DESCRIPTION
Clearing out some unused packages from our package.json.

The react-typist package was used in early prototypes of Dance AI to make it look like the AI was typing its explanation. We moved away from that design and it is no longer used. Here is the original PR: https://github.com/code-dot-org/code-dot-org/pull/53889

Note: It does not get fully removed from the yarn.lock because it is imported as a dependency of @code-dot-org/ml-activities

This was found using [depcheck](https://www.npmjs.com/package/depcheck)