### PR TITLE
Music: use SamplePlayerWrapper in MusicPlayer

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -157,6 +157,8 @@ export interface SoundData {
   restricted?: boolean;
   sequence?: SampleSequence;
   preview?: boolean;
+  bpm?: number;
+  key?: Key;
 }
 
 export interface SoundFolder {

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -20,8 +20,6 @@ import SamplePlayerWrapper from './SamplePlayerWrapper';
 // Using require() to import JS in TS files
 const constants = require('../constants');
 
-// Default to 4/4 time, 120 BPM, C Major
-const BEATS_PER_MEASURE = 4;
 const DEFAULT_BPM = 120;
 const DEFAULT_KEY = Key.C;
 
@@ -221,22 +219,6 @@ export default class MusicPlayer {
     return this.audioPlayer.getCurrentPlaybackPosition();
   }
 
-  // Converts actual seconds used by the audio system into a playhead
-  // position, which is 1-based and scaled to measures.
-  convertSecondsToPlayheadPosition(seconds: number): number {
-    return 1 + seconds / this.secondsPerMeasure();
-  }
-
-  // Converts a playhead position, which is 1-based and scaled to measures,
-  // into actual seconds used by the audio system.
-  convertPlayheadPositionToSeconds(playheadPosition: number): number {
-    return this.secondsPerMeasure() * (playheadPosition - 1);
-  }
-
-  secondsPerMeasure() {
-    return (60 / this.bpm) * BEATS_PER_MEASURE;
-  }
-
   private convertEventToSamples(event: PlaybackEvent): SampleEvent[] {
     const library = MusicLibrary.getInstance();
     if (!library) {
@@ -375,11 +357,10 @@ export default class MusicPlayer {
       const sampleId = this.getSampleForNote(tranposedNote, instrument);
       if (sampleId !== null) {
         const eventWhen = eventStart + (event.position - 1) / 16;
-        const lengthSeconds = (event.length / 16) * this.secondsPerMeasure();
         samples.push({
           sampleId,
           playbackPosition: eventWhen,
-          lengthSeconds,
+          length: event.length,
           triggered,
           effects,
           originalBpm: this.bpm,

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -2,14 +2,20 @@ import {ChordEvent, ChordEventValue} from './interfaces/ChordEvent';
 import {PatternEvent, PatternEventValue} from './interfaces/PatternEvent';
 import {PlaybackEvent} from './interfaces/PlaybackEvent';
 import {SoundEvent} from './interfaces/SoundEvent';
-import MusicLibrary, {SampleSequence, SoundFolder} from './MusicLibrary';
-import SamplePlayer, {SampleEvent} from './SamplePlayer';
+import MusicLibrary, {
+  SampleSequence,
+  SoundData,
+  SoundFolder,
+} from './MusicLibrary';
+import SamplePlayer from './SamplePlayer';
 import {generateNotesFromChord, ChordNote} from '../utils/Chords';
 import {getTranposedNote, Key} from '../utils/Notes';
 import {Effects} from './interfaces/Effects';
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {LoadFinishedCallback, UpdateLoadProgressCallback} from '../types';
+import {AudioPlayer, SampleEvent} from './types';
+import SamplePlayerWrapper from './SamplePlayerWrapper';
 
 // Using require() to import JS in TS files
 const constants = require('../constants');
@@ -25,7 +31,7 @@ const DEFAULT_KEY = Key.C;
  */
 export default class MusicPlayer {
   private readonly metricsReporter: LabMetricsReporter;
-  private readonly samplePlayer: SamplePlayer;
+  private readonly audioPlayer: AudioPlayer;
   private updateLoadProgress: UpdateLoadProgressCallback | undefined;
 
   private bpm: number = DEFAULT_BPM;
@@ -34,10 +40,10 @@ export default class MusicPlayer {
   constructor(
     bpm: number = DEFAULT_BPM,
     key: Key = DEFAULT_KEY,
-    samplePlayer: SamplePlayer = new SamplePlayer(),
+    audioPlayer: AudioPlayer = new SamplePlayerWrapper(new SamplePlayer()),
     metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter()
   ) {
-    this.samplePlayer = samplePlayer;
+    this.audioPlayer = audioPlayer;
     this.metricsReporter = metricsReporter;
     this.updateConfiguration(bpm, key);
   }
@@ -45,7 +51,7 @@ export default class MusicPlayer {
   updateConfiguration(bpm?: number, key?: Key) {
     if (bpm) {
       this.bpm = this.validateBpm(bpm);
-      this.samplePlayer.setBpm(this.bpm);
+      this.audioPlayer.setBpm(this.bpm);
     }
     if (key) {
       this.key = this.validateKey(key);
@@ -89,7 +95,7 @@ export default class MusicPlayer {
       )
     );
 
-    return this.samplePlayer.loadSounds(sampleIds, {
+    return this.audioPlayer.loadSounds(sampleIds, {
       onLoadFinished,
       updateLoadProgress: this.updateLoadProgress,
     });
@@ -102,7 +108,21 @@ export default class MusicPlayer {
    * @param onStop called when the sound finished playing
    */
   previewSound(id: string, onStop?: () => void) {
-    this.samplePlayer.previewSample(id, onStop);
+    // Wrap this in a SoundEvent so it's converted with the correct bpm and pitch shift.
+    const preview: SoundEvent = {
+      type: 'sound',
+      when: 1,
+      id,
+      triggered: false,
+      length: 1,
+      blockId: 'preview',
+      soundType: 'beat',
+    };
+
+    this.audioPlayer.playSampleImmediately(
+      this.convertEventToSamples(preview)[0],
+      onStop
+    );
   }
 
   previewChord(chordValue: ChordEventValue, onStop?: () => void) {
@@ -115,7 +135,7 @@ export default class MusicPlayer {
       id: 'preview',
       blockId: 'preview',
     };
-    this.samplePlayer.previewSamples(
+    this.audioPlayer.playSamplesImmediately(
       this.convertEventToSamples(chordEvent),
       onStop
     );
@@ -141,7 +161,7 @@ export default class MusicPlayer {
       blockId: 'preview',
     };
 
-    this.samplePlayer.previewSamples(
+    this.audioPlayer.playSamplesImmediately(
       this.convertEventToSamples(patternEvent),
       onStop
     );
@@ -151,55 +171,54 @@ export default class MusicPlayer {
    * Cancels any ongoing previews.
    */
   cancelPreviews() {
-    this.samplePlayer.cancelPreviews();
+    this.audioPlayer.cancelPreviews();
   }
 
   /**
    * Start playback. Schedules all queued playback events for playback
-   * and tells the {@link SamplePlayer} to start playing.
+   * and tells the {@link AudioPlayer} to start playing.
    *
    * @param startPosition to start playback from. Defaults to 1
    * (beginning of song) if not specified.
    */
   playSong(events: PlaybackEvent[], startPosition = 1) {
-    this.samplePlayer.startPlayback(
-      events.map(event => this.convertEventToSamples(event)).flat(),
-      this.convertPlayheadPositionToSeconds(startPosition)
-    );
+    this.scheduleEvents(events);
+    this.audioPlayer.start(startPosition);
   }
 
   /**
    * Play the given events. Assumes that playback is in progress.
+   *
+   * @param events events to play
+   * @param [replace=false] if true, cancels any pending events before playing the new ones
    */
-  playEvents(events: PlaybackEvent[]) {
-    this.samplePlayer.playSamples(
-      events.map(event => this.convertEventToSamples(event)).flat()
-    );
+  playEvents(events: PlaybackEvent[], replace = false) {
+    if (replace) {
+      this.audioPlayer.cancelPendingEvents();
+    }
+    this.scheduleEvents(events);
+  }
+
+  private scheduleEvents(events: PlaybackEvent[]) {
+    for (const event of events
+      .map(event => this.convertEventToSamples(event))
+      .flat()) {
+      this.audioPlayer.scheduleSample(event);
+    }
   }
 
   /**
    * Stop playback. Tells the {@link SamplePlayer} to stop all sample playback.
    */
   stopSong() {
-    this.samplePlayer.stopPlayback();
-  }
-
-  /**
-   * Stop any sounds that have not yet been played if playback is in progress.
-   */
-  stopAllSoundsStillToPlay() {
-    this.samplePlayer.stopAllSamplesStillToPlay();
+    this.audioPlayer.stop();
   }
 
   // Returns the current playhead position, in floating point for an exact position,
   // 1-based, and scaled to measures.
   // Returns 0 if music is not playing.
   getCurrentPlayheadPosition(): number {
-    const elapsedTime = this.samplePlayer.getElapsedPlaybackTimeSeconds();
-    if (elapsedTime === -1) {
-      return 0;
-    }
-    return this.convertSecondsToPlayheadPosition(elapsedTime);
+    return this.audioPlayer.getCurrentPlaybackPosition();
   }
 
   // Converts actual seconds used by the audio system into a playhead
@@ -249,9 +268,11 @@ export default class MusicPlayer {
       return [
         {
           sampleId: soundEvent.id,
-          offsetSeconds: this.convertPlayheadPositionToSeconds(soundEvent.when),
+          playbackPosition: event.when,
           triggered: soundEvent.triggered,
           effects: soundEvent.effects,
+          originalBpm: soundData.bpm || DEFAULT_BPM,
+          pitchShift: this.calculatePitchShift(soundData),
         },
       ];
     } else if (event.type === 'pattern') {
@@ -264,11 +285,11 @@ export default class MusicPlayer {
       for (const event of patternEvent.value.events) {
         const resultEvent = {
           sampleId: `${kit}/${event.src}`,
-          offsetSeconds: this.convertPlayheadPositionToSeconds(
-            patternEvent.when + (event.tick - 1) / 16
-          ),
+          playbackPosition: patternEvent.when + (event.tick - 1) / 16,
           triggered: patternEvent.triggered,
           effects: patternEvent.effects,
+          originalBpm: this.bpm,
+          pitchShift: 0,
         };
 
         results.push(resultEvent);
@@ -305,7 +326,9 @@ export default class MusicPlayer {
 
         results.push({
           sampleId,
-          offsetSeconds: this.convertPlayheadPositionToSeconds(noteWhen),
+          playbackPosition: noteWhen,
+          originalBpm: this.bpm,
+          pitchShift: 0,
           ...event,
         });
       }
@@ -355,10 +378,12 @@ export default class MusicPlayer {
         const lengthSeconds = (event.length / 16) * this.secondsPerMeasure();
         samples.push({
           sampleId,
-          offsetSeconds: this.convertPlayheadPositionToSeconds(eventWhen),
+          playbackPosition: eventWhen,
           lengthSeconds,
           triggered,
           effects,
+          originalBpm: this.bpm,
+          pitchShift: 0,
         });
       }
     });
@@ -382,5 +407,9 @@ export default class MusicPlayer {
     }
 
     return key;
+  }
+
+  private calculatePitchShift(soundData: SoundData) {
+    return soundData.type === 'beat' ? 0 : this.key - (soundData.key || Key.C);
   }
 }

--- a/apps/src/music/player/SamplePlayerWrapper.ts
+++ b/apps/src/music/player/SamplePlayerWrapper.ts
@@ -3,6 +3,9 @@ import {SoundLoadCallbacks} from '../types';
 import SamplePlayer from './SamplePlayer';
 import {AudioPlayer, SampleEvent} from './types';
 
+/**
+ * An {@link AudioPlayer} implementation that wraps the {@link SamplePlayer}.
+ */
 class SamplePlayerWrapper implements AudioPlayer {
   constructor(
     private readonly samplePlayer: SamplePlayer,
@@ -46,6 +49,16 @@ class SamplePlayerWrapper implements AudioPlayer {
     return this.samplePlayer.previewSample(sample.sampleId, onStop);
   }
 
+  async playSamplesImmediately(
+    samples: SampleEvent[],
+    onStop?: () => void
+  ): Promise<void> {
+    return this.samplePlayer.previewSamples(
+      samples.map(sample => this.getSampleWithOffset(sample)),
+      onStop
+    );
+  }
+
   async playSequenceImmediately(): Promise<void> {
     console.log('Not supported');
   }
@@ -77,6 +90,10 @@ class SamplePlayerWrapper implements AudioPlayer {
 
   stop() {
     this.samplePlayer.stopPlayback();
+  }
+
+  cancelPendingEvents(): void {
+    this.samplePlayer.stopAllSamplesStillToPlay();
   }
 
   // Converts actual seconds used by the audio system into a playhead

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -118,6 +118,12 @@ class ToneJSPlayer implements AudioPlayer {
     this.currentPreview = {id: sample.sampleId, player};
   }
 
+  async playSamplesImmediately() {
+    console.log(
+      'Not supported. Use playSequenceImmediately for previewing note sequences.'
+    );
+  }
+
   async playSequenceImmediately({instrument, events}: SamplerSequence) {
     if (this.samplers[instrument] === undefined) {
       this.metricsReporter.logError(`Instrument not loaded: ${instrument}`);
@@ -197,7 +203,7 @@ class ToneJSPlayer implements AudioPlayer {
     this.stopAllPlayers();
   }
 
-  cancelAllEvents() {
+  cancelPendingEvents() {
     this.stopAllPlayers();
     Transport.cancel();
   }

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -74,8 +74,8 @@ export interface SampleEvent {
   pitchShift: number;
   // Effects to apply
   effects?: Effects;
-  // Length to play the sample for
-  lengthSeconds?: number;
+  // Length in measures to play the sample for
+  length?: number;
 }
 
 /** A sequence of notes played on a sampler instrument */

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -8,6 +8,9 @@ export interface AudioPlayer {
   /** If this player supports samplers */
   supportsSamplers(): boolean;
 
+  /** Set the current BPM */
+  setBpm(bpm: number): void;
+
   /** Get the current playback position in 1-based measures */
   getCurrentPlaybackPosition(): number;
 
@@ -30,6 +33,11 @@ export interface AudioPlayer {
     onStop?: () => void
   ): Promise<void>;
 
+  playSamplesImmediately(
+    samples: SampleEvent[],
+    onStop?: () => void
+  ): Promise<void>;
+
   /** Play a sequence of notes immediately (used for previews) */
   playSequenceImmediately(sequence: SamplerSequence): Promise<void>;
 
@@ -47,6 +55,9 @@ export interface AudioPlayer {
 
   /** Stop playback */
   stop(): void;
+
+  /** Cancel pending audio events */
+  cancelPendingEvents(): void;
 }
 
 /** A single sound played on the timeline */

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -381,8 +381,7 @@ class UnconnectedMusicView extends React.Component {
       this.executeCompiledSong().then(() => {
         // If code has changed mid-playback, clear and re-queue all events in the player
         if (this.props.isPlaying) {
-          this.player.stopAllSoundsStillToPlay();
-          this.player.playEvents(this.sequencer.getPlaybackEvents());
+          this.player.playEvents(this.sequencer.getPlaybackEvents(), true);
         }
       });
 


### PR DESCRIPTION
Part 3 of ToneJS player integration, follow-up to https://github.com/code-dot-org/code-dot-org/pull/56742. Now that we have a wrapper around our `SamplePlayer` that conforms it to the `AudioPlayer` interface, this change starts using `SamplePlayerWrapper` in place of `SamplePlayer` in our existing `MusicPlayer`. Still no user facing changes, but we are now starting to use this new code path via the new common interface. In the subsequent change, we will add a URL param to optionally use the ToneJS player implementation in place of this one.

## Links

https://codedotorg.atlassian.net/browse/LABS-513

## Testing story

Tested on /projectbeats, /music-intro-2024, and standalone projects.