### PR TITLE
P20-739: Fix `sync-all` after resetting the `i18n` server

### DIFF
--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -40,17 +40,17 @@ class I18nSync
 
   def run
     if @options[:interactive]
-      # download and distribute translations from the previous sync
+      # Run `sync-in` first to generate `original` files for the restoration of redacted files during `sync-out`
       return_to_staging_branch
-      sync_down if should_i "sync down"
-      sync_out if should_i "sync out"
-      CreateI18nPullRequests.down_and_out if @options[:with_pull_request] && should_i("create the down & out PR")
-
-      # force switch to the staging branch to collect and upload the most relevant English content
-      return_to_staging_branch(force: true)
       sync_in if should_i "sync in"
       sync_up if should_i "sync up"
       CreateI18nPullRequests.in_and_up if @options[:with_pull_request] && should_i("create the in & up PR")
+
+      # Force switch to the `staging` branch to avoid potential merge conflicts with the `sync-in-up` PR
+      return_to_staging_branch(force: true)
+      sync_down if should_i "sync down"
+      sync_out if should_i "sync out"
+      CreateI18nPullRequests.down_and_out if @options[:with_pull_request] && should_i("create the down & out PR")
     elsif @options[:command]
       case @options[:command]
       when 'in'


### PR DESCRIPTION
### Issue
The clean run of `sync-all` always fails after resetting the `i18n` server because it executes `sync-out` first, which depends on the `original` files generated by `sync-in`.
### Solution
Run `sync-in` first to generate `original` files for the restoration of redacted files during `sync-out`.

- JIRA ticket: [P20-739](https://codedotorg.atlassian.net/browse/P20-739)
