### PR TITLE
Pass down course name for certificates and pass to Amplitude

### DIFF
--- a/apps/src/sites/studio/pages/congrats/index.js
+++ b/apps/src/sites/studio/pages/congrats/index.js
@@ -26,18 +26,15 @@ $(document).ready(function () {
   // Allows us to conditionally hide the promotional card for the Dance Party
   // Extras tutorial if we have problems during Hour of Code.
   const hideDancePartyFollowUp = congratsData.hide_dance_followup;
-  const certificateImageUrl = congratsData.certificate_image_url;
   const isHocTutorial = congratsData.is_hoc_tutorial;
   const isPlCourse = congratsData.is_pl_course;
   const isK5PlCourse = congratsData.is_k5_pl_course;
+  const courseName = congratsData.course_name || 'hourofcode';
 
   let certificateId = '';
-  let tutorial = '';
   try {
     const params = queryString.parse(window.location.search);
     certificateId = params['i'] && params['i'].replace(/[^a-z0-9_]/g, '');
-    const s = params['s'];
-    tutorial = s ? atob(s).replace(/[^A-Za-z0-9_\- ]/g, '') : 'hourofcode';
   } catch (e) {}
 
   const mcShareLink = tryGetLocalStorage('craftHeroShareLink', '');
@@ -47,13 +44,14 @@ $(document).ready(function () {
       isHocTutorial,
       isPlCourse,
       isK5PlCourse,
+      courseNames: [courseName],
     });
 
   ReactDOM.render(
     <Provider store={store}>
       <Congrats
         certificateId={certificateId}
-        tutorial={tutorial}
+        tutorial={courseName}
         userType={userType}
         under13={under13}
         language={language}
@@ -61,7 +59,6 @@ $(document).ready(function () {
         randomDonorTwitter={randomDonorTwitter}
         randomDonorName={randomDonorName}
         hideDancePartyFollowUp={hideDancePartyFollowUp}
-        initialCertificateImageUrl={certificateImageUrl}
         isHocTutorial={isHocTutorial}
         isPlCourse={isPlCourse}
         isK5PlCourse={isK5PlCourse}

--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -112,14 +112,10 @@ function Certificate(props) {
     randomDonorTwitter,
     under13,
     children,
-    initialCertificateImageUrl,
     isHocTutorial,
   } = props;
 
-  const personalizedCertificate = getCertificateImagePath();
-  const imgSrc = personalized
-    ? personalizedCertificate
-    : initialCertificateImageUrl;
+  const imgSrc = getCertificateImagePath();
   const certificateShareLink = getCertificateSharePath();
   const externalCertificateShareLink = getExternalCertificateSharePath();
   const desktop =
@@ -235,7 +231,6 @@ Certificate.propTypes = {
   responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']).isRequired,
   under13: PropTypes.bool,
   children: PropTypes.node,
-  initialCertificateImageUrl: PropTypes.string.isRequired,
   isHocTutorial: PropTypes.bool,
 };
 

--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -54,7 +54,6 @@ export default function Congrats(props) {
     language,
     randomDonorTwitter,
     randomDonorName,
-    initialCertificateImageUrl,
     isHocTutorial,
     isPlCourse,
     isK5PlCourse,
@@ -363,7 +362,6 @@ export default function Congrats(props) {
           randomDonorTwitter={randomDonorTwitter}
           randomDonorName={randomDonorName}
           under13={under13}
-          initialCertificateImageUrl={initialCertificateImageUrl}
           isHocTutorial={isHocTutorial}
           isPlCourse={isPlCourse}
         >
@@ -383,7 +381,6 @@ Congrats.propTypes = {
   language: PropTypes.string.isRequired,
   randomDonorTwitter: PropTypes.string,
   randomDonorName: PropTypes.string,
-  initialCertificateImageUrl: PropTypes.string.isRequired,
   isHocTutorial: PropTypes.bool,
   isPlCourse: PropTypes.bool,
   isK5PlCourse: PropTypes.bool,

--- a/apps/test/unit/templates/certificates/CertificateTest.js
+++ b/apps/test/unit/templates/certificates/CertificateTest.js
@@ -32,12 +32,6 @@ describe('Certificate', () => {
     window.dashboard = storedWindowDashboard;
   });
 
-  it('renders image with initialCertificateImageUrl', () => {
-    const imageUrl = 'https://code.org/images/placeholder-hoc-image.jpg';
-    const wrapper = wrapperWithParams({initialCertificateImageUrl: imageUrl});
-    expect(wrapper.find('img').html()).to.include(imageUrl);
-  });
-
   describe('personalized certificate', () => {
     let server;
 
@@ -69,7 +63,7 @@ describe('Certificate', () => {
         isHocTutorial: true,
       });
       let image = wrapper.find('#uitest-certificate img');
-      expect(image.prop('src')).to.equal(initialCertificateImageUrl);
+      expect(image.prop('src')).to.include('/certificate_images/');
 
       const printLink = wrapper.find('.social-print-link');
       expect(printLink.prop('href')).to.match(/^\/print_certificates/);

--- a/dashboard/app/controllers/congrats_controller.rb
+++ b/dashboard/app/controllers/congrats_controller.rb
@@ -9,20 +9,19 @@ class CongratsController < ApplicationController
     @random_donor_twitter = DashboardCdoDonor.get_random_donor_twitter
     @random_donor_name = DashboardCdoDonor.get_random_donor_name
     begin
-      course_name = params[:s] && Base64.urlsafe_decode64(params[:s])
-      @certificate_image_url = certificate_image_url(nil, course_name, nil)
+      @course_name = params[:s] && Base64.urlsafe_decode64(params[:s])
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       return render status: :bad_request, json: {message: 'invalid base64'}
     end
 
-    course_type = CertificateImage.course_type(course_name)
+    course_type = CertificateImage.course_type(@course_name)
     @is_hoc_tutorial = course_type == 'hoc'
     @is_pl_course = course_type == 'pl'
     if @is_pl_course
-      course_version = CurriculumHelper.find_matching_course_version(course_name)
+      course_version = CurriculumHelper.find_matching_course_version(@course_name)
       @is_k5_pl_course = course_version&.course_offering&.pl_for_elementary_school?
     end
-    @next_course_script_name = ScriptConstants.csf_next_course_recommendation(course_name)
+    @next_course_script_name = ScriptConstants.csf_next_course_recommendation(@course_name)
     next_script = Unit.get_from_cache(@next_course_script_name) if @next_course_script_name
     @next_course_title = next_script.localized_title if next_script
     @next_course_description = next_script.localized_description if next_script

--- a/dashboard/app/views/congrats/index.html.haml
+++ b/dashboard/app/views/congrats/index.html.haml
@@ -8,10 +8,10 @@
   congrats_data[:next_course_title] = @next_course_title
   congrats_data[:next_course_description] = @next_course_description
   congrats_data[:hide_dance_followup] = DCDO.get("hide_dance_followup", false)
-  congrats_data[:certificate_image_url] = @certificate_image_url
   congrats_data[:is_hoc_tutorial] = @is_hoc_tutorial
   congrats_data[:is_pl_course] = @is_pl_course
   congrats_data[:is_k5_pl_course] = @is_k5_pl_course
+  congrats_data[:course_name] = @course_name
   if current_user
     congrats_data[:current_user] = current_user
     # We need to know the user's age to determine whether we should suggest

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -19,7 +19,7 @@ Scenario: Completing Minecraft HoC should go to certificate page and generate a 
 
 @eyes
 Scenario: Flappy customized dashboard certificate pages
-  When I open my eyes to test 'flappy certificates'
+  When I open my eyes to test "flappy certificates"
   Given I am on "http://studio.code.org/congrats"
   And I wait until element "#uitest-certificate" is visible
 
@@ -27,13 +27,13 @@ Scenario: Flappy customized dashboard certificate pages
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
   Then the href of selector ".social-print-link" contains "/print_certificates/"
-  And I see no difference for 'flappy congrats page'
+  And I see no difference for "flappy congrats page"
 
   When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
   Then I wait to see an image "/certificate_images/"
-  And I see no difference for 'personalixed flappy congrats page'
+  And I see no difference for "personalixed flappy congrats page"
 
   When I press the first "#uitest-certificate img" element to load a new page
   And I wait until current URL contains "/certificates/"
@@ -81,7 +81,7 @@ Scenario: non-mee 3rd party tutorial redirects to congrats page with params
 
 @eyes
 Scenario: Oceans uncustomized dashboard certificate pages
-  When I open my eyes to test 'oceans certificates'
+  When I open my eyes to test "oceans certificates"
   Given I am on "http://studio.code.org/congrats"
   And I wait until element "#uitest-certificate" is visible
 
@@ -89,15 +89,15 @@ Scenario: Oceans uncustomized dashboard certificate pages
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
   Then the href of selector ".social-print-link" contains "/print_certificates/"
-  And I see no difference for 'oceans congrats page'
+  And I see no difference for "oceans congrats page"
 
   When I press the first "#uitest-certificate img" element to load a new page
   And I wait until current URL contains "/certificates/"
-  And I see no difference for 'oceans certificate page'
+  And I see no difference for "oceans certificate page"
 
   When I press the first "#certificate-share img" element to load a new page
   And I wait until current URL contains "/print_certificates/"
-  And I see no difference for 'oceans print certificate page'
+  And I see no difference for "oceans print certificate page"
 
   And I close my eyes
 
@@ -121,27 +121,27 @@ Scenario: Course A 2017 uncustomized dashboard certificate pages
 
 @eyes
 Scenario: customized dashboard certificate pages with no course name
-  When I open my eyes to test 'customized certificates'
+  When I open my eyes to test "customized certificates"
   Given I am on "http://studio.code.org/congrats"
   And I wait to see element with ID "uitest-certificate"
   Then the href of selector ".social-print-link" contains "/print_certificates/"
-  And I see no difference for 'uncustomized congrats page'
+  And I see no difference for "uncustomized congrats page"
 
   When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
   Then I wait to see an image "/certificate_images/"
-  And I see no difference for 'personalized congrats page'
+  And I see no difference for "personalized congrats page"
 
   When I press the first "#uitest-certificate img" element to load a new page
   And I wait until current URL contains "/certificates/"
   Then I wait to see an image "/certificate_images/"
-  And I see no difference for 'certificate page'
+  And I see no difference for "certificate page"
 
   When I press the first "#certificate-share img" element to load a new page
   And I wait until current URL contains "/print_certificates/"
   Then I wait to see an image "/certificate_images/"
-  And I see no difference for 'print certificate page'
+  And I see no difference for "print certificate page"
 
   And I close my eyes
 

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -17,7 +17,9 @@ Scenario: Completing Minecraft HoC should go to certificate page and generate a 
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
 
+@eyes
 Scenario: Flappy customized dashboard certificate pages
+  When I open my eyes to test 'flappy certificates'
   Given I am on "http://studio.code.org/congrats"
   And I wait until element "#uitest-certificate" is visible
 
@@ -25,12 +27,13 @@ Scenario: Flappy customized dashboard certificate pages
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
   Then the href of selector ".social-print-link" contains "/print_certificates/"
-  Then I wait to see an image "/images/hour_of_code_certificate.jpg"
+  And I see no difference for 'flappy congrats page'
 
   When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
   Then I wait to see an image "/certificate_images/"
+  And I see no difference for 'personalixed flappy congrats page'
 
   When I press the first "#uitest-certificate img" element to load a new page
   And I wait until current URL contains "/certificates/"
@@ -39,6 +42,7 @@ Scenario: Flappy customized dashboard certificate pages
   When I press the first "#certificate-share img" element to load a new page
   And I wait until current URL contains "/print_certificates/"
   Then I wait to see an image "/certificate_images/"
+  And I close my eyes
 
 Scenario: Pegasus share page preserves certificate when redirecting
   # Reset lesson data (otherwise it will pull a cached certificate from
@@ -75,7 +79,9 @@ Scenario: non-mee 3rd party tutorial redirects to congrats page with params
   And I press "button:contains(Submit)" using jQuery
   Then I wait to see element with ID "uitest-thanks"
 
+@eyes
 Scenario: Oceans uncustomized dashboard certificate pages
+  When I open my eyes to test 'oceans certificates'
   Given I am on "http://studio.code.org/congrats"
   And I wait until element "#uitest-certificate" is visible
 
@@ -83,15 +89,17 @@ Scenario: Oceans uncustomized dashboard certificate pages
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
   Then the href of selector ".social-print-link" contains "/print_certificates/"
-  And I wait to see an image "/images/oceans_hoc_certificate.png"
+  And I see no difference for 'oceans congrats page'
 
   When I press the first "#uitest-certificate img" element to load a new page
   And I wait until current URL contains "/certificates/"
-  Then I wait to see an image "/images/oceans_hoc_certificate.png"
+  And I see no difference for 'oceans certificate page'
 
   When I press the first "#certificate-share img" element to load a new page
   And I wait until current URL contains "/print_certificates/"
-  Then I wait to see an image "/images/oceans_hoc_certificate.png"
+  And I see no difference for 'oceans print certificate page'
+
+  And I close my eyes
 
 Scenario: Course A 2017 uncustomized dashboard certificate pages
   Given I am on "http://studio.code.org/congrats"
@@ -111,24 +119,31 @@ Scenario: Course A 2017 uncustomized dashboard certificate pages
   And I wait until current URL contains "/print_certificates/"
   Then I wait to see an image "/certificate_images/"
 
+@eyes
 Scenario: customized dashboard certificate pages with no course name
+  When I open my eyes to test 'customized certificates'
   Given I am on "http://studio.code.org/congrats"
   And I wait to see element with ID "uitest-certificate"
   Then the href of selector ".social-print-link" contains "/print_certificates/"
-  Then I wait to see an image "/images/hour_of_code_certificate.jpg"
+  And I see no difference for 'uncustomized congrats page'
 
   When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
   Then I wait to see an image "/certificate_images/"
+  And I see no difference for 'personalized congrats page'
 
   When I press the first "#uitest-certificate img" element to load a new page
   And I wait until current URL contains "/certificates/"
   Then I wait to see an image "/certificate_images/"
+  And I see no difference for 'certificate page'
 
   When I press the first "#certificate-share img" element to load a new page
   And I wait until current URL contains "/print_certificates/"
   Then I wait to see an image "/certificate_images/"
+  And I see no difference for 'print certificate page'
+
+  And I close my eyes
 
 @eyes
 Scenario: congrats certificate pages

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1,6 +1,6 @@
 require 'cdo/url_converter'
 
-DEFAULT_WAIT_TIMEOUT = 2.minutes
+DEFAULT_WAIT_TIMEOUT = 3.minutes
 SHORT_WAIT_TIMEOUT = 30.seconds
 MODULE_PROGRESS_COLOR_MAP = {not_started: 'rgb(255, 255, 255)', in_progress: 'rgb(239, 205, 28)', completed: 'rgb(14, 190, 14)'}
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1,6 +1,6 @@
 require 'cdo/url_converter'
 
-DEFAULT_WAIT_TIMEOUT = 3.minutes
+DEFAULT_WAIT_TIMEOUT = 2.minutes
 SHORT_WAIT_TIMEOUT = 30.seconds
 MODULE_PROGRESS_COLOR_MAP = {not_started: 'rgb(255, 255, 255)', in_progress: 'rgb(239, 205, 28)', completed: 'rgb(14, 190, 14)'}
 


### PR DESCRIPTION
This PR does a couple things:
- adds courseNames to the amplitude event for visiting the congrats page
  - I made this plural because I'm working on showing multiple certificates but I'm open to push back!
- Uses the `tutorial` slug to generate the image URL. We already do this when the certificate is personalized, so I didn't see the reason for the redundancy is decoding the URL param in both [the controller](https://github.com/code-dot-org/code-dot-org/blob/e4e4c475df0449dd304fa68d20cf87ee1289fd4e/dashboard/app/controllers/congrats_controller.rb#L12) and on the client
  - This did require updating some UI tests, which I decided to turn into eyes tests (we are interested in how things look). I'm open for feedback here -- I decided on eyes tests as the image srcs are now obfuscated URLs, but I believe they are stable so I could keep these as UI tests. 

Some successful UI test runs with this change:
- https://app.saucelabs.com/tests/a7812e8a92244b6f9de146de68001aa5#72
- https://app.saucelabs.com/tests/6b3f12ba4461486880fb191e6bc71eee#17
- https://app.saucelabs.com/tests/6e945d5ac60244388150496dfdb62244#24
- https://app.saucelabs.com/tests/adea0fa1403546288153f69559b2cc0c#54