### PR TITLE
Music: add sampler playback support

### DIFF
--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -471,23 +471,6 @@ export default class MusicPlayer {
     return soundData.type === 'beat' ? 0 : this.key - (soundData.key || Key.C);
   }
 
-  // TODO: Kind of a hack to preload all instrument sounds. Ideally, load each instrument as needed when
-  // opening the chord/pattern panel.
-  async setupAllInstruments(onLoadFinished?: LoadFinishedCallback) {
-    const library = MusicLibrary.getInstance();
-    if (library === undefined) {
-      return;
-    }
-
-    const instruments = library.groups[0].folders
-      .filter(folder => folder.type === 'kit' || folder.type === 'instrument')
-      .map(folder => folder.path);
-
-    for (const instrument of instruments) {
-      await this.setupSampler(instrument, onLoadFinished);
-    }
-  }
-
   async setupSampler(
     instrument: string,
     onLoadFinished?: LoadFinishedCallback

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -475,7 +475,10 @@ export default class MusicPlayer {
     instrument: string,
     onLoadFinished?: LoadFinishedCallback
   ) {
-    if (!this.audioPlayer.supportsSamplers()) {
+    if (
+      !this.audioPlayer.supportsSamplers() ||
+      this.audioPlayer.isInstrumentLoaded(instrument)
+    ) {
       return;
     }
 

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -16,8 +16,6 @@ import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {LoadFinishedCallback, UpdateLoadProgressCallback} from '../types';
 import {AudioPlayer, SampleEvent, SamplerSequence} from './types';
 import SamplePlayerWrapper from './SamplePlayerWrapper';
-import appConfig from '../appConfig';
-import ToneJSPlayer from './ToneJSPlayer';
 
 // Using require() to import JS in TS files
 const constants = require('../constants');
@@ -40,17 +38,11 @@ export default class MusicPlayer {
   constructor(
     bpm: number = DEFAULT_BPM,
     key: Key = DEFAULT_KEY,
-    metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter(),
-    audioPlayer?: AudioPlayer
+    audioPlayer: AudioPlayer = new SamplePlayerWrapper(new SamplePlayer()),
+    metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter()
   ) {
+    this.audioPlayer = audioPlayer;
     this.metricsReporter = metricsReporter;
-    if (!audioPlayer && appConfig.getValue('player') === 'tonejs') {
-      this.audioPlayer = new ToneJSPlayer();
-      console.log('[MusicPlayer] Using ToneJSPlayer');
-    } else {
-      this.audioPlayer = new SamplePlayerWrapper(new SamplePlayer());
-      console.log('[MusicPlayer] Using SamplePlayer');
-    }
     this.updateConfiguration(bpm, key);
   }
 
@@ -446,7 +438,6 @@ export default class MusicPlayer {
       return null;
     }
 
-    // TODO: Store note index instead of src for easier lookup
     return {
       instrument: kit,
       events: patternEvent.value.events.map(event => {

--- a/apps/src/music/player/SamplePlayerWrapper.ts
+++ b/apps/src/music/player/SamplePlayerWrapper.ts
@@ -42,6 +42,10 @@ class SamplePlayerWrapper implements AudioPlayer {
     console.log('Not supported');
   }
 
+  isInstrumentLoaded(): boolean {
+    return false;
+  }
+
   async playSampleImmediately(
     sample: SampleEvent,
     onStop?: () => void

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -11,7 +11,7 @@ import {DEFAULT_BPM} from '../constants';
 /**
  * An {@link AudioPlayer} implementation using the Tone.js library.
  *
- * TODO for ToneJS integration:
+ * TODO:
  * - Effects
  * - Sample sequences
  */

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -69,6 +69,9 @@ class ToneJSPlayer implements AudioPlayer {
     sampleMap: {[note: number]: string},
     callbacks?: SoundLoadCallbacks
   ) {
+    if (this.samplers[instrumentName]) {
+      return;
+    }
     const urls: {[note: number]: AudioBuffer} = {};
     await this.soundCache.loadSounds(Object.values(sampleMap), callbacks);
     Object.keys(sampleMap).forEach(note => {
@@ -80,6 +83,10 @@ class ToneJSPlayer implements AudioPlayer {
 
     const sampler = new Sampler(urls).toDestination();
     this.samplers[instrumentName] = sampler;
+  }
+
+  isInstrumentLoaded(instrumentName: string): boolean {
+    return this.samplers[instrumentName] !== undefined;
   }
 
   async playSampleImmediately(sample: SampleEvent, onStop?: () => void) {

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -11,7 +11,7 @@ import {DEFAULT_BPM} from '../constants';
 /**
  * An {@link AudioPlayer} implementation using the Tone.js library.
  *
- * TODO:
+ * TODO for ToneJS integration:
  * - Effects
  * - Sample sequences
  */

--- a/apps/src/music/player/interfaces/PatternEvent.ts
+++ b/apps/src/music/player/interfaces/PatternEvent.ts
@@ -16,4 +16,5 @@ export interface PatternEventValue {
 export interface PatternTickEvent {
   tick: number;
   src: string;
+  note: number;
 }

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -27,6 +27,9 @@ export interface AudioPlayer {
     callbacks?: SoundLoadCallbacks
   ): Promise<void>;
 
+  /** If the given instrument has been loaded */
+  isInstrumentLoaded(instrumentName: string): boolean;
+
   /** Play a sample immediately (used for previews) */
   playSampleImmediately(
     sample: SampleEvent,

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -1,10 +1,10 @@
 import {SoundLoadCallbacks} from '../types';
 import {Effects} from './interfaces/Effects';
 
-/** Common interface for the internal audio player */
+/**
+ * Common interface for the internal audio player
+ */
 export interface AudioPlayer {
-  // TODO: Fill in as we align ToneJSPlayer and SamplePlayer
-
   /** If this player supports samplers */
   supportsSamplers(): boolean;
 

--- a/apps/src/music/utils/Notes.ts
+++ b/apps/src/music/utils/Notes.ts
@@ -34,11 +34,14 @@ export const isBlackKey = (note: number): boolean => {
   );
 };
 
+// Get the note name ('C', 'D', 'E', etc.) from the MIDI note value.
 export const getNoteName = (note: number): string => Key[note % 12];
 
+// Get the note octave from the MIDI note value.
 export const getNoteOctave = (note: number): number =>
   Math.floor(note / 12) - 1;
 
+// Get the full pitch name ('C4', 'D5', etc.) from the MIDI note value.
 export const getPitchName = (note: number): string =>
   getNoteName(note) + getNoteOctave(note);
 

--- a/apps/src/music/utils/Notes.ts
+++ b/apps/src/music/utils/Notes.ts
@@ -36,6 +36,12 @@ export const isBlackKey = (note: number): boolean => {
 
 export const getNoteName = (note: number): string => Key[note % 12];
 
+export const getNoteOctave = (note: number): number =>
+  Math.floor(note / 12) - 1;
+
+export const getPitchName = (note: number): string =>
+  getNoteName(note) + getNoteOctave(note);
+
 // Transpose the note by adding the note offset to the target note defined
 // by the target key.
 export const getTranposedNote = (targetKey: Key, noteOffset: number) =>

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -305,6 +305,8 @@ class UnconnectedMusicView extends React.Component {
       this.library.getKey()
     );
 
+    this.player.setupAllInstruments();
+
     this.setState({
       currentLibraryName: libraryName,
     });

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -305,8 +305,6 @@ class UnconnectedMusicView extends React.Component {
       this.library.getKey()
     );
 
-    this.player.setupAllInstruments();
-
     this.setState({
       currentLibraryName: libraryName,
     });

--- a/apps/src/music/views/PatternPanel.tsx
+++ b/apps/src/music/views/PatternPanel.tsx
@@ -49,7 +49,7 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
   const [currentPreviewTick, setCurrentPreviewTick] = useState(0);
 
   const toggleEvent = useCallback(
-    (sound: SoundData, tick: number) => {
+    (sound: SoundData, tick: number, note: number) => {
       const index = currentValue.events.findIndex(
         event => event.src === sound.src && event.tick === tick
       );
@@ -58,7 +58,7 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
         currentValue.events.splice(index, 1);
       } else {
         // Not found, so add.
-        currentValue.events.push({src: sound.src, tick});
+        currentValue.events.push({src: sound.src, tick, note});
         previewSound(`${currentValue.kit}/${sound.src}`);
       }
 
@@ -117,7 +117,7 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
           </option>
         ))}
       </select>
-      {currentFolder.sounds.map(sound => {
+      {currentFolder.sounds.map((sound, index) => {
         return (
           <div className={styles.row} key={sound.src}>
             <div className={styles.nameContainer}>
@@ -135,7 +135,7 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
                     styles.outerCell,
                     tick === currentPreviewTick && styles.outerCellPlaying
                   )}
-                  onClick={() => toggleEvent(sound, tick)}
+                  onClick={() => toggleEvent(sound, tick, index)}
                   key={tick}
                 >
                   <div className={getCellClasses(sound, tick)} />


### PR DESCRIPTION
Part 4 of adding ToneJS player support, follow-up to https://github.com/code-dot-org/code-dot-org/pull/56807. This adds support for using samplers to play instrument sounds (notes/beats) which will be used by the ToneJS player when it is available.

## Links

https://codedotorg.atlassian.net/browse/LABS-513

## Testing story

Tested on /projectbeats, /music-intro-2024, standalone projects