### PR TITLE
Fix broken Spotify data sync

### DIFF
--- a/lib/cdo/web_purify.rb
+++ b/lib/cdo/web_purify.rb
@@ -2,6 +2,7 @@ require 'net/http'
 require 'open-uri'
 require 'json'
 require 'dynamic_config/gatekeeper'
+require 'dynamic_config/dcdo'
 
 module WebPurify
   # WebPurify limits us to 30,000 characters per request and 4 simultaneous requests per API key


### PR DESCRIPTION
A cronjob that syncs data from Spotify for Applab has been failing for the past 4 weeks or so ([Honeybadger error here](https://app.honeybadger.io/projects/45435/faults/104043741#)). Based on the timing, my guess is that it is a result of a change we made to remove a dependency on pegasus in our webpurify code [here](https://github.com/code-dot-org/code-dot-org/pull/56091). I update here to explicitly require DCDO.

## Testing story

I didn't test the full Spotify download, but I did simplify the `spotify` script to just include the line that checks for profanity, ran it, and could repro the issue. With this change, no error.