### PR TITLE
Check if channel_id is already appended before appending it to WebLab footer links

### DIFF
--- a/dashboard/public/weblab/footer.js
+++ b/dashboard/public/weblab/footer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa9dfbba08578f25e24a97535e3c950edde6b52d1e86e9bc66465215560f1c81
-size 1546
+oid sha256:8b35c465973cb975a3012c5c4fd991476f9cf821c389f68fc94d1f102853ddad
+size 1535

--- a/dashboard/public/weblab/footer.js
+++ b/dashboard/public/weblab/footer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77561bc0aaaff298c949abcbffd627bdb0de330b4995eac5792ea8665ee4a46f
-size 1140
+oid sha256:fa9dfbba08578f25e24a97535e3c950edde6b52d1e86e9bc66465215560f1c81
+size 1546


### PR DESCRIPTION
Here's the diff using an external tool since Github won't show it for an LFS file:
<img width="1236" alt="Screenshot 2024-02-26 at 4 58 13 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/c5ed7c71-b26c-4aa5-af6e-1bb4c221c389">

We've got a long-standing and intermittent issue where the "View Code" button on the Web Lab footer sometimes generates invalid links with the channel ID and `/view` suffix appended twice.

My guess at the root cause: Given the setup with a `readystatechange` event listener and an asynchronous XHR request loading the footer content, I think there are multiple pathways for applyFooter to be called. If both these events happen at times when applyFooter’s conditions are met (i.e., both footerContents and ready are truthy), the function might run more than once, appending the channel_id and /view to the URLs twice.

However, as I have not been able to reproduce locally, this is a speculative fix. 

## Links

Slack thread: https://codedotorg.slack.com/archives/C03DBDN67B7/p1708992954857889?thread_ts=1708988274.961119&cid=C03DBDN67B7
Most recent Zendesk ticket: https://codeorg.zendesk.com/agent/tickets/486903

## Testing story

This is a speculative fix because I haven't repro'ed locally. I might be able to repro locally by forcing some of these conditions to be true. 

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
