### PR TITLE
Revert "Revert "Removed explicit import of react-typist""

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -290,7 +290,6 @@
     "react-tether": "^1.0.4",
     "react-tooltip": "^3.2.7",
     "react-transition-group": "2.9.0",
-    "react-typist": "^2.0.5",
     "react-virtualized": "^9.18.5",
     "react-virtualized-select": "^3.0.1",
     "react-with-context": "^2.0.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8381,7 +8381,6 @@ __metadata:
     react-tether: ^1.0.4
     react-tooltip: ^3.2.7
     react-transition-group: 2.9.0
-    react-typist: ^2.0.5
     react-virtualized: ^9.18.5
     react-virtualized-select: ^3.0.1
     react-with-context: ^2.0.0


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#56819

We suspected that this change might be causing the staging build to fail, but it continued to fail after this revert. Re-enabling the code change.