### PR TITLE
Allow emojis in DatablockStorage key names and table names

### DIFF
--- a/dashboard/app/models/datablock_storage_kvp.rb
+++ b/dashboard/app/models/datablock_storage_kvp.rb
@@ -3,7 +3,7 @@
 # Table name: datablock_storage_kvps
 #
 #  project_id :integer          not null, primary key
-#  key        :string(768)      not null, primary key
+#  key        :string(700)      not null, primary key
 #  value      :json
 #
 class DatablockStorageKvp < ApplicationRecord

--- a/dashboard/app/models/datablock_storage_record.rb
+++ b/dashboard/app/models/datablock_storage_record.rb
@@ -3,7 +3,7 @@
 # Table name: datablock_storage_records
 #
 #  project_id  :integer          not null, primary key
-#  table_name  :string(768)      not null, primary key
+#  table_name  :string(700)      not null, primary key
 #  record_id   :integer          not null, primary key
 #  record_json :json
 #

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -3,9 +3,9 @@
 # Table name: datablock_storage_tables
 #
 #  project_id      :integer          not null, primary key
-#  table_name      :string(768)      not null, primary key
+#  table_name      :string(700)      not null, primary key
 #  columns         :json
-#  is_shared_table :string(768)
+#  is_shared_table :string(700)
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #

--- a/dashboard/db/migrate/20240110234501_create_datablock_storage_kvps.rb
+++ b/dashboard/db/migrate/20240110234501_create_datablock_storage_kvps.rb
@@ -1,8 +1,12 @@
 class CreateDatablockStorageKvps < ActiveRecord::Migration[6.1]
   def change
-    create_table :datablock_storage_kvps, primary_key: [:project_id, :key] do |t|
+    # We use utf8mb4 because we want .string to support emoji
+    create_table :datablock_storage_kvps, primary_key: [:project_id, :key], charset: 'utf8mb4', collation: 'utf8mb4_bin' do |t|
       t.integer :project_id
-      t.string :key, limit: 768
+      # this is part of the composite primary_key and max key length in mysql is 3072 bytes,
+      # so 700 * 4-bytes per utf8 character. This also slightly exceeds the existing Firebase
+      # data's max key length.
+      t.string :key, limit: 700
       t.json :value
     end
   end

--- a/dashboard/db/migrate/20240111002910_create_datablock_storage_records.rb
+++ b/dashboard/db/migrate/20240111002910_create_datablock_storage_records.rb
@@ -1,8 +1,11 @@
 class CreateDatablockStorageRecords < ActiveRecord::Migration[6.1]
   def change
-    create_table :datablock_storage_records, primary_key: [:project_id, :table_name, :record_id] do |t|
+    # We use utf8mb4 because we want .table_name to support emoji
+    create_table :datablock_storage_records, primary_key: [:project_id, :table_name, :record_id], charset: 'utf8mb4', collation: 'utf8mb4_bin' do |t|
       t.integer :project_id
-      t.string :table_name, limit: 768
+      # this is part of the composite primary_key for datablock_storage_tables
+      # and max key length in mysql is 3072 bytes, so 700 * 4-bytes per utf8 character
+      t.string :table_name, limit: 700
       t.integer :record_id
       t.json :record_json
     end

--- a/dashboard/db/migrate/20240111003957_create_datablock_storage_tables.rb
+++ b/dashboard/db/migrate/20240111003957_create_datablock_storage_tables.rb
@@ -1,10 +1,12 @@
 class CreateDatablockStorageTables < ActiveRecord::Migration[6.1]
   def change
-    create_table :datablock_storage_tables, primary_key: [:project_id, :table_name] do |t|
+    # We use utf8mb4 because we want .table_name to support emoji
+    create_table :datablock_storage_tables, primary_key: [:project_id, :table_name], charset: 'utf8mb4', collation: 'utf8mb4_bin' do |t|
       t.integer :project_id
-      t.string :table_name, limit: 768
+      # this is part of the composite primary_key and max key length in mysql is 3072 bytes * 4-bytes per utf8 character
+      t.string :table_name, limit: 700
       t.json :columns
-      t.string :is_shared_table, limit: 768
+      t.string :is_shared_table, limit: 700
 
       t.timestamps
     end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -435,9 +435,9 @@ ActiveRecord::Schema.define(version: 2024_02_16_071353) do
     t.index ["name"], name: "index_data_docs_on_name"
   end
 
-  create_table "datablock_storage_kvps", primary_key: ["project_id", "key"], charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "datablock_storage_kvps", primary_key: ["project_id", "key"], charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "project_id", null: false
-    t.string "key", limit: 768, null: false
+    t.string "key", limit: 700, null: false
     t.json "value"
   end
 
@@ -449,19 +449,19 @@ ActiveRecord::Schema.define(version: 2024_02_16_071353) do
     t.index ["singleton_guard"], name: "index_datablock_storage_library_manifest_on_singleton_guard", unique: true
   end
 
-  create_table "datablock_storage_records", primary_key: ["project_id", "table_name", "record_id"], charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "datablock_storage_records", primary_key: ["project_id", "table_name", "record_id"], charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "project_id", null: false
-    t.string "table_name", limit: 768, null: false
+    t.string "table_name", limit: 700, null: false
     t.integer "record_id", null: false
     t.json "record_json"
     t.index ["project_id", "table_name"], name: "index_datablock_storage_records_on_project_id_and_table_name"
   end
 
-  create_table "datablock_storage_tables", primary_key: ["project_id", "table_name"], charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "datablock_storage_tables", primary_key: ["project_id", "table_name"], charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "project_id", null: false
-    t.string "table_name", limit: 768, null: false
+    t.string "table_name", limit: 700, null: false
     t.json "columns"
-    t.string "is_shared_table", limit: 768
+    t.string "is_shared_table", limit: 700
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
Our existing Firebase storage allows full JSON, which means full support for UTF-8 characters, including 4-byte characters like Emoji. To match Firebase, and allow import of existing data, we need to support the full 4-byte characters, but code.org's DBs default to using the mysql `utf8` type, which unfortunately is only 3-byte UTF-8 (UGH!). Thus we need to explicitly specify that our tables will be `utf8mb4`, and support emojis. That is all.

We also shortened the length for table_names and keys to 700 characters, see: https://github.com/code-dot-org/code-dot-org/issues/55344#issuecomment-1965686475 for details.