### PR TITLE
Exlude `dashboard/config/locales/en.yml` from Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 apps/i18n/** filter=lfs diff=lfs merge=lfs -text
 dashboard/config/locales/** filter=lfs diff=lfs merge=lfs -text
+dashboard/config/locales/en.yml !text !filter !merge !diff
 i18n/locales/** filter=lfs diff=lfs merge=lfs -text
 apps/static/** filter=lfs diff=lfs merge=lfs -text
 dashboard/app/assets/** filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
[`dashboard/config/locales/en.yml`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/config/locales/en.yml) is a system-important file which not so often updated manually by developers and is used as a source for the `i18n sync`, so it's important to track its changes.
- Reference: https://github.com/code-dot-org/code-dot-org/pull/56737