### PR TITLE
Remove JS after removing corresponding HAML

### DIFF
--- a/apps/src/sites/code.org/pages/public/educate/curriculum/courses.js
+++ b/apps/src/sites/code.org/pages/public/educate/curriculum/courses.js
@@ -1,3 +1,0 @@
-import {initCourseExplorer} from '@cdo/apps/courseExplorer/courseExplorer';
-
-$(document).ready(initCourseExplorer);

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -173,7 +173,6 @@ const INTERNAL_ENTRIES = {
 const PEGASUS_ENTRIES = {
   // code.org
   'code.org/public/dance': './src/sites/code.org/pages/public/dance.js',
-  'code.org/public/educate/curriculum/courses': './src/sites/code.org/pages/public/educate/curriculum/courses.js',
   'code.org/public/teacher-dashboard/index': './src/sites/code.org/pages/public/teacher-dashboard/index.js',
   'code.org/public/yourschool': './src/sites/code.org/pages/public/yourschool.js',
   'code.org/public/yourschool/thankyou': './src/sites/code.org/pages/public/yourschool/thankyou.js',


### PR DESCRIPTION
The `public/education/courses.haml` file was removed in the [staging scoop](https://github.com/code-dot-org/code-dot-org/commit/8fe1f1f1a513f319d73b6c5a1da8bc7e1cc9c142#diff-df1cb23efd931bae9ca6828f4055481c1754f0ea4303eb0db101140c33811f7e), without removing the corresponding JS file, which caused the build to fail. Unfortunately, Drone does not run on these scoops, so this is currently blocking all Drone runs.

This has happened in some fashion a few times in the past several years and is unfortunately a flaw in our pegasus / dropbox system. :(

## Testing story

`yarn build` succeeded locally after this change

