### PR TITLE
AI Tutor: delete AiTutorInteractions when a user is purged

### DIFF
--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1588,7 +1588,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   # Table: dashboard.ai_tutor_interactions
   #
 
-  test "deletes all of a soft-deleted user's ai tutor interactions (chat messages)" do
+  test "deletes all of a purged user's ai tutor interactions (chat messages)" do
     student = create :student_with_ai_tutor_access
     num_ai_tutor_interactions = 3
     create_list :ai_tutor_interaction, num_ai_tutor_interactions, user: student

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1593,11 +1593,9 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     num_ai_tutor_interactions = 3
     create_list :ai_tutor_interaction, num_ai_tutor_interactions, user: student
 
-    assert AiTutorInteraction.where(user_id: student.id).count, num_ai_tutor_interactions
-
-    student.destroy
-
-    assert AiTutorInteraction.where(user_id: student.id).count, 0
+    assert_changes -> {AiTutorInteraction.where(user: student).count}, from: num_ai_tutor_interactions, to: 0 do
+      student.destroy
+    end
   end
 
   #

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1585,6 +1585,24 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   end
 
   #
+  # Table: dashboard.ai_tutor_interactions
+  #
+
+  test "deletes all of a soft-deleted user's ai tutor interactions (chat messages)" do
+    student = create :student_with_ai_tutor_access
+    num_ai_tutor_interactions = 3
+    num_ai_tutor_interactions.times do
+      create :ai_tutor_interaction, user: student
+    end
+
+    assert AiTutorInteraction.where(user_id: student.id).count, num_ai_tutor_interactions
+
+    student.destroy
+
+    assert AiTutorInteraction.where(user_id: student.id).count, 0
+  end
+
+  #
   # Table: dashboard.projects
   #
 

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1591,9 +1591,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "deletes all of a soft-deleted user's ai tutor interactions (chat messages)" do
     student = create :student_with_ai_tutor_access
     num_ai_tutor_interactions = 3
-    num_ai_tutor_interactions.times do
-      create :ai_tutor_interaction, user: student
-    end
+    create_list :ai_tutor_interaction, num_ai_tutor_interactions, user: student
 
     assert AiTutorInteraction.where(user_id: student.id).count, num_ai_tutor_interactions
 

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1594,7 +1594,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     create_list :ai_tutor_interaction, num_ai_tutor_interactions, user: student
 
     assert_changes -> {AiTutorInteraction.where(user: student).count}, from: num_ai_tutor_interactions, to: 0 do
-      student.destroy
+      purge_user student
     end
   end
 

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -308,6 +308,13 @@ class DeleteAccountsHelper
     @log.puts "Cleared #{as_student_count} TeacherFeedback" if as_student_count > 0
   end
 
+  def delete_ai_tutor_interactions(user_id)
+    chat_messages_to_delete = AiTutorInteraction.where(user_id: user_id)
+    count = chat_messages_to_delete.count
+    chat_messages_to_delete.destroy_all
+    @log.puts "Deleted #{count} AI Tutor Interactions" if count > 0
+  end
+
   def clean_and_destroy_code_reviews(user_id)
     # anonymize notes the user wrote
     comments_written = CodeReviewComment.where(commenter_id: user_id)
@@ -427,6 +434,7 @@ class DeleteAccountsHelper
     clean_level_source_backed_progress(user.id)
     clean_pegasus_forms_for_user(user)
     delete_project_backed_progress(user)
+    delete_ai_tutor_interactions(user.id)
     clean_and_destroy_pd_content(user.id, user_email)
     clean_user_sections(user.id)
     remove_user_from_sections_as_student(user)

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -311,7 +311,7 @@ class DeleteAccountsHelper
   def delete_ai_tutor_interactions(user_id)
     chat_messages_to_delete = AiTutorInteraction.where(user_id: user_id)
     count = chat_messages_to_delete.count
-    chat_messages_to_delete.destroy_all
+    chat_messages_to_delete.in_batches.destroy_all
     @log.puts "Deleted #{count} AI Tutor Interactions" if count > 0
   end
 


### PR DESCRIPTION
[CT-250](https://codedotorg.atlassian.net/browse/CT-250)
[AI Tutor Product Spec ](https://docs.google.com/document/d/1rEWpIA6zXzevldiyi6DH-Pt4UU7uqPlWjTnUbz9uVLE/edit) req 4.7 

Deletes a user's chat messages with the AI Tutor when the user is purged from our system.  We'll still have a record in Amplitude for aggregate metrics regarding the relative uses of compilation, validation and general chat support; but we will no longer have database records that contain the content of the messages the user sent to and received from AI Tutor. This alleviates a privacy concern for the tool since the `AiTutorInteractions` table can contain PII. 


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
