### PR TITLE
Refactor .editorial-card-wrapper css

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -832,14 +832,6 @@ form {
   .flex-container {
     gap: 1.5rem;
     flex-direction: column;
-
-    &.self-paced-english {
-      gap: 1.3rem;
-
-      @media screen and (max-width: $width-md) {
-        gap: 0;
-      }
-    }
   }
 
   img {

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -1,4 +1,4 @@
-@import 'font', 'typography', 'breakpoints';
+@import "font", "typography", "breakpoints";
 
 // Variables
 $border-radius: 4px;
@@ -15,9 +15,15 @@ p {
 }
 
 // Use these classes to change a section's background color
-section.bg-neutral-light { background-color: var(--neutral_light); }
-section.bg-neutral-dark { background-color: var(--neutral_dark); }
-section.bg-secondary { background-color: var(--brand_secondary_light); }
+section.bg-neutral-light {
+  background-color: var(--neutral_light);
+}
+section.bg-neutral-dark {
+  background-color: var(--neutral_dark);
+}
+section.bg-secondary {
+  background-color: var(--brand_secondary_light);
+}
 section.bg-primary-light {
   background-color: rgba(171, 223, 229, 0.5);
 
@@ -29,13 +35,19 @@ section.bg-primary-light {
     }
   }
 
-  a { color: var(--neutral_dark) !important;
-    &:hover { color: var(--brand_secondary_dark) !important; }
-    &.link-button { color: var(--neutral_white) !important; }
+  a {
+    color: var(--neutral_dark) !important;
+    &:hover {
+      color: var(--brand_secondary_dark) !important;
+    }
+    &.link-button {
+      color: var(--neutral_white) !important;
+    }
   }
 }
 section.bg-pattern-dark {
-  background: url("/images/banners/banner-bg-lines-neutral-dark.png") center repeat;
+  background: url("/images/banners/banner-bg-lines-neutral-dark.png") center
+    repeat;
   background-size: 12rem;
   background-color: var(--neutral_dark);
 }
@@ -62,13 +74,19 @@ section.bg-pattern-dark {
 }
 
 // Centers a block-level element
-.centered { text-align: center !important; }
+.centered {
+  text-align: center !important;
+}
 
 // Removes the bottom margin or padding —
 // often helpful on a last paragraphs or list elements
 // to maintain consistent white space between sections
-.no-margin-bottom { margin-bottom: 0 !important;}
-.no-padding-bottom { padding-bottom: 0 !important;}
+.no-margin-bottom {
+  margin-bottom: 0 !important;
+}
+.no-padding-bottom {
+  padding-bottom: 0 !important;
+}
 
 // FontAwesome icon defaults
 // Sets fixed height on icon container to maintain consistent
@@ -88,19 +106,45 @@ i.fa-fw {
 .flex-container {
   display: flex;
 
-  &.flex-direction-column { flex-direction: column; }
-  &.flex-direction-row { flex-direction: row; }
-  &.justify-space-between { justify-content: space-between }
-  &.justify-center { justify-content: center }
-  &.justify-end { justify-content: end; }
-  &.align-content-baseline { align-content: baseline; }
-  &.align-items-center { align-items: center; }
-  &.align-items-start { align-items: flex-start; }
-  &.wrap { flex-wrap: wrap; }
-  &.wrap-reverse { flex-wrap: wrap-reverse; }
-  &.gap-1 { gap: 1rem }
-  &.gap-1-5 { gap: 1.5rem }
-  &.gap-2 { gap: 2rem }
+  &.flex-direction-column {
+    flex-direction: column;
+  }
+  &.flex-direction-row {
+    flex-direction: row;
+  }
+  &.justify-space-between {
+    justify-content: space-between;
+  }
+  &.justify-center {
+    justify-content: center;
+  }
+  &.justify-end {
+    justify-content: end;
+  }
+  &.align-content-baseline {
+    align-content: baseline;
+  }
+  &.align-items-center {
+    align-items: center;
+  }
+  &.align-items-start {
+    align-items: flex-start;
+  }
+  &.wrap {
+    flex-wrap: wrap;
+  }
+  &.wrap-reverse {
+    flex-wrap: wrap-reverse;
+  }
+  &.gap-1 {
+    gap: 1rem;
+  }
+  &.gap-1-5 {
+    gap: 1.5rem;
+  }
+  &.gap-2 {
+    gap: 2rem;
+  }
 }
 
 // Grid container
@@ -226,7 +270,7 @@ ul {
     // stretch to the width of the container
     &.full-width {
       li {
-        width: 100%
+        width: 100%;
       }
     }
 
@@ -284,7 +328,7 @@ ul {
 
         &:before {
           color: var(--brand_secondary_default);
-          transition: color ease-in-out .2s;
+          transition: color ease-in-out 0.2s;
         }
       }
 
@@ -299,7 +343,6 @@ ul {
       }
 
       &:hover {
-
         i:before {
           color: var(--brand_secondary_dark);
         }
@@ -347,9 +390,16 @@ ul {
         border-radius: 1rem;
       }
 
-      &:nth-of-type(1) span { background: var(--brand_primary_light) }
-      &:nth-of-type(2) span { background: var(--brand_primary_default); opacity: 0.75; }
-      &:nth-of-type(3) span { background: var(--brand_primary_dark)}
+      &:nth-of-type(1) span {
+        background: var(--brand_primary_light);
+      }
+      &:nth-of-type(2) span {
+        background: var(--brand_primary_default);
+        opacity: 0.75;
+      }
+      &:nth-of-type(3) span {
+        background: var(--brand_primary_dark);
+      }
 
       h3 {
         @include heading-sm;
@@ -473,7 +523,7 @@ ol.steps-list {
 details {
   padding: 1.5rem 1rem 1rem;
   border-bottom: 1px solid var(--neutral_dark80);
-  transition: background ease-in-out .2s;
+  transition: background ease-in-out 0.2s;
 
   &:hover {
     background: var(--neutral_light);
@@ -500,7 +550,7 @@ details {
 
   // Hides the default arrow on Safari
   & summary::-webkit-details-marker {
-    display:none;
+    display: none;
   }
 
   // Uses FontAwesome arrow icons to
@@ -522,7 +572,6 @@ details {
 
 // Forms
 form {
-
   label {
     display: block;
     text-align: left;
@@ -530,17 +579,18 @@ form {
     font-weight: var(--semi-bold-font-weight);
   }
 
-  input[type="text"], select {
+  input[type="text"],
+  select {
     display: block;
     width: 100%;
-    margin: .25rem auto 1.5rem;
+    margin: 0.25rem auto 1.5rem;
     padding: 0.5rem;
     border: 1px solid;
     border-radius: $border-radius;
     font-family: var(--main-font);
     font-weight: var(--regular-font-weight);
     font-size: 1rem;
-    transition: all ease-in-out .2s;
+    transition: all ease-in-out 0.2s;
 
     &:focus {
       @include focus-outline;
@@ -548,7 +598,7 @@ form {
   }
 
   button,
-  &[type=submit] {
+  &[type="submit"] {
     margin-top: 1rem;
 
     @media screen and (max-width: $width-sm) {
@@ -561,7 +611,8 @@ form {
   .form-group {
     margin: 0;
 
-    input[type="text"], select {
+    input[type="text"],
+    select {
       margin: 0;
     }
   }
@@ -636,7 +687,6 @@ form {
   }
 
   figure {
-
     &.video-responsive {
       margin-bottom: 1rem;
     }
@@ -648,7 +698,6 @@ form {
   }
 
   &.secondary {
-
     h3 {
       @include heading-sm;
     }
@@ -761,7 +810,8 @@ form {
   }
 
   @media screen and (max-width: $width-sm) {
-    a.link-button, button {
+    a.link-button,
+    button {
       width: 100%;
       text-align: center;
     }
@@ -796,6 +846,7 @@ form {
     width: 12rem;
     height: 12rem;
     border-radius: 50%;
+    margin-bottom: 1.5rem;
   }
 
   p {
@@ -862,13 +913,13 @@ form {
       background: none;
       border: none;
       transform: translateY(-50%);
-      transition: .3s;
+      transition: 0.3s;
       padding: 0;
       width: 1.75rem;
 
       &:hover {
         background: none;
-        opacity: .8;
+        opacity: 0.8;
       }
 
       img {
@@ -915,7 +966,7 @@ form {
       }
     }
 
-    a{
+    a {
       background: var(--brand_primary_light);
 
       &.selected {
@@ -937,7 +988,6 @@ form {
 // See code.org/educate/professional-learning/middle-high
 // and /views/pl_middle_high_carousel.haml for an example
 .quotes-wrapper {
-
   img {
     border-radius: $border-radius;
     width: 100%;
@@ -953,7 +1003,6 @@ form {
   }
 
   .carousel-wrapper {
-
     .with-image {
       display: flex;
       justify-content: space-between;
@@ -986,7 +1035,8 @@ form {
         font-size: 1.5rem;
         line-height: 1.3;
 
-        &:before, &:after {
+        &:before,
+        &:after {
           font: var(--fa-font-solid);
           color: var(--brand_primary_default);
         }
@@ -1014,7 +1064,6 @@ form {
 // See code.org/educate/professional-learning/middle-high
 // and /views/pl_middle_high_carousel.haml for an example
 .photo-carousel-wrapper {
-
   .with-image {
     display: flex;
     justify-content: space-between;
@@ -1066,7 +1115,8 @@ form {
 // Individual quote section
 // See code.org/teach for an example
 section.quote {
-  background: url("/images/banners/banner-bg-lines-neutral-dark.png") center repeat;
+  background: url("/images/banners/banner-bg-lines-neutral-dark.png") center
+    repeat;
   background-size: 12rem;
   background-color: var(--neutral_dark);
 
@@ -1082,7 +1132,8 @@ section.quote {
         font-size: 1.5rem;
       }
 
-      &:before, &:after {
+      &:before,
+      &:after {
         font: var(--fa-font-solid);
         color: var(--brand_primary_default);
       }
@@ -1131,8 +1182,7 @@ section.quote {
 
 // Blog post callout
 .blog-post-callout {
-
-  .wrapper{
+  .wrapper {
     display: flex;
     justify-content: space-between;
     gap: 1rem;
@@ -1149,7 +1199,7 @@ section.quote {
 
 // Tabs section
 // See code.org/teach or code.org/donate for examples
-.tabs-section{
+.tabs-section {
   margin-top: 2rem;
   min-height: 408px;
 
@@ -1251,7 +1301,6 @@ section.quote {
   }
 }
 
-
 // At a glance sections
 // See code.org/educate/csp and code.org/teach for examples
 .at-a-glance {
@@ -1300,7 +1349,8 @@ section.quote {
 // Subscribe form
 // See code.org/csf for an example
 .subscribe-form {
-  background: url("/images/banners/banner-bg-lines-neutral-dark.png") center repeat;
+  background: url("/images/banners/banner-bg-lines-neutral-dark.png") center
+    repeat;
   background-size: 22%;
   background-color: var(--neutral_dark);
   border-radius: $border-radius;
@@ -1326,7 +1376,8 @@ section.quote {
       width: 100%;
     }
 
-    h2, p {
+    h2,
+    p {
       color: var(--neutral_white);
     }
   }
@@ -1347,7 +1398,8 @@ section.quote {
 // Action wrapper
 // See code.org/donate for example
 .action-wrapper {
-  background: url("/images/banners/banner-bg-lines-neutral-light.png") center repeat;
+  background: url("/images/banners/banner-bg-lines-neutral-light.png") center
+    repeat;
   background-size: 10rem;
   background-color: var(--brand_primary_default);
   border-radius: $border-radius;

--- a/pegasus/sites.v3/code.org/views/help/help_page_bring_cs_to_school.haml
+++ b/pegasus/sites.v3/code.org/views/help/help_page_bring_cs_to_school.haml
@@ -12,13 +12,13 @@
 
 %div.editorial-cards-wrapper
   - bring_cs_to_school_index.times do |index|
-    %div.flex-container.align-content-baseline.wrap
-      %figure
-        %img{src: bring_cs_to_school_img_src[index], alt: ""}
+    .flex-container.justify-space-between.align-content-baseline.wrap
       .content-wrapper
+        %img{src: bring_cs_to_school_img_src[index], alt: ""}
         %h3.heading-sm
           = bring_cs_to_school_title[index]
-        %p
+        %p.no-margin-bottom
           = bring_cs_to_school_desc[index]
+      .content-footer
         %a.link-button{href: bring_cs_to_school_url[index]}
           = bring_cs_to_school_button_label[index]

--- a/pegasus/sites.v3/code.org/views/hoc_page_beyond.haml
+++ b/pegasus/sites.v3/code.org/views/hoc_page_beyond.haml
@@ -28,13 +28,13 @@
 
 %div.editorial-cards-wrapper
   - card_item.each do |card_item|
-    %div.flex-container.align-content-baseline.wrap
-      %figure
-        %img{src: card_item[:image], alt: ""}
+    .flex-container.justify-space-between.align-content-baseline.wrap
       .content-wrapper
+        %img{src: card_item[:image], alt: ""}
         %h3.heading-sm
           = card_item[:title]
-        %p
+        %p.no-margin-bottom
           = card_item[:desc]
+      .content-footer
         %a.link-button{href: card_item[:url], "aria-label": card_item[:aria_label]}
           = card_item[:button_label]

--- a/pegasus/sites.v3/code.org/views/professional_learning/intl_pl_resources.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning/intl_pl_resources.haml
@@ -27,7 +27,7 @@
   - card_item.each do |card_item|
     .flex-container.justify-space-between.align-content-baseline.wrap
       .content-wrapper
-        %img{src: card_item[:image], alt: "", style: "margin-bottom: 1.5rem"}
+        %img{src: card_item[:image], alt: ""}
         %h3.heading-sm
           = card_item[:title]
         %p.no-margin-bottom

--- a/pegasus/sites.v3/code.org/views/professional_learning/pl_page_resources.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning/pl_page_resources.haml
@@ -27,7 +27,7 @@
   - card_item.each do |card_item|
     .flex-container.justify-space-between.align-content-baseline.wrap
       .content-wrapper
-        %img{src: card_item[:image], alt: "", style: "margin-bottom: 1.5rem"}
+        %img{src: card_item[:image], alt: ""}
         %h3.heading-sm
           = card_item[:title]
         %p.no-margin-bottom

--- a/pegasus/sites.v3/code.org/views/teach_page_pl_list_forums.haml
+++ b/pegasus/sites.v3/code.org/views/teach_page_pl_list_forums.haml
@@ -1,9 +1,10 @@
-%div.flex-container.align-content-baseline.wrap
-  %figure
-    %img{src: "/images/teach-page-pl-offerings-forums.png", alt: ""}
+.flex-container.justify-space-between.align-content-baseline.wrap
   .content-wrapper
+    %img{src: "/images/teach-page-pl-offerings-forums.png", alt: ""}
     %h3.heading-sm
       =hoc_s(:teach_page_pl_offerings_list_heading_forums)
-    %p=hoc_s(:teach_page_pl_offerings_list_desc_forums)
+    %p.no-margin-bottom
+      =hoc_s(:teach_page_pl_offerings_list_desc_forums)
+  .content-footer
     %a.link-button{href: "https://forum.code.org/", target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_join_teacher_forums)

--- a/pegasus/sites.v3/code.org/views/teach_page_pl_list_self_paced.haml
+++ b/pegasus/sites.v3/code.org/views/teach_page_pl_list_self_paced.haml
@@ -1,23 +1,21 @@
-%div.flex-container.align-content-baseline.wrap
-  %figure
-    %img{src: "/images/teach-page-pl-offerings-self-paced.png", alt: ""}
-  -# Align the buttons at the bottom of the sections for English.
-  -# Allow non-English buttons to flow with the preceding paragraph
-  -# due to a greater chance for varying paragraph heights.
+.flex-container.justify-space-between.align-content-baseline.wrap
   - if request.language == "en"
-    .flex-container.flex-space-between.self-paced-english
-      .content-wrapper
-        %h3.heading-sm
-          =hoc_s(:teach_page_pl_offerings_list_heading_self_paced)
-        %p=hoc_s(:teach_page_pl_offerings_list_desc_self_paced)
-      .content-footer
-        %a.link-button{href: "/educate/professional-development-online"}
-          =hoc_s(:call_to_action_find_self_paced_modules)
-  - else
     .content-wrapper
+      %img{src: "/images/teach-page-pl-offerings-self-paced.png", alt: ""}
       %h3.heading-sm
         =hoc_s(:teach_page_pl_offerings_list_heading_self_paced)
-      %p=hoc_s(:teach_page_pl_offerings_list_desc_self_paced)
+      %p.no-margin-bottom
+        =hoc_s(:teach_page_pl_offerings_list_desc_self_paced)
+    .content-footer
       %a.link-button{href: "/educate/professional-development-online"}
         =hoc_s(:call_to_action_find_self_paced_modules)
-
+  - else
+    .content-wrapper
+      %img{src: "/images/teach-page-pl-offerings-self-paced.png", alt: ""}
+      %h3.heading-sm
+        =hoc_s(:teach_page_pl_offerings_list_heading_self_paced)
+      %p.no-margin-bottom
+        =hoc_s(:teach_page_pl_offerings_list_desc_self_paced)
+    .content-footer
+      %a.link-button{href: "/educate/professional-development-online"}
+        =hoc_s(:call_to_action_find_self_paced_modules)

--- a/pegasus/sites.v3/code.org/views/teach_page_pl_list_workshops.haml
+++ b/pegasus/sites.v3/code.org/views/teach_page_pl_list_workshops.haml
@@ -1,16 +1,21 @@
-%div.flex-container.align-content-baseline.wrap
-  %figure
-    %img{src: "/images/teach-page-pl-offerings-workshops.png", alt: ""}
-  .content-wrapper
-    - if request.language == "en"
+.flex-container.justify-space-between.align-content-baseline.wrap
+  - if request.language == "en"
+    .content-wrapper
+      %img{src: "/images/teach-page-pl-offerings-workshops.png", alt: ""}
       %h3.heading-sm
         =hoc_s(:teach_page_pl_offerings_list_heading_workshops_facilitator_led)
-      %p=hoc_s(:teach_page_pl_offerings_list_desc_workshops_en)
+      %p.no-margin-bottom
+        =hoc_s(:teach_page_pl_offerings_list_desc_workshops_en)
+    .content-footer
       %a.link-button{href: "/professional-learning"}
         =hoc_s(:call_to_action_explore_workshops)
-    - else
+  - else
+    .content-wrapper
+      %img{src: "/images/teach-page-pl-offerings-workshops.png", alt: ""}
       %h3.heading-sm
         =hoc_s(:teach_page_pl_offerings_list_heading_workshops)
-      %p=hoc_s(:teach_page_pl_offerings_list_desc_workshops_intl)
+      %p.no-margin-bottom
+        =hoc_s(:teach_page_pl_offerings_list_desc_workshops_intl)
+    .content-footer
       %a.link-button{href: "https://support.code.org/hc/en-us/articles/115003865532-I-teach-outside-of-the-US-Are-there-resources-to-help-me-teach-computer-science-", target: "_blank", rel: "noopener noreferrer"}
         =hoc_s(:call_to_action_learn_more)

--- a/pegasus/sites.v3/hourofcode.com/public/css/action-blocks.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/action-blocks.scss
@@ -39,7 +39,6 @@
   }
 
   figure {
-
     &.video-responsive {
       margin-bottom: 1rem;
     }
@@ -110,40 +109,10 @@
   }
 
   @media screen and (max-width: $width-sm) {
-    a.link-button, button {
+    a.link-button,
+    button {
       width: 100%;
       text-align: center;
     }
-  }
-}
-
-// Editorial cards
-// See code.org/teach and code.org/help for examples
-.editorial-cards-wrapper {
-  display: grid;
-  margin-top: 4rem;
-  gap: 2.5rem;
-
-  @media screen and (min-width: $width-sm) {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
-  .flex-container {
-    gap: 1.5rem;
-    flex-direction: column;
-
-    &.self-paced-english {
-      gap: 1.3rem;
-
-      @media screen and (max-width: $width-md) {
-        gap: 0;
-      }
-    }
-  }
-
-  img {
-    width: 12rem;
-    height: 12rem;
-    border-radius: 50%;
   }
 }


### PR DESCRIPTION
Updates the places that use the `.editorial-card-wrapper` class to align the buttons at the bottom for varying heights of content.
- This should have negligible (if any) aesthetic changes, I just wrapped things differently in a flex container and broke sections up into `.content-wrapper` and `.content-footer` containers.
- The `design-system-pegasus.scss` and `action-blocks.scss` files got linted (changed my setting in VSCode to format on save 🙃) so there are a lot of linty changes included here, but only a couple things actually changed which I'll comment on.

**Jira ticket:** [ACQ-1486](https://codedotorg.atlassian.net/browse/ACQ-1486)

----

## Example of this element on code.org/teach

<img width="1129" alt="Screenshot 2024-02-27 at 3 05 29 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/282451c7-5af6-4e8e-8608-b89a83cd1f67">
