### PR TITLE
Levelbuilder cannot view as peer reviewer on non-javalab level

### DIFF
--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -157,39 +157,6 @@ class Ability
         can?(:manage, section) || user.sections_as_student.include?(section)
       end
 
-      can :view_as_user, ScriptLevel do |script_level, user_to_assume, sublevel_to_view|
-        user.project_validator? ||
-          user_to_assume.student_of?(user) ||
-          can?(:view_as_user_for_code_review, script_level, user_to_assume, sublevel_to_view)
-      end
-
-      can :view_as_user_for_code_review, ScriptLevel do |script_level, user_to_assume, level_to_view|
-        can_view_as_user_for_code_review = false
-
-        level_to_view ||= script_level&.oldest_active_level
-
-        # Only allow a student to view another student's project
-        # only on levels where we have our peer review feature.
-        # For now, that's only Javalab.
-        if level_to_view.is_a?(Javalab)
-          project_level_id = level_to_view.project_template_level.try(:id) ||
-            level_to_view.id
-
-          if user != user_to_assume &&
-              !user_to_assume.student_of?(user) &&
-              can?(:code_review, user_to_assume) &&
-              CodeReview.open_reviews.find_by(
-                user_id: user_to_assume.id,
-                script_id: script_level.script_id,
-                project_level_id: project_level_id
-              )
-            can_view_as_user_for_code_review = true
-          end
-        end
-
-        can_view_as_user_for_code_review
-      end
-
       if user.teacher?
         can :manage, Section do |s|
           s.instructors.include?(user)
@@ -431,6 +398,39 @@ class Ability
     end
 
     if user.persisted?
+      can :view_as_user, ScriptLevel do |script_level, user_to_assume, sublevel_to_view|
+        user.project_validator? ||
+          user_to_assume.student_of?(user) ||
+          can?(:view_as_user_for_code_review, script_level, user_to_assume, sublevel_to_view)
+      end
+
+      can :view_as_user_for_code_review, ScriptLevel do |script_level, user_to_assume, level_to_view|
+        can_view_as_user_for_code_review = false
+
+        level_to_view ||= script_level&.oldest_active_level
+
+        # Only allow a student to view another student's project
+        # only on levels where we have our peer review feature.
+        # For now, that's only Javalab.
+        if level_to_view.is_a?(Javalab)
+          project_level_id = level_to_view.project_template_level.try(:id) ||
+            level_to_view.id
+
+          if user != user_to_assume &&
+              !user_to_assume.student_of?(user) &&
+              can?(:code_review, user_to_assume) &&
+              CodeReview.open_reviews.find_by(
+                user_id: user_to_assume.id,
+                script_id: script_level.script_id,
+                project_level_id: project_level_id
+              )
+            can_view_as_user_for_code_review = true
+          end
+        end
+
+        can_view_as_user_for_code_review
+      end
+
       # TODO: should add editor experiment for Unit Group
       editor_experiment = Experiment.get_editor_experiment(user)
       if editor_experiment
@@ -440,9 +440,7 @@ class Ability
         can [:edit, :update], Unit, editor_experiment: editor_experiment
         can [:edit, :update], Lesson, editor_experiment: editor_experiment
       end
-    end
 
-    if user.persisted?
       # These checks control access to Javabuilder.
       # All teachers can generate a Javabuilder session token to run Java code,
       # although only verified teachers can generate tokens will be valid for "main" javabuilder.

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -404,6 +404,8 @@ class Ability
           can?(:view_as_user_for_code_review, script_level, user_to_assume, sublevel_to_view)
       end
 
+      # make sure levelbuilders do not have this permission outside of javalab
+      cannot :view_as_user_for_code_review, ScriptLevel
       can :view_as_user_for_code_review, ScriptLevel do |script_level, user_to_assume, level_to_view|
         can_view_as_user_for_code_review = false
 

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -854,6 +854,16 @@ class AbilityTest < ActiveSupport::TestCase
     refute Ability.new(student_1).can? :view_as_user_for_code_review, @login_required_script_level, student_2
   end
 
+  test 'levelbuilders cannot view as peer on non-Javalab levels' do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    levelbuilder = create :levelbuilder
+    student = create :student
+
+    assert Ability.new(levelbuilder).can? :view_as_user, @login_required_script_level, student
+    refute Ability.new(levelbuilder).can? :view_as_user_for_code_review, @login_required_script_level, student
+  end
+
   test 'only the project owner can create a code review on that project' do
     skip 'tests that create a project'
     project_owner = create :student


### PR DESCRIPTION
## background

@cearachew noticed that the teacher panel sometimes does not show up on localhost, and @Nokondi  and I have also been able to repro. The root cause of the issue is as follows:
* `shouldRenderTeacherPanel` is `false` here: https://github.com/code-dot-org/code-dot-org/blob/64661ce07b845d8de18b2286a414d29899a64f66/apps/src/sites/studio/pages/levels/_teacher_panel.js#L44-L46
* because `is_code_reviewing` is set here: https://github.com/code-dot-org/code-dot-org/blob/49cd73cbf430a43ba21b23faecf015c84a12e480/dashboard/app/controllers/script_levels_controller.rb#L424-L426
* we try to limit this permission to javalab levels here: https://github.com/code-dot-org/code-dot-org/blob/3f187477d45a6245a45f76a9696ae000881c41b7/dashboard/app/models/ability.rb#L166-L174
* however, for levelbuilders, this gets overridden here: https://github.com/code-dot-org/code-dot-org/blob/3f187477d45a6245a45f76a9696ae000881c41b7/dashboard/app/models/ability.rb#L389-L410

For additional context on how ability.rb works, see: https://github.com/CanCanCommunity/cancancan/blob/develop/docs/combine_abilities.md#abilities-precedence

> An ability rule will override a previous one.

## description

the two changes needed to fix this issue are:
1. move the definition of the `view_as_user_for_code_review` rule to after levelbuilder permissions are assigned
2. remove `view_as_user_for_code_review` permissions from everyone before assigning `view_as_user_for_code_review` permissions to anyone

## Testing story

* extensive existing test coverage of `view_as_user_for_code_review` in ability_test.rb
* new unit test covering the levelbuilder case
* verified new unit test fails without the code change and passes with it