### PR TITLE
Aitt rubric header polish

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2162,6 +2162,7 @@
   "rubricLevelTwoHeader": "Convincing Evidence",
   "rubricLevelFourHeader": "No Evidence",
   "rubricScores": "Rubric Scores",
+  "rubricAiHeaderText": "AI Teaching Assistant",
   "rubricTabStudent": "Student Rubric",
   "rubricTabClassManagement": "Class Management",
   "runAiAssessment": "Run AI Assessment for {studentName}",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2165,7 +2165,7 @@
   "rubricAiHeaderText": "AI Teaching Assistant",
   "rubricTabStudent": "Student Rubric",
   "rubricTabClassManagement": "Class Management",
-  "runAiAssessment": "Run AI Assessment for {studentName}",
+  "runAiAssessment": "Run AI Assessment for Project",
   "runAiAssessmentAll": "Run AI Assessment for all unsubmitted",
   "runAiAssessmentClass": "Run AI Assessment for Class",
   "runAiAssessmentDescription": "Manually run the AI Assessment if a student forgot to press Submit on their project",

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -79,6 +79,10 @@ export default function RubricContainer({
       })}
     >
       <div className={style.rubricHeaderRedesign}>
+        <div className={style.rubricHeaderLeftSide}>
+          <FontAwesome icon="house" />
+          AI Teaching Assistant
+        </div>
         <div className={style.rubricHeaderRightSide}>
           <button
             type="button"

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -12,6 +12,7 @@ import {
 import RubricContent from './RubricContent';
 import RubricSettings from './RubricSettings';
 import RubricTabButtons from './RubricTabButtons';
+import i18n from '@cdo/locale';
 
 const TAB_NAMES = {
   RUBRIC: 'rubric',
@@ -81,7 +82,7 @@ export default function RubricContainer({
       <div className={style.rubricHeaderRedesign}>
         <div className={style.rubricHeaderLeftSide}>
           <FontAwesome icon="house" />
-          AI Teaching Assistant
+          {i18n.rubricAiHeaderText()}
         </div>
         <div className={style.rubricHeaderRightSide}>
           <button

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -5,6 +5,7 @@ import i18n from '@cdo/locale';
 import {
   BodyThreeText,
   BodyTwoText,
+  Heading3,
   Heading5,
 } from '@cdo/apps/componentLibrary/typography';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
@@ -109,12 +110,12 @@ export default function RubricContent({
     >
       {infoText && <InfoAlert text={infoText} />}
       <div className={style.studentInfoGroup}>
-        <Heading5>
+        <Heading3>
           {i18n.lessonNumbered({
             lessonNumber: lesson.position,
             lessonName: lesson.name,
           })}
-        </Heading5>
+        </Heading3>
 
         <div className={style.selectors}>
           <SectionSelector reloadOnChange={true} requireSelection={false} />

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -6,7 +6,7 @@ import {
   BodyThreeText,
   BodyTwoText,
   Heading3,
-  Heading5,
+  Heading4,
 } from '@cdo/apps/componentLibrary/typography';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {
@@ -165,7 +165,7 @@ export default function RubricContent({
         )}
       </div>
       <div className={style.learningGoalsWrapper}>
-        <Heading5>{i18n.rubric()}</Heading5>
+        <Heading4>{i18n.rubric()}</Heading4>
         <LearningGoals
           open={open}
           learningGoals={rubric.learningGoals}

--- a/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
+++ b/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
@@ -155,7 +155,7 @@ export default function RunAIAssessmentButton({
           <Button
             className="uitest-run-ai-assessment"
             text={studentButtonText()}
-            color={Button.ButtonColor.brandSecondaryDefault}
+            color={Button.ButtonColor.neutralDark}
             onClick={handleRunAiAssessment}
             style={{margin: 0}}
             disabled={status !== STATUS.READY}

--- a/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
+++ b/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
@@ -53,9 +53,7 @@ export default function RunAIAssessmentButton({
   );
 
   const studentButtonText = () => {
-    return i18n.runAiAssessment({
-      studentName: studentName,
-    });
+    return i18n.runAiAssessment();
   };
 
   useEffect(() => {

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -132,6 +132,7 @@
   align-items: flex-start;
   gap: 1.5rem;
   align-self: stretch;
+  justify-content: center;
 }
 
 .levelAndStudentDetails {

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -182,7 +182,7 @@
 
   display: flex;
   height: 40px;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   align-self: stretch;
 }
@@ -191,6 +191,9 @@
   display: flex;
   gap: 4px;
   align-items: flex-start;
+  margin-left: 20px;
+  font-size: 14px;
+  font-weight: 600;
 }
 
 .rubricHeaderRightSide {

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -247,7 +247,7 @@ describe('RubricContainer', () => {
     wrapper.update();
     expect(wrapper.find('Button')).to.have.lengthOf(3);
     expect(wrapper.find('Button').first().props().text).to.equal(
-      i18n.runAiAssessment({studentName: defaultStudentInfo.name})
+      i18n.runAiAssessment()
     );
   });
 

--- a/apps/test/unit/templates/rubrics/RubricContentTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContentTest.jsx
@@ -140,7 +140,7 @@ describe('RubricContent', () => {
 
   it('shows level title when teacher is viewing student work', () => {
     const wrapper = shallow(<RubricContent {...defaultProps} />);
-    expect(wrapper.find('Heading5').at(0).props().children).to.equal(
+    expect(wrapper.find('Heading3').at(0).props().children).to.equal(
       'Lesson 3: Data Structures'
     );
   });
@@ -149,7 +149,7 @@ describe('RubricContent', () => {
     const wrapper = shallow(
       <RubricContent {...defaultProps} studentLevelInfo={null} />
     );
-    expect(wrapper.find('Heading5').at(0).props().children).to.equal(
+    expect(wrapper.find('Heading3').at(0).props().children).to.equal(
       'Lesson 3: Data Structures'
     );
   });


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-470 and https://codedotorg.atlassian.net/browse/AITT-367. more specifically:

#### AITT-470
1. add "AI Teaching Assistant" header text
2. change "Run AI..." button color

#### AITT-367
3. Remove student name from "Run AI..." button
4. make “Lesson…“ H1 (actually H3)
5. center ("0 attempts") 
6. add dropdowns built in 365 and 366 (no work needed)
7. make 'Rubric' H2 (actually H4)

## screenshots

### before
![before](https://github.com/code-dot-org/code-dot-org/assets/8001765/85b77a03-068b-4cc7-a18e-c2191aa997a7)

### after
![after](https://github.com/code-dot-org/code-dot-org/assets/8001765/f3e9642f-fb8b-4c6b-9347-0c15a2fc03ce)

### spec
![spec](https://github.com/code-dot-org/code-dot-org/assets/8001765/86f79395-96a7-43b1-8c08-58fc14384802)

## Testing story

manual verification shown in screenshots

## Follow-up work

https://codedotorg.atlassian.net/browse/AITT-367