### PR TITLE
P20-714: Prevent uploading the `animations` localized manifest during sync-out when testing

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -28,6 +28,24 @@ class I18nScriptUtils
     @crowdin_creds ||= YAML.load_file(CROWDIN_CREDS_PATH).freeze
   end
 
+  # Parses sync options from the command line
+  #
+  # @param options [Hash] the default options to populate
+  # @return [Hash] the parsed options
+  def self.parse_options(argv = ARGV, options: {})
+    options[:testing] = TESTING_BY_DEFAULT if options[:testing].nil?
+
+    OptionParser.new do |parser|
+      parser.on('-t', '--testing', 'Run in testing mode') do
+        options[:testing] = true
+      end
+
+      yield(parser, options) if block_given?
+    end.parse!(argv)
+
+    options
+  end
+
   # List of supported CDO Languages
   # @see https://docs.google.com/spreadsheets/d/10dS5PJKRt846ol9f9L3pKh03JfZkN7UIEcwMmiGS4i0 Supported CDO languages doc
   # @return [Array<CdoLanguage>] Supported CDO languages

--- a/bin/i18n/resources/apps.rb
+++ b/bin/i18n/resources/apps.rb
@@ -21,8 +21,8 @@ module I18n
         Labs.sync_down(**opts)
       end
 
-      def self.sync_out
-        Animations.sync_out
+      def self.sync_out(**opts)
+        Animations.sync_out(**opts)
         ExternalSources.sync_out
         Labs.sync_out
 

--- a/bin/i18n/resources/apps/animations.rb
+++ b/bin/i18n/resources/apps/animations.rb
@@ -20,8 +20,8 @@ module I18n
           SyncDown.perform(**opts)
         end
 
-        def self.sync_out
-          SyncOut.perform
+        def self.sync_out(**opts)
+          SyncOut.perform(**opts)
         end
       end
     end

--- a/bin/i18n/resources/apps/animations/sync_out.rb
+++ b/bin/i18n/resources/apps/animations/sync_out.rb
@@ -16,7 +16,7 @@ module I18n
 
             js_locale = I18nScriptUtils.to_js_locale(language[:locale_s])
             i18n_data = I18nScriptUtils.parse_file(crowdin_file_path)
-            spritelab_manifest_builder.upload_localized_manifest(js_locale, i18n_data)
+            spritelab_manifest_builder.upload_localized_manifest(js_locale, i18n_data) unless options[:testing]
 
             i18n_file_path = I18nScriptUtils.locale_dir(language[:locale_s], DIR_NAME, FILE_NAME)
             I18nScriptUtils.move_file(crowdin_file_path, i18n_file_path)

--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -98,11 +98,12 @@ class I18nSync
   end
 
   def parse_options(args)
-    options = {
-      testing: I18nScriptUtils::TESTING_BY_DEFAULT,
-    }
+    options = {}
+    opt_parser = nil
 
-    opt_parser = OptionParser.new do |opts|
+    I18nScriptUtils.parse_options(args, options: options) do |opts|
+      opt_parser = opts
+
       opts.banner = <<-USAGE
   Usage: sync-all [options]
 
@@ -130,12 +131,7 @@ class I18nSync
       opts.on("-y", "--yes", "Run without confirmation") do
         options[:yes] = true
       end
-
-      opts.on('-t', '--testing', 'Run in testing mode') do
-        options[:testing] = true
-      end
     end
-    opt_parser.parse!(args)
 
     unless options[:interactive] || options[:command]
       puts "  ERROR: Must specify either interactive or command mode\n\n"

--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -86,15 +86,15 @@ class I18nSync
   end
 
   def sync_up
-    I18n::SyncUp.perform(options.slice(:testing))
+    I18n::SyncUp.perform(options)
   end
 
   def sync_down
-    I18n::SyncDown.perform(options.slice(:testing))
+    I18n::SyncDown.perform(options)
   end
 
   def sync_out
-    I18n::SyncOut.perform
+    I18n::SyncOut.perform(options)
   end
 
   def parse_options(args)

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -23,9 +23,13 @@ Dir[File.expand_path('../resources/**/*.rb', __FILE__)].sort.each {|file| requir
 
 module I18n
   module SyncOut
-    def self.perform
+    def self.parse_options
+      I18n::Utils::SyncOutBase.parse_options
+    end
+
+    def self.perform(opts = parse_options)
       puts "Sync out starting"
-      I18n::Resources::Apps.sync_out
+      I18n::Resources::Apps.sync_out(**opts)
       I18n::Resources::Dashboard.sync_out
       I18n::Resources::Pegasus.sync_out
 

--- a/bin/i18n/utils/sync_down_base.rb
+++ b/bin/i18n/utils/sync_down_base.rb
@@ -10,9 +10,6 @@ module I18n
     class SyncDownBase
       Config = Struct.new :crowdin_project, :download_paths, keyword_init: true
       DownloadPath = Struct.new :crowdin_src, :dest_subdir, keyword_init: true
-      Options = Struct.new :testing, keyword_init: true do
-        def initialize(testing: I18nScriptUtils::TESTING_BY_DEFAULT, **) super end
-      end
 
       def self.config
         @config ||= Config.new(
@@ -22,15 +19,7 @@ module I18n
       end
 
       def self.parse_options
-        options = Options.new
-
-        OptionParser.new do |opts|
-          opts.on('-t', '--testing', 'Run in testing mode') do
-            options[:testing] = true
-          end
-        end.parse!
-
-        options.to_h
+        I18nScriptUtils.parse_options
       end
 
       # Sync-down an i18n resource.
@@ -52,7 +41,7 @@ module I18n
 
       def initialize(**options)
         @config = self.class.config.freeze
-        @options = Options.new(**options).freeze
+        @options = options.freeze
       end
 
       def perform
@@ -99,7 +88,7 @@ module I18n
 
       def crowdin_project
         @crowdin_project ||=
-          if options.testing
+          if options[:testing]
             # When testing, use a set of test Crowdin projects that mirrors our regular set of projects.
             CDO.crowdin_project_test_mapping[config.crowdin_project]
           else

--- a/bin/i18n/utils/sync_out_base.rb
+++ b/bin/i18n/utils/sync_out_base.rb
@@ -4,15 +4,27 @@ require_relative '../metrics'
 module I18n
   module Utils
     class SyncOutBase
-      def self.perform
+      def self.parse_options
+        I18nScriptUtils.parse_options
+      end
+
+      def self.perform(options = parse_options)
+        sync_out = new(**options)
+
         resource_class = name[/^.*::(\w+::\w+)::SyncOut/, 1] || name
 
         I18n::Metrics.report_runtime(resource_class, 'sync-out') do
-          new.send(:perform)
+          sync_out.send(:perform)
         end
       end
 
       protected
+
+      attr_reader :options
+
+      def initialize(**options)
+        @options = options.freeze
+      end
 
       def process(_language)
         raise NotImplementedError

--- a/bin/i18n/utils/sync_up_base.rb
+++ b/bin/i18n/utils/sync_up_base.rb
@@ -19,15 +19,7 @@ module I18n
       end
 
       def self.parse_options
-        options = Options.new
-
-        OptionParser.new do |opts|
-          opts.on('-t', '--testing', 'Run in testing mode') do
-            options[:testing] = true
-          end
-        end.parse!
-
-        options.to_h
+        I18nScriptUtils.parse_options
       end
 
       # Sync-up an i18n resource.
@@ -47,15 +39,11 @@ module I18n
 
       protected
 
-      Options = Struct.new :testing, keyword_init: true do
-        def initialize(testing: I18nScriptUtils::TESTING_BY_DEFAULT, **) super end
-      end
-
       attr_reader :config, :options
 
       def initialize(**options)
         @config = self.class.config.freeze
-        @options = Options.new(**options).freeze
+        @options = options.freeze
       end
 
       def perform
@@ -72,7 +60,7 @@ module I18n
 
       def crowdin_project
         @crowdin_project ||=
-          if options.testing
+          if options[:testing]
             # When testing, use a set of test Crowdin projects that mirrors our regular set of projects.
             CDO.crowdin_project_test_mapping[config.crowdin_project]
           else

--- a/bin/test/i18n/resources/apps/animation/test_sync_out.rb
+++ b/bin/test/i18n/resources/apps/animation/test_sync_out.rb
@@ -28,6 +28,9 @@ describe I18n::Resources::Apps::Animations::SyncOut do
   describe '#process' do
     let(:process_language) {described_instance.process(language)}
 
+    let(:is_testing) {false}
+    let(:options) {{testing: is_testing}}
+
     let(:crowdin_file_path) {CDO.dir('i18n/crowdin', i18n_locale, 'animations/spritelab_animation_library.json')}
     let(:crowdin_file_data) {{'i18n_key' => 'i18n_val'}}
     let(:i18n_file_path) {CDO.dir('i18n/locales', i18n_locale, 'animations/spritelab_animation_library.json')}
@@ -45,6 +48,10 @@ describe I18n::Resources::Apps::Animations::SyncOut do
     end
 
     before do
+      spritelab_manifest_builder.stubs(:upload_localized_manifest)
+
+      described_instance.stubs(:options).returns(options)
+
       FileUtils.mkdir_p File.dirname(crowdin_file_path)
       File.write crowdin_file_path, JSON.dump(crowdin_file_data)
     end
@@ -58,6 +65,17 @@ describe I18n::Resources::Apps::Animations::SyncOut do
       expect_crowdin_resource_dir_removing.in_sequence(execution_sequence)
 
       process_language
+    end
+
+    context 'when testing' do
+      let(:is_testing) {true}
+
+      it 'does not upload localized manifest' do
+        expect_localized_manifest_uploading.never
+        expect_crowdin_file_to_i18n_locale_dir_moving.once
+
+        process_language
+      end
     end
 
     context 'when the Crowdin locale dir does not exists' do

--- a/bin/test/i18n/test_i18n_script_utils.rb
+++ b/bin/test/i18n/test_i18n_script_utils.rb
@@ -52,6 +52,38 @@ describe I18nScriptUtils do
     end
   end
 
+  describe '.parse_options' do
+    let(:parse_options) {described_class.parse_options}
+
+    describe ':testing' do
+      let(:option_testing) {parse_options[:testing]}
+
+      it 'returns false by default' do
+        _(option_testing).must_equal false
+      end
+
+      context 'when "-t" command line option is set' do
+        before do
+          ARGV << '-t'
+        end
+
+        it 'returns true' do
+          _(option_testing).must_equal true
+        end
+      end
+
+      context 'when "--testing" command line option is set' do
+        before do
+          ARGV << '--testing'
+        end
+
+        it 'returns true' do
+          _(option_testing).must_equal true
+        end
+      end
+    end
+  end
+
   describe '.unit_directory_change?' do
     let(:unit_directory_change?) {I18nScriptUtils.unit_directory_change?(content_dir, unit_i18n_filepath)}
 

--- a/bin/test/i18n/utils/test_sync_down_base.rb
+++ b/bin/test/i18n/utils/test_sync_down_base.rb
@@ -56,32 +56,12 @@ describe I18n::Utils::SyncDownBase do
   describe '.parse_options' do
     let(:parse_options) {described_class.parse_options}
 
-    it 'returns default options' do
-      _(parse_options).must_equal({testing: false})
-    end
+    it 'returns parsed options' do
+      parsed_options = {parsed: 'options'}
 
-    describe ':testing' do
-      let(:option_testing) {parse_options[:testing]}
+      I18nScriptUtils.expects(:parse_options).returns(parsed_options)
 
-      context 'when "-t" command line option is set' do
-        before do
-          ARGV << '-t'
-        end
-
-        it 'returns true' do
-          _(option_testing).must_equal true
-        end
-      end
-
-      context 'when "--testing" command line option is set' do
-        before do
-          ARGV << '--testing'
-        end
-
-        it 'returns true' do
-          _(option_testing).must_equal true
-        end
-      end
+      _(parse_options).must_equal parsed_options
     end
   end
 
@@ -219,7 +199,7 @@ describe I18n::Utils::SyncDownBase do
     let(:crowdin_test_project) {'expected_crowdin_test_project'}
 
     let(:config) {stub(crowdin_project: crowdin_prod_project)}
-    let(:options) {stub(testing: is_testing)}
+    let(:options) {{testing: is_testing}}
 
     let(:is_testing) {false}
 

--- a/bin/test/i18n/utils/test_sync_out_base.rb
+++ b/bin/test/i18n/utils/test_sync_out_base.rb
@@ -14,6 +14,18 @@ describe I18n::Utils::SyncOutBase do
     I18nScriptUtils.stubs(:remove_empty_dir)
   end
 
+  describe '.parse_options' do
+    let(:parse_options) {described_class.parse_options}
+
+    it 'returns parsed options' do
+      parsed_options = {parsed: 'options'}
+
+      I18nScriptUtils.expects(:parse_options).returns(parsed_options)
+
+      _(parse_options).must_equal parsed_options
+    end
+  end
+
   describe '.perform' do
     before do
       described_class.any_instance.stubs(:process)

--- a/bin/test/i18n/utils/test_sync_up_base.rb
+++ b/bin/test/i18n/utils/test_sync_up_base.rb
@@ -96,32 +96,12 @@ describe I18n::Utils::SyncUpBase do
   describe '.parse_options' do
     let(:parse_options) {described_class.parse_options}
 
-    it 'returns default options' do
-      _(parse_options).must_equal({testing: false})
-    end
+    it 'returns parsed options' do
+      parsed_options = {parsed: 'options'}
 
-    describe ':testing' do
-      let(:option_testing) {parse_options[:testing]}
+      I18nScriptUtils.expects(:parse_options).returns(parsed_options)
 
-      context 'when "-t" command line option is set' do
-        before do
-          ARGV << '-t'
-        end
-
-        it 'returns true' do
-          _(option_testing).must_equal true
-        end
-      end
-
-      context 'when "--testing" command line option is set' do
-        before do
-          ARGV << '--testing'
-        end
-
-        it 'returns true' do
-          _(option_testing).must_equal true
-        end
-      end
+      _(parse_options).must_equal parsed_options
     end
   end
 
@@ -192,36 +172,6 @@ describe I18n::Utils::SyncUpBase do
     end
   end
 
-  describe '#options' do
-    let(:options) {described_instance.send(:options)}
-
-    it 'returns instance of Options struct' do
-      _(options).must_be_instance_of described_class::Options
-    end
-
-    it 'is frozen' do
-      _(options).must_be :frozen?
-    end
-
-    describe ':testing' do
-      let(:option_testing) {options.testing}
-
-      it 'returns false by default' do
-        _(option_testing).must_equal false
-      end
-
-      context 'when value is provided' do
-        let(:described_instance) {described_class.new(testing: expected_option_testing)}
-
-        let(:expected_option_testing) {'expected_option_testing'}
-
-        it 'returns provided value' do
-          _(option_testing).must_equal expected_option_testing
-        end
-      end
-    end
-  end
-
   describe '#crowdin_project' do
     let(:crowdin_project) {described_instance.send(:crowdin_project)}
 
@@ -229,7 +179,7 @@ describe I18n::Utils::SyncUpBase do
     let(:crowdin_test_project) {'expected_crowdin_test_project'}
 
     let(:config) {stub(crowdin_project: crowdin_prod_project)}
-    let(:options) {stub(testing: is_testing)}
+    let(:options) {{testing: is_testing}}
 
     let(:is_testing) {false}
 


### PR DESCRIPTION
The AWS S3 instance, to which we upload the `animations` localized manifest, is used in production.
So we must prevent the uploading of any testing data to it.

- jira ticket: [P20-714](https://codedotorg.atlassian.net/browse/P20-714)