### PR TITLE
Flaky test: fixing instances where section set up save doesn't wait for new page

### DIFF
--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -37,7 +37,7 @@ And /^I create a new "([^"]*)" student section named "([^"]*)" assigned to "([^"
   end
 
   individual_steps <<~GHERKIN
-    And I press the first "#uitest-save-section-changes" element
+    And I press the first "#uitest-save-section-changes" element to load a new page
     And I wait until element "#classroom-sections" is visible
   GHERKIN
 end

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments1.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments1.feature
@@ -18,7 +18,7 @@ Feature: Using the assessments tab in the teacher dashboard
     And I click selector ".assignment-version-title:contains('17-'18)" once I see it
     And I wait until element "#uitest-secondary-assignment" is visible
     And I select the "CSP Student Post-Course Survey ('17-'18)" option in dropdown "uitest-secondary-assignment"
-    And I press the first "#uitest-save-section-changes" element
+    And I press the first "#uitest-save-section-changes" element to load a new page
     And I wait until element "#classroom-sections" is visible
 
     # Progress tab

--- a/dashboard/test/ui/features/teacher_tools/teacher_homepage.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_homepage.feature
@@ -133,7 +133,7 @@ Feature: Using the teacher homepage sections feature
     And I click selector ".edit-section-details-link" once I see it
     And I wait until element "#uitest-secondary-assignment" is visible
     And I select the "CSP Unit 2 - Digital Information ('17-'18)" option in dropdown "uitest-secondary-assignment"
-    And I press the first "#uitest-save-section-changes" element
+    And I press the first "#uitest-save-section-changes" element to load a new page
     And I wait until element "#classroom-sections" is visible 
 
     # TODO: TEACH-537 If we add in this confirmation dialogue later, uncomment this test
@@ -170,7 +170,7 @@ Feature: Using the teacher homepage sections feature
     And element "#assignment-version-year" contains text "2017"
     And I press "assignment-version-year"
     And I click selector ".assignment-version-title:contains(2019)" once I see it
-    And I press the first "#uitest-save-section-changes" element
+    And I press the first "#uitest-save-section-changes" element to load a new page
     And I wait until element "#classroom-sections" is visible
     And the section table row at index 0 has primary assignment path "/s/coursea-2019"
 


### PR DESCRIPTION
There are a few instances where the test doesn't wait for the dashboard page to load after hitting save on section set up. More details on the investigation and fix is in this PR https://github.com/code-dot-org/code-dot-org/pull/56711. Applying similar fix for more instances of this issue.

## Links

No JIRA ticket - making these changes based on observed flakiness as DOTD.

## Testing story

Locally ran the specific tests, going to use Drone to catch other potential issues

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
