### PR TITLE
Replace nil or empty pegasus helper in Spotify script

### DIFF
--- a/bin/cron/applab_datasets/spotify
+++ b/bin/cron/applab_datasets/spotify
@@ -132,14 +132,14 @@ def main
   get_token
   fb = FirebaseHelper.new('shared')
 
-  if $token.nil_or_empty?
+  if $token.nil? || $token.empty?
     Honeybadger.notify_cronjob_error(error_message: "Did not to retrieve Spotify playlist data due to missing authentication token.")
     return
   end
 
   SPOTIFY_CHARTS.each do |chart|
     records, columns = get_playlist_data(chart['type'], chart['id'])
-    if records.nil_or_empty?
+    if records.nil? || records.empty?
       Honeybadger.notify_cronjob_error(
         error_message: "Did not to upload Spotify playlist data due to nil or empty list of records.",
         context: {


### PR DESCRIPTION
Apparently we were depending on an injected helper (`nil_or_empty?`) [that was provided by pegasus](https://github.com/code-dot-org/code-dot-org/blob/staging/lib/cdo/pegasus/object.rb), which we had a roundabout dependency on in this script (see more info in [this PR](https://github.com/code-dot-org/code-dot-org/pull/56829)). Remove this to use built-in Ruby methods `nil?` and `empty?`

## Links

- Honeybadger error: https://app.honeybadger.io/projects/45435/faults/105112397

## Testing story

I didn't test the script directly, but played around with the `nil?` and `empty?` methods via `irb`.