### PR TITLE
AI Tutor: change character set for AiTutorInteractions to allow emojis 🐼

### DIFF
--- a/dashboard/app/models/ai_tutor_interaction.rb
+++ b/dashboard/app/models/ai_tutor_interaction.rb
@@ -10,9 +10,9 @@
 #  type               :string(255)
 #  project_id         :string(255)
 #  project_version_id :string(255)
-#  prompt             :text(65535)
+#  prompt             :text(16777215)
 #  status             :string(255)
-#  ai_response        :text(65535)
+#  ai_response        :text(16777215)
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/dashboard/db/migrate/20240228195613_convert_ai_tutor_interactions_to_utf8mb4.rb
+++ b/dashboard/db/migrate/20240228195613_convert_ai_tutor_interactions_to_utf8mb4.rb
@@ -1,0 +1,9 @@
+class ConvertAiTutorInteractionsToUtf8mb4 < ActiveRecord::Migration[6.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute "ALTER TABLE ai_tutor_interactions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+      end
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_22_193916) do
+ActiveRecord::Schema.define(version: 2024_02_28_195613) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2024_01_22_193916) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
-  create_table "ai_tutor_interactions", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "ai_tutor_interactions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id"
     t.integer "script_id"
@@ -47,9 +47,9 @@ ActiveRecord::Schema.define(version: 2024_01_22_193916) do
     t.string "type"
     t.string "project_id"
     t.string "project_version_id"
-    t.text "prompt"
+    t.text "prompt", size: :medium
     t.string "status"
-    t.text "ai_response"
+    t.text "ai_response", size: :medium
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["level_id"], name: "index_ai_tutor_interactions_on_level_id"


### PR DESCRIPTION
Previously `AiTutorInteractions` failed to save when there was an emoji in the data 😱. This was problematic especially because the starter code for many Javalab levels includes "/* ---- 🔎 ADD YOUR CODE BELOW THIS LINE ---- */" and we want to store the student's code as part of the `prompt` field. 

This PR addresses the issue by changing to the charset for `AiTutorInteractions` to "utf8mb4".

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

### Links
[CT-365](https://codedotorg.atlassian.net/browse/CT-365)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

### Testing story

Locally, I confirmed that we can now save text containing emojis to the prompt field. 🎉 

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->



## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
