### PR TITLE
[Google Blockly] Convert cdoUtils to TypeScript

### DIFF
--- a/apps/src/blockly/addons/cdoFieldButton.ts
+++ b/apps/src/blockly/addons/cdoFieldButton.ts
@@ -7,13 +7,13 @@ interface ColorOverrides {
 }
 
 interface CdoFieldButtonOptions {
-  value: string | undefined;
-  validator: FieldValidator<string> | null;
+  value?: string;
+  validator?: FieldValidator<string> | null;
   onClick: () => void;
-  transformText: ((text: string) => string) | undefined;
-  icon: SVGElement | undefined;
-  colorOverrides: ColorOverrides | undefined;
-  allowReadOnlyClick: boolean | undefined;
+  transformText?: (text: string) => string;
+  icon?: SVGElement;
+  colorOverrides?: ColorOverrides;
+  allowReadOnlyClick?: boolean;
 }
 
 export default class CdoFieldButton extends GoogleBlockly.Field {

--- a/apps/src/blockly/addons/cdoSerializationHelpers.ts
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.ts
@@ -439,9 +439,7 @@ export function convertFunctionsXmlToJson(functionsXml: string) {
  * TODO: define a type for projectState and proceduresState. Blockly defines these as any.
  */
 export function appendProceduresToState(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   projectState: WorkspaceSerialization,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   proceduresState: WorkspaceSerialization
 ) {
   console.log({projectState, proceduresState});
@@ -472,8 +470,7 @@ export function appendProceduresToState(
 
 // Function to check if a block with the given behaviorId exists in the project
 // TODO: define type for projectBlocks.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function blockExists(behaviorId: string, projectBlocks: any[]) {
+function blockExists(behaviorId: string, projectBlocks: JsonBlockConfig[]) {
   return projectBlocks.some(
     block =>
       block.type === BLOCK_TYPES.behaviorDefinition &&

--- a/apps/src/blockly/addons/cdoSerializationHelpers.ts
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.ts
@@ -98,7 +98,7 @@ export function convertXmlToJson(xml: Element, embedded: boolean) {
     // Create a map of ids (key) and block serializations (value).
     const blockIdMap = stateToLoad.blocks.blocks.reduce(
       (map: Map<string, JsonBlockConfig>, blockJson: JsonBlockConfig) =>
-        map.set(blockJson.id, blockJson),
+        map.set(blockJson.id || '', blockJson),
       new Map()
     );
 

--- a/apps/src/blockly/addons/cdoSerializationHelpers.ts
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.ts
@@ -92,7 +92,9 @@ export function convertXmlToJson(xml: Element, embedded: boolean) {
   //   x: the x attribute found in <block/> element
   //   y: the y attribute found in <block/> element
   const xmlBlocks = Blockly.Xml.domToBlockSpace(tempWorkspace, xml);
-  const stateToLoad = Blockly.serialization.workspaces.save(tempWorkspace);
+  const stateToLoad = Blockly.serialization.workspaces.save(
+    tempWorkspace
+  ) as WorkspaceSerialization;
 
   if (xmlBlocks.length && hasBlocks(stateToLoad)) {
     // Create a map of ids (key) and block serializations (value).
@@ -341,15 +343,18 @@ export function partitionJsonBlocksByType(
  * @returns {Object} The combined JSON serialization of the workspace and the hidden definition workspace.
  */
 export function getProjectSerialization(workspace: WorkspaceSvg) {
-  const workspaceSerialization =
-    Blockly.serialization.workspaces.save(workspace);
+  const workspaceSerialization = Blockly.serialization.workspaces.save(
+    workspace
+  ) as WorkspaceSerialization;
 
   if (shouldSkipHiddenWorkspace(workspace)) {
     return workspaceSerialization;
   }
   const hiddenDefinitionWorkspace = Blockly.getHiddenDefinitionWorkspace();
   const hiddenWorkspaceSerialization = hiddenDefinitionWorkspace
-    ? Blockly.serialization.workspaces.save(hiddenDefinitionWorkspace)
+    ? (Blockly.serialization.workspaces.save(
+        hiddenDefinitionWorkspace
+      ) as WorkspaceSerialization)
     : null;
 
   // Blocks rendered in the hidden workspace get extra properties that need to be
@@ -415,7 +420,9 @@ export function convertFunctionsXmlToJson(functionsXml: string) {
   const xml = parser.parseFromString(`<xml>${functionsXml}</xml>`, 'text/xml');
   const tempWorkspace = new Blockly.Workspace();
   Blockly.Xml.domToBlockSpace(tempWorkspace, xml.children[0]);
-  const proceduresState = Blockly.serialization.workspaces.save(tempWorkspace);
+  const proceduresState = Blockly.serialization.workspaces.save(
+    tempWorkspace
+  ) as WorkspaceSerialization;
   tempWorkspace.dispose();
   return proceduresState;
 }
@@ -433,17 +440,16 @@ export function convertFunctionsXmlToJson(functionsXml: string) {
  */
 export function appendProceduresToState(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  projectState: any,
+  projectState: WorkspaceSerialization,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  proceduresState: any
+  proceduresState: WorkspaceSerialization
 ) {
+  console.log({projectState, proceduresState});
   const projectBlocks = projectState.blocks?.blocks || [];
   const projectProcedures = projectState.procedures || [];
 
-  // TODO: define these types better.
-  const sharedBlocks =
-    (proceduresState.blocks?.blocks as JsonBlockConfig[]) || [];
-  const sharedProcedures = (proceduresState.procedures as {id: string}[]) || [];
+  const sharedBlocks = proceduresState.blocks?.blocks || [];
+  const sharedProcedures = proceduresState.procedures || [];
 
   sharedBlocks.forEach(block => {
     const {behaviorId, procedureId} = block.extraState;
@@ -451,9 +457,12 @@ export function appendProceduresToState(
     if (!blockExists(behaviorId, projectBlocks)) {
       // If the block doesn't exist, add it to the student project
       projectBlocks.push(block);
-      projectProcedures.push(
-        sharedProcedures.find(procedure => procedure.id === procedureId)
+      const procedure = sharedProcedures.find(
+        procedure => procedure.id === procedureId
       );
+      if (procedure) {
+        projectProcedures.push(procedure);
+      }
     }
   });
   projectState.blocks = {blocks: projectBlocks};

--- a/apps/src/blockly/addons/cdoSerializationHelpers.ts
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.ts
@@ -78,7 +78,7 @@ function getSpaceBetweenBlocks(block: ExtendedBlockSvg) {
  * for an embedded workspace for not.
  * @returns {json} stateToLoad - modern workspace serialization
  */
-export function convertXmlToJson(xml: Document, embedded: boolean) {
+export function convertXmlToJson(xml: Element, embedded: boolean) {
   const tempWorkspace = new Blockly.Workspace();
 
   // The temporary workspace should mirror the embedded state of the workspace
@@ -414,7 +414,7 @@ export function convertFunctionsXmlToJson(functionsXml: string) {
   const parser = new DOMParser();
   const xml = parser.parseFromString(`<xml>${functionsXml}</xml>`, 'text/xml');
   const tempWorkspace = new Blockly.Workspace();
-  Blockly.Xml.domToBlockSpace(tempWorkspace, xml);
+  Blockly.Xml.domToBlockSpace(tempWorkspace, xml.children[0]);
   const proceduresState = Blockly.serialization.workspaces.save(tempWorkspace);
   tempWorkspace.dispose();
   return proceduresState;

--- a/apps/src/blockly/addons/cdoSerializationHelpers.ts
+++ b/apps/src/blockly/addons/cdoSerializationHelpers.ts
@@ -442,7 +442,6 @@ export function appendProceduresToState(
   projectState: WorkspaceSerialization,
   proceduresState: WorkspaceSerialization
 ) {
-  console.log({projectState, proceduresState});
   const projectBlocks = projectState.blocks?.blocks || [];
   const projectProcedures = projectState.procedures || [];
 

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -112,7 +112,6 @@ function parseSource(source: string, embedded: boolean) {
   } else {
     parsedSource = JSON.parse(source);
   }
-  console.log({parsedSource});
   return parsedSource;
 }
 
@@ -145,7 +144,7 @@ export function moveHiddenBlocks(
   hiddenDefinitionSource.blocks.blocks = [];
   hiddenDefinitionSource.procedures = [];
 
-  source.blocks.blocks.forEach((block: JsonBlockConfig) => {
+  source.blocks.blocks.forEach(block => {
     const {invisible, procedureId} = block.extraState || {};
     const hideBlock = procedureTypesToHide.includes(block.type) || invisible;
     const destination = hideBlock ? hiddenDefinitionSource : mainSource;
@@ -244,10 +243,10 @@ export function workspaceSvgResize(workspace: WorkspaceSvg) {
   return Blockly.svgResize(workspace);
 }
 
-// We use Object and Function here because they are what Blockly uses.
 export function bindBrowserEvent(
   element: EventTarget,
   name: string,
+  // We use Object and Function here because those are what Blockly uses.
   // eslint-disable-next-line @typescript-eslint/ban-types
   thisObject: Object | null,
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -426,13 +425,13 @@ export function getSimplifiedStateForFlyout(
   serialization: WorkspaceSerialization
 ) {
   const variableMap: {[key: string]: string} = {};
-  const variables = serialization.variables as {id: string; name: string}[];
+  const variables = serialization.variables;
   variables?.forEach(variable => {
     variableMap[variable.id] = variable.name;
   });
 
   const blocksList = hasBlocks(serialization)
-    ? (serialization.blocks.blocks as JsonBlockConfig[]).map(block =>
+    ? serialization.blocks.blocks.map(block =>
         simplifyBlockState(block, variableMap)
       )
     : [];
@@ -512,6 +511,7 @@ export function appendSharedFunctions(
 ) {
   let startBlocks;
   if (stringIsXml(startBlocksSource)) {
+    // TODO: define a type for blockUtils
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     startBlocks = (blockUtils as any).appendNewFunctions(
       startBlocksSource,

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -112,7 +112,7 @@ function parseSource(source: string, embedded: boolean) {
   } else {
     parsedSource = JSON.parse(source);
   }
-
+  console.log({parsedSource});
   return parsedSource;
 }
 
@@ -154,10 +154,13 @@ export function moveHiddenBlocks(
     // Also copy the procedure model for blocks to that need to be hidden
     // Equality check works because hiddenDefinitionSource and mainSource are different object references
     if (destination === hiddenDefinitionSource && procedureId) {
-      const procedureModel = (source.procedures as {id: string}[]).find(
+      const procedureModel = source.procedures?.find(
         procedure => procedure.id === procedureId
       );
       if (procedureModel) {
+        if (!hiddenDefinitionSource.procedures) {
+          hiddenDefinitionSource.procedures = [];
+        }
         hiddenDefinitionSource.procedures.push(procedureModel);
       }
     }

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -380,7 +380,8 @@ export function registerCustomProcedureBlocks() {
  */
 export function getLevelToolboxBlocks(customCategory: string) {
   const parser = new DOMParser();
-  if (!Blockly.toolboxBlocks) {
+  // This method only works for string toolboxes.
+  if (!Blockly.toolboxBlocks || typeof Blockly.toolboxBlocks !== 'string') {
     return;
   }
   // TODO: Update this to support JSON once https://codedotorg.atlassian.net/browse/CT-8 is merged

--- a/apps/src/blockly/addons/cdoXml.ts
+++ b/apps/src/blockly/addons/cdoXml.ts
@@ -450,7 +450,7 @@ function makeLockedBlockImmovable(block: Element) {
  * @param {Element} xml - The XML element containing block elements.
  * @returns {Element[]} An array of block elements or an empty array if no blocks are present.
  */
-export function getBlockElements(xml: Document) {
+export function getBlockElements(xml: Element) {
   // Convert XML to an array of block elements
   return Array.from(xml.querySelectorAll('xml > block'));
 }

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -586,7 +586,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   // We used to refer to these as "readOnlyBlockSpaces", which was confusing with normal,
   // read only workspaces.
   blocklyWrapper.createEmbeddedWorkspace = function (container, xml, options) {
-    const theme = cdoUtils.getUserTheme(options.theme) as Theme;
+    const theme = cdoUtils.getUserTheme(options.theme as string) as Theme;
     const workspace = new Blockly.WorkspaceSvg({
       readOnly: true,
       theme: theme,
@@ -652,7 +652,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     const optOptionsExtended = opt_options as ExtendedBlocklyOptions;
     const options = {
       ...optOptionsExtended,
-      theme: cdoUtils.getUserTheme(optOptionsExtended.theme),
+      theme: cdoUtils.getUserTheme(optOptionsExtended.theme as string),
       trashcan: false, // Don't use default trashcan.
       move: {
         wheel: true,
@@ -695,7 +695,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.isStartMode = !!optOptionsExtended.editBlocks;
     blocklyWrapper.isToolboxMode =
       optOptionsExtended.editBlocks === 'toolbox_blocks';
-    blocklyWrapper.toolboxBlocks = options.toolbox;
+    blocklyWrapper.toolboxBlocks = options.toolbox as string;
     const workspace = blocklyWrapper.blockly_.inject(
       container,
       options

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -695,7 +695,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.isStartMode = !!optOptionsExtended.editBlocks;
     blocklyWrapper.isToolboxMode =
       optOptionsExtended.editBlocks === 'toolbox_blocks';
-    blocklyWrapper.toolboxBlocks = options.toolbox as string;
+    blocklyWrapper.toolboxBlocks = options.toolbox;
     const workspace = blocklyWrapper.blockly_.inject(
       container,
       options

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -30,7 +30,6 @@ import {
   ObservableProcedureModel,
 } from '@blockly/block-shareable-procedures';
 import {Abstract} from 'blockly/core/events/events_abstract';
-//import {ToolboxDefinition} from 'blockly/core/utils/toolbox';
 import FunctionEditor from './addons/functionEditor';
 import WorkspaceSvgFrame from './addons/workspaceSvgFrame';
 import {IProcedureBlock} from 'blockly/core/procedures';
@@ -274,7 +273,7 @@ export type WorkspaceSerialization =
   | {
       blocks: {blocks: JsonBlockConfig[]};
       procedures?: ProcedureDefinitionConfig[];
-      variables?: {name: string; id: string}[];
+      variables?: VariableConfig[];
     }
   | Record<string, never>; // empty object
 
@@ -283,6 +282,11 @@ export interface ProcedureDefinitionConfig {
   name: string;
   // As of now we only use null. Will we ever use return types?
   returnTypes: null;
+}
+
+export interface VariableConfig {
+  name: string;
+  id: string;
 }
 
 export interface ProcedureBlockConfiguration {

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -34,6 +34,7 @@ import FunctionEditor from './addons/functionEditor';
 import WorkspaceSvgFrame from './addons/workspaceSvgFrame';
 import {IProcedureBlock} from 'blockly/core/procedures';
 import BlockSvgFrame from './addons/blockSvgFrame';
+import {ToolboxDefinition} from 'blockly/core/utils/toolbox';
 
 export interface BlockDefinition {
   category: string;
@@ -86,7 +87,7 @@ export interface BlocklyWrapperType extends GoogleBlocklyType {
   levelBlockIds: string[];
   isStartMode: boolean;
   isToolboxMode: boolean;
-  toolboxBlocks: string | undefined;
+  toolboxBlocks: ToolboxDefinition | undefined;
   useModalFunctionEditor: boolean;
   functionEditor: FunctionEditor;
   mainBlockSpace: ExtendedWorkspaceSvg;

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -244,7 +244,7 @@ export interface JsonBlockConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   extraState?: any;
   type: string;
-  fields: {[key: string]: {name: string; type: string; id: string}};
+  fields: {[key: string]: {name: string; type: string; id?: string}};
   inputs: {[key: string]: {block: JsonBlockConfig}};
   next: {block: JsonBlockConfig};
   kind: string;
@@ -267,9 +267,23 @@ export interface ProcedureBlock extends Block, IProcedureBlock {
   userCreated: boolean;
 }
 
-// Blockly uses any here. We may be able to define this better.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type WorkspaceSerialization = {[key: string]: any};
+// Blockly uses {[key: string]: any} to define workspace serialization.
+// We have defined this more specifically, and therefore need to cast
+// to this value when getting the serialzation of a workspace.
+export type WorkspaceSerialization =
+  | {
+      blocks: {blocks: JsonBlockConfig[]};
+      procedures?: ProcedureDefinitionConfig[];
+      variables?: {name: string; id: string}[];
+    }
+  | Record<string, never>; // empty object
+
+export interface ProcedureDefinitionConfig {
+  id: string;
+  name: string;
+  // As of now we only use null. Will we ever use return types?
+  returnTypes: null;
+}
 
 export interface ProcedureBlockConfiguration {
   kind: 'block';

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -30,7 +30,7 @@ import {
   ObservableProcedureModel,
 } from '@blockly/block-shareable-procedures';
 import {Abstract} from 'blockly/core/events/events_abstract';
-import {ToolboxDefinition} from 'blockly/core/utils/toolbox';
+//import {ToolboxDefinition} from 'blockly/core/utils/toolbox';
 import FunctionEditor from './addons/functionEditor';
 import WorkspaceSvgFrame from './addons/workspaceSvgFrame';
 import {IProcedureBlock} from 'blockly/core/procedures';
@@ -87,7 +87,7 @@ export interface BlocklyWrapperType extends GoogleBlocklyType {
   levelBlockIds: string[];
   isStartMode: boolean;
   isToolboxMode: boolean;
-  toolboxBlocks: Element | ToolboxDefinition | undefined;
+  toolboxBlocks: string | undefined;
   useModalFunctionEditor: boolean;
   functionEditor: FunctionEditor;
   mainBlockSpace: ExtendedWorkspaceSvg;
@@ -235,7 +235,7 @@ export interface XmlBlockConfig {
 // This type is likely incomplete. We should add to it if we discover
 // more properties it contains.
 export interface JsonBlockConfig {
-  id: string;
+  id?: string;
   x?: number;
   y?: number;
   movable?: boolean;
@@ -244,6 +244,10 @@ export interface JsonBlockConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   extraState?: any;
   type: string;
+  fields: {[key: string]: {name: string; type: string; id: string}};
+  inputs: {[key: string]: {block: JsonBlockConfig}};
+  next: {block: JsonBlockConfig};
+  kind: string;
 }
 
 export interface Collider {
@@ -283,3 +287,5 @@ export interface ProcedureBlockConfiguration {
 export type ProcedureType =
   | BLOCK_TYPES.procedureDefinition
   | BLOCK_TYPES.behaviorDefinition;
+
+export type BlockColor = [number, number, number];

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -221,7 +221,7 @@ type XmlType = typeof Xml;
 export interface ExtendedXml extends XmlType {
   textToDom: (text: string) => Element;
   blockSpaceToDom: (workspace: Workspace, opt_noId?: boolean) => Element;
-  domToBlockSpace: (workspace: Workspace, xml: Document) => XmlBlockConfig[];
+  domToBlockSpace: (workspace: Workspace, xml: Element) => XmlBlockConfig[];
 }
 
 // This type is likely incomplete. We should add to it if we discover
@@ -243,6 +243,7 @@ export interface JsonBlockConfig {
   // extraState can be any object. We may be able to define this better.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   extraState?: any;
+  type: string;
 }
 
 export interface Collider {


### PR DESCRIPTION
Convert `cdoUtils` to Typescript. As part of this work I also improved the serialization types I initially created in #56805, so they no longer include `any`. In addition, I updated an incorrect typing from that PR, where we were using `Document` when really we should have been using `Element`. Because of the typing changes this includes some changes to `cdoSerializationHelpers` as well. I have added inline comments where there are interesting code changes.

## Links
- jira ticket: [CT-335](https://codedotorg.atlassian.net/browse/CT-335)


## Testing story
Tested locally. I tested various scenarios where these functions get hit, such as converting from xml to json, loading an existing json project, and loading a project with shared functions.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
