### PR TITLE
Add initial types for Gen AI tool

### DIFF
--- a/apps/src/aichat/locale.ts
+++ b/apps/src/aichat/locale.ts
@@ -1,6 +1,6 @@
 /**
  * A TypeScript wrapper for the AichatLocale object which casts
- * it to the {@link AichatLocale} type.
+ * it to the {@link Locale} type.
  */
 import {Locale} from '@cdo/apps/types/locale';
 

--- a/apps/src/aichat/locale.ts
+++ b/apps/src/aichat/locale.ts
@@ -2,7 +2,8 @@
  * A TypeScript wrapper for the AichatLocale object which casts
  * it to the {@link AichatLocale} type.
  */
-import {AichatLocale} from './types';
-const aichatLocale = require('@cdo/aichat/locale');
+import {Locale} from '@cdo/apps/types/locale';
 
-export default aichatLocale as AichatLocale;
+export default require('@cdo/aichat/locale') as Locale<
+  typeof import('@cdo/i18n/aichat/en_us.json')
+>;

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -1,16 +1,6 @@
 import {LevelProperties} from '@cdo/apps/lab2/types';
 import {AiTutorInteractionSaveStatus} from '@cdo/apps/util/sharedConstants';
 
-// TODO: Ideally this type would only contain keys present in
-// translated string JSON files (ex. apps/i18n/aichat/en_us.json).
-// However, this requires depending on files outside of apps/src,
-// so this approach is still being investigated. For now, this type
-// is an object whose keys are all functions which return strings,
-// matching what we expect for a locale object.
-export type AichatLocale = {
-  [key: string]: () => string;
-};
-
 export type ChatCompletionMessage = {
   id: number;
   role: Role;
@@ -31,7 +21,52 @@ export const Status = AiTutorInteractionSaveStatus;
 export const PII = [Status.EMAIL, Status.ADDRESS, Status.PHONE];
 
 export interface AichatLevelProperties extends LevelProperties {
+  // --- DEPRECATED - used for old AI Chat
   systemPrompt: string;
   botTitle?: string;
   botDescription?: string;
+  // ---
+
+  /** Initial AI customizations set by the level. */
+  initialAiCustomizations?: LevelAiCustomizations;
 }
+
+/** AI customizations for student chat bots */
+export interface AiCustomizations {
+  botName: string;
+  temperature: number;
+  systemPrompt: string;
+  retrievalContexts: string[];
+  modelCardInfo?: ModelCardInfo;
+}
+
+/** Chat bot Model Card information */
+export interface ModelCardInfo {
+  description: string;
+  intendedUse: string;
+  limitationsAndWarnings: string;
+  testingAndEvaluation: string;
+  askAboutTopics: string[];
+}
+
+// Visibility for AI customization fields set by levelbuilders.
+type Visibility = 'hidden' | 'readonly' | 'editable';
+
+/**
+ * Level-defined AI customizations for student chat bots set by levelbuilders on the level's properties.
+ * Each field is the same as AiCustomizations, but with an additional visibility property.
+ */
+export type LevelAiCustomizations = {
+  [key in keyof AiCustomizations]: {
+    value: AiCustomizations[key];
+    visibility: Visibility;
+  };
+} & {
+  /** The initial panel to show when displaying the level */
+  initialPanel?: 'edit' | 'presentation';
+  /**
+   * If the student can go back to the editing panel after starting on the presentation panel.
+   * Only applies if initialPanel is 'presentation'.
+   */
+  canGoBackToEditing?: boolean;
+};

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -27,7 +27,12 @@ export interface AichatLevelProperties extends LevelProperties {
   botDescription?: string;
   // ---
 
-  /** Initial AI customizations set by the level. */
+  /**
+   * Initial AI customizations set by the level.
+   * For each field, levelbuilders may define the initial default value,
+   * and visibility (hidden, readonly, or editable).
+   * Visibility is not editable by the student; students can only change the value if it is set to editable.
+   */
   initialAiCustomizations?: LevelAiCustomizations;
 }
 


### PR DESCRIPTION
Add some initial types for the new Gen AI unit chatbot tool, which will repurpose the AI chat created for EduBot. These will most likely be tweaked as we go along, but these should hopefully give us a good starting point to start creating UI and mock levels.

## Links
[Gen AI Tool Spec](https://docs.google.com/document/d/1yIez6ooHbfwfM2W16pQvGHgKTe97AdGJN7YECTOpmBU/edit)

## Testing story

Tested locally; not actually used anywhere so no user-facing impact.