### PR TITLE
Updating a11y linter to remove unnecessary toggled off blob rule

### DIFF
--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -7,8 +7,8 @@
 // reenabling.
 const rulesToEventuallyReenable = {
   'jsx-a11y/anchor-is-valid': 'off',
+  'jsx-a11y/blob': 'off',
   'jsx-a11y/click-events-have-key-events': 'off',
-  'jsx-a11y/label-has-associated-control': 'off',
   'jsx-a11y/mouse-events-have-key-events': 'off',
   'jsx-a11y/no-noninteractive-element-interactions': 'off',
   'jsx-a11y/no-static-element-interactions': 'off',

--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -6,7 +6,6 @@
 // below, so that we can more easily track fixing violations and eventually
 // reenabling.
 const rulesToEventuallyReenable = {
-  'jsx-a11y/anchor-is-valid': 'off',
   'jsx-a11y/blob': 'off',
   'jsx-a11y/click-events-have-key-events': 'off',
   'jsx-a11y/label-has-associated-control': 'off',

--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -6,7 +6,7 @@
 // below, so that we can more easily track fixing violations and eventually
 // reenabling.
 const rulesToEventuallyReenable = {
-  'jsx-a11y/blob': 'off',
+  'jsx-a11y/anchor-is-valid': 'off',
   'jsx-a11y/click-events-have-key-events': 'off',
   'jsx-a11y/label-has-associated-control': 'off',
   'jsx-a11y/mouse-events-have-key-events': 'off',

--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -7,8 +7,8 @@
 // reenabling.
 const rulesToEventuallyReenable = {
   'jsx-a11y/anchor-is-valid': 'off',
-  'jsx-a11y/blob': 'off',
   'jsx-a11y/click-events-have-key-events': 'off',
+  'jsx-a11y/label-has-associated-control': 'off',
   'jsx-a11y/mouse-events-have-key-events': 'off',
   'jsx-a11y/no-noninteractive-element-interactions': 'off',
   'jsx-a11y/no-static-element-interactions': 'off',


### PR DESCRIPTION
I was taking another look at how many errors arise from various rules if we were to turn them on from the accessibility linter. When I turned off the line disabling the /blob rule, the build passed. Through some research of the [linter documentation](https://www.npmjs.com/package/eslint-plugin-jsx-a11y) and [this log of errors](https://gist.github.com/bethanyaconnor/7f59c9f892a290f863a9692472512472) when the linter was first implemented, it appears the blob rule is actually from the 'anchor-is-valid' rule, which has its own line. When you add up all the lines in that log, it totals 615, which would align with the 69 errors being counted twice. 

This is from the initial sorting the team did when implementing the linter:
<img width="362" alt="Screenshot 2024-02-28 at 10 50 22 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/bc2541f0-4adc-4cd0-bb56-1e242c38ec96">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
