### PR TITLE
Fix all coerce, populate and import issues founds with new tests 

### DIFF
--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -314,7 +314,8 @@ DatablockStorage.deleteKeyValue = function (key, onSuccess, onError) {
  */
 DatablockStorage.populateTable = function (jsonData) {
   return _fetch('populate_tables', 'PUT', {
-    tables_json: JSON.stringify(jsonData),
+    tables_json:
+      typeof jsonData === 'string' ? jsonData : JSON.stringify(jsonData),
   });
 };
 

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -76,6 +76,8 @@ class DatablockStorageController < ApplicationController
     DatablockStorageTable.add_shared_table @project_id, params[:table_name]
 
     render json: true
+  rescue ActiveRecord::RecordNotUnique
+    raise StudentFacingError.new(:DUPLICATE_TABLE_NAME), "There is already a table with name #{params[:table_name].inspect}"
   end
 
   def import_csv

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -82,6 +82,10 @@ class DatablockStorageController < ApplicationController
 
   def import_csv
     table = table_or_create
+
+    # import_csv should overwrite existing data:
+    table.records.delete_all
+
     table.import_csv params[:table_data_csv]
     table.save!
 

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -113,6 +113,8 @@ class DatablockStorageController < ApplicationController
     tables_json = JSON.parse params[:tables_json]
     DatablockStorageTable.populate_tables @project_id, tables_json
     render json: true
+  rescue JSON::ParserError => exception
+    raise StudentFacingError, "SyntaxError #{exception.message}\n while parsing initial table data: #{params[:tables_json]}"
   end
 
   ##########################################################

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -59,7 +59,7 @@ class DatablockStorageController < ApplicationController
   def populate_key_values
     key_values_json = JSON.parse params[:key_values_json]
     raise "key_values_json must be a hash" unless key_values_json.is_a? Hash
-    DatablockStorageKvp.set_kvps(@project_id, key_values_json)
+    DatablockStorageKvp.set_kvps(@project_id, key_values_json, upsert: false)
     render json: true
   end
 

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -111,8 +111,6 @@ class DatablockStorageController < ApplicationController
 
   def populate_tables
     tables_json = JSON.parse params[:tables_json]
-    # FIXME: unfirebase - Why are json encoding a string that's already a json encoded object?
-    tables_json = JSON.parse tables_json unless tables_json.is_a? Hash
     DatablockStorageTable.populate_tables @project_id, tables_json
     render json: true
   end

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -54,8 +54,12 @@ class DatablockStorageController < ApplicationController
   def populate_key_values
     key_values_json = JSON.parse params[:key_values_json]
     raise "key_values_json must be a hash" unless key_values_json.is_a? Hash
+
     DatablockStorageKvp.set_kvps(@project_id, key_values_json, upsert: false)
+
     render json: true
+  rescue JSON::ParserError => exception
+    raise StudentFacingError, "SyntaxError #{exception.message}\n while parsing initial key/value data: #{params[:key_values_json]}"
   end
 
   ##########################################################

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -47,12 +47,7 @@ class DatablockStorageController < ApplicationController
   end
 
   def get_key_values
-    # SELECT key, value FROM datablock_storage_kvps WHERE project_id='{@project_id}';
-    kvps = DatablockStorageKvp.
-      where(project_id: @project_id).
-      select(:key, :value).
-      to_h {|kvp| [kvp.key, JSON.parse(kvp.value)]}
-
+    kvps = DatablockStorageKvp.get_kvps(@project_id)
     render json: kvps
   end
 

--- a/dashboard/app/models/datablock_storage_kvp.rb
+++ b/dashboard/app/models/datablock_storage_kvp.rb
@@ -13,10 +13,12 @@ class DatablockStorageKvp < ApplicationRecord
   # but we're skipping it until this is implemented.
   MAX_VALUE_LENGTH = 4096
 
-  def self.set_kvps(project_id, key_value_hashmap)
-    # [
-    #   {project_id: project_id, key: key, value: value.to_json}
-    # ]
+  def self.get_kvps(project_id)
+    where(project_id: project_id).
+      select(:key, :value).
+      to_h {|kvp| [kvp.key, JSON.parse(kvp.value)]}
+  end
+
     kvps = key_value_hashmap.map do |key, value|
       {project_id: project_id, key: key, value: value.to_json}
     end

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -58,9 +58,12 @@ class DatablockStorageTable < ApplicationRecord
 
   def self.populate_tables(project_id, tables_json)
     tables_json.each do |table_name, records|
-      table = DatablockStorageTable.where(project_id: project_id, table_name: table_name).first_or_create
+      table = DatablockStorageTable.create!(project_id: project_id, table_name: table_name)
       table.create_records records
       table.save!
+    rescue ActiveRecord::RecordNotUnique
+      # Its ok if the table already exists, but we won't re-populate it
+      logger.warn "Table already exists: not populating project_id=#{project_id}, table_name=#{table_name}"
     end
   end
 

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -406,9 +406,7 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
       record_json: NYC_RECORD.to_json,
     }
 
-    put _url(:populate_tables), params: {table_data_json: POPULATE_TABLE_DATA_JSON_STRING}
-
-    skip "FIXME: controller bug, populate_tables is returning a 500, desired behavior is to not return even a warning, and silently fail if the table already exists"
+    put _url(:populate_tables), params: {tables_json: POPULATE_TABLE_DATA_JSON_STRING}
     assert_response :success
 
     assert_equal [NYC_RECORD], read_records('cities')
@@ -416,7 +414,7 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
 
   test "populate_table prints a friendly error message when given bad table json" do
     BAD_JSON = '{'
-    put _url(:populate_tables), params: {table_data_json: BAD_JSON}
+    put _url(:populate_tables), params: {tables_json: BAD_JSON}
 
     skip "FIXME: controller bug, populate_tables is returning a 500, desired behavior is to return a 400 with an error message"
     assert_response :bad_request

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -449,14 +449,12 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
   test "populate_key_values prints a friendly error message when given bad key value json" do
     put _url(:populate_key_values), params: {key_values_json: '{'}
 
-    skip "FIXME: controller bug, populate_key_values is returning a 500, expected behavior is to return a 400 with an error message"
     assert_response :bad_request
 
     error = JSON.parse(@response.body)
-    # Error message should be like (from the JS):
-    # `${e}\nwhile parsing initial key/value data: ${jsonData}`
-    assert_match(/SyntaxError/, error)
-    assert_match(/while parsing initial key\/value data: {/, error)
+
+    assert_match(/SyntaxError/, error['msg'])
+    assert_match(/while parsing initial key\/value data: {/, error['msg'])
   end
 
   def create_shared_table

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -442,7 +442,6 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
     get _url(:get_key_values)
     assert_response :success
 
-    skip "FIXME: controller bug, populate_key_values is overwriting the existing key value"
     assert_equal ({"click_count" => 1}), JSON.parse(@response.body)
   end
 

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -610,7 +610,7 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
     }
     assert_response :success
 
-    IMPORT_CSV_DATA = <<~CSV
+    CSV_DATA = <<~CSV
       id,name
       1,alice
       2,bob
@@ -628,8 +628,6 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
       table_data_csv: CSV_DATA,
     }
     assert_response :success
-
-    skip "FIXME: controller bug, test will fail because import_csv doesn't properly overwrite existing data"
 
     # Tim, age 2 record should be gone:
     assert_equal EXPECTED_RECORDS, read_records

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -415,15 +415,12 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
   test "populate_table prints a friendly error message when given bad table json" do
     BAD_JSON = '{'
     put _url(:populate_tables), params: {tables_json: BAD_JSON}
-
-    skip "FIXME: controller bug, populate_tables is returning a 500, desired behavior is to return a 400 with an error message"
     assert_response :bad_request
 
     error = JSON.parse(@response.body)
-    # Error message should be like (from the JS):
-    # `${e}\nwhile parsing initial table data: ${jsonData}`
-    assert_match(/SyntaxError/, error)
-    assert_match(/while parsing initial table data: {/, error)
+
+    assert_match(/SyntaxError/, error['msg'])
+    assert_match(/while parsing initial table data: {/, error['msg'])
   end
 
   test "populate_key_values" do

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -519,6 +519,8 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "add_shared_table cannot overwrite an existing table" do
+    _shared_records, _mysharedtable = create_shared_table
+
     post _url(:create_record), params: {
       table_name: 'mysharedtable',
       record_json: {"name" => 'bob', "age" => 8}.to_json,
@@ -526,12 +528,12 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     post _url(:add_shared_table), params: {table_name: 'mysharedtable'}
-
-    skip "FIXME: controller bug, add_shared_table is returning a 500, expected behavior is to not return even a warning, and silently fail if the table already exists"
     assert_response :bad_request
 
     error = JSON.parse(@response.body)
     assert_equal 'DUPLICATE_TABLE_NAME', error['type']
+
+    assert_equal [{"id" => 1, "name" => 'bob', "age" => 8}], read_records('mysharedtable')
   end
 
   test "deletes a record" do


### PR DESCRIPTION
Controller now passes 6 more tests that were formerly skipped.

Remaining skips are:
- 4 skips due to not having limits implemented
- 1 skip due to import_csv not auto-casting from string (same issue as reported by Molly: #56771)

State of running `bundle exec spring testunit ./test/controllers/datablock_storage_controller_test.rb` after this PR:
<img width="401" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/cc528f9e-86e3-4e1c-a369-cdc982dba464">
