### PR TITLE
Datablock Storage: auto-cast values on import_csv

### DIFF
--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -156,6 +156,22 @@ class DatablockStorageTable < ApplicationRecord
 
   def import_csv(table_data_csv)
     records = CSV.parse(table_data_csv, headers: true).map(&:to_h)
+
+    # Auto-cast CSV strings on import, e.g. "5.0" => 5.0
+    same_as_undefined = ['', 'undefined']
+    records.map! do |record|
+      # This is equivalent to setting the value to be 'undefined' in JS: it deletes the key
+      record.reject! {|_key, value| same_as_undefined.include? value}
+      record.transform_values! do |string_value|
+        # Attempt to parse as JSON, fall back to original string on error
+        json_value = JSON.parse(string_value)
+        raise TypeError, 'Invalid entry type: object' if json_value.is_a?(Hash) || json_value.is_a?(Array)
+        json_value
+      rescue JSON::ParserError, TypeError
+        string_value
+      end
+    end
+
     create_records(records)
   end
 

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -114,6 +114,10 @@ class DatablockStorageTable < ApplicationRecord
 
       cols_in_records = Set.new
       record_jsons.each do |record_json|
+        record_json.each do |_key, json_value|
+          raise StudentFacingError.new(:INVALID_RECORD), 'Invalid record: nested objects and arrays are not permitted' if json_value.is_a?(Hash) || json_value.is_a?(Array)
+        end
+
         # We write the record_id into the JSON as well as storing it in its own column
         # only create_record and update_record should be at risk of modifying this
         record_json['id'] = next_record_id

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -100,6 +100,24 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
     assert_equal ['mytable'], JSON.parse(@response.body)
   end
 
+  test "create_record wont create objects or arrays" do
+    create_bob_record
+
+    post _url(:create_record), params: {
+      table_name: 'mytable',
+      record_json: '{"name": "badbob", "badval": {"key":"value"}}',
+    }
+    assert_response :bad_request
+    assert_equal [{"name" => 'bob', "age" => 8, "id" => 1}], read_records
+
+    post _url(:create_record), params: {
+      table_name: 'mytable',
+      record_json: '{"name": "badbob", "badval": [1,2,3]}',
+    }
+    assert_response :bad_request
+    assert_equal [{"name" => 'bob', "age" => 8, "id" => 1}], read_records
+  end
+
   test "create_record can't create more than MAX_TABLE_COUNT tables" do
     # Lower the max table count to 3 so it's easy to test
     original_max_table_count = DatablockStorageTable::MAX_TABLE_COUNT

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -599,7 +599,6 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
     }
     assert_response :success
 
-    skip "FIXME: controller bug, test will fail because import_csv doesn't cast values, see bottom of test"
     assert_equal EXPECTED_RECORDS, read_records
   end
 


### PR DESCRIPTION
When importing a CSV into your local data table, the Firebase version checks if each value can be parsed as JSON and uses that to "auto cast" them. This code causes the `import_csv` test to pass, so no longer skipping it.

Additionally, added a test (and implementation) to guard against using `create_records` to create nested JS objects and arrays. These are not permitted, but the old implementation would let them leak in using populateValues.

After this commit, all our controller tests are passing except 4 "limit enforcement" tests that have their backends still TODO:
<img width="400" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/6a35a847-4487-4cf4-8d68-69817fdb6e4e">

Fixes: #56771 reported by Molly in the bug bash