### PR TITLE
AI Tutor: add id column to Student Chat Messages table on Teacher Dashboard

### DIFF
--- a/apps/src/code-studio/components/aiTutor/aiTutorChatMessageTableRow.tsx
+++ b/apps/src/code-studio/components/aiTutor/aiTutorChatMessageTableRow.tsx
@@ -29,6 +29,7 @@ const AITutorChatMessagesTableRow: React.FunctionComponent<
 
   return (
     <tr className={style.row}>
+      <td className={style.cell}>{chatMessage.id}</td>
       <td className={style.cell}>{chatMessage.studentName}</td>
       <td className={style.cell}>
         <div>{getTimestamp(chatMessage.createdAt)}</div>

--- a/apps/src/code-studio/components/aiTutor/aiTutorChatMessagesTable.tsx
+++ b/apps/src/code-studio/components/aiTutor/aiTutorChatMessagesTable.tsx
@@ -32,6 +32,9 @@ const AITutorChatMessagesTable: React.FunctionComponent<
       <table>
         <thead>
           <tr>
+          <td>
+              <div className={style.header}>Id</div>
+            </td>
             <td>
               <div className={style.header}>Student</div>
             </td>

--- a/apps/src/code-studio/components/aiTutor/aiTutorChatMessagesTable.tsx
+++ b/apps/src/code-studio/components/aiTutor/aiTutorChatMessagesTable.tsx
@@ -32,7 +32,7 @@ const AITutorChatMessagesTable: React.FunctionComponent<
       <table>
         <thead>
           <tr>
-          <td>
+            <td>
               <div className={style.header}>Id</div>
             </td>
             <td>


### PR DESCRIPTION
Small follow up to #56885. Adds the id column that I thought I'd already pushed 🤦‍♀️ 
