### PR TITLE
AI Tutor: add level type to Amplitude logs for AI Tutor so we can use for groupBy analysis 

### DIFF
--- a/apps/src/code-studio/components/aiTutor/userChatMessageEditor.tsx
+++ b/apps/src/code-studio/components/aiTutor/userChatMessageEditor.tsx
@@ -94,6 +94,7 @@ const UserChatMessageEditor: React.FunctionComponent = () => {
     }
     analyticsReporter.sendEvent(event, {
       levelId: level?.id,
+      levelType: level?.type,
     });
   }, [
     generalChat,
@@ -102,7 +103,7 @@ const UserChatMessageEditor: React.FunctionComponent = () => {
     isWaitingForChatResponse,
     compilation,
     validation,
-    level?.id,
+    level,
     tutorType,
     dispatch,
   ]);


### PR DESCRIPTION
We had real users in a classroom visit today! As I was reviewing the Amplitude AI Tutor usage logs, I realized that we aren't tracking `levelType` when we log what type of tutor the student is using. We are already tracking `levelType` when the [panel is opened or closed](https://github.com/code-dot-org/code-dot-org/blob/f76661a133b2661fe8ef55463e7b4fcd308d2ec4/apps/src/code-studio/components/aiTutor/aiTutorFloatingActionButton.tsx#L27). Adding in `levelType` so we can use it in groupBy analysis for each tutor type. 
