### PR TITLE
P20-746: Fix the `studio_saySpriteChoices` Blockly function

### DIFF
--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -3208,9 +3208,9 @@ exports.install = function (blockly, blockInstallOptions) {
       this.id +
       "', " +
       (this.getFieldValue('SPRITE') || '0') +
-      ", '" +
-      (this.getFieldValue('VALUE') || ' ') +
-      "');\n"
+      ', ' +
+      JSON.stringify(this.getFieldValue('VALUE') || ' ') +
+      ');\n'
     );
   };
 

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -3202,16 +3202,11 @@ exports.install = function (blockly, blockInstallOptions) {
   };
 
   generator.studio_saySpriteChoices = function () {
+    const sprite = JSON.stringify(String(this.getFieldValue('SPRITE') || '0'));
+    const value = JSON.stringify(String(this.getFieldValue('VALUE') || ' '));
+
     // Generate JavaScript for saying (choices version).
-    return (
-      "Studio.saySprite('block_id_" +
-      this.id +
-      "', " +
-      (this.getFieldValue('SPRITE') || '0') +
-      ', ' +
-      JSON.stringify(String(this.getFieldValue('VALUE') || ' ')) +
-      ');\n'
-    );
+    return `Studio.saySprite('block_id_${this.id}', ${sprite}, ${value});\n`;
   };
 
   generator.studio_saySpriteParams = function () {

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -3209,7 +3209,7 @@ exports.install = function (blockly, blockInstallOptions) {
       "', " +
       (this.getFieldValue('SPRITE') || '0') +
       ', ' +
-      JSON.stringify(this.getFieldValue('VALUE') || ' ') +
+      JSON.stringify(String(this.getFieldValue('VALUE') || ' ')) +
       ');\n'
     );
   };

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -3202,7 +3202,7 @@ exports.install = function (blockly, blockInstallOptions) {
   };
 
   generator.studio_saySpriteChoices = function () {
-    const sprite = JSON.stringify(String(this.getFieldValue('SPRITE') || '0'));
+    const sprite = this.getFieldValue('SPRITE') || '0';
     const value = JSON.stringify(String(this.getFieldValue('VALUE') || ' '));
 
     // Generate JavaScript for saying (choices version).

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -3209,7 +3209,7 @@ exports.install = function (blockly, blockInstallOptions) {
       "', " +
       (this.getFieldValue('SPRITE') || '0') +
       ', ' +
-      JSON.stringify(this.getFieldValue('VALUE') || ' ') +
+      JSON.stringify(String(this.getFieldValue('VALUE')) || ' ') +
       ');\n'
     );
   };

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -3209,7 +3209,7 @@ exports.install = function (blockly, blockInstallOptions) {
       "', " +
       (this.getFieldValue('SPRITE') || '0') +
       ', ' +
-      JSON.stringify(String(this.getFieldValue('VALUE')) || ' ') +
+      JSON.stringify(this.getFieldValue('VALUE') || ' ') +
       ');\n'
     );
   };


### PR DESCRIPTION
The function `studio_saySpriteChoices` dynamically invokes the function `Studio.saySprite` with varying arguments. 
The invocation fails when any argument includes an apostrophe (`'`), due to the lack of proper escaping.
| Before  | After |
| ------- | ----- |
| ![before](https://github.com/code-dot-org/code-dot-org/assets/11708250/273e417e-6246-4de5-baa4-77f74ba3eabb) | ![after](https://github.com/code-dot-org/code-dot-org/assets/11708250/9ca71bc8-c471-4e88-b662-6feb75b0c165) |


- jira ticket: [P20-746](https://codedotorg.atlassian.net/browse/P20-746)
