### PR TITLE
Add small top skinny banners on code.org

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/csd/index.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csd/index.haml
@@ -6,7 +6,7 @@ theme: responsive_full_width
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/csd-styles.css", rel: "stylesheet"}
 
-= view :top_skinny_banner, banner_url: CDO.studio_url("/s/csd2-2024"), banner_icon: "fa fa-sparkles", banner_text: hoc_s(:call_to_action_pilot_web_dev_unit), light_theme: true
+= view :top_skinny_banner, banner_id: "banner-csd", banner_url: CDO.studio_url("/s/csd2-2024"), banner_icon: "fa fa-sparkles", banner_text: hoc_s(:call_to_action_pilot_web_dev_unit), light_theme: true
 
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap

--- a/pegasus/sites.v3/code.org/public/educate/csd/index.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csd/index.haml
@@ -6,6 +6,8 @@ theme: responsive_full_width
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/csd-styles.css", rel: "stylesheet"}
 
+= view :top_skinny_banner, banner_url: CDO.studio_url("/s/csd2-2024"), banner_icon: "fa fa-sparkles", banner_text: hoc_s(:call_to_action_pilot_web_dev_unit), light_theme: true
+
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.haml
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.haml
@@ -6,7 +6,7 @@ theme: responsive_full_width
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/school-curricula.css", rel: "stylesheet"}
 
-= view :top_skinny_banner, banner_url: CDO.studio_url("/s/csd2-2024"), banner_icon: "fa fa-sparkles", banner_text: hoc_s(:call_to_action_pilot_web_dev_unit), light_theme: false
+= view :top_skinny_banner, banner_id: "banner-middle-school", banner_url: CDO.studio_url("/s/csd2-2024"), banner_icon: "fa fa-sparkles", banner_text: hoc_s(:call_to_action_pilot_web_dev_unit), light_theme: false
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.haml
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.haml
@@ -6,6 +6,8 @@ theme: responsive_full_width
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/school-curricula.css", rel: "stylesheet"}
 
+= view :top_skinny_banner, banner_url: CDO.studio_url("/s/csd2-2024"), banner_icon: "fa fa-sparkles", banner_text: hoc_s(:call_to_action_pilot_web_dev_unit), light_theme: false
+
 %section
   .wrapper
     %h1

--- a/pegasus/sites.v3/code.org/public/js/top_skinny_banner.js
+++ b/pegasus/sites.v3/code.org/public/js/top_skinny_banner.js
@@ -1,0 +1,15 @@
+const banners = document.querySelectorAll(".top-skinny-banner");
+
+banners.forEach((banner) => {
+  const bannerId = banner.getAttribute("id");
+  const closeButton = banner.querySelector("button");
+
+  if (localStorage.getItem(`hideBanner-${bannerId}`) === "true") {
+    banner.style.display = "none";
+  }
+
+  closeButton.addEventListener("click", () => {
+    banner.style.display = "none";
+    localStorage.setItem(`hideBanner-${bannerId}`, "true");
+  });
+});

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -630,6 +630,10 @@ aside.top-skinny-banner {
 
     &:focus {
       outline: 5px auto -webkit-focus-ring-color;
+
+      &:not(:focus-visible) {
+        outline: none;
+      }
     }
 
     & > i {

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -628,6 +628,10 @@ aside.top-skinny-banner {
       opacity: 1;
     }
 
+    &:focus {
+      outline: 5px auto -webkit-focus-ring-color;
+    }
+
     & > i {
       color: var(--neutral_white);
     }

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -616,7 +616,7 @@ aside.top-skinny-banner {
 
   & > button {
     all: unset;
-    padding: 1rem;
+    padding: 1rem 1.1rem;
     margin-top: 2px;
     cursor: pointer;
     text-align: center;

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -8,31 +8,31 @@
 
 :root {
   /* Colors */
-  --brand_primary_light: #ABDFE5;
-  --brand_primary_medium: #7BC6CF;
-  --brand_primary_default: #0093A4;
+  --brand_primary_light: #abdfe5;
+  --brand_primary_medium: #7bc6cf;
+  --brand_primary_default: #0093a4;
   --brand_primary_dark: #008291;
-  --brand_secondary_light: #E0D1EC;
-  --brand_secondary_default: #8C52BA;
-  --brand_secondary_dark: #6F488E;
-  --brand_accent_default: #ED6060;
-  --neutral_white: #FFFFFF;
-  --neutral_light: #F7F8FA;
-  --neutral_dark10: #EAEBEB;
-  --neutral_dark20: #D4D5D7;
-  --neutral_dark30: #BFC1C3;
-  --neutral_dark40: #A9ACAF;
-  --neutral_dark50: #94979B;
-  --neutral_dark60: #7F8286;
-  --neutral_dark70: #6A6E73;
-  --neutral_dark80: #54595E;
-  --neutral_dark90: #3F444B;
-  --neutral_dark: #292F36;
+  --brand_secondary_light: #e0d1ec;
+  --brand_secondary_default: #8c52ba;
+  --brand_secondary_dark: #6f488e;
+  --brand_accent_default: #ed6060;
+  --neutral_white: #ffffff;
+  --neutral_light: #f7f8fa;
+  --neutral_dark10: #eaebeb;
+  --neutral_dark20: #d4d5d7;
+  --neutral_dark30: #bfc1c3;
+  --neutral_dark40: #a9acaf;
+  --neutral_dark50: #94979b;
+  --neutral_dark60: #7f8286;
+  --neutral_dark70: #6a6e73;
+  --neutral_dark80: #54595e;
+  --neutral_dark90: #3f444b;
+  --neutral_dark: #292f36;
   --orange: #ffa400; /* legacy color */
   /* Typography */
-  --barlowSemiCondensed-semibold: 'Barlow Semi Condensed Semibold', sans-serif;
-  --barlowSemiCondensed-medium: 'Barlow Semi Condensed Medium', sans-serif;
-  --main-font: 'Metropolis', sans-serif;
+  --barlowSemiCondensed-semibold: "Barlow Semi Condensed Semibold", sans-serif;
+  --barlowSemiCondensed-medium: "Barlow Semi Condensed Medium", sans-serif;
+  --main-font: "Metropolis", sans-serif;
   --thin-font-weight: 100;
   --extra-light-font-weight: 200;
   --light-font-weight: 300;
@@ -104,7 +104,7 @@ h5,
   font-family: var(--main-font);
   font-weight: var(--semi-bold-font-weight);
   font-size: 1.25rem;
-  line-height: 1.40;
+  line-height: 1.4;
   margin-bottom: 0.5em;
 }
 
@@ -201,7 +201,7 @@ a:is(:link, :visited) {
   font-weight: var(--semi-bold-font-weight);
   color: var(--brand_secondary_default);
   text-decoration: underline;
-  transition: color ease-in-out .2s;
+  transition: color ease-in-out 0.2s;
 }
 
 a:is(:hover, :active) {
@@ -219,13 +219,13 @@ a:link:has(*) {
 a.link-button,
 button,
 .btn,
-input[type=submit] {
+input[type="submit"] {
   display: inline-block;
   color: var(--neutral_white);
   background: var(--brand_secondary_default);
   border: 2px solid var(--brand_secondary_default);
   border-radius: 4px;
-  padding: .75rem 1rem;
+  padding: 0.75rem 1rem;
   margin: 0.5rem 0;
   font-size: 1rem;
   font-family: var(--main-font);
@@ -233,7 +233,7 @@ input[type=submit] {
   line-height: 1;
   text-decoration: none;
   text-align: center;
-  transition: all ease-in-out .2s;
+  transition: all ease-in-out 0.2s;
 
   /* Hover styles */
   &:hover {
@@ -364,13 +364,13 @@ li > ul {
 
 ul {
   list-style: none;
-  padding:0;
-  margin:20px;
+  padding: 0;
+  margin: 20px;
 }
 
 ul li {
   padding-left: 1em;
-  text-indent: -.7em;
+  text-indent: -0.7em;
 }
 
 ul li:before {
@@ -573,6 +573,67 @@ nav.main #hamburger #hamburger-icon {
   }
 }
 
+/* Start top skinny banner styles --------------- */
+aside.top-skinny-banner {
+  background: var(--neutral_dark);
+  display: flex;
+
+  &.light-theme {
+    background: var(--neutral_dark10);
+
+    a > *,
+    button > i {
+      color: var(--neutral_dark);
+    }
+  }
+
+  & a {
+    width: 100%;
+    padding: 1rem;
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+
+    & > * {
+      color: var(--neutral_white);
+    }
+
+    & > i {
+      margin-top: 2px;
+    }
+
+    & > p {
+      margin-bottom: 0;
+      text-decoration: none;
+    }
+
+    &:hover {
+      & > p {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  & > button {
+    all: unset;
+    padding: 1rem;
+    margin-top: 2px;
+    cursor: pointer;
+    text-align: center;
+    align-self: start;
+    opacity: 0.7;
+    transition: opacity 0.2s ease-in-out;
+
+    &:hover {
+      opacity: 1;
+    }
+
+    & > i {
+      color: var(--neutral_white);
+    }
+  }
+}
+
 /* Start carousel styles ------------------------ */
 .carousel-wrapper {
   position: relative;
@@ -645,10 +706,11 @@ swiper-slide {
 
 .grey_input {
   font-size: 14px;
-  height:34px;
-  background-color: rgb(226,228,227);
-  border: none; padding: 5px;
-  color: rgb(89,89,89);
+  height: 34px;
+  background-color: rgb(226, 228, 227);
+  border: none;
+  padding: 5px;
+  color: rgb(89, 89, 89);
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
   border-top-left-radius: 4px;
@@ -659,17 +721,19 @@ swiper-slide {
   font-family: var(--main-font);
 }
 
-#petition_form a:link, #petition_form a:visited {
+#petition_form a:link,
+#petition_form a:visited {
   color: #dcdcdc;
   text-decoration: none;
 }
 
-#petition_form a:hover, #petition_form a:active {
+#petition_form a:hover,
+#petition_form a:active {
   color: #fff;
   text-decoration: underline;
 }
 
-.listed_supporter{
+.listed_supporter {
   font-family: var(--main-font);
   font-weight: var(--bold-font-weight);
   font-weight: normal;
@@ -680,7 +744,7 @@ swiper-slide {
   color: var(--neutral_white);
   padding: 20px;
   text-align: center;
-  overflow:hidden;
+  overflow: hidden;
 }
 
 #about_nav {

--- a/pegasus/sites.v3/code.org/views/font_awesome_icon_class.haml
+++ b/pegasus/sites.v3/code.org/views/font_awesome_icon_class.haml
@@ -1,1 +1,1 @@
-%script{src: '../js/font_awesome_icon_class.js'}
+%script{src: '/js/font_awesome_icon_class.js'}

--- a/pegasus/sites.v3/code.org/views/top_skinny_banner.haml
+++ b/pegasus/sites.v3/code.org/views/top_skinny_banner.haml
@@ -1,7 +1,9 @@
-%aside.top-skinny-banner{class: light_theme ? "light-theme" : ""}
+%aside.top-skinny-banner{class: light_theme ? "light-theme" : "", id: banner_id}
   %a{href: banner_url}
     %i{class: "#{banner_icon}"}
     %p.body-two
       = banner_text
   %button{aria:{label: hoc_s(:call_to_action_hide_banner)}}
     %i{class: "fa fa-xmark"}
+
+%script{src: "/js/top_skinny_banner.js"}

--- a/pegasus/sites.v3/code.org/views/top_skinny_banner.haml
+++ b/pegasus/sites.v3/code.org/views/top_skinny_banner.haml
@@ -1,0 +1,7 @@
+%aside.top-skinny-banner{class: light_theme ? "light-theme" : ""}
+  %a{href: banner_url}
+    %i{class: "#{banner_icon}"}
+    %p.body-two
+      = banner_text
+  %button{aria:{label: hoc_s(:call_to_action_hide_banner)}}
+    %i{class: "fa fa-xmark"}

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -405,6 +405,8 @@
   call_to_action_see_district_partners: "See our District Partners"
   call_to_action_read_full_story: "Read the full story"
   call_to_action_learn_about_pl: "Learn about Professional Learning"
+  call_to_action_pilot_web_dev_unit: "Pilot our newly updated Web Development unit!"
+  call_to_action_hide_banner: "Hide banner"
 
   aria_label_call_to_action_hoc_how_to_educators: "View how-to guide for Educators"
   aria_label_call_to_action_hoc_how_to_companies: "View how-to guide for Companies"


### PR DESCRIPTION
Adds a new `top_skinny_banner` view for use across code.org, and specifically added to [code.org/csd](http://code.org/csd) and [code.org/educate/curriculum/middle-school](https://code.org/educate/curriculum/middle-school) in this PR.
- Allows for a light or dark option based on a page's UI needs 
- When the close button is clicked, the banner is hidden and uses `localStorage` to keep it hidden ([ref](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage))
- Fully responsive and keyboard/screen reader navigable 
- Works with LTR and RTL languages
- Also fixed the path on some site-wide JS that adds a width to all icon (`<i>`) elements ([see file](https://github.com/code-dot-org/code-dot-org/pull/56910/files#diff-7a789de52a116115d4b12143392501e53b981c64eab13e29f80731084d90a76f))
  - This was breaking on pages within subdirectories so the help icon in the top nav (`?`) and the close icon in this skinny banner (`x`) were unaligned on [code.org/educate/curriculum/middle-school](https://code.org/educate/curriculum/middle-school)

**Jira ticket:** [ACQ-1507](https://codedotorg.atlassian.net/browse/ACQ-1507)

----

## Light version
<img width="970" alt="Light" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/0c246152-1bdb-40b0-8fd0-8f32e6c7dc60">

## Dark version
<img width="970" alt="Dark" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/45f52444-db2c-4fa8-81c9-43b144f2b121">

## Hiding the banners

https://github.com/code-dot-org/code-dot-org/assets/9256643/47ea0a1b-c206-46ec-a321-d3c1b2490cb3

## Responsive

https://github.com/code-dot-org/code-dot-org/assets/9256643/9d4e6fa9-f008-4e9e-8f86-76400a1c9f9d
