### PR TITLE
AI Tutor: restrict general chat topics and responses 

### DIFF
--- a/apps/src/aiTutor/constants.ts
+++ b/apps/src/aiTutor/constants.ts
@@ -1,11 +1,11 @@
 import {Role, Status} from '@cdo/apps/aiTutor/types';
 
 export const compilationSystemPrompt =
-  'You are a tutor in a high school computer science class. Students in the class are studying Java and they would like to know in age-appropriate, clear language why their code does not compile.';
+  'You are a tutor in a high school computer science class. Students in the class are studying Java and they would like to know in age-appropriate, clear language why their code does not compile. Do not write any code.';
 export const validationSystemPrompt =
-  'You are a tutor in a high school computer science class. Students in the class are studying Java and they would like to know in age-appropriate, clear language why their tests are not passing.';
+  'You are a tutor in a high school computer science class. Students in the class are studying Java and they would like to know in age-appropriate, clear language why their tests are not passing. Do not write any code.';
 export const generalChatSystemPrompt =
-  'You are a tutor in a high school classroom where the students are learning Java using the Code.org curriculum. Answer their questions in plain, easy-to-understanding English. Do not write any code in your response.';
+  'You are a tutor in a high school classroom where the students are learning Java using the Code.org curriculum. Answer their questions in plain, easy-to-understand English. Do not write any code. Do not answer the question if it is not about Java or computer programming.';
 
 // Initial messages we set when the user selects a tutor type.
 // General Chat


### PR DESCRIPTION
Students are very inquisitive, and we've found in recent classroom visits that they will utilize the general chat feature of AI Tutor to ask completely random questions. In an effort to better keep students focused on the task at hand (and ultimately reduce costs by hopefully reducing the temptation to send off-topic questions to OpenAI), I modified the system prompt to explicitly include "Do not answer the question if it is not about Java or computer programming." 

BEFORE 
<img width="727" alt="Screenshot 2024-02-29 at 2 44 25 PM" src="https://github.com/code-dot-org/code-dot-org/assets/12300669/6ee7569f-a538-49a4-88fa-394208f43836">

AFTER 
<img width="743" alt="Screenshot 2024-02-29 at 2 47 57 PM" src="https://github.com/code-dot-org/code-dot-org/assets/12300669/8e6fbb22-1460-423d-b9ef-69c88b3f6639">

Additionally, we don't want AI Tutor writing code for students (at least not right now) so I also added "Do not write any code." to the system prompts for compilation and validation. This is already included in the general chat system prompt.  AI Tutor sometimes disobeys this part of the prompt. We're tracking [CT-331](https://codedotorg.atlassian.net/browse/CT-331) to investigate and further iterate on preventing code generation. 
