### PR TITLE
Music: enable ToneJS player behind url param

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -305,6 +305,9 @@ class UnconnectedMusicView extends React.Component {
       this.library.getKey()
     );
 
+    // Temporarily loading all instruments for ToneJS player.
+    this.player.loadAllInstruments();
+
     this.setState({
       currentLibraryName: libraryName,
     });

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {LOCAL_STORAGE, REMOTE_STORAGE} from '../music/constants';
 
-const baseUrl = window.location.origin + '/musiclab';
+const baseUrl = window.location.origin + '/projectbeats';
 
 const optionsList = [
   {
@@ -96,6 +96,14 @@ const optionsList = [
     values: [
       {value: 'false', description: 'Disable keyboard shortcuts.'},
       {value: 'true', description: 'Enable keyboard shortcuts.'},
+    ],
+  },
+  {
+    name: 'player',
+    type: 'radio',
+    values: [
+      {value: 'sample', description: 'Use the sample player (default).'},
+      {value: 'tonejs', description: 'Use the ToneJS player.'},
     ],
   },
 ];


### PR DESCRIPTION
Last part (for now) for adding ToneJS player support (follow-up to https://github.com/code-dot-org/code-dot-org/pull/56821). This enables the ToneJS player behind a url param. There are still a number of follow-up tasks (plus testing) we should finish before formally switching over, but this gives us the option to start trying it out in production. One significant callout here is that, as a temporary workaround, we're loading all samples for all instruments up-front to pre-create all the samplers in the ToneJS player. Instead, we should load instrument samples and create samplers on-demand as those blocks are added to a project. I held off on that for now since it was proving to be a little tricky with our current caching logic, and required some additional UI work to show some loading UI on the chord and drum panels. This work (and others) have been captured as follow-ups in JIRAs below.

To enable the ToneJS player, include `?player=tonejs` in the URL. Can confirm that this is working by looking for `[MusicPlayer] using ToneJSPlayer` in the console.

## Links

https://codedotorg.atlassian.net/browse/LABS-513

## Testing story

Tested on /projectbeats, /music-intro-2024, and standalone projects.

## Follow-up work

- Add effects support: https://codedotorg.atlassian.net/browse/LABS-528
- Add library-defined sound sequence support: https://codedotorg.atlassian.net/browse/LABS-529
- Add "advanced controls" panel behind URL param: https://codedotorg.atlassian.net/browse/LABS-530
- Load instruments on demand instead of all at once: https://codedotorg.atlassian.net/browse/LABS-531