### PR TITLE
add LTI tables to redshift yml

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -104,6 +104,12 @@ cron:
 - dashboard.standard_categories
 - dashboard.frameworks
 - dashboard.user_project_storage_ids
+- dashboard.lti_integrations:
+    remove_column: [admin_email]
+- dashboard.lti_deployments
+- dashboard.lti_courses
+- dashboard.lti_sections
+- dashboard.lti_user_identities
 cron-user-hierarchy:
 - dashboard.users:
     remove_column:


### PR DESCRIPTION
This adds the following tables to the Redshift config:

- lti_integrations
- lti_deployments
- lti_courses
- lti_sections
- lti_user_identities

Of these tables, only `lti_integrations` contains PII in the form of an admin contact email address. This field isn't important for the queries we need to do, so it is explicitly omitted.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-392)

## Deployment strategy

To be deployed by the infrastructure team.

## Follow-up work

After the tables are exported to Redshift, I'll open a data work request to get them into Hydrone/Trevor

## Privacy

The `lti_integrations` table contains the admin emails. This field is omitted using using `remove_column`.

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
