### PR TITLE
Lab2: convert disable_projects to uses_projects

### DIFF
--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -106,9 +106,9 @@ export const setUpWithLevel = createAsyncThunk(
         .getMetricsReporter()
         .updateProperties({appName: levelProperties.appName});
 
-      const {isProjectLevel, disableProjects} = levelProperties;
+      const {isProjectLevel, usesProjects} = levelProperties;
 
-      if (disableProjects) {
+      if (!usesProjects) {
         // If projects are disabled on this level, we can skip loading projects data.
         setProjectAndLevelData(
           {levelProperties},

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -92,11 +92,7 @@ export interface LevelProperties {
   // Not a complete list; add properties as needed.
   isProjectLevel?: boolean;
   hideShareAndRemix?: boolean;
-  // TODO: Rework this field into an "enableProjects" or more complex list of
-  // "enabledFeatures" that is calculated on the back end. For now, since
-  // the only labs we support have projects enabled, it's easier to make this a
-  // disabled flag for specific exceptions.
-  disableProjects?: boolean;
+  usesProjects?: boolean;
   levelData?: LevelData;
   appName: AppName;
   longInstructions?: string;

--- a/dashboard/app/models/levels/aichat.rb
+++ b/dashboard/app/models/levels/aichat.rb
@@ -29,7 +29,6 @@ class Aichat < Level
     system_prompt
     bot_title
     bot_description
-    disable_projects
   )
 
   def self.create_from_level_builder(params, level_params)
@@ -38,9 +37,7 @@ class Aichat < Level
         user: params[:user],
         game: Game.aichat,
         level_num: 'custom',
-        properties: {
-          disable_projects: true
-        }
+        properties: {}
       )
     )
   end

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -790,6 +790,7 @@ class Level < ApplicationRecord
     properties_camelized[:type] = type
     properties_camelized[:appName] = game&.app
     properties_camelized[:useRestrictedSongs] = game.use_restricted_songs?
+    properties_camelized[:usesProjects] = try(:is_project_level) || channel_backed?
     properties_camelized
   end
 

--- a/dashboard/app/models/levels/standalone_video.rb
+++ b/dashboard/app/models/levels/standalone_video.rb
@@ -32,7 +32,6 @@ class StandaloneVideo < Level
     video_full_width
     background
     uses_lab2
-    disable_projects
   )
 
   before_validation do
@@ -66,14 +65,12 @@ class StandaloneVideo < Level
   end
 
   def self.create_from_level_builder(params, level_params)
-    # Note: the disable_projects property was only added to levels created after August 2023,
-    # so not all levels of this type have this property.
     create!(
       level_params.merge(
         user: params[:user],
         game: Game.standalone_video,
         level_num: 'custom',
-        properties: {disable_projects: true}
+        properties: {}
       )
     )
   end

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -83,7 +83,7 @@ class LevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => []}, body)
+    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => [], "usesProjects" => false}, body)
   end
 
   test "should get filtered levels with just page param" do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -112,7 +112,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => []}, body)
+    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => [], "usesProjects" => false}, body)
   end
 
   test 'should show script level for csp1-2020 lockable lesson with lesson plan' do


### PR DESCRIPTION
Change the opt-out `disable_projects` flag on lab2 labs to an opt-in `uses_projects` flag that can be computed from `is_project_level || channel_backed`. We've had a desire to update this for a while, but this recently resurfaced because I noticed we were getting 404s on the new "panels" level type in the music lab intro script, because we forgot the `disable_projects` flag there. With this change, most labs shouldn't need to specify if they support projects or not, because we can infer that from other properties. This is especially helpful, for example, with Dance Party, where certain levels (free play, standalone) use projects, while others don't.

**Question for @molly-moen / code-tools**: currently, pythonlab and weblab2 are not in the "always channel backed" list [here](https://github.com/code-dot-org/code-dot-org/blob/4c3897673c20d615f952bc5a604bcc2e6eded7c4/dashboard/app/models/game.rb#L277) - should they be? With this change, we would stop loading projects for those level types, but I wasn't sure if we've actually started using projects on these levels or not.

## Links

https://codedotorg.atlassian.net/browse/LABS-177

## Testing story

Tested this across all Lab2 labs -
- AIChat - always `false` since there are no standalone levels and for now projects are not supported (this will change though)
- Dance - `true` if free play or standalone, `false` otherwise
- Music - always `true`
- Panels - always `false`
- PythonLab - always `false` because it's currently not part of the `channel_backed` list in `game.rb` (but will update if that's not right)
- Weblab2 - always `false`, same as above
- StandaloneVideo - always `false`