### PR TITLE
Kaitie/tests for icon key pop up

### DIFF
--- a/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
+++ b/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
@@ -26,12 +26,12 @@ export default function MoreDetailsDialog({hasValidation, onClose}) {
 
   return (
     <AccessibleDialog onClose={onClose}>
+      <Heading3>{i18n.progressTrackingIconKey()}</Heading3>
+      <button type="button" onClick={onClose} className={styles.xCloseButton}>
+        <i id="x-close" className="fa-solid fa-xmark" />
+      </button>
+      <hr />
       <div role="region" className={styles.dialog}>
-        <Heading3>{i18n.progressTrackingIconKey()}</Heading3>
-        <button type="button" onClick={onClose} className={styles.xCloseButton}>
-          <i id="x-close" className="fa-solid fa-xmark" />
-        </button>
-        <hr />
         <Heading6>{i18n.assignmentCompletionStates()}</Heading6>
         {renderItem(
           ITEM_TYPE.NOT_STARTED,

--- a/apps/src/templates/sectionProgressV2/progress-key-popup.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-key-popup.module.scss
@@ -19,6 +19,8 @@
 .dialog {
   margin-left: 8px;
   margin-right: 8px;
+  overflow-y: scroll;
+  max-height: 70vh;
 
   hr {
     margin-top: 0;

--- a/apps/test/unit/templates/sectionProgressV2/IconKeyTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/IconKeyTest.jsx
@@ -7,6 +7,7 @@ describe('IconKey Component', () => {
   it('renders the collapsed state initially', () => {
     render(<IconKey isViewingValidatedLevel={false} expandedLessonIds={[]} />);
     expect(screen.getByLabelText('Icon key')).be.visible;
+    expect(screen.queryByText('More Details')).be.visible;
     expect(screen.queryByText('Assignment Completion States')).to.be.null;
     expect(screen.queryByText('Teacher Actions')).to.be.null;
     expect(screen.queryByText('Level Types')).to.be.null;
@@ -39,5 +40,14 @@ describe('IconKey Component', () => {
     const containerDiv = screen.getByTestId('expandable-container');
     fireEvent.click(containerDiv);
     expect(screen.getByText('Validated')).to.exist;
+  });
+
+  it('shows pop-up when more details are clicked', () => {
+    render(<IconKey isViewingValidatedLevel={false} expandedLessonIds={[]} />);
+    const moreDetailsLink = screen.queryByText('More Details');
+    expect(moreDetailsLink).be.visible;
+    expect(screen.queryByText('Progress Tracking Icon Key')).to.be.null;
+    fireEvent.click(moreDetailsLink);
+    expect(screen.getByText('Progress Tracking Icon Key')).to.exist;
   });
 });

--- a/apps/test/unit/templates/sectionProgressV2/MoreDetailsDialogTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/MoreDetailsDialogTest.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {expect} from '../../../util/reconfiguredChai';
+import MoreDetailsDialog from '@cdo/apps/templates/sectionProgressV2/MoreDetailsDialog';
+import sinon from 'sinon';
+
+describe('MoreDetailsDialog', () => {
+  const onCloseMock = sinon.spy();
+
+  it('renders the dialog with required elements', () => {
+    render(<MoreDetailsDialog hasValidation={true} onClose={onCloseMock} />);
+
+    expect(screen.getByText('Progress Tracking Icon Key')).be.visible;
+    expect(screen.getByRole('button')).be.visible;
+    expect(screen.getByText('Assignment Completion States')).be.visible;
+    expect(screen.getByText('Teacher Actions')).be.visible;
+    expect(screen.getByText('Level Types')).be.visible;
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    render(<MoreDetailsDialog hasValidation={false} onClose={onCloseMock} />);
+
+    const closeButton = screen.getByRole('button');
+    fireEvent.click(closeButton);
+
+    expect(onCloseMock).to.have.been.calledOnce;
+  });
+
+  it('conditionally renders the validated item based on hasValidation prop', () => {
+    const {rerender} = render(
+      <MoreDetailsDialog hasValidation={false} onClose={onCloseMock} />
+    );
+    expect(screen.queryByText('Validated')).not.be.visible;
+
+    rerender(<MoreDetailsDialog hasValidation={true} onClose={onCloseMock} />);
+    expect(screen.queryByText('Validated')).be.visible;
+  });
+});

--- a/apps/test/unit/templates/sectionProgressV2/MoreDetailsDialogTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/MoreDetailsDialogTest.jsx
@@ -5,10 +5,8 @@ import MoreDetailsDialog from '@cdo/apps/templates/sectionProgressV2/MoreDetails
 import sinon from 'sinon';
 
 describe('MoreDetailsDialog', () => {
-  const onCloseMock = sinon.spy();
-
   it('renders the dialog with required elements', () => {
-    render(<MoreDetailsDialog hasValidation={true} onClose={onCloseMock} />);
+    render(<MoreDetailsDialog hasValidation={true} onClose={() => {}} />);
 
     expect(screen.getByText('Progress Tracking Icon Key')).be.visible;
     expect(screen.getByRole('button')).be.visible;
@@ -18,6 +16,7 @@ describe('MoreDetailsDialog', () => {
   });
 
   it('calls onClose when the close button is clicked', () => {
+    const onCloseMock = sinon.spy();
     render(<MoreDetailsDialog hasValidation={false} onClose={onCloseMock} />);
 
     const closeButton = screen.getByRole('button');
@@ -28,11 +27,11 @@ describe('MoreDetailsDialog', () => {
 
   it('conditionally renders the validated item based on hasValidation prop', () => {
     const {rerender} = render(
-      <MoreDetailsDialog hasValidation={false} onClose={onCloseMock} />
+      <MoreDetailsDialog hasValidation={false} onClose={() => {}} />
     );
     expect(screen.queryByText('Validated')).not.be.visible;
 
-    rerender(<MoreDetailsDialog hasValidation={true} onClose={onCloseMock} />);
+    rerender(<MoreDetailsDialog hasValidation={true} onClose={() => {}} />);
     expect(screen.queryByText('Validated')).be.visible;
   });
 });


### PR DESCRIPTION
Added tests (with RTL!) and scrolling behavior for icon key pop-up.


Left to do: Figure out how to display the icons with the gray boxes around the outside of the icons... 
<img width="94" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/c8bcd2bb-8b77-470c-840d-5af5e86bbddb">


https://github.com/code-dot-org/code-dot-org/assets/24883357/ad41bc97-78e3-4d3d-92a2-e13133b1d5f8


## Links

[Jira](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-780)
[Figma](https://www.figma.com/file/gCktlnafGYQSNJafD3FUgA/Progress-Tracking?node-id=2177%3A34456&mode=dev)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
