### PR TITLE
Add feedback indicators to level cells

### DIFF
--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -326,6 +326,7 @@ export const levelProgressFromServer = serverProgress => {
     paired: serverProgress.paired || false,
     timeSpent: serverProgress.time_spent,
     teacherFeedbackReviewState: serverProgress.teacher_feedback_review_state,
+    teacherFeedbackNew: serverProgress.teacher_feedback_new || false,
     lastTimestamp: serverProgress.last_progress_at,
     pages: getPagesProgress(serverProgress),
   };

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -106,6 +106,7 @@ const studentLevelProgressShape = {
   timeSpent: PropTypes.number,
   lastTimestamp: PropTypes.number,
   teacherFeedbackReviewState: PropTypes.oneOf(Object.keys(ReviewStates)),
+  teacherFeedbackNew: PropTypes.bool.isRequired,
   /** pages: PropTypes.array */ // See below
 };
 // Avoid recursive definition

--- a/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
+++ b/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
@@ -110,7 +110,8 @@ function randomProgress(level) {
         paired: paired,
         timeSpent: timeSpent,
         lastTimestamp: timestamp,
-        reviewState: randomReviewState(),
+        teacherFeedbackReviewState: randomReviewState(),
+        teacherFeedbackNew: false,
       };
     case 1:
       return {
@@ -120,7 +121,8 @@ function randomProgress(level) {
         paired: paired,
         timeSpent: timeSpent,
         lastTimestamp: timestamp,
-        reviewState: randomReviewState(),
+        teacherFeedbackReviewState: randomReviewState(),
+        teacherFeedbackNew: true,
       };
     case 2:
       return {
@@ -130,7 +132,8 @@ function randomProgress(level) {
         paired: paired,
         timeSpent: timeSpent,
         lastTimestamp: timestamp,
-        reviewState: randomReviewState(),
+        teacherFeedbackReviewState: randomReviewState(),
+        teacherFeedbackNew, false,
       };
     default:
       return null;

--- a/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
+++ b/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
@@ -133,7 +133,7 @@ function randomProgress(level) {
         timeSpent: timeSpent,
         lastTimestamp: timestamp,
         teacherFeedbackReviewState: randomReviewState(),
-        teacherFeedbackNew, false,
+        teacherFeedbackNew: false,
       };
     default:
       return null;

--- a/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {studentLevelProgressType} from '../progress/progressTypes';
 import classNames from 'classnames';
 import styles from './progress-table-v2.module.scss';
+import legendStyles from './progress-table-legend.module.scss';
 import queryString from 'query-string';
 import {Link} from '@dsco_/link';
 import ProgressIcon from './ProgressIcon';
@@ -72,7 +73,13 @@ export default function LevelDataCell({
       href={navigateToLevelOverviewUrl(level.url, studentId, sectionId)}
       openInNewTab
       external
-      className={classNames(styles.gridBox, styles.gridBoxLevel)}
+      className={classNames(
+        styles.gridBox,
+        styles.gridBoxLevel,
+        studentLevelProgress?.teacherFeedbackReviewState !== 'keepWorking' &&
+          studentLevelProgress?.teacherFeedbackNew &&
+          legendStyles.feedbackGiven
+      )}
     >
       {itemType && <ProgressIcon itemType={itemType} />}
     </Link>

--- a/apps/src/types/progressTypes.ts
+++ b/apps/src/types/progressTypes.ts
@@ -77,6 +77,7 @@ export interface UnitProgress {
   result: number;
   status: string;
   teacherFeedbackReviewState: keyof typeof ReviewStates | undefined;
+  teacherFeedbackNew: boolean;
   timeSpent: number | undefined;
 }
 

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -151,6 +151,7 @@ const fullExpectedResult = {
           paired: false,
           timeSpent: undefined,
           teacherFeedbackReviewState: undefined,
+          teacherFeedbackNew: false,
           lastTimestamp: 12345,
         },
         2001: {
@@ -161,6 +162,7 @@ const fullExpectedResult = {
           paired: true,
           timeSpent: 12345,
           teacherFeedbackReviewState: undefined,
+          teacherFeedbackNew: false,
           lastTimestamp: 12345,
         },
       },
@@ -173,6 +175,7 @@ const fullExpectedResult = {
           paired: false,
           timeSpent: 6789,
           teacherFeedbackReviewState: undefined,
+          teacherFeedbackNew: false,
           lastTimestamp: 6789,
         },
       },

--- a/apps/test/unit/templates/sectionProgressV2/LessonProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/LessonProgressDataColumnTest.jsx
@@ -43,6 +43,7 @@ const LEVEL_PROGRESS = {
       status: 'perfect',
       result: 100,
       paired: true,
+      teacherFeedbackNew: false,
     },
   },
   [STUDENT_2.id]: {
@@ -51,6 +52,7 @@ const LEVEL_PROGRESS = {
       status: 'not_tried',
       result: 1,
       paired: false,
+      teacherFeedbackNew: true,
     },
   },
 };

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -176,7 +176,7 @@ module UsersHelper
       script: unit,
       users: users,
       user_levels_by_level: User.user_levels_by_user_by_level(users, unit),
-      teacher_feedback_by_level: teacher_feedbacks_by_student_by_level(users, unit, current_user.id),
+      teacher_feedback_by_level: teacher_feedbacks_by_student_by_level(users, unit, current_user&.id),
       paired_user_levels: PairedUserLevel.pairs_by_user(users),
       include_timestamp: true
     )

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -375,7 +375,8 @@ module UsersHelper
       last_progress_at: include_timestamp ? user_level.updated_at&.to_i : nil,
       time_spent: user_level.time_spent&.to_i,
       teacher_feedback_review_state: teacher_feedback&.review_state,
-      teacher_feedback_new: (teacher_feedback&.updated_at&.to_i || 0) > (user_level.updated_at&.to_i || 0)
+      teacher_feedback_new:
+        ((teacher_feedback&.updated_at&.to_i || 0) > (user_level.updated_at&.to_i || 0)) || nil
     }.compact
   end
 

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -176,7 +176,7 @@ module UsersHelper
       script: unit,
       users: users,
       user_levels_by_level: User.user_levels_by_user_by_level(users, unit),
-      teacher_feedback_by_level: teacher_feedbacks_by_student_by_level(users, unit),
+      teacher_feedback_by_level: teacher_feedbacks_by_student_by_level(users, unit, current_user.id),
       paired_user_levels: PairedUserLevel.pairs_by_user(users),
       include_timestamp: true
     )
@@ -205,10 +205,10 @@ module UsersHelper
   #   },
   #   3: {}
   # }
-  private def teacher_feedbacks_by_student_by_level(users, unit)
+  private def teacher_feedbacks_by_student_by_level(users, unit, teacher_id = nil)
     initial_hash = users.map {|user| [user.id, {}]}.to_h
     TeacherFeedback.
-      get_latest_feedbacks_received(users.map(&:id), nil, unit.id).
+      get_latest_feedbacks_received(users.map(&:id), nil, unit.id, teacher_id).
       group_by(&:student_id).
       inject(initial_hash) do |memo, (student_id, teacher_feedbacks)|
         memo[student_id] = teacher_feedbacks.index_by(&:level_id)
@@ -288,6 +288,7 @@ module UsersHelper
     include_timestamp: false
   )
     progress = users.map {|user| [user.id, {}]}.to_h
+
     script.script_levels.each do |sl|
       sl.level_ids.each do |level_id|
         level = Level.cache_find(level_id)

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -66,7 +66,7 @@ class TeacherFeedback < ApplicationRecord
   end
 
   # returns the latest feedback from each teacher for the student on the level
-  def self.get_latest_feedbacks_received(student_id, level_id, script_id, teacher_id)
+  def self.get_latest_feedbacks_received(student_id, level_id, script_id, teacher_id = nil)
     query = {
       student_id: student_id,
       level_id: level_id,

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -66,11 +66,12 @@ class TeacherFeedback < ApplicationRecord
   end
 
   # returns the latest feedback from each teacher for the student on the level
-  def self.get_latest_feedbacks_received(student_id, level_id, script_id)
+  def self.get_latest_feedbacks_received(student_id, level_id, script_id, teacher_id)
     query = {
       student_id: student_id,
       level_id: level_id,
-      script_id: script_id
+      script_id: script_id,
+      teacher_id: teacher_id,
     }.compact
 
     where(query).


### PR DESCRIPTION
This puts little triangles in the corners of levels where the teacher has left feedback for that student more recently than the student has last worked on the level.

![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/8d016460-275b-4a89-b27f-63303ee49aca)

Note: I noticed that the progress API currently does not filter out feedback objects left by other teachers. This means that on the current progress view a teacher will see a red "keep working" bubble on a level if another teacher (whether a co-teacher on this section or not) told the student to keep working on the level. I believe this is a bug, as teachers currently have no other means of seeing other teachers' feedback. That bug is fixed as part of this work. Along the same lines the "feedback given" triangle will only show if the current teacher has left feedback, not if feedback has only been left by other teachers.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
