### PR TITLE
Add amplitude events for new international PL pages

### DIFF
--- a/pegasus/helpers/analytics_constants.rb
+++ b/pegasus/helpers/analytics_constants.rb
@@ -35,6 +35,8 @@ module AnalyticsConstants
     RP_LANDING_PAGE_VISITED_EVENT = 'Regional Partner Landing Page Visited'.freeze,
     TEACH_PAGE_VISITED_EVENT = 'Teach Page Visited'.freeze,
     TEACHER_LOGIN_EVENT = 'Teacher Login'.freeze,
-    VIDEO_LIBRARY_PAGE_VISIT_EVENT = 'Video Library Page Visited'.freeze
+    VIDEO_LIBRARY_PAGE_VISIT_EVENT = 'Video Library Page Visited'.freeze,
+    INTL_PL_PAGE_VISIT_EVENT = 'International Professional Learning Page Visited'.freeze,
+    INTL_PL_PARTNERS_PAGE_VISIT_EVENT = 'International Professional Learning Partners Page Visited'.freeze
   ].freeze
 end

--- a/pegasus/sites.v3/code.org/public/professional-learning/international-partners.haml
+++ b/pegasus/sites.v3/code.org/public/professional-learning/international-partners.haml
@@ -21,3 +21,5 @@ set_dir: true
   .wrapper
     %h2=hoc_s("intl_pl_partners_page.join.heading")
     %p=hoc_s("intl_pl_partners_page.join.desc", markdown: :inline, locals: {apply_url: "/international/apply"})
+
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::INTL_PL_PARTNERS_PAGE_VISIT_EVENT

--- a/pegasus/sites.v3/code.org/public/professional-learning/international.haml
+++ b/pegasus/sites.v3/code.org/public/professional-learning/international.haml
@@ -64,3 +64,5 @@ set_dir: true
         %p
           %strong
             =hoc_s("intl_pl_page.contact.cta", markdown: :inline, locals: {email_url: "mailto:international@code.org"})
+
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::INTL_PL_PAGE_VISIT_EVENT


### PR DESCRIPTION
Adds Amplitude events for https://code.org/professional-learning/international and https://code.org/professional-learning/international-partners.

**Jira ticket:** [ACQ-1519](https://codedotorg.atlassian.net/browse/ACQ-1519)

----

## code.org/professional-learning/international
<img width="1049" alt="intl-pl" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/1d396c9d-aff6-4bfc-88ed-a3ce3a7a7495">

##
<img width="1049" alt="intl-pl-partners" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/9461bec6-573e-4dbb-9223-38aa38a3a4fa">
