### PR TITLE
Fix Safari image bug on TwoColumnActionBlock component

### DIFF
--- a/apps/src/templates/studioHomepages/twoColumnActionBlock.module.scss
+++ b/apps/src/templates/studioHomepages/twoColumnActionBlock.module.scss
@@ -22,7 +22,6 @@ $breakpoint: 993px;
   .image {
     margin: 1.25rem;
     width: calc(50% - 1.25rem);
-    height: fit-content;
 
     @media (max-width: $breakpoint) {
       display: none;


### PR DESCRIPTION
Makes the image on the TwoColumnActionBlock component not stretched out on Safari! This was my bad for not cross-browser checking [this PR](https://github.com/code-dot-org/code-dot-org/pull/56753) 🤦‍♀️ I checked it in Chrome, Safari, and Firefox this time and it looks good.

**Jira ticket:** [ACQ-1567](https://codedotorg.atlassian.net/browse/ACQ-1567)

---- 

## Before
<img width="1175" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/792f4018-83a3-40e6-8873-6949a6cf3773">

## After
<img width="1175" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/59f509ab-85ef-40b8-b774-341c2d8688d4">
