### PR TITLE
Add Districts string for top nav

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -372,6 +372,7 @@ en:
       course_catalog: "Course Catalog"
       project_gallery: "Projects"
       schools: "Schools"
+      schools: "Districts"
       sections: "Sections"
       help_support: "Help and support"
       report_bug: "Report a problem"

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -372,7 +372,7 @@ en:
       course_catalog: "Course Catalog"
       project_gallery: "Projects"
       schools: "Schools"
-      schools: "Districts"
+      districts: "Districts"
       sections: "Sections"
       help_support: "Help and support"
       report_bug: "Report a problem"


### PR DESCRIPTION
Adds a new string "Districts" for use in the signed out top nav on code.org. Once this string is translated I will replace the Projects link with this Districts link. Also added to the [I18n gsheet](https://docs.google.com/spreadsheets/d/1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU/edit#gid=0&range=1538:1538) for Peagsus sites.

_Note:_ this is related to [this ticket](https://codedotorg.atlassian.net/browse/ACQ-1464), where the team originally wanted the Projects link replaced with Schools.

Jira ticket: [ACQ-1568](https://codedotorg.atlassian.net/browse/ACQ-1568)