### PR TITLE
Make the 'choice level' arrows gray

### DIFF
--- a/apps/src/templates/sectionProgressV2/ItemType.jsx
+++ b/apps/src/templates/sectionProgressV2/ItemType.jsx
@@ -7,7 +7,7 @@ export const ITEM_TYPE = Object.freeze({
   NEEDS_FEEDBACK: 3,
   FEEDBACK_GIVEN: 4,
   ASSESSMENT_LEVEL: ['star', color.neutral_dark],
-  CHOICE_LEVEL: ['split', color.neutral_dark],
+  CHOICE_LEVEL: ['split', color.neutral_dark60],
   KEEP_WORKING: ['rotate-left', color.neutral_dark],
   NO_ONLINE_WORK: ['dash', color.neutral_dark],
   IN_PROGRESS: ['circle-o', color.neutral_dark],


### PR DESCRIPTION
The "choice level" cells in the new progress table are supposed to have a gray arrow icon, instead of black. Here's what it will look like now:

![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/243c5b41-d870-41bb-a6ba-125e951d3292)

## Links

[JIRA](https://codedotorg.atlassian.net/browse/TEACH-890)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
