### PR TITLE
Conditionally add rlid to options for membership if not using Schoology

### DIFF
--- a/dashboard/lib/clients/lti_advantage_client.rb
+++ b/dashboard/lib/clients/lti_advantage_client.rb
@@ -22,7 +22,6 @@ class LtiAdvantageClient
       },
     }
     options[:query][:rlid] = resource_link_id unless url.include?("schoology")
-
     res = make_request(url, options)
     next_page = next_page_url(res[:headers])
     parsed_res = res[:body]

--- a/dashboard/lib/clients/lti_advantage_client.rb
+++ b/dashboard/lib/clients/lti_advantage_client.rb
@@ -18,10 +18,11 @@ class LtiAdvantageClient
         'Authorization' => "Bearer #{get_access_token(@client_id, @issuer)}",
       },
       query: {
-        rlid: resource_link_id,
         limit: page_limit,
       },
     }
+    options[:query][:rlid] = resource_link_id unless url.include?("schoology")
+
     res = make_request(url, options)
     next_page = next_page_url(res[:headers])
     parsed_res = res[:body]

--- a/dashboard/lib/clients/lti_advantage_client.rb
+++ b/dashboard/lib/clients/lti_advantage_client.rb
@@ -21,7 +21,7 @@ class LtiAdvantageClient
         limit: page_limit,
       },
     }
-    options[:query][:rlid] = resource_link_id unless url.include?("schoology")
+    options[:query][:rlid] = resource_link_id unless @issuer == Policies::Lti::LMS_PLATFORMS[:schoology][:issuer]
     res = make_request(url, options)
     next_page = next_page_url(res[:headers])
     parsed_res = res[:body]


### PR DESCRIPTION
Adds `rlid` to options for retrieving context membership if the issuer is not Schoology. 
Although `rlid` is an optional parameter, we get an invalid paramater error when including the `rlid` in the options while retrieving the context membership for a Schoology course. Not inlcuding the optional parameter allows is to make the request.
## Links


- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/P20/boards/69?assignee=712020%3Af0e2716f-09f9-4686-8490-9f1f9a08bb06&selectedIssue=P20-700)


## Testing story



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
