### PR TITLE
[ProgressV2] Fix tooltip numbering and placement

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1423,6 +1423,7 @@
   "lessonExtrasDetails": "Your students won’t see this page unless you turn them on. You can turn Lesson Extras on by editing section details from your Teacher Dashboard.",
   "lessonName": "Lesson Name",
   "lessonNumber": "Lesson Number",
+  "lessonNumbered": "Lesson {lessonNumber}: {lessonName}",
   "lessonPlans": "Lesson Plans",
   "lessonsAttempted": "Lessons attempted in",
   "lessonsAvailableWithColon": "Lessons available: ",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1423,7 +1423,6 @@
   "lessonExtrasDetails": "Your students won’t see this page unless you turn them on. You can turn Lesson Extras on by editing section details from your Teacher Dashboard.",
   "lessonName": "Lesson Name",
   "lessonNumber": "Lesson Number",
-  "lessonNumbered": "Lesson {lessonNumber}: {lessonName}",
   "lessonPlans": "Lesson Plans",
   "lessonsAttempted": "Lessons attempted in",
   "lessonsAvailableWithColon": "Lessons available: ",

--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -196,6 +196,7 @@ export const fakeLessonWithLevels = (overrideFields = {}, levelCount = 1) => {
   return {
     id: lessonId++,
     name: `Lesson - ${position}`,
+    title: `Lesson ${position}: Lesson - ${position}`,
     lockable: false,
     relative_position: position,
     position: position,

--- a/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressColumnHeader.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import styles from './progress-table-v2.module.scss';
 import classNames from 'classnames';
 import FontAwesome from '../FontAwesome';
-import i18n from '@cdo/locale';
 import LevelProgressHeader from './LevelProgressHeader';
 import LessonTitleTooltip, {getTooltipId} from './LessonTitleTooltip';
 
@@ -17,10 +16,7 @@ export default function ExpandedProgressColumnHeader({
   const headerText =
     lesson.levels.length < 3 && expandedChoiceLevels.length === 0
       ? lesson.relative_position
-      : i18n.lessonNumbered({
-          lessonNumber: lesson.relative_position,
-          lessonName: lesson.name,
-        });
+      : lesson.title;
 
   // Manual width is necessary so that overflow text is hidden and lesson header exactly fits levels.
   // Add (numLevels + 1)px to account for borders.
@@ -40,13 +36,7 @@ export default function ExpandedProgressColumnHeader({
   }, [lesson, expandedChoiceLevels]);
 
   return (
-    <div
-      className={styles.expandedHeader}
-      key={lesson.id}
-      data-tip
-      data-for={getTooltipId(lesson)}
-    >
-      <LessonTitleTooltip lesson={lesson} />
+    <div className={styles.expandedHeader} key={lesson.id}>
       <div
         className={classNames(
           styles.gridBox,
@@ -56,7 +46,10 @@ export default function ExpandedProgressColumnHeader({
         style={{width}}
         onClick={() => removeExpandedLesson(lesson.id)}
         aria-label={headerText}
+        data-tip
+        data-for={getTooltipId(lesson)}
       >
+        <LessonTitleTooltip lesson={lesson} />
         <FontAwesome icon="caret-down" className={styles.expandedHeaderCaret} />
         <div className={styles.expandedHeaderLessonText}>{headerText}</div>
       </div>

--- a/apps/src/templates/sectionProgressV2/LessonTitleTooltip.jsx
+++ b/apps/src/templates/sectionProgressV2/LessonTitleTooltip.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactTooltip from 'react-tooltip';
 import PropTypes from 'prop-types';
-import i18n from '@cdo/locale';
 import styles from './progress-table-v2.module.scss';
 
 export const getTooltipId = lesson => `tooltip-${lesson.id}`;
@@ -10,12 +9,7 @@ export default function LessonTitleTooltip({lesson}) {
   const tooltipId = getTooltipId(lesson);
   return (
     <ReactTooltip id={tooltipId} key={tooltipId} role="tooltip" wrapper="div">
-      <div className={styles.lessonHeaderTooltip}>
-        {i18n.lessonNumbered({
-          lessonNumber: lesson.relative_position,
-          lessonName: lesson.name,
-        })}
-      </div>
+      <div className={styles.lessonHeaderTooltip}>{lesson.title}</div>
     </ReactTooltip>
   );
 }

--- a/apps/test/unit/templates/sectionProgressV2/LessonTitleTooltipTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/LessonTitleTooltipTest.jsx
@@ -12,12 +12,13 @@ describe('LessonTitleTooltip', () => {
     const lesson = fakeLessonWithLevels({
       id: 6789,
       relative_position: 9999,
+      title: 'Lesson 9999 title',
       name: 'this is a test lesson',
     });
     console.log(lesson);
     render(<LessonTitleTooltip lesson={lesson} />);
 
-    expect(screen.getByText('Lesson 9999: this is a test lesson')).to.exist;
+    expect(screen.getByText('Lesson 9999 title')).to.exist;
   });
 
   it('id is parsed correctly', () => {


### PR DESCRIPTION
Fixes:
* Tooltip and lesson header are showing numbered lessons for lessons without numbers
* Tooltip was appearing over levels and lesson, it should just be on the lesson


https://github.com/code-dot-org/code-dot-org/assets/25193259/145565d7-085e-43d6-8be3-77360e8d32c9



## Links
[TEACH-901](https://codedotorg.atlassian.net/browse/TEACH-901)
[TEACH-902](https://codedotorg.atlassian.net/browse/TEACH-902)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
