### PR TITLE
[Google Blockly] fix bug with expanded mini toolbox in uncategorized toolboxes

### DIFF
--- a/apps/src/blockly/addons/cdoFieldFlyout.ts
+++ b/apps/src/blockly/addons/cdoFieldFlyout.ts
@@ -47,8 +47,10 @@ export default class CdoFieldFlyout extends GoogleBlockly.Field {
    */
   initView() {
     this.workspace_ = this.getSourceBlock()?.workspace as WorkspaceSvg;
+    const options =
+      Blockly.getMainWorkspace()?.options || this.workspace_?.options || {};
     this.flyout_ = new CdoBlockFlyout({
-      ...Blockly.getMainWorkspace().options,
+      ...options,
       parentWorkspace: this.workspace_,
       RTL: this.workspace_.RTL,
       minWidth: this.minWidth_,

--- a/apps/src/blockly/addons/cdoSpritePointer.js
+++ b/apps/src/blockly/addons/cdoSpritePointer.js
@@ -22,7 +22,7 @@ export function getPointerBlockImageUrl(
   let imageSourceBlock = undefined;
   const mainWorkspace = Blockly.getMainWorkspace();
   if (imageSourceId !== undefined) {
-    imageSourceBlock = mainWorkspace.getBlockById(imageSourceId);
+    imageSourceBlock = mainWorkspace?.getBlockById(imageSourceId);
   }
   if (!imageSourceBlock) {
     const rootBlock = block.getRootBlock();
@@ -33,7 +33,12 @@ export function getPointerBlockImageUrl(
       // If this block has itself as a root and is in a flyout workspace,
       // it is a in a mini toolbox. A block can't be moved from one flyout to
       // another, so if it's in a flyout, it is in its original flyout.
-      if (blockWorkspace && blockWorkspace.isFlyout && block.imageSourceId) {
+      if (
+        mainWorkspace &&
+        blockWorkspace &&
+        blockWorkspace.isFlyout &&
+        block.imageSourceId
+      ) {
         imageSourceBlock = mainWorkspace.getBlockById(block.imageSourceId);
       }
     }

--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.js
@@ -198,7 +198,7 @@ export const blocks = {
         this.imageSourceId = state['imageSourceId'];
         if (this.imageSourceId) {
           updatePointerBlockImage(this, spriteLabPointers, this.imageSourceId);
-          const imageSourceBlock = Blockly.getMainWorkspace().getBlockById(
+          const imageSourceBlock = Blockly.getMainWorkspace()?.getBlockById(
             this.imageSourceId
           );
           if (imageSourceBlock) {


### PR DESCRIPTION
We found an issue where if there was an expanded mini toolbox in an uncategorized workspace toolbox, the page would crash. This was because we were trying to get information from the main workspace before it was finished being created. The fix for this was to add a couple null checks and fall back to the block's workspace where it made sense.

Before this change, the page would completely crash. After it looks like this:
![Screenshot 2024-03-01 at 4 37 56 PM](https://github.com/code-dot-org/code-dot-org/assets/33666587/c9c5bd0f-ae3c-4e44-8e24-178861050c5a)

It's expected that we see "subject sprite" and "object sprite" rather than correctly mirroring here. That's what happens in a categorized toolbox too. This is because we search the main workspace to get the image to mirror, and the block doesn't exist on the main workspace. We can consider whether we want to fix this or leave it as-is. Generally mini toolboxes are not expanded in the toolbox.

## Links
- [slack discussion](https://codedotorg.slack.com/archives/C05DK21DAHK/p1709337308671429)
- [jira ticket](https://codedotorg.atlassian.net/browse/CT-381)

## Testing story
Tested locally that the page no longer crashes and sprite pointer image mirroring still works.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
