### PR TITLE
Enable source maps for TypeScript

### DIFF
--- a/apps/tsconfig.build.json
+++ b/apps/tsconfig.build.json
@@ -31,5 +31,6 @@
     },
     "resolveJsonModule": true,
     "incremental": true,
+    "sourceMap": true,
   }
 }


### PR DESCRIPTION
This PR enables sourcemaps for TypeScript. This means you'll see actual TS source in the browser devtool, when setting breakpoints, etc.

**Before 😱:**
<img width="716" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/1d4fab52-835a-46ba-87bb-92cbea66a023">

**After 🥰:**
<img width="732" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/ff2392b5-d553-42f8-ab46-aa799c984c46">
