### PR TITLE
Incubator: update music buttons

### DIFF
--- a/apps/src/templates/studioHomepages/Incubator.jsx
+++ b/apps/src/templates/studioHomepages/Incubator.jsx
@@ -45,11 +45,11 @@ class Incubator extends Component {
             buttons={[
               {
                 url: '/s/music-intro-2024/reset',
-                text: 'Get started',
+                text: 'Get Started: learn how to use Project Beats in a step by step intro',
               },
               {
                 url: '/projectbeats',
-                text: 'Skip to project',
+                text: 'Make Music: skip direct to a Project Beats project',
                 color: Button.ButtonColor.neutralDark,
               },
             ]}

--- a/apps/src/templates/studioHomepages/Incubator.jsx
+++ b/apps/src/templates/studioHomepages/Incubator.jsx
@@ -52,7 +52,7 @@ class Incubator extends Component {
               {
                 url: '/projectbeats',
                 text: 'Make Music',
-                extraText: 'Skip direct to a Project Beats project.',
+                extraText: 'Skip directly to creating a Project Beats project.',
                 color: Button.ButtonColor.neutralDark,
               },
             ]}

--- a/apps/src/templates/studioHomepages/Incubator.jsx
+++ b/apps/src/templates/studioHomepages/Incubator.jsx
@@ -45,11 +45,13 @@ class Incubator extends Component {
             buttons={[
               {
                 url: '/s/music-intro-2024/reset',
-                text: 'Get Started: learn how to use Project Beats in a step by step intro',
+                text: 'Get Started',
+                extraText: 'Learn how to use Project Beats in a step by step intro.',
               },
               {
                 url: '/projectbeats',
-                text: 'Make Music: skip direct to a Project Beats project',
+                text: 'Make Music',
+                extraText: 'Skip direct to a Project Beats project.',
                 color: Button.ButtonColor.neutralDark,
               },
             ]}

--- a/apps/src/templates/studioHomepages/Incubator.jsx
+++ b/apps/src/templates/studioHomepages/Incubator.jsx
@@ -46,7 +46,8 @@ class Incubator extends Component {
               {
                 url: '/s/music-intro-2024/reset',
                 text: 'Get Started',
-                extraText: 'Learn how to use Project Beats in a step by step intro.',
+                extraText:
+                  'Learn how to use Project Beats in a step by step intro.',
               },
               {
                 url: '/projectbeats',

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -7,6 +7,7 @@ import {
   BodyThreeText,
 } from '@cdo/apps/componentLibrary/typography';
 import styles from './twoColumnActionBlock.module.scss';
+import classNames from 'classnames';
 
 export default function TwoColumnActionBlock({
   id,
@@ -35,9 +36,15 @@ export default function TwoColumnActionBlock({
             </BodyOneText>
           )}
           <BodyThreeText>{description}</BodyThreeText>
-          <div className={styles.buttonsContainer}>
+          <div
+            className={classNames(
+              styles.buttonsContainer,
+              buttons.some(button => button.extraText) &&
+                styles.buttonsContainerVerticalButtons
+            )}
+          >
             {buttons.map((button, index) => (
-              <span key={index}>
+              <div key={index}>
                 <Button
                   __useDeprecatedTag
                   href={button.url}
@@ -49,7 +56,8 @@ export default function TwoColumnActionBlock({
                   id={button.id}
                   onClick={button.onClick}
                 />
-              </span>
+                {button.extraText && <div>{button.extraText}</div>}
+              </div>
             ))}
           </div>
         </div>
@@ -68,6 +76,7 @@ TwoColumnActionBlock.propTypes = {
     PropTypes.shape({
       url: PropTypes.string.isRequired,
       text: PropTypes.string.isRequired,
+      extraText: PropTypes.string,
       target: PropTypes.string,
       id: PropTypes.string,
       color: PropTypes.oneOf(Object.values(Button.ButtonColor)),

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -5,6 +5,7 @@ import {
   Heading2,
   BodyOneText,
   BodyThreeText,
+  BodyFourText,
 } from '@cdo/apps/componentLibrary/typography';
 import styles from './twoColumnActionBlock.module.scss';
 import classNames from 'classnames';
@@ -56,7 +57,9 @@ export default function TwoColumnActionBlock({
                   id={button.id}
                   onClick={button.onClick}
                 />
-                {button.extraText && <div>{button.extraText}</div>}
+                {button.extraText && (
+                  <BodyFourText>{button.extraText}</BodyFourText>
+                )}
               </div>
             ))}
           </div>

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.story.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.story.jsx
@@ -29,3 +29,30 @@ export const Basic = () => (
     marginBottom={'64px'}
   />
 );
+
+export const ExtraButtonText = () => (
+  <TwoColumnActionBlock
+    id={'id'}
+    heading={'Heading goes here'}
+    subHeading={'Subheading goes here'}
+    description={'Description goes here'}
+    imageUrl={
+      'https://code.org/images/dance-hoc/dance-party-activity-ai-edition.png'
+    }
+    buttons={[
+      {
+        id: 'your_school_professional_learning',
+        url: 'https://code.org/professional-learning',
+        text: 'Learn more',
+        extraText: 'Click here to learn more about professional learning options.'
+      },
+      {
+        id: 'your_school_administrators',
+        url: 'https://code.org/administrators',
+        text: 'Try this',
+        extraText: 'School administrators can learn more about our curriculum options.'
+      },
+    ]}
+    marginBottom={'64px'}
+  />
+);

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.story.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.story.jsx
@@ -44,13 +44,15 @@ export const ExtraButtonText = () => (
         id: 'your_school_professional_learning',
         url: 'https://code.org/professional-learning',
         text: 'Learn more',
-        extraText: 'Click here to learn more about professional learning options.'
+        extraText:
+          'Click here to learn more about professional learning options.',
       },
       {
         id: 'your_school_administrators',
         url: 'https://code.org/administrators',
         text: 'Try this',
-        extraText: 'School administrators can learn more about our curriculum options.'
+        extraText:
+          'School administrators can learn more about our curriculum options.',
       },
     ]}
     marginBottom={'64px'}

--- a/apps/src/templates/studioHomepages/twoColumnActionBlock.module.scss
+++ b/apps/src/templates/studioHomepages/twoColumnActionBlock.module.scss
@@ -44,5 +44,9 @@ $breakpoint: 993px;
     display: flex;
     flex-wrap: wrap;
     gap: 1.25rem;
+
+    &VerticalButtons {
+      flex-direction: column;
+    }
   }
 }


### PR DESCRIPTION
This updates the **Music Lab** buttons at https://studio.code.org/incubator to get some extra explanatory text.  The intention is that users will have a better idea where they are going, and the onboarding funnel will strengthen because less users will want to skip directly to their project.

This updates the `TwoColumnActionBlock` component so that if any button is given some `extraText`, it switches layout to a vertical stack.  Otherwise, the component remains the same, with the buttons arranged horizontally.  The Storybook has been updated to demonstrate this new capability.

<img width="1000" alt="Screenshot 2024-03-06 at 8 29 55 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/58c550ef-2724-4d5c-9e7e-1f0ecd3da12f">
