### PR TITLE
String translation for new Create Account button

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -431,6 +431,7 @@ en:
       logout: 'Sign out'
       signin: 'Sign in'
       signup: 'Create an account'
+      create_account: 'Create Account'
       already_registered: 'Already registered?'
       pair_programming: 'Pair programming'
       team: 'Team'


### PR DESCRIPTION
Getting a head start on the process for the header AB test. I chose this file and header to nest the string over based on [this PR](https://github.com/code-dot-org/code-dot-org/pull/56937/files) and because the other strings in this portion of the header live in the 'user' section of the file as well:

<img width="289" alt="Screenshot 2024-03-04 at 11 44 10 AM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/e8c18f33-0d23-4cf5-a785-6d2d78c75c7c">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
