### PR TITLE
Removed explicit import of babel plugin

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -45,7 +45,6 @@
     "@babel/plugin-proposal-optional-chaining": "^7.18.9",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-classes": "^7.18.9",
-    "@babel/plugin-transform-react-jsx": "^7.18.10",
     "@babel/plugin-transform-regenerator": "^7.18.6",
     "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "^7.18.10",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1643,7 +1643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-jsx@npm:^7.12.12, @babel/plugin-transform-react-jsx@npm:^7.18.10, @babel/plugin-transform-react-jsx@npm:^7.18.6":
+"@babel/plugin-transform-react-jsx@npm:^7.12.12, @babel/plugin-transform-react-jsx@npm:^7.18.6":
   version: 7.18.10
   resolution: "@babel/plugin-transform-react-jsx@npm:7.18.10"
   dependencies:
@@ -8142,7 +8142,6 @@ __metadata:
     "@babel/plugin-proposal-optional-chaining": ^7.18.9
     "@babel/plugin-syntax-dynamic-import": ^7.8.3
     "@babel/plugin-transform-classes": ^7.18.9
-    "@babel/plugin-transform-react-jsx": ^7.18.10
     "@babel/plugin-transform-regenerator": ^7.18.6
     "@babel/polyfill": ^7.12.1
     "@babel/preset-env": ^7.18.10


### PR DESCRIPTION
Clearing out some unused packages from our package.json.

[A long time ago](https://github.com/code-dot-org/code-dot-org/pull/8479), we added support for webpack. At that time, we explicitly added the babel plugin `transform-react-jsx`. This is now [imported](https://babeljs.io/docs/babel-plugin-transform-react-jsx) as part of the `@babel/preset-react` plugin, and we no longer need the explicit import of the plugin. 

(Note, it's unclear if the explicit import was required in the past - docs from that time are no longer easy to find, but I'm assuming it was required at one point and is no longer, or was accidentally imported).

This was discovered using [depcheck](https://www.npmjs.com/package/depcheck)


