### PR TITLE
[ProgressV2] fix title header overflowing on window resize

### DIFF
--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -111,6 +111,8 @@ $level-cell-width: 52;
     display: flex;
     flex-direction: row;
     line-height: 32px;
+    min-width: fit-content;
+    max-height: 32px;
 
     &Dropdown {
       margin-inline-start: 8px;


### PR DESCRIPTION

<img width="398" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25193259/cc8501c5-22d5-4d58-a005-e8cfe429d57a">

Fix small width windows putting `Lessons` and `in` on two different lines for the unit selector title.

## Links
[TEACH-888](https://codedotorg.atlassian.net/browse/TEACH-888)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
