### PR TITLE
Tag prod autoscaled instances with Name and environment

### DIFF
--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -170,8 +170,8 @@ frontend_device_name ||= '/dev/sda1'
 
           STACK=${AWS::StackName}
           REGION=${AWS::Region}
-          INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 
+          INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
           <%=indent(build_frontend, 10)%>
           if [ $? -eq 0 ]
           then

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -163,8 +163,18 @@ frontend_device_name ||= '/dev/sda1'
 
           STACK=${AWS::StackName}
           REGION=${AWS::Region}
+          AUTO_SCALING_GROUP=Frontends-${AWS::StackName}
+          ENVIRONMENT=<%=environment%>
 
           INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+
+          # Tag the new EC2 instance's Name and environment for easy recognition in the AWS console
+          aws ec2 create-tags --resources $INSTANCE_ID \
+            --tags  Key=Name,Value="${AUTO_SCALING_GROUP}-${INSTANCE_ID}" \
+                    Key=environment,Value="$ENVIRONMENT" \
+            --region $REGION \
+            || true
+
           <%=indent(build_frontend, 10)%>
           if [ $? -eq 0 ]
           then
@@ -177,7 +187,6 @@ frontend_device_name ||= '/dev/sda1'
 
           # Signal CompleteLifecycleAction, in case this instance was launched from an Auto Scaling process.
           LIFECYCLE_HOOK=WebServerHook-${AWS::StackName}
-          AUTO_SCALING_GROUP=Frontends-${AWS::StackName}
           if [ -n "$LIFECYCLE_HOOK" ] && [ -n "$AUTO_SCALING_GROUP" ]; then
             aws autoscaling complete-lifecycle-action \
               --lifecycle-action-result $LIFECYCLE_ACTION \

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -143,6 +143,13 @@ frontend_device_name ||= '/dev/sda1'
   FrontendLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     DependsOn: FastSnapshotRestore
+    Tags:
+      - Key: "Name"
+        Value: !Sub "Frontend-${AWS::StackName}"
+        PropagateAtLaunch: true
+      - Key: "environment"
+        Value: <%=environment%>
+        PropagateAtLaunch: true
     Properties:
       ImageId: !GetAtt [AMI<%=ami%>, ImageId]
       InstanceType: <%=instance_type%>
@@ -163,17 +170,7 @@ frontend_device_name ||= '/dev/sda1'
 
           STACK=${AWS::StackName}
           REGION=${AWS::Region}
-          AUTO_SCALING_GROUP=Frontends-${AWS::StackName}
-          ENVIRONMENT=<%=environment%>
-
           INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-
-          # Tag the new EC2 instance's Name and environment for easy recognition in the AWS console
-          aws ec2 create-tags --resources $INSTANCE_ID \
-            --tags  Key=Name,Value="${AUTO_SCALING_GROUP}-${INSTANCE_ID}" \
-                    Key=environment,Value="$ENVIRONMENT" \
-            --region $REGION \
-            || true
 
           <%=indent(build_frontend, 10)%>
           if [ $? -eq 0 ]
@@ -187,6 +184,7 @@ frontend_device_name ||= '/dev/sda1'
 
           # Signal CompleteLifecycleAction, in case this instance was launched from an Auto Scaling process.
           LIFECYCLE_HOOK=WebServerHook-${AWS::StackName}
+          AUTO_SCALING_GROUP=Frontends-${AWS::StackName}
           if [ -n "$LIFECYCLE_HOOK" ] && [ -n "$AUTO_SCALING_GROUP" ]; then
             aws autoscaling complete-lifecycle-action \
               --lifecycle-action-result $LIFECYCLE_ACTION \

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -143,19 +143,19 @@ frontend_device_name ||= '/dev/sda1'
   FrontendLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     DependsOn: FastSnapshotRestore
-    Tags:
-      - Key: "Name"
-        Value: !Sub "Frontend-${AWS::StackName}"
-        PropagateAtLaunch: true
-      - Key: "environment"
-        Value: <%=environment%>
-        PropagateAtLaunch: true
     Properties:
       ImageId: !GetAtt [AMI<%=ami%>, ImageId]
       InstanceType: <%=instance_type%>
       IamInstanceProfile: !Ref FrontendInstanceProfile
       SecurityGroups: [!ImportValue VPC-FrontendSecurityGroup]
       KeyName: <%=ssh_key_name%>
+      Tags:
+        - Key: "Name"
+          Value: !Sub "Frontend-${AWS::StackName}"
+          PropagateAtLaunch: true
+        - Key: "environment"
+          Value: <%=environment%>
+          PropagateAtLaunch: true
       BlockDeviceMappings:
         - DeviceName: <%=frontend_device_name%>
           Ebs:


### PR DESCRIPTION
Right now our production web-request-serving dashboard instances, created by the `Frontends-autoscale-prod` autoscaling group have no EC2 name set/tagged. This makes it unclear what they are in the AWS console.

This PR is totally untested because I don't know how to test cloudformation safely, but its my first attempt to find the right place to set the EC2 Name tag to something sensible. In this case it would be like:
`Name=Frontends-autoscale-prod-i-0f1b7e30ce0b09d6a`

To match dashboard-console and dashboard-daemon, I'm also setting tags:
`environment=production`.