### PR TITLE
I18n-sync-down: Limit the number of requests to around 20 per second to avoid hitting Crowdin's rate limit

### DIFF
--- a/bin/i18n/utils/sync_down_base.rb
+++ b/bin/i18n/utils/sync_down_base.rb
@@ -72,7 +72,12 @@ module I18n
 
               locale_etags[source_file['path']] = translation_etag
             ensure
-              mutex.synchronize {progress_bar.increment}
+              mutex.synchronize do
+                progress_bar.increment
+
+                # Limits the number of requests to around 20 per second to avoid hitting Crowdin's rate limit
+                sleep(0.5) if progress_bar.progress % I18n::Utils::CrowdinClient::MAX_CONCURRENT_REQUESTS == 0
+              end
             end
           end
         end


### PR DESCRIPTION
https://codedotorg.slack.com/archives/C99KAHFK9/p1709595232044199
```
bundler: failed to load command: ./bin/i18n/sync-all.rb (./bin/i18n/sync-all.rb)
/home/ubuntu/code-dot-org/bin/i18n/utils/crowdin_client.rb:287:in `request':
Something went wrong while response processing. Details - 859: unexpected token at 
<html>                                                                                                           
<head><title>429 Too Many Requests</title></head>
<body>
<center><h1>429 Too Many Requests</h1></center>
<hr><center>nginx</center>
</body>
</html>
```