### PR TITLE
Re-enable tests that were skipped for leap day

### DIFF
--- a/dashboard/test/lib/school_info_interstitial_helper_test.rb
+++ b/dashboard/test/lib/school_info_interstitial_helper_test.rb
@@ -137,8 +137,6 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
   end
 
   test 'user school info updates as expected over lifetime of user' do
-    skip 'fails one week before a leap day'
-
     user = create :teacher
 
     assert_nil user.school_info

--- a/dashboard/test/lib/school_info_interstitial_helper_test.rb
+++ b/dashboard/test/lib/school_info_interstitial_helper_test.rb
@@ -127,7 +127,6 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
   end
 
   test 'shows the confirmation dialog if all above conditions are met' do
-    skip 'skipping for leap year'
     user = create :teacher
     user.update! school_info: create(:school_info)
 


### PR DESCRIPTION
These tests were skipped in https://github.com/code-dot-org/code-dot-org/pull/56736 and https://github.com/code-dot-org/code-dot-org/pull/56903, as they were breaking due to leap day. Now that leap day is passed, I'm re-enabling them!

