### PR TITLE
Remove tech setup text from CSD AYW 4 reminder emails

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
@@ -25,18 +25,6 @@
       join the workshop - we will walk you through what you need to know in our
       time together.
 
-- if @is_reminder && @workshop.course == Pd::Workshop::COURSE_CSD && @workshop.subject == Pd::Workshop::SUBJECT_CSD_WORKSHOP_4
-  %h3
-    Pre-Workshop Tech Setup
-  %p
-    During the workshop, we will explore Unit 6 of the CS Discoveries course.
-    Unit 6 uses the Circuit Playground and Maker App to get students hands-on experience with physical computing.
-    In order to save time during the workshop for more exploration, we ask that you install the Maker App
-    before attending the workshop. Directions for setting up the Maker App can be found at
-    = link_to('https://studio.code.org/maker/setup', 'https://studio.code.org/maker/setup') + '.'
-    School- or district-owned laptops may require administrator permission to download Maker App,
-    so we encourage you to start this process soon.
-
 - if @workshop.virtual?
   = render partial: 'virtual_tips'
 - elsif !@workshop.virtual? && @is_reminder


### PR DESCRIPTION
Changes were suggested by the PL team in [this doc](https://docs.google.com/document/d/1swUE_BvaZRgA-lbGwyaRZdQh42k-BV3EvSovkV-V4YM/edit?usp_dm=true). The content of these workshops was rearranged so that the tech setup piece no longer applies to AYW 4.