### PR TITLE
Add section promoting certificates to Professional Learning page

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/professional-learning.haml
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning.haml
@@ -46,6 +46,10 @@ theme: responsive_full_width
   .wrapper
     = view :section_basic_image_text, image_url: "/images/pl-page-educator-support.png", heading: hoc_s("pl_page.support.heading"), desc: hoc_s("pl_page.support.desc"), wrap_reverse: false
 
+%section
+  .wrapper
+    = view :section_basic_image_text, image_url: "/images/fill-448x280/pl-page-share.png", heading: hoc_s("pl_page.share.heading"), desc: hoc_s("pl_page.share.desc"), wrap_reverse: true
+
 %section.bg-neutral-light
   .wrapper.centered
     %h2=hoc_s("pl_page.resources.heading")

--- a/pegasus/sites.v3/code.org/public/images/pl-page-share.png
+++ b/pegasus/sites.v3/code.org/public/images/pl-page-share.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fa453e2b33b9d2a034af4e3ae8f35d61d7b0043488f8433d66beb1f6b0cbb92
+size 150950

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -1684,6 +1684,9 @@
     support:
       heading: "Educator support at every level"
       desc: "Our comprehensive support network caters to educators at all stages, offering year-round assistance, additional programming, and access to vibrant teacher communities. Stay connected, continually develop your skills, and find inspiration within a supportive peer network."
+    share:
+      heading: "Share your accomplishment"
+      desc: "All of our professional learning offerings provide a certificate of completion to share with your network or share with your administrator. Check with your school to find out if you can use the certificates to get professional development credits."
     resources:
       heading: "Additional resources and support for educators"
       intl:


### PR DESCRIPTION
Small update to code.org/professional-learning to advertise new certificates!


![Screenshot 2024-03-05 at 10 15 43 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/841d6941-43cb-4f00-b0e7-ac5ca0550eef)



## Links

[task](https://codedotorg.atlassian.net/browse/ACQ-1508)
[figma](https://www.figma.com/file/sZ6d1uhJWFksJ6j3Fnmbnc/PL-Flow-Improvements?type=design&node-id=2266-7189&mode=design&t=tRHgCEp44wk6PONV-0)


