### PR TITLE
Aitt add ai rubric sticky submit

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -118,6 +118,7 @@
   "aiEvaluationStatusAll_summary": "The AI assessment has successfully run for {evaluatedCount}/{totalCount} student projects.",
   "aiEvaluationDetails": "The AI Assessment runs automatically when a student presses \"submit\" for their project. If students forget to submit, you can run the AI Assessment for the entire class using the button above, or run it for an individual student while viewing their rubric.",
   "aiStudentAssessment": "{studentName} has achieved {understandingLevel} for this learning goal.",
+  "aiSubmitShouldKeepWorking": "Student should keep working",
   "aiTrainedModels": "AI Trained Models",
   "aiTrainedModelsNoModels": "You have not trained any AI models yet.",
   "aiTrainedModelsDeleteModelConfirm": "Are you sure you would like to delete this model?",

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -759,7 +759,7 @@ class TopInstructions extends Component {
                 }
               />
             )}
-            {!fetchingData && (
+            {!fetchingData && displayFeedbackTab && (
               <TeacherFeedbackTab
                 teacherViewingStudentWork={teacherViewingStudentWork}
                 visible={tabSelected === TabType.COMMENTS}

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import style from './rubrics.module.scss';
 import i18n from '@cdo/locale';
 import classnames from 'classnames';
-import {BodyFourText, Heading6} from '@cdo/apps/componentLibrary/typography';
+import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {
   reportingDataShape,
@@ -13,14 +13,9 @@ import {
 import RubricContent from './RubricContent';
 import RubricSettings from './RubricSettings';
 import RubricTabButtons from './RubricTabButtons';
+import RubricSubmitFooter from './RubricSubmitFooter';
 import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
 import Draggable from 'react-draggable';
-
-import HttpClient from '@cdo/apps/util/HttpClient';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
-import Button from '@cdo/apps/templates/Button';
-import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 
 const TAB_NAMES = {
   RUBRIC: 'rubric',
@@ -47,64 +42,7 @@ export default function RubricContainer({
   );
   const [aiEvaluations, setAiEvaluations] = useState(null);
 
-  const [isSubmittingToStudent, setIsSubmittingToStudent] = useState(false);
-  const [errorSubmitting, setErrorSubmitting] = useState(false);
-  const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
   const [feedbackAdded, setFeedbackAdded] = useState(false);
-  const [keepWorking, setKeepWorking] = useState(false);
-
-  useEffect(() => {
-    if (open && studentLevelInfo) {
-      // Get the teacher feedback
-      const studentId = studentLevelInfo.user_id;
-      const endPoint = `/rubrics/${rubric.id}/get_teacher_feedback?student=${studentId}`;
-      fetch(endPoint)
-        .then(response => response.json())
-        .then(json => {
-          setKeepWorking(json.review_state === 'keepWorking');
-          const lastSubmittedDateObj = new Date(json.updated_at);
-          setLastSubmittedTimestamp(lastSubmittedDateObj.toLocaleString());
-        });
-    }
-  }, [open, rubric.id, studentLevelInfo]);
-
-  const submitFeedbackToStudent = () => {
-    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_SUBMITTED, {
-      ...reportingData,
-      studentId: studentLevelInfo.user_id,
-    });
-    setIsSubmittingToStudent(true);
-    setErrorSubmitting(false);
-    const body = JSON.stringify({
-      student_id: studentLevelInfo.user_id,
-      keep_working: keepWorking,
-    });
-    const endPoint = `/rubrics/${rubric.id}/submit_evaluations`;
-    HttpClient.post(endPoint, body, true, {'Content-Type': 'application/json'})
-      .then(response => response.json())
-      .then(json => {
-        setIsSubmittingToStudent(false);
-        if (!json.submittedAt) {
-          throw new Error('Unexpected response object');
-        }
-        const lastSubmittedDateObj = new Date(json.submittedAt);
-        setLastSubmittedTimestamp(lastSubmittedDateObj.toLocaleString());
-      })
-      .catch(() => {
-        setIsSubmittingToStudent(false);
-        setErrorSubmitting(true);
-      });
-    if (feedbackAdded) {
-      analyticsReporter.sendEvent(
-        EVENTS.TA_RUBRIC_SUBMITTEED_WRITTEN_FEEDBACK,
-        {
-          ...reportingData,
-          studentId: studentLevelInfo.user_id,
-        }
-      );
-      setFeedbackAdded(false);
-    }
-  };
 
   const tabSelectCallback = tabSelection => {
     setSelectedTab(tabSelection);
@@ -196,6 +134,8 @@ export default function RubricContainer({
             reportingData={reportingData}
             visible={selectedTab === TAB_NAMES.RUBRIC}
             aiEvaluations={aiEvaluations}
+            feedbackAdded={feedbackAdded}
+            setFeedbackAdded={setFeedbackAdded}
           />
           {showSettings && (
             <RubricSettings
@@ -206,46 +146,14 @@ export default function RubricContainer({
           )}
         </div>
         {canProvideFeedback && (
-          <div className={style.rubricFooter}>
-            <div className={style.rubricFooterContent}>
-              <Checkbox
-                label={'Student should keep working'}
-                size="xs"
-                name="keepWorking"
-                onChange={() => {
-                  setKeepWorking(!keepWorking);
-                }}
-                checked={keepWorking}
-              />
-            </div>
-            <div className={style.submitToStudentButtonAndError}>
-              <Button
-                id="ui-submitFeedbackButton"
-                text={i18n.submitToStudent()}
-                color={Button.ButtonColor.brandSecondaryDefault}
-                onClick={submitFeedbackToStudent}
-                className={style.submitToStudentButton}
-                disabled={isSubmittingToStudent}
-              />
-              {errorSubmitting && (
-                <div>
-                  <BodyFourText className={style.errorMessage}>
-                    {i18n.errorSubmittingFeedback()}
-                  </BodyFourText>
-                </div>
-              )}
-              {!errorSubmitting && (
-                <div id="ui-feedback-submitted-timestamp">
-                  <BodyFourText>
-                    {!!lastSubmittedTimestamp &&
-                      i18n.feedbackSubmittedAt({
-                        timestamp: lastSubmittedTimestamp,
-                      })}
-                  </BodyFourText>
-                </div>
-              )}
-            </div>
-          </div>
+          <RubricSubmitFooter
+            open={open}
+            rubric={rubric}
+            reportingData={reportingData}
+            studentLevelInfo={studentLevelInfo}
+            feedbackAdded={feedbackAdded}
+            setFeedbackAdded={setFeedbackAdded}
+          />
         )}
       </div>
     </Draggable>

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -47,7 +47,6 @@ export default function RubricContainer({
   );
   const [aiEvaluations, setAiEvaluations] = useState(null);
 
-  // TODO move to separate footer component
   const [isSubmittingToStudent, setIsSubmittingToStudent] = useState(false);
   const [errorSubmitting, setErrorSubmitting] = useState(false);
   const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
@@ -55,7 +54,7 @@ export default function RubricContainer({
   const [keepWorking, setKeepWorking] = useState(false);
 
   useEffect(() => {
-    if (open) {
+    if (open && studentLevelInfo) {
       // Get the teacher feedback
       const studentId = studentLevelInfo.user_id;
       const endPoint = `/rubrics/${rubric.id}/get_teacher_feedback?student=${studentId}`;
@@ -67,7 +66,7 @@ export default function RubricContainer({
           setLastSubmittedTimestamp(lastSubmittedDateObj.toLocaleString());
         });
     }
-  }, [open, rubric.id, studentLevelInfo.user_id]);
+  }, [open, rubric.id, studentLevelInfo]);
 
   const submitFeedbackToStudent = () => {
     analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_SUBMITTED, {

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -1,8 +1,9 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import style from './rubrics.module.scss';
+import i18n from '@cdo/locale';
 import classnames from 'classnames';
-import {Heading6} from '@cdo/apps/componentLibrary/typography';
+import {BodyFourText, Heading6} from '@cdo/apps/componentLibrary/typography';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {
   reportingDataShape,
@@ -15,6 +16,12 @@ import RubricTabButtons from './RubricTabButtons';
 import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 import Draggable from 'react-draggable';
+
+import HttpClient from '@cdo/apps/util/HttpClient';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import Button from '@cdo/apps/templates/Button';
+import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 
 const TAB_NAMES = {
   RUBRIC: 'rubric',
@@ -40,6 +47,66 @@ export default function RubricContainer({
       TAB_NAMES.RUBRIC
   );
   const [aiEvaluations, setAiEvaluations] = useState(null);
+
+  // TODO move to separate footer component
+  const [isSubmittingToStudent, setIsSubmittingToStudent] = useState(false);
+  const [errorSubmitting, setErrorSubmitting] = useState(false);
+  const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
+  const [feedbackAdded, setFeedbackAdded] = useState(false);
+  const [keepWorking, setKeepWorking] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      // Get the teacher feedback
+      const studentId = studentLevelInfo.user_id;
+      const endPoint = `/rubrics/${rubric.id}/get_teacher_feedback?student=${studentId}`;
+      fetch(endPoint)
+        .then(response => response.json())
+        .then(json => {
+          setKeepWorking(json.review_state === 'keepWorking');
+          const lastSubmittedDateObj = new Date(json.updated_at);
+          setLastSubmittedTimestamp(lastSubmittedDateObj.toLocaleString());
+        });
+    }
+  }, [open, rubric.id, studentLevelInfo.user_id]);
+
+  const submitFeedbackToStudent = () => {
+    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_SUBMITTED, {
+      ...reportingData,
+      studentId: studentLevelInfo.user_id,
+    });
+    setIsSubmittingToStudent(true);
+    setErrorSubmitting(false);
+    const body = JSON.stringify({
+      student_id: studentLevelInfo.user_id,
+      keep_working: keepWorking,
+    });
+    const endPoint = `/rubrics/${rubric.id}/submit_evaluations`;
+    HttpClient.post(endPoint, body, true, {'Content-Type': 'application/json'})
+      .then(response => response.json())
+      .then(json => {
+        setIsSubmittingToStudent(false);
+        if (!json.submittedAt) {
+          throw new Error('Unexpected response object');
+        }
+        const lastSubmittedDateObj = new Date(json.submittedAt);
+        setLastSubmittedTimestamp(lastSubmittedDateObj.toLocaleString());
+      })
+      .catch(() => {
+        setIsSubmittingToStudent(false);
+        setErrorSubmitting(true);
+      });
+    if (feedbackAdded) {
+      analyticsReporter.sendEvent(
+        EVENTS.TA_RUBRIC_SUBMITTEED_WRITTEN_FEEDBACK,
+        {
+          ...reportingData,
+          studentId: studentLevelInfo.user_id,
+        }
+      );
+      setFeedbackAdded(false);
+    }
+  };
 
   const tabSelectCallback = tabSelection => {
     setSelectedTab(tabSelection);
@@ -140,6 +207,48 @@ export default function RubricContainer({
             />
           )}
         </div>
+        {canProvideFeedback && (
+          <div className={style.rubricFooter}>
+            <div className={style.rubricFooterContent}>
+              <Checkbox
+                label={'Student should keep working'}
+                size="xs"
+                name="keepWorking"
+                onChange={() => {
+                  setKeepWorking(!keepWorking);
+                }}
+                checked={keepWorking}
+              />
+            </div>
+            <div className={style.submitToStudentButtonAndError}>
+              <Button
+                id="ui-submitFeedbackButton"
+                text={i18n.submitToStudent()}
+                color={Button.ButtonColor.brandSecondaryDefault}
+                onClick={submitFeedbackToStudent}
+                className={style.submitToStudentButton}
+                disabled={isSubmittingToStudent}
+              />
+              {errorSubmitting && (
+                <div>
+                  <BodyFourText className={style.errorMessage}>
+                    {i18n.errorSubmittingFeedback()}
+                  </BodyFourText>
+                </div>
+              )}
+              {!errorSubmitting && (
+                <div id="ui-feedback-submitted-timestamp">
+                  <BodyFourText>
+                    {!!lastSubmittedTimestamp &&
+                      i18n.feedbackSubmittedAt({
+                        timestamp: lastSubmittedTimestamp,
+                      })}
+                  </BodyFourText>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </Draggable>
   );

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -14,7 +14,6 @@ import RubricContent from './RubricContent';
 import RubricSettings from './RubricSettings';
 import RubricTabButtons from './RubricTabButtons';
 import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
-import i18n from '@cdo/locale';
 import Draggable from 'react-draggable';
 
 import HttpClient from '@cdo/apps/util/HttpClient';

--- a/apps/src/templates/rubrics/RubricContainer.story.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.story.jsx
@@ -26,7 +26,11 @@ const defaultRubric = {
     position: 3,
     name: 'Testing',
   },
+  script: {
+    id: 107,
+  },
   level: {
+    id: 42,
     name: rubricLevelName,
     position: 5,
   },

--- a/apps/src/templates/rubrics/RubricContainer.story.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.story.jsx
@@ -95,6 +95,7 @@ const defaultStudentLevelInfo = {
   attempts: 2,
   timeSpent: 404,
   lastAttempt: '5/26/23',
+  user_id: 107,
 };
 
 const Template = args => (

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -44,11 +44,11 @@ export default function RubricContent({
   reportingData,
   visible,
   aiEvaluations,
+  feedbackAdded,
+  setFeedbackAdded,
 }) {
   const {lesson} = rubric;
   const rubricLevel = rubric.level;
-
-  const [feedbackAdded, setFeedbackAdded] = useState(false);
 
   let infoText = null;
   if (!onLevelForEvaluation) {
@@ -150,6 +150,8 @@ RubricContent.propTypes = {
   teacherHasEnabledAi: PropTypes.bool,
   visible: PropTypes.bool,
   aiEvaluations: PropTypes.arrayOf(aiEvaluationShape),
+  feedbackAdded: PropTypes.bool,
+  setFeedbackAdded: PropTypes.func,
 };
 
 export const InfoAlert = ({text, dismissable}) => {

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -16,11 +16,7 @@ import {
   studentLevelInfoShape,
 } from './rubricShapes';
 import LearningGoals from './LearningGoals';
-import Button from '@cdo/apps/templates/Button';
-import HttpClient from '@cdo/apps/util/HttpClient';
 import classnames from 'classnames';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import StudentSelector from './StudentSelector';
 import SectionSelector from './SectionSelector';
 
@@ -52,46 +48,7 @@ export default function RubricContent({
   const {lesson} = rubric;
   const rubricLevel = rubric.level;
 
-  const [isSubmittingToStudent, setIsSubmittingToStudent] = useState(false);
-  const [errorSubmitting, setErrorSubmitting] = useState(false);
-  const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
   const [feedbackAdded, setFeedbackAdded] = useState(false);
-  const submitFeedbackToStudent = () => {
-    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_SUBMITTED, {
-      ...reportingData,
-      studentId: studentLevelInfo.user_id,
-    });
-    setIsSubmittingToStudent(true);
-    setErrorSubmitting(false);
-    const body = JSON.stringify({
-      student_id: studentLevelInfo.user_id,
-    });
-    const endPoint = `/rubrics/${rubric.id}/submit_evaluations`;
-    HttpClient.post(endPoint, body, true, {'Content-Type': 'application/json'})
-      .then(response => response.json())
-      .then(json => {
-        setIsSubmittingToStudent(false);
-        if (!json.submittedAt) {
-          throw new Error('Unexpected response object');
-        }
-        const lastSubmittedDateObj = new Date(json.submittedAt);
-        setLastSubmittedTimestamp(lastSubmittedDateObj.toLocaleString());
-      })
-      .catch(() => {
-        setIsSubmittingToStudent(false);
-        setErrorSubmitting(true);
-      });
-    if (feedbackAdded) {
-      analyticsReporter.sendEvent(
-        EVENTS.TA_RUBRIC_SUBMITTEED_WRITTEN_FEEDBACK,
-        {
-          ...reportingData,
-          studentId: studentLevelInfo.user_id,
-        }
-      );
-      setFeedbackAdded(false);
-    }
-  };
 
   let infoText = null;
   if (!onLevelForEvaluation) {
@@ -179,34 +136,6 @@ export default function RubricContent({
           aiEvaluations={aiEvaluations}
         />
       </div>
-      {false && canProvideFeedback && (
-        <div className={style.rubricContainerFooter}>
-          <div className={style.submitToStudentButtonAndError}>
-            <Button
-              id="ui-submitFeedbackButton"
-              text={i18n.submitToStudent()}
-              color={Button.ButtonColor.brandSecondaryDefault}
-              onClick={submitFeedbackToStudent}
-              className={style.submitToStudentButton}
-              disabled={isSubmittingToStudent}
-            />
-            {errorSubmitting && (
-              <BodyThreeText className={style.errorMessage}>
-                {i18n.errorSubmittingFeedback()}
-              </BodyThreeText>
-            )}
-            {!errorSubmitting && !!lastSubmittedTimestamp && (
-              <div id="ui-feedback-submitted-timestamp">
-                <BodyThreeText>
-                  {i18n.feedbackSubmittedAt({
-                    timestamp: lastSubmittedTimestamp,
-                  })}
-                </BodyThreeText>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -179,7 +179,7 @@ export default function RubricContent({
           aiEvaluations={aiEvaluations}
         />
       </div>
-      {canProvideFeedback && (
+      {false && canProvideFeedback && (
         <div className={style.rubricContainerFooter}>
           <div className={style.submitToStudentButtonAndError}>
             <Button

--- a/apps/src/templates/rubrics/RubricSubmitFooter.jsx
+++ b/apps/src/templates/rubrics/RubricSubmitFooter.jsx
@@ -1,0 +1,199 @@
+import React, {useEffect, useState} from 'react';
+import PropTypes from 'prop-types';
+import style from './rubrics.module.scss';
+import i18n from '@cdo/locale';
+import {connect} from 'react-redux';
+import {BodyFourText} from '@cdo/apps/componentLibrary/typography';
+import {
+  reportingDataShape,
+  rubricShape,
+  studentLevelInfoShape,
+} from './rubricShapes';
+import HttpClient from '@cdo/apps/util/HttpClient';
+import {getTeacherFeedbackForStudent} from '@cdo/apps/templates/instructions/topInstructionsDataApi';
+import {updateTeacherFeedback} from '@cdo/apps/templates/instructions/teacherFeedback/teacherFeedbackDataApi';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import Button from '@cdo/apps/templates/Button';
+import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+
+function RubricSubmitFooter({
+  rubric,
+  reportingData,
+  studentLevelInfo,
+  open,
+  feedbackAdded,
+  setFeedbackAdded,
+
+  // redux
+  teacherId,
+}) {
+  // When the rubric opens, we should get the current feedback, if any
+  useEffect(() => {
+    if (open && studentLevelInfo) {
+      // Get the teacher feedback
+      const studentId = studentLevelInfo.user_id;
+      const levelId = rubric.level.id;
+      const scriptId = rubric.script.id;
+
+      getTeacherFeedbackForStudent(studentId, levelId, scriptId).done(
+        (data, _, request) => {
+          // Get the token for the future submission
+          setToken(request.getResponseHeader('csrf-token'));
+
+          // It returns all feedback records, we can just get the first one
+          const json = data[0];
+          if (json) {
+            setKeepWorking(json.review_state === 'keepWorking');
+            const lastSubmittedDateObj = new Date(json.created_at);
+            setLastSubmittedTimestamp(lastSubmittedDateObj.toLocaleString());
+          }
+
+          setFeedbackLoaded(true);
+        }
+      );
+    }
+  }, [
+    open,
+    teacherId,
+    rubric.id,
+    rubric.level.id,
+    rubric.script.id,
+    studentLevelInfo,
+  ]);
+
+  const [feedbackLoaded, setFeedbackLoaded] = useState(false);
+  const [isSubmittingToStudent, setIsSubmittingToStudent] = useState(false);
+  const [errorSubmitting, setErrorSubmitting] = useState(false);
+  const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
+  const [keepWorking, setKeepWorking] = useState(false);
+  const [token, setToken] = useState('');
+
+  // The first stage of submission is the progress state submission
+  // via the teacher_feedbacks API
+  const submitFeedbackToStudent = () => {
+    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_SUBMITTED, {
+      ...reportingData,
+      studentId: studentLevelInfo.user_id,
+    });
+    setIsSubmittingToStudent(true);
+    setErrorSubmitting(false);
+
+    // Submit 'feedback' record
+    const studentId = studentLevelInfo.user_id;
+    const levelId = rubric.level.id;
+    const scriptId = rubric.script.id;
+
+    const payload = {
+      comment: '',
+      review_state: keepWorking ? 'keepWorking' : null,
+      student_id: studentId,
+      script_id: scriptId,
+      level_id: levelId,
+      teacher_id: teacherId,
+    };
+
+    // Submit the teacher feedback and then submit the rubric feedback
+    updateTeacherFeedback(payload, token)
+      .done(submitFeedbackToEndpoint)
+      .fail(() => {
+        setIsSubmittingToStudent(false);
+        setErrorSubmitting(true);
+      });
+  };
+
+  // The second stage of submission is the feedback submission
+  // via the rubrics API
+  const submitFeedbackToEndpoint = () => {
+    console.log('feedback');
+    const body = JSON.stringify({
+      student_id: studentLevelInfo.user_id,
+    });
+    const endPoint = `/rubrics/${rubric.id}/submit_evaluations`;
+    HttpClient.post(endPoint, body, true, {'Content-Type': 'application/json'})
+      .then(response => response.json())
+      .then(json => {
+        setIsSubmittingToStudent(false);
+        if (!json.submittedAt) {
+          throw new Error('Unexpected response object');
+        }
+        const lastSubmittedDateObj = new Date(json.submittedAt);
+        setLastSubmittedTimestamp(lastSubmittedDateObj.toLocaleString());
+
+        if (feedbackAdded) {
+          analyticsReporter.sendEvent(
+            EVENTS.TA_RUBRIC_SUBMITTEED_WRITTEN_FEEDBACK,
+            {
+              ...reportingData,
+              studentId: studentLevelInfo.user_id,
+            }
+          );
+          setFeedbackAdded(false);
+        }
+      })
+      .catch(() => {
+        setIsSubmittingToStudent(false);
+        setErrorSubmitting(true);
+      });
+  };
+
+  return (
+    <div className={style.rubricFooter}>
+      <div className={style.rubricFooterContent}>
+        <Checkbox
+          label={i18n.aiSubmitShouldKeepWorking()}
+          size="xs"
+          name="keepWorking"
+          onChange={() => {
+            setKeepWorking(!keepWorking);
+          }}
+          disabled={!feedbackLoaded}
+          checked={keepWorking}
+        />
+      </div>
+      <div className={style.submitToStudentButtonAndError}>
+        <Button
+          id="ui-submitFeedbackButton"
+          text={i18n.submitToStudent()}
+          color={Button.ButtonColor.brandSecondaryDefault}
+          onClick={submitFeedbackToStudent}
+          className={style.submitToStudentButton}
+          disabled={isSubmittingToStudent || !feedbackLoaded}
+        />
+        {errorSubmitting && (
+          <div>
+            <BodyFourText className={style.errorMessage}>
+              {i18n.errorSubmittingFeedback()}
+            </BodyFourText>
+          </div>
+        )}
+        {!errorSubmitting && (
+          <div id="ui-feedback-submitted-timestamp">
+            <BodyFourText>
+              {!!lastSubmittedTimestamp &&
+                i18n.feedbackSubmittedAt({
+                  timestamp: lastSubmittedTimestamp,
+                })}
+            </BodyFourText>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const UnconnectedRubricSubmitFooter = RubricSubmitFooter;
+
+RubricSubmitFooter.propTypes = {
+  rubric: rubricShape,
+  reportingData: reportingDataShape,
+  studentLevelInfo: studentLevelInfoShape,
+  open: PropTypes.bool,
+  feedbackAdded: PropTypes.bool,
+  setFeedbackAdded: PropTypes.func,
+  teacherId: PropTypes.number,
+};
+
+export default connect(state => ({
+  teacherId: state.currentUser.userId,
+}))(RubricSubmitFooter);

--- a/apps/src/templates/rubrics/RubricSubmitFooter.jsx
+++ b/apps/src/templates/rubrics/RubricSubmitFooter.jsx
@@ -28,6 +28,13 @@ function RubricSubmitFooter({
   // redux
   teacherId,
 }) {
+  const [feedbackLoaded, setFeedbackLoaded] = useState(false);
+  const [isSubmittingToStudent, setIsSubmittingToStudent] = useState(false);
+  const [errorSubmitting, setErrorSubmitting] = useState(false);
+  const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
+  const [keepWorking, setKeepWorking] = useState(false);
+  const [csrfToken, setCsrfToken] = useState('');
+
   // When the rubric opens, we should get the current feedback, if any
   useEffect(() => {
     if (open && studentLevelInfo) {
@@ -39,7 +46,7 @@ function RubricSubmitFooter({
       getTeacherFeedbackForStudent(studentId, levelId, scriptId).done(
         (data, _, request) => {
           // Get the token for the future submission
-          setToken(request.getResponseHeader('csrf-token'));
+          setCsrfToken(request.getResponseHeader('csrf-token'));
 
           // It returns all feedback records, we can just get the first one
           const json = data[0];
@@ -61,13 +68,6 @@ function RubricSubmitFooter({
     rubric.script.id,
     studentLevelInfo,
   ]);
-
-  const [feedbackLoaded, setFeedbackLoaded] = useState(false);
-  const [isSubmittingToStudent, setIsSubmittingToStudent] = useState(false);
-  const [errorSubmitting, setErrorSubmitting] = useState(false);
-  const [lastSubmittedTimestamp, setLastSubmittedTimestamp] = useState(false);
-  const [keepWorking, setKeepWorking] = useState(false);
-  const [token, setToken] = useState('');
 
   // The first stage of submission is the progress state submission
   // via the teacher_feedbacks API
@@ -94,7 +94,7 @@ function RubricSubmitFooter({
     };
 
     // Submit the teacher feedback and then submit the rubric feedback
-    updateTeacherFeedback(payload, token)
+    updateTeacherFeedback(payload, csrfToken)
       .done(submitFeedbackToEndpoint)
       .fail(() => {
         setIsSubmittingToStudent(false);
@@ -160,7 +160,7 @@ function RubricSubmitFooter({
           disabled={isSubmittingToStudent || !feedbackLoaded}
         />
         {errorSubmitting && (
-          <div>
+          <div id="ui-feedback-submitted-error">
             <BodyFourText className={style.errorMessage}>
               {i18n.errorSubmittingFeedback()}
             </BodyFourText>

--- a/apps/src/templates/rubrics/RubricSubmitFooter.jsx
+++ b/apps/src/templates/rubrics/RubricSubmitFooter.jsx
@@ -105,7 +105,6 @@ function RubricSubmitFooter({
   // The second stage of submission is the feedback submission
   // via the rubrics API
   const submitFeedbackToEndpoint = () => {
-    console.log('feedback');
     const body = JSON.stringify({
       student_id: studentLevelInfo.user_id,
     });

--- a/apps/src/templates/rubrics/rubricShapes.jsx
+++ b/apps/src/templates/rubrics/rubricShapes.jsx
@@ -19,6 +19,12 @@ export const rubricShape = PropTypes.shape({
     position: PropTypes.number,
     name: PropTypes.string,
   }),
+  script: PropTypes.shape({
+    id: PropTypes.number,
+  }),
+  level: PropTypes.shape({
+    id: PropTypes.number,
+  }),
 });
 
 // Used for any data that is only for reporting purposes. Other data may be used for event reporting

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -1,5 +1,5 @@
-@import 'color.scss';
-@import 'font.scss';
+@import 'color';
+@import 'font';
 
 .floatingActionButton {
   position: fixed;
@@ -86,19 +86,19 @@
 }
 
 .rubricContent {
-  border-radius: 0 0 4px 4px;
   border-right: 2px solid $neutral_dark;
   border-left: 2px solid $neutral_dark;
-  border-bottom: 2px solid $neutral_dark;
   background: $neutral_light;
-  box-shadow: 4px 4px 6px 0 rgba(0 0 0 / 0.25);
-
+  box-shadow: 0.25rem 0.25rem 0.375rem 0 rgba(0 0 0 / 0.25);
   height: 408px;
-
   overflow-x: hidden;
   overflow-y: auto;
-
   padding: 16px;
+
+  &:last-child {
+    border-radius: 0 0 4px 4px;
+    border-bottom: 2px solid $neutral_dark;
+  }
 }
 
 .visibleRubricContent {
@@ -112,18 +112,52 @@
   display: none;
 }
 
-.rubricContainerFooter {
+.rubricFooter {
+  background: $neutral_dark;
+  border-radius: 0 0 4px 4px;
+  border-bottom: 2px solid $neutral_dark;
+  color: $neutral_white;
   display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  align-self: stretch;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding: 0.5rem 2rem 0.5rem 1rem;
+}
+
+.rubricFooterContent {
+  flex: 1 1 100%;
+  padding: 0.25rem 0;
+
+  input[type="checkbox"] {
+    & + i::before {
+      background: $neutral_white;
+    }
+
+    & ~ span {
+      color: $neutral_white;
+    }
+  }
 }
 
 .submitToStudentButtonAndError {
   display: flex;
+  flex: 0 0 auto;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.5rem;
+  gap: 0.25rem;
+  align-self: stretch;
+
+  p {
+    color: $neutral_white;
+    line-height: 0.75rem;
+    margin: 0;
+    min-height: 0.75rem;
+  }
+}
+
+.rubricContainerFooter {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
   align-self: stretch;
 }
 
@@ -994,18 +1028,20 @@ p.evidenceLevelHeaderText {
   display: flex;
   flex-direction: column;
   gap: 28px;
-  width: 724px;
-  padding: 16px 16px 32px 16px;
-  border-radius: 0 0 4px 4px;
-  border-right: 2px solid $neutral_dark;
-  border-bottom: 2px solid $neutral_dark;
-  border-left: 2px solid $neutral_dark;
+  padding: 1rem;
+  border-right: 0.125rem solid $neutral_dark;
+  border-left: 0.125rem solid $neutral_dark;
   background: $neutral_white;
-  box-shadow: 4px 4px 6px 0 rgb(0 0 0 / 0.25);
+  box-shadow: 0.25rem 0.25rem 0.375rem 0 rgba(0 0 0 / 0.25);
   height: 408px;
-
   overflow-x: hidden;
   overflow-y: auto;
+
+  &:last-child {
+    border-radius: 0 0 0.25rem 0.25rem;
+    border-bottom: 0.125rem solid $neutral_dark;
+  }
+
   h2 {
     margin-bottom: 0;
   }

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -151,6 +151,8 @@
     line-height: 0.75rem;
     margin: 0;
     min-height: 0.75rem;
+    position: relative;
+    top: 0.1875rem;
   }
 }
 

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -153,6 +153,7 @@
     min-height: 0.75rem;
     position: relative;
     top: 0.1875rem;
+    font-size: 0.6875rem;
   }
 }
 

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -22,6 +22,7 @@ import $ from 'jquery';
 import {render, fireEvent, act} from '@testing-library/react';
 
 describe('RubricContainer', () => {
+  let clock;
   let store;
   let fetchStub;
   let ajaxStub;
@@ -74,6 +75,9 @@ describe('RubricContainer', () => {
   });
 
   afterEach(() => {
+    if (clock) {
+      clock.restore();
+    }
     restoreRedux();
     utils.queryParams.restore();
     fetchStub.restore();
@@ -378,7 +382,7 @@ describe('RubricContainer', () => {
       7. Fetch returns a json object with puts AI Status into SUCCESS state
       8. Calls refreshAiEvaluations
     */
-    const clock = sinon.useFakeTimers();
+    clock = sinon.useFakeTimers();
 
     stubFetchEvalStatusForUser(readyJson);
     stubFetchEvalStatusForAll(readyJsonAll);

--- a/apps/test/unit/templates/rubrics/RubricContentTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContentTest.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import {expect} from '../../../util/reconfiguredChai';
 import {mount, shallow} from 'enzyme';
-import sinon from 'sinon';
-import HttpClient from '@cdo/apps/util/HttpClient';
 import RubricContent from '@cdo/apps/templates/rubrics/RubricContent';
 import experiments from '@cdo/apps/util/experiments';
 import {
@@ -14,7 +12,6 @@ import {
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import teacherPanel from '@cdo/apps/code-studio/teacherPanelRedux';
 import {Provider} from 'react-redux';
-import {act} from 'react-dom/test-utils';
 
 describe('RubricContent', () => {
   let store;
@@ -201,83 +198,6 @@ describe('RubricContent', () => {
     );
     expect(wrapper.text()).to.not.include('6 attempts');
     expect(wrapper.text()).to.include('Feedback will be available on Level 7');
-  });
-
-  it('shows submit button if has student data and on level for evaluation', () => {
-    const wrapper = shallow(
-      <RubricContent
-        rubric={defaultRubric}
-        studentLevelInfo={{name: 'Grace Hopper'}}
-        canProvideFeedback
-      />
-    );
-    expect(wrapper.find('Button').length).to.equal(1);
-  });
-
-  it('handles successful submit button click', async () => {
-    const postStub = sinon.stub(HttpClient, 'post').returns(
-      Promise.resolve({
-        json: () => {
-          return {submittedAt: '1990-07-31T00:00:00.000Z'};
-        },
-      })
-    );
-    const wrapper = shallow(
-      <RubricContent
-        rubric={defaultRubric}
-        teacherHasEnabledAi
-        canProvideFeedback
-        studentLevelInfo={{name: 'Grace Hopper'}}
-      />
-    );
-
-    wrapper.find('Button').simulate('click');
-    expect(postStub).to.have.been.calledOnce;
-    expect(wrapper.find('Button').props().disabled).to.be.true;
-    await act(async () => {
-      await Promise.resolve();
-    });
-    await act(async () => {
-      await Promise.resolve();
-    });
-    await act(async () => {
-      await Promise.resolve();
-    });
-    wrapper.update();
-    expect(wrapper.find('Button').props().disabled).to.be.false;
-    expect(wrapper.find('BodyThreeText').at(1).props().children).to.include(
-      'Feedback submitted at'
-    );
-    postStub.restore();
-  });
-
-  it('handles error on submit button click', async () => {
-    const postStub = sinon.stub(HttpClient, 'post').returns(Promise.reject());
-    const wrapper = shallow(
-      <RubricContent
-        rubric={defaultRubric}
-        teacherHasEnabledAi
-        studentLevelInfo={{name: 'Grace Hopper'}}
-        canProvideFeedback
-      />
-    );
-    wrapper.find('Button').simulate('click');
-    expect(postStub).to.have.been.calledOnce;
-    expect(wrapper.find('Button').props().disabled).to.be.true;
-    await act(async () => {
-      await Promise.resolve();
-    });
-    await act(async () => {
-      await Promise.resolve();
-    });
-    await act(async () => {
-      await Promise.resolve();
-    });
-    wrapper.update();
-    expect(wrapper.find('BodyThreeText').at(1).props().children).to.equal(
-      'Error submitting feedback to student.'
-    );
-    postStub.restore();
   });
 
   it('does not pass down AI analysis to components when teacher has disabled AI', () => {

--- a/apps/test/unit/templates/rubrics/RubricSettingsTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricSettingsTest.jsx
@@ -16,6 +16,7 @@ import {Provider} from 'react-redux';
 import i18n from '@cdo/locale';
 
 describe('RubricSettings', () => {
+  let clock;
   let fetchStub;
   let store;
   let refreshAiEvaluationsSpy;
@@ -45,8 +46,11 @@ describe('RubricSettings', () => {
   });
 
   afterEach(() => {
-    utils.queryParams.restore();
+    if (clock) {
+      clock.restore();
+    }
     restoreRedux();
+    utils.queryParams.restore();
     fetchStub.restore();
   });
 
@@ -163,7 +167,7 @@ describe('RubricSettings', () => {
   it('runs AI assessment for all unevaluated projects when requested by teacher', async () => {
     stubFetchEvalStatusForAll(ready);
 
-    const clock = sinon.useFakeTimers();
+    clock = sinon.useFakeTimers();
 
     const wrapper = mount(
       <Provider store={store}>

--- a/apps/test/unit/templates/rubrics/RubricSubmitFooterTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricSubmitFooterTest.jsx
@@ -239,7 +239,7 @@ describe('RubricSubmitFooter', () => {
     // Wait until feedback is retrieved successfully
     await wait();
 
-    // See that the submit button is enabled
+    // See that the submit button and keep-working checkbox are enabled
     expect(checkbox).to.not.be.disabled;
     expect(button).to.not.be.disabled;
 
@@ -305,7 +305,7 @@ describe('RubricSubmitFooter', () => {
     // Wait until feedback is retrieved successfully
     await wait();
 
-    // See that the submit button is enabled
+    // See that the submit button and keep-working checkbox are enabled
     expect(checkbox).to.not.be.disabled;
     expect(button).to.not.be.disabled;
 
@@ -338,14 +338,14 @@ describe('RubricSubmitFooter', () => {
       </Provider>
     );
 
-    // See that the submit button and keep working checkbox is disabled
+    // See that the keep-working checkbox is not checked at first
     const checkbox = screen.getByLabelText(i18n.aiSubmitShouldKeepWorking());
-    expect(checkbox).to.be.checked;
+    expect(checkbox).to.not.be.checked;
 
     // Wait until feedback is retrieved successfully
     await wait();
 
-    // See that the submit button is enabled
+    // See that the keep-working checkbox is then checked to reflect the progress state
     expect(checkbox).to.be.checked;
   });
 

--- a/apps/test/unit/templates/rubrics/RubricSubmitFooterTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricSubmitFooterTest.jsx
@@ -1,0 +1,514 @@
+import React from 'react';
+import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
+import RubricSubmitFooter from '@cdo/apps/templates/rubrics/RubricSubmitFooter';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux,
+} from '@cdo/apps/redux';
+import HttpClient from '@cdo/apps/util/HttpClient';
+import currentUser from '@cdo/apps/templates/currentUserRedux';
+import {Provider} from 'react-redux';
+import i18n from '@cdo/locale';
+import * as topInstructionDataApi from '@cdo/apps/templates/instructions/topInstructionsDataApi';
+import * as teacherFeedbackDataApi from '@cdo/apps/templates/instructions/teacherFeedback/teacherFeedbackDataApi';
+
+// react testing library import
+import {render, screen, act} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('RubricSubmitFooter', () => {
+  let store;
+  let postStub;
+  let crsfToken;
+  let timestamp;
+  let updateTeacherFeedbackStub;
+  let getTeacherFeedbackForStudentStub;
+
+  async function wait() {
+    for (let _ = 0; _ < 10; _++) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+  }
+
+  // Stubs updateTeacherFeedback() to call the fail callback only.
+  function stubFailedUpdateTeacherFeedback() {
+    updateTeacherFeedbackStub.returns({
+      done: _ => {
+        return {fail: cb => cb()};
+      },
+    });
+  }
+
+  // Stubs updateTeacherFeedback() to call the done callback only.
+  function stubSuccessfulUpdateTeacherFeedback() {
+    updateTeacherFeedbackStub.returns({
+      done: cb => {
+        cb();
+        return {fail: _ => {}};
+      },
+    });
+  }
+
+  // Stubs HttpClient.post() to throw an error in order to run the catch block
+  function stubFailedSubmitEvaluations() {
+    postStub
+      .withArgs(
+        sinon.match(/\/rubrics\/\d+\/submit_evaluations$/),
+        sinon.match.any,
+        true,
+        sinon.match.any
+      )
+      .returns(
+        new Promise(resolve => {
+          throw new Error('some error');
+        })
+      );
+  }
+
+  // Stubs HttpClient.post() to respond with some incorrect response body
+  function stubInvalidResponseFromSubmitEvaluations() {
+    postStub
+      .withArgs(
+        sinon.match(/\/rubrics\/\d+\/submit_evaluations$/),
+        sinon.match.any,
+        true,
+        sinon.match.any
+      )
+      .returns(
+        new Promise(resolve => {
+          resolve({
+            json: () =>
+              Promise.resolve({
+                someOtherStuff: 42,
+              }),
+          });
+        })
+      );
+  }
+
+  // Stubs HttpClient.post() to respond with the expected response body
+  function stubSuccessfulSubmitEvaluations() {
+    postStub
+      .withArgs(
+        sinon.match(/\/rubrics\/\d+\/submit_evaluations$/),
+        sinon.match.any,
+        true,
+        sinon.match.any
+      )
+      .returns(
+        new Promise(resolve => {
+          resolve({
+            json: () =>
+              Promise.resolve({
+                submittedAt: timestamp,
+              }),
+          });
+        })
+      );
+  }
+
+  // Stubs getTeacherFeedbackForStudent to respond successfully as expected
+  function stubGetTeacherFeedbackForStudent(
+    studentId,
+    levelId,
+    scriptId,
+    data
+  ) {
+    const request = sinon.stub();
+    request.getResponseHeader = sinon
+      .stub()
+      .withArgs('crsf-token')
+      .returns(crsfToken);
+    getTeacherFeedbackForStudentStub
+      .withArgs(studentId, levelId, scriptId)
+      .returns({
+        done: cb => {
+          new Promise(resolve => {
+            resolve([data, null, request]);
+          }).then(([a, b, c]) => {
+            cb(a, b, c);
+          });
+        },
+      });
+  }
+
+  beforeEach(() => {
+    // Stub out the updateTeacherFeedback function
+    updateTeacherFeedbackStub = sinon.stub(
+      teacherFeedbackDataApi,
+      'updateTeacherFeedback'
+    );
+    updateTeacherFeedbackStub.returns({});
+
+    // Stub out the getTeacherFeedbackForStudent and return a crsf token
+    crsfToken = 'some-crsf-token';
+    getTeacherFeedbackForStudentStub = sinon.stub(
+      topInstructionDataApi,
+      'getTeacherFeedbackForStudent'
+    );
+    getTeacherFeedbackForStudentStub.returns({});
+
+    // Stub out the submit with timestamp
+    timestamp = '2024-03-10';
+    postStub = sinon.stub(HttpClient, 'post');
+    postStub.returns({});
+
+    // Stub redux
+    stubRedux();
+    registerReducers({currentUser});
+    store = getStore();
+  });
+
+  afterEach(() => {
+    // Restore all stubs
+    restoreRedux();
+    postStub.restore();
+    getTeacherFeedbackForStudentStub.restore();
+    updateTeacherFeedbackStub.restore();
+  });
+
+  const defaultRubric = {
+    id: 1,
+    learningGoals: [
+      {
+        id: 1,
+        key: '1',
+        learningGoal: 'goal 1',
+        aiEnabled: false,
+        evidenceLevels: [],
+      },
+      {
+        id: 2,
+        key: '2',
+        learningGoal: 'goal 2',
+        aiEnabled: true,
+        evidenceLevels: [],
+      },
+    ],
+    script: {
+      id: 42,
+    },
+    lesson: {
+      position: 3,
+      name: 'Data Structures',
+    },
+    level: {
+      id: 107,
+      name: 'test_level',
+      position: 7,
+    },
+  };
+
+  const defaultStudentInfo = {user_id: 1, name: 'Jane Doe'};
+
+  it('gets the prior teacher feedback and remembers csrf-token', async () => {
+    const priorTimestamp = '2024-02-09';
+    stubGetTeacherFeedbackForStudent(
+      defaultStudentInfo.user_id,
+      defaultRubric.level.id,
+      defaultRubric.script.id,
+      [{review_state: '', created_at: priorTimestamp}]
+    );
+    stubSuccessfulUpdateTeacherFeedback();
+    stubSuccessfulSubmitEvaluations();
+
+    const user = userEvent.setup();
+
+    const {container} = render(
+      <Provider store={store}>
+        <RubricSubmitFooter
+          rubric={defaultRubric}
+          reportingData={{}}
+          studentLevelInfo={defaultStudentInfo}
+          open
+        />
+      </Provider>
+    );
+
+    // See that the submit button and keep working checkbox is disabled
+    const checkbox = screen.getByLabelText(i18n.aiSubmitShouldKeepWorking());
+    expect(checkbox.disabled).to.be.true;
+    const button = screen.getByRole('button', {name: i18n.submitToStudent()});
+    expect(button.disabled).to.be.true;
+
+    // Wait until feedback is retrieved successfully
+    await wait();
+
+    // See that the submit button is enabled
+    expect(checkbox.disabled).to.be.false;
+    expect(button.disabled).to.be.false;
+
+    // Assert that 'feedback submitted' appears with the old timestamp
+    const priorDate = new Date(priorTimestamp);
+    const priorCheck = priorDate.toLocaleString();
+    expect(
+      container.querySelector('#ui-feedback-submitted-timestamp').textContent
+    ).to.contain(priorCheck);
+
+    // Press submit, wait until things resolve, and see the crsf-token from the initial request
+    await user.click(button);
+    sinon.assert.calledWith(
+      updateTeacherFeedbackStub,
+      sinon.match.any,
+      crsfToken
+    );
+
+    // Assert that the post was also called
+    sinon.assert.called(postStub);
+
+    // Assert that 'feedback submitted' appears
+    const lastSubmittedDateObj = new Date(timestamp);
+    const check = lastSubmittedDateObj.toLocaleString();
+    expect(
+      container.querySelector('#ui-feedback-submitted-timestamp').textContent
+    ).to.contain(check);
+  });
+
+  it('gracefully handles no prior teacher feedback and still sets csrf-token', async () => {
+    stubGetTeacherFeedbackForStudent(
+      defaultStudentInfo.user_id,
+      defaultRubric.level.id,
+      defaultRubric.script.id,
+      []
+    );
+    stubSuccessfulUpdateTeacherFeedback();
+    stubSuccessfulSubmitEvaluations();
+    const user = userEvent.setup();
+
+    const {container} = render(
+      <Provider store={store}>
+        <RubricSubmitFooter
+          rubric={defaultRubric}
+          reportingData={{}}
+          studentLevelInfo={defaultStudentInfo}
+          open
+        />
+      </Provider>
+    );
+
+    // See that the submit button and keep working checkbox is disabled
+    const checkbox = screen.getByLabelText(i18n.aiSubmitShouldKeepWorking());
+    expect(checkbox.disabled).to.be.true;
+    const button = screen.getByRole('button', {name: i18n.submitToStudent()});
+    expect(button.disabled).to.be.true;
+
+    // There's no prior timestamp
+    expect(
+      container.querySelector('#ui-feedback-submitted-timestamp').textContent
+    ).to.equal('');
+
+    // Wait until feedback is retrieved successfully
+    await wait();
+
+    // See that the submit button is enabled
+    expect(checkbox.disabled).to.be.false;
+    expect(button.disabled).to.be.false;
+
+    // Press submit, wait until things resolve, and see the crsf-token from the initial request
+    await user.click(button);
+    sinon.assert.calledWith(
+      updateTeacherFeedbackStub,
+      sinon.match.any,
+      crsfToken
+    );
+    sinon.assert.called(postStub);
+  });
+
+  it('sets keepWorking when previously set in teacher feedback', async () => {
+    stubGetTeacherFeedbackForStudent(
+      defaultStudentInfo.user_id,
+      defaultRubric.level.id,
+      defaultRubric.script.id,
+      [{review_state: 'keepWorking'}]
+    );
+
+    render(
+      <Provider store={store}>
+        <RubricSubmitFooter
+          rubric={defaultRubric}
+          reportingData={{}}
+          studentLevelInfo={defaultStudentInfo}
+          open
+        />
+      </Provider>
+    );
+
+    // See that the submit button and keep working checkbox is disabled
+    const checkbox = screen.getByLabelText(i18n.aiSubmitShouldKeepWorking());
+    expect(checkbox.checked).to.be.false;
+
+    // Wait until feedback is retrieved successfully
+    await wait();
+
+    // See that the submit button is enabled
+    expect(checkbox.checked).to.be.true;
+  });
+
+  it('handles successful submit button click by not displaying any error text', async () => {
+    stubGetTeacherFeedbackForStudent(
+      defaultStudentInfo.user_id,
+      defaultRubric.level.id,
+      defaultRubric.script.id,
+      []
+    );
+    stubSuccessfulUpdateTeacherFeedback();
+    stubSuccessfulSubmitEvaluations();
+    const user = userEvent.setup();
+
+    const {container} = render(
+      <Provider store={store}>
+        <RubricSubmitFooter
+          rubric={defaultRubric}
+          reportingData={{}}
+          studentLevelInfo={defaultStudentInfo}
+          open
+        />
+      </Provider>
+    );
+
+    // There's no prior timestamp
+    expect(
+      container.querySelector('#ui-feedback-submitted-timestamp').textContent
+    ).to.equal('');
+
+    // Wait until feedback is retrieved successfully
+    await wait();
+
+    // Press submit, wait until things resolve, and see the crsf-token from the initial request
+    const button = screen.getByRole('button', {name: i18n.submitToStudent()});
+    await user.click(button);
+    sinon.assert.calledWith(
+      updateTeacherFeedbackStub,
+      sinon.match.any,
+      crsfToken
+    );
+    sinon.assert.called(postStub);
+
+    // Assert that the feedback error is NOT there
+    expect(container.querySelector('#ui-feedback-submitted-error')).to.be.null;
+  });
+
+  it('handles error updating feedback on submit button click', async () => {
+    stubGetTeacherFeedbackForStudent(
+      defaultStudentInfo.user_id,
+      defaultRubric.level.id,
+      defaultRubric.script.id,
+      []
+    );
+    stubFailedUpdateTeacherFeedback();
+    const user = userEvent.setup();
+
+    const {container} = render(
+      <Provider store={store}>
+        <RubricSubmitFooter
+          rubric={defaultRubric}
+          reportingData={{}}
+          studentLevelInfo={defaultStudentInfo}
+          open
+        />
+      </Provider>
+    );
+
+    // There's no prior timestamp
+    expect(
+      container.querySelector('#ui-feedback-submitted-timestamp').textContent
+    ).to.equal('');
+
+    // Wait until feedback is retrieved successfully
+    await wait();
+
+    // Press submit
+    const button = screen.getByRole('button', {name: i18n.submitToStudent()});
+    await user.click(button);
+
+    // Assert that the feedback error appears
+    expect(
+      container.querySelector('#ui-feedback-submitted-error').textContent
+    ).to.contain(i18n.errorSubmittingFeedback());
+  });
+
+  it('handles error submitting evaluations on submit button click', async () => {
+    stubGetTeacherFeedbackForStudent(
+      defaultStudentInfo.user_id,
+      defaultRubric.level.id,
+      defaultRubric.script.id,
+      []
+    );
+    stubSuccessfulUpdateTeacherFeedback();
+    stubFailedSubmitEvaluations();
+    const user = userEvent.setup();
+
+    const {container} = render(
+      <Provider store={store}>
+        <RubricSubmitFooter
+          rubric={defaultRubric}
+          reportingData={{}}
+          studentLevelInfo={defaultStudentInfo}
+          open
+        />
+      </Provider>
+    );
+
+    // There's no prior timestamp
+    expect(
+      container.querySelector('#ui-feedback-submitted-timestamp').textContent
+    ).to.equal('');
+
+    // Wait until feedback is retrieved successfully
+    await wait();
+
+    // Press submit
+    const button = screen.getByRole('button', {name: i18n.submitToStudent()});
+    await user.click(button);
+
+    // Assert that the feedback error appears
+    expect(
+      container.querySelector('#ui-feedback-submitted-error').textContent
+    ).to.contain(i18n.errorSubmittingFeedback());
+  });
+
+  it('handles error when submitting evaluations returns an invalid response on submit button click', async () => {
+    stubGetTeacherFeedbackForStudent(
+      defaultStudentInfo.user_id,
+      defaultRubric.level.id,
+      defaultRubric.script.id,
+      []
+    );
+    stubSuccessfulUpdateTeacherFeedback();
+    stubInvalidResponseFromSubmitEvaluations();
+    const user = userEvent.setup();
+
+    const {container} = render(
+      <Provider store={store}>
+        <RubricSubmitFooter
+          rubric={defaultRubric}
+          reportingData={{}}
+          studentLevelInfo={defaultStudentInfo}
+          open
+        />
+      </Provider>
+    );
+
+    // There's no prior timestamp
+    expect(
+      container.querySelector('#ui-feedback-submitted-timestamp').textContent
+    ).to.equal('');
+
+    // Wait until feedback is retrieved successfully
+    await wait();
+
+    // Press submit
+    const button = screen.getByRole('button', {name: i18n.submitToStudent()});
+    await user.click(button);
+
+    // Assert that the feedback error appears
+    expect(
+      container.querySelector('#ui-feedback-submitted-error').textContent
+    ).to.contain(i18n.errorSubmittingFeedback());
+  });
+});

--- a/apps/test/unit/templates/rubrics/RubricSubmitFooterTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricSubmitFooterTest.jsx
@@ -232,16 +232,16 @@ describe('RubricSubmitFooter', () => {
 
     // See that the submit button and keep working checkbox is disabled
     const checkbox = screen.getByLabelText(i18n.aiSubmitShouldKeepWorking());
-    expect(checkbox.disabled).to.be.true;
+    expect(checkbox).to.be.disabled;
     const button = screen.getByRole('button', {name: i18n.submitToStudent()});
-    expect(button.disabled).to.be.true;
+    expect(button).to.be.disabled;
 
     // Wait until feedback is retrieved successfully
     await wait();
 
     // See that the submit button is enabled
-    expect(checkbox.disabled).to.be.false;
-    expect(button.disabled).to.be.false;
+    expect(checkbox).to.not.be.disabled;
+    expect(button).to.not.be.disabled;
 
     // Assert that 'feedback submitted' appears with the old timestamp
     const priorDate = new Date(priorTimestamp);
@@ -293,9 +293,9 @@ describe('RubricSubmitFooter', () => {
 
     // See that the submit button and keep working checkbox is disabled
     const checkbox = screen.getByLabelText(i18n.aiSubmitShouldKeepWorking());
-    expect(checkbox.disabled).to.be.true;
+    expect(checkbox).to.be.disabled;
     const button = screen.getByRole('button', {name: i18n.submitToStudent()});
-    expect(button.disabled).to.be.true;
+    expect(button).to.be.disabled;
 
     // There's no prior timestamp
     expect(
@@ -340,13 +340,13 @@ describe('RubricSubmitFooter', () => {
 
     // See that the submit button and keep working checkbox is disabled
     const checkbox = screen.getByLabelText(i18n.aiSubmitShouldKeepWorking());
-    expect(checkbox.checked).to.be.false;
+    expect(checkbox).to.be.checked;
 
     // Wait until feedback is retrieved successfully
     await wait();
 
     // See that the submit button is enabled
-    expect(checkbox.checked).to.be.true;
+    expect(checkbox).to.be.checked;
   });
 
   it('handles successful submit button click by not displaying any error text', async () => {

--- a/apps/test/unit/templates/rubrics/RubricSubmitFooterTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricSubmitFooterTest.jsx
@@ -306,8 +306,8 @@ describe('RubricSubmitFooter', () => {
     await wait();
 
     // See that the submit button is enabled
-    expect(checkbox.disabled).to.be.false;
-    expect(button.disabled).to.be.false;
+    expect(checkbox).to.not.be.disabled;
+    expect(button).to.not.be.disabled;
 
     // Press submit, wait until things resolve, and see the crsf-token from the initial request
     await user.click(button);

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -1,9 +1,9 @@
 class RubricsController < ApplicationController
   include Rails.application.routes.url_helpers
 
-  before_action :require_levelbuilder_mode_or_test_env, except: [:submit_evaluations, :get_ai_evaluations, :get_teacher_evaluations, :get_teacher_feedback, :ai_evaluation_status_for_user, :ai_evaluation_status_for_all, :run_ai_evaluations_for_user, :run_ai_evaluations_for_all]
-  load_resource only: [:get_teacher_evaluations, :get_teacher_feedback, :ai_evaluation_status_for_user, :ai_evaluation_status_for_all, :run_ai_evaluations_for_user, :run_ai_evaluations_for_all]
-  load_and_authorize_resource except: [:submit_evaluations, :get_ai_evaluations, :get_teacher_evaluations, :get_teacher_feedback, :ai_evaluation_status_for_user, :ai_evaluation_status_for_all, :run_ai_evaluations_for_user, :run_ai_evaluations_for_all]
+  before_action :require_levelbuilder_mode_or_test_env, except: [:submit_evaluations, :get_ai_evaluations, :get_teacher_evaluations, :ai_evaluation_status_for_user, :ai_evaluation_status_for_all, :run_ai_evaluations_for_user, :run_ai_evaluations_for_all]
+  load_resource only: [:get_teacher_evaluations, :ai_evaluation_status_for_user, :ai_evaluation_status_for_all, :run_ai_evaluations_for_user, :run_ai_evaluations_for_all]
+  load_and_authorize_resource except: [:submit_evaluations, :get_ai_evaluations, :get_teacher_evaluations, :ai_evaluation_status_for_user, :ai_evaluation_status_for_all, :run_ai_evaluations_for_user, :run_ai_evaluations_for_all]
 
   # GET /rubrics/:rubric_id/edit
   def edit
@@ -45,7 +45,7 @@ class RubricsController < ApplicationController
   # POST /rubrics/:id/submit_evaluations
   def submit_evaluations
     return head :forbidden unless current_user&.teacher?
-    permitted_params = params.permit(:id, :student_id, :keep_working)
+    permitted_params = params.permit(:id, :student_id)
     rubric = Rubric.find(permitted_params[:id])
     learning_goal_ids = LearningGoal.where(rubric_id: permitted_params[:id]).pluck(:id)
     evaluations = LearningGoalTeacherEvaluation.where(user_id: permitted_params[:student_id], learning_goal_id: learning_goal_ids, teacher_id: current_user.id)
@@ -67,16 +67,6 @@ class RubricsController < ApplicationController
         version_id = source_data[:version_id]
       end
     end
-
-    # Update the main TeacherFeedback
-    teacher_feedback = TeacherFeedback.find_or_create_by!(student_id: permitted_params[:student_id], teacher_id: current_user.id, script: rubric.get_script_level.script, level: rubric.level)
-
-    if permitted_params[:keep_working]
-      teacher_feedback.update(review_state: TeacherFeedback::REVIEW_STATES.keepWorking)
-    else
-      teacher_feedback.update(review_state: nil)
-    end
-    teacher_feedback.save!
 
     submitted_at = Time.now
     if evaluations.update_all(submitted_at: submitted_at, project_id: project_id, project_version: version_id)
@@ -116,23 +106,6 @@ class RubricsController < ApplicationController
         group_by(&:learning_goal_id).
         map {|_, eval_list| eval_list.max_by(&:submitted_at)}
     render json: teacher_evaluations.map(&:summarize_for_participant)
-  end
-
-  def get_teacher_feedback
-    return head :bad_request unless current_user
-
-    permitted_params = params.permit(:id, :student_id)
-    teacher_feedback = TeacherFeedback.get_latest_feedback_given(
-      permitted_params[:student_id],
-      @rubric.level.id,
-      current_user.id,
-      @rubric.get_script_level.script.id
-    )
-    summarization = {}
-    [:created_at, :updated_at, :review_state].each do |k|
-      summarization[k] = teacher_feedback[k]
-    end
-    render json: summarization.compact
   end
 
   def run_ai_evaluations_for_user

--- a/dashboard/app/models/rubric.rb
+++ b/dashboard/app/models/rubric.rb
@@ -26,11 +26,15 @@ class Rubric < ApplicationRecord
     {
       id: id,
       learningGoals: learning_goals.map(&:summarize),
+      script: {
+        id: get_script_level.script.id,
+      },
       lesson: {
         name: lesson.name,
         position: lesson.relative_position,
       },
       level: {
+        id: level.id,
         name: level.name,
         position: script_level&.position,
       }

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1071,6 +1071,7 @@ Dashboard::Application.routes.draw do
       member do
         get 'get_ai_evaluations'
         get 'get_teacher_evaluations'
+        get 'get_teacher_feedback'
         get 'ai_evaluation_status_for_user'
         get 'ai_evaluation_status_for_all'
         post 'run_ai_evaluations_for_user'

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1071,7 +1071,6 @@ Dashboard::Application.routes.draw do
       member do
         get 'get_ai_evaluations'
         get 'get_teacher_evaluations'
-        get 'get_teacher_feedback'
         get 'ai_evaluation_status_for_user'
         get 'ai_evaluation_status_for_all'
         post 'run_ai_evaluations_for_user'


### PR DESCRIPTION
Adds a 'sticky' footer to the bottom of the rubric modal.

This:
* Adds this footer... moving it from `RubricContent` to `RubricContainer` so it can exist outside of the content level
* Fixes an issue where the tab does not show for teacher feedback, but the textarea will, causing a 'are you sure' to appear on every navigation once general feedback is added
* Adds a route for adding general feedback relative to a student and rubric that is used to mark the student progress as 'keep working'
* Currently, it will write blank general feedback for this using the pre-existing mechanism.
* Refactors a bit of the tests that were getting unwieldy due to lots of async network activity.

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/e0007f00-656f-4111-8c40-36367bce840c)

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/ff47f591-8ba3-479a-8a21-c71cd442177b)

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/3588c045-9a37-491c-acce-1de20b66560e)

The 'keep working' checkbox causes the student's bubble to reflect this in the progress view:

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/86f1a141-a381-4766-9cd8-107e59f78e10)

**Updated:** New styling that pushes down the feedback text a little bit:

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/66a5a99b-a8d2-4a96-8c45-8fc813c37b30)

## Links

- figma; [design](https://www.figma.com/file/WBcs7BY9IC6Nq5rG4V1SWF/AI-TA%3A-Rubrics?type=design&node-id=3488-115&mode=design&t=HDR4VqGdJWqj0Vh0-0)
- jira ticket: [AITT-469](https://codedotorg.atlassian.net/browse/AITT-469)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
