### PR TITLE
Setup initial levelbuilder editing for Gen AI fields

### DIFF
--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -55,7 +55,7 @@ export interface ModelCardInfo {
 }
 
 // Visibility for AI customization fields set by levelbuilders.
-type Visibility = 'hidden' | 'readonly' | 'editable';
+export type Visibility = 'hidden' | 'readonly' | 'editable';
 
 /**
  * Level-defined AI customizations for student chat bots set by levelbuilders on the level's properties.

--- a/apps/src/lab2/levelEditors/aiCustomizations/EditAiCustomizations.tsx
+++ b/apps/src/lab2/levelEditors/aiCustomizations/EditAiCustomizations.tsx
@@ -1,0 +1,92 @@
+import {
+  AiCustomizations,
+  LevelAiCustomizations,
+  Visibility,
+} from '@cdo/apps/aichat/types';
+import React, {useCallback, useState} from 'react';
+import {AppName} from '../../types';
+import {Heading3} from '@cdo/apps/componentLibrary/typography';
+import SimpleDropdown from '@cdo/apps/componentLibrary/simpleDropdown/SimpleDropdown';
+
+interface EditAiCustomizationsProps {
+  initialCustomizations: LevelAiCustomizations;
+  levelName: string;
+  appName: AppName;
+}
+
+const EditAiCustomizations: React.FunctionComponent<
+  EditAiCustomizationsProps
+> = ({initialCustomizations, levelName, appName}) => {
+  const [aiCustomizations, setAiCustomizations] =
+    useState<LevelAiCustomizations>(initialCustomizations);
+
+  const setPropertyVisiblity = useCallback(
+    (property: keyof AiCustomizations, visibility: Visibility) => {
+      setAiCustomizations({
+        ...aiCustomizations,
+        [property]: {
+          value: aiCustomizations[property]?.value,
+          visibility,
+        },
+      });
+    },
+    [setAiCustomizations, aiCustomizations]
+  );
+
+  return (
+    <div>
+      <input
+        type="hidden"
+        id="level_validations"
+        name="level[initial_ai_customizations]"
+        value={JSON.stringify(aiCustomizations)}
+      />
+      <div>
+        <Heading3>Bot Name</Heading3>
+        <input
+          type="text"
+          value={aiCustomizations.botName?.value || ''}
+          onChange={e =>
+            setAiCustomizations({
+              ...aiCustomizations,
+              botName: {
+                value: e.target.value,
+                visibility: aiCustomizations.botName?.visibility,
+              },
+            })
+          }
+        />
+        <VisibilityDropdown
+          property="botName"
+          setVisibility={setPropertyVisiblity}
+        />
+      </div>
+    </div>
+  );
+};
+
+const VisibilityDropdown: React.FunctionComponent<{
+  property: keyof AiCustomizations;
+  setVisibility: (
+    property: keyof AiCustomizations,
+    visibility: Visibility
+  ) => void;
+}> = ({property, setVisibility}) => {
+  return (
+    <SimpleDropdown
+      labelText="Visibility"
+      name="bot_name_visibility"
+      size="s"
+      items={[
+        {value: 'hidden', text: 'Hidden'},
+        {value: 'readonly', text: 'Readonly'},
+        {value: 'editable', text: 'Editable'},
+      ]}
+      onChange={e => {
+        setVisibility(property, e.target.value as Visibility);
+      }}
+    />
+  );
+};
+
+export default EditAiCustomizations;

--- a/apps/src/lab2/levelEditors/aiCustomizations/EditAiCustomizations.tsx
+++ b/apps/src/lab2/levelEditors/aiCustomizations/EditAiCustomizations.tsx
@@ -41,7 +41,7 @@ const EditAiCustomizations: React.FunctionComponent<
     <div>
       <input
         type="hidden"
-        id="level_validations"
+        id="level_initial_ai_customizations"
         name="level[initial_ai_customizations]"
         value={JSON.stringify(aiCustomizations)}
       />
@@ -51,7 +51,7 @@ const EditAiCustomizations: React.FunctionComponent<
         <br />
         <b>Editable:</b> students can change the value.
         <br />
-        <b>Readonly:</b> students can see the value but cannot change it.
+        <b>Read Only:</b> students can see the value but cannot change it.
         <br />
         <b>Hidden:</b> the field is not shown on the customization panel.
       </BodyThreeText>

--- a/apps/src/lab2/levelEditors/aiCustomizations/EditAiCustomizations.tsx
+++ b/apps/src/lab2/levelEditors/aiCustomizations/EditAiCustomizations.tsx
@@ -5,8 +5,12 @@ import {
 } from '@cdo/apps/aichat/types';
 import React, {useCallback, useState} from 'react';
 import {AppName} from '../../types';
-import {Heading3} from '@cdo/apps/componentLibrary/typography';
+import {
+  BodyOneText,
+  BodyThreeText,
+} from '@cdo/apps/componentLibrary/typography';
 import SimpleDropdown from '@cdo/apps/componentLibrary/simpleDropdown/SimpleDropdown';
+import moduleStyles from './edit-ai-customizations.module.scss';
 
 interface EditAiCustomizationsProps {
   initialCustomizations: LevelAiCustomizations;
@@ -41,25 +45,41 @@ const EditAiCustomizations: React.FunctionComponent<
         name="level[initial_ai_customizations]"
         value={JSON.stringify(aiCustomizations)}
       />
-      <div>
-        <Heading3>Bot Name</Heading3>
-        <input
-          type="text"
-          value={aiCustomizations.botName?.value || ''}
-          onChange={e =>
-            setAiCustomizations({
-              ...aiCustomizations,
-              botName: {
-                value: e.target.value,
-                visibility: aiCustomizations.botName?.visibility,
-              },
-            })
-          }
-        />
-        <VisibilityDropdown
-          property="botName"
-          setVisibility={setPropertyVisiblity}
-        />
+      <BodyThreeText>
+        Set the initial values and visibility for AI model customizations.
+        <br />
+        <br />
+        <b>Editable:</b> students can change the value.
+        <br />
+        <b>Readonly:</b> students can see the value but cannot change it.
+        <br />
+        <b>Hidden:</b> the field is not shown on the customization panel.
+      </BodyThreeText>
+      <div className={moduleStyles.fieldSection}>
+        <BodyOneText>Bot Name</BodyOneText>
+        <div className={moduleStyles.fieldRow}>
+          <div className={moduleStyles.fieldValue}>
+            <label htmlFor="botName">Initial Value</label>
+            <input
+              id="botName"
+              type="text"
+              value={aiCustomizations.botName?.value || ''}
+              onChange={e =>
+                setAiCustomizations({
+                  ...aiCustomizations,
+                  botName: {
+                    value: e.target.value,
+                    visibility: aiCustomizations.botName?.visibility,
+                  },
+                })
+              }
+            />
+          </div>
+          <VisibilityDropdown
+            property="botName"
+            setVisibility={setPropertyVisiblity}
+          />
+        </div>
       </div>
     </div>
   );
@@ -78,9 +98,9 @@ const VisibilityDropdown: React.FunctionComponent<{
       name="bot_name_visibility"
       size="s"
       items={[
-        {value: 'hidden', text: 'Hidden'},
-        {value: 'readonly', text: 'Readonly'},
         {value: 'editable', text: 'Editable'},
+        {value: 'readonly', text: 'Read Only'},
+        {value: 'hidden', text: 'Hidden'},
       ]}
       onChange={e => {
         setVisibility(property, e.target.value as Visibility);

--- a/apps/src/lab2/levelEditors/aiCustomizations/edit-ai-customizations.module.scss
+++ b/apps/src/lab2/levelEditors/aiCustomizations/edit-ai-customizations.module.scss
@@ -1,0 +1,15 @@
+.fieldSection {
+  display: flex;
+  flex-direction: column;
+}
+
+.fieldRow {
+  display: flex;
+  flex-direction: row;
+}
+
+.fieldValue {
+  display: flex;
+  flex-direction: column;
+  margin-right: 20px;
+}

--- a/apps/src/sites/studio/pages/levels/editors/fields/_ai_customizations.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_ai_customizations.js
@@ -1,0 +1,22 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import EditAiCustomizations from '@cdo/apps/lab2/levelEditors/aiCustomizations/EditAiCustomizations';
+
+$(document).ready(function () {
+  const initialCustomizations = getScriptData('aicustomizations');
+  const levelName = document.querySelector('script[data-levelname]').dataset
+    .levelname;
+  const appName = document.querySelector('script[data-appname]').dataset
+    .appname;
+
+  ReactDOM.render(
+    <EditAiCustomizations
+      initialCustomizations={initialCustomizations}
+      levelName={levelName}
+      appName={appName}
+    />,
+    document.getElementById('ai-customizations-container')
+  );
+});

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -128,6 +128,7 @@ const INTERNAL_ENTRIES = {
   'levels/editors/_applab': './src/sites/studio/pages/levels/editors/_applab.js',
   'levels/editors/_craft': './src/sites/studio/pages/levels/editors/_craft.js',
   'levels/editors/_dsl': './src/sites/studio/pages/levels/editors/_dsl.js',
+  'levels/editors/fields/_ai_customizations': './src/sites/studio/pages/levels/editors/fields/_ai_customizations.js',
   'levels/editors/fields/_animation': './src/sites/studio/pages/levels/editors/fields/_animation.js',
   'levels/editors/fields/_bubble_choice_sublevel': './src/sites/studio/pages/levels/editors/fields/_bubble_choice_sublevel.js',
   'levels/editors/fields/_blockly': './src/sites/studio/pages/levels/editors/fields/_blockly.js',

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -286,7 +286,6 @@ class LevelsController < ApplicationController
   # PATCH/PUT /levels/1
   # PATCH/PUT /levels/1.json
   def update
-    puts "Updating level"
     if level_params[:name] &&
         @level.name != level_params[:name] &&
         @level.name.casecmp?(level_params[:name])
@@ -298,16 +297,13 @@ class LevelsController < ApplicationController
     end
 
     update_level_params = level_params.to_h
-    p update_level_params
 
-    # Parse the incoming level_data JSON so that it's stored in the database as a
-    # first-order member of the properties JSON, rather than simply as a string of
-    # JSON belonging to a single property.
+    # Parse a few specific JSON fields used by modern (Lab2) labs so that they are
+    # stored in the database as a first-order member of the properties JSON, rather
+    # than simply as a string of JSON belonging to a single property.
     [:level_data, :initial_ai_customizations].each do |key|
       update_level_params[key] = JSON.parse(update_level_params[key]) if update_level_params[key]
     end
-    #update_level_params[:level_data] = JSON.parse(level_params[:level_data]) if level_params[:level_data]
-    #update_level_params[:initial_ai_customizations] = JSON.parse(level_params[:initial_ai_customizations]) if level_params[:initial_ai_customizations]
     # Update level data with validations, and remove from level properties.
     # We can remove this once validations are read from level properties directly.
     update_level_params[:level_data]["validations"] = JSON.parse(update_level_params[:validations]) if update_level_params[:validations]

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -286,6 +286,7 @@ class LevelsController < ApplicationController
   # PATCH/PUT /levels/1
   # PATCH/PUT /levels/1.json
   def update
+    puts "Updating level"
     if level_params[:name] &&
         @level.name != level_params[:name] &&
         @level.name.casecmp?(level_params[:name])
@@ -297,11 +298,16 @@ class LevelsController < ApplicationController
     end
 
     update_level_params = level_params.to_h
+    p update_level_params
 
     # Parse the incoming level_data JSON so that it's stored in the database as a
     # first-order member of the properties JSON, rather than simply as a string of
     # JSON belonging to a single property.
-    update_level_params[:level_data] = JSON.parse(level_params[:level_data]) if level_params[:level_data]
+    [:level_data, :initial_ai_customizations].each do |key|
+      update_level_params[key] = JSON.parse(update_level_params[key]) if update_level_params[key]
+    end
+    #update_level_params[:level_data] = JSON.parse(level_params[:level_data]) if level_params[:level_data]
+    #update_level_params[:initial_ai_customizations] = JSON.parse(level_params[:initial_ai_customizations]) if level_params[:initial_ai_customizations]
     # Update level data with validations, and remove from level properties.
     # We can remove this once validations are read from level properties directly.
     update_level_params[:level_data]["validations"] = JSON.parse(update_level_params[:validations]) if update_level_params[:validations]

--- a/dashboard/app/models/levels/aichat.rb
+++ b/dashboard/app/models/levels/aichat.rb
@@ -29,6 +29,7 @@ class Aichat < Level
     system_prompt
     bot_title
     bot_description
+    initial_ai_customizations
   )
 
   def self.create_from_level_builder(params, level_params)

--- a/dashboard/app/views/levels/editors/_aichat.html.haml
+++ b/dashboard/app/views/levels/editors/_aichat.html.haml
@@ -1,3 +1,4 @@
 = render partial: 'levels/editors/fields/aichat_fields', locals: {f: f}
 = render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/ai_customizations', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_ai_customizations.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_ai_customizations.html.haml
@@ -1,0 +1,8 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#ai-customizations-container"}}
+  AI ChatBot Customizations
+
+#ai-customizations-container.in.collapse
+
+- content_for :body_scripts do
+  %script{src: webpack_asset_path('js/levels/editors/fields/_ai_customizations.js'),
+        data: {aicustomizations: (@level.properties["initial_ai_customizations"] || {}).to_json, levelname: @level.name, appname: @level.game&.app}}


### PR DESCRIPTION
This is primarily adding the plumbing and boilerplate to hook up the React-based editing UI with the levelbuilder system. I've also just added one field (bot name) to get things working end-to-end. The rest of the fields will come in a separate change.

@dancodedotorg let me know if this is looking ok so far and if I should reword any of the text/labels for clarity!

<img width="757" alt="Screenshot 2024-03-05 at 11 52 53 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/fd4b21cd-8225-4007-aa03-0fbd6ee14b33">

Once saved, this data is available in level properties (screenshot of the JSON returned from the /level_properties server call):

<img width="607" alt="Screenshot 2024-03-05 at 11 48 19 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/1a2f539a-2884-4c64-8c5d-8c5aa90c24ba">


## Links

https://codedotorg.atlassian.net/browse/LABS-516

## Testing story

Tested locally on allthethings AI Chat level. Confirmed that level properties are updated and read correctly.