### PR TITLE
Remove important rule from icon style

### DIFF
--- a/apps/src/templates/tables/QuickActionsCell.jsx
+++ b/apps/src/templates/tables/QuickActionsCell.jsx
@@ -145,13 +145,11 @@ const styles = {
     [QuickActionsCellType.body]: {
       border: '1px solid ' + color.white,
       borderRadius: 5,
-      color: color.darker_gray,
       margin: 3,
     },
     [QuickActionsCellType.header]: {
       fontSize: 20,
       lineHeight: '15px',
-      color: color.charcoal,
     },
   },
   hoverFocus: {
@@ -159,7 +157,6 @@ const styles = {
       backgroundColor: color.lighter_gray,
       border: '1px solid ' + color.light_gray,
       borderRadius: 5,
-      color: color.white,
     },
   },
 };

--- a/shared/css/phase1-design-system.scss
+++ b/shared/css/phase1-design-system.scss
@@ -160,7 +160,7 @@ p {
       background-color: $neutral_dark !important;
 
       i {
-        color: $neutral_white;
+        color: $neutral_white !important;
       }
     }
 

--- a/shared/css/phase1-design-system.scss
+++ b/shared/css/phase1-design-system.scss
@@ -160,7 +160,7 @@ p {
       background-color: $neutral_dark !important;
 
       i {
-        color: $neutral_white !important;
+        color: $neutral_white;
       }
     }
 
@@ -169,7 +169,7 @@ p {
       background-color: $neutral_light;
 
       i {
-        color: $neutral_dark !important;
+        color: $neutral_dark;
       }
     }
   }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR removes the `!important` rule from the style rules of icons used in a table row within id `classroom-sections` or `uitest-personal-projects`.

This is no longer needed since `!important` is no longer used for icons in `application.scss`.

This change is motivated by updates made in https://github.com/code-dot-org/code-dot-org/pull/56932. See discussion [here](https://github.com/code-dot-org/code-dot-org/pull/56932/files#r1511566155)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
