### PR TITLE
P20-750: LTI integration early access

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -7,6 +7,9 @@ require "clients/lti_advantage_client"
 require "cdo/honeybadger"
 
 class LtiV1Controller < ApplicationController
+  before_action -> {redirect_to lti_v1_integrations_path, alert: I18n.t('lti.integration.early_access.closed')},
+                if: -> {Policies::Lti.early_access_closed?}, only: :create_integration
+
   # Don't require an authenticity token because LTI Platforms POST to this
   # controller.
   skip_before_action :verify_authenticity_token
@@ -324,7 +327,7 @@ class LtiV1Controller < ApplicationController
       {platform: key, name: value[:name]}
     end
 
-    render lti_v1_integrations_path
+    render template: Policies::Lti.early_access? ? 'lti/v1/integrations/early_access' : 'lti/v1/integrations'
   end
 
   # POST /lti/v1/upgrade_account

--- a/dashboard/app/views/lti/v1/integrations.html.haml
+++ b/dashboard/app/views/lti/v1/integrations.html.haml
@@ -8,36 +8,7 @@
       %p= t('lti.integration.form_instructions')
       %p
         != I18n.t('lti.integration.form_instructions_2', install_instructions: SharedConstants::LMS_LINKS.INSTALL_INSTRUCTIONS_URL, markdown: true)
-    = form_with(url: :lti_v1_integrations, method: :post, class: "lti-integration-form") do |f|
-      .row
-        .span8
-          .padded-container
-            .row
-              .span3.lti-integration-field-label
-                = f.label :name, t('lti.integration.name')
-              .span5
-                = f.text_field :name, maxlength: 100
-            .row
-              .span3.lti-integration-field-label
-                = f.label :client_id, t('lti.integration.client_id')
-              .span5
-                = f.text_field :client_id, maxlength: 50
-            .row
-              .span3.lti-integration-field-label
-                = f.label :email, t('lti.integration.email')
-              .span5
-                = f.email_field :email, maxlength: 255
-            .row
-              .span3.lti-integration-field-label
-                = f.label :lms, t('lti.integration.lms_selector')
-              .span5
-                = f.select :lms, @form_data[:lms_platforms].map {|p| [p[:name], p[:platform].to_s]}
-            .row
-              .span10
-                %p
-                  != I18n.t('lti.integration.form_instructions_3', lms_guides: 'https://support.code.org/hc/en-us/articles/23120014459405-Learning-Management-System-LMS-and-Single-Sign-On-SSO-Integrations-and-Support-for-Code-org', contact_us: SharedConstants::EMAIL_LINKS.CONTACT_US_URL, markdown: true)
-
-            %button.lti-btn-purple= t('lti.integration.register')
+      = render partial: 'lti/v1/integrations/form', locals: {form_data: @form_data}
 
   .row
     .span10

--- a/dashboard/app/views/lti/v1/integrations/_form.html.haml
+++ b/dashboard/app/views/lti/v1/integrations/_form.html.haml
@@ -1,0 +1,30 @@
+= form_with(url: :lti_v1_integrations, method: :post, class: 'lti-integration-form') do |f|
+  .row
+    .span8
+      .padded-container
+        .row
+          .span3.lti-integration-field-label
+            = f.label :name, t('lti.integration.name')
+          .span5
+            = f.text_field :name, maxlength: 100, required: true
+        .row
+          .span3.lti-integration-field-label
+            = f.label :client_id, t('lti.integration.client_id')
+          .span5
+            = f.text_field :client_id, maxlength: 50, required: true
+        .row
+          .span3.lti-integration-field-label
+            = f.label :email, t('lti.integration.email')
+          .span5
+            = f.email_field :email, maxlength: 255, required: true
+        .row
+          .span3.lti-integration-field-label
+            = f.label :lms, t('lti.integration.lms_selector')
+          .span5
+            = f.select :lms, form_data[:lms_platforms].map {|p| [p[:name], p[:platform].to_s]}
+        .row
+          .span10
+            %p
+              != I18n.t('lti.integration.form_instructions_3', lms_guides: 'https://support.code.org/hc/en-us/articles/23120014459405-Learning-Management-System-LMS-and-Single-Sign-On-SSO-Integrations-and-Support-for-Code-org', contact_us: SharedConstants::EMAIL_LINKS.CONTACT_US_URL, markdown: true)
+
+        %button.lti-btn-purple= t('lti.integration.register')

--- a/dashboard/app/views/lti/v1/integrations/early_access.html.haml
+++ b/dashboard/app/views/lti/v1/integrations/early_access.html.haml
@@ -1,0 +1,20 @@
+#lti-integration-portal
+  .row
+    .span10.header
+      %h1= t('lti.integration.early_access.form_header')
+
+  - if Policies::Lti.early_access_closed?
+    .row
+      .span10
+        %p= t('lti.integration.early_access.closed')
+        != t('lti.integration.early_access.waitlist', sign_up_link: SharedConstants::LMS_LINKS.INTEGRATION_EARLY_ACCESS_URL, markdown: true)
+  - else
+    .row
+      .span10
+        %p= t('lti.integration.early_access.form_instructions')
+        != t('lti.integration.form_instructions_2', install_instructions: SharedConstants::LMS_LINKS.INSTALL_INSTRUCTIONS_URL, markdown: true)
+        = render partial: 'lti/v1/integrations/form', locals: {form_data: @form_data}
+
+    .row
+      .span10
+        %em!= t('lti.integration.privacy_policy', privacy_policy: SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL, markdown: true)

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1441,6 +1441,13 @@ en:
       success_body: "Great news! Your LMS has been registered with Code.org, and you can continue installing and using your LMS integration. You should receive a confirmation email shortly."
       success_header: "Thank you for registering your LMS!"
       register: "Register LMS"
+      early_access:
+        closed: Sorry, all Early Access slots for Code.org Learning Management System Integrations have been claimed.
+        waitlist: Please [sign-up here](%{sign_up_link}) to join the Early Access waitlist and get updates about LMS Integration releases.
+        form_header: Register your LMS for Integration Early Access
+        form_instructions:
+          Please use this form to register your Learning Management System (LMS) with Code.org.
+          This will allow Early Access to install our LTI integration on your LMS.
     upgrade_to_teacher_account:
       error:
         missing_email: "Missing required parameter: Email"

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -117,4 +117,17 @@ class Policies::Lti
   def self.roster_sync_enabled?(user)
     user.teacher? && user.lti_roster_sync_enabled
   end
+
+  def self.early_access?
+    DCDO.get('lti_early_access_limit', false).present?
+  end
+
+  def self.early_access_closed?
+    return unless early_access?
+
+    lti_early_access_limit = DCDO.get('lti_early_access_limit', false)
+    return false unless lti_early_access_limit.is_a?(Integer)
+
+    LtiIntegration.count >= lti_early_access_limit
+  end
 end

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -553,6 +553,22 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_response :internal_server_error
   end
 
+  test 'integration form - renders the integration template' do
+    Policies::Lti.stubs(:early_access?).returns(false)
+
+    get '/lti/v1/integrations'
+
+    assert_template 'lti/v1/integrations'
+  end
+
+  test 'integration form - renders the early access template when early access is enabled' do
+    Policies::Lti.stubs(:early_access?).returns(true)
+
+    get '/lti/v1/integrations'
+
+    assert_template 'lti/v1/integrations/early_access'
+  end
+
   test 'integration - given valid inputs, creates a new integration if one does not exist' do
     name = "Fake School"
     client_id = "1234canvas"
@@ -567,6 +583,22 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
     post '/lti/v1/integrations', params: {name: name, client_id: client_id, lms: lms, email: email}
     assert_response :ok
+  end
+
+  test 'integration - redirects to the form without integration creation when early access is closed' do
+    Policies::Lti.expects(:early_access_closed?).returns(true)
+
+    name = 'Fake School'
+    client_id = '1234canvas'
+    lms = 'canvas_cloud'
+    email = 'fake@email.com'
+
+    assert_no_difference 'LtiIntegration.count' do
+      post '/lti/v1/integrations', params: {name: name, client_id: client_id, lms: lms, email: email}
+    end
+
+    assert_redirected_to lti_v1_integrations_path
+    assert_match /Learning Management System Integrations have been claimed/, flash[:alert]
   end
 
   test 'integration - given missing inputs, does not create a new integration' do

--- a/dashboard/test/views/lti/v1/integrations/early_access_test.rb
+++ b/dashboard/test/views/lti/v1/integrations/early_access_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+require 'policies/lti'
+
+class LtiV1IntegrationEarlyAccessTemplateTest < ActionView::TestCase
+  setup do
+    @form_data = {lms_platforms: [name: 'expected_lms_platform_name', platform: 'expected_lms_platform']}
+  end
+
+  test 'renders the integration form' do
+    Policies::Lti.expects(:early_access_closed?).returns(false)
+
+    render template: 'lti/v1/integrations/early_access'
+
+    refute_includes rendered, 'Sorry, all Early Access slots for Code.org Learning Management System Integrations have been claimed.'
+    refute_includes rendered, 'Please <a href="https://docs.google.com/forms/d/e/1FAIpQLScjfVR4CZs8Utf5vI4mz3e1q8vdH6RNIgTUWygZXN0oovBSQg/viewform">sign-up here</a> to join the Early Access waitlist and get updates about LMS Integration releases.'
+
+    assert_includes rendered, 'Register your LMS for Integration Early Access'
+    assert_includes rendered, 'Please use this form to register your Learning Management System (LMS) with Code.org.'
+    assert_includes rendered, 'This will allow Early Access to install our LTI integration on your LMS.'
+    assert_includes rendered, 'Full guides for obtaining your LMS Client ID, using LMS/LTI integrations, and our list of supported Learning Management Systems <a href="https://support.code.org/hc/en-us/articles/23621907533965-Install-Code-org-Integrations-for-your-Learning-Management-System">can be found here</a>.'
+    assert_includes rendered, 'Your privacy is of utmost importance to us. Your personal information will not be used for any marketing purposes. Please see our <a href="https://code.org/privacy">Privacy Policy here</a> for more information.'
+
+    assert document_root_element.at('form[action="/lti/v1/integrations"]')
+  end
+
+  test 'does not render the integration form when early access is closed' do
+    Policies::Lti.expects(:early_access_closed?).returns(true)
+
+    render template: 'lti/v1/integrations/early_access'
+
+    assert_includes rendered, 'Register your LMS for Integration Early Access'
+    assert_includes rendered, 'Sorry, all Early Access slots for Code.org Learning Management System Integrations have been claimed.'
+    assert_includes rendered, 'Please <a href="https://docs.google.com/forms/d/e/1FAIpQLScjfVR4CZs8Utf5vI4mz3e1q8vdH6RNIgTUWygZXN0oovBSQg/viewform">sign-up here</a> to join the Early Access waitlist and get updates about LMS Integration releases.'
+
+    refute_includes rendered, 'Please use this form to register your Learning Management System (LMS) with Code.org.'
+    refute_includes rendered, 'This will allow Early Access to install our LTI integration on your LMS.'
+    refute_includes rendered, 'Full guides for obtaining your LMS Client ID, using LMS/LTI integrations, and our list of supported Learning Management Systems <a href="https://support.code.org/hc/en-us/articles/23621907533965-Install-Code-org-Integrations-for-your-Learning-Management-System">can be found here</a>.'
+    refute_includes rendered, 'Your privacy is of utmost importance to us. Your personal information will not be used for any marketing purposes. Please see our <a href="https://code.org/privacy">Privacy Policy here</a> for more information.'
+
+    refute document_root_element.at('form[action="/lti/v1/integrations"]')
+  end
+end

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -658,6 +658,7 @@ module SharedConstants
       INTEGRATION_GUIDE_URL: 'https://support.code.org/hc/en-us/articles/23120014459405-Learning-Management-System-LMS-and-Single-Sign-On-SSO-Integrations-and-Support-for-Code-org',
       INSTALL_INSTRUCTIONS_URL: 'https://support.code.org/hc/en-us/articles/23621907533965-Install-Code-org-Integrations-for-your-Learning-Management-System',
       ROSTER_SYNC_INSTRUCTIONS_URL: 'https://support.code.org/hc/en-us/articles/23621978654605-Sync-Rosters-with-your-Learning-Management-System',
+      INTEGRATION_EARLY_ACCESS_URL: 'https://docs.google.com/forms/d/e/1FAIpQLScjfVR4CZs8Utf5vI4mz3e1q8vdH6RNIgTUWygZXN0oovBSQg/viewform',
     }
   ).freeze
 


### PR DESCRIPTION
## DCDO `lti_early_access_limit`
`DCDO.get('lti_early_access_limit', false)` options:
- `false` — Early Access is disabled
- `true` — Early Access is enabled
- `0` — Early Access is closed
- `100` — Early Access is closed when the LTI integration count reaches the provided limit

## Early Access disabled 
<img width="792" alt="Screenshot 2024-03-05 at 22 39 54" src="https://github.com/code-dot-org/code-dot-org/assets/11708250/64b642c0-c280-4ebf-a404-c09b0ac5f551">

## Early Access enabled
<img width="791" alt="Screenshot 2024-03-05 at 22 40 32" src="https://github.com/code-dot-org/code-dot-org/assets/11708250/47a882de-f317-40ba-b3e2-8c01fe8e2d98">

## Early Access closed
<img width="790" alt="Screenshot 2024-03-05 at 22 41 10" src="https://github.com/code-dot-org/code-dot-org/assets/11708250/0475ce92-8a48-4dac-b48e-c4eb9bc544fc">

## Links
- JIRA ticket: [P20-750](https://codedotorg.atlassian.net/browse/P20-750)
- Related JIRA ticket: [P20-753](https://codedotorg.atlassian.net/browse/P20-753)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/55855