### PR TITLE
Add Int'l PL Partners page tile to code.org/administrators

### DIFF
--- a/pegasus/sites.v3/code.org/views/administrators/admins_additional_resources.haml
+++ b/pegasus/sites.v3/code.org/views/administrators/admins_additional_resources.haml
@@ -1,6 +1,13 @@
 :ruby
   resource_item = [
     {
+      title: hoc_s(:heading_intl_opportunities),
+      image: "/images/admins-page-resources-intl.png",
+      desc: hoc_s(:admins_page_resources_desc_intl),
+      url: "/professional-learning/international-partners",
+      button_label: hoc_s(:call_to_action_learn_more)
+    },
+    {
       title: hoc_s(:teach_page_additional_materials_list_heading_02),
       image: "/images/admins-page-resources-videos.png",
       desc: hoc_s(:admins_page_resources_desc_videos),
@@ -16,7 +23,7 @@
     },
   ]
 
-.action-block__wrapper.action-block__wrapper--two-col
+.action-block__wrapper.action-block__wrapper--three-col
   - resource_item.each do |resource_item|
     .action-block.action-block--one-col.flex-space-between
       .content-wrapper
@@ -28,12 +35,3 @@
       .content-footer
         %a.link-button{href: resource_item[:url]}
           = resource_item[:button_label]
-
--# TODO - add this back in once the international opportunities page is live
--# {
--#   title: hoc_s(:heading_intl_opportunities),
--#   image: "/images/admins-page-resources-intl.png",
--#   desc: hoc_s(:admins_page_resources_desc_intl),
--#   url: "#",
--#   button_label: hoc_s(:call_to_action_learn_more)
--# },


### PR DESCRIPTION
Shows the Int'l PL Partners tile on https://code.org/administrators

**Jira ticket:** [ACQ-1585](https://codedotorg.atlassian.net/browse/ACQ-1585)

----

<img width="1036" alt="Screenshot 2024-03-05 at 1 09 11 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/98b528ec-78a5-4a00-8f1f-0211106e3d74">