### PR TITLE
Force LTI launch out of iframe

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -358,7 +358,7 @@ app_servers: {}
 rack_mini_profiler_enabled:
 https_development:
 default_scheme: '<%=(env == 'development') || ci ? 'http:' : 'https:'%>'
-allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net cuantrix.mx <%=pegasus_site_host%> <%=dashboard_site_host%> curriculum.code.org https://*.lausd.iap.allhere.co
+allowed_iframe_ancestors: https://*.schoology.com http://*.disney.com http://*.diznee.net cuantrix.mx <%=pegasus_site_host%> <%=dashboard_site_host%> curriculum.code.org https://*.lausd.iap.allhere.co
 
 skip_locales:
 secret_pictures_csv:

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -77,10 +77,11 @@ class LtiV1Controller < ApplicationController
     rescue => exception
       return log_unauthorized(exception)
     end
-    # client_id is the aud[ience] in the JWT
-    extracted_client_id = decoded_jwt_no_auth[:aud]
+    # client_id is the aud[ience] in the JWT, it can be a string or an array
+    extracted_client_id = decoded_jwt_no_auth[:aud].is_a?(Array) ? decoded_jwt_no_auth[:aud].first : decoded_jwt_no_auth[:aud]
     extracted_issuer_id = decoded_jwt_no_auth[:iss]
 
+    return log_unauthorized('Missing "aud" or "iss" from ID token') unless extracted_client_id.present? && extracted_issuer_id.present?
     # set cache key
     integration_cache_key = "#{extracted_issuer_id}/#{extracted_client_id}"
 

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -221,9 +221,8 @@ class LtiV1Controller < ApplicationController
 
           // Append the new query parameter appropriately
           const auth_url = `${fullUrl}?${idTokenParam}&${stateParam}&${newTabParam}`
-          console.log(`Auth URL: ${auth_url}`)
           // Check if the current window is the top-level window
-          if (window !== window.top) {
+          if (window.location !== window.parent.location) {
             // Create a div to hold the message and button
             var messageDiv = document.createElement("div");
             messageDiv.style.position = "fixed";

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -71,7 +71,6 @@ class LtiV1Controller < ApplicationController
 
   def authenticate
     unless params[:open_in_new_tab]
-      puts "OPEN IN NEW TAB #{params[:open_in_new_tab]}"
       id_token = params[:id_token]
       state = params[:state]
       token_hash = {id_token: id_token, state: state}

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -70,6 +70,9 @@ class LtiV1Controller < ApplicationController
   end
 
   def authenticate
+    # This checks to see if the param new_tab=true is present, which would
+    # indicate we have already mitigated an iframe launch, and are ready to
+    # proceed with the rest of the authentication flow.
     unless params[:new_tab]
       id_token = params[:id_token]
       state = params[:state]
@@ -198,8 +201,8 @@ class LtiV1Controller < ApplicationController
   end
 
   # GET /lti/v1/iframe
-  # Detects if LMS is trying open Code.org in an iframe, prompt user to open in
-  # new tab. The experience is unchanged to non-iframe users.
+  # Detects if an LMS is trying open Code.org in an iframe and prompts user to
+  # open in new tab. The experience is unchanged to non-iframe users.
   def iframe
     auth_url_base = CDO.studio_url('/lti/v1/authenticate', CDO.default_scheme)
     id_token_param = params[:id_token]

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -74,7 +74,6 @@ class LtiV1Controller < ApplicationController
       id_token = params[:id_token]
       state = params[:state]
       token_hash = {id_token: id_token, state: state}
-      # url = "#{lti_v1_iframe_url}?#{token_hash.to_query}"
       redirect_to "#{lti_v1_iframe_url}?#{token_hash.to_query}"
       return
     end
@@ -200,7 +199,7 @@ class LtiV1Controller < ApplicationController
 
   # GET /lti/v1/iframe
   # Detects if LMS is trying open Code.org in an iframe, prompt user to open in
-  # new tab. Non-iframe experience is opaq to user
+  # new tab. The experience is unchanged to non-iframe users.
   def iframe
     render html: <<~HTML.html_safe, layout: false
       <!DOCTYPE html>

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -201,13 +201,10 @@ class LtiV1Controller < ApplicationController
   # Detects if LMS is trying open Code.org in an iframe, prompt user to open in
   # new tab. The experience is unchanged to non-iframe users.
   def iframe
-    # Define your variables
     auth_url_base = CDO.studio_url('/lti/v1/authenticate', CDO.default_scheme)
     id_token_param = params[:id_token]
     state_param = params[:state]
     new_tab_param = 'new_tab=true'
-
-    # Construct the URL with interpolated query parameters
     @auth_url = "#{auth_url_base}?id_token=#{id_token_param}&state=#{state_param}&#{new_tab_param}"
     render 'lti/v1/iframe', layout: false
   end

--- a/dashboard/app/views/lti/v1/iframe.html.haml
+++ b/dashboard/app/views/lti/v1/iframe.html.haml
@@ -1,3 +1,4 @@
+!!!
 %html{lang: "en"}
   %head
     %meta{charset: "UTF-8"}

--- a/dashboard/app/views/lti/v1/iframe.html.haml
+++ b/dashboard/app/views/lti/v1/iframe.html.haml
@@ -1,0 +1,38 @@
+%html{lang: "en"}
+  %head
+    %meta{charset: "UTF-8"}
+    %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}
+    %title= t('lti.iframe_title')
+    :javascript
+      window.onload = function() {
+        const auth_url = `#{@auth_url}`;
+        const iframe_message = `#{t('lti.iframe_message')}`;
+        const iframe_button = `#{t('lti.iframe_button')}`;
+        if (window.location !== window.parent.location) {
+          var messageDiv = document.createElement("div");
+          messageDiv.style.position = "fixed";
+          messageDiv.style.left = "0";
+          messageDiv.style.top = "0";
+          messageDiv.style.width = "100%";
+          messageDiv.style.height = "100%";
+          messageDiv.style.backgroundColor = "white";
+          messageDiv.style.zIndex = "10000";
+          messageDiv.style.display = "flex";
+          messageDiv.style.justifyContent = "center";
+          messageDiv.style.alignItems = "center";
+          messageDiv.style.flexDirection = "column";
+          messageDiv.style.textAlign = "center";
+          messageDiv.innerHTML = `
+            <p>${iframe_message}</p>
+            <button onclick="openInNewTab()">${iframe_button}</button>
+          `;
+
+          window.openInNewTab = function() {
+            window.open(auth_url, '_blank');
+          };
+
+          document.body.appendChild(messageDiv);
+        } else {
+          window.location.replace(auth_url);
+        }
+      };

--- a/dashboard/app/views/lti/v1/iframe.html.haml
+++ b/dashboard/app/views/lti/v1/iframe.html.haml
@@ -9,6 +9,7 @@
         const auth_url = `#{@auth_url}`;
         const iframe_message = `#{t('lti.iframe_message')}`;
         const iframe_button = `#{t('lti.iframe_button')}`;
+        // Determine if we are running in an iframe
         if (window.location !== window.parent.location) {
           var messageDiv = document.createElement("div");
           messageDiv.style.position = "fixed";

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1421,6 +1421,9 @@ en:
       missing_params: "Missing required param(s): School/District name, Client ID, LMS, Email"
       unsupported_lms_type: "Unsupported LMS platform type"
       wrong_resource_type: "Only LtiResourceLink is supported right now"
+    iframe_button: "Open in New Tab"
+    iframe_message: "Code.org cannot be run in an embedded window. Please open it in a new tab."
+    iframe_title: "Opening Code.org in New Tab"
     integration:
       client_id: "LMS Client ID"
       email: "Your email"

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -602,7 +602,8 @@ Dashboard::Application.routes.draw do
 
     # LTI API endpoints
     match '/lti/v1/login(/:platform_id)', to: 'lti_v1#login', via: [:get, :post]
-    post '/lti/v1/authenticate', to: 'lti_v1#authenticate'
+    match '/lti/v1/authenticate', to: 'lti_v1#authenticate', via: [:get, :post]
+    get '/lti/v1/iframe', to: 'lti_v1#iframe'
     match '/lti/v1/sync_course', to: 'lti_v1#sync_course', via: [:get, :post]
     post '/lti/v1/integrations', to: 'lti_v1#create_integration'
     get '/lti/v1/integrations', to: 'lti_v1#new_integration'

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -140,3 +140,8 @@ class Policies::Lti
     ['Canvas'].include?(issuer_name(issuer))
   end
 end
+
+# Force Schoology through iframe mitigation flow
+def self.force_iframe_launch?(issuer)
+  ['Schoology'].include?(issuer_name(issuer))
+end

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -139,9 +139,9 @@ class Policies::Lti
   def self.issuer_accepts_resource_link?(issuer)
     ['Canvas'].include?(issuer_name(issuer))
   end
-end
 
-# Force Schoology through iframe mitigation flow
-def self.force_iframe_launch?(issuer)
-  ['Schoology'].include?(issuer_name(issuer))
+  # Force Schoology through iframe mitigation flow
+  def self.force_iframe_launch?(issuer)
+    ['Schoology'].include?(issuer_name(issuer))
+  end
 end

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -227,7 +227,8 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
   setup do
     # stub cache reads for each test
-    LtiV1Controller.any_instance.stubs(:read_cache).returns({state: @state, nonce: @nonce})
+    LtiV1Controller.any_instance.stubs(:read_cache).with(@state).returns({state: @state, nonce: @nonce})
+    LtiV1Controller.any_instance.stubs(:read_cache).with("#{@integration.issuer}/#{@integration.client_id}").returns(@integration)
     Honeybadger.stubs(:notify)
   end
 
@@ -487,6 +488,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   test 'auth - should redirect to iframe route if LMS caller is Schoology AND new_tab=true param is missing' do
     issuer = Policies::Lti::LMS_PLATFORMS[:schoology][:issuer]
     integration = create :lti_integration, issuer: issuer
+    LtiV1Controller.any_instance.stubs(:read_cache).with("#{integration.issuer}/#{integration.client_id}").returns(integration)
     payload = {**get_valid_payload, iss: issuer, aud: integration.client_id}
     jwt = create_jwt_and_stub(payload)
     post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
@@ -497,6 +499,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   test 'auth - should NOT redirect to iframe route if LMS caller is Schoology AND new_tab=true param is present' do
     issuer = Policies::Lti::LMS_PLATFORMS[:schoology][:issuer]
     integration = create :lti_integration, issuer: issuer
+    LtiV1Controller.any_instance.stubs(:read_cache).with("#{integration.issuer}/#{integration.client_id}").returns(integration)
     payload = {**get_valid_payload, iss: issuer, aud: integration.client_id, azp: integration.client_id}
     jwt = create_jwt_and_stub(payload)
     post '/lti/v1/authenticate', params: {id_token: jwt, state: @state, new_tab: true}

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -488,6 +488,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   test 'auth - should redirect to iframe route if LMS caller is Schoology AND new_tab=true param is missing' do
     issuer = Policies::Lti::LMS_PLATFORMS[:schoology][:issuer]
     integration = create :lti_integration, issuer: issuer
+    # Override read_cache stub with this integration
     LtiV1Controller.any_instance.stubs(:read_cache).with("#{integration.issuer}/#{integration.client_id}").returns(integration)
     payload = {**get_valid_payload, iss: issuer, aud: integration.client_id}
     jwt = create_jwt_and_stub(payload)
@@ -499,6 +500,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   test 'auth - should NOT redirect to iframe route if LMS caller is Schoology AND new_tab=true param is present' do
     issuer = Policies::Lti::LMS_PLATFORMS[:schoology][:issuer]
     integration = create :lti_integration, issuer: issuer
+    # Override read_cache stub with this integration
     LtiV1Controller.any_instance.stubs(:read_cache).with("#{integration.issuer}/#{integration.client_id}").returns(integration)
     payload = {**get_valid_payload, iss: issuer, aud: integration.client_id, azp: integration.client_id}
     jwt = create_jwt_and_stub(payload)

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -484,6 +484,25 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
+  test 'auth - should redirect to iframe route if LMS caller is Schoology AND new_tab=true param is missing' do
+    issuer = Policies::Lti::LMS_PLATFORMS[:schoology][:issuer]
+    integration = create :lti_integration, issuer: issuer
+    payload = {**get_valid_payload, iss: issuer, aud: integration.client_id}
+    jwt = create_jwt_and_stub(payload)
+    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
+    assert_response :redirect
+    assert_redirected_to '/lti/v1/iframe' + "?id_token=#{jwt}&state=#{@state}"
+  end
+
+  test 'auth - should NOT redirect to iframe route if LMS caller is Schoology AND new_tab=true param is present' do
+    issuer = Policies::Lti::LMS_PLATFORMS[:schoology][:issuer]
+    integration = create :lti_integration, issuer: issuer
+    payload = {**get_valid_payload, iss: issuer, aud: integration.client_id, azp: integration.client_id}
+    jwt = create_jwt_and_stub(payload)
+    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state, new_tab: true}
+    assert_response :redirect
+  end
+
   test 'sync - should redirect students to homepage without syncing' do
     user = create :student
     sign_in user

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -501,6 +501,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     jwt = create_jwt_and_stub(payload)
     post '/lti/v1/authenticate', params: {id_token: jwt, state: @state, new_tab: true}
     assert_response :redirect
+    assert_redirected_to '/users/sign_up'
   end
 
   test 'sync - should redirect students to homepage without syncing' do

--- a/dashboard/test/lib/policies/lti_test.rb
+++ b/dashboard/test/lib/policies/lti_test.rb
@@ -80,6 +80,11 @@ class Policies::LtiTest < ActiveSupport::TestCase
     end
   end
 
+  test `force_iframe_launch? should return true for Schoology and false for other LMS platforms` do
+    assert Policies::Lti.force_iframe_launch?('https://schoology.schoology.com')
+    refute Policies::Lti.force_iframe_launch?('https://canvas.instructure.com')
+  end
+
   class EarlyAccessTest < ActiveSupport::TestCase
     setup do
       @lti_early_access_limit = DCDO.stubs(:get).with('lti_early_access_limit', false)


### PR DESCRIPTION
This PR adds a new route, controller, and view to mitigate when Schoology tries to open us in an iframe. This new flow will prompt the user to open in a new tab, and continue the LTI launch there. This will only happen for Schoology, as Canvas does not attempt to open us in an iframe.

Below is a screen shot of the UI that are rendered in an iframe, prompting the user open in a new tab
<img width="1209" alt="Screenshot 2024-03-08 at 9 20 43 AM" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/5b86a8cf-52be-4963-bd99-63d2f2803777">


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[Jira](https://codedotorg.atlassian.net/browse/P20-760)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
```
bundle exec spring testunit ./test/controllers/lti_v1_controller_test.rb
Running via Spring preloader in process 41839
Started with run options --seed 25940

Since there is no EDITOR or BETTER_ERRORS_EDITOR environment variable, using Textmate by default.==========================================================                   ] 89% Time: 00:00:24,  ETA: 00:00:03
  38/38: [===================================================================================================================================================================] 100% Time: 00:00:25, Time: 00:00:25

Finished in 26.02297s
38 tests, 77 assertions, 0 failures, 0 errors, 0 skips
```
```
bundle exec spring testunit ./test/lib/policies/lti_test.rb
Running via Spring preloader in process 9317
sh: force_iframe_launch?: command not found
Started with run options --seed 23111

DEPRECATED: Use assert_nil if expecting nil from test/lib/policies/lti_test.rb:65. This will fail in Minitest 6.=====                                                         ] 66% Time: 00:00:12,  ETA: 00:00:07
  9/9: [=====================================================================================================================================================================] 100% Time: 00:00:13, Time: 00:00:13

Finished in 13.09107s
9 tests, 14 assertions, 0 failures, 0 errors, 0 skips
```
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
