### PR TITLE
Direct units to course congrats page

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1466,6 +1466,7 @@ class Unit < ApplicationRecord
   def finish_url
     return hoc_finish_url if hoc?
     return csf_finish_url if csf?
+    return CDO.code_org_url "/congrats/#{unit_group.name}" if unit_group
     CDO.code_org_url "/congrats/#{name}"
   end
 

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -2433,6 +2433,20 @@ class UnitTest < ActiveSupport::TestCase
     assert_includes error.message, 'Instruction type must be set on the unit if its a standalone unit.'
   end
 
+  test 'finish_url returns unit group finish url if in a unit group' do
+    unit_group = create :unit_group
+    unit = create :script
+    create :unit_group_unit, unit_group: unit_group, script: unit, position: 1
+    unit.reload
+
+    assert unit.finish_url.include?(unit_group.name)
+  end
+
+  test 'finish_url returns unit finish url if not in a unit group' do
+    unit = create :script, is_course: true
+    assert unit.finish_url.include?(unit.name)
+  end
+
   private
 
   def has_unlaunched_unit?(units)


### PR DESCRIPTION
Instead of unit-specific congrats pages for units-within-a-course, we actually want to send users to the course congrats page. Standalone units should still go to the unit congrats page.


https://github.com/code-dot-org/code-dot-org/assets/46464143/a1b65cba-78a6-420d-abf4-c785c8c794be


