### PR TITLE
Update code.org/minecraft activities carousel to use Swiper

### DIFF
--- a/pegasus/sites.v3/code.org/public/js/page/minecraft_page.js
+++ b/pegasus/sites.v3/code.org/public/js/page/minecraft_page.js
@@ -48,13 +48,6 @@ function handleScreenSize(carouselId, cardsList) {
   if (windowWidth < 639) {
     reorganizeAndWrapSlides(carouselId, 1);
     console.log("< 639");
-  } else if (
-    windowWidth > 639 &&
-    windowWidth < 959 &&
-    carouselId === "minecraft_cdo_activities"
-  ) {
-    reorganizeAndWrapSlides(carouselId, 2);
-    console.log("639 - 959");
   } else if (windowWidth > 959) {
     reorganizeAndWrapSlides(carouselId, cardsList);
     console.log("> 959");
@@ -62,20 +55,6 @@ function handleScreenSize(carouselId, cardsList) {
 }
 
 $(document).ready(function () {
-  let idMinecraftActivities = "#minecraft_cdo_activities";
-  handleScreenSize("minecraft_cdo_activities", 3);
-  $(idMinecraftActivities + " .slides").carouFredSel({
-    auto: false,
-    pagination: "#minecraft_cdo_activities-pagination",
-    prev: "#prev_1",
-    next: "#next_1",
-    responsive: true,
-    scroll: 1,
-    swipe: {
-      onTouch: true,
-      onMouse: true,
-    },
-  });
   let idInspirationalVideo = "#inspirational_works_collection";
   handleScreenSize("inspirational_works_collection", 2);
   $(idInspirationalVideo + " .slides").carouFredSel({

--- a/pegasus/sites.v3/code.org/views/minecraft/minecraft_activities_carousel.haml
+++ b/pegasus/sites.v3/code.org/views/minecraft/minecraft_activities_carousel.haml
@@ -1,5 +1,5 @@
 :ruby
-  slide_item = [
+  block_item = [
     {
       title: hoc_s(:minecraft_cdo_activity_title_aquatic),
       image: "/images/mc/minecraft-activity-aquatic.png",
@@ -37,27 +37,28 @@
       aria_label_lesson: hoc_s(:aria_label_call_to_action_minecraft_designer_lesson)
     },
   ]
+  
+.carousel-wrapper
+  %swiper-container.three-col{navigation: "true", "navigation-next-el": ".swiper-nav-next", "navigation-prev-el": ".swiper-nav-prev", init: "false"}
+    - block_item.each do |block_item|
+      %swiper-slide
+        .action-block.action-block--one-col.flex-space-between
+          .content-wrapper
+            %p.overline
+              =hoc_s(:module_label_grades)
+              =hoc_s(:module_grade_2_12)
+            %h3
+              = block_item[:title]
+            %img{src: "#{block_item[:image]}", alt: "", style: "width: 100%"}
+            %p
+              = block_item[:desc]
+          .content-footer
+            %a.link-button{href: "#{block_item[:url]}", "aria-label": "#{block_item[:aria_label]}"}
+              =hoc_s(:call_to_action_get_started)
+            %a.link-button.secondary{href: "#{block_item[:url_lesson]}", "aria-label": "#{block_item[:aria_label_lesson]}"}
+              =hoc_s(:call_to_action_view_lesson_plan)
 
-.carousel-wrapper#minecraft_cdo_activities
-  .carousel.blocks
-    .slides
-      - slide_item.each do |slide_item|
-        .slide
-          .slide-content
-            .action-block.action-block--one-col
-              .content-wrapper
-                %p.overline
-                  =hoc_s(:module_label_grades)
-                  =hoc_s(:module_grade_2_12)
-                %h3
-                  = slide_item[:title]
-                %img{src: "#{slide_item[:image]}", alt: ""}
-                %p.body-three.no-margin-bottom
-                  = slide_item[:desc]
-              .content-footer
-                %a.link-button{href: "#{slide_item[:url]}", "aria-label": "#{slide_item[:aria_label]}"}
-                  =hoc_s(:call_to_action_get_started)
-                %a.link-button.secondary{href: "#{slide_item[:url_lesson]}", "aria-label": "#{slide_item[:aria_label_lesson]}"}
-                  =hoc_s(:call_to_action_view_lesson_plan)
+  %button.swiper-nav-prev
+  %button.swiper-nav-next
 
-  = view :carousel_pagination, carousel_id: "minecraft_cdo_activities-pagination", carousel_index: "1"
+= view :swiper


### PR DESCRIPTION
Updates the Minecraft page to use the Swiper carousel. I used [Kelby's self-paced PL page update](https://github.com/code-dot-org/code-dot-org/pull/55827) as a guide.

### Before
![Before](https://github.com/code-dot-org/code-dot-org/assets/56283563/2c90d60b-0fef-47f9-ae66-4d87adedfcdb)

### Now
![After](https://github.com/code-dot-org/code-dot-org/assets/56283563/3ca694c4-6f8d-4c8d-ac1e-664f58747898)

### Right-to-left language support
![RTL](https://github.com/code-dot-org/code-dot-org/assets/56283563/639dc114-e828-4aae-90da-ad4d6f2af209)

### Tab-navigable
https://github.com/code-dot-org/code-dot-org/assets/56283563/bb97d907-1ba5-42a2-a24e-b6374e7df9a2

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1471)

## Testing story
Local testing.
