### PR TITLE
Removing redundant babel plugin

### DIFF
--- a/apps/babel.config.json
+++ b/apps/babel.config.json
@@ -9,8 +9,6 @@
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-class-properties",
     ["@babel/plugin-transform-regenerator", {"async": true, "asyncGenerators": true}],
-    // needed for IE 9/10 support
-    ["@babel/plugin-transform-classes", {"loose": true}],
     "@babel/plugin-transform-modules-commonjs",
     "@babel/plugin-proposal-optional-chaining"
   ],

--- a/apps/package.json
+++ b/apps/package.json
@@ -44,7 +44,6 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.18.9",
     "@babel/plugin-proposal-optional-chaining": "^7.18.9",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-    "@babel/plugin-transform-classes": "^7.18.9",
     "@babel/plugin-transform-regenerator": "^7.18.6",
     "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "^7.18.10",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8479,7 +8479,6 @@ __metadata:
     "@babel/plugin-proposal-object-rest-spread": ^7.18.9
     "@babel/plugin-proposal-optional-chaining": ^7.18.9
     "@babel/plugin-syntax-dynamic-import": ^7.8.3
-    "@babel/plugin-transform-classes": ^7.18.9
     "@babel/plugin-transform-regenerator": ^7.18.6
     "@babel/polyfill": ^7.12.1
     "@babel/preset-env": ^7.18.10


### PR DESCRIPTION
Cleaning out some unused NPM packages

I noticed this one while clearing out another package.  `@babel/plugin-transform-classes` [was added](https://github.com/code-dot-org/code-dot-org/pull/8614) to keep us supporting IE 9/10. We don't support any version of IE anymore, including IE 11 so the original reasons for keeping it no longer apply. Additionally, this package is now imported and used by `@babel/preset-env`, which transpires our JS code to align to the ES5 spec. 

Some additional details: The `@babel/plugin-transform-classes` package rarely gets imported on its own anymore, so the documentation is a little sparse, however, the [NPM page](https://www.npmjs.com/package/@babel/plugin-transform-classes) says it gets used to "Compile ES2015 classes to ES5." (The [Babel page](https://babeljs.io/docs/babel-plugin-transform-classes) mostly discusses how to use it, rather than what it does.) However, looking at the [Babel docs](https://babeljs.io/docs/babel-preset-env) for `@babel/preset-env`, it looks like that is already done by preset-env. Babel [recommends](https://babeljs.io/docs/options#no-targets) setting a target when using `present-env`, which we do not do. Specifically: "When no targets are specified: Babel will assume you are targeting the oldest browsers possible. For example, @babel/preset-env will transform all ES2015-ES2020 code to be ES5 compatible." All of that to say, this appears to no longer be needed.