### PR TITLE
Re-enable Key/Value Pairs Tab test

### DIFF
--- a/dashboard/test/ui/features/star_labs/applab/data_tab.feature
+++ b/dashboard/test/ui/features/star_labs/applab/data_tab.feature
@@ -45,9 +45,6 @@ Feature: App Lab Data Tab
     And I click selector ".uitest-data-table-row:eq(0) td:nth-child(4) button:first-of-type"
     Then I wait until element ".uitest-data-table-content:first-of-type td:nth-child(2)" contains text "21"
 
-  # TODO: Re-enable this test and root cause the failure. Skipping to unblock the deploy pipeline. 
-  # See https://codedotorg.atlassian.net/browse/LABS-267 for additional context.
-  @skip
   Scenario: Key/Value Pairs Tab
     Then I click selector "#keyValuePairsTab" once I see it
     And I wait until element "#keyValuePairsBody" is visible


### PR DESCRIPTION
This test was turned off in this PR: https://github.com/code-dot-org/code-dot-org/pull/55494

Since it was disabled over 3 months ago, there aren't any historical failures saved in sauce labs, and running it locally isn't producing any failures, I'd like to re-enable and see if it's still flaky in the test pipeline.

[jira](https://codedotorg.atlassian.net/browse/LABS-267)