### PR TITLE
Lazy load python lab in LabViewsRenderer

### DIFF
--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -1,42 +1,6 @@
 @import 'color.scss';
 @import './common.scss';
 
-// We actually fade out the block to reveal the lab underneath.
-// We will do it over 1s, and then leave it invisible.
-@keyframes fade-out-block {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-
-// We will fade in the spinner container for 1s after a 2s delay, then leave it showing.
-@keyframes fade-in-spinner-container {
-  0% {
-    opacity: 0;
-  }
-  66% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-// We will fade in the spinner text for 1s after a 10s delay, then leave it showing.
-@keyframes fade-in-spinner-text {
-  0% {
-    opacity: 0;
-  }
-  91% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
 
 .labContainer {
   position: fixed;
@@ -48,60 +12,6 @@
 
   &Loading {
     pointer-events: none;
-  }
-
-  .solidBlock {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: $dark_black;
-    width: 100%;
-    height: 100%;
-    position: fixed;
-    top: 52px;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    pointer-events: none;
-    opacity: 0;
-    z-index: 70;
-
-    &.noFadeLoading {
-      opacity: 0;
-      pointer-events: initial;
-    }
-
-    &.noFadeLoaded {
-      opacity: 0;
-    }
-
-    &.fadeLoading {
-      opacity: 1;
-      pointer-events: initial;
-    }
-
-    &.fadeLoaded {
-      animation: fade-out-block 0.5s;
-    }
-
-
-
-    .slowLoadContainer {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 20px;
-
-      .spinnerContainer {
-        color: $neutral_dark40;
-        animation: fade-in-spinner-container 3s;
-      }
-
-      .spinnerText {
-        color: $neutral_dark60;
-        animation: fade-in-spinner-text 11s;
-      }
-    }
   }
 
   .pageErrorContainer {

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -12,17 +12,14 @@ import classNames from 'classnames';
 import moduleStyles from './Lab2Wrapper.module.scss';
 import ErrorBoundary from '../ErrorBoundary';
 import {LabState, isLabLoading, hasPageError} from '../lab2Redux';
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
-const i18n = require('@cdo/locale');
 
 import {ErrorFallbackPage, ErrorUI} from './ErrorFallbackPage';
 import Lab2Registry from '../Lab2Registry';
+import Loading from './Loading';
 
 export interface Lab2WrapperProps {
   children: React.ReactNode;
 }
-
-const noFade = window.location.href.includes('lab2-no-fade');
 
 const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
   const isLoading: boolean = useSelector(isLabLoading);
@@ -31,14 +28,6 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
     (state: {lab: LabState}) =>
       state.lab.pageError?.errorMessage || state.lab.pageError?.error?.message
   );
-
-  const overlayStyle: string = noFade
-    ? isLoading
-      ? moduleStyles.noFadeLoading
-      : moduleStyles.noFadeLoaded
-    : isLoading
-    ? moduleStyles.fadeLoading
-    : moduleStyles.fadeLoaded;
 
   return (
     <ErrorBoundary
@@ -59,25 +48,7 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
         )}
       >
         {children}
-        <div
-          id="fade-overlay"
-          className={classNames(moduleStyles.solidBlock, overlayStyle)}
-        >
-          {isLoading && (
-            <div className={moduleStyles.slowLoadContainer}>
-              <div className={moduleStyles.spinnerContainer}>
-                <FontAwesome
-                  title={undefined}
-                  icon="spinner"
-                  className={classNames('fa-pulse', 'fa-3x')}
-                />
-              </div>
-              <div className={moduleStyles.spinnerText}>
-                {i18n.slowLoading()}
-              </div>
-            </div>
-          )}
-        </div>
+        <Loading isLoading={isLoading} />
 
         {isPageError && <ErrorUI message={errorMessage} />}
       </div>

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -9,14 +9,21 @@ import {setUpBlocklyForMusicLab} from '@cdo/apps/music/blockly/setup';
 import MusicView from '@cdo/apps/music/views/MusicView';
 import StandaloneVideo from '@cdo/apps/standaloneVideo/StandaloneVideo';
 import classNames from 'classnames';
-import React, {useContext, useEffect, useState} from 'react';
+import React, {
+  ComponentType,
+  LazyExoticComponent,
+  Suspense,
+  lazy,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import {useSelector} from 'react-redux';
 import {LabState} from '../lab2Redux';
 import ProgressContainer from '../progress/ProgressContainer';
 import {AppName} from '../types';
 import moduleStyles from './lab-views-renderer.module.scss';
 import {DEFAULT_THEME, Theme, ThemeContext} from './ThemeWrapper';
-import PythonlabView from '@cdo/apps/pythonlab/PythonlabView';
 import PanelsView from '@cdo/apps/panels/PanelsView';
 import Weblab2View from '@cdo/apps/weblab2/Weblab2View';
 
@@ -31,6 +38,8 @@ interface AppProperties {
   backgroundMode: boolean;
   /** React View for the Lab */
   node: React.ReactNode;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  renderNode?: LazyExoticComponent<ComponentType<any>>;
   /**
    * Display theme for this lab. This will likely be configured by user
    * preferences eventually, but for now this is fixed for each lab. Defaults
@@ -67,7 +76,12 @@ const appsProperties: {[appName in AppName]?: AppProperties} = {
   },
   pythonlab: {
     backgroundMode: false,
-    node: <PythonlabView />,
+    node: <div />,
+    renderNode: lazy(() =>
+      import('../../pythonlab/index.js').then(({PythonlabView}) => ({
+        default: PythonlabView,
+      }))
+    ),
     theme: Theme.LIGHT,
   },
   panels: {
@@ -134,6 +148,9 @@ const LabViewsRenderer: React.FunctionComponent = () => {
             {!properties.backgroundMode && currentAppName === appName && (
               <VisibilityContainer appName={appName} visible={true}>
                 {properties.node}
+                <Suspense fallback={<div />}>
+                  {properties.renderNode && <properties.renderNode />}
+                </Suspense>
               </VisibilityContainer>
             )}
           </ProgressContainer>

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -26,6 +26,7 @@ import moduleStyles from './lab-views-renderer.module.scss';
 import {DEFAULT_THEME, Theme, ThemeContext} from './ThemeWrapper';
 import PanelsView from '@cdo/apps/panels/PanelsView';
 import Weblab2View from '@cdo/apps/weblab2/Weblab2View';
+import Loading from './Loading';
 
 // Configuration for how a Lab should be rendered
 interface AppProperties {
@@ -129,7 +130,7 @@ const LabViewsRenderer: React.FunctionComponent = () => {
 
   const renderApp = (appProperties: AppProperties) => {
     return appProperties.lazyNode ? (
-      <Suspense fallback={<div />}>
+      <Suspense fallback={<Loading isLoading={true} />}>
         <appProperties.lazyNode />
       </Suspense>
     ) : (

--- a/apps/src/lab2/views/Loading.tsx
+++ b/apps/src/lab2/views/Loading.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import moduleStyles from './loading.module.scss';
+import classNames from 'classnames';
+import {commonI18n} from '@cdo/apps/types/locale';
+
+export interface LoadingProps {
+  isLoading: boolean;
+}
+
+const Loading: React.FunctionComponent<LoadingProps> = ({
+  isLoading,
+}: LoadingProps) => {
+  const overlayStyle = isLoading
+    ? moduleStyles.fadeLoading
+    : moduleStyles.fadeLoaded;
+  return (
+    <div
+      id="fade-overlay"
+      className={classNames(moduleStyles.solidBlock, overlayStyle)}
+    >
+      {isLoading && (
+        <div className={moduleStyles.slowLoadContainer}>
+          <div className={moduleStyles.spinnerContainer}>
+            <FontAwesome
+              title={undefined}
+              icon="spinner"
+              className={classNames('fa-pulse', 'fa-3x')}
+            />
+          </div>
+          <div className={moduleStyles.spinnerText}>
+            {commonI18n.slowLoading()}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Loading;

--- a/apps/src/lab2/views/Loading.tsx
+++ b/apps/src/lab2/views/Loading.tsx
@@ -8,12 +8,19 @@ export interface LoadingProps {
   isLoading: boolean;
 }
 
+const noFade = window.location.href.includes('lab2-no-fade');
+
 const Loading: React.FunctionComponent<LoadingProps> = ({
   isLoading,
 }: LoadingProps) => {
-  const overlayStyle = isLoading
+  const overlayStyle: string = noFade
+    ? isLoading
+      ? moduleStyles.noFadeLoading
+      : moduleStyles.noFadeLoaded
+    : isLoading
     ? moduleStyles.fadeLoading
     : moduleStyles.fadeLoaded;
+
   return (
     <div
       id="fade-overlay"

--- a/apps/src/lab2/views/loading.module.scss
+++ b/apps/src/lab2/views/loading.module.scss
@@ -1,0 +1,93 @@
+@import 'color.scss';
+@import './common.scss';
+
+// We actually fade out the block to reveal the lab underneath.
+// We will do it over 1s, and then leave it invisible.
+@keyframes fade-out-block {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+// We will fade in the spinner container for 1s after a 2s delay, then leave it showing.
+@keyframes fade-in-spinner-container {
+  0% {
+    opacity: 0;
+  }
+  66% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+// We will fade in the spinner text for 1s after a 10s delay, then leave it showing.
+@keyframes fade-in-spinner-text {
+  0% {
+    opacity: 0;
+  }
+  91% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.solidBlock {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: $dark_black;
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 52px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  opacity: 0;
+  z-index: 70;
+
+  &.noFadeLoading {
+    opacity: 0;
+    pointer-events: initial;
+  }
+
+  &.noFadeLoaded {
+    opacity: 0;
+  }
+
+  &.fadeLoading {
+    opacity: 1;
+    pointer-events: initial;
+  }
+
+  &.fadeLoaded {
+    animation: fade-out-block 0.5s;
+  }
+
+
+
+  .slowLoadContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+
+    .spinnerContainer {
+      color: $neutral_dark40;
+      animation: fade-in-spinner-container 3s;
+    }
+
+    .spinnerText {
+      color: $neutral_dark60;
+      animation: fade-in-spinner-text 11s;
+    }
+  }
+}

--- a/apps/src/lab2/views/loading.module.scss
+++ b/apps/src/lab2/views/loading.module.scss
@@ -1,5 +1,4 @@
 @import 'color.scss';
-@import './common.scss';
 
 // We actually fade out the block to reveal the lab underneath.
 // We will do it over 1s, and then leave it invisible.

--- a/apps/src/pythonlab/PythonEditor.tsx
+++ b/apps/src/pythonlab/PythonEditor.tsx
@@ -3,7 +3,7 @@ import {darkMode} from '@cdo/apps/lab2/views/components/editor/editorThemes';
 import {python} from '@codemirror/lang-python';
 import moduleStyles from './python-editor.module.scss';
 import {useDispatch} from 'react-redux';
-import {resetOutput, setCode} from './pythonlabRedux';
+import {appendOutput, resetOutput, setCode} from './pythonlabRedux';
 import Button from '@cdo/apps/templates/Button';
 import {runPythonCode} from './pyodideRunner';
 import {useFetch} from '@cdo/apps/util/useFetch';
@@ -27,6 +27,7 @@ const PythonEditor: React.FunctionComponent = () => {
     const parsedData = data ? (data as PermissionResponse) : {permissions: []};
     // For now, restrict running python code to levelbuilders.
     if (parsedData.permissions.includes('levelbuilder')) {
+      dispatch(appendOutput('Running code...'));
       runPythonCode(code);
     } else {
       alert('You do not have permission to run python code.');

--- a/apps/src/pythonlab/PythonEditor.tsx
+++ b/apps/src/pythonlab/PythonEditor.tsx
@@ -3,9 +3,9 @@ import {darkMode} from '@cdo/apps/lab2/views/components/editor/editorThemes';
 import {python} from '@codemirror/lang-python';
 import moduleStyles from './python-editor.module.scss';
 import {useDispatch} from 'react-redux';
-import {appendOutput, resetOutput, setCode} from './pythonlabRedux';
+import {resetOutput, setCode} from './pythonlabRedux';
 import Button from '@cdo/apps/templates/Button';
-// import {runPythonCode} from './pyodideRunner';
+import {runPythonCode} from './pyodideRunner';
 import {useFetch} from '@cdo/apps/util/useFetch';
 import CodeEditor from '@cdo/apps/lab2/views/components/editor/CodeEditor';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -15,7 +15,7 @@ interface PermissionResponse {
 }
 
 const PythonEditor: React.FunctionComponent = () => {
-  const code = useAppSelector(state => state.pythonlab.code); // eslint-disable-line @typescript-eslint/no-unused-vars
+  const code = useAppSelector(state => state.pythonlab.code);
   const codeOutput = useAppSelector(state => state.pythonlab.output);
   const {loading, data} = useFetch('/api/v1/users/current/permissions');
   const dispatch = useDispatch();
@@ -27,10 +27,7 @@ const PythonEditor: React.FunctionComponent = () => {
     const parsedData = data ? (data as PermissionResponse) : {permissions: []};
     // For now, restrict running python code to levelbuilders.
     if (parsedData.permissions.includes('levelbuilder')) {
-      dispatch(appendOutput('Simulating running code.'));
-      // TODO: re-enable once we fix iPad issues.
-      // https://codedotorg.atlassian.net/browse/CT-299
-      // runPythonCode(code);
+      runPythonCode(code);
     } else {
       alert('You do not have permission to run python code.');
     }

--- a/apps/src/pythonlab/index.js
+++ b/apps/src/pythonlab/index.js
@@ -1,0 +1,3 @@
+// This file allows us to lazily load the PythonlabView component.
+// Due to our configuration this needs to be in js so we can use dynamic imports.
+export {default as PythonlabView} from './PythonlabView';


### PR DESCRIPTION
We saw an issue a while ago where pyodide in Python Lab was causing crashes in Music Lab on old iOS versions. This is because the assets for Python Lab were being loaded for every Lab2 lab due us importing all lab views in `LabViewsRenderer`. In order to re-enable pyodide I wrapped `PythonlabView` in [lazy](https://react.dev/reference/react/lazy) so it will only be loaded when we actually view Python Lab. We are ok with python lab potentially not working on old iOS versions since it is a prototype (I also haven't been able to repro this error anymore so it may be resolved). 

Getting lazy loading to work with a TypeScript component and our webpack config was a little tricky. I had to re-export the component in an `index.js` file in order to get things to work properly. The syntax is a little funky, but not too long. 

Using `lazy` requires wrapping the lazily-loaded component in a [Suspense](https://react.dev/reference/react/Suspense) component with a fallback. I refactored our loading spinner that fades in after 3 seconds and shows a slow loading message after 11 seconds into a separate component so it could be reused.

## Links
- jira ticket: [CT-299](https://codedotorg.atlassian.net/browse/CT-299)


## Testing story
Tested locally that Lab2 labs still all load as expected, and only Python Lab loads the pyodide-specific assets. 

## Follow-up work
If we like this, we can re-use this pattern for the other Lab2 views. I think it would be best to isolate each lab's assets so we can feel comfortable prototyping new labs without causing bugs on existing labs.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
