### PR TITLE
React Testing Library: Update ProjectCardTest 

### DIFF
--- a/apps/test/unit/templates/projects/ProjectCardTest.js
+++ b/apps/test/unit/templates/projects/ProjectCardTest.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import {shallow} from 'enzyme';
-import {expect} from '../../../util/reconfiguredChai';
+import {render, screen} from '@testing-library/react';
 import ProjectCard from '@cdo/apps/templates/projects/ProjectCard';
 import msg from '@cdo/locale';
 
@@ -15,26 +14,25 @@ describe('ProjectCard', () => {
     isFeatured: false,
     publishedAt: '2017-12-08T10:00:00.000+00:00',
   };
+
   it('displays featured project label', () => {
-    const wrapper = shallow(
+    render(
       <ProjectCard
         projectData={featuredProjectData}
         currentGallery="public"
         isDetailView={true}
       />
     );
-    const featuredLabel = wrapper.find('div').last();
-    expect(featuredLabel.text()).to.equal(msg.featuredProject());
+    screen.getByText(msg.featuredProject());
   });
   it('displays published label', () => {
-    const wrapper = shallow(
+    render(
       <ProjectCard
         projectData={unfeaturedProjectData}
         currentGallery="public"
         isDetailView={true}
       />
     );
-    const publishedLabel = wrapper.find('div').last();
-    expect(publishedLabel.text()).to.have.string(msg.published());
+    screen.getByText(`${msg.published()}:`);
   });
 });


### PR DESCRIPTION
Baby steps! 

This PR updates `ProjectCardTest.js` to use React Testing Library.

A couple of notes: 
1.) I needed to update to check for an exact string match "Published:" versus just the substring "Published" 
2.) This is a lower level component, so potentially the test content here could get rolled into a parent component now that we're using deep rendering, but it maintains test coverage parity with the existing test for now. 