### PR TITLE
Improve `bin/dotd` first time experience

### DIFF
--- a/bin/dotd
+++ b/bin/dotd
@@ -40,7 +40,7 @@ def check_for_cdo_keys
 
   puts <<~EOS.unindent
 
-    Missing required CDO keys: #{missing_cdo_keys.map {|msg| "\n  - #{msg}"}.join}
+    Error, missing required CDO keys: #{missing_cdo_keys.map {|msg| "\n  - #{msg}"}.join}
 
     Please fix the required CDO keys and rerun the script.
   EOS
@@ -517,6 +517,11 @@ end
 
 # The main method of the script, responsible for dispatching control flow to other methods.
 def main
+  puts
+  puts "👋, if you run into trouble or have questions, consult the DotD guide:"
+  puts "https://docs.google.com/document/d/166j9G-Kn_PeHoV4RRX9l-x-42NlahPn0sT6tTFTX5LY/edit#heading=h.mf5058xaezl2"
+  puts
+
   check_for_cdo_keys
   check_github_token
 

--- a/bin/dotd
+++ b/bin/dotd
@@ -29,20 +29,20 @@ end
 # Checks that CDO.github_access_token, CDO.slack_bot_token, CDO.honeybadger_api_token, and CDO.devinternal_db_writer
 # are defined. If not, exits the program.
 def check_for_cdo_keys
-  return if CDO.github_access_token && CDO.slack_bot_token && CDO.honeybadger_api_token && CDO.devinternal_db_writer
+  missing_cdo_keys = [
+    CDO.github_access_token ? nil :   "#{bold 'CDO.github_access_token'}: set `github_access_token: <your token>` in locals.yml. Get <your token> from https://github.com/settings/tokens, by creating a classic token with the \"public_repo\" permission.",
+    CDO.honeybadger_api_token ? nil : "#{bold 'CDO.honeybadger_api_token'}: this should be pulled in automatically from AWS Secrets Manager, does `bin/aws_access` succeed?",
+    CDO.slack_bot_token ? nil :       "#{bold 'CDO.slack_bot_token'}: this should be pulled in automatically from AWS Secrets Manager, does `bin/aws_access` succeed?",
+    CDO.devinternal_db_writer ? nil : "#{bold 'CDO.devinternal_db_writer'}: set `devinternal_db_writer: <your token>` locals.yml. Get <your token> from https://app.honeybadger.io/users/edit#authentication."
+  ].compact
 
-  puts <<-EOS.unindent
+  return if missing_cdo_keys.empty?
 
-    This script requires CDO.github_access_token, CDO.slack_bot_token, and CDO.honeybadger_api_token and CDO.devinternal_db_writer.
+  puts <<~EOS.unindent
 
-    Create your API tokens from these pages:
+    Missing required CDO keys: #{missing_cdo_keys.map {|msg| "\n  - #{msg}"}.join}
 
-      https://github.com/settings/tokens (classic token with 'public_repo' permission)
-      https://app.honeybadger.io/users/edit#authentication
-
-    Please add them to your locals.yml and rerun the script.
-    CDO.devinternal_db_writer and CDO.slack_bot_token should be pulled automatically from AWS Secrets Manager.
-
+    Please fix the required CDO keys and rerun the script.
   EOS
   exit
 end


### PR DESCRIPTION
The first few times you do DotD, it can make you nervous. This improves two small details of the DotD experience that might help a little:

1. Print a link to the DotD doc when running `bin/dotd`
2. Improve `bin/dotd` error messages when missing CDO keys like CDO.github_access_key. Previously a completely static message was printed for any missing key. It wasn't clear which keys were actually missing, and instructions for fixing each type of error were jumbled together.

Before, not clear which key(s) were missing:
<img width="757" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/061d9c96-1576-413e-8e5a-e4facd9cea3e">

After, shows only the missing keys (two of them in this case):
<img width="867" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/a3a1ae11-8700-4a33-96d2-811d3e34a92f">