### PR TITLE
Remove button color reference in control share settings dialog

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1987,7 +1987,7 @@
   "projectSharingColumnHeader": "Sharing",
   "projectSharingDialogButton": "Show project sharing column",
   "projectSharingDialogHeader": "Control sharing for App Lab / Game Lab / Web Lab projects",
-  "projectSharingDialogInstructions": "App Lab, Game Lab and Web Lab are programming environments that allow students to personalize and customize their creations through writing free-form text, uploading images and sounds, etc. By default, students under the age of 13 are not able to share their projects with others, but students aged 13 and over are.\n\n If you want to be able to manage exactly which students can and can not share these project types, you can show the project sharing column by clicking the orange button below.",
+  "projectSharingDialogInstructions": "App Lab, Game Lab and Web Lab are programming environments that allow students to personalize and customize their creations through writing free-form text, uploading images and sounds, etc. By default, students under the age of 13 are not able to share their projects with others, but students aged 13 and over are.\n\n If you want to be able to manage exactly which students can and can not share these project types, you can show the project sharing column by clicking the button below.",
   "projectSharingDisableAll": "Disable all",
   "projectSharingEnableAll": "Enable all",
   "projectStartNew": "Start a new project",

--- a/i18n/locales/source/blockly-mooc/common.json
+++ b/i18n/locales/source/blockly-mooc/common.json
@@ -1981,7 +1981,7 @@
   "projectSharingColumnHeader": "Sharing",
   "projectSharingDialogButton": "Show project sharing column",
   "projectSharingDialogHeader": "Control sharing for App Lab / Game Lab / Web Lab projects",
-  "projectSharingDialogInstructions": "App Lab, Game Lab and Web Lab are programming environments that allow students to personalize and customize their creations through writing free-form text, uploading images and sounds, etc. By default, students under the age of 13 are not able to share their projects with others, but students aged 13 and over are.\n\n If you want to be able to manage exactly which students can and can not share these project types, you can show the project sharing column by clicking the orange button below.",
+  "projectSharingDialogInstructions": "App Lab, Game Lab and Web Lab are programming environments that allow students to personalize and customize their creations through writing free-form text, uploading images and sounds, etc. By default, students under the age of 13 are not able to share their projects with others, but students aged 13 and over are.\n\n If you want to be able to manage exactly which students can and can not share these project types, you can show the project sharing column by clicking the button below.",
   "projectSharingDisableAll": "Disable all",
   "projectSharingEnableAll": "Enable all",
   "projectStartNew": "Start a new project",


### PR DESCRIPTION
The text in the dialog to control project share settings on the Manage Students tab of the Teacher Dashboard referenced an orange button. The button is purple 🙃. I updated the string to no longer reference a specific color to make it more resilient to the side effects of design changes. The instructions, button location and button text should be sufficient to guide users to the correct action. 

**BEFORE** 
<img width="769" alt="before" src="https://github.com/code-dot-org/code-dot-org/assets/12300669/5ef4fb81-1dce-483d-b0fa-8e69b541ae0e">


**AFTER** 
<img width="760" alt="after" src="https://github.com/code-dot-org/code-dot-org/assets/12300669/dea18e1d-3f7e-45f3-ae0f-0ec3431b49d0">
