### PR TITLE
Add state not listed option to state dropdown in student interstitial

### DIFF
--- a/dashboard/app/views/layouts/_student_information_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_student_information_interstitial.html.haml
@@ -19,7 +19,7 @@
             %div{style: 'display: flex;'}
               = f.label :us_state, t('activerecord.attributes.user.us_state'), class: 'label-title'
               .state-required *
-            = f.select :us_state, User::US_STATE_DROPDOWN_OPTIONS, include_blank: t('school_info.select_state')
+            = f.select :us_state, us_state_options, include_blank: t('school_info.select_state')
             .required-message.state-required= t('activerecord.attributes.user.required')
           .field
             = f.label :gender_student_input, t('gender'), class: 'label-title'


### PR DESCRIPTION
Adds "I live somewhere not listed here" in the `us_state` dropdown list within the student information interstitial.

## Option in dropdown list
<img width="578" alt="Screenshot 2024-03-06 at 9 44 51 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/d0b602f6-31ce-4bad-a806-63a77806b3bd">

## Save as "??" in db
<img width="369" alt="Screenshot 2024-03-06 at 9 45 05 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/6aeccea6-def2-43f6-a757-9cd8e3623063">

## Saves state if state chosen
<img width="346" alt="Screenshot 2024-03-06 at 9 45 47 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/df8091a4-c972-4090-a935-b1d7d84e9328">



## Links

- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/P20/boards/69?assignee=712020%3Af0e2716f-09f9-4686-8490-9f1f9a08bb06&selectedIssue=P20-697)


## Testing story
Local




