### PR TITLE
Fix broken link on inspire page

### DIFF
--- a/pegasus/sites.v3/code.org/public/careers.moved
+++ b/pegasus/sites.v3/code.org/public/careers.moved
@@ -1,2 +1,2 @@
-/careers-in-tech
+/careers-with-cs
 

--- a/pegasus/sites.v3/code.org/public/girls.md
+++ b/pegasus/sites.v3/code.org/public/girls.md
@@ -143,7 +143,7 @@ Both boys and girls care about making the world a better place and may not be aw
 
 You can help by showing examples of CS careers that blend academic skills such as problem solving with intrinsic social causes like conservation or medical care. When students see that a career in CS can be rewarding in a variety of ways, they’re more likely to continue pursuing their interest.
 
-Take a look at some <a href="https://code.org/careers-in-tech">great examples</a> of how everyday people use CS in their careers.
+Take a look at some <a href="https://code.org/careers-with-cs">great examples</a> of how everyday people use CS in their careers.
 
 
 [col-50]
@@ -174,7 +174,7 @@ Take a look at some <a href="https://code.org/careers-in-tech">great examples</a
 
 Dispel misconceptions about what a future in computer science looks like by using our [inspirational videos](https://code.org/educate/resources/inspire), many of which feature women in a variety of creative and impactful industries!
 
-Students have positive attitudes about science careers when they’re able to see what a day in the life really looks like, especially if it’s highly collaborative. In addition to [videos that dive deep into potential careers](https://code.org/careers-in-tech), it’s a great idea to connect with a local university or college’s CS department to coordinate a school visit or guest speaker.
+Students have positive attitudes about science careers when they’re able to see what a day in the life really looks like, especially if it’s highly collaborative. In addition to [videos that dive deep into potential careers](https://code.org/careers-with-cs), it’s a great idea to connect with a local university or college’s CS department to coordinate a school visit or guest speaker.
 
 [breakoutquote]
 

--- a/pegasus/sites.v3/code.org/views/inspirational_videos.haml
+++ b/pegasus/sites.v3/code.org/views/inspirational_videos.haml
@@ -24,4 +24,4 @@
 .video-smalltext
   %ul
     %li!= I18n.t(:videos_more_markdown, inspiring_videos_playlist: 'https://www.youtube.com/playlist?list=PLzdnOPI1iJNfpD8i4Sx7U0y2MccnrNZuP', markdown: :inline)
-    %li!= I18n.t(:careers_page_more_markdown, careers_url: CDO.code_org_url('/careers'), markdown: :inline)
+    %li!= I18n.t(:careers_page_more_markdown, careers_url: CDO.code_org_url('/careers-with-cs'), markdown: :inline)


### PR DESCRIPTION
We received a Zendesk ticket about a broken link on the [/educate/resources/inspire](https://code.org/educate/resources/inspire) page that sent the user to the no-longer active [/careers](https://code.org/careers-in-tech) page. This PR fixes it to send the user to [/careers-with-cs](https://code.org/careers-with-cs). It also updates `careers.moved` and a use of `/careers-in-tech` on the [/girls](https://code.org/girls) page.

### Previous /inspire page
![PREV](https://github.com/code-dot-org/code-dot-org/assets/56283563/20764c52-1442-4e45-86bf-7e7274aac7eb)

### New /inspire page
![fix_link](https://github.com/code-dot-org/code-dot-org/assets/56283563/dd88a183-281b-4952-8a31-1846acbdc166)

### Previous /girls page
![old](https://github.com/code-dot-org/code-dot-org/assets/56283563/38e5c763-a36a-4d75-a46a-607094dae1dd)

### New /girls page
![new](https://github.com/code-dot-org/code-dot-org/assets/56283563/496b6bf9-ffcc-4c4f-b539-1014392a0871)

## Links
Zendesk ticket: [here](https://codeorg.zendesk.com/agent/tickets/488732)

## Testing story
Local testing.
