### PR TITLE
add ai_confidence_exact_match field to learning_goal_ai_evaluations table

### DIFF
--- a/dashboard/app/models/learning_goal_ai_evaluation.rb
+++ b/dashboard/app/models/learning_goal_ai_evaluation.rb
@@ -2,14 +2,15 @@
 #
 # Table name: learning_goal_ai_evaluations
 #
-#  id                      :bigint           not null, primary key
-#  rubric_ai_evaluation_id :bigint           not null
-#  learning_goal_id        :bigint           not null
-#  understanding           :integer
-#  ai_confidence           :integer
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  observations            :text(65535)
+#  id                        :bigint           not null, primary key
+#  rubric_ai_evaluation_id   :bigint           not null
+#  learning_goal_id          :bigint           not null
+#  understanding             :integer
+#  ai_confidence             :integer
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  observations              :text(65535)
+#  ai_confidence_exact_match :integer
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20240306184654_add_exact_confidence_to_learning_goal_ai_evaluations.rb
+++ b/dashboard/db/migrate/20240306184654_add_exact_confidence_to_learning_goal_ai_evaluations.rb
@@ -1,0 +1,5 @@
+class AddExactConfidenceToLearningGoalAiEvaluations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :learning_goal_ai_evaluations, :ai_confidence_exact_match, :integer
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_28_195613) do
+ActiveRecord::Schema.define(version: 2024_03_06_184654) do
 
   create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -633,6 +633,7 @@ ActiveRecord::Schema.define(version: 2024_02_28_195613) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "observations"
+    t.integer "ai_confidence_exact_match"
     t.index ["learning_goal_id"], name: "index_learning_goal_ai_evaluations_on_learning_goal_id"
     t.index ["rubric_ai_evaluation_id"], name: "index_learning_goal_ai_evaluations_on_rubric_ai_evaluation_id"
   end


### PR DESCRIPTION
starts https://codedotorg.atlassian.net/browse/AITT-489. This is a small first PR to follow the best practice of putting the migration in its own PR.

For now there will be 2 confidence-related fields on the LearningGoalAiEvalution table: 
* `ai_confidence` -- our confidence level in the AI score, interpreted as a pass-fail score
* `ai_confidence_exact_match` -- our confidence level in the exact AI score

`ai_confidence_exact_match` will contain the same format data as `ai_confidence`, i.e. null or an integer representing low, medium or high confidence.

## Testing story

existing test coverage