### PR TITLE
LTI metrics and Statsig wrapper init

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -163,13 +163,12 @@ class LtiV1Controller < ApplicationController
         sign_in user
 
         metadata = {
-          'LMS_Type' => integration.platform_name,
           'User_Type' => user.user_type,
+          'LMS_Type' => integration[:platform_name],
         }
         Metrics::Events.log_event(
           user: user,
-          event_type: 'LTI_EVENT',
-          event_name: 'LTI_EXISTING_USER_LOGIN',
+          event_name: 'LTI_User_Signin',
           metadata: metadata,
         )
         # If on code.org, the user is a student and the LTI has the same user as a teacher, upgrade the student to a teacher.

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -5,6 +5,7 @@ require "policies/lti"
 require "concerns/partial_registration"
 require "clients/lti_advantage_client"
 require "cdo/honeybadger"
+require 'metrics/events'
 
 class LtiV1Controller < ApplicationController
   before_action -> {redirect_to lti_v1_integrations_path, alert: I18n.t('lti.integration.early_access.closed')},
@@ -161,6 +162,16 @@ class LtiV1Controller < ApplicationController
       if user
         sign_in user
 
+        metadata = {
+          'LMS_Type' => integration.platform_name,
+          'User_Type' => user.user_type,
+        }
+        Metrics::Events.log_event(
+          user: user,
+          event_type: 'LTI_EVENT',
+          event_name: 'LTI_EXISTING_USER_LOGIN',
+          metadata: metadata,
+        )
         # If on code.org, the user is a student and the LTI has the same user as a teacher, upgrade the student to a teacher.
         if lti_account_type == User::TYPE_TEACHER && user.user_type == User::TYPE_STUDENT
           @form_data = {

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -163,12 +163,12 @@ class LtiV1Controller < ApplicationController
         sign_in user
 
         metadata = {
-          'User_Type' => user.user_type,
-          'LMS_Type' => integration[:platform_name],
+          'user_type' => user.user_type,
+          'lms_type' => integration[:platform_name],
         }
         Metrics::Events.log_event(
           user: user,
-          event_name: 'LTI_User_Signin',
+          event_name: 'lti_user_signin',
           metadata: metadata,
         )
         # If on code.org, the user is a student and the LTI has the same user as a teacher, upgrade the student to a teacher.

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -1,0 +1,40 @@
+module Metrics
+  module Events
+    class << self
+      # Logs an event, delegating to the appropriate handler based on environment
+      def log_event(user:, event_type:, event_name:, metadata: {})
+        if CDO.rack_env?(:development)
+          log_event_to_stdout(user: user, event_type: event_type, event_name: event_name, metadata: metadata)
+        else
+          log_event_with_statsig(user: user, event_type: event_type, event_name: event_name, metadata: metadata)
+        end
+      rescue => exception
+        Honeybadger.notify(exception)
+      end
+
+      private
+
+      # Logs an event to Statsig
+      def log_event_with_statsig(user:, event_type:, event_name:, metadata:)
+        statsig_user = build_statsig_user(user)
+        Statsig.log_event(statsig_user, event_type, event_name, metadata)
+      end
+
+      # Builds a StatsigUser object from a user entity
+      def build_statsig_user(user)
+        StatsigUser.new({'userID' => user.id.to_s})
+      end
+
+      # Logs an event to stdout, useful for development and debugging
+      def log_event_to_stdout(user:, event_type:, event_name:, metadata:)
+        event_details = {
+          user_id: user.id,
+          event_type: event_type,
+          event_name: event_name,
+          metadata: metadata
+        }
+        puts "Logging Event: #{event_details.to_json}"
+      end
+    end
+  end
+end

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -2,25 +2,26 @@ module Metrics
   module Events
     class << self
       # Logs an event, delegating to the appropriate handler based on environment
-      def log_event(user:, event_type:, event_name:, metadata: {})
+      def log_event(user:, event_name:, event_value: nil, metadata: {})
+        event_value = event_name if event_value.nil?
         if CDO.rack_env?(:development)
-          log_event_to_stdout(user: user, event_type: event_type, event_name: event_name, metadata: metadata)
+          log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata)
         else
-          log_event_with_statsig(user: user, event_type: event_type, event_name: event_name, metadata: metadata)
+          log_event_with_statsig(user: user, event_name: event_name, event_value: event_value, metadata: metadata)
         end
       rescue => exception
         Honeybadger.notify(
           exception,
-          error_message: 'Error logging event to Statsig',
+          error_message: 'Error logging event',
       )
       end
 
       private
 
       # Logs an event to Statsig
-      def log_event_with_statsig(user:, event_type:, event_name:, metadata:)
+      def log_event_with_statsig(user:, event_name:, event_value:, metadata:)
         statsig_user = build_statsig_user(user)
-        Statsig.log_event(statsig_user, event_type, event_name, metadata)
+        Statsig.log_event(statsig_user, event_name, event_value, metadata)
       end
 
       # Builds a StatsigUser object from a user entity
@@ -29,11 +30,11 @@ module Metrics
       end
 
       # Logs an event to stdout, useful for development and debugging
-      def log_event_to_stdout(user:, event_type:, event_name:, metadata:)
+      def log_event_to_stdout(user:, event_name:, event_value:, metadata:)
         event_details = {
           user_id: user.id,
-          event_type: event_type,
           event_name: event_name,
+          event_value: event_value,
           metadata: metadata
         }
         puts "Logging Event: #{event_details.to_json}"

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -9,7 +9,10 @@ module Metrics
           log_event_with_statsig(user: user, event_type: event_type, event_name: event_name, metadata: metadata)
         end
       rescue => exception
-        Honeybadger.notify(exception)
+        Honeybadger.notify(
+          exception,
+          error_message: 'Error logging event to Statsig',
+      )
       end
 
       private

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -220,17 +220,6 @@ class Services::Lti
           }
         )
         lti_section = LtiSection.create(lti_course_id: lti_course.id, lms_section_id: lms_section_id, section: section)
-        # log_event LTI_Section_Created
-        metadata = {
-          'LMS_Type' => lti_integration.platform_name,
-          'Number_Of_Students' => '', #TODO: We don't know number of students yet, that happens when this gets called again on recursive redirect to sync course endpoint
-        }
-        Metrics::Events.log_event(
-          user: user, # TODO: We don't have access to user here, should we make it a param for this function?
-          event_type: 'LTI_EVENT',
-          event_name: 'LTI_Section_Created',
-          metadata: metadata,
-        )
         had_changes = true
       end
 

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -3,6 +3,7 @@ require 'queries/lti'
 require 'user'
 require 'authentication_option'
 require 'sections/section'
+require 'metrics/events'
 
 class Services::Lti
   def self.initialize_lti_user(id_token)
@@ -219,6 +220,17 @@ class Services::Lti
           }
         )
         lti_section = LtiSection.create(lti_course_id: lti_course.id, lms_section_id: lms_section_id, section: section)
+        # log_event LTI_Section_Created
+        metadata = {
+          'LMS_Type' => lti_integration.platform_name,
+          'Number_Of_Students' => '', #TODO: We don't know number of students yet, that happens when this gets called again on recursive redirect to sync course endpoint
+        }
+        Metrics::Events.log_event(
+          user: user, # TODO: We don't have access to user here, should we make it a param for this function?
+          event_type: 'LTI_EVENT',
+          event_name: 'LTI_Section_Created',
+          metadata: metadata,
+        )
         had_changes = true
       end
 

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -3,7 +3,6 @@ require 'queries/lti'
 require 'user'
 require 'authentication_option'
 require 'sections/section'
-require 'metrics/events'
 
 class Services::Lti
   def self.initialize_lti_user(id_token)


### PR DESCRIPTION
This PR adds a wrapper to the Statsig Ruby SDK, and adds an example log event using the wrapper.

There will be a follow up PR adding more event logging throughout the LTI code using this wrapper.

(UPDATE 3.20.24):

Statsig has an interesting event log format. It's `sendEvent` function takes an `event name`, `event value`, and an optional `metadata` object that can contain arbitrary key/values. Their examples for usage are something like `event_name: item_added_to_cart`, `event_value: SKU_109483`, `metadata: {price: 1.99, item_name: 'diet_coke'}`.

From what I can foresee in our logging cases, we care about `event_name` as this is what we will index on when building dashboards, and the `metadata` field which we will put things like `lms_type`, `user_type`, etc. We may not always care about adding an `event_value` field to our log.

As a result, I refactored the sendEvent wrapper function to set `event_value` to nil as a default. If it is nil, it will set this value to be the same as `event_name`, otherwise it will pass the supplied `event_value` down to the Statsig sendEvent.

Example:

**Send event WITH NO `event_value`**
```
metadata = {
  'user_type' => user.user_type,
  'lms_type' => integration[:platform_name],
}
Metrics::Events.log_event(
  user: user,
  event_name: 'lti_user_signin',
  metadata: metadata,
)
```
<img width="1125" alt="Screenshot 2024-03-20 at 3 00 16 PM" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/c558bbc1-7b21-460e-942c-3b90e2769b82">

**Send event WITH `event_value`**
```
metadata = {
  'user_type' => user.user_type,
  'lms_type' => integration[:platform_name],
}
Metrics::Events.log_event(
  user: user,
  event_name: 'lti_user_signin',
  event_value: 'some_value'
  metadata: metadata,
)
```
<img width="1125" alt="Screenshot 2024-03-20 at 3 00 16 PM copy" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/5d2db699-f2f2-4187-87d8-0bd785c7d767">
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [Previous PR configuring Statsig](https://github.com/code-dot-org/code-dot-org/pull/56879)
- [Jira ticket](https://codedotorg.atlassian.net/browse/P20-736)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
