### PR TITLE
Put 'needs feedback' indicators on progress lesson and level cells

### DIFF
--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -164,6 +164,7 @@ export const studentNeedsFeedback = (progress, level) =>
   progress &&
   progress.status !== LevelStatus.not_tried &&
   level.kind === 'assessment' &&
+  level.canHaveFeedback &&
   !feedbackLeft(progress);
 
 /**

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -156,6 +156,16 @@ export function lessonHasLevels(lesson) {
   return !!lesson.levels?.length;
 }
 
+export const feedbackLeft = progress =>
+  progress?.teacherFeedbackReviewState !== 'keepWorking' &&
+  progress?.teacherFeedbackNew;
+
+export const studentNeedsFeedback = (progress, level) =>
+  progress &&
+  progress.status !== LevelStatus.not_tried &&
+  level.kind === 'assessment' &&
+  !feedbackLeft(progress);
+
 /**
  * Determines if we should show "Keep working" and "Needs review" states for
  * progress in a unit. Unit must be either CSD or CSP.
@@ -276,6 +286,7 @@ export const processedLevel = level => {
         : level.letter || level.title.toString(),
     isConceptLevel: level.is_concept_level,
     isValidated: level.is_validated,
+    canHaveFeedback: level.can_have_feedback,
     bonus: level.bonus,
     pageNumber:
       typeof level.page_number !== 'undefined'

--- a/apps/src/templates/sectionProgressV2/LessonDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LessonDataCell.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {studentLessonProgressType} from '../progress/progressTypes';
 import classNames from 'classnames';
 import styles from './progress-table-v2.module.scss';
+import legendStyles from './progress-table-legend.module.scss';
 import {lessonHasLevels} from '../progress/progressHelpers';
 import {ITEM_TYPE} from './ItemType';
 import ProgressIcon from './ProgressIcon';
@@ -14,6 +15,7 @@ function LessonDataCell({
   lesson,
   sectionId,
   locked,
+  needsFeedback,
   studentLessonProgress,
   addExpandedLesson,
   studentId,
@@ -49,7 +51,8 @@ function LessonDataCell({
           styles.gridBox,
           styles.gridBoxLesson,
           locked && styles.littleLock,
-          interactive && styles.lessonInteractive
+          interactive && styles.lessonInteractive,
+          !locked && needsFeedback && legendStyles.needsFeedback
         )}
         onClick={expandLesson}
         data-testid={'lesson-data-cell-' + lesson.id + '-' + studentId}
@@ -83,4 +86,5 @@ LessonDataCell.propTypes = {
   lesson: PropTypes.object.isRequired,
   addExpandedLesson: PropTypes.func.isRequired,
   studentId: PropTypes.number.isRequired,
+  needsFeedback: PropTypes.bool,
 };

--- a/apps/src/templates/sectionProgressV2/LessonProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/LessonProgressDataColumn.jsx
@@ -8,6 +8,7 @@ import {
 } from '../progress/progressTypes';
 import {connect} from 'react-redux';
 import LessonDataCell from './LessonDataCell';
+import {studentNeedsFeedback} from '../progress/progressHelpers';
 import LessonProgressColumnHeader from './LessonProgressColumnHeader';
 
 function LessonProgressDataColumn({
@@ -29,6 +30,22 @@ function LessonProgressDataColumn({
         ])
       ),
     [levelProgressByStudent, sortedStudents, lesson]
+  );
+
+  const needsFeedbackByStudent = React.useMemo(
+    () =>
+      Object.fromEntries(
+        sortedStudents.map(student => [
+          student.id,
+          lesson.levels.some(level =>
+            studentNeedsFeedback(
+              levelProgressByStudent[student.id][level.id],
+              level
+            )
+          ),
+        ])
+      ),
+    [levelProgressByStudent, sortedStudents, lesson.levels]
   );
 
   // For lockable lessons, check whether each level is locked for each student.
@@ -54,6 +71,7 @@ function LessonProgressDataColumn({
             studentLessonProgress={
               lessonProgressByStudent[student.id][lesson.id]
             }
+            needsFeedback={needsFeedbackByStudent[student.id]}
             key={student.id + '.' + lesson.id}
             studentId={student.id}
             addExpandedLesson={addExpandedLesson}

--- a/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
@@ -10,6 +10,7 @@ import ProgressIcon from './ProgressIcon';
 import {ITEM_TYPE} from './ItemType';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import queryString from 'query-string';
+import {feedbackLeft, studentNeedsFeedback} from '../progress/progressHelpers';
 
 export const navigateToLevelOverviewUrl = (levelUrl, studentId, sectionId) => {
   if (!levelUrl) {
@@ -69,18 +70,21 @@ function LevelDataCell({
     }
   }, [studentLevelProgress, level, expandedChoiceLevel]);
 
+  const feedbackStyle = React.useMemo(() => {
+    if (feedbackLeft(studentLevelProgress)) {
+      return legendStyles.feedbackGiven;
+    }
+    if (studentNeedsFeedback(studentLevelProgress, level)) {
+      return legendStyles.needsFeedback;
+    }
+  }, [studentLevelProgress, level]);
+
   return (
     <Link
       href={navigateToLevelOverviewUrl(level.url, studentId, sectionId)}
       openInNewTab
       external
-      className={classNames(
-        styles.gridBox,
-        styles.gridBoxLevel,
-        studentLevelProgress?.teacherFeedbackReviewState !== 'keepWorking' &&
-          studentLevelProgress?.teacherFeedbackNew &&
-          legendStyles.feedbackGiven
-      )}
+      className={classNames(styles.gridBox, styles.gridBoxLevel, feedbackStyle)}
     >
       {itemType && <ProgressIcon itemType={itemType} />}
     </Link>

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -610,6 +610,7 @@ describe('progressReduxTest', () => {
             app: 'maze',
             usesLab2: false,
             isValidated: true,
+            canHaveFeedback: undefined,
           },
           {
             id: '323',
@@ -634,6 +635,7 @@ describe('progressReduxTest', () => {
             app: 'maze',
             usesLab2: false,
             isValidated: true,
+            canHaveFeedback: undefined,
           },
           {
             id: '322',
@@ -658,6 +660,7 @@ describe('progressReduxTest', () => {
             app: 'maze',
             usesLab2: false,
             isValidated: false,
+            canHaveFeedback: undefined,
           },
         ],
         [
@@ -684,6 +687,7 @@ describe('progressReduxTest', () => {
             app: 'maze',
             usesLab2: false,
             isValidated: true,
+            canHaveFeedback: undefined,
           },
           {
             id: '339',
@@ -708,6 +712,7 @@ describe('progressReduxTest', () => {
             app: 'maze',
             usesLab2: false,
             isValidated: false,
+            canHaveFeedback: undefined,
           },
           {
             id: '341',
@@ -732,6 +737,7 @@ describe('progressReduxTest', () => {
             app: 'maze',
             usesLab2: false,
             isValidated: false,
+            canHaveFeedback: undefined,
           },
         ],
       ];

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -520,7 +520,8 @@ class Level < ApplicationRecord
       type: self.class.to_s,
       name: name,
       display_name: display_name,
-      is_validated: validated?
+      is_validated: validated?,
+      can_have_feedback: can_have_feedback?
     }
   end
 

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -334,7 +334,8 @@ class ScriptLevel < ApplicationRecord
         display_as_unplugged: level.display_as_unplugged?,
         app: level.game&.app,
         uses_lab2: level.uses_lab2?,
-        is_validated: level.validated?
+        is_validated: level.validated?,
+        can_have_feedback: level.can_have_feedback?
       }
 
       if progression

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -129,7 +129,7 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
         "display_name" => nil, "answers" => expected_answers, "question_text" => sub_level4.get_question_text, "question_index" => 3},
       {"level_id" => sub_level6.id.to_s, "type" => "Match", "name" => sub_level6.name, 'is_validated' => false, 'can_have_feedback' => false,
        "display_name" => nil, "answers" => expected_match_answers, "options" => expected_match_options, "question_text" => sub_level6.get_question_text, "question" => sub_level6.question, "question_index" => 4},
-      {"level_id" => sub_level7.id.to_s, "type" => "Weblab", "name" => sub_level7.name, 'is_validated' => false, 'can_have_feedback' => false,
+      {"level_id" => sub_level7.id.to_s, "type" => "Match", "name" => sub_level7.name, 'is_validated' => false, 'can_have_feedback' => false,
        "display_name" => nil, "answers" => expected_match_answers, "options" => expected_match_options, "question_text" => sub_level7.get_question_text, "question" => sub_level7.question, "question_index" => 5},
       {"level_id" => sub_level8.id.to_s, "type" => "Match", "name" => sub_level8.name, 'is_validated' => false, 'can_have_feedback' => false,
        "display_name" => nil, "answers" => expected_match_answers, "options" => expected_match_options, "question_text" => sub_level8.get_question_text, "question" => sub_level8.question, "question_index" => 6},

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -119,21 +119,21 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
     expected_match_options = [{"text" => "one"}, {"text" => "two"}]
 
     expected_questions = [
-      {"level_id" => sub_level1.id.to_s, "type" => "TextMatch", "name" => sub_level1.name, 'is_validated' => true,
+      {"level_id" => sub_level1.id.to_s, "type" => "TextMatch", "name" => sub_level1.name, 'is_validated' => true, 'can_have_feedback' => false,
         "display_name" => nil, "title" => "title", "question_text" => nil, "question_index" => 0},
-      {"level_id" => sub_level2.id.to_s, "type" => "Multi", "name" => sub_level2.name, 'is_validated' => true,
+      {"level_id" => sub_level2.id.to_s, "type" => "Multi", "name" => sub_level2.name, 'is_validated' => true, 'can_have_feedback' => false,
         "display_name" => nil, "answers" => expected_answers, "question_text" => sub_level2.get_question_text, "question_index" => 1},
-      {"level_id" => sub_level3.id.to_s, "type" => "Multi", "name" => sub_level3.name, 'is_validated' => true,
+      {"level_id" => sub_level3.id.to_s, "type" => "Multi", "name" => sub_level3.name, 'is_validated' => true, 'can_have_feedback' => false,
         "display_name" => nil, "answers" => expected_answers, "question_text" => sub_level3.get_question_text, "question_index" => 2},
-      {"level_id" => sub_level4.id.to_s, "type" => "Multi", "name" => sub_level4.name, 'is_validated' => true,
+      {"level_id" => sub_level4.id.to_s, "type" => "Multi", "name" => sub_level4.name, 'is_validated' => true, 'can_have_feedback' => false,
         "display_name" => nil, "answers" => expected_answers, "question_text" => sub_level4.get_question_text, "question_index" => 3},
-      {"level_id" => sub_level6.id.to_s, "type" => "Match", "name" => sub_level6.name, 'is_validated' => false,
+      {"level_id" => sub_level6.id.to_s, "type" => "Match", "name" => sub_level6.name, 'is_validated' => false, 'can_have_feedback' => false,
        "display_name" => nil, "answers" => expected_match_answers, "options" => expected_match_options, "question_text" => sub_level6.get_question_text, "question" => sub_level6.question, "question_index" => 4},
-      {"level_id" => sub_level7.id.to_s, "type" => "Match", "name" => sub_level7.name, 'is_validated' => false,
+      {"level_id" => sub_level7.id.to_s, "type" => "Weblab", "name" => sub_level7.name, 'is_validated' => false, 'can_have_feedback' => false,
        "display_name" => nil, "answers" => expected_match_answers, "options" => expected_match_options, "question_text" => sub_level7.get_question_text, "question" => sub_level7.question, "question_index" => 5},
-      {"level_id" => sub_level8.id.to_s, "type" => "Match", "name" => sub_level8.name, 'is_validated' => false,
+      {"level_id" => sub_level8.id.to_s, "type" => "Match", "name" => sub_level8.name, 'is_validated' => false, 'can_have_feedback' => false,
        "display_name" => nil, "answers" => expected_match_answers, "options" => expected_match_options, "question_text" => sub_level8.get_question_text, "question" => sub_level8.question, "question_index" => 6},
-      {"level_id" => sub_level5.id.to_s, "type" => "Multi", "name" => sub_level5.name, 'is_validated' => true,
+      {"level_id" => sub_level5.id.to_s, "type" => "Multi", "name" => sub_level5.name, 'is_validated' => true, 'can_have_feedback' => false,
         "display_name" => nil, "answers" => expected_answers, "question_text" => sub_level5.get_question_text, "question_index" => 7},
     ]
     level_response = JSON.parse(@response.body)[level1.id.to_s]

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -105,7 +105,8 @@ class LessonTest < ActiveSupport::TestCase
         type: level.class.to_s,
         name: level.name,
         display_name: level.display_name,
-        is_validated: false
+        is_validated: false,
+        can_have_feedback: level.can_have_feedback?
       }
     ]
 

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -191,7 +191,8 @@ class BubbleChoiceTest < ActiveSupport::TestCase
         letter: 'a',
         icon: nil,
         status: 'not_tried',
-        is_validated: false
+        is_validated: false,
+        can_have_feedback: false
       },
       {
         level_id: @sublevel2.id.to_s,
@@ -207,7 +208,8 @@ class BubbleChoiceTest < ActiveSupport::TestCase
         icon: nil,
         status: 'not_tried',
         short_instructions: @sublevel2.short_instructions,
-        is_validated: false
+        is_validated: false,
+        can_have_feedback: false
       }
     ]
 
@@ -237,7 +239,8 @@ class BubbleChoiceTest < ActiveSupport::TestCase
           type: "FreeResponse",
           name: "Sublevel contained level",
           display_name: nil,
-          is_validated: false
+          is_validated: false,
+          can_have_feedback: false
         }],
         id: @sublevel_with_contained.id.to_s,
         description: @sublevel_with_contained.bubble_choice_description,
@@ -250,7 +253,8 @@ class BubbleChoiceTest < ActiveSupport::TestCase
         status: 'perfect',
         teacher_feedback_review_state: nil,
         exampleSolutions: [],
-        is_validated: false
+        is_validated: false,
+        can_have_feedback: false
       },
       {
         level_id: @sublevel2.id.to_s,
@@ -269,7 +273,8 @@ class BubbleChoiceTest < ActiveSupport::TestCase
         status: 'passed',
         teacher_feedback_review_state: nil,
         exampleSolutions: [],
-        is_validated: false
+        is_validated: false,
+        can_have_feedback: false
       }
     ]
 


### PR DESCRIPTION
This change adds a triangle to progress cells to indicate a lesson or level needs feedback.

A level needs feedback when it's an assessement level that can receive feedback that the student has worked on and has not received feedback since their last changes. 
A lesson needs feedback when any of the levels do.

![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/fa8ca831-81ef-4f0e-b236-8ece8a3207e5)

## Links

[JIRA](https://codedotorg.atlassian.net/browse/TEACH-878)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
