### PR TITLE
Revert "re-enable PDF generation"

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -133,12 +133,12 @@ namespace :build do
           RakeUtils.git_push
         end
 
-        if rack_env?(:staging)
-          # This step will only complete successfully if we succeed in
-          # generating all curriculum PDFs.
-          ChatClient.log "Generating missing pdfs..."
-          RakeUtils.rake_stream_output 'curriculum_pdfs:generate_missing_pdfs'
-        end
+        # if rack_env?(:staging)
+        #  This step will only complete successfully if we succeed in
+        #  generating all curriculum PDFs.
+        #  ChatClient.log "Generating missing pdfs..."
+        #  RakeUtils.rake_stream_output 'curriculum_pdfs:generate_missing_pdfs'
+        # end
       end
 
       # Skip asset precompile in development.


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#56948

Got this error:

Generating missing Unit Overview PDF for csa5-2023
Generating missing Unit Resources PDF for csa5-2023
rake aborted!
NoMethodError: undefined method `getFile' for #<Google::Apis::DriveV3::DriveService:0x000055d5731561e0 @root_url="https://www.googleapis.com/", @base_path="drive/v3/", @client_name="google-apis-drive_v3", @client_version="0.32.0", @upload_path="upload/drive/v3/", @batch_path="batch/drive/v3", @client_options=#<struct Google::Apis::ClientOptions application_name="unknown", application_version="0.0.0", proxy_url=nil, open_timeout_sec=nil, read_timeout_sec=nil, send_timeout_sec=nil, log_http_requests=false, transparent_gzip_decompression=true>, @request_options=#<struct Google::Apis::RequestOptions authorization=#<Google::Auth::ServiceAccountCredentials:0x000055d5731541d8 @project_id="cdo-gdrive-export-staging", @quota_project_id=nil, @enable_self_signed_jwt=false, @authorization_uri=nil, @token_credential_uri=#<Addressable::URI:0x586664 URI:https://www.googleapis.com/oauth2/v4/token>, @client_id=nil, @client_secret=nil, @code=nil, @expires_at=nil, @issued_at=nil, @issuer="writer@cdo-gdrive-export-staging.iam.gserviceaccount.com", @password=nil, @principal=nil, @redirect_uri=nil, @scope=["https://www.googleapis.com/auth/drive"], @target_audience=nil, @state=nil, @username=nil, @access_type=:offline, @expiry=60, @audience="https://www.googleapis.com/oauth2/v4/token", @signing_key=#<OpenSSL::PKey::RSA:0x000055d573154228 oid=rsaEncryption>, @extension_parameters={}, @additional_parameters={}, @connection_info=nil>, retries=0, max_elapsed_time=900, base_interval=1, max_interval=60, multiplier=2, header=nil, normalize_unicode=false, skip_serialization=false, skip_deserialization=false, api_format_version=nil, use_opencensus=true, quota_project=nil, query=nil, add_invocation_id_header=false>>
Did you mean?  get_file
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs/resources.rb:185:in `fetch_url_to_path'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs/resources.rb:167:in `fetch_resource_pdf'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs/resources.rb:59:in `block (2 levels) in generate_script_resources_pdf'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs/resources.rb:58:in `filter_map'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs/resources.rb:58:in `block in generate_script_resources_pdf'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs/resources.rb:56:in `generate_script_resources_pdf'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs.rb:175:in `block (2 levels) in generate_missing_pdfs'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs.rb:157:in `block in generate_missing_pdfs'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs.rb:156:in `each'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs.rb:156:in `generate_missing_pdfs'
/home/ubuntu/staging/dashboard/lib/tasks/curriculum_pdfs.rake:38:in `block (3 levels) in <top (required)>'
/home/ubuntu/staging/dashboard/lib/tasks/curriculum_pdfs.rake:37:in `block (2 levels) in <top (required)>'
/home/ubuntu/staging/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `block in execute'
/home/ubuntu/staging/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `execute'
/usr/local/bin/bundle:25:in `load'`