### PR TITLE
Removed explicit import of postcss

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -128,7 +128,6 @@
     "mocha": "^4.1.0",
     "mock-firmata": "0.2.0",
     "node-js-marker-clusterer": "^1.0.0",
-    "postcss": "8",
     "prettier": "2.8.7",
     "process": "^0.11.10",
     "progress-bar-webpack-plugin": "^2.1.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8644,7 +8644,6 @@ __metadata:
     pepjs: ^0.4.3
     pixelmatch: ^5.2.0
     playground-io: "code-dot-org/playground-io#v0.6.0-cdo.2"
-    postcss: 8
     prettier: 2.8.7
     process: ^0.11.10
     progress-bar-webpack-plugin: ^2.1.0
@@ -22976,17 +22975,6 @@ es6-shim@latest:
   languageName: node
   linkType: hard
 
-"postcss@npm:8, postcss@npm:^8.2.15, postcss@npm:^8.4.7":
-  version: 8.4.16
-  resolution: "postcss@npm:8.4.16"
-  dependencies:
-    nanoid: ^3.3.4
-    picocolors: ^1.0.0
-    source-map-js: ^1.0.2
-  checksum: 10eee25efd77868036403858577da0cefaf2e0905feeaba5770d5438ccdddba3d01cba8063e96b8aac4c6daa0ed413dd5ae0554a433a3c4db38df1d134cffc1f
-  languageName: node
-  linkType: hard
-
 "postcss@npm:^7.0.14":
   version: 7.0.14
   resolution: "postcss@npm:7.0.14"
@@ -23005,6 +22993,17 @@ es6-shim@latest:
     picocolors: ^0.2.1
     source-map: ^0.6.1
   checksum: 4ac793f506c23259189064bdc921260d869a115a82b5e713973c5af8e94fbb5721a5cc3e1e26840500d7e1f1fa42a209747c5b1a151918a9bc11f0d7ed9048e3
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.2.15, postcss@npm:^8.4.7":
+  version: 8.4.16
+  resolution: "postcss@npm:8.4.16"
+  dependencies:
+    nanoid: ^3.3.4
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 10eee25efd77868036403858577da0cefaf2e0905feeaba5770d5438ccdddba3d01cba8063e96b8aac4c6daa0ed413dd5ae0554a433a3c4db38df1d134cffc1f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Cleaning up some old NPM packages with the help of depcheck

From what I can tell, we were thinking about using postcss directly, but opted for a different option that does everything postcss does and more. Here's the original PR: https://github.com/code-dot-org/code-dot-org/pull/47591