### PR TITLE
Removed unused progress-bar package

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -131,7 +131,6 @@
     "postcss": "8",
     "prettier": "2.8.7",
     "process": "^0.11.10",
-    "progress-bar-webpack-plugin": "^2.1.0",
     "raw-loader": "^4.0.2",
     "react-addons-test-utils": "~15.4.0",
     "redux-mock-store": "^1.2.3",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8647,7 +8647,6 @@ __metadata:
     postcss: 8
     prettier: 2.8.7
     process: ^0.11.10
-    progress-bar-webpack-plugin: ^2.1.0
     prop-types: ^15.6.2
     pusher-js: 4.1.0
     pyodide: ^0.24.1
@@ -9690,16 +9689,6 @@ canvg@gabelerner/canvg:
     escape-string-regexp: ^1.0.5
     supports-color: ^5.3.0
   checksum: ec3661d38fe77f681200f878edbd9448821924e0f93a9cefc0e26a33b145f1027a2084bf19967160d11e1f03bfe4eaffcabf5493b89098b2782c3fe0b03d80c2
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "chalk@npm:3.0.0"
-  dependencies:
-    ansi-styles: ^4.1.0
-    supports-color: ^7.1.0
-  checksum: 8e3ddf3981c4da405ddbd7d9c8d91944ddf6e33d6837756979f7840a29272a69a5189ecae0ff84006750d6d1e92368d413335eab4db5476db6e6703a1d1e0505
   languageName: node
   linkType: hard
 
@@ -23183,19 +23172,7 @@ es6-shim@latest:
   languageName: node
   linkType: hard
 
-"progress-bar-webpack-plugin@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "progress-bar-webpack-plugin@npm:2.1.0"
-  dependencies:
-    chalk: ^3.0.0
-    progress: ^2.0.3
-  peerDependencies:
-    webpack: ^1.3.0 || ^2 || ^3 || ^4 || ^5
-  checksum: 90d765f363bd2b5c220c75cdd66037453690500e20206838d7dc67e49813dc742079a69d663663a4d4405c70b43738add347abe31d1c4abd4ab52f473019321a
-  languageName: node
-  linkType: hard
-
-"progress@npm:^2.0.1, progress@npm:^2.0.3":
+"progress@npm:^2.0.1":
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
   checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7


### PR DESCRIPTION
Cleaning up some old packages using depcheck.

Looks like we used a progress bar plugin for a while, but eventually stopped using it. Interestingly, we didn't even know why we were using it back then https://github.com/code-dot-org/code-dot-org/pull/9455 :) . Going ahead and removing it.