### PR TITLE
feat(lms): do not exclude teachers from roster syncing

### DIFF
--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -97,7 +97,7 @@ class Services::Lti
     members = nrps_response[:members]
     context_title = nrps_response.dig(:context, :title)
     members.each do |member|
-      next if member[:status] == 'Inactive' || member[:roles].exclude?(Policies::Lti::CONTEXT_LEARNER_ROLE)
+      next if member[:status] == 'Inactive'
       # TODO: handle multiple messages. Shouldn't be needed until we support Deep Linking.
       message = member[:message].first
 


### PR DESCRIPTION
Previous Behavior:

1. If a teacher attempts to sync a canvas course with only the teacher in the course, the section is deleted.
2. If a teacher attempts to sync a course with multiple teachers but no students in the course, the section is deleted.

New Behavior:

1. If a teacher attempts to sync a canvas course with only the teacher in the course, the section does not get deleted.
2. If a teacher attempts to sync a course with multiple teachers but no students in the course, the section is synced with the other teachers as students in the course.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-727)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. Unit tests added to test teacher only syncing, completely empty section syncing, and single teacher syncing.
2. Manually tested the same scenarios on Canvas

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
