### PR TITLE
update LTI sync dialog links

### DIFF
--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
@@ -4,6 +4,7 @@ import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import Button from '@cdo/apps/templates/Button';
 import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import {LmsLinks} from '@cdo/apps/util/sharedConstants';
 import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
 import {
   LtiSectionSyncDialogProps,
@@ -89,12 +90,13 @@ export default function LtiSectionSyncDialog({
    * @param syncResult
    */
   const syncResultView = (syncResult: LtiSectionSyncResult) => {
-    const aboutSectionsUrl = '/sections';
-    const aboutSyncingUrl = '/syncing';
+    const aboutSectionsUrl =
+      'https://support.code.org/hc/en-us/articles/115000488132-Creating-a-Classroom-Section';
+    const aboutSyncingUrl = LmsLinks.ROSTER_SYNC_INSTRUCTIONS_URL;
     const dialogTitle = i18n.ltiSectionSyncDialogTitle();
     const dialogDescription = i18n.ltiSectionSyncDialogDescription({
-      aboutSectionsUrl: aboutSectionsUrl,
-      aboutSyncingUrl: aboutSyncingUrl,
+      aboutSectionsUrl,
+      aboutSyncingUrl,
     });
     let sectionListItems;
     if (syncResult && syncResult.all) {


### PR DESCRIPTION
Minor update to add the support article links in the sync confirmation dialog. The first link is still to the generic sections support article, so it doesn't have an entry in `sharedConstants` yet. For now I've hardcoded the string since that seems to be the pattern in other files. The other link is LMS-specific so we already have a const for it.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-763)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
