### PR TITLE
modified pdfs stored as google files

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -182,9 +182,9 @@ module Services
             return path
           elsif url.start_with?("https://drive.google.com/")
             file_id = url_to_id(url)
-            file = service.getFile(file_id)
-            return nil unless file.export_links.include? "application/pdf"
-            service.export_file(file_id, 'application/pdf', download_dest: path)
+            file = service.get_file(file_id)
+            return nil unless file.mime_type == "application/pdf"
+            service.get_file(file_id, download_dest: path)
             return path
           elsif url.end_with?(".pdf")
             IO.copy_stream(URI.parse(url)&.open, path)

--- a/dashboard/test/lib/services/curriculum_pdfs/resources_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs/resources_test.rb
@@ -128,19 +128,19 @@ class Services::CurriculumPdfs::ResourcesTest < ActiveSupport::TestCase
 
   test 'fetch_url_to_path works for google drive resources that can be exported as pdfs' do
     fake_file = OpenStruct.new
-    fake_file.export_links = {"application/pdf" => "fake_export_link_to_pdf"}
+    fake_file.mime_type = "application/pdf"
     Services::CurriculumPdfs.expects(:url_to_id).with(@google_drive_resource.url).returns(@drive_file_id)
-    @fake_service.stubs(:getFile).returns(fake_file)
-    @fake_service.expects(:export_file).with(@drive_file_id, 'application/pdf', download_dest: @drive_path)
+    @fake_service.stubs(:get_file).returns(fake_file)
+    @fake_service.expects(:get_file).with(@drive_file_id, download_dest: @drive_path)
     assert_equal @drive_path, Services::CurriculumPdfs.fetch_url_to_path(@drive_url, @drive_path)
   end
 
   test 'fetch_url_to_path returns nil if google doc cannot be exported as PDF' do
     fake_file = OpenStruct.new
-    fake_file.export_links = {}
+    fake_file.mime_type = {}
     Services::CurriculumPdfs.expects(:url_to_id).with(@google_drive_resource.url).returns(@drive_file_id)
-    @fake_service.stubs(:getFile).returns(fake_file)
-    @fake_service.expects(:export_file).never
+    @fake_service.stubs(:get_file).returns(fake_file)
+    @fake_service.expects(:get_file).with(@drive_file_id, download_dest: @drive_path).never
     assert_nil Services::CurriculumPdfs.fetch_url_to_path(@drive_url, @drive_path)
   end
 end


### PR DESCRIPTION
When attempting to re-enable auto PDF generation, the staging build failed with the warning below.  This PR is intended to fix the issue.

```
Generating missing Unit Overview PDF for csa5-2023
Generating missing Unit Resources PDF for csa5-2023
rake aborted!
NoMethodError: undefined method `getFile' for #<Google::Apis::DriveV3::DriveService:0x000055d5731561e0 @root_url="https://www.googleapis.com/", @base_path="drive/v3/", @client_name="google-apis-drive_v3", @client_version="0.32.0", @upload_path="upload/drive/v3/", @batch_path="batch/drive/v3", @client_options=#<struct Google::Apis::ClientOptions application_name="unknown", application_version="0.0.0", proxy_url=nil, open_timeout_sec=nil, read_timeout_sec=nil, send_timeout_sec=nil, log_http_requests=false, transparent_gzip_decompression=true>, @request_options=#<struct Google::Apis::RequestOptions authorization=#<Google::Auth::ServiceAccountCredentials:0x000055d5731541d8 @project_id="cdo-gdrive-export-staging", @quota_project_id=nil, @enable_self_signed_jwt=false, @authorization_uri=nil, @token_credential_uri=#<Addressable::URI:0x586664 URI:https://www.googleapis.com/oauth2/v4/token>, @client_id=nil, @client_secret=nil, @code=nil, @expires_at=nil, @issued_at=nil, @issuer="writer@cdo-gdrive-export-staging.iam.gserviceaccount.com", @password=nil, @principal=nil, @redirect_uri=nil, @scope=["https://www.googleapis.com/auth/drive"], @target_audience=nil, @state=nil, @username=nil, @access_type=:offline, @expiry=60, @audience="https://www.googleapis.com/oauth2/v4/token", @signing_key=#<OpenSSL::PKey::RSA:0x000055d573154228 oid=rsaEncryption>, @extension_parameters={}, @additional_parameters={}, @connection_info=nil>, retries=0, max_elapsed_time=900, base_interval=1, max_interval=60, multiplier=2, header=nil, normalize_unicode=false, skip_serialization=false, skip_deserialization=false, api_format_version=nil, use_opencensus=true, quota_project=nil, query=nil, add_invocation_id_header=false>>
Did you mean?  get_file
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs/resources.rb:185:in `fetch_url_to_path'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs/resources.rb:167:in `fetch_resource_pdf'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs/resources.rb:59:in `block (2 levels) in generate_script_resources_pdf'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs/resources.rb:58:in `filter_map'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs/resources.rb:58:in `block in generate_script_resources_pdf'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs/resources.rb:56:in `generate_script_resources_pdf'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs.rb:175:in `block (2 levels) in generate_missing_pdfs'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs.rb:157:in `block in generate_missing_pdfs'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs.rb:156:in `each'
/home/ubuntu/staging/dashboard/lib/services/curriculum_pdfs.rb:156:in `generate_missing_pdfs'
/home/ubuntu/staging/dashboard/lib/tasks/curriculum_pdfs.rake:38:in `block (3 levels) in <top (required)>'
/home/ubuntu/staging/dashboard/lib/tasks/curriculum_pdfs.rake:37:in `block (2 levels) in <top (required)>'
/home/ubuntu/staging/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `block in execute'
/home/ubuntu/staging/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `execute'
/usr/local/bin/bundle:25:in `load'
```

## Links

[Part of the larger goal of re-enabling PDF generation](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-913)

## Testing story

- I tested this locally with `csa5-2023`.  
- I really looked throughout all of CSA and much of CSF and couldn't find any other place this used... I did find a file in `coursec-2023` that wasn't supposed to be included in the PDF but matched the type of file we wanted to test.  I locally included it in levelbuilder and then re-ran the script.  It generated the PDF accurately without issues. 
- I updated the existing tests.


## Deployment strategy

- Goal to merge this in before re-enabling automatic PDF generation.

