### PR TITLE
Flaky test in firefox Firefox_teacher_tools_levelbuilder_create_and_delete_data_docs

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/levelbuilder/create_and_delete_data_docs.feature
+++ b/dashboard/test/ui/features/teacher_tools/levelbuilder/create_and_delete_data_docs.feature
@@ -6,7 +6,7 @@ Feature: Creating and deleting data docs
     And I am on "http://studio.code.org/data_docs/edit"
 
     # create data doc
-    And I click selector "#create_new_data_doc"
+    And I click selector "#create_new_data_doc" to load a new page
     And I wait until element "#form" is visible
     And I enter a temp data doc key and temp data doc name
     And I press keys "Description of Doc" for element "textarea"


### PR DESCRIPTION
Flaky test failing due to error `ReferenceError: $ is not defined`. The screen shots in sauce labs suggest the issue is happening during a page navigation, but the failure is happening on the old page.

Fix: waiting for the page to load in the step where page navigation is triggered.

## Links

Sauce labs run: https://app.saucelabs.com/tests/3e4e4ef06ffa41f18ddc2f6c232650d4#13

## Testing story

Using Drone runs for validation

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
