### PR TITLE
[Sprite Lab] setGroup block

### DIFF
--- a/apps/src/p5lab/spritelab/commands/actionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/actionCommands.js
@@ -318,6 +318,16 @@ export const commands = {
     });
   },
 
+  setGroup(spriteArg, val) {
+    if (val === undefined) {
+      return;
+    }
+    let sprites = this.getSpriteArray(spriteArg);
+    sprites.forEach(sprite => {
+      sprite.group = val;
+    });
+  },
+
   spriteSay(spriteArg, text) {
     addSpriteSpeechBubble(this, spriteArg, text, 4 /* seconds */, 'say');
   },

--- a/dashboard/config/blocks/GameDev/GameDev_setGroup.json
+++ b/dashboard/config/blocks/GameDev/GameDev_setGroup.json
@@ -1,0 +1,35 @@
+{
+  "category": "Sprites",
+  "config": {
+    "func": "setGroup",
+    "blockText": "set {SPRITE} type to {GROUP}",
+    "args": [
+      {
+        "name": "SPRITE",
+        "type": "Sprite"
+      },
+      {
+        "name": "GROUP",
+        "options": [
+          [
+            "player",
+            "\"players\""
+          ],
+          [
+            "environment",
+            "\"walls\""
+          ],
+          [
+            "object",
+            "\"objects\""
+          ],
+          [
+            "enemy",
+            "\"enemies\""
+          ]
+        ]
+      }
+    ],
+    "style": "default"
+  }
+}


### PR DESCRIPTION
Creates a new block for Sprite Lab that allows setting a sprite's "group":
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/100f0a55-6351-44dd-a2eb-ade13f8d0596)

This concept was introduce here:
- https://github.com/code-dot-org/code-dot-org/pull/57022

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
