### PR TITLE
Render actions column for LTI sections with sync disabled

### DIFF
--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -29,6 +29,7 @@ import {
   sectionName,
   selectedSection,
   sectionUnitName,
+  syncEnabled,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {
   convertStudentDataToArray,
@@ -126,6 +127,7 @@ class ManageStudentsTable extends Component {
     transferData: PropTypes.object,
     transferStatus: PropTypes.object,
     setSortByFamilyName: PropTypes.func,
+    syncEnabled: PropTypes.bool,
   };
 
   constructor(props) {
@@ -204,6 +206,14 @@ class ManageStudentsTable extends Component {
   // Helper function to determine if user is a teacher
   isTeacher(userType) {
     return userType === 'teacher';
+  }
+
+  shouldShowActionColumn() {
+    const {loginType} = this.props;
+    return (
+      LOGIN_TYPES_WITH_ACTIONS_COLUMN.includes(loginType) ||
+      (loginType === SectionLoginType.lti_v1 && !this.props.syncEnabled)
+    );
   }
 
   // Cell formatters.
@@ -509,7 +519,7 @@ class ManageStudentsTable extends Component {
       columns.push(this.projectSharingColumn());
     }
 
-    if (LOGIN_TYPES_WITH_ACTIONS_COLUMN.includes(loginType)) {
+    if (this.shouldShowActionColumn()) {
       columns.push(this.controlsColumn());
     }
 
@@ -1098,6 +1108,7 @@ export default connect(
     addStatus: state.manageStudents.addStatus,
     transferData: state.manageStudents.transferData,
     transferStatus: state.manageStudents.transferStatus,
+    syncEnabled: syncEnabled(state, state.teacherSections.selectedSectionId),
   }),
   dispatch => ({
     saveAllStudents() {

--- a/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
@@ -118,35 +118,6 @@ describe('ManageStudentsTable', () => {
     });
   });
 
-  // describe('LTI section tests', () => {
-  //   const DEFAULT_PROPS = {
-  //     loginType: SectionLoginType.lti_v1,
-  //     studentData: [],
-  //     editingData: {},
-  //     addStatus: {},
-  //     transferStatus: {},
-  //   };
-
-  //   it('Should not render the action column for LTI sections with sync enabled', () => {
-  //     const wrapper = shallow(
-  //       <UnconnectedManageStudentsTable
-  //         {...{...DEFAULT_PROPS, ...{loginType: SectionLoginType.lti_v1, syncEnabled: true}}}
-  //       />
-  //     );
-  //     expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be.false;
-  //   });
-
-  //   it('Should render the action column for LTI sections with sync disabled', () => {
-  //     const wrapper = shallow(
-  //       <UnconnectedManageStudentsTable
-  //         {...{...DEFAULT_PROPS, ...{loginType: SectionLoginType.email, syncEnabled: false}}}
-  //       />
-  //     );
-  //     console.log(wrapper.debug());
-  //     expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be.true;
-  //   });
-  // });
-
   describe('full render tests', () => {
     const fakeStudent = {
       id: 1,
@@ -177,7 +148,6 @@ describe('ManageStudentsTable', () => {
       studentCount: 10,
       students: Object.values(fakeStudents),
       hidden: false,
-      sync_enabled: false,
     };
 
     beforeEach(() => {

--- a/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
@@ -177,7 +177,7 @@ describe('ManageStudentsTable', () => {
       studentCount: 10,
       students: Object.values(fakeStudents),
       hidden: false,
-      syncEnabled: true,
+      sync_enabled: false,
     };
 
     beforeEach(() => {
@@ -221,35 +221,29 @@ describe('ManageStudentsTable', () => {
     });
 
     describe('LTI section tests', () => {
-      it('does not render the Actions column if loginType is lti_v1', () => {
+      it('does not render the Actions column if loginType is lti_v1 and sync is enabled', () => {
         const store = getStore();
         store.dispatch(setLoginType(SectionLoginType.lti_v1));
+        store.dispatch(setSections([{...fakeSection, sync_enabled: true}]));
         const wrapper = mount(
           <Provider store={store}>
-            <ManageStudentsTable syncEnabled={true} />
+            <ManageStudentsTable />
           </Provider>
         );
-        const manageStudentsTable = wrapper.find('ManageStudentsTable');
-        
-        manageStudentsTable.setState('sections', {101: {syncEnabled: true}});
-        console.log(manageStudentsTable.state());
-        store.dispatch(syncEnabled(manageStudentsTable.state, 101));
+
         expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be.false;
       });
-
-      // const manageStudentsTable = wrapper.find('ManageStudentsTable');
-      // manageStudentsTable.setState({showPasswordLengthFailure: true});
   
-      it('does render the Actions column if loginType is lti_v1 and syncEnabled is false', () => {
+      it('does render the Actions column if loginType is lti_v1 and sync is disabled', () => {
         const store = getStore();
         store.dispatch(setLoginType(SectionLoginType.lti_v1));
-        // store.dispatch(syncEnabled(false));
+        store.dispatch(setSections([{...fakeSection, sync_enabled: false}]));
         const wrapper = mount(
           <Provider store={store}>
-            <ManageStudentsTable syncEnabled={false} />
+            <ManageStudentsTable />
           </Provider>
         );
-        // console.log(wrapper.find(ManageStudentActionsHeaderCell).debug())
+
         expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be.true;
       });
     });

--- a/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
@@ -16,6 +16,7 @@ import ManageStudentsTable, {
 } from '@cdo/apps/templates/manageStudents/ManageStudentsTable';
 import CodeReviewGroupsDialog from '@cdo/apps/templates/manageStudents/CodeReviewGroupsDialog';
 import ManageStudentsActionsCell from '@cdo/apps/templates/manageStudents/ManageStudentsActionsCell';
+import ManageStudentActionsHeaderCell from '@cdo/apps/templates/manageStudents/ManageStudentsActionsHeaderCell';
 import ManageStudentNameCell from '@cdo/apps/templates/manageStudents/ManageStudentsNameCell';
 import ManageStudentFamilyNameCell from '@cdo/apps/templates/manageStudents/ManageStudentsFamilyNameCell';
 import ManageStudentsGenderCell from '@cdo/apps/templates/manageStudents/ManageStudentsGenderCell';
@@ -37,6 +38,7 @@ import manageStudents, {
 import teacherSections, {
   setSections,
   selectSection,
+  syncEnabled,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
@@ -116,6 +118,35 @@ describe('ManageStudentsTable', () => {
     });
   });
 
+  // describe('LTI section tests', () => {
+  //   const DEFAULT_PROPS = {
+  //     loginType: SectionLoginType.lti_v1,
+  //     studentData: [],
+  //     editingData: {},
+  //     addStatus: {},
+  //     transferStatus: {},
+  //   };
+
+  //   it('Should not render the action column for LTI sections with sync enabled', () => {
+  //     const wrapper = shallow(
+  //       <UnconnectedManageStudentsTable
+  //         {...{...DEFAULT_PROPS, ...{loginType: SectionLoginType.lti_v1, syncEnabled: true}}}
+  //       />
+  //     );
+  //     expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be.false;
+  //   });
+
+  //   it('Should render the action column for LTI sections with sync disabled', () => {
+  //     const wrapper = shallow(
+  //       <UnconnectedManageStudentsTable
+  //         {...{...DEFAULT_PROPS, ...{loginType: SectionLoginType.email, syncEnabled: false}}}
+  //       />
+  //     );
+  //     console.log(wrapper.debug());
+  //     expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be.true;
+  //   });
+  // });
+
   describe('full render tests', () => {
     const fakeStudent = {
       id: 1,
@@ -146,6 +177,7 @@ describe('ManageStudentsTable', () => {
       studentCount: 10,
       students: Object.values(fakeStudents),
       hidden: false,
+      syncEnabled: true,
     };
 
     beforeEach(() => {
@@ -186,6 +218,40 @@ describe('ManageStudentsTable', () => {
           }
         />
       );
+    });
+
+    describe('LTI section tests', () => {
+      it('does not render the Actions column if loginType is lti_v1', () => {
+        const store = getStore();
+        store.dispatch(setLoginType(SectionLoginType.lti_v1));
+        const wrapper = mount(
+          <Provider store={store}>
+            <ManageStudentsTable syncEnabled={true} />
+          </Provider>
+        );
+        const manageStudentsTable = wrapper.find('ManageStudentsTable');
+        
+        manageStudentsTable.setState('sections', {101: {syncEnabled: true}});
+        console.log(manageStudentsTable.state());
+        store.dispatch(syncEnabled(manageStudentsTable.state, 101));
+        expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be.false;
+      });
+
+      // const manageStudentsTable = wrapper.find('ManageStudentsTable');
+      // manageStudentsTable.setState({showPasswordLengthFailure: true});
+  
+      it('does render the Actions column if loginType is lti_v1 and syncEnabled is false', () => {
+        const store = getStore();
+        store.dispatch(setLoginType(SectionLoginType.lti_v1));
+        // store.dispatch(syncEnabled(false));
+        const wrapper = mount(
+          <Provider store={store}>
+            <ManageStudentsTable syncEnabled={false} />
+          </Provider>
+        );
+        // console.log(wrapper.find(ManageStudentActionsHeaderCell).debug())
+        expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be.true;
+      });
     });
 
     describe('Gender field feature flag', () => {

--- a/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
@@ -38,7 +38,6 @@ import manageStudents, {
 import teacherSections, {
   setSections,
   selectSection,
-  syncEnabled,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
@@ -201,9 +200,10 @@ describe('ManageStudentsTable', () => {
           </Provider>
         );
 
-        expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be.false;
+        expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be
+          .false;
       });
-  
+
       it('does render the Actions column if loginType is lti_v1 and sync is disabled', () => {
         const store = getStore();
         store.dispatch(setLoginType(SectionLoginType.lti_v1));
@@ -214,7 +214,8 @@ describe('ManageStudentsTable', () => {
           </Provider>
         );
 
-        expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be.true;
+        expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be
+          .true;
       });
     });
 


### PR DESCRIPTION
LTI sections don't currently allow teachers to manually remove/edit students from the section. Now that users can disable syncing, we want to allow teachers who have disabled sync to manually edit students in pre-existing LTI sections.

This PR enables the "Actions" column in the Manage Students table, which contains the delete and edit options, if the owner of the section has roster sync disabled. If the owner has sync enabled, we don't render the column, because all changes to the roster should be done in the LMS, then synced into Code.org.

Sync disabled, action column shows up:
<img width="1005" alt="Screenshot 2024-03-06 at 4 20 00 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/1e4b8b6c-1d3e-49a7-b2b6-50e2cea5307a">

Student manually removed:
<img width="1002" alt="Screenshot 2024-03-06 at 4 27 48 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/68ec92a4-d437-4175-bab4-9cc9c38fdf8a">

Sync re-enabled, student synced back in. Action column no longer shows up:
<img width="994" alt="Screenshot 2024-03-06 at 4 28 47 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/b46ff54c-6174-4023-a275-162fdd8fef33">



## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-652)

<!--
- spec: []()
- jira ticket: []()
-->

```
yarn test:unit --entry=./test/unit/templates/manageStudents/ManageStudentsTableTest.js
Finished in 19.19 secs / 17.353 secs @ 18:40:06 GMT+0000 (Coordinated Universal Time)

SUMMARY:
✔ 34 tests completed

Done.
```

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
