### PR TITLE
Count level progress for contained_levels

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1365,7 +1365,19 @@ class User < ApplicationRecord
     user_levels_by_level = user_levels_by_level(script)
 
     script.script_levels.none? do |script_level|
-      user_levels = script_level.level_ids.map {|id| user_levels_by_level[id]}
+      user_levels = []
+      script_level.levels.each do |level|
+        curr_user_level = user_levels_by_level[level.id]
+
+        # If level.id is not present in user_levels_by_level, check if level has contained_levels with present ids
+        if !curr_user_level && !level.contained_levels.empty?
+          level.contained_levels.each do |contained_level|
+            user_levels.push(user_levels_by_level[contained_level.id])
+          end
+        else
+          user_levels.push(curr_user_level)
+        end
+      end
       unpassed_progression_level?(script_level, user_levels)
     end
   end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1194,6 +1194,72 @@ class UserTest < ActiveSupport::TestCase
     refute next_script_level.nil?
   end
 
+  test 'completed_progression_levels returns false if not all progression levels have a passing result' do
+    user = create :user
+    script = create(:script, :with_levels, levels_count: 3)
+
+    # Only complete the first one
+    UserLevel.create(
+      user: user,
+      level: script.script_levels.first.level,
+      script: script,
+      attempts: 1,
+      best_result: Activity::MINIMUM_PASS_RESULT
+    )
+
+    refute(user.completed_progression_levels?(script))
+  end
+
+  test 'completed_progression_levels returns true if all progression levels have a passing result' do
+    user = create :user
+    script = create(:script, :with_levels, levels_count: 3)
+
+    script.script_levels.each do |sl|
+      UserLevel.create(
+        user: user,
+        level: sl.level,
+        script: script,
+        attempts: 1,
+        best_result: Activity::MINIMUM_PASS_RESULT
+      )
+    end
+
+    assert(user.completed_progression_levels?(script))
+  end
+
+  test 'completed_progression_levels returns true if all progression levels with contained levels have a passing result' do
+    user = create :user
+    script = create(:script, :with_levels, levels_count: 3)
+
+    # Set up the first level to have contained_levels
+    contained_level = create :free_response, name: 'contained level'
+    level_with_contained_levels = script.script_levels.first.level
+    level_with_contained_levels.contained_level_names = [contained_level.name]
+    level_with_contained_levels.save!
+
+    # User progress in contained_level
+    UserLevel.create(
+      user: user,
+      level: level_with_contained_levels.contained_levels.first,
+      script: script,
+      attempts: 1,
+      best_result: Activity::MINIMUM_PASS_RESULT
+    )
+
+    # User progress in remaining levels
+    script.script_levels.drop(1).each do |sl|
+      UserLevel.create(
+        user: user,
+        level: sl.level,
+        script: script,
+        attempts: 1,
+        best_result: Activity::MINIMUM_PASS_RESULT
+      )
+    end
+
+    assert(user.completed_progression_levels?(script))
+  end
+
   test 'track_level_progress does not record quiz or survey responses for partner when pairing' do
     user = create :user
     partner = create :user


### PR DESCRIPTION
We've been receiving several Zendesk tickets (e.g. [here](https://codeorg.zendesk.com/agent/tickets/488769) and [here](https://codeorg.zendesk.com/agent/tickets/488982)) about users who complete certain courses but are not directed to print their certificates nor given access to do so. @bethanyaconnor tracked down that the issue was that if a `level` in a `script_level` had `contained_levels` it would check the outer level for completion rather than the inner `contained_levels`. This would always result in the level being deemed incomplete because it would search for `UserLevels` with progress with the outer level's id (which returned `null`) rather than the `contained_levels` ids.

This PR updates the logic for checking completion so that if a `UserLevel` can't be found with a given level id, it will check if that level has `contained_levels` and if those level ids result in completed `UserLevel` entries.

### Previous progress page show "Continue" rather than "Print Certificate"
![BROKEN](https://github.com/code-dot-org/code-dot-org/assets/56283563/ac43da98-28c3-4983-a36e-a4af10e357fe)

### Previous page when a user attempted to view their certificate
![Certificate Issue](https://github.com/code-dot-org/code-dot-org/assets/56283563/ed34a1ab-601b-4e9e-b99b-bedad4370e54)

### Fixed progress page shows "Print Certificate"
![WORKS](https://github.com/code-dot-org/code-dot-org/assets/56283563/6e11be2d-1714-4539-ad39-d3abc8b356e6)

### Now user is shown the certificate for completing all levels
![WORKS_CERT](https://github.com/code-dot-org/code-dot-org/assets/56283563/3c05393f-d979-4444-b7b1-18cae7372bde)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1591)
Zendesk ticket examples: [here](https://codeorg.zendesk.com/agent/tickets/488769) and [here](https://codeorg.zendesk.com/agent/tickets/488982)

## Testing story
Local testing and adding unit tests.
