### PR TITLE
Music: fix trigger button opacity

### DIFF
--- a/apps/src/music/views/beatpad.module.scss
+++ b/apps/src/music/views/beatpad.module.scss
@@ -22,12 +22,13 @@
   opacity: 75%;
   background-color: $neutral_dark40;
   cursor: default;
-  
+
   &Active {
     cursor: pointer;
     border-color: #00bc3e;
     background-color: #00bc3e;
     color: white;
+    opacity: 100%
   }
 
   &Selected {


### PR DESCRIPTION
The trigger button is again full brightness when active.