### PR TITLE
Add ul.three-col class to design-system-pegasus.scss

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -361,10 +361,8 @@ ul {
     display: grid;
     grid-gap: 1.5rem;
 
-    &.three-col {
-      @media screen and (min-width: $width-lg) {
-        grid-template-columns: repeat(3, 1fr);
-      }
+    @media screen and (min-width: $width-lg) {
+      grid-template-columns: repeat(3, 1fr);
     }
 
     li {

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -254,6 +254,16 @@ ul {
     }
   }
 
+  // Show list items in three columns
+  &.three-col {
+    @media screen and (min-width: $width-sm) { column-count: 2; }
+    @media screen and (min-width: $width-md) { column-count: 3; }
+
+    li:first-child {
+      margin-top: 0;
+    }
+  }
+
   // Lists that use icons next to content
   &.icon-bullet-list {
     margin: 1rem 0;
@@ -398,31 +408,6 @@ ul {
 
       h3 {
         @include heading-sm;
-      }
-    }
-  }
-
-  // Lists that show supporters or other text content in a table format
-  &.supporters-list {
-    margin: 3rem auto;
-    display: grid;
-    justify-items: center;
-    gap: 1.5rem;
-
-    @media screen and (min-width: $width-sm) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
-    @media screen and (min-width: $width-md) {
-      grid-template-columns: repeat(3, 1fr);
-    }
-
-    li {
-      all: unset;
-      text-align: center;
-
-      &:before {
-        content: "";
       }
     }
   }

--- a/pegasus/sites.v3/code.org/public/css/page/naipi-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/page/naipi-styles.scss
@@ -28,16 +28,4 @@ section.partners {
     margin-top: 2rem;
     color: var(--neutral_dark70);
   }
-
-  ul.naipi-partners {
-    margin-top: 1rem;
-
-    @media screen and (min-width: $width-sm) { column-count: 2; }
-    @media screen and (min-width: $width-md) { column-count: 3; }
-
-    li {
-      margin: 0 0 0.75rem;
-    }
-  }
 }
-

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.haml
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.haml
@@ -56,7 +56,7 @@ theme: responsive_full_width
   .wrapper
     %h2=hoc_s(:heading_program_design)
     %p=hoc_s(:pl_middle_high_program_design_desc)
-    %ul.progressive-list.three-col
+    %ul.progressive-list
       %li
         %span
         %h3=hoc_s(:pl_middle_high_program_design_summer_title)

--- a/pegasus/sites.v3/code.org/public/farsi.haml
+++ b/pegasus/sites.v3/code.org/public/farsi.haml
@@ -32,7 +32,7 @@ set_dir: true
     %h2=hoc_s(:farsi_page_supporters_heading)
     %p.heading-sm
       =hoc_s(:farsi_page_supporters_desc)
-    %ul.supporters-list
+    %ul.three-col.clear-styles{style: "margin-top: 2rem"}
       %li Amidi Family
       %li Nima Asgharbeygi
       %li Nima and Cindi Badiey

--- a/pegasus/sites.v3/code.org/views/naipi/naipi_regional_partners.haml
+++ b/pegasus/sites.v3/code.org/views/naipi/naipi_regional_partners.haml
@@ -18,6 +18,6 @@
     "University of California San Diego CREATE"
   ];
 
-%ul.naipi-partners.clear-styles
+%ul.three-col.clear-styles{style: "margin-top: 1rem"}
   - naipi_partners.each do |partner|
     %li= partner


### PR DESCRIPTION
Adds a `.three-col` class to basic `ul` elements and removes the need for flexbox or grid styling for the same effect.
- Cleans this up on https://code.org/farsi and https://code.org/naipi
- Also removed some unneeded column styles on the `.progressive-list` element on https://code.org/educate/professional-learning/middle-high

**Jira ticket:** [ACQ-1593](https://codedotorg.atlassian.net/browse/ACQ-1593)

----

## Example on code.org/farsi

https://github.com/code-dot-org/code-dot-org/assets/9256643/dc3b56e7-414b-4505-9ca0-eafededc63d4

