### PR TITLE
feat(lms): do not sync if not section owner

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -247,6 +247,7 @@ class LtiV1Controller < ApplicationController
       nrps_sections = Services::Lti.parse_nrps_response(nrps_response, lti_integration.issuer)
 
       sync_course_roster_results = Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: nrps_sections, current_user: current_user)
+
       had_changes ||= sync_course_roster_results
 
       # Report which sections were updated

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -247,7 +247,6 @@ class LtiV1Controller < ApplicationController
       nrps_sections = Services::Lti.parse_nrps_response(nrps_response, lti_integration.issuer)
 
       sync_course_roster_results = Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: nrps_sections, current_user: current_user)
-
       had_changes ||= sync_course_roster_results
 
       # Report which sections were updated

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -189,6 +189,9 @@ class Services::Lti
     had_changes = false
     lti_sections = LtiSection.where(lti_course_id: lti_course.id)
 
+    # Only sync the section if the section's owner is equal to the current user
+    return false unless lti_sections.first.section.user_id == current_user_id
+
     # Prune sections that have been deleted in the LMS
     lti_sections.each do |lti_section|
       unless nrps_sections.key?(lti_section.lms_section_id)
@@ -218,6 +221,7 @@ class Services::Lti
         lti_section = LtiSection.create(lti_course_id: lti_course.id, lms_section_id: lms_section_id, section: section)
         had_changes = true
       end
+
       unless lti_section.section.name == section_name
         lti_section.section.update(name: section_name)
         had_changes = true

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -189,8 +189,8 @@ class Services::Lti
     had_changes = false
     lti_sections = LtiSection.where(lti_course_id: lti_course.id)
 
-    # Only sync the section if the section's owner is equal to the current user
-    return false unless lti_sections.first.section.user_id == current_user_id
+    # Only sync the section if there are no sections or the section's owner is equal to the current user
+    return false unless lti_sections.empty? || lti_sections.first.section.user_id == current_user.id
 
     # Prune sections that have been deleted in the LMS
     lti_sections.each do |lti_section|


### PR DESCRIPTION
Previously, any teacher on the LMS for a course will trigger course syncing even if the section owner may not actually want syncing to occur.

This PR updates the behavior to only trigger course syncing if this is the section owner. The "Sync Course" button is also hidden unless you are the section owner.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-758)

## Testing story

1. Created unit test to assert that teacher of a course does not sync if not section owner
2. Manually tested the same scenario on canvas


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  3.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
