### PR TITLE
Cleanup adding Similar Recommender to the Curriculum Catalog

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -1,6 +1,6 @@
 import React, {useState, useEffect} from 'react';
 import PropTypes from 'prop-types';
-import {curriculumDataShape} from './curriculumCatalogShapes';
+import {curriculumDataShape} from './curriculumCatalogConstants';
 import i18n from '@cdo/locale';
 import style from '../../../style/code-studio/curriculum_catalog_container.module.scss';
 import HeaderBanner from '../HeaderBanner';

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -30,6 +30,7 @@ import {
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import ExpandedCurriculumCatalogCard from './ExpandedCurriculumCatalogCard';
+import {defaultImageSrc} from './curriculumCatalogConstants';
 
 const CurriculumCatalogCard = ({
   courseKey,
@@ -37,7 +38,7 @@ const CurriculumCatalogCard = ({
   duration,
   gradesArray,
   imageAltText = '', // for decorative images
-  imageSrc = 'https://images.code.org/0a24eb3b51bd86e054362f0760c6e64e-image-1681413990565.png',
+  imageSrc = defaultImageSrc,
   subjects = [],
   topics = [],
   pathToCourse,

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogFilters.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogFilters.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import {queryParams, updateQueryParam} from '../../code-studio/utils';
 import style from '../../../style/code-studio/curriculum_catalog_filters.module.scss';
-import {curriculumDataShape} from './curriculumCatalogShapes';
+import {curriculumDataShape} from './curriculumCatalogConstants';
 import CheckboxDropdown from '../CheckboxDropdown';
 import Toggle from '../../componentLibrary/toggle/Toggle.tsx';
 import Button from '@cdo/apps/templates/Button';

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -15,6 +15,7 @@ import {
   translatedCourseOfferingDeviceTypes,
   translatedAvailableResources,
 } from '../teacherDashboard/CourseOfferingHelpers';
+import {defaultImageSrc} from './curriculumCatalogConstants';
 
 const ExpandedCurriculumCatalogCard = ({
   courseKey,
@@ -287,7 +288,7 @@ const ExpandedCurriculumCatalogCard = ({
                 </Heading4>
                 <hr className={style.thickDivider} />
                 <img
-                  src={recommendedSimilarCurriculum.image}
+                  src={recommendedSimilarCurriculum.image || defaultImageSrc}
                   alt={recommendedSimilarCurriculum.display_name}
                   style={{height: '100%'}}
                 />

--- a/apps/src/templates/curriculumCatalog/curriculumCatalogConstants.jsx
+++ b/apps/src/templates/curriculumCatalog/curriculumCatalogConstants.jsx
@@ -12,3 +12,6 @@ export const curriculumDataShape = PropTypes.shape({
   course_version_path: PropTypes.string,
   marketing_initiative: PropTypes.string,
 });
+
+export const defaultImageSrc =
+  'https://images.code.org/0a24eb3b51bd86e054362f0760c6e64e-image-1681413990565.png';

--- a/apps/src/util/curriculumRecommender/curriculumRecommender.js
+++ b/apps/src/util/curriculumRecommender/curriculumRecommender.js
@@ -195,7 +195,7 @@ const hasImportantButNotDesiredTopic = (curriculum, csTopics) => {
   const curriculumTopics = curriculum.cs_topic?.split(',');
   const desiredTopics = csTopics?.split(',');
 
-  if (curriculumTopics) {
+  if (curriculumTopics && desiredTopics) {
     for (const topic of curriculumTopics) {
       if (IMPORTANT_TOPICS.includes(topic) && !desiredTopics.includes(topic)) {
         return true;


### PR DESCRIPTION
After the Similar Curriculum Recommender launched on the Curriculum Catalog, there were 2 quick bugs that needed cleaning up.

### Set default image
When a curriculum without an image was recommended, there was no default image ready for it to use so this PR implements it. Since the same default image was being used in `CurriculumCatalogCard.jsx`, I moved it to a constants file (which was the `curriculumCatalogShapes.jsx` file). This accounts for nearly all changes in this PR.

Previous look:
![missing_image](https://github.com/code-dot-org/code-dot-org/assets/56283563/cca9f501-39dc-4467-9d7d-80b78d416811)

New look:
![FIX_IMAGE](https://github.com/code-dot-org/code-dot-org/assets/56283563/33f60c8f-40a5-40e2-a028-a414cbbec663)

### Render expanded card for curricula without topics
When trying to view the expanded card of a curriculum without topics, it would throw an error from running the recommender within the `hasImportantButNotDesiredTopic` question. This PR ensures that the curriculum has topics before checking them for the recommender.

Currently, the "Nevada Standards Aligned: Beta - CSF Course C" expanded card throws an error. However, with this change it now renders fine:
![NO_TOPICS](https://github.com/code-dot-org/code-dot-org/assets/56283563/5bc05a17-f64d-4329-9ca1-3ad7711d27fd)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1594)

## Testing story
Local testing.
