### PR TITLE
Music: sound library tweaks

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -186,6 +186,7 @@ export type SoundFolderType = 'sound' | 'kit' | 'instrument';
 
 export interface SoundFolder {
   name: string;
+  artist?: string;
   id: string;
   type?: SoundFolderType;
   path: string;

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -254,26 +254,26 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
     currentSoundRef.current = ref;
   };
 
-  let possibleSounds: SoundEntry[] = [];
-  let rightColumnSounds: SoundEntry[] = [];
+  let possibleSoundEntries: SoundEntry[] = [];
+  let rightColumnSoundEntries: SoundEntry[] = [];
 
   if (mode === 'packs') {
-    possibleSounds = selectedFolder.sounds.map(sound => ({
+    possibleSoundEntries = selectedFolder.sounds.map(sound => ({
       folder: selectedFolder,
       sound,
     }));
   } else {
     folders.forEach(folder => {
       folder.sounds.forEach(sound => {
-        possibleSounds.push({folder, sound});
+        possibleSoundEntries.push({folder, sound});
       });
     });
   }
 
   if (filter === 'all') {
-    rightColumnSounds = possibleSounds;
+    rightColumnSoundEntries = possibleSoundEntries;
   } else {
-    rightColumnSounds = possibleSounds.filter(
+    rightColumnSoundEntries = possibleSoundEntries.filter(
       soundEntry => soundEntry.sound.type === filter
     );
   }
@@ -331,7 +331,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
             </div>
           )}
           <div id="sounds-panel-right" className={styles.rightColumn}>
-            {rightColumnSounds.map((soundEntry, soundIndex) => {
+            {rightColumnSoundEntries.map((soundEntry, soundIndex) => {
               return (
                 <SoundsPanelRow
                   key={soundIndex}

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -20,6 +20,11 @@ const AppConfig = require('../appConfig').default;
 type Mode = 'packs' | 'sounds';
 type Filter = 'all' | SoundType;
 
+type SoundEntry = {
+  folder: SoundFolder;
+  sound: SoundData;
+};
+
 const getLengthRepresentation = (length: number) => {
   const lengthToSymbol: {[length: number]: string} = {
     0.5: '\u00bd',
@@ -90,6 +95,9 @@ const FolderPanelRow: React.FunctionComponent<FolderPanelRowProps> = ({
       </div>
       <div className={styles.folderRowMiddle}>
         <div className={styles.folderRowMiddleName}>{folder.name}</div>
+        {folder.artist && (
+          <div className={styles.folderRowMiddleSubTitle}>{folder.artist}</div>
+        )}
       </div>
       <div className={styles.folderRowRight}>
         <div className={styles.length}>&nbsp;</div>
@@ -116,6 +124,7 @@ interface SoundsPanelRowProps {
   playingPreview: string;
   folder: SoundFolder;
   sound: SoundData;
+  showingSoundsOnly: boolean;
   onSelect: (path: string) => void;
   onPreview: (path: string) => void;
   currentSoundRefCallback: (ref: HTMLDivElement) => void;
@@ -126,6 +135,7 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
   playingPreview,
   folder,
   sound,
+  showingSoundsOnly,
   onSelect,
   onPreview,
   currentSoundRefCallback,
@@ -164,8 +174,13 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
     >
       <div className={styles.soundRowLeft}>
         <img src={typeIconPath} className={styles.typeIcon} alt="" />
+        <div className={styles.name}>{sound.name}</div>
       </div>
-      <div className={styles.soundRowMiddle}>{sound.name}</div>
+      {showingSoundsOnly && (
+        <div className={styles.soundRowMiddle}>
+          {folder.name} &bull; {folder.artist}
+        </div>
+      )}
       <div className={styles.soundRowRight}>
         <div className={styles.length}>
           {getLengthRepresentation(sound.length)}
@@ -239,15 +254,18 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
     currentSoundRef.current = ref;
   };
 
-  let possibleSounds: SoundData[] = [];
-  let rightColumnSounds: SoundData[] = [];
+  let possibleSounds: SoundEntry[] = [];
+  let rightColumnSounds: SoundEntry[] = [];
 
   if (mode === 'packs') {
-    possibleSounds = selectedFolder.sounds;
+    possibleSounds = selectedFolder.sounds.map(sound => ({
+      folder: selectedFolder,
+      sound,
+    }));
   } else {
     folders.forEach(folder => {
       folder.sounds.forEach(sound => {
-        possibleSounds.push(sound);
+        possibleSounds.push({folder, sound});
       });
     });
   }
@@ -255,7 +273,9 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
   if (filter === 'all') {
     rightColumnSounds = possibleSounds;
   } else {
-    rightColumnSounds = possibleSounds.filter(sound => sound.type === filter);
+    rightColumnSounds = possibleSounds.filter(
+      soundEntry => soundEntry.sound.type === filter
+    );
   }
 
   const showSoundFilters = AppConfig.getValue('show-sound-filters') === 'true';
@@ -311,14 +331,15 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
             </div>
           )}
           <div id="sounds-panel-right" className={styles.rightColumn}>
-            {rightColumnSounds.map((sound, soundIndex) => {
+            {rightColumnSounds.map((soundEntry, soundIndex) => {
               return (
                 <SoundsPanelRow
                   key={soundIndex}
                   currentValue={currentValue}
                   playingPreview={playingPreview}
-                  folder={selectedFolder}
-                  sound={sound}
+                  folder={soundEntry.folder}
+                  sound={soundEntry.sound}
+                  showingSoundsOnly={mode === 'sounds'}
                   onSelect={onSelect}
                   onPreview={onPreview}
                   currentSoundRefCallback={currentSoundRefCallback}

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -80,6 +80,7 @@
 
       &SubTitle {
         font-size: 11px;
+        line-height: 2em;
       }
     }
 
@@ -95,6 +96,9 @@
     padding: 4px 0;
     font-size: 14px;
     margin: 1px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 
     &:hover {
       background-color: $neutral_dark90;
@@ -109,25 +113,33 @@
     }
 
     &Left {
-      width: 15px;
-      margin: 0 6px 0 4px;
-      float: left;
+      display: flex;
+      align-items: center;
+      width: 200px;
 
       .typeIcon {
         width: 13px;
+        height: 13px;
+        margin-right: 6px;
+        margin-left: 4px;
+      }
+
+      .name {
+        font-size: 14px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
     }
 
+
     &Middle {
-      width: calc(100% - 25px - 58px);
-      float: left;
+      font-size: 11px;
     }
 
     &Right {
-      float: right;
-      width: 43px;
+      display: flex;
       margin-right: 15px;
-
     }
   }
 

--- a/apps/static/music/music-library-launch2024.json
+++ b/apps/static/music/music-library-launch2024.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d1d49230721f3591094570a9111452d8a1a61f75548e5f50ee9483490a1b49f
-size 45207
+oid sha256:3abfd43bf4f13e8c7d869851c0ad04dfac5755c2d0b273ba7e5dc1f2524187ad
+size 27335


### PR DESCRIPTION
This makes some tweaks to the sound library content and UI.

The `launch2024` sound library is updated with 6 new in-house packs.  S3 has the corresponding updates.

The sound selection UI now shows the artist name when viewing packs, and the artist name and pack name when viewing all sounds.

### Screenshots

<img width="646" alt="Screenshot 2024-03-08 at 4 10 15 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/94845588-7bb1-4091-824f-0548c913c9a2">

<img width="646" alt="Screenshot 2024-03-08 at 4 16 41 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/adf6d7fc-87c6-4e2f-b20d-11c61be64e1f">

