### PR TITLE
[Levelbuilder] use Google Blockly for all migrated labs

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_blockly.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_blockly.html.haml
@@ -1,6 +1,6 @@
 - content_for(:head) do
   - if @level.is_a?(Blockly) && !@level.uses_droplet?
-    - if @level.is_a?(Dancelab) || @level.is_a?(Poetry)
+    - if [Bounce, Dancelab, Flappy, GamelabJr, Music].any? { |level_type| @level.is_a?(level_type) }
       %script{src: webpack_asset_path('js/googleblockly.js')}
     - else
       %script{src: webpack_asset_path('js/blockly.js')}

--- a/dashboard/app/views/levels/editors/fields/_blockly.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_blockly.html.haml
@@ -1,6 +1,6 @@
 - content_for(:head) do
   - if @level.is_a?(Blockly) && !@level.uses_droplet?
-    - if [Bounce, Dancelab, Flappy, GamelabJr, Music].any? { |level_type| @level.is_a?(level_type) }
+    - if @level.uses_google_blockly?
       %script{src: webpack_asset_path('js/googleblockly.js')}
     - else
       %script{src: webpack_asset_path('js/blockly.js')}


### PR DESCRIPTION
Now that Sprite Lab is reliably using Google Blockly, we should also use it for levelbuilder level edit pages. I updated this line to check for the full list of migrated labs. `Poetry` inherits from `GamelabJr` (Sprite Lab), so we don't need to list both. `Flappy` and `Bounce` could have been flipped in this way any time but AFAIK nobody has been editing these levels. I also added `Music` to the list despite the fact that it doesn't appear we ever attempt to render blocks for those levels.

## Links

Jira - https://codedotorg.atlassian.net/browse/CT-338

## Testing story

I tested this by confirming that `Blockly.version` returned `'CDO'` or `'Google'` as expected for each Blockly level type by using my browser console. I also tested that a new Google Blockly block could be rendered as expected in the long instructions markdown field for a Sprite Lab level: 
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/78fcd572-750f-4691-8114-55c57900fd20)
I also checked a level's hint that was listed in the Jira ticket and confirmed that it now uses Google Blockly:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/9b6c73ea-e221-4700-9507-dd957d312a7e)


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
