### PR TITLE
Added DEV=1 to unit test command so webpack uses build optimized for development rather than for production

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -13,7 +13,7 @@
     "lint:js": "eslint --format ./.eslintCustomMessagesFormatter.js --ext .js,.jsx,.ts,.tsx src test --resolve-plugins-relative-to .",
     "lint:scss": "npx stylelint '**/*.scss'",
     "test": "./run-tests-in-parallel.sh",
-    "test:unit": "grunt karma --testType=unit",
+    "test:unit": "DEV=1 grunt karma --testType=unit",
     "test:integration": "grunt karma --testType=integration",
     "test:storybook": "grunt karma --testType=storybook",
     "clean": "grunt clean",


### PR DESCRIPTION
For some reason, our Karma tests are running a full webpack build every time tests are run, even if no files were changed. Investigation is ongoing into why this is happening, however, an early optimization can be applied:

The dev build was recently optimized... (more details to come)

URL: https://github.com/code-dot-org/code-dot-org/pull/55707

EDIT: This doesn't actually decrease build time.