### PR TITLE
fix(karma): clear the body tag in the dom on each test execution

### DIFF
--- a/apps/test/tests-entry.js
+++ b/apps/test/tests-entry.js
@@ -40,6 +40,19 @@ if (testType('unit')) {
     // throwOnConsoleWarningsEverywhere();
 
     clearTimeoutsBetweenTests();
+
+    beforeEach(() => {
+      // Some tests anchor to the body tag and is not reset per test execution, leading to a case where the DOM
+      // is full of elements from prior test runs. This leads to scenarios where a test runs if executed alone but
+      // fails if run as part of the whole test suite.
+      // Ensure that the <body> tag is empty before each test execution.
+      const bodyTags = Array.from(document.getElementsByTagName('body'));
+
+      bodyTags.forEach(bodyTag => {
+        bodyTag.innerHTML = '';
+      });
+    });
+
     tests.forEach(testsContext);
   });
 }

--- a/apps/test/tests-entry.js
+++ b/apps/test/tests-entry.js
@@ -49,7 +49,13 @@ if (testType('unit')) {
       const bodyTags = Array.from(document.getElementsByTagName('body'));
 
       bodyTags.forEach(bodyTag => {
-        bodyTag.innerHTML = '';
+        // Add a <script> tag to avoid recaptcha error
+        // The <script> portion can be removed if the RecaptchaDialog test is updated to remove the downloading of
+        // the recaptcha.js file in Karma. The recaptcha script looks for the <script> tag which is inserted in the
+        // RecaptchaDialog file. That test finishes early but the recaptcha javascript never finished loading.
+        // This causes an error to surface in later tests and cause those to fail. Instead, adding a stub <script>
+        // allows subsequent tests to pass.
+        bodyTag.innerHTML = '<script></script>';
       });
     });
 


### PR DESCRIPTION
Some tests anchor to the body tag and is not reset per test execution, leading to a case where the DOM is full of elements from prior test runs. This leads to scenarios where a test runs if executed alone but fails if run as part of the whole test suite.

Ensure that the <body> tag is empty before each test execution.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
