### PR TITLE
[JIMT][CDOIDE] 3rd rev of the cdo ide poc 

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -209,7 +209,7 @@
     "bootstrap-sass": "^3.3.6",
     "buffer": "^6.0.3",
     "canvg": "gabelerner/canvg",
-    "cdo-ide-poc": "git+https://github.com/code-dot-org/cdo-ide-poc.git#6099cf73db90ece2212df5217033ed1a33addf79",
+    "cdo-ide-poc": "git+https://github.com/code-dot-org/cdo-ide-poc.git#6dfb0916fda9fdb65065a24cab512a727404568c",
     "classnames": "^2.3.2",
     "codemirror": "5.5",
     "codemirror-spell-checker": "^1.1.2",

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -17,12 +17,16 @@ Add javascript files (ending in .js) and execute javascript code in the right pa
 Use the file browser to add/rename/delete files, or to add/rename/delete folders (including hierarchically!)`;
 
 const defaultConfig: ConfigType = {
-  showSideBar: true,
-  showPreview: true,
-  showRunBar: true,
-  showDebug: true,
+  //showSideBar: true,
+  // showLeftNav: false,
+  // showEditor: false,
+  // showPreview: false,
+  // showRunBar: true,
+  // showDebug: true,
   activeLeftNav: 'Files',
   EditorComponent: CDOEditor,
+  // editableFileTypes: ["html"],
+  // previewFileTypes: ["html"],
   leftNav: [
     {
       icon: 'fa-square-check',
@@ -39,9 +43,19 @@ const defaultConfig: ConfigType = {
   ],
   sideBar: ['fa-circle-question', 'fa-folder'],
   instructions,
+  //editableFileTypes: ["html", "json", "js", "css"],
+  //previewFileTypes: ["json", "html", "js"],
+  /* PreviewComponents: {
+    html: () => <div>I am previewing HTML</div>,
+    js: () => <div>I am previewing JavaSript</div>,
+    json: () => <div>I am previewing JSON</div>,
+  }, */
+  //blankEmptyEditor: true,
+  //EmptyEditorComponent: () => <div>Nothing is open.</div>,
 };
 
 const defaultProject: ProjectType = {
+  // folders: {},
   folders: {
     '1': {id: '1', name: 'foo', parentId: '0'},
     '2': {id: '2', name: 'bar', parentId: '1'},
@@ -50,6 +64,24 @@ const defaultProject: ProjectType = {
     '5': {id: '5', name: 'f2', parentId: '1'},
     '6': {id: '6', name: 'b1', parentId: '2'},
   },
+  /*files: {
+    "1": {
+      id: "1",
+      name: "index.html",
+      language: "html",
+      contents: `<!DOCTYPE html><html>
+    <link rel="stylesheet" href="styles.css"/>
+    <body>
+      Content goes here!
+      <div class="foo">Foo class!</div>
+    </body>
+  </html>
+  `,
+      open: true,
+      active: true,
+      folderId: "0",
+    },
+  },*/
   files: {
     '1': {
       id: '1',
@@ -111,10 +143,18 @@ const defaultProject: ProjectType = {
       open: false,
       folderId: '1',
     },
+    '7': {
+      id: '7',
+      name: 'some-javascript.js',
+      language: 'js',
+      contents: 'const a = 5; const b = 7; console.log(a + b);',
+      open: false,
+      folderId: '0',
+    },
   },
 };
 
-const App = () => {
+const Weblab2View = () => {
   const [project, setProject] = useState<ProjectType>(defaultProject);
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
   const [showConfig, setShowConfig] = useState<'project' | 'config' | ''>('');
@@ -159,4 +199,4 @@ const App = () => {
   );
 };
 
-export default App;
+export default Weblab2View;

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8559,7 +8559,7 @@ __metadata:
     browser-process-hrtime: 0.1.2
     buffer: ^6.0.3
     canvg: gabelerner/canvg
-    cdo-ide-poc: "git+https://github.com/code-dot-org/cdo-ide-poc.git#6099cf73db90ece2212df5217033ed1a33addf79"
+    cdo-ide-poc: "git+https://github.com/code-dot-org/cdo-ide-poc.git#6dfb0916fda9fdb65065a24cab512a727404568c"
     chai: 3.5.0
     chai-as-promised: ^7.1.1
     chai-enzyme: ^1.0.0-beta.1
@@ -9567,9 +9567,9 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
-"cdo-ide-poc@git+https://github.com/code-dot-org/cdo-ide-poc.git#6099cf73db90ece2212df5217033ed1a33addf79":
+"cdo-ide-poc@git+https://github.com/code-dot-org/cdo-ide-poc.git#6dfb0916fda9fdb65065a24cab512a727404568c":
   version: 0.0.0
-  resolution: "cdo-ide-poc@https://github.com/code-dot-org/cdo-ide-poc.git#commit=6099cf73db90ece2212df5217033ed1a33addf79"
+  resolution: "cdo-ide-poc@https://github.com/code-dot-org/cdo-ide-poc.git#commit=6dfb0916fda9fdb65065a24cab512a727404568c"
   dependencies:
     "@codemirror/lang-css": ^6.2.1
     "@codemirror/lang-html": ^6.4.8
@@ -9583,13 +9583,9 @@ canvg@gabelerner/canvg:
     vite-plugin-libcss: ^1.1.1
     websandbox: ^0.5.3
   peerDependencies:
-    "@codemirror/lang-css": ^6.2.1
-    "@codemirror/lang-html": ^6.4.8
-    "@codemirror/lang-javascript": ^6.2.1
-    "@codemirror/lang-json": ^6.0.1
     react: ^16.14.0
     react-dom: ^16.14.0
-  checksum: c10b4c1985dfb0cb5403d65e3b128fc1f9c857205722a74d98ae598594422f7a515208907a9940341fe5c27e7a8e4592986e41f9da199b70a3212f14c85a351b
+  checksum: 3b0514dc4fb6d9552c65d09679440dd8aaa6d4eed350e642a095a95be941d244c93e521a85c1255b8d5bd9441c6ca13a5603465917c4c254c5460dd1ac640ac8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
As before, you can basically just rubber stamp this as it's chucking code over the wall to get it up onto allthethings

code-tools has access to the code-dot-org/cdo-ide-poc repo if you want to poke around, but writes are on the honor system. I'll yank it out and get it merged back in later this month. It's just _so_ much faster to develop externally.

Anyway, a lot of the work this time around was internal modifications bringing the code up in quality. Some is external facing:

- retooled internal logic to use `useReducer` instead of a mishmash of hardwired functions
- exposed `getEmptyProject` to create an empty project that can be handed back in.
- added `moveFile` function to move files to new folders in the file nav.
- projects properly sync internally/externally 
- closing an active file will activate the next one
- better typing, including `FileId` and `FolderId` aliases
- several new utility functions
- exposed more configuration functionality, which is commented out in `Weblab2View` for demonstration purposes.
- toggling the editor theme is available internally, _but_ the editor we're using in cdo won't redraw when it's toggled. So that'll need to be fixed up before we can expose it here.

For everyone that's interested, we should sit down in the next week or two and walk through the code so I can bring people up to speed on it.