### PR TITLE
Restrict Drone Runner docker API port to Autoscaler

### DIFF
--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -493,6 +493,7 @@ Resources:
     Properties:
       Name: !Sub "AutoscalerTargGrp-${AWS::StackName}"
       VpcId: !Ref VpcId
+      TargetType: ip
       Port: 8080
       Protocol: HTTP
       HealthCheckPath: /healthz

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -491,7 +491,7 @@ Resources:
   DroneAutoscalerTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: !Sub "AutoscalerTargGroup-${AWS::StackName}"
+      Name: !Sub "AutoscalerTargGrp-${AWS::StackName}"
       VpcId: !Ref VpcId
       TargetType: ip
       Port: 8080

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -147,7 +147,7 @@ Resources:
           IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          CidrIp: 0.0.0.0/0
+          CidrIp: 3.90.82.166/32
 
   DroneMasterECSCluster:
     Type: AWS::ECS::Cluster
@@ -396,9 +396,13 @@ Resources:
   AutoscalerEcsServiceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Placeholder SecurityGroup for Drone Autoscaler Service
+      GroupDescription: SecurityGroup for Drone Autoscaler ECS Service
       VpcId: !Ref VpcId
-      # No Ingress rules specified - doesn't open new inbound traffic paths
+      SecurityGroupIngress:
+        -
+          IpProtocol: tcp
+          FromPort: 8080
+          SourceSecurityGroupId: !Ref ElbSecurityGroup
       SecurityGroupEgress:
         - IpProtocol: -1 # Allows all protocols
           CidrIp: 0.0.0.0/0 # Allows all destinations
@@ -463,8 +467,8 @@ Resources:
       SecurityGroupIngress:
         -
           IpProtocol: tcp
-          FromPort: 1
-          ToPort: 65535
+          FromPort: 8080
+          ToPort: 8080
           SourceSecurityGroupId: !Ref ElbSecurityGroup
         - IpProtocol: tcp
           FromPort: 8080
@@ -474,7 +478,7 @@ Resources:
           IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          CidrIp: 0.0.0.0/0
+          CidrIp: 3.90.82.166/32
 
   AutoscalerLoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -486,27 +486,20 @@ Resources:
           Key: Name
           Value: !Sub "ECS ${AWS::StackName} - Autoscaler TargetGroup"
 
-  DroneWorkerEcsSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: ECS Allowed Ports
-      VpcId: !Ref VpcId
-
   DroneRunnerEcsSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Drone Runner Allowed Ports
       VpcId: !Ref VpcId
       SecurityGroupIngress:
-        # Enable Autoscaler to issue Docker API calls to EC2 Instances
         -
+          Description: Enable Autoscaler to issue Docker API calls to Runner EC2 Instances.
+          SourceSecurityGroupId: !Ref DroneAutoscalerEcsSecurityGroup
           IpProtocol: tcp
           FromPort: 2376
           ToPort: 2376
-          # TODO: (suresh) Restrict to Drone Autoscaler.
-          CidrIp: 0.0.0.0/0
-        # Enable SSH to EC2 Instances hosting Drone Runner from gateway
         -
+          Description: Enable SSH to Drone Runner EC2 Instances from gateway.code.org (in the production AWS Account).
           IpProtocol: tcp
           FromPort: 22
           ToPort: 22

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -491,7 +491,7 @@ Resources:
   DroneAutoscalerTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: !Sub "AutoscalerTrgGrp-${AWS::StackName}"
+      Name: !Sub "AutoscalerTrgGp-${AWS::StackName}"
       VpcId: !Ref VpcId
       TargetType: ip
       Port: 8080

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -392,7 +392,15 @@ Resources:
               Name: DRONE_AGENT_CONCURRENCY
               Value: 1
             # END: Settings for the Drone Runner.
-
+  AutoscalerEcsServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Placeholder SecurityGroup for Drone Autoscaler Service
+      VpcId: !Ref VpcId
+      # No Ingress rules specified - doesn't open new inbound traffic paths
+      SecurityGroupEgress:
+        - IpProtocol: -1 # Allows all protocols
+          CidrIp: 0.0.0.0/0 # Allows all destinations
   DroneAutoscalerEcsService:
     Type: AWS::ECS::Service
     DependsOn: LoadBalancerListener
@@ -404,6 +412,11 @@ Resources:
         - ContainerName: drone-autoscaler
           ContainerPort: 8080
           TargetGroupArn: !Ref DroneAutoscalerTargetGroup
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          SecurityGroups:
+            - !Ref AutoscalerEcsServiceSecurityGroup
       TaskDefinition: !Ref DroneAutoscalerTaskDefinition
 
   DroneAutoscalerECSCluster:
@@ -494,7 +507,7 @@ Resources:
       SecurityGroupIngress:
         -
           Description: Enable Autoscaler to issue Docker API calls to Runner EC2 Instances.
-          SourceSecurityGroupId: !GetAtt DroneAutoscalerEcsSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt AutoscalerEcsServiceSecurityGroup.GroupId
           IpProtocol: tcp
           FromPort: 2376
           ToPort: 2376

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -491,7 +491,7 @@ Resources:
   DroneAutoscalerTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: !Sub "AutoscalerTargGrp-${AWS::StackName}"
+      Name: !Sub "AutoscalerTrgGrp-${AWS::StackName}"
       VpcId: !Ref VpcId
       TargetType: ip
       Port: 8080

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -491,7 +491,7 @@ Resources:
   DroneAutoscalerTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: !Sub "AutoscalerTargGrp-${AWS::StackName}"
+      Name: !Sub "AutoscalerTargGroup-${AWS::StackName}"
       VpcId: !Ref VpcId
       TargetType: ip
       Port: 8080

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -402,6 +402,7 @@ Resources:
         -
           IpProtocol: tcp
           FromPort: 8080
+          ToPort: 8080
           SourceSecurityGroupId: !Ref ElbSecurityGroup
       SecurityGroupEgress:
         - IpProtocol: -1 # Allows all protocols

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -494,7 +494,7 @@ Resources:
       SecurityGroupIngress:
         -
           Description: Enable Autoscaler to issue Docker API calls to Runner EC2 Instances.
-          SourceSecurityGroupId: !Ref DroneAutoscalerEcsSecurityGroup
+          SourceSecurityGroupId: !GetAtt DroneAutoscalerEcsSecurityGroup.GroupId
           IpProtocol: tcp
           FromPort: 2376
           ToPort: 2376

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -295,6 +295,7 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family: !Sub "${AWS::StackName}-drone-autoscaler"
+      NetworkMode: awsvpc
       RequiresCompatibilities:
         - EC2
       ExecutionRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/DroneEcsTaskExecutionRole"
@@ -417,6 +418,7 @@ Resources:
           AssignPublicIp: DISABLED
           SecurityGroups:
             - !Ref AutoscalerEcsServiceSecurityGroup
+          Subnets: !Ref ServiceSubnetIds
       TaskDefinition: !Ref DroneAutoscalerTaskDefinition
 
   DroneAutoscalerECSCluster:


### PR DESCRIPTION
Speculative fix for Drone Runner EC2 Instances entering a Drone "error" state on launch by the Drone Autoscaler.

I hypothesized that the Drone Runner startup errors were due to those EC2 Instances issuing docker pull requests that exceeded the DockerHub rate limit, but the anonymous limit is 100 pulls per 6 hours per source IP address. The Drone Runner instances do not issue 100 image pulls when they start up (though it's possible they are assigned a public IP address from AWS that was previously used by an Instance that issued many image pulls.

Looking through the docker daemon logs in syslog on some of the EC2 Instances that went into Drone Runner "error" state, I saw at least one failed, unauthorized attempt to connect to the Docker API port on the Runner.

## Testing story

Manually upload the new template in this feature branch. All Drone Runner Instances are in Error state, so I reverted back to the template committed to `staging` branch:

```
Name              Address           State    Created
agent-XzgqOx6F    35.94.151.156     error    49 minutes ago
agent-DbiNblqF    54.203.23.151     error    49 minutes ago
agent-rgUjwVIK    34.219.69.35      error    44 minutes ago
agent-yhLl0owy    54.188.10.10      error    44 minutes ago
agent-GmTUj3Py    34.212.32.171     error    39 minutes ago
agent-gZtha43A    35.91.230.61      error    39 minutes ago
agent-P2H1iofY    35.91.225.98      error    38 minutes ago
agent-9zkMrEr2    34.221.205.45     error    38 minutes ago
agent-sHG9ijFD    35.91.216.148     error    38 minutes ago
agent-ODTP8B8w    54.185.3.255      error    38 minutes ago
agent-RXFQDFkf    52.11.172.158     error    38 minutes ago
agent-ezGA2MEf    18.246.238.197    error    38 minutes ago
agent-i05lnruN    54.214.127.235    error    38 minutes ago
agent-M1elMtQO    35.87.154.5       error    38 minutes ago
agent-FRewVf9z    35.91.231.190     error    38 minutes ago
agent-LAWh2e1G    54.185.240.241    error    38 minutes ago
agent-8PAYF4W3    18.237.254.66     error    38 minutes ago
agent-utdZdZUE    35.89.145.61      error    38 minutes ago
agent-uD4E7I76    35.93.146.119     error    38 minutes ago
agent-EE5JIlAG    34.211.230.204    error    38 minutes ago
agent-j7H9UGiD    54.185.24.114     error    38 minutes ago
agent-tzSPaiQB    34.218.255.191    error    38 minutes ago
agent-5d3jHfil    35.87.95.27       error    38 minutes ago
agent-LHbXL1Gm    35.91.205.228     error    38 minutes ago
agent-AqEUfsp3    52.24.235.38      error    38 minutes ago
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
