### PR TITLE
Music: revive the advanced model

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -755,16 +755,18 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
 
     blocklyWrapper.setMainWorkspace(workspace);
 
-    // Same flyout callbacks are used for both main workspace categories
-    // and categories when modal function editor is enabled.
-    workspace.registerToolboxCategoryCallback(
-      'PROCEDURE',
-      functionsFlyoutCategory
-    );
-    workspace.registerToolboxCategoryCallback(
-      'VARIABLE',
-      variablesFlyoutCategory
-    );
+    if (!optOptionsExtended.useBlocklyDynamicCategories) {
+      // Same flyout callbacks are used for both main workspace categories
+      // and categories when modal function editor is enabled.
+      workspace.registerToolboxCategoryCallback(
+        'PROCEDURE',
+        functionsFlyoutCategory
+      );
+      workspace.registerToolboxCategoryCallback(
+        'VARIABLE',
+        variablesFlyoutCategory
+      );
+    }
 
     workspace.registerToolboxCategoryCallback(
       'Behavior',

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -211,6 +211,7 @@ export interface ExtendedBlocklyOptions extends BlocklyOptions {
   editBlocks: string | undefined;
   noFunctionBlockFrame: boolean;
   useModalFunctionEditor: boolean;
+  useBlocklyDynamicCategories: boolean;
 }
 
 export interface ExtendedWorkspace extends Workspace {

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -81,20 +81,13 @@ export default class MusicBlocklyWorkspace {
         startScale: experiments.isEnabled('zelos') ? 0.9 : 1,
       },
       readOnly: isReadOnlyWorkspace,
+      useBlocklyDynamicCategories: true,
     } as BlocklyOptions);
 
     this.resizeBlockly();
 
     this.workspace.addChangeListener(onBlockSpaceChange);
 
-    (this.workspace as WorkspaceSvg).registerButtonCallback(
-      'createVariableHandler',
-      button => {
-        Blockly.Variables.createVariableButtonHandler(
-          button.getTargetWorkspace()
-        );
-      }
-    );
     this.headlessMode = false;
   }
 
@@ -347,6 +340,11 @@ export default class MusicBlocklyWorkspace {
    */
   getTriggerStartPosition(id: string, currentPosition: number) {
     const triggerStart = this.triggerIdToStartType[triggerIdToEvent(id)];
+
+    if (getBlockMode() === BlockMode.ADVANCED) {
+      return currentPosition;
+    }
+
     if (!triggerStart) {
       console.warn('No compiled trigger with ID: ' + id);
       return;

--- a/apps/src/music/blockly/blocks/advanced.js
+++ b/apps/src/music/blockly/blocks/advanced.js
@@ -36,5 +36,7 @@ export const playSound = {
     ) +
     ', ' +
     (isBlockInsideWhenRun(ctx) ? 'true' : 'false') +
-    ');\n',
+    ', "' +
+    ctx.id +
+    '");\n',
 };

--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -426,7 +426,9 @@ export function getToolbox(toolbox) {
           ],
           Logic: ['controls_if', 'logic_compare'],
         },
-        {includeVariables: true}
+        {
+          includeVariables: true,
+        }
       );
     case BlockMode.SIMPLE2:
     default:

--- a/apps/src/music/player/sequencer/AdvancedSequencer.ts
+++ b/apps/src/music/player/sequencer/AdvancedSequencer.ts
@@ -30,7 +30,7 @@ export default class AdvancedSequencer extends Sequencer {
       return;
     }
 
-    this.addNewEvent<SoundEvent>({
+    this.playbackEvents.push({
       id,
       type: 'sound',
       length: soundData.length,
@@ -38,7 +38,7 @@ export default class AdvancedSequencer extends Sequencer {
       blockId,
       triggered: false,
       when: measure,
-    });
+    } as PlaybackEvent);
   }
 
   createTrack() {
@@ -63,9 +63,5 @@ export default class AdvancedSequencer extends Sequencer {
 
   getLastMeasure(): number {
     return 0;
-  }
-
-  private addNewEvent<T extends PlaybackEvent>(event: T) {
-    this.playbackEvents.push(event);
   }
 }

--- a/apps/src/music/player/sequencer/AdvancedSequencer.ts
+++ b/apps/src/music/player/sequencer/AdvancedSequencer.ts
@@ -1,0 +1,71 @@
+import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
+import {PlaybackEvent} from '../interfaces/PlaybackEvent';
+import {SoundEvent} from '../interfaces/SoundEvent';
+import MusicLibrary from '../MusicLibrary';
+import Sequencer from './Sequencer';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+
+/**
+ * A {@link Sequencer} used in the Advanced (programming with variables) block mode.
+ */
+export default class AdvancedSequencer extends Sequencer {
+  private playbackEvents: PlaybackEvent[];
+
+  constructor(
+    private readonly metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter()
+  ) {
+    super();
+    this.playbackEvents = [];
+  }
+
+  playSoundAtMeasureById(
+    id: string,
+    measure: number,
+    isBlockInsideWhenRun: boolean,
+    blockId: string
+  ) {
+    const soundData = MusicLibrary.getInstance()?.getSoundForId(id);
+    if (!soundData) {
+      this.metricsReporter.logWarning('Could not find sound with ID: ' + id);
+      return;
+    }
+
+    this.addNewEvent<SoundEvent>({
+      id,
+      type: 'sound',
+      length: soundData.length,
+      soundType: soundData.type,
+      blockId,
+      triggered: false,
+      when: measure,
+    });
+  }
+
+  createTrack() {
+    console.log('Not implemented');
+  }
+
+  addSoundsToTrack() {
+    console.log('Not implemented');
+  }
+
+  addRestToTrack() {
+    console.log('Not implemented');
+  }
+
+  getPlaybackEvents(): PlaybackEvent[] {
+    return this.playbackEvents;
+  }
+
+  clear(): void {
+    this.playbackEvents = [];
+  }
+
+  getLastMeasure(): number {
+    return 0;
+  }
+
+  private addNewEvent<T extends PlaybackEvent>(event: T) {
+    this.playbackEvents.push(event);
+  }
+}

--- a/apps/src/music/player/sequencer/AdvancedSequencer.ts
+++ b/apps/src/music/player/sequencer/AdvancedSequencer.ts
@@ -1,6 +1,5 @@
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import {PlaybackEvent} from '../interfaces/PlaybackEvent';
-import {SoundEvent} from '../interfaces/SoundEvent';
 import MusicLibrary from '../MusicLibrary';
 import Sequencer from './Sequencer';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -450,9 +450,7 @@ class UnconnectedMusicView extends React.Component {
       lastMeasure: this.sequencer.getLastMeasure(),
     });
     this.props.addOrderedFunctions({
-      orderedFunctions:
-        this.sequencer.getOrderedFunctions &&
-        this.sequencer.getOrderedFunctions(),
+      orderedFunctions: this.sequencer.getOrderedFunctions?.() || [],
     });
     this.player.playEvents(playbackEvents);
 
@@ -486,9 +484,7 @@ class UnconnectedMusicView extends React.Component {
       lastMeasure: this.sequencer.getLastMeasure(),
     });
     this.props.addOrderedFunctions({
-      orderedFunctions:
-        this.sequencer.getOrderedFunctions &&
-        this.sequencer.getOrderedFunctions(),
+      orderedFunctions: this.sequencer.getOrderedFunctions?.() || [],
     });
 
     return this.player.preloadSounds(

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -40,6 +40,7 @@ import {
   setPageError,
 } from '@cdo/apps/lab2/lab2Redux';
 import Simple2Sequencer from '../player/sequencer/Simple2Sequencer';
+import AdvancedSequencer from '../player/sequencer/AdvancedSequencer';
 import MusicPlayerStubSequencer from '../player/sequencer/MusicPlayerStubSequencer';
 import {BlockMode, LEGACY_DEFAULT_LIBRARY, DEFAULT_LIBRARY} from '../constants';
 import {Key} from '../utils/Notes';
@@ -295,6 +296,8 @@ class UnconnectedMusicView extends React.Component {
 
     if (getBlockMode() === BlockMode.SIMPLE2) {
       this.sequencer = new Simple2Sequencer();
+    } else if (getBlockMode() === BlockMode.ADVANCED) {
+      this.sequencer = new AdvancedSequencer();
     } else {
       this.sequencer = new MusicPlayerStubSequencer();
     }
@@ -429,6 +432,7 @@ class UnconnectedMusicView extends React.Component {
     if (this.props.onProjectBeats) {
       this.analyticsReporter.onButtonClicked('trigger', {id});
     }
+
     const triggerStartPosition =
       this.musicBlocklyWorkspace.getTriggerStartPosition(
         id,
@@ -446,7 +450,9 @@ class UnconnectedMusicView extends React.Component {
       lastMeasure: this.sequencer.getLastMeasure(),
     });
     this.props.addOrderedFunctions({
-      orderedFunctions: this.sequencer.getOrderedFunctions(),
+      orderedFunctions:
+        this.sequencer.getOrderedFunctions &&
+        this.sequencer.getOrderedFunctions(),
     });
     this.player.playEvents(playbackEvents);
 
@@ -480,7 +486,9 @@ class UnconnectedMusicView extends React.Component {
       lastMeasure: this.sequencer.getLastMeasure(),
     });
     this.props.addOrderedFunctions({
-      orderedFunctions: this.sequencer.getOrderedFunctions(),
+      orderedFunctions:
+        this.sequencer.getOrderedFunctions &&
+        this.sequencer.getOrderedFunctions(),
     });
 
     return this.player.preloadSounds(

--- a/apps/src/music/views/TimelineSampleEvents.jsx
+++ b/apps/src/music/views/TimelineSampleEvents.jsx
@@ -8,6 +8,7 @@ import {useSelector} from 'react-redux';
  * Renders timeline events, organized by unique sample ID.
  */
 const TimelineSampleEvents = ({
+  paddingOffset,
   barWidth,
   eventVerticalSpace,
   getEventHeight,
@@ -42,8 +43,8 @@ const TimelineSampleEvents = ({
           height={
             getEventHeight(currentUniqueSounds.length) - eventVerticalSpace
           }
-          top={20 + getVerticalOffsetForEventId(eventData.id)}
-          left={barWidth * (eventData.when - 1)}
+          top={32 + getVerticalOffsetForEventId(eventData.id)}
+          left={paddingOffset + barWidth * (eventData.when - 1)}
           when={eventData.when}
         />
       ))}
@@ -52,6 +53,7 @@ const TimelineSampleEvents = ({
 };
 
 TimelineSampleEvents.propTypes = {
+  paddingOffset: PropTypes.number.isRequired,
   barWidth: PropTypes.number.isRequired,
   eventVerticalSpace: PropTypes.number.isRequired,
   getEventHeight: PropTypes.func.isRequired,


### PR DESCRIPTION
This revives the original Music Lab programming model, which came to be known as the advanced model, which uses variables and absolute positioning of play sound events.  This is due to new interest from the curriculum team in using something like this for grades 6-12.  

This is designed for internal evaluation only.  It can be viewed by using the `?blocks=advanced` URL parameter.

It's also certainly possible that we could build a new programming model off of this one.

The same model can be seen working in the very first PR for Music Lab at https://github.com/code-dot-org/code-dot-org/pull/47808.  

<img width="1512" alt="Screenshot 2024-03-11 at 6 05 08 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/9bf13373-e419-42af-a92c-c24a924d709e">
