### PR TITLE
Add and improve alt text for certificates

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -357,7 +357,6 @@
   "censusWebDesign": "Web design using HTML or CSS",
   "certificateAltTextNoName": "Certificate for completion of {courseTitle}",
   "certificateAltTextWithName": "Certificate for {studentName} for completion of {courseTitle}",
-  "certificateForCompletion": "Certificate for Completion of One Hour of Code",
   "challengeLevelIntro": "Challenge Puzzles are lessons designed to stretch your brain! Just do the best that you can!",
   "challengeLevelPassTitle": "You did it!",
   "challengeLevelPassText": "However, you could've done it with only {idealBlocks, plural, one {1 block} other {# blocks}}. Can you make your program even better?",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -355,6 +355,8 @@
   "censusRequiredSelect": "Required. Please select an option.",
   "censusTextBased": "Text-based programming in a language such as Java, JavaScript, Python, C++, etc. (Excluding HTML or CSS)",
   "censusWebDesign": "Web design using HTML or CSS",
+  "certificateAltTextNoName": "Certificate for completion of {courseTitle}",
+  "certificateAltTextWithName": "Certificate for {studentName} for completion of {courseTitle}",
   "certificateForCompletion": "Certificate for Completion of One Hour of Code",
   "challengeLevelIntro": "Challenge Puzzles are lessons designed to stretch your brain! Just do the best that you can!",
   "challengeLevelPassTitle": "You did it!",

--- a/apps/src/sites/studio/pages/certificates/show.js
+++ b/apps/src/sites/studio/pages/certificates/show.js
@@ -8,13 +8,14 @@ import {getStore} from '@cdo/apps/redux';
 $(document).ready(function () {
   const store = getStore();
   const certificateData = getScriptData('certificate');
-  const {imageUrl, printUrl, announcement} = certificateData;
+  const {imageAlt, imageUrl, printUrl, announcement} = certificateData;
   ReactDOM.render(
     <Provider store={store}>
       <CertificateShare
         imageUrl={imageUrl}
         printUrl={printUrl}
         announcement={announcement}
+        imageAlt={imageAlt}
       />
     </Provider>,
     document.getElementById('certificate-share')

--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -211,13 +211,18 @@ function Certificate(props) {
             {certificateData.map(image => (
               <swiper-slide key={image.courseName} class={style.swiperSlide}>
                 <a href={getCertificateSharePath(image.courseName)}>
-                  {
-                    // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
-                    // Verify or update this alt-text as necessary
-                  }
                   <img
                     src={getCertificateImagePath(image.courseName)}
-                    alt=""
+                    alt={
+                      studentName
+                        ? i18n.certificateAltTextWithName({
+                            studentName,
+                            courseTitle: image.courseTitle,
+                          })
+                        : i18n.certificateAltTextNoName({
+                            courseTitle: image.courseTitle,
+                          })
+                    }
                     style={{width: 470}}
                   />
                 </a>

--- a/apps/src/templates/certificates/CertificateShare.jsx
+++ b/apps/src/templates/certificates/CertificateShare.jsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import i18n from '@cdo/locale';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import TwoColumnActionBlock from '@cdo/apps/templates/studioHomepages/TwoColumnActionBlock';
 import styleConstants from '../../styleConstants';
 
-export default function CertificateShare({announcement, printUrl, imageUrl}) {
+export default function CertificateShare({
+  announcement,
+  printUrl,
+  imageUrl,
+  imageAlt,
+}) {
   return (
     <div style={styles.wrapper}>
       <a href={printUrl}>
         <img
           src={imageUrl}
-          alt={i18n.certificateForCompletion()}
+          alt={imageAlt}
           width="100%"
           style={styles.certificate}
         />
@@ -48,6 +52,7 @@ const styles = {
 
 CertificateShare.propTypes = {
   imageUrl: PropTypes.string.isRequired,
+  imageAlt: PropTypes.string.isRequired,
   printUrl: PropTypes.string.isRequired,
   announcement: PropTypes.object,
 };

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -18,13 +18,22 @@ export default function TwoColumnActionBlock({
   marginBottom = '64px',
 }) {
   return (
-    <div id={id} className={styles.container}>
+    <div
+      id={id}
+      className={styles.container}
+      data-testid="two-column-action-block"
+    >
       {heading && <Heading2>{heading}</Heading2>}
       <div
         className={styles.actionBlockWrapper}
         style={{marginBottom: marginBottom}}
       >
-        <img src={imageUrl} alt="" className={styles.image} />
+        <img
+          src={imageUrl}
+          alt=""
+          className={styles.image}
+          data-testid="two-column-action-block-img"
+        />
         <div className={styles.contentWrapper}>
           {subHeading && (
             <BodyOneText

--- a/apps/test/unit/templates/certificates/CertificateShareTest.js
+++ b/apps/test/unit/templates/certificates/CertificateShareTest.js
@@ -1,10 +1,11 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {render, screen, within} from '@testing-library/react';
 import {expect} from '../../../util/reconfiguredChai';
 import CertificateShare from '@cdo/apps/templates/certificates/CertificateShare';
 
 const defaultProps = {
   imageUrl: '/certificate-image',
+  imageAlt: 'certificate alt text',
   printUrl: '/certificate-print',
   announcement: {
     image: '/announcement-image',
@@ -31,15 +32,19 @@ describe('CertificateShare', () => {
   });
 
   it('renders announcement image url relative to pegasus', () => {
-    const wrapper = shallow(<CertificateShare {...defaultProps} />);
+    render(<CertificateShare {...defaultProps} />);
 
-    const printLink = wrapper.find('a');
-    expect(printLink.prop('href')).to.equal('/certificate-print');
-    const image = printLink.find('img');
-    expect(image.prop('src')).to.equal('/certificate-image');
+    const printLink = screen.getByRole('link', {name: 'certificate alt text'});
+    expect(printLink.href).to.include('/certificate-print');
+    const image = screen.getByRole('img', {name: 'certificate alt text'});
+    expect(image.src).to.include('/certificate-image');
 
-    const block = wrapper.find('TwoColumnActionBlock');
-    expect(block.prop('imageUrl')).to.equal('//code.org/announcement-image');
+    const twoColumnActionBlock = screen.getByTestId('two-column-action-block');
+    expect(twoColumnActionBlock).to.exist;
+    const announcementImg = within(twoColumnActionBlock).getByTestId(
+      'two-column-action-block-img'
+    );
+    expect(announcementImg.src).to.include('//code.org/announcement-image');
   });
 
   it('renders no announcement without announcement prop', () => {
@@ -47,12 +52,10 @@ describe('CertificateShare', () => {
       ...defaultProps,
       announcement: null,
     };
-    const wrapper = shallow(<CertificateShare {...props} />);
+    render(<CertificateShare {...props} />);
 
-    const printLink = wrapper.find('a');
-    expect(printLink.length).to.equal(1);
+    screen.findByRole('link', {name: 'certificate alt text'});
 
-    const block = wrapper.find('TwoColumnActionBlock');
-    expect(block.length).to.equal(0);
+    expect(screen.queryByTestId('two-column-action-block')).to.not.exist;
   });
 });

--- a/apps/test/unit/templates/certificates/CertificateShareTest.js
+++ b/apps/test/unit/templates/certificates/CertificateShareTest.js
@@ -3,9 +3,10 @@ import {render, screen, within} from '@testing-library/react';
 import {expect} from '../../../util/reconfiguredChai';
 import CertificateShare from '@cdo/apps/templates/certificates/CertificateShare';
 
+const defaultImageAlt = 'certificate alt text';
 const defaultProps = {
   imageUrl: '/certificate-image',
-  imageAlt: 'certificate alt text',
+  imageAlt: defaultImageAlt,
   printUrl: '/certificate-print',
   announcement: {
     image: '/announcement-image',
@@ -34,13 +35,12 @@ describe('CertificateShare', () => {
   it('renders announcement image url relative to pegasus', () => {
     render(<CertificateShare {...defaultProps} />);
 
-    const printLink = screen.getByRole('link', {name: 'certificate alt text'});
+    const printLink = screen.getByRole('link', {name: defaultImageAlt});
     expect(printLink.href).to.include('/certificate-print');
-    const image = screen.getByRole('img', {name: 'certificate alt text'});
+    const image = screen.getByRole('img', {name: defaultImageAlt});
     expect(image.src).to.include('/certificate-image');
 
     const twoColumnActionBlock = screen.getByTestId('two-column-action-block');
-    expect(twoColumnActionBlock).to.exist;
     const announcementImg = within(twoColumnActionBlock).getByTestId(
       'two-column-action-block-img'
     );
@@ -54,7 +54,7 @@ describe('CertificateShare', () => {
     };
     render(<CertificateShare {...props} />);
 
-    screen.findByRole('link', {name: 'certificate alt text'});
+    screen.findByRole('link', {name: defaultImageAlt});
 
     expect(screen.queryByTestId('two-column-action-block')).to.not.exist;
   });

--- a/dashboard/app/controllers/certificates_controller.rb
+++ b/dashboard/app/controllers/certificates_controller.rb
@@ -20,8 +20,14 @@ class CertificatesController < ApplicationController
     announcement = Announcements.get_announcement_for_page('/certificates')
 
     @image_url = certificate_image_url(data['name'], data['course'], data['donor'])
+    course_name = CurriculumHelper.find_matching_unit_or_unit_group(data['course'])&.localized_title || I18n.t('certificates.one_hour_of_code')
+    image_alt = data['name'] ?
+      I18n.t('certificates.alt_text_with_name', course_name: course_name, student_name: data['name']) :
+      I18n.t('certificates.alt_text_no_name', course_name: course_name)
+
     @certificate_data = {
       imageUrl: @image_url,
+      imageAlt: image_alt,
       printUrl: certificate_print_url(data['name'], data['course'], data['donor']),
       announcement: announcement
     }

--- a/dashboard/app/controllers/congrats_controller.rb
+++ b/dashboard/app/controllers/congrats_controller.rb
@@ -25,12 +25,14 @@ class CongratsController < ApplicationController
         if completed_units.length == units.length
           [{
             courseName: @course_name,
+            courseTitle: curriculum.localized_title,
             coursePath: course_path(curriculum),
           }]
         else
           completed_units.map do |unit|
             {
               courseName: unit.name,
+              courseTitle: unit.localized_title,
               coursePath: script_path(unit),
             }
           end
@@ -40,6 +42,7 @@ class CongratsController < ApplicationController
       @curriculum_url = script_path('hourofcode')
       @certificate_data = [{
         courseName: @course_name,
+        courseTitle: I18n.t('certificates.one_hour_of_code'),
         coursePath: @curriculum_url,
       }]
     else
@@ -50,6 +53,7 @@ class CongratsController < ApplicationController
         if curriculum&.hoc? || UserScript.where(user: current_user, script: curriculum).where.not(completed_at: nil).exists?
           [{
             courseName: @course_name,
+            courseTitle: curriculum.localized_title,
             coursePath: @curriculum_url,
           }]
         else

--- a/dashboard/app/controllers/print_certificates_controller.rb
+++ b/dashboard/app/controllers/print_certificates_controller.rb
@@ -18,6 +18,7 @@ class PrintCertificatesController < ApplicationController
     end
 
     @student_name = data['name']
+    @course_name = CurriculumHelper.find_matching_unit_or_unit_group(data['course'])&.localized_title || I18n.t('certificates.one_hour_of_code')
     @certificate_image_url = certificate_image_url(data['name'], data['course'], data['donor'])
   end
 

--- a/dashboard/app/views/print_certificates/show.html.haml
+++ b/dashboard/app/views/print_certificates/show.html.haml
@@ -1,4 +1,4 @@
-- alt_text = @student_name ? "Certificate for #{@student_name}" : 'Certificate for Completion of One Hour of Code'
+- alt_text = @student_name ? I18n.t('certificates.alt_text_with_name', student_name: @student_name, course_name: @course_name) : I18n.t('certificates.alt_text_no_name', course_name: @course_name)
 %img{src: @certificate_image_url, alt: alt_text, width:"100%", style: "margin-top: 25px"}
 
 %script{src: webpack_asset_path('js/print_certificates/show.js')}

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1444,3 +1444,7 @@ en:
     upgrade_to_teacher_account:
       error:
         missing_email: "Missing required parameter: Email"
+  certificates:
+    alt_text_with_name: "Certificate for %{student_name} for completion of %{course_name}"
+    alt_text_no_name: "Certificate for completion of %{course_name}"
+    one_hour_of_code: "One Hour of Code"


### PR DESCRIPTION
Adds, improves, and makes translateable alt text for certificates! I also converted one test to RTL as part of this.

Finishes [ACQ-1554](https://codedotorg.atlassian.net/browse/ACQ-1554). 


Dev console with alt text highlighted:

|    | personalized | unpersonalized |
|--| ------------- | --------------- |
|congrats page| ![Screenshot 2024-03-11 at 9 55 06 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/8f2f76a2-e462-4b83-8aec-20a3e33e792f) | ![Screenshot 2024-03-11 at 9 56 11 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/c76e8acd-1673-413b-bbc7-6dcb2e4523d3)|
|print certificate page|![Screenshot 2024-03-11 at 9 55 42 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/9e2410ac-0a53-4e31-8669-e05b53ec4d4f)|![Screenshot 2024-03-11 at 9 56 51 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/2d2ec07a-424c-49a3-a341-2cca6c3cd221)|
|certificate show|![Screenshot 2024-03-11 at 9 55 24 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/e598973a-2ff5-493e-bb27-85a14910d613)|![Screenshot 2024-03-11 at 9 56 35 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/df133380-6c22-4781-a382-b72cc2ddc270)|






