### PR TITLE
update TA FAB icon

### DIFF
--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import style from './rubrics.module.scss';
 import aiFabIcon from '@cdo/static/ai-bot-centered-teal.png';
 import rubricFabIcon from '@cdo/static/rubric-fab-background.png';
+import taIcon from '@cdo/static/ai-bot-tag-TA.png';
 import RubricContainer from './RubricContainer';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
@@ -68,7 +69,7 @@ function RubricFloatingActionButton({
     trySetSessionStorage(sessionStorageKey, isOpen);
   }, [isOpen]);
 
-  const icon = aiEnabled ? aiFabIcon : rubricFabIcon;
+  const fabIcon = aiEnabled ? aiFabIcon : rubricFabIcon;
 
   return (
     <div id="fab-contained">
@@ -76,9 +77,14 @@ function RubricFloatingActionButton({
         id="ui-floatingActionButton"
         className={style.floatingActionButton}
         // I couldn't get an image url to work in the SCSS module, so using an inline style for now
-        style={{backgroundImage: `url(${icon})`}}
+        style={{backgroundImage: `url(${fabIcon})`}}
         onClick={handleClick}
         type="button"
+      />
+      <div
+        id="ui-floatingActionButton-overlay"
+        className={style.taOverlay}
+        style={{backgroundImage: `url(${taIcon})`}}
       />
       {/* TODO: do not hardcode in AI setting */}
       <RubricContainer

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -2,7 +2,7 @@ import React, {useEffect, useMemo, useState} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import style from './rubrics.module.scss';
-import aiFabIcon from '@cdo/static/ai-fab-background.png';
+import aiFabIcon from '@cdo/static/ai-bot-centered-teal.png';
 import rubricFabIcon from '@cdo/static/rubric-fab-background.png';
 import RubricContainer from './RubricContainer';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -34,7 +34,7 @@
 .rubricContainer {
   position: fixed;
   left: 10px;
-  bottom: 116px;
+  bottom: 120px;
   z-index: 2000;
   width: 760px;
 }

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -6,9 +6,9 @@
   left: 10px;
   bottom: 48px;
 
-  height: 60px;
-  width: 60px;
-  background-size: 60px;
+  height: 55px;
+  width: 55px;
+  background-size: 55px;
   padding: 0;
 
   border-width: 0;
@@ -17,15 +17,15 @@
 
 .taOverlay {
   position: fixed;
-  left: 56px;
-  bottom: 99px;
+  left: 51px;
+  bottom: 97px;
 
-  height: 20px;
-  width: 30px;
-  background-size: 32px;
+  height: 18px;
+  width: 28px;
+  background-size: 28px;
   padding: 0;
 
-  border-width: 3px;
+  border-width: 2px;
   border-color: $background_gray;
   border-radius: 15px;
   border-style: solid;

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -15,6 +15,22 @@
   border-radius: 30px;
 }
 
+.taOverlay {
+  position: fixed;
+  left: 56px;
+  bottom: 99px;
+
+  height: 20px;
+  width: 30px;
+  background-size: 32px;
+  padding: 0;
+
+  border-width: 3px;
+  border-color: $background_gray;
+  border-radius: 15px;
+  border-style: solid;
+}
+
 .rubricContainer {
   position: fixed;
   left: 10px;

--- a/apps/static/ai-bot-centered-teal.png
+++ b/apps/static/ai-bot-centered-teal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8664cb6ce81e698a1207c040ba62c099bb58f2c47e3aa66a9596a45b124b52da
+size 289958

--- a/apps/static/ai-bot-tag-TA.png
+++ b/apps/static/ai-bot-tag-TA.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7aa778d498146e98ff1811b13111468ee457dd9471b536ccbc883ab0e69070b0
+size 3315


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-475. Positions bot + background circle as one image and TA oval as another, because this will make it easier to animate the css in the next task (https://codedotorg.atlassian.net/browse/AITT-500). 

## Screenshots

### before
![Screenshot 2024-03-11 at 9 52 26 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/d2cf1fcf-25bc-4669-ab68-63955b320573)

![Screenshot 2024-03-11 at 10 26 41 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/4e2e4643-f034-4e8e-b0bd-650d9dcf3b6b)

### after
![Screenshot 2024-03-11 at 9 52 08 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/c788395e-dcd2-40ad-be28-e34938ae6ef5)

![Screenshot 2024-03-11 at 10 53 30 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/4863657a-d9aa-4988-aec9-7b68fb028297)

### spec

original figma:

![Screenshot 2024-03-11 at 9 51 45 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/73fad5f2-208b-405a-9287-08f4cf235167)

figma scaled to 66x64:

![AI Teaching Assistant teal 66x64](https://github.com/code-dot-org/code-dot-org/assets/8001765/292dcc05-c446-41b5-8d1e-9f9307a15852)

## Testing story

I expect some eyes tests to need updating when this PR ships.