### PR TITLE
Use .0 at the end of unplugged levels

### DIFF
--- a/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
@@ -67,7 +67,7 @@ export default function ExpandedProgressColumnHeader({
       >
         {level.sublevels?.length > 0 && <FontAwesome icon="caret-right" />}
         <div>{`${lesson.relative_position}.${
-          level.kind === 'unplugged' ? 0 : level.bubbleText
+          level.isUnplugged ? 0 : level.bubbleText
         }`}</div>
         {level.kind === 'assessment' && (
           <FontAwesome

--- a/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
@@ -66,7 +66,9 @@ export default function ExpandedProgressColumnHeader({
         onClick={() => toggleExpandedChoiceLevel(level)}
       >
         {level.sublevels?.length > 0 && <FontAwesome icon="caret-right" />}
-        <div>{lesson.relative_position + '.' + level.bubbleText}</div>
+        <div>{`${lesson.relative_position}.${
+          level.kind === 'unplugged' ? 0 : level.bubbleText
+        }`}</div>
         {level.kind === 'assessment' && (
           <FontAwesome
             icon="star"
@@ -78,6 +80,8 @@ export default function ExpandedProgressColumnHeader({
     ),
     [lesson, level, toggleExpandedChoiceLevel, isExpandable]
   );
+
+  console.log(level);
 
   return level.sublevels?.length > 0 && isLevelExpanded
     ? expandedChoiceLevel()

--- a/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
@@ -81,8 +81,6 @@ export default function ExpandedProgressColumnHeader({
     [lesson, level, toggleExpandedChoiceLevel, isExpandable]
   );
 
-  console.log(level);
-
   return level.sublevels?.length > 0 && isLevelExpanded
     ? expandedChoiceLevel()
     : unexpandedLevel();


### PR DESCRIPTION
This change makes the level header for unplugged levels have a ".0" suffix (as these are always before level 1 in a lesson). Students who have marked this lesson complete will have that reflected in the table.

![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/81f30159-10cf-4d39-9094-14d1f57026c3)

## Links

[JIRA](https://codedotorg.atlassian.net/browse/TEACH-903)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
