### PR TITLE
Gen AI: make level edit sub-sections collapsible

### DIFF
--- a/apps/src/lab2/levelEditors/aiCustomizations/CollapsibleSection.tsx
+++ b/apps/src/lab2/levelEditors/aiCustomizations/CollapsibleSection.tsx
@@ -11,7 +11,7 @@ const CollapsibleSection: React.FunctionComponent<{
   const [collapsed, setCollapsed] = useState(initiallyCollapsed);
 
   return (
-    <div>
+    <>
       <div className={moduleStyles.titleRow}>
         <button
           type="button"
@@ -26,7 +26,7 @@ const CollapsibleSection: React.FunctionComponent<{
         <BodyOneText className={moduleStyles.fieldTitle}>{title}</BodyOneText>
       </div>
       {!collapsed && children}
-    </div>
+    </>
   );
 };
 

--- a/apps/src/lab2/levelEditors/aiCustomizations/CollapsibleSection.tsx
+++ b/apps/src/lab2/levelEditors/aiCustomizations/CollapsibleSection.tsx
@@ -1,0 +1,33 @@
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
+import {BodyOneText} from '@cdo/apps/componentLibrary/typography';
+import React, {useState} from 'react';
+import moduleStyles from './edit-ai-customizations.module.scss';
+
+const CollapsibleSection: React.FunctionComponent<{
+  title: string;
+  children: React.ReactNode;
+  initiallyCollapsed?: boolean;
+}> = ({title, children, initiallyCollapsed = true}) => {
+  const [collapsed, setCollapsed] = useState(initiallyCollapsed);
+
+  return (
+    <div>
+      <div className={moduleStyles.titleRow}>
+        <button
+          type="button"
+          onClick={() => setCollapsed(!collapsed)}
+          className={moduleStyles.expandCollapseButton}
+        >
+          <FontAwesomeV6Icon
+            iconName={collapsed ? 'chevron-down' : 'chevron-up'}
+            iconStyle="solid"
+          />
+        </button>
+        <BodyOneText className={moduleStyles.fieldTitle}>{title}</BodyOneText>
+      </div>
+      {!collapsed && children}
+    </div>
+  );
+};
+
+export default CollapsibleSection;

--- a/apps/src/lab2/levelEditors/aiCustomizations/EditAiCustomizations.tsx
+++ b/apps/src/lab2/levelEditors/aiCustomizations/EditAiCustomizations.tsx
@@ -7,7 +7,6 @@ import {
 import React, {useCallback, useState} from 'react';
 import {
   BodyFourText,
-  BodyOneText,
   BodyThreeText,
 } from '@cdo/apps/componentLibrary/typography';
 import moduleStyles from './edit-ai-customizations.module.scss';
@@ -22,6 +21,7 @@ import ModelCardFields from './ModelCardFields';
 import VisibilityDropdown from './VisibilityDropdown';
 import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
 import {UpdateContext} from './UpdateContext';
+import CollapsibleSection from './CollapsibleSection';
 
 const EMPTY_MODEL_CARD_INFO: ModelCardInfo = {
   description: '',
@@ -192,45 +192,48 @@ const EditAiCustomizations: React.FunctionComponent<{
         />
         <div className={moduleStyles.fieldSection}>
           <hr />
-          <BodyOneText>Model Card</BodyOneText>
-          <div className={moduleStyles.fieldRow}>
-            <ModelCardFields />
-            <VisibilityDropdown
-              value={aiCustomizations.modelCardInfo?.visibility || 'editable'}
-              property="modelCardInfo"
-            />
-          </div>
+          <CollapsibleSection title="Model Card">
+            <div className={moduleStyles.fieldRow}>
+              <ModelCardFields />
+              <VisibilityDropdown
+                value={aiCustomizations.modelCardInfo?.visibility || 'editable'}
+                property="modelCardInfo"
+              />
+            </div>
+          </CollapsibleSection>
         </div>
         <div className={moduleStyles.fieldSection}>
           <hr />
-          <BodyOneText>Additional Configuration</BodyOneText>
-          <BodyFourText>
-            <i>
-              Students always have access to the Edit View, where they can
-              customize their chatbot. Published chatbots are able to be viewed
-              in a Presentation View which mimics a user-centered experience by
-              hiding instructions and displaying the model card. Use the setting
-              below to hide the option to enter presentation view in a level.
-            </i>
-          </BodyFourText>
-          <div className={moduleStyles.fieldRow}>
-            <label
-              htmlFor="hidePresentationPanel"
-              className={moduleStyles.inlineLabel}
-            >
-              Hide Presentation Panel
-            </label>
-            <Checkbox
-              name="hidePresentationPanel"
-              checked={aiCustomizations.hidePresentationPanel || false}
-              onChange={e => {
-                setAiCustomizations({
-                  ...aiCustomizations,
-                  hidePresentationPanel: e.target.checked,
-                });
-              }}
-            />
-          </div>
+          <CollapsibleSection title="Additional Configuration">
+            <BodyFourText>
+              <i>
+                Students always have access to the Edit View, where they can
+                customize their chatbot. Published chatbots are able to be
+                viewed in a Presentation View which mimics a user-centered
+                experience by hiding instructions and displaying the model card.
+                Use the setting below to hide the option to enter presentation
+                view in a level.
+              </i>
+            </BodyFourText>
+            <div className={moduleStyles.fieldRow}>
+              <label
+                htmlFor="hidePresentationPanel"
+                className={moduleStyles.inlineLabel}
+              >
+                Hide Presentation Panel
+              </label>
+              <Checkbox
+                name="hidePresentationPanel"
+                checked={aiCustomizations.hidePresentationPanel || false}
+                onChange={e => {
+                  setAiCustomizations({
+                    ...aiCustomizations,
+                    hidePresentationPanel: e.target.checked,
+                  });
+                }}
+              />
+            </div>
+          </CollapsibleSection>
         </div>
         <hr />
       </div>

--- a/apps/src/lab2/levelEditors/aiCustomizations/FieldSection.tsx
+++ b/apps/src/lab2/levelEditors/aiCustomizations/FieldSection.tsx
@@ -1,10 +1,11 @@
 import {AiCustomizations} from '@cdo/apps/aichat/types';
 import React, {useContext} from 'react';
-import {BodyFourText, BodyOneText} from '@cdo/apps/componentLibrary/typography';
+import {BodyFourText} from '@cdo/apps/componentLibrary/typography';
 import classNames from 'classnames';
 import moduleStyles from './edit-ai-customizations.module.scss';
 import VisibilityDropdown from './VisibilityDropdown';
 import {UpdateContext} from './UpdateContext';
+import CollapsibleSection from './CollapsibleSection';
 
 interface FieldSectionProps {
   fieldName: keyof AiCustomizations;
@@ -32,38 +33,39 @@ const FieldSection: React.FunctionComponent<FieldSectionProps> = ({
   return (
     <div className={moduleStyles.fieldSection}>
       <hr />
-      <BodyOneText>{labelText}</BodyOneText>
-      {description && (
-        <BodyFourText>
-          <i>{description}</i>
-        </BodyFourText>
-      )}
-      <div className={moduleStyles.fieldRow}>
-        <div className={moduleStyles['field-value']}>
-          <label htmlFor={fieldName}>Initial Value(s)</label>
-          {inputType === 'custom' && inputNode ? (
-            inputNode
-          ) : (
-            <InputTag
-              id={fieldName}
-              type={inputType}
-              value={
-                (aiCustomizations[fieldName]?.value as string | number) ||
-                (inputType === 'number' ? 0 : '')
-              }
-              onChange={e => setPropertyValue(fieldName, e.target.value)}
-              className={classNames(
-                inputType === 'textarea' && moduleStyles.textarea
-              )}
-              {...(inputType === 'number' && {min, max, step})}
-            />
-          )}
+      <CollapsibleSection title={labelText}>
+        {description && (
+          <BodyFourText>
+            <i>{description}</i>
+          </BodyFourText>
+        )}
+        <div className={moduleStyles.fieldRow}>
+          <div className={moduleStyles['field-value']}>
+            <label htmlFor={fieldName}>Initial Value(s)</label>
+            {inputType === 'custom' && inputNode ? (
+              inputNode
+            ) : (
+              <InputTag
+                id={fieldName}
+                type={inputType}
+                value={
+                  (aiCustomizations[fieldName]?.value as string | number) ||
+                  (inputType === 'number' ? 0 : '')
+                }
+                onChange={e => setPropertyValue(fieldName, e.target.value)}
+                className={classNames(
+                  inputType === 'textarea' && moduleStyles.textarea
+                )}
+                {...(inputType === 'number' && {min, max, step})}
+              />
+            )}
+          </div>
+          <VisibilityDropdown
+            value={aiCustomizations[fieldName]?.visibility || 'editable'}
+            property={fieldName}
+          />
         </div>
-        <VisibilityDropdown
-          value={aiCustomizations[fieldName]?.visibility || 'editable'}
-          property={fieldName}
-        />
-      </div>
+      </CollapsibleSection>
     </div>
   );
 };

--- a/apps/src/lab2/levelEditors/aiCustomizations/edit-ai-customizations.module.scss
+++ b/apps/src/lab2/levelEditors/aiCustomizations/edit-ai-customizations.module.scss
@@ -4,12 +4,28 @@
 .fieldSection {
   display: flex;
   flex-direction: column;
-  margin-bottom: 25px;
+  margin-bottom: 20px;
 }
 
 .fieldRow {
   display: flex;
   flex-direction: row;
+}
+
+.titleRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.fieldTitle {
+  margin-left: 10px;
+  margin-bottom: 0;
+}
+
+.expandCollapseButton {
+  @include remove-button-styles;
 }
 
 .inlineLabel {


### PR DESCRIPTION
Quick follow-up to make the sub-sections of the Gen AI level edit fields collapsible. Code-wise this is just wrapping the fields in a new `CollapsibleSection` widget that generically displays some collapsible content with a title. Sections are collapsed by default.

https://github.com/code-dot-org/code-dot-org/assets/85528507/8ea37873-3307-495e-9f95-8f30a90bd4a4


## Links

https://codedotorg.atlassian.net/browse/LABS-551

## Testing story

Tested locally on allthethings AI Chat