### PR TITLE
use pulse animation on TA floating action button

### DIFF
--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -112,8 +112,8 @@ export default function RubricContent({
       <div className={style.studentInfoGroup}>
         <Heading3>
           {i18n.lessonNumbered({
-            lessonNumber: lesson.position,
-            lessonName: lesson.name,
+            lessonNumber: lesson?.position,
+            lessonName: lesson?.name,
           })}
         </Heading3>
 

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -29,6 +29,11 @@ function RubricFloatingActionButton({
   const [isOpen, setIsOpen] = useState(
     JSON.parse(tryGetSessionStorage(sessionStorageKey, false)) || false
   );
+  // Show the pulse if this is the first time the user has seen the FAB in this
+  // session. Depends on other logic which sets the open state in session storage.
+  const [showPulse] = useState(
+    JSON.parse(tryGetSessionStorage(sessionStorageKey, null)) === null
+  );
 
   const eventData = useMemo(() => {
     return {
@@ -72,11 +77,15 @@ function RubricFloatingActionButton({
 
   const fabIcon = aiEnabled ? aiFabIcon : rubricFabIcon;
 
+  const classes = showPulse
+    ? classNames(style.floatingActionButton, style.pulse)
+    : style.floatingActionButton;
+
   return (
     <div id="fab-contained">
       <button
         id="ui-floatingActionButton"
-        className={classNames(style.floatingActionButton, style.pulse)}
+        className={classes}
         // I couldn't get an image url to work in the SCSS module, so using an inline style for now
         style={{backgroundImage: `url(${fabIcon})`}}
         onClick={handleClick}

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -15,6 +15,7 @@ import {
 } from './rubricShapes';
 import {selectedSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
+import classNames from 'classnames';
 
 function RubricFloatingActionButton({
   rubric,
@@ -75,7 +76,7 @@ function RubricFloatingActionButton({
     <div id="fab-contained">
       <button
         id="ui-floatingActionButton"
-        className={style.floatingActionButton}
+        className={classNames(style.floatingActionButton, style.pulse)}
         // I couldn't get an image url to work in the SCSS module, so using an inline style for now
         style={{backgroundImage: `url(${fabIcon})`}}
         onClick={handleClick}

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -93,14 +93,12 @@ function RubricFloatingActionButton({
       >
         <img
           alt="AI bot"
-          id="unittest-fab-image"
           src={fabIcon}
           onLoad={() => setIsFabImageLoaded(true)}
           style={{opacity: 1.0}}
         />
       </button>
       <div
-        id="ui-floatingActionButton-overlay"
         className={style.taOverlay}
         style={{backgroundImage: `url(${taIcon})`}}
       />

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -78,7 +78,7 @@ function RubricFloatingActionButton({
   const fabIcon = aiEnabled ? aiFabIcon : rubricFabIcon;
 
   const classes = showPulse
-    ? classNames(style.floatingActionButton, style.pulse)
+    ? classNames(style.floatingActionButton, style.pulse, 'unittest-fab-pulse')
     : style.floatingActionButton;
 
   return (

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -35,6 +35,7 @@ function RubricFloatingActionButton({
     JSON.parse(tryGetSessionStorage(sessionStorageKey, null)) === null
   );
   const [isFabImageLoaded, setIsFabImageLoaded] = useState(false);
+  const [isTaImageLoaded, setIsTaImageLoaded] = useState(false);
 
   const eventData = useMemo(() => {
     return {
@@ -78,7 +79,7 @@ function RubricFloatingActionButton({
 
   const fabIcon = aiEnabled ? aiFabIcon : rubricFabIcon;
 
-  const showPulse = isFirstSession && isFabImageLoaded;
+  const showPulse = isFirstSession && isFabImageLoaded && isTaImageLoaded;
   const classes = showPulse
     ? classNames(style.floatingActionButton, style.pulse, 'unittest-fab-pulse')
     : style.floatingActionButton;
@@ -94,14 +95,20 @@ function RubricFloatingActionButton({
         <img
           alt="AI bot"
           src={fabIcon}
-          onLoad={() => setIsFabImageLoaded(true)}
+          onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
           style={{opacity: 1.0}}
         />
       </button>
       <div
         className={style.taOverlay}
         style={{backgroundImage: `url(${taIcon})`}}
-      />
+      >
+        <img
+          src={taIcon}
+          alt="TA overlay"
+          onLoad={() => !isTaImageLoaded && setIsTaImageLoaded(true)}
+        />
+      </div>
       {/* TODO: do not hardcode in AI setting */}
       <RubricContainer
         rubric={rubric}

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -31,9 +31,10 @@ function RubricFloatingActionButton({
   );
   // Show the pulse if this is the first time the user has seen the FAB in this
   // session. Depends on other logic which sets the open state in session storage.
-  const [showPulse] = useState(
+  const [isFirstSession] = useState(
     JSON.parse(tryGetSessionStorage(sessionStorageKey, null)) === null
   );
+  const [isFabImageLoaded, setIsFabImageLoaded] = useState(false);
 
   const eventData = useMemo(() => {
     return {
@@ -77,12 +78,19 @@ function RubricFloatingActionButton({
 
   const fabIcon = aiEnabled ? aiFabIcon : rubricFabIcon;
 
+  const showPulse = isFirstSession && isFabImageLoaded;
   const classes = showPulse
     ? classNames(style.floatingActionButton, style.pulse, 'unittest-fab-pulse')
     : style.floatingActionButton;
 
   return (
     <div id="fab-contained">
+      <img
+        id="unittest-fab-image-preloader"
+        src={fabIcon}
+        onLoad={() => setIsFabImageLoaded(true)}
+        style={{display: 'none'}}
+      />
       <button
         id="ui-floatingActionButton"
         className={classes}

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -96,7 +96,6 @@ function RubricFloatingActionButton({
           alt="AI bot"
           src={fabIcon}
           onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
-          style={{opacity: 1.0}}
         />
       </button>
       <div

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -85,20 +85,20 @@ function RubricFloatingActionButton({
 
   return (
     <div id="fab-contained">
-      <img
-        id="unittest-fab-image-preloader"
-        src={fabIcon}
-        onLoad={() => setIsFabImageLoaded(true)}
-        style={{display: 'none'}}
-      />
       <button
         id="ui-floatingActionButton"
         className={classes}
-        // I couldn't get an image url to work in the SCSS module, so using an inline style for now
-        style={{backgroundImage: `url(${fabIcon})`}}
         onClick={handleClick}
         type="button"
-      />
+      >
+        <img
+          alt="AI bot"
+          id="unittest-fab-image"
+          src={fabIcon}
+          onLoad={() => setIsFabImageLoaded(true)}
+          style={{opacity: 1.0}}
+        />
+      </button>
       <div
         id="ui-floatingActionButton-overlay"
         className={style.taOverlay}

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -27,6 +27,9 @@
 
   border-width: 0;
   border-radius: 30px;
+}
+
+.pulse {
   animation: pulse 1.5s 1.7;
   box-shadow: 0 0 0 0 rgba(90 153 212 / 0.5);
 }

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -1,6 +1,20 @@
 @import 'color.scss';
 @import 'font.scss';
 
+@keyframes pulse {
+  0% {
+    transform: scale(.9);
+  }
+  70% {
+    transform: scale(1);
+    box-shadow: 0 0 0 50px rgba(90 153 212 / 0);
+  }
+  100% {
+    transform: scale(.9);
+    box-shadow: 0 0 0 0 rgba(90 153 212 / 0);
+  }
+}
+
 .floatingActionButton {
   position: fixed;
   left: 10px;
@@ -13,6 +27,8 @@
 
   border-width: 0;
   border-radius: 30px;
+  animation: pulse 1.5s 1.7;
+  box-shadow: 0 0 0 0 rgba(90 153 212 / 0.5);
 }
 
 .taOverlay {

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -27,6 +27,10 @@
 
   border-width: 0;
   border-radius: 30px;
+
+  img {
+    opacity: 1.0;
+  }
 }
 
 .pulse {

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -64,10 +64,16 @@ describe('RubricFloatingActionButton - React Testing Library', () => {
           <RubricFloatingActionButton {...defaultProps} />
         </Provider>
       );
+
       const fab = screen.getByRole('button', {name: 'AI bot'});
       expect(fab.classList.contains('unittest-fab-pulse')).to.be.false;
-      const image = screen.getByRole('img', {name: 'AI bot'});
-      fireEvent.load(image);
+
+      const fabImage = screen.getByRole('img', {name: 'AI bot'});
+      fireEvent.load(fabImage);
+      expect(fab.classList.contains('unittest-fab-pulse')).to.be.false;
+
+      const taImage = screen.getByRole('img', {name: 'TA overlay'});
+      fireEvent.load(taImage);
       expect(fab.classList.contains('unittest-fab-pulse')).to.be.true;
     });
 

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -64,11 +64,9 @@ describe('RubricFloatingActionButton - React Testing Library', () => {
           <RubricFloatingActionButton {...defaultProps} />
         </Provider>
       );
-      const images = screen.getAllByRole('img');
-      const image = images.find(i => i.id === 'unittest-fab-image');
+      const image = screen.getByRole('img', {name: 'AI bot'});
       fireEvent.load(image);
-      const buttons = screen.getAllByRole('button');
-      const fab = buttons.find(b => b.id === 'ui-floatingActionButton');
+      const fab = screen.getByRole('button', {name: 'AI bot'});
       expect(fab.classList.contains('unittest-fab-pulse')).to.be.true;
     });
 
@@ -79,11 +77,9 @@ describe('RubricFloatingActionButton - React Testing Library', () => {
           <RubricFloatingActionButton {...defaultProps} />
         </Provider>
       );
-      const images = screen.getAllByRole('img');
-      const image = images.find(i => i.id === 'unittest-fab-image');
+      const image = screen.getByRole('img', {name: 'AI bot'});
       fireEvent.load(image);
-      const buttons = screen.getAllByRole('button');
-      const fab = buttons.find(b => b.id === 'ui-floatingActionButton');
+      const fab = screen.getByRole('button', {name: 'AI bot'});
       expect(fab.classList.contains('unittest-fab-pulse')).to.be.false;
     });
   });

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {UnconnectedRubricFloatingActionButton as RubricFloatingActionButton} from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import {
   getStore,
   registerReducers,
@@ -65,10 +65,8 @@ describe('RubricFloatingActionButton - React Testing Library', () => {
         </Provider>
       );
       const images = screen.getAllByRole('img');
-      const preloader = images.find(
-        i => i.id === 'unittest-fab-image-preloader'
-      );
-      preloader.onload();
+      const image = images.find(i => i.id === 'unittest-fab-image');
+      fireEvent.load(image);
       const buttons = screen.getAllByRole('button');
       const fab = buttons.find(b => b.id === 'ui-floatingActionButton');
       expect(fab.classList.contains('unittest-fab-pulse')).to.be.true;
@@ -82,10 +80,8 @@ describe('RubricFloatingActionButton - React Testing Library', () => {
         </Provider>
       );
       const images = screen.getAllByRole('img');
-      const preloader = images.find(
-        i => i.id === 'unittest-fab-image-preloader'
-      );
-      preloader.onload();
+      const image = images.find(i => i.id === 'unittest-fab-image');
+      fireEvent.load(image);
       const buttons = screen.getAllByRole('button');
       const fab = buttons.find(b => b.id === 'ui-floatingActionButton');
       expect(fab.classList.contains('unittest-fab-pulse')).to.be.false;

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -64,9 +64,10 @@ describe('RubricFloatingActionButton - React Testing Library', () => {
           <RubricFloatingActionButton {...defaultProps} />
         </Provider>
       );
+      const fab = screen.getByRole('button', {name: 'AI bot'});
+      expect(fab.classList.contains('unittest-fab-pulse')).to.be.false;
       const image = screen.getByRole('img', {name: 'AI bot'});
       fireEvent.load(image);
-      const fab = screen.getByRole('button', {name: 'AI bot'});
       expect(fab.classList.contains('unittest-fab-pulse')).to.be.true;
     });
 

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -48,13 +48,38 @@ describe('RubricFloatingActionButton - React Testing Library', () => {
     restoreRedux();
   });
 
-  it('renders default props', () => {
-    render(
-      <Provider store={getStore()}>
-        <RubricFloatingActionButton {...defaultProps} />
-      </Provider>
-    );
-    screen.debug();
+  describe('pulse animation', () => {
+    beforeEach(() => {
+      sinon.stub(sessionStorage, 'getItem');
+    });
+
+    afterEach(() => {
+      sessionStorage.getItem.restore();
+    });
+
+    it('renders pulse animation when session storage is empty', () => {
+      sessionStorage.getItem.withArgs('RubricFabOpenStateKey').returns(null);
+      render(
+        <Provider store={getStore()}>
+          <RubricFloatingActionButton {...defaultProps} />
+        </Provider>
+      );
+      const buttons = screen.getAllByRole('button');
+      const fab = buttons.find(b => b.id === 'ui-floatingActionButton');
+      expect(fab.classList.contains('unittest-fab-pulse')).to.be.true;
+    });
+
+    it('does not render pulse animation when open state is present in session storage', () => {
+      sessionStorage.getItem.withArgs('RubricFabOpenStateKey').returns(false);
+      render(
+        <Provider store={getStore()}>
+          <RubricFloatingActionButton {...defaultProps} />
+        </Provider>
+      );
+      const buttons = screen.getAllByRole('button');
+      const fab = buttons.find(b => b.id === 'ui-floatingActionButton');
+      expect(fab.classList.contains('unittest-fab-pulse')).to.be.false;
+    });
   });
 });
 

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -5,18 +5,60 @@ import sinon from 'sinon';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {UnconnectedRubricFloatingActionButton as RubricFloatingActionButton} from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
+import {render, screen} from '@testing-library/react';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux,
+} from '@cdo/apps/redux';
+import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import teacherPanel from '@cdo/apps/code-studio/teacherPanelRedux';
+import {Provider} from 'react-redux';
 
-describe('RubricFloatingActionButton', () => {
-  const defaultProps = {
-    rubric: {
-      level: {
-        name: 'test-level',
-      },
+const defaultProps = {
+  rubric: {
+    level: {
+      name: 'test-level',
     },
-    currentLevelName: 'test-level',
-    studentLevelInfo: null,
-  };
+    learningGoals: [
+      {
+        id: 1,
+        key: 'abc',
+        learningGoal: 'Learning Goal 1',
+        aiEnabled: true,
+        evidenceLevels: [
+          {id: 1, understanding: 1, teacherDescription: 'lg level 1'},
+        ],
+        tips: 'Tips',
+      },
+    ],
+  },
+  currentLevelName: 'test-level',
+  studentLevelInfo: null,
+};
 
+describe('RubricFloatingActionButton - React Testing Library', () => {
+  beforeEach(() => {
+    stubRedux();
+    registerReducers({teacherSections, teacherPanel});
+  });
+
+  afterEach(() => {
+    restoreRedux();
+  });
+
+  it('renders default props', () => {
+    render(
+      <Provider store={getStore()}>
+        <RubricFloatingActionButton {...defaultProps} />
+      </Provider>
+    );
+    screen.debug();
+  });
+});
+
+describe('RubricFloatingActionButton - Enzyme', () => {
   it('begins closed when student level info is null', () => {
     const wrapper = shallow(<RubricFloatingActionButton {...defaultProps} />);
     expect(wrapper.find('RubricContainer').length).to.equal(1);

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -64,6 +64,11 @@ describe('RubricFloatingActionButton - React Testing Library', () => {
           <RubricFloatingActionButton {...defaultProps} />
         </Provider>
       );
+      const images = screen.getAllByRole('img');
+      const preloader = images.find(
+        i => i.id === 'unittest-fab-image-preloader'
+      );
+      preloader.onload();
       const buttons = screen.getAllByRole('button');
       const fab = buttons.find(b => b.id === 'ui-floatingActionButton');
       expect(fab.classList.contains('unittest-fab-pulse')).to.be.true;
@@ -76,6 +81,11 @@ describe('RubricFloatingActionButton - React Testing Library', () => {
           <RubricFloatingActionButton {...defaultProps} />
         </Provider>
       );
+      const images = screen.getAllByRole('img');
+      const preloader = images.find(
+        i => i.id === 'unittest-fab-image-preloader'
+      );
+      preloader.onload();
       const buttons = screen.getAllByRole('button');
       const fab = buttons.find(b => b.id === 'ui-floatingActionButton');
       expect(fab.classList.contains('unittest-fab-pulse')).to.be.false;


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-500 . 

There is logic in this PR to make sure that we only show the pulse animation when/if:
* it is the user's first time viewing the TA bot this session
* the AI bot and TA overlay images have both finished loading

## screenshots

https://github.com/code-dot-org/code-dot-org/assets/8001765/86be4de6-baf2-4ac9-a7f0-c81060a8ab84

For past screenshots see https://github.com/code-dot-org/code-dot-org/pull/57172.

## Testing story

new unit tests including first RTL tests for this component.

RTL really encourages you to add tags like "name" and "alt" in order to be able to write your tests, which seems like a great forcing function for accessibility!