### PR TITLE
Music: enable advanced controls for ToneJS player behind URL param

### DIFF
--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -1,3 +1,5 @@
+import {Key} from './utils/Notes';
+
 export const baseAssetUrl = 'https://curriculum.code.org/media/musiclab/';
 export const baseAssetUrlRestricted =
   'https://curriculum.code.org/restricted/musiclab/';
@@ -72,3 +74,6 @@ export const DEFAULT_LIBRARY = 'intro2024';
 
 export const DEFAULT_BPM = 120;
 export const DEFAULT_BEATS_PER_MEASURE = 4;
+export const DEFAULT_KEY = Key.C;
+export const MIN_BPM = 60;
+export const MAX_BPM = 200;

--- a/apps/src/music/player/SamplePlayerWrapper.ts
+++ b/apps/src/music/player/SamplePlayerWrapper.ts
@@ -39,7 +39,7 @@ class SamplePlayerWrapper implements AudioPlayer {
   }
 
   async loadInstrument(): Promise<void> {
-    console.log('Not supported');
+    console.warn('loadInstrument not supported');
   }
 
   isInstrumentLoaded(): boolean {
@@ -64,7 +64,7 @@ class SamplePlayerWrapper implements AudioPlayer {
   }
 
   async playSequenceImmediately(): Promise<void> {
-    console.log('Not supported');
+    console.warn('playSequenceImmediately not supported');
   }
 
   cancelPreviews(): void {
@@ -80,7 +80,7 @@ class SamplePlayerWrapper implements AudioPlayer {
   }
 
   scheduleSamplerSequence(): void {
-    console.log('Not supported');
+    console.warn('scheduleSamplerSequence not supported');
   }
 
   async start(startPosition = 1) {
@@ -101,19 +101,19 @@ class SamplePlayerWrapper implements AudioPlayer {
   }
 
   setLoopEnabled(): void {
-    console.log('Not supported');
+    console.warn('setLoopEnabled not supported');
   }
 
   setLoopStart() {
-    console.log('Not supported');
+    console.warn('setLoopStart not supported');
   }
 
   setLoopEnd() {
-    console.log('Not supported');
+    console.warn('setLoopEnd not supported');
   }
 
   jumpToPosition() {
-    console.log('Not supported');
+    console.warn('jumpToPosition not supported');
   }
 
   // Converts actual seconds used by the audio system into a playhead

--- a/apps/src/music/player/SamplePlayerWrapper.ts
+++ b/apps/src/music/player/SamplePlayerWrapper.ts
@@ -100,6 +100,22 @@ class SamplePlayerWrapper implements AudioPlayer {
     this.samplePlayer.stopAllSamplesStillToPlay();
   }
 
+  setLoopEnabled(): void {
+    console.log('Not supported');
+  }
+
+  setLoopStart() {
+    console.log('Not supported');
+  }
+
+  setLoopEnd() {
+    console.log('Not supported');
+  }
+
+  jumpToPosition() {
+    console.log('Not supported');
+  }
+
   // Converts actual seconds used by the audio system into a playhead
   // position, which is 1-based and scaled to measures.
   private convertSecondsToPlayheadPosition(seconds: number): number {

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -44,7 +44,7 @@ class ToneJSPlayer implements AudioPlayer {
     );
   }
 
-  goToPosition(position: number) {
+  jumpToPosition(position: number) {
     Transport.position = this.playbackTimeToTransportTime(position);
   }
 

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -61,6 +61,18 @@ export interface AudioPlayer {
 
   /** Cancel pending audio events */
   cancelPendingEvents(): void;
+
+  /** Enable/disable looping */
+  setLoopEnabled(enabled: boolean): void;
+
+  /** Set the loop start point */
+  setLoopStart(loopStart: number): void;
+
+  /** Set the loop end point */
+  setLoopEnd(loopEnd: number): void;
+
+  /** Jump to the given playback position */
+  jumpToPosition(position: number): void;
 }
 
 /** A single sound played on the timeline */

--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -1,7 +1,14 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
-import {MIN_NUM_MEASURES} from '../constants';
+import {
+  DEFAULT_BPM,
+  DEFAULT_KEY,
+  MAX_BPM,
+  MIN_BPM,
+  MIN_NUM_MEASURES,
+} from '../constants';
 import {PlaybackEvent} from '../player/interfaces/PlaybackEvent';
 import {FunctionEvents} from '../player/interfaces/FunctionEvents';
+import {Key} from '../utils/Notes';
 
 const registerReducers = require('@cdo/apps/redux').registerReducers;
 
@@ -55,6 +62,13 @@ export interface MusicState {
     id?: string;
     index: number;
   };
+
+  // State used by advanced controls (currently internal-only) with the ToneJS player
+  loopEnabled: boolean;
+  loopStart: number;
+  loopEnd: number;
+  key: Key;
+  bpm: number;
 }
 
 const initialState: MusicState = {
@@ -81,6 +95,11 @@ const initialState: MusicState = {
     id: undefined,
     index: 0,
   },
+  loopEnabled: false,
+  loopStart: 1,
+  loopEnd: 5,
+  key: DEFAULT_KEY,
+  bpm: DEFAULT_BPM,
 };
 
 const musicSlice = createSlice({
@@ -204,6 +223,33 @@ const musicSlice = createSlice({
     clearCallout: state => {
       state.currentCallout.id = undefined;
     },
+    setLoopEnabled: (state, action: PayloadAction<boolean>) => {
+      state.loopEnabled = action.payload;
+    },
+    setLoopStart: (state, action: PayloadAction<number>) => {
+      state.loopStart = action.payload;
+    },
+    setLoopEnd: (state, action: PayloadAction<number>) => {
+      state.loopEnd = action.payload;
+    },
+    setKey: (state, action: PayloadAction<Key>) => {
+      let key = action.payload;
+      if (Key[key] === undefined) {
+        console.warn('Invalid key. Defaulting to C');
+        key = Key.C;
+      }
+
+      state.key = key;
+    },
+    setBpm: (state, action: PayloadAction<number>) => {
+      let bpm = action.payload;
+      if (bpm < MIN_BPM || bpm > MAX_BPM) {
+        console.warn('Invalid BPM. Defaulting to 120');
+        bpm = DEFAULT_BPM;
+      }
+
+      state.bpm = bpm;
+    },
   },
 });
 
@@ -267,4 +313,9 @@ export const {
   setUndoStatus,
   showCallout,
   clearCallout,
+  setLoopEnabled,
+  setLoopStart,
+  setLoopEnd,
+  setKey,
+  setBpm,
 } = musicSlice.actions;

--- a/apps/src/music/views/AdvancedControls.tsx
+++ b/apps/src/music/views/AdvancedControls.tsx
@@ -1,0 +1,146 @@
+import React, {useCallback} from 'react';
+import {Key} from '../utils/Notes';
+import moduleStyles from './advanced-controls.module.scss';
+import {
+  setBpm,
+  setKey,
+  setLoopEnabled,
+  setLoopEnd,
+  setLoopStart,
+} from '../redux/musicRedux';
+import {Heading5} from '@cdo/apps/componentLibrary/typography';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import classNames from 'classnames';
+import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
+import {MAX_BPM, MIN_BPM} from '../constants';
+
+/**
+ * Displays advanced controls used only by the ToneJS player, including
+ * custom BPM, custom key, and loop settings.
+ *
+ * Currently this is internal-only.
+ */
+const AdvancedControls: React.FunctionComponent = () => {
+  const dispatch = useAppDispatch();
+  const bpm = useAppSelector(state => state.music.bpm);
+  const key = useAppSelector(state => state.music.key);
+  const loopEnabled = useAppSelector(state => state.music.loopEnabled);
+  const loopStart = useAppSelector(state => state.music.loopStart);
+  const loopEnd = useAppSelector(state => state.music.loopEnd);
+  const isPlaying = useAppSelector(state => state.music.isPlaying);
+
+  const onBpmChange = useCallback(
+    (bpm: number) => {
+      dispatch(setBpm(bpm));
+    },
+    [dispatch]
+  );
+
+  const onKeyChange = useCallback(
+    (key: string) => {
+      dispatch(setKey(Key[key as keyof typeof Key]));
+    },
+    [dispatch]
+  );
+
+  const onLoopChange = useCallback(
+    (checked: boolean) => {
+      dispatch(setLoopEnabled(checked));
+    },
+    [dispatch]
+  );
+
+  const onLoopStartChange = useCallback(
+    (loopStart: number) => {
+      dispatch(setLoopStart(loopStart));
+    },
+    [dispatch]
+  );
+
+  const onLoopEndChange = useCallback(
+    (loopEnd: number) => {
+      dispatch(setLoopEnd(loopEnd));
+    },
+    [dispatch]
+  );
+
+  return (
+    <div className={moduleStyles.container}>
+      <Heading5 className={moduleStyles.title}>Advanced Controls</Heading5>
+      <div className={moduleStyles.section}>
+        <div className={moduleStyles.row}>
+          <div>BPM: {bpm}</div>
+        </div>
+        <input
+          type="range"
+          min={MIN_BPM}
+          max={MAX_BPM}
+          step="5"
+          value={bpm}
+          onChange={event => {
+            onBpmChange(Number(event.target.value));
+          }}
+          disabled={isPlaying}
+        />
+      </div>
+      <div className={classNames(moduleStyles.row, moduleStyles.section)}>
+        <div className={moduleStyles.rowLabel}>Key</div>
+        <select
+          className={moduleStyles.input}
+          name="key"
+          value={Key[key]}
+          onChange={event => {
+            onKeyChange(event.target.value);
+          }}
+          disabled={isPlaying}
+        >
+          {Object.keys(Key)
+            .filter(key => isNaN(Number(key)))
+            .map((key, index) => {
+              return <option key={index}>{key}</option>;
+            })}
+        </select>
+      </div>
+      <div className={classNames(moduleStyles.section)}>
+        <div className={moduleStyles.row}>
+          <div className={moduleStyles.rowLabel}>Loop</div>
+          <Checkbox
+            name="loop"
+            checked={loopEnabled}
+            onChange={event => onLoopChange(event.target.checked)}
+          />
+        </div>
+        <div className={moduleStyles.row}>
+          <label className={moduleStyles.rowLabel} htmlFor="loopStart">
+            Start:
+          </label>
+          <input
+            className={moduleStyles.measureInput}
+            name="loopStart"
+            type="number"
+            value={loopStart}
+            min={1}
+            max={loopEnd - 1}
+            disabled={!loopEnabled}
+            onChange={event => onLoopStartChange(Number(event.target.value))}
+          />
+          <label className={moduleStyles.rowLabel} htmlFor="loopEnd">
+            End:
+          </label>
+          <input
+            className={moduleStyles.measureInput}
+            name="loopEnd"
+            type="number"
+            min={loopStart + 1}
+            max={100}
+            value={loopEnd}
+            disabled={!loopEnabled}
+            onChange={event => onLoopEndChange(Number(event.target.value))}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdvancedControls;

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -17,6 +17,9 @@ import Controls from './Controls';
 import Timeline from './Timeline';
 import {ProgressManagerContext} from '@cdo/apps/lab2/progress/ProgressContainer';
 import usePlaybackUpdate from './hooks/usePlaybackUpdate';
+import MusicPlayer from '../player/MusicPlayer';
+import useUpdatePlayer from './hooks/useUpdatePlayer';
+import AdvancedControls from './AdvancedControls';
 
 interface MusicLabViewProps {
   blocklyDivId: string;
@@ -29,6 +32,7 @@ interface MusicLabViewProps {
   redo: () => void;
   clearCode: () => void;
   validator: MusicValidator;
+  player: MusicPlayer;
 }
 
 const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
@@ -42,7 +46,9 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   redo,
   clearCode,
   validator,
+  player,
 }) => {
+  useUpdatePlayer(player);
   const dispatch = useAppDispatch();
   const showInstructions = useAppSelector(
     state => state.music.showInstructions
@@ -165,6 +171,10 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
     [setPlaying, playTrigger, hasTrigger, hideHeaders]
   );
 
+  const showAdvancedControls =
+    AppConfig.getValue('player') === 'tonejs' &&
+    AppConfig.getValue('advanced-controls-enabled') === 'true';
+
   return (
     <div id="music-lab" className={moduleStyles.musicLab}>
       {showInstructions &&
@@ -192,6 +202,11 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
             }
           >
             <div id={blocklyDivId} />
+            {showAdvancedControls && (
+              <div className={moduleStyles.advancedControlsContainer}>
+                <AdvancedControls />
+              </div>
+            )}
           </PanelContainer>
         </div>
 

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -612,6 +612,7 @@ class UnconnectedMusicView extends React.Component {
           redo={this.redo}
           clearCode={this.clearCode}
           validator={this.musicValidator}
+          player={this.player}
         />
         <Callouts />
       </AnalyticsContext.Provider>

--- a/apps/src/music/views/PatternPanel.tsx
+++ b/apps/src/music/views/PatternPanel.tsx
@@ -42,8 +42,7 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
   const currentFolder = useMemo(() => {
     // Default to the first available kit if the current kit is not found in this library.
     return (
-      availableKits.find(kit => kit.path === currentValue.kit) ||
-      availableKits[0]
+      availableKits.find(kit => kit.id === currentValue.kit) || availableKits[0]
     );
   }, [availableKits, currentValue.kit]);
   const [currentPreviewTick, setCurrentPreviewTick] = useState(0);

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import TimelineSampleEvents from './TimelineSampleEvents';
 import TimelineTrackEvents from './TimelineTrackEvents';
 import TimelineSimple2Events from './TimelineSimple2Events';
-import {getBlockMode} from '../appConfig';
+import appConfig, {getBlockMode} from '../appConfig';
 import {BlockMode, MIN_NUM_MEASURES} from '../constants';
 import {useDispatch} from 'react-redux';
 import {
@@ -56,6 +56,9 @@ const Timeline: React.FunctionComponent = () => {
     MIN_NUM_MEASURES,
     useMusicSelector(state => state.music.lastMeasure)
   );
+  const loopEnabled = useMusicSelector(state => state.music.loopEnabled);
+  const loopStart = useMusicSelector(state => state.music.loopStart);
+  const loopEnd = useMusicSelector(state => state.music.loopEnd);
   const playheadRef = useRef<HTMLDivElement>(null);
   const timelineRef = useRef<HTMLDivElement>(null);
 
@@ -79,8 +82,8 @@ const Timeline: React.FunctionComponent = () => {
 
   const onMeasuresBackgroundClick = useCallback(
     (event: MouseEvent) => {
-      // Ignore if playing
-      if (isPlaying) {
+      // Ignore if playing unless using ToneJS player
+      if (isPlaying && appConfig.getValue('player') !== 'tonejs') {
         return;
       }
       const offset =
@@ -204,7 +207,43 @@ const Timeline: React.FunctionComponent = () => {
           &nbsp;
         </div>
       </div>
+      {loopEnabled && <LoopMarkers loopStart={loopStart} loopEnd={loopEnd} />}
     </div>
+  );
+};
+
+const LoopMarkers: React.FunctionComponent<{
+  loopStart: number;
+  loopEnd: number;
+}> = ({loopStart, loopEnd}) => {
+  const startOffset = (loopStart - 1) * barWidth;
+  const endOffset = (loopEnd - 1) * barWidth;
+
+  return (
+    <>
+      <div id="timeline-playhead" className={moduleStyles.fullWidthOverlay}>
+        <div
+          className={classNames(
+            moduleStyles.playhead,
+            moduleStyles.playheadLoop
+          )}
+          style={{left: paddingOffset + startOffset}}
+        >
+          &nbsp;
+        </div>
+      </div>
+      <div id="timeline-playhead" className={moduleStyles.fullWidthOverlay}>
+        <div
+          className={classNames(
+            moduleStyles.playhead,
+            moduleStyles.playheadLoop
+          )}
+          style={{left: paddingOffset + endOffset}}
+        >
+          &nbsp;
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/apps/src/music/views/advanced-controls.module.scss
+++ b/apps/src/music/views/advanced-controls.module.scss
@@ -1,0 +1,40 @@
+@import 'color.scss';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  color: $neutral_light;
+  padding: 10px;
+  background: $neutral_dark70;
+  border: 2px solid $neutral_light;
+  border-radius: 4px;
+  margin: 10px;
+}
+
+.title {
+  color: $neutral_light;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin: 10px 0px;
+
+  .rowLabel {
+    margin-right: 10px;
+  }
+}
+
+.section {
+  margin: 15px 0px;
+}
+
+.input {
+  width: auto;
+}
+
+.measureInput {
+  width: 30px;
+  margin-right: 10px;
+}

--- a/apps/src/music/views/advanced-controls.module.scss
+++ b/apps/src/music/views/advanced-controls.module.scss
@@ -19,7 +19,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin: 10px 0px;
+  margin: 10px 0;
 
   .rowLabel {
     margin-right: 10px;
@@ -27,7 +27,7 @@
 }
 
 .section {
-  margin: 15px 0px;
+  margin: 15px 0;
 }
 
 .input {

--- a/apps/src/music/views/advanced-controls.module.scss
+++ b/apps/src/music/views/advanced-controls.module.scss
@@ -5,7 +5,7 @@
   flex-direction: column;
   color: $neutral_light;
   padding: 10px;
-  background: $neutral_dark70;
+  background: $neutral_dark80;
   border: 2px solid $neutral_light;
   border-radius: 4px;
   margin: 10px;

--- a/apps/src/music/views/hooks/useUpdatePlayer.ts
+++ b/apps/src/music/views/hooks/useUpdatePlayer.ts
@@ -1,0 +1,63 @@
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import MusicPlayer from '../../player/MusicPlayer';
+import MusicLibrary from '../../player/MusicLibrary';
+import {useEffect} from 'react';
+import {setBpm, setKey} from '../../redux/musicRedux';
+
+/**
+ * A hook for updating the {@link MusicPlayer} when relevant redux state changes.
+ */
+export default function useUpdatePlayer(player: MusicPlayer) {
+  const bpm = useAppSelector(state => state.music.bpm);
+  const key = useAppSelector(state => state.music.key);
+  const loopEnabled = useAppSelector(state => state.music.loopEnabled);
+  const loopStart = useAppSelector(state => state.music.loopStart);
+  const loopEnd = useAppSelector(state => state.music.loopEnd);
+  const startingPlayheadPosition = useAppSelector(
+    state => state.music.startingPlayheadPosition
+  );
+  const isPlaying = useAppSelector(state => state.music.isPlaying);
+
+  const dispatch = useAppDispatch();
+  const library = MusicLibrary.getInstance();
+
+  useEffect(() => {
+    player.setBpm(bpm);
+  }, [player, bpm]);
+
+  useEffect(() => {
+    player.setKey(key);
+  }, [player, key]);
+
+  useEffect(() => {
+    if (!library) {
+      return;
+    }
+    const bpm = library.getBPM();
+    const key = library.getKey();
+    if (bpm) {
+      dispatch(setBpm(bpm));
+    }
+    if (key) {
+      dispatch(setKey(key));
+    }
+  }, [library, dispatch]);
+
+  useEffect(() => {
+    player.setLoopEnabled(loopEnabled);
+  }, [player, loopEnabled]);
+
+  useEffect(() => {
+    player.setLoopStart(loopStart);
+  }, [player, loopStart]);
+
+  useEffect(() => {
+    player.setLoopEnd(loopEnd);
+  }, [player, loopEnd]);
+
+  useEffect(() => {
+    if (isPlaying) {
+      player.jumpToPosition(startingPlayheadPosition);
+    }
+  }, [player, startingPlayheadPosition, isPlaying]);
+}

--- a/apps/src/music/views/music-view.module.scss
+++ b/apps/src/music/views/music-view.module.scss
@@ -80,3 +80,9 @@ $default-spacing: 2px;
   flex: 1;
   position: relative;
 }
+
+.advancedControlsContainer {
+  position: absolute;
+  right: 10px;
+  bottom: 0;
+}

--- a/apps/src/music/views/timeline.module.scss
+++ b/apps/src/music/views/timeline.module.scss
@@ -162,5 +162,9 @@
     &Playing {
       border-left: 3px yellow solid;
     }
+
+    &Loop {
+      border-left: 3px $light_primary_500 solid;
+    }
   }
 }

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -85,6 +85,22 @@ const optionsList = [
       {value: 'tonejs', description: 'Use the ToneJS player.'},
     ],
   },
+  {
+    name: 'advanced-controls-enabled',
+    type: 'radio',
+    values: [
+      {
+        value: 'false',
+        description:
+          'Disable advanced controls for the ToneJS player (default).',
+      },
+      {
+        value: 'true',
+        description:
+          'Enable advanced controls for the ToneJS player. Requires player=tonejs to be set.',
+      },
+    ],
+  },
 ];
 
 export default class MusicMenu extends React.Component {


### PR DESCRIPTION
Enable the "advanced controls" panel to expose some ToneJS player-specific advanced features, for internal experimentation only. These include manual BPM and key control, and loop settings. This can be enabled by `advanced-controls-enabled=true` in the URL, but requires `player=tonejs` as well to work (e.g. `studio.code.org/projectbeats?player=tonejs&advanced-controls-enabled=true`).

<img width="1512" alt="Screenshot 2024-03-12 at 11 19 45 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/d028b0ad-4255-4688-949b-b767dc73a918">

## Links

https://codedotorg.atlassian.net/browse/LABS-530

## Testing story

Tested on /projectbeats, intro script, and standalone projects