### PR TITLE
Return info about feedback even if student has not started on level

### DIFF
--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -359,7 +359,7 @@ module UsersHelper
       elsif teacher_feedback.present?
         return {
           status: LEVEL_STATUS.not_tried,
-          teacher_feedback_review_state: teacher_feedback&.review_state,
+          teacher_feedback_review_state: teacher_feedback.review_state,
           teacher_feedback_new: true
         }.compact
       else

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -356,12 +356,12 @@ module UsersHelper
     if user_level.nil?
       if script_level.lesson.lockable?
         return {locked: true}
-      elsif teacher_feedback&.review_state&.present?
+      elsif teacher_feedback.present?
         return {
           status: LEVEL_STATUS.not_tried,
-          teacher_feedback_review_state: teacher_feedback.review_state,
+          teacher_feedback_review_state: teacher_feedback&.review_state,
           teacher_feedback_new: true
-        }
+        }.compact
       else
         return nil
       end

--- a/dashboard/test/helpers/users_helper_test.rb
+++ b/dashboard/test/helpers/users_helper_test.rb
@@ -291,11 +291,13 @@ class UsersHelperTest < ActionView::TestCase
   def test_script_progress_for_users
     user_1 = create :user
     user_2 = create :user
+    user_3 = create :user
 
     teacher = create :teacher
     section = create :section, teacher: teacher
     section.students << user_1 # we query for feedback where student is currently in section
     section.students << user_2
+    section.students << user_3
 
     # set up progress
     script = create :script
@@ -324,6 +326,8 @@ class UsersHelperTest < ActionView::TestCase
     sublevel1_user_level_2 = create :user_level, user: user_2, level: sublevel1_contained_level, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180
     sublevel2_user_level_2 = create :user_level, user: user_2, level: sublevel2, script: script, best_result: 20, time_spent: 300
     create :teacher_feedback, student: user_2, teacher: teacher, level: sublevel2, script: script, review_state: TeacherFeedback::REVIEW_STATES.keepWorking
+    create :teacher_feedback, student: user_3, teacher: teacher, level: sublevel1, script: script, review_state: TeacherFeedback::REVIEW_STATES.keepWorking
+    create :teacher_feedback, student: user_3, teacher: teacher, level: sublevel2, script: script, comment: 'Better get working on this one!'
 
     sublevel1_last_progress_2 = UserLevel.find(sublevel1_user_level_2.id).updated_at.to_i
     sublevel2_last_progress_2 = UserLevel.find(sublevel2_user_level_2.id).updated_at.to_i
@@ -371,16 +375,33 @@ class UsersHelperTest < ActionView::TestCase
             time_spent: 480, # sum of time spent on sublevels
             teacher_feedback_review_state: TeacherFeedback::REVIEW_STATES.keepWorking
           }
+        },
+        user_3.id => {
+          sublevel1.id => {
+            status: LEVEL_STATUS.not_tried,
+            teacher_feedback_new: true,
+            teacher_feedback_review_state: TeacherFeedback::REVIEW_STATES.keepWorking
+          },
+          sublevel2.id => {
+            status: LEVEL_STATUS.not_tried,
+            teacher_feedback_new: true
+          },
+          level.id => {
+            status: LEVEL_STATUS.not_tried,
+            teacher_feedback_review_state: TeacherFeedback::REVIEW_STATES.keepWorking,
+            teacher_feedback_new: true
+          }
         }
       },
       {
         user_1.id => sublevel1_last_progress,
-        user_2.id => sublevel2_last_progress_2
+        user_2.id => sublevel2_last_progress_2,
+        user_3.id => nil
       }
     ]
 
     assert_equal expected_progress, script_progress_for_users(
-      [user_1, user_2], script
+      [user_1, user_2, user_3], script
     )
   end
 


### PR DESCRIPTION
This modifies the section progress API call to return information about feedback when "keep working" is not marked and the student has not started on the level. This allows the new progress table to show a black triangle when feedback has been given on unsubmitted levels.

![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/b41b50ae-1a05-4acc-8430-83c6e99c8b82)


## Links

[JIRA](https://codedotorg.atlassian.net/browse/TEACH-923)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
