### PR TITLE
Music: standalone projects

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2040,7 +2040,7 @@
   "projectTypeMinecraftAquatic": "Minecraft Aquatic",
   "projectTypeMinecraftDesigner": "Minecraft Designer",
   "projectTypeMinecraftHero": "Minecraft Hero",
-  "projectTypeMusic": "Music Lab",
+  "projectTypeMusic": "Project Beats",
   "projectTypePlaylab": "Play Lab",
   "projectTypePlaylabPreReader": "Play Lab (Pre-reader)",
   "projectTypePoetry": "Poetry",

--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -109,6 +109,7 @@ class FieldSounds extends GoogleBlockly.Field {
         library={this.options.getLibrary()}
         currentValue={this.getValue()}
         playingPreview={this.playingPreview}
+        showSoundFilters={this.options.getShowSoundFilters()}
         onPreview={value => {
           this.playingPreview = value;
           this.renderContent();

--- a/apps/src/music/blockly/fields.js
+++ b/apps/src/music/blockly/fields.js
@@ -23,6 +23,7 @@ export const fieldSoundsDefinition = {
     Globals.getPlayer().previewSound(id, onStop);
   },
   currentValue: null,
+  getShowSoundFilters: () => Globals.getShowSoundFilters(),
 };
 
 export const fieldPatternDefinition = {

--- a/apps/src/music/globals.js
+++ b/apps/src/music/globals.js
@@ -23,7 +23,7 @@ export default {
     showSoundFilters = show;
   },
 
-  getShowSoundFilters(get) {
+  getShowSoundFilters() {
     return showSoundFilters;
   },
 };

--- a/apps/src/music/globals.js
+++ b/apps/src/music/globals.js
@@ -8,6 +8,7 @@
 // this data.
 
 let playerRef = null;
+let showSoundFilters = false;
 
 export default {
   setPlayer(player) {
@@ -16,5 +17,13 @@ export default {
 
   getPlayer() {
     return playerRef;
+  },
+
+  setShowSoundFilters(show) {
+    showSoundFilters = show;
+  },
+
+  getShowSoundFilters(get) {
+    return showSoundFilters;
   },
 };

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -271,6 +271,11 @@ class UnconnectedMusicView extends React.Component {
       }
       this.loadCode(codeToLoad);
     }
+
+    Globals.setShowSoundFilters(
+      AppConfig.getValue('show-sound-filters') === 'true' ||
+        levelData.showSoundFilters
+    );
   }
 
   // Load the library and initialize the music player, if not already loaded.

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -205,6 +205,7 @@ interface SoundsPanelProps {
   library: MusicLibrary;
   currentValue: string;
   playingPreview: string;
+  showSoundFilters: boolean;
   onSelect: (path: string) => void;
   onPreview: (path: string) => void;
 }
@@ -213,6 +214,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
   library,
   currentValue,
   playingPreview,
+  showSoundFilters,
   onSelect,
   onPreview,
 }) => {
@@ -277,8 +279,6 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
       soundEntry => soundEntry.sound.type === filter
     );
   }
-
-  const showSoundFilters = AppConfig.getValue('show-sound-filters') === 'true';
 
   return (
     <FocusLock>

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -10,7 +10,6 @@ import MusicLibrary, {
 } from '../player/MusicLibrary';
 import FocusLock from 'react-focus-lock';
 import SegmentedButtons from '@cdo/apps/componentLibrary/segmentedButtons';
-const AppConfig = require('../appConfig').default;
 
 /*
  * Renders a UI for previewing and choosing samples. This is currently used within a

--- a/apps/src/templates/studioHomepages/Incubator.jsx
+++ b/apps/src/templates/studioHomepages/Incubator.jsx
@@ -50,7 +50,7 @@ class Incubator extends Component {
                   'Learn how to use Project Beats in a step by step intro.',
               },
               {
-                url: '/projectbeats',
+                url: '/projects/music/new',
                 text: 'Make Music',
                 extraText: 'Skip directly to creating a Project Beats project.',
                 color: Button.ButtonColor.neutralDark,

--- a/dashboard/config/levels/custom/music/New Music Lab Project.level
+++ b/dashboard/config/levels/custom/music/New Music Lab Project.level
@@ -11,6 +11,8 @@
     "encrypted": "false",
     "background": "music-black",
     "level_data": {
+      "library": "launch2024",
+      "showSoundFilters": true,
       "startSources": {
         "blocks": {
           "languageVersion": 0,

--- a/dashboard/config/levels/custom/panels/musiclab_intro_panels_end.level
+++ b/dashboard/config/levels/custom/panels/musiclab_intro_panels_end.level
@@ -17,7 +17,7 @@
         {
           "imageUrl": "https://images.code.org/aa31c5258bbb31a623d50ba9482e6a00-musiclab_intro_end_1.png",
           "text": "You'll see even more new things in the toolbox, including:\n\n- A beat-making block\n\n- Sound effects like reverb and filter\n\n- A synthesizer block\n\n- A block for randomizing what gets played\n\n- ...and more!\n\nHave fun!",
-          "nextUrl": "/projectbeats"
+          "nextUrl": "/projects/music/new"
         }
       ]
     }

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -460,6 +460,7 @@ en:
       minecraft_codebuilder: 'Minecraft: Code Connection'
       minecraft_designer: 'Minecraft'
       minecraft_hero: 'Minecraft Hero'
+      music: 'Project Beats'
       playlab: 'Play Lab'
       playlab_k1: 'Play Lab (Pre-reader)'
       poetry: 'Poetry'

--- a/shared/images/courses/logo_music.png
+++ b/shared/images/courses/logo_music.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f92a6ba2fe78958c16e22ff41b85a6c4d33d1c31195a41e17c27971722f8a8c
+size 393632


### PR DESCRIPTION
This exposes standalone Music Lab projects to end-users for the first time.  

- The links from https://studio.code.org/incubator and from the final level in https://studio.code.org/s/music-intro-2024 now go to https://studio.code.org/projects/music/new.  This takes the user to a https://studio.code.org/projects/music/[channel-id]/edit URL which shows `Rename`, `Share`, `Remix` buttons in the header.
- The level backing these projects now uses the `"launch2024"` sound library
- The level backing these projects also has a new `"showSoundFilters": true` parameter which tells Music Lab to show the filters in the sound selection UI.
- When on a Music Lab standalone project page, the `Create` menu lists `Project Beats` as an option, which is existing behaviour.
- The `My Projects` tab at https://studio.code.org/projects will list Music Lab projects created by the user, but with a `Type` of `Project Beats`.