### PR TITLE
Music: fix missing condition value in intro script validation

### DIFF
--- a/apps/src/lab2/levelEditors/validations/EditCondition.tsx
+++ b/apps/src/lab2/levelEditors/validations/EditCondition.tsx
@@ -26,6 +26,7 @@ const EditCondition: React.FunctionComponent<EditConditionProps> = ({
   });
 
   const isNumeric = currentConditionType?.valueType === 'number';
+  const hasValue = currentConditionType?.valueType !== undefined;
 
   return (
     <div className={moduleStyles.row}>
@@ -39,7 +40,7 @@ const EditCondition: React.FunctionComponent<EditConditionProps> = ({
         value={condition.name}
         onChange={e => {
           condition.name = e.target.value;
-          if (!currentConditionType?.hasValue) {
+          if (!hasValue) {
             condition.value = undefined;
           }
           onConditionChange(condition, index);
@@ -53,7 +54,7 @@ const EditCondition: React.FunctionComponent<EditConditionProps> = ({
           );
         })}
       </select>
-      {currentConditionType?.hasValue && (
+      {hasValue && (
         <>
           <label htmlFor="conditionValue" className={moduleStyles.label}>
             Value:

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -131,7 +131,6 @@ export interface Condition {
 
 export interface ConditionType {
   name: string;
-  hasValue: boolean;
   valueType?: 'string' | 'number';
 }
 

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -11,18 +11,10 @@ export interface ConditionNames {
 }
 
 export const MusicConditions: ConditionNames = {
-  PLAYED_SOUNDS_TOGETHER: {
-    name: 'played_sounds_together',
-    hasValue: true,
-    valueType: 'number',
-  },
-  PLAYED_SOUND_TRIGGERED: {name: 'played_sound_triggered', hasValue: false},
-  PLAYED_SOUNDS: {name: 'played_sounds', hasValue: true, valueType: 'number'},
-  PLAYED_SOUND_ID: {
-    name: 'played_sound_id',
-    hasValue: false,
-    valueType: 'string',
-  },
+  PLAYED_SOUNDS_TOGETHER: {name: 'played_sounds_together', valueType: 'number'},
+  PLAYED_SOUND_TRIGGERED: {name: 'played_sound_triggered'},
+  PLAYED_SOUNDS: {name: 'played_sounds', valueType: 'number'},
+  PLAYED_SOUND_ID: {name: 'played_sound_id', valueType: 'string'},
 };
 
 export default class MusicValidator extends Validator {


### PR DESCRIPTION
Quick fix for the validations editor on level 2 of the intro script. I noticed that the "value" field wasn't displaying for the `played_sound_id` validation condition, which was because in the validation configuration, `hasValue` was set to `false`. I update this to just remove the `hasValue` field and infer if we should display the value based on the presence of the `valueType` field. This way we'll always show the value field if a value type has been specified.

Before:
<img width="1008" alt="Screenshot 2024-03-12 at 11 48 19 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/50473a30-708a-4f34-a703-9d8af0f52617">

After:
<img width="997" alt="Screenshot 2024-03-12 at 11 47 42 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/460ae18d-dd19-452b-9481-5182abcb7710">

## Testing story

Tested locally.