### PR TITLE
Add privacy link in demographic pop-up

### DIFF
--- a/dashboard/app/views/layouts/_student_information_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_student_information_interstitial.html.haml
@@ -6,7 +6,7 @@
       %p{style: 'font-size: 13px; line-height: 18px; color: #333'}
         = t('parent_mailer.parent_email_added_subject')
         = t('activerecord.attributes.user.finish_sign_up_header_account_information')
-        = t('age_interstitial.disclaimer')
+        = t('age_interstitial.disclaimer', url: CDO.code_org_url('/privacy'), markdown: :inline).html_safe
       = form_for(current_user, url: registration_url('user'), html: {id: 'edit_user'}) do |f|
         .form-group
           %div{style: 'display: flex;'}

--- a/dashboard/app/views/layouts/_student_information_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_student_information_interstitial.html.haml
@@ -6,7 +6,7 @@
       %p{style: 'font-size: 13px; line-height: 18px; color: #333'}
         = t('parent_mailer.parent_email_added_subject')
         = t('activerecord.attributes.user.finish_sign_up_header_account_information')
-        = t('age_interstitial.disclaimer', url: CDO.code_org_url('/privacy'), markdown: :inline).html_safe
+        = t('age_interstitial.disclaimer', url: SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL, markdown: :inline).html_safe
       = form_for(current_user, url: registration_url('user'), html: {id: 'edit_user'}) do |f|
         .form-group
           %div{style: 'display: flex;'}

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -946,7 +946,7 @@ en:
     age: Your age
     header: Account Information Update
     warning: "We're in the process of updating our experience to provide you with even stronger privacy protections. To do this, we need existing users to enter their age here."
-    disclaimer: "Code.org will never rent, sell or share this information with any third parties."
+    disclaimer: 'Code.org [will never rent, sell or share this information with any third parties](%{url}).'
     sign_out_markdown: 'If you do not wish to provide your age you may [sign out](%{url}).'
   terms_interstitial:
     title: "Updated Terms of Service and Privacy Policy"


### PR DESCRIPTION
Hyperlinks the privacy policy page to “will never rent, sell or share this information with any third parties” in dempgraphic pop-up.
<img width="602" alt="Screenshot 2024-03-12 at 12 23 40 PM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/8f326a53-3d2a-4cef-ac31-b21afaae6691">


## Links
- jira ticket: [here](https://codedotorg.atlassian.net/browse/P20-776)


## Testing story
Local
