### PR TITLE
Finalize details on IconKey

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1954,7 +1954,7 @@
   "progressLegendDetailsValidated": "The student has passed all validation tests on this level.",
   "progressLegendDetailsViewed": "You have viewed the student's work on this level.",
   "progressLegendDetailsFeedbackGiven": "You have left feedback for the student on this level.",
-  "progressLegendDetailsAssessmentLevels": "These are levels that Code.org recommends for teacher review. Assessment levels are marked with a purple circle behind the level number.",
+  "progressLegendDetailsAssessmentLevels": "These are levels that Code.org recommends for teacher review. Assessment levels are marked with a star next to the level number in the column header.",
   "progressLegendDetailsChoiceLevels": "These are levels with multiple options. Students can choose which option to complete.",
   "progressBubbleDescription": "Level {levelID}",
   "progressBubbleDescriptionWithLesson": "Level {levelID} Lesson {lessonName}",

--- a/apps/src/templates/sectionProgressV2/IconKey.jsx
+++ b/apps/src/templates/sectionProgressV2/IconKey.jsx
@@ -11,7 +11,7 @@ import Link from '@cdo/apps/componentLibrary/link';
 import MoreDetailsDialog from './MoreDetailsDialog.jsx';
 
 export default function IconKey({isViewingValidatedLevel, expandedLessonIds}) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
   const [isIconDetailsOpen, setIconDetailsOpen] = useState(false);
 
   const toggleIsViewingDetails = event => {

--- a/apps/src/templates/sectionProgressV2/ItemType.jsx
+++ b/apps/src/templates/sectionProgressV2/ItemType.jsx
@@ -6,7 +6,7 @@ export const ITEM_TYPE = Object.freeze({
   VIEWED: 2,
   NEEDS_FEEDBACK: 3,
   FEEDBACK_GIVEN: 4,
-  ASSESSMENT_LEVEL: ['star', color.neutral_dark],
+  ASSESSMENT_LEVEL: ['star', color.neutral_dark60],
   CHOICE_LEVEL: ['split', color.neutral_dark60],
   KEEP_WORKING: ['rotate-left', color.neutral_dark],
   NO_ONLINE_WORK: ['dash', color.neutral_dark],

--- a/apps/src/templates/sectionProgressV2/LegendItem.jsx
+++ b/apps/src/templates/sectionProgressV2/LegendItem.jsx
@@ -5,11 +5,11 @@ import {BodyThreeText} from '@cdo/apps/componentLibrary/typography';
 import {ITEM_TYPE_SHAPE} from './ItemType';
 import ProgressIcon from './ProgressIcon';
 
-export default function LegendItem({itemType, labelText, colorOverride}) {
+export default function LegendItem({itemType, labelText}) {
   return (
     <div className={styles.legendItem}>
       <div className={styles.legendIcon}>
-        <ProgressIcon itemType={itemType} colorOverride={colorOverride} />
+        <ProgressIcon itemType={itemType} />
       </div>
       <BodyThreeText className={styles.labelText}>{labelText}</BodyThreeText>
     </div>
@@ -19,5 +19,4 @@ export default function LegendItem({itemType, labelText, colorOverride}) {
 LegendItem.propTypes = {
   labelText: PropTypes.string,
   itemType: ITEM_TYPE_SHAPE,
-  colorOverride: PropTypes.string,
 };

--- a/apps/src/templates/sectionProgressV2/LevelTypesBox.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelTypesBox.jsx
@@ -22,7 +22,6 @@ export default function LevelTypesBox() {
           <LegendItem
             itemType={ITEM_TYPE.CHOICE_LEVEL}
             labelText={i18n.choiceLevel()}
-            colorOverride={color.neutral_dark}
           />
         </div>
       </div>

--- a/apps/src/templates/sectionProgressV2/LevelTypesBox.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelTypesBox.jsx
@@ -5,7 +5,6 @@ import LegendItem from './LegendItem';
 import {ITEM_TYPE} from './ItemType';
 import styles from './progress-table-legend.module.scss';
 import {StrongText} from '@cdo/apps/componentLibrary/typography';
-import color from '@cdo/apps/util/color';
 
 export default function LevelTypesBox() {
   return (

--- a/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
+++ b/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
@@ -12,12 +12,11 @@ import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {ITEM_TYPE} from './ItemType';
 import ProgressIcon from './ProgressIcon';
 import styles from './progress-table-legend.module.scss';
-import color from '@cdo/apps/util/color';
 
 export default function MoreDetailsDialog({hasValidation, onClose}) {
-  const renderItem = (itemType, itemTitle, itemDetails, colorOverride) => (
+  const renderItem = (itemType, itemTitle, itemDetails) => (
     <div className={styles.item}>
-      <ProgressIcon itemType={itemType} colorOverride={colorOverride} />
+      <ProgressIcon itemType={itemType} />
       <BodyThreeText>
         <StrongText>{itemTitle + ': '}</StrongText>
         {itemDetails}
@@ -95,8 +94,7 @@ export default function MoreDetailsDialog({hasValidation, onClose}) {
         {renderItem(
           ITEM_TYPE.CHOICE_LEVEL,
           i18n.choiceLevel(),
-          i18n.progressLegendDetailsChoiceLevels(),
-          color.neutral_dark
+          i18n.progressLegendDetailsChoiceLevels()
         )}
       </div>
     </AccessibleDialog>

--- a/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 
 export const PROGRESS_ICON_TITLE_PREFIX = 'progressicon-';
 
-export default function ProgressIcon({itemType, colorOverride}) {
+export default function ProgressIcon({itemType}) {
   const needsFeedbackTriangle = () => (
     <div
       className={classNames(styles.needsFeedback, styles.cornerBox)}
@@ -53,7 +53,7 @@ export default function ProgressIcon({itemType, colorOverride}) {
         <FontAwesome
           id={'uitest-' + itemType[0]}
           icon={itemType[0]}
-          style={{color: colorOverride ? colorOverride : itemType[1]}}
+          style={{color: itemType[1]}}
           className={styles.fontAwesomeIcon}
           aria-label={PROGRESS_ICON_TITLE_PREFIX + itemType[0]}
         />
@@ -67,5 +67,4 @@ export default function ProgressIcon({itemType, colorOverride}) {
 
 ProgressIcon.propTypes = {
   itemType: ITEM_TYPE_SHAPE,
-  colorOverride: PropTypes.string,
 };

--- a/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {ITEM_TYPE, ITEM_TYPE_SHAPE} from './ItemType';
 import styles from './progress-table-legend.module.scss';
 import FontAwesome from '../FontAwesome';

--- a/apps/test/unit/templates/sectionProgressV2/IconKeyTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/IconKeyTest.jsx
@@ -4,21 +4,21 @@ import {expect} from '../../../util/reconfiguredChai';
 import IconKey from '@cdo/apps/templates/sectionProgressV2/IconKey';
 
 describe('IconKey Component', () => {
-  it('renders the collapsed state initially', () => {
+  it('renders the open state initially', () => {
     render(<IconKey isViewingValidatedLevel={false} expandedLessonIds={[]} />);
     expect(screen.getByLabelText('Icon key')).be.visible;
     expect(screen.queryByText('More Details')).be.visible;
-    expect(screen.queryByText('Assignment Completion States')).to.be.null;
-    expect(screen.queryByText('Teacher Actions')).to.be.null;
+    expect(screen.getByText('Assignment Completion States')).to.exist;
+    expect(screen.getByText('Teacher Actions')).to.exist;
     expect(screen.queryByText('Level Types')).to.be.null;
   });
 
-  it('expands content on click', () => {
+  it('expands collapses on click', () => {
     render(<IconKey isViewingValidatedLevel={false} expandedLessonIds={[]} />);
     const containerDiv = screen.getByTestId('expandable-container');
     fireEvent.click(containerDiv);
-    expect(screen.getByText('Assignment Completion States')).to.exist;
-    expect(screen.getByText('Teacher Actions')).to.exist;
+    expect(screen.queryByText('Assignment Completion States')).to.be.null;
+    expect(screen.queryByText('Teacher Actions')).to.be.null;
     expect(screen.queryByText('Level Types')).to.be.null;
   });
 
@@ -26,8 +26,6 @@ describe('IconKey Component', () => {
     render(
       <IconKey isViewingValidatedLevel={false} expandedLessonIds={[123]} />
     );
-    const containerDiv = screen.getByTestId('expandable-container');
-    fireEvent.click(containerDiv);
     expect(screen.getByText('Assignment Completion States')).to.exist;
     expect(screen.getByText('Teacher Actions')).to.exist;
     expect(screen.getByText('Level Types')).to.exist;
@@ -37,8 +35,6 @@ describe('IconKey Component', () => {
     render(
       <IconKey isViewingValidatedLevel={true} expandedLessonIds={[123]} />
     );
-    const containerDiv = screen.getByTestId('expandable-container');
-    fireEvent.click(containerDiv);
     expect(screen.getByText('Validated')).to.exist;
   });
 


### PR DESCRIPTION
This PR:

- Changes the color of the star and choice icons to be consistently grey
- Changes the string for the assessment description
- Makes the IconKey start open
- Adds associated tests

<img width="1046" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/53ad1bf1-4b55-4912-9411-0f917fcaed10">


## Links

Two tickets
- [Teach-924](https://codedotorg.atlassian.net/browse/TEACH-924)
- [Teach-919](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-919)

## Testing story

- Modified exisiting tests
