### PR TITLE
Lab2: begin moving validation out of level data and into level properties

### DIFF
--- a/apps/src/lab2/progress/ProgressContainer.tsx
+++ b/apps/src/lab2/progress/ProgressContainer.tsx
@@ -4,10 +4,10 @@ import {
   ProgressLevelType,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
 import ProgressManager from '@cdo/apps/lab2/progress/ProgressManager';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import React, {useCallback, useEffect, useRef} from 'react';
 import {useSelector} from 'react-redux';
-import {LabState, setValidationState} from '../lab2Redux';
+import {setValidationState} from '../lab2Redux';
 import {ProjectLevelData} from '../types';
 
 interface ProgressContainerProps {
@@ -43,15 +43,21 @@ const ProgressContainer: React.FunctionComponent<ProgressContainerProps> = ({
     new ProgressManager(onProgressChange)
   );
 
-  const levelData = useSelector(
-    (state: {lab: LabState}) => state.lab.levelProperties?.levelData
+  const levelDataValidations = useAppSelector(
+    state =>
+      (state.lab.levelProperties?.levelData as ProjectLevelData | undefined)
+        ?.validations
+  );
+  const levelValidations = useAppSelector(
+    state => state.lab.levelProperties?.validations
   );
 
   useEffect(() => {
+    // Use validations on level properties if present, otherwise fallback to validations in level data.
     progressManager.current.onLevelChange(
-      levelData as ProjectLevelData | undefined
+      levelValidations || levelDataValidations
     );
-  }, [levelData]);
+  }, [levelValidations, levelDataValidations]);
 
   return (
     <ProgressManagerContext.Provider value={progressManager.current}>

--- a/apps/src/lab2/progress/ProgressManager.ts
+++ b/apps/src/lab2/progress/ProgressManager.ts
@@ -1,7 +1,7 @@
 // This file contains a generic ProgressManager which any lab can include,
 // if it wants to make progress without reloading the page.
 
-import {ProjectLevelData, Condition} from '@cdo/apps/lab2/types';
+import {Condition, Validation} from '@cdo/apps/lab2/types';
 
 // Abstract class that validates a set of conditions. How
 // the validation works is up to the implementor.
@@ -28,13 +28,13 @@ export const getInitialValidationState: () => ValidationState = () => ({
 });
 
 export default class ProgressManager {
-  private levelData: ProjectLevelData | undefined;
+  private currentValidations: Validation[] | undefined;
   private validator: Validator | undefined;
   private onProgressChange: () => void;
   private currentValidationState: ValidationState;
 
   constructor(onProgressChange: () => void) {
-    this.levelData = undefined;
+    this.currentValidations = undefined;
     this.onProgressChange = onProgressChange;
     this.currentValidationState = getInitialValidationState();
   }
@@ -43,8 +43,8 @@ export default class ProgressManager {
    * Update the ProgressManager with level data for a new level.
    * Resets validation status internally.
    */
-  onLevelChange(levelData?: ProjectLevelData) {
-    this.levelData = levelData;
+  onLevelChange(validations?: Validation[]) {
+    this.currentValidations = validations;
     this.resetValidation();
   }
 
@@ -57,9 +57,7 @@ export default class ProgressManager {
   }
 
   updateProgress(): void {
-    const validations = this.levelData?.validations;
-
-    if (!validations || !this.validator) {
+    if (!this.currentValidations || !this.validator) {
       return;
     }
 
@@ -76,7 +74,7 @@ export default class ProgressManager {
     this.validator.checkConditions();
 
     // Go through each validation to see if we have a match.
-    for (const validation of validations) {
+    for (const validation of this.currentValidations) {
       if (validation.conditions) {
         // Ask the lab-specific validator if this validation's
         // conditions are met.
@@ -103,8 +101,7 @@ export default class ProgressManager {
     }
 
     const hasConditions =
-      (this.levelData?.validations && this.levelData.validations.length > 0) ||
-      false;
+      (this.currentValidations && this.currentValidations.length > 0) || false;
 
     this.currentValidationState = {
       hasConditions,

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -102,6 +102,9 @@ export interface LevelProperties {
   skin?: string;
   toolboxBlocks?: string;
   sharedBlocks?: BlockDefinition[];
+  // We are moving level validations out of level data and into level properties.
+  // Temporarily keeping them in both places to avoid breaking existing code.
+  validations?: Validation[];
 }
 
 // Level configuration data used by project-backed labs that don't require

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -571,13 +571,11 @@ class LevelsController < ApplicationController
     # Parse a few specific JSON fields used by modern (Lab2) labs so that they are
     # stored in the database as a first-order member of the properties JSON, rather
     # than simply as a string of JSON belonging to a single property.
-    [:level_data, :initial_ai_customizations].each do |key|
+    [:level_data, :initial_ai_customizations, :validations].each do |key|
       level_params[key] = JSON.parse(level_params[key]) if level_params[key]
     end
-    # Update level data with validations, and remove from level properties.
-    # We can remove this once validations are read from level properties directly.
-    level_params[:level_data]["validations"] = JSON.parse(level_params[:validations]) if level_params[:validations]
-    level_params[:validations] = nil if level_params[:validations]
+    # Delete validations from level data if present. We'll use the validations in level properties instead.
+    level_params[:level_data].delete('validations') if level_params[:level_data]&.key?('validations')
     level_params
   end
 

--- a/dashboard/app/models/levels/music.rb
+++ b/dashboard/app/models/levels/music.rb
@@ -27,10 +27,8 @@
 # Music uses level_data, which is actual JSON in each .level file, and
 # currently contains the following top-level fields:
 #
-#   text: instructions text
 #   toolbox: an object containing blockly toolbox categories and member blocks
 #   sounds: an object containing sound categories and member sounds
-#   validations: an array containing validation conditions, responses, and actions.
 #   startSources: an object used as starter content for blockly
 
 class Music < Blockly

--- a/dashboard/app/views/levels/editors/fields/_validations.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_validations.html.haml
@@ -5,4 +5,4 @@
 
 - content_for :body_scripts do
   %script{src: webpack_asset_path('js/levels/editors/fields/_validations.js'),
-        data: {validations: (@level.properties.dig('level_data', 'validations') || []).to_json, levelname: @level.name, appname: @level.game&.app}}
+        data: {validations: (@level.properties['validations'] || @level.properties.dig('level_data', 'validations') || []).to_json, levelname: @level.name, appname: @level.game&.app}}


### PR DESCRIPTION
The primary motivation behind this change is to make validation localization easier; instead of digging into level data to retrieve strings during sync-in, and reconstructing the level data object with translated strings when sending out level data, we can work with the validations property directly. This also simplifies code a bit, since we were previously plucking validations out of level properties and merging it back into the level data JSON which we no longer need to do.

This should be backwards compatible; we'll look for validations on level properties first, but fall back to the level data validations if they're not present in level properties. When levels with validations are edited/saved, we'll keep validations on level properties, and just delete them from level data.

Local diff for a level that was opened and saved without any manual edits - validations are moved to level properties and deleted from level data.

<img width="2069" alt="Screenshot 2024-03-12 at 2 25 58 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/bc2f9136-d4bc-4633-89ec-2a03813b8543">

## Links

https://codedotorg.atlassian.net/browse/LABS-535

## Testing story

Tested locally with the intro script, with a mix of levels that have validation in level properties and level data.