### PR TITLE
feat(lms): do not sync or create sections if on the LMS, the user is not an instructor

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -246,7 +246,7 @@ class LtiV1Controller < ApplicationController
       nrps_response = lti_advantage_client.get_context_membership(nrps_url, resource_link_id)
       nrps_sections = Services::Lti.parse_nrps_response(nrps_response, lti_integration.issuer)
 
-      sync_course_roster_results = Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: nrps_sections, section_owner_id: current_user.id)
+      sync_course_roster_results = Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: nrps_sections, current_user: current_user)
       had_changes ||= sync_course_roster_results
 
       # Report which sections were updated

--- a/dashboard/lib/queries/lti.rb
+++ b/dashboard/lib/queries/lti.rb
@@ -7,6 +7,11 @@ class Queries::Lti
     User.find_by_credential(type: AuthenticationOption::LTI_V1, id: auth_id)
   end
 
+  # Returns the LTI user id for a particular code.org user and LTI integration
+  def self.lti_user_id(user, lti_integration)
+    user.lti_user_identities.find_by(lti_integration_id: lti_integration.id)&.subject
+  end
+
   def self.get_lti_integration(issuer, client_id)
     LtiIntegration.find_by(issuer: issuer, client_id: client_id)
   end

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -80,7 +80,7 @@ class Services::Lti
   end
 
   def self.lti_user_type(current_user, lti_integration, nrps_section)
-    lti_user_id = Policies::Lti.lti_user_id(current_user, lti_integration)
+    lti_user_id = Queries::Lti.lti_user_id(current_user, lti_integration)
     member_roles = lti_user_roles(nrps_section, lti_user_id)
 
     if Policies::Lti.lti_teacher?(member_roles)
@@ -197,8 +197,7 @@ class Services::Lti
       end
     end
 
-    nrps_sections.keys.each do |lms_section_id|
-      nrps_section = nrps_sections[lms_section_id]
+    nrps_sections.each do |lms_section_id, nrps_section|
       section_name = nrps_section[:name]
       # Check if lti_sections already contains a section with this lms_section_id
       lti_section = lti_sections.find_by(lms_section_id: lms_section_id)

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -71,6 +71,25 @@ class Services::Lti
     id_token[key] || id_token.dig(Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym, key)
   end
 
+  def self.lti_user_roles(nrps_section, lti_user_id)
+    nrps_member = nrps_section[:members].find {|member| member[:user_id] == lti_user_id}
+
+    if nrps_member.present?
+      nrps_member[:roles]
+    end
+  end
+
+  def self.lti_user_type(current_user, lti_integration, nrps_section)
+    lti_user_id = Policies::Lti.lti_user_id(current_user, lti_integration)
+    member_roles = lti_user_roles(nrps_section, lti_user_id)
+
+    if Policies::Lti.lti_teacher?(member_roles)
+      return User::TYPE_TEACHER
+    end
+
+    return User::TYPE_STUDENT
+  end
+
   def self.initialize_lti_student_from_nrps(client_id:, issuer:, nrps_member:)
     nrps_member_message = Policies::Lti.issuer_accepts_resource_link?(issuer) ? nrps_member[:message].first : nrps_member
     user = User.new
@@ -166,7 +185,7 @@ class Services::Lti
   end
 
   # Syncs a course and all its sections from an NRPS response.
-  def self.sync_course_roster(lti_integration:, lti_course:, nrps_sections:, section_owner_id:)
+  def self.sync_course_roster(lti_integration:, lti_course:, nrps_sections:, current_user:)
     had_changes = false
     lti_sections = LtiSection.where(lti_course_id: lti_course.id)
 
@@ -179,13 +198,20 @@ class Services::Lti
     end
 
     nrps_sections.keys.each do |lms_section_id|
-      section_name = nrps_sections[lms_section_id][:name]
+      nrps_section = nrps_sections[lms_section_id]
+      section_name = nrps_section[:name]
       # Check if lti_sections already contains a section with this lms_section_id
       lti_section = lti_sections.find_by(lms_section_id: lms_section_id)
+
+      lti_user_type = lti_user_type(current_user, lti_integration, nrps_section)
+
+      # Skip if the current user is not an instructor
+      next unless lti_user_type == User::TYPE_TEACHER
+
       if lti_section.nil?
         section = Section.new(
           {
-            user_id: section_owner_id,
+            user_id: current_user.id,
             name: section_name,
             login_type: Section::LOGIN_TYPE_LTI_V1,
           }

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -22,6 +22,27 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
         members: [
           {
             status: "Active",
+            user_id: "f2a16942-ed81-4c98-96dc-5cac16e354ec",
+            roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor"],
+            message: [
+              {
+                'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+                locale: "en",
+                'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                  email: "teacher0@code.org",
+                  course_id: "115",
+                  full_name: "Teacher",
+                  given_name: "Test",
+                  family_name: "Zero",
+                  section_ids: "1,2,3",
+                  display_name: "Test Teacher Zero",
+                  section_names: "[\"Section 1\", \"Section 2\", \"Section 3\"]"
+                }
+              }
+            ]
+          },
+          {
+            status: "Active",
             user_id: "0c00f8db-a039-45e1-8e2d-f1e17a047836",
             roles: ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"],
             message: [
@@ -254,7 +275,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
           end
     roles_key = Policies::Lti::LTI_ROLES_KEY
     custom_claims_key = Policies::Lti::LTI_CUSTOM_CLAIMS
-    teacher_roles = Policies::Lti::TEACHER_ROLES
+    teacher_roles = Policies::Lti::STAFF_ROLES
     nrps_url_key = Policies::Lti::LTI_NRPS_CLAIM
     resource_link_key = Policies::Lti::LTI_RESOURCE_LINK_CLAIM
     deployment_id_key = Policies::Lti::LTI_DEPLOYMENT_ID_CLAIM
@@ -539,6 +560,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     sign_in user
     lti_integration = create :lti_integration
     lti_course = create :lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid, resource_link_id: SecureRandom.uuid, nrps_url: 'https://example.com/nrps'
+    create :lti_user_identity, lti_integration: lti_integration, user: user, subject: 'f2a16942-ed81-4c98-96dc-5cac16e354ec'
 
     LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id)
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)

--- a/dashboard/test/lib/policies/lti_test.rb
+++ b/dashboard/test/lib/policies/lti_test.rb
@@ -65,6 +65,33 @@ class Policies::LtiTest < ActiveSupport::TestCase
     assert_equal nil, Policies::Lti.lti_provided_email(user)
   end
 
+  test 'lti_user_id should return the subject (user id) for a given user' do
+    lti_integration = create :lti_integration
+    lti_user_identity = create :lti_user_identity, lti_integration: lti_integration
+
+    assert_equal "subject", Policies::Lti.lti_user_id(lti_user_identity.user, lti_integration)
+  end
+
+  test 'lti_user_id should return nil if there are no matching identities' do
+    lti_integration = create :lti_integration
+    other_lti_integration = create :lti_integration
+    lti_user_identity = create :lti_user_identity, lti_integration: lti_integration
+
+    assert_nil Policies::Lti.lti_user_id(lti_user_identity.user, other_lti_integration)
+  end
+
+  test 'lti_teacher returns false if administrator' do
+    assert_equal false, Policies::Lti.lti_teacher?(["http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator"])
+  end
+
+  test 'lti_teacher returns false if learner' do
+    assert_equal false, Policies::Lti.lti_teacher?([Policies::Lti.CONTEXT_LEARNER_ROLE])
+  end
+
+  test 'lti_teacher returns true if instructor' do
+    assert_equal true, Policies::Lti.lti_teacher?(['http://purl.imsglobal.org/vocab/lis/v1/institution/person#Instructor'])
+  end
+
   test 'show_email_input?' do
     test_matrix = [
       [true, [:teacher, :with_lti_auth]],

--- a/dashboard/test/lib/policies/lti_test.rb
+++ b/dashboard/test/lib/policies/lti_test.rb
@@ -85,7 +85,7 @@ class Policies::LtiTest < ActiveSupport::TestCase
   end
 
   test 'lti_teacher returns false if learner' do
-    assert_equal false, Policies::Lti.lti_teacher?([Policies::Lti.CONTEXT_LEARNER_ROLE])
+    assert_equal false, Policies::Lti.lti_teacher?([Policies::Lti::CONTEXT_LEARNER_ROLE])
   end
 
   test 'lti_teacher returns true if instructor' do

--- a/dashboard/test/lib/policies/lti_test.rb
+++ b/dashboard/test/lib/policies/lti_test.rb
@@ -65,21 +65,6 @@ class Policies::LtiTest < ActiveSupport::TestCase
     assert_equal nil, Policies::Lti.lti_provided_email(user)
   end
 
-  test 'lti_user_id should return the subject (user id) for a given user' do
-    lti_integration = create :lti_integration
-    lti_user_identity = create :lti_user_identity, lti_integration: lti_integration
-
-    assert_equal "subject", Policies::Lti.lti_user_id(lti_user_identity.user, lti_integration)
-  end
-
-  test 'lti_user_id should return nil if there are no matching identities' do
-    lti_integration = create :lti_integration
-    other_lti_integration = create :lti_integration
-    lti_user_identity = create :lti_user_identity, lti_integration: lti_integration
-
-    assert_nil Policies::Lti.lti_user_id(lti_user_identity.user, other_lti_integration)
-  end
-
   test 'lti_teacher returns false if administrator' do
     assert_equal false, Policies::Lti.lti_teacher?(["http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator"])
   end

--- a/dashboard/test/lib/queries/lti_test.rb
+++ b/dashboard/test/lib/queries/lti_test.rb
@@ -74,4 +74,19 @@ class Services::LtiTest < ActiveSupport::TestCase
     lti_course = create :lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid
     assert_equal lti_course, Queries::Lti.find_or_create_lti_course(lti_integration_id: lti_integration.id, context_id: lti_course.context_id, deployment_id: 'deployment-id', nrps_url: 'http://some-nrps-url.com', resource_link_id: 'rlid')
   end
+
+  test 'lti_user_id should return the subject (user id) for a given user' do
+    lti_integration = create :lti_integration
+    lti_user_identity = create :lti_user_identity, lti_integration: lti_integration
+
+    assert_equal "subject", Policies::Lti.lti_user_id(lti_user_identity.user, lti_integration)
+  end
+
+  test 'lti_user_id should return nil if there are no matching identities' do
+    lti_integration = create :lti_integration
+    other_lti_integration = create :lti_integration
+    lti_user_identity = create :lti_user_identity, lti_integration: lti_integration
+
+    assert_nil Policies::Lti.lti_user_id(lti_user_identity.user, other_lti_integration)
+  end
 end

--- a/dashboard/test/lib/queries/lti_test.rb
+++ b/dashboard/test/lib/queries/lti_test.rb
@@ -79,7 +79,7 @@ class Services::LtiTest < ActiveSupport::TestCase
     lti_integration = create :lti_integration
     lti_user_identity = create :lti_user_identity, lti_integration: lti_integration
 
-    assert_equal "subject", Policies::Lti.lti_user_id(lti_user_identity.user, lti_integration)
+    assert_equal "subject", Queries::Lti.lti_user_id(lti_user_identity.user, lti_integration)
   end
 
   test 'lti_user_id should return nil if there are no matching identities' do
@@ -87,6 +87,6 @@ class Services::LtiTest < ActiveSupport::TestCase
     other_lti_integration = create :lti_integration
     lti_user_identity = create :lti_user_identity, lti_integration: lti_integration
 
-    assert_nil Policies::Lti.lti_user_id(lti_user_identity.user, other_lti_integration)
+    assert_nil Queries::Lti.lti_user_id(lti_user_identity.user, other_lti_integration)
   end
 end

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -319,10 +319,11 @@ class Services::LtiTest < ActiveSupport::TestCase
   test 'should update a section name if it has changed' do
     teacher = create :teacher
     lti_integration = create :lti_integration
+    create :lti_user_identity, lti_integration: lti_integration, user: teacher, subject: 'user-id-1'
     lti_course = create :lti_course, lti_integration: lti_integration
     Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
     parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response, @id_token[:iss])
-    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
+    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
 
     # initial names
     expected_section_names = @lms_section_names.map {|name| "#{@course_name}: #{name}"}
@@ -337,7 +338,7 @@ class Services::LtiTest < ActiveSupport::TestCase
     end
     Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
     parsed_response = Services::Lti.parse_nrps_response(new_response, @id_token[:iss])
-    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
+    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
     new_expected_names = JSON.parse(new_names).map {|name| "#{@course_name}: #{name}"}
     actual_section_names = lti_course.reload.sections.map(&:name)
     assert_empty new_expected_names - actual_section_names
@@ -374,38 +375,82 @@ class Services::LtiTest < ActiveSupport::TestCase
   test 'should add or remove sections when syncing a course' do
     teacher = create :teacher
     lti_integration = create :lti_integration
+    create :lti_user_identity, lti_integration: lti_integration, user: teacher
     lti_course = create :lti_course, lti_integration: lti_integration
     Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
     parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response, @id_token[:iss])
-    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
+    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
 
     # Adding new sections
     assert lti_course.reload.sections.length, 3
 
     # Removing old sections
     parsed_response.delete(@lms_section_ids.first.to_s)
-    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
+    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
     assert lti_course.reload.sections.length, 2
 
     # Remove empty sections with no users
-    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
+    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
     assert lti_course.reload.sections.length, 1
   end
 
   test 'should remove empty sections when syncing a course' do
     teacher = create :teacher
     lti_integration = create :lti_integration
+    create :lti_user_identity, lti_integration: lti_integration, user: teacher
     lti_course = create :lti_course, lti_integration: lti_integration
     Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
     parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response, @id_token[:iss])
-    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
+    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
 
     assert lti_course.reload.sections.length, 3
 
     # Remove empty sections with no users
     @nrps_full_response[:members] = []
     parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response, @id_token[:iss])
-    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, section_owner_id: teacher.id)
+    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
     assert lti_course.reload.sections.length, 2
+  end
+
+  test 'should NOT sync if the user is not a teacher on LTI' do
+    teacher = create :teacher
+    lti_integration = create :lti_integration
+    create :lti_user_identity, lti_integration: lti_integration, user: teacher, subject: 'user-id-2'
+    lti_course = create :lti_course, lti_integration: lti_integration
+    Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
+    parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response, @id_token[:iss])
+    had_changes = Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
+
+    assert_equal false, had_changes
+  end
+
+  test 'lti_user_roles should return the LTI roles for a given user' do
+    roles = Services::Lti.lti_user_roles(@nrps_full_response, "user-id-1")
+
+    assert_equal ["http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor"], roles
+  end
+
+  test 'lti_user_roles should return nil if the user cannot be found' do
+    roles = Services::Lti.lti_user_roles(@nrps_full_response, "unknown")
+
+    assert_nil roles
+  end
+
+  test 'lti_user_type should return teacher if LTI user role is instructor' do
+    teacher = create :teacher
+    lti_integration = create :lti_integration
+    create :lti_user_identity, lti_integration: lti_integration, user: teacher, subject: 'user-id-1'
+    user_type = Services::Lti.lti_user_type(teacher, lti_integration, @nrps_full_response)
+
+    assert_equal User::TYPE_TEACHER, user_type
+  end
+
+  test 'lti_user_type should return student if LTI user role is not instructor' do
+    teacher = create :teacher
+    lti_integration = create :lti_integration
+    create :lti_user_identity, lti_integration: lti_integration, user: teacher, subject: 'user-id-2'
+    user_type = Services::Lti.lti_user_type(teacher, lti_integration, @nrps_full_response)
+
+    assert_equal User::TYPE_STUDENT, user_type
   end
 end

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -412,7 +412,7 @@ class Services::LtiTest < ActiveSupport::TestCase
     assert lti_course.reload.sections.length, 2
   end
 
-  test 'should NOT sync if the user is not a teacher on LTI' do
+  test 'should NOT sync if the user is not a teacher on the LMS' do
     teacher = create :teacher
     lti_integration = create :lti_integration
     create :lti_user_identity, lti_integration: lti_integration, user: teacher, subject: 'user-id-2'


### PR DESCRIPTION
Previously, the sync_course logic will operate regardless of the user's role on the LMS. This resulted in some cases where synchronization occurred when not a teacher (for example, an administrator inadvertently synchronizing a course, or a student creating a course). When a non-instructor creates a course, the section becomes "owned" by the non-instructor potentially locking out the actual instructor.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [jira](https://codedotorg.atlassian.net/browse/P20-759)

## Testing story

1. I tested creating a new course in Canvas, and never visiting Code.org.
2. I added a student in this course and had the student visit Code.org

Previous: The student becomes the section owner
Now: The result was that the course did not get created and the student goes to the home page.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
