### PR TITLE
Update feedback indicator logic

### DIFF
--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -156,16 +156,16 @@ export function lessonHasLevels(lesson) {
   return !!lesson.levels?.length;
 }
 
-export const feedbackLeft = progress =>
-  progress?.teacherFeedbackReviewState !== 'keepWorking' &&
-  progress?.teacherFeedbackNew;
+export const commentLeft = progress =>
+  progress?.teacherFeedbackCommented && progress?.teacherFeedbackNew;
 
 export const studentNeedsFeedback = (progress, level) =>
   progress &&
   progress.status !== LevelStatus.not_tried &&
+  progress.teacherFeedbackReviewState !== 'keepWorking' &&
   level.kind === 'assessment' &&
   level.canHaveFeedback &&
-  !feedbackLeft(progress);
+  !commentLeft(progress);
 
 /**
  * Determines if we should show "Keep working" and "Needs review" states for
@@ -339,6 +339,8 @@ export const levelProgressFromServer = serverProgress => {
     timeSpent: serverProgress.time_spent,
     teacherFeedbackReviewState: serverProgress.teacher_feedback_review_state,
     teacherFeedbackNew: serverProgress.teacher_feedback_new || false,
+    teacherFeedbackCommented:
+      serverProgress.teacher_feedback_commented || false,
     lastTimestamp: serverProgress.last_progress_at,
     pages: getPagesProgress(serverProgress),
   };

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -162,10 +162,9 @@ export const commentLeft = progress =>
 export const studentNeedsFeedback = (progress, level) =>
   progress &&
   progress.status !== LevelStatus.not_tried &&
-  progress.teacherFeedbackReviewState !== 'keepWorking' &&
+  !progress.teacherFeedbackNew &&
   level.kind === 'assessment' &&
-  level.canHaveFeedback &&
-  !commentLeft(progress);
+  level.canHaveFeedback;
 
 /**
  * Determines if we should show "Keep working" and "Needs review" states for

--- a/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
+++ b/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
@@ -116,6 +116,7 @@ function randomProgress(level) {
         lastTimestamp: timestamp,
         teacherFeedbackReviewState: randomReviewState(),
         teacherFeedbackNew: false,
+        teacherFeedbackCommented: true,
       };
     case 1:
       return {
@@ -127,6 +128,7 @@ function randomProgress(level) {
         lastTimestamp: timestamp,
         teacherFeedbackReviewState: randomReviewState(),
         teacherFeedbackNew: true,
+        teacherFeedbackCommented: false,
       };
     case 2:
       return {
@@ -138,6 +140,7 @@ function randomProgress(level) {
         lastTimestamp: timestamp,
         teacherFeedbackReviewState: randomReviewState(),
         teacherFeedbackNew: false,
+        teacherFeedbackCommented: true,
       };
     default:
       return null;

--- a/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
@@ -10,7 +10,7 @@ import ProgressIcon from './ProgressIcon';
 import {ITEM_TYPE} from './ItemType';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import queryString from 'query-string';
-import {feedbackLeft, studentNeedsFeedback} from '../progress/progressHelpers';
+import {commentLeft, studentNeedsFeedback} from '../progress/progressHelpers';
 
 export const navigateToLevelOverviewUrl = (levelUrl, studentId, sectionId) => {
   if (!levelUrl) {
@@ -41,7 +41,10 @@ function LevelDataCell({
     if (expandedChoiceLevel) {
       return ITEM_TYPE.CHOICE_LEVEL;
     }
-    if (studentLevelProgress?.teacherFeedbackReviewState === 'keepWorking') {
+    if (
+      studentLevelProgress?.teacherFeedbackReviewState === 'keepWorking' &&
+      studentLevelProgress?.teacherFeedbackNew
+    ) {
       return ITEM_TYPE.KEEP_WORKING;
     }
     if (
@@ -71,13 +74,16 @@ function LevelDataCell({
   }, [studentLevelProgress, level, expandedChoiceLevel]);
 
   const feedbackStyle = React.useMemo(() => {
-    if (feedbackLeft(studentLevelProgress)) {
+    if (expandedChoiceLevel) {
+      return;
+    }
+    if (commentLeft(studentLevelProgress)) {
       return legendStyles.feedbackGiven;
     }
     if (studentNeedsFeedback(studentLevelProgress, level)) {
       return legendStyles.needsFeedback;
     }
-  }, [studentLevelProgress, level]);
+  }, [studentLevelProgress, level, expandedChoiceLevel]);
 
   return (
     <Link

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -152,6 +152,7 @@ const fullExpectedResult = {
           timeSpent: undefined,
           teacherFeedbackReviewState: undefined,
           teacherFeedbackNew: false,
+          teacherFeedbackCommented: false,
           lastTimestamp: 12345,
         },
         2001: {
@@ -163,6 +164,7 @@ const fullExpectedResult = {
           timeSpent: 12345,
           teacherFeedbackReviewState: undefined,
           teacherFeedbackNew: false,
+          teacherFeedbackCommented: false,
           lastTimestamp: 12345,
         },
       },
@@ -176,6 +178,7 @@ const fullExpectedResult = {
           timeSpent: 6789,
           teacherFeedbackReviewState: undefined,
           teacherFeedbackNew: false,
+          teacherFeedbackCommented: false,
           lastTimestamp: 6789,
         },
       },

--- a/apps/test/unit/templates/sectionProgressV2/LevelDataCellTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/LevelDataCellTest.jsx
@@ -50,10 +50,24 @@ describe('ProgressTableV2', () => {
       studentLevelProgress: {
         ...PROGRESS,
         teacherFeedbackReviewState: 'keepWorking',
+        teacherFeedbackNew: true,
       },
     });
 
     screen.getByRole('link', {name: 'progressicon-rotate-left'});
+  });
+
+  it('Keep working level that the student has revisited', () => {
+    renderDefault({
+      studentLevelProgress: {
+        ...PROGRESS,
+        status: LevelStatus.perfect,
+        teacherFeedbackReviewState: 'keepWorking',
+        teacherFeedbackNew: false,
+      },
+    });
+
+    screen.getByRole('link', {name: 'progressicon-circle'});
   });
 
   it('Not tried level', () => {

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -360,6 +360,7 @@ module UsersHelper
         return {
           status: LEVEL_STATUS.not_tried,
           teacher_feedback_review_state: teacher_feedback.review_state,
+          teacher_feedback_commented: teacher_feedback.comment.present? || nil,
           teacher_feedback_new: true
         }.compact
       else
@@ -375,6 +376,7 @@ module UsersHelper
       last_progress_at: include_timestamp ? user_level.updated_at&.to_i : nil,
       time_spent: user_level.time_spent&.to_i,
       teacher_feedback_review_state: teacher_feedback&.review_state,
+      teacher_feedback_commented: teacher_feedback&.comment&.present? || nil,
       teacher_feedback_new:
         ((teacher_feedback&.updated_at&.to_i || 0) > (user_level.updated_at&.to_i || 0)) || nil
     }.compact

--- a/dashboard/test/helpers/users_helper_test.rb
+++ b/dashboard/test/helpers/users_helper_test.rb
@@ -384,6 +384,7 @@ class UsersHelperTest < ActionView::TestCase
           },
           sublevel2.id => {
             status: LEVEL_STATUS.not_tried,
+            teacher_feedback_commented: true,
             teacher_feedback_new: true
           },
           level.id => {


### PR DESCRIPTION
Updates to the teacher feedback indicator logic per JIRA task [TEACH-922](https://codedotorg.atlassian.net/browse/TEACH-922).

1) Only display the "keep working" arrow indicator and "feedback given" indicator if the student has not updated their work since the teacher requested the student keep working. Similarly, display "needs feedback" indicator on feedback-able assessment levels when the student has updated their work since the last round of feedback.
2) Don't display feedback triangles next to the expanded choice level arrow icons.
3) Add a new item to the progress API response to indicate whether the teacher has left a comment, so that "feedback given" can be shown alongside the "keep working" indicator when appropriate.
.<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
