### PR TITLE
remove weird new shadow from ai bot image

### DIFF
--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -30,6 +30,7 @@
 
   img {
     opacity: 1.0;
+    border-radius: 30px;
   }
 }
 


### PR DESCRIPTION
Eyes tests revealed a small but legit regression in the appearance of the ai bot as a result of https://github.com/code-dot-org/code-dot-org/pull/57182. 

the regression was due to switching from using css background image to using a separate image tag. the image tag, which renders a round image, needs to have a border-radius so that it only appears within the circular space occupied by the image.

## screenshots

before means before this PR. after means after this PR (which is the same as how it looked before #57182 ).

![Screenshot 2024-03-12 at 5 07 38 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/6b066188-da08-4028-b6ca-6272652f6ca7)

## Testing story

This visual change will be covered by eyes tests