### PR TITLE
Music: share dialog UI

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -563,23 +563,7 @@ class ShareAllowedDialog extends React.Component {
           {isAbusive && renderAbuseError()}
 
           <div style={styles.newLayoutContainer}>
-            <div
-              id="share-thumbnail-image-container"
-              style={{
-                ...styles.thumbnail,
-                ...styles.thumbnailBigger,
-              }}
-            >
-              <img
-                id="share-thumbnail-image"
-                style={styles.thumbnailImg}
-                src={thumbnailUrl}
-                alt={i18n.projectThumbnail()}
-              />
-            </div>
-
             {renderCopyButton()}
-
             <div id="share-qrcode-container">
               <QRCode value={shareUrl + '?qr=true'} size={180} />
             </div>
@@ -681,10 +665,6 @@ const styles = {
     backgroundColor: color.white,
     position: 'relative',
   },
-  thumbnailBigger: {
-    width: 180,
-    height: 180,
-  },
   thumbnailImg: {
     position: 'absolute',
     left: '50%',
@@ -738,6 +718,7 @@ const styles = {
   },
   newLayoutContainer: {
     display: 'flex',
+    justifyContent: 'space-around',
     alignItems: 'center',
     gap: 12,
   },

--- a/apps/src/code-studio/components/ShareAllowedDialog.story.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.story.jsx
@@ -48,6 +48,12 @@ SpriteLab.args = {
   appType: 'spritelab',
 };
 
+export const MusicLab = Template.bind({});
+MusicLab.args = {
+  ...defaultArgs,
+  appType: 'music',
+};
+
 export const WithThumbnail = Template.bind({});
 WithThumbnail.args = {
   ...defaultArgs,
@@ -127,3 +133,41 @@ InRestrictedShareMode.args = {
   inRestrictedShareMode: true,
   appType: 'spritelab',
 };
+
+/*
+export const MusicLabWithUnder13Warning = Template.bind({});
+MusicLabWithUnder13Warning.args = {
+  ...defaultArgs,
+  appType: 'music',
+  canShareSocial: false,
+};
+*/
+
+export const MusicLabAbusive = Template.bind({});
+MusicLabAbusive.args = {
+  ...defaultArgs,
+  appType: 'music',
+  isAbusive: true,
+};
+
+/*
+export const MusicLabWithSharingForUserDisabled = Template.bind({});
+MusicLabWithSharingForUserDisabled.args = {
+  ...defaultArgs,
+  appType: 'music',
+  canPublish: true,
+  isPublished: true,
+  isUnpublishPending: true,
+  userSharingDisabled: true,
+};
+*/
+
+/*
+export const MusicLabInRestrictedShareMode = Template.bind({});
+MusicLabInRestrictedShareMode.args = {
+  ...defaultArgs,
+  appType: 'music',
+  canPublish: true,
+  inRestrictedShareMode: true,
+};
+*/


### PR DESCRIPTION
Initial work on a new project share dialog UI for Music Lab.  

This leaves the current share dialog UI intact, but does some refactoring to enable some component reuse, and adds a "V2" variant which we can use for Music Lab and other labs if desired.

This initial version for Music Lab just has a "copy to clipboard" button, and a bigger QR code.

<img width="833" alt="Screenshot 2024-03-14 at 10 50 18 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/85b4ec07-47cd-4439-bb51-3f9afa8757f7">

