### PR TITLE
Set up secrets for MailJet

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -639,3 +639,7 @@ ai_proxy_origin: https://aiproxy-test.code.org
 # local_mode.
 statsig_server_secret_key: 'secret-fake-key'
 statsig_api_client_key: 'client-fake-key'
+
+# MailJet API keys
+mailjet_api_key:
+mailjet_secret_key:

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -50,3 +50,7 @@ mapbox_access_tileset:    'censustiles'
 # Statsig API keys
 statsig_server_secret_key: !Secret
 statsig_api_client_key: !Secret
+
+# MailJet API keys
+mailjet_api_key: !Secret
+mailjet_secret_key: !Secret

--- a/config/staging.yml.erb
+++ b/config/staging.yml.erb
@@ -16,3 +16,7 @@ imm_reader_client_id:     '74937af0-55ee-411a-867a-57eefadec7d9'
 
 # General CDO Amplitude key
 cdo_amplitude_api_key: !Secret
+
+# MailJet API keys
+mailjet_api_key: !Secret
+mailjet_secret_key: !Secret


### PR DESCRIPTION
Note: I have already updated the secrets in AWS Secrets Manager using [these instructions](https://github.com/code-dot-org/code-dot-org/blob/staging/config/secrets.md#creatingupdating-a-secret).

This is subject to change but my current plan for these secrets per environment is: (copied from the [lightweight tech plan](https://docs.google.com/document/d/1gLY6PezbIAV6Rm4WwRb_4Ig6I762iq8liM0sUKTE1ZI/edit#heading=h.af7ca3ejojfo))
- `production` and `staging` share an API key by default. This allows at least one non-production environment to behave like production.
- `test` and Drone will not have an API key. The test environment creates a lot of user accounts as part of UI testing and would generate a lot of spam in our MailJet account.
- `levelbuilder` will not have an API key. Users who create an account on levelbuilder generally do not require regular emails.
- `development` and `adhoc` will not have an API key by default but can use one if needed. (Details on how to come.)

This secret isn't used yet.

