### PR TITLE
Fix "Run AI Assessment for Class" button

### DIFF
--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -135,6 +135,7 @@ export default function RubricContainer({
           {showSettings && (
             <RubricSettings
               visible={selectedTab === TAB_NAMES.SETTINGS}
+              refreshAiEvaluations={fetchAiEvaluations}
               rubric={rubric}
               sectionId={sectionId}
             />

--- a/apps/src/templates/rubrics/RubricSettings.jsx
+++ b/apps/src/templates/rubrics/RubricSettings.jsx
@@ -201,10 +201,14 @@ export default function RubricSettings({
         <Heading2>{i18n.aiAssessment()}</Heading2>
         <div className={style.settingsContainers}>
           <div className={style.runAiAllStatuses}>
-            <BodyTwoText className="uitest-eval-status-all-text">
+            <BodyTwoText>
               <StrongText>{summaryText()}</StrongText>
             </BodyTwoText>
-            {statusAllText() && <BodyTwoText>{statusAllText()}</BodyTwoText>}
+            {statusAllText() && (
+              <BodyTwoText className="uitest-eval-status-all-text">
+                {statusAllText()}
+              </BodyTwoText>
+            )}
           </div>
           <Button
             className="uitest-run-ai-assessment-all"

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -91,7 +91,7 @@ Feature: Evaluate student code against rubrics using AI
     # Teacher runs AI evaluation
     When I click selector ".uitest-run-ai-assessment"
     Then I wait until element ".uitest-info-alert" is visible
-    And element ".uitest-info-alert" contains text "AI analysis complete."
+    And I wait until element ".uitest-info-alert" contains text "AI analysis complete."
 
     # Teacher views AI evaluation results in rubric tab
     And I wait until element "#uitest-next-goal" is visible

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -135,12 +135,18 @@ Feature: Evaluate student code against rubrics using AI
     And I wait until element "#uitest-rubric-content" is visible
     And element ".uitest-run-ai-assessment" is enabled
 
-    # Teacher runs AI evaluation
-    When I click selector ".uitest-run-ai-assessment"
-    Then I wait until element ".uitest-info-alert" is visible
-    And I wait until element ".uitest-info-alert" contains text "AI analysis complete."
+    # Teacher switches to Class Management tab
+    When I click selector "button:contains('Class Management')"
+    And I wait until element ".uitest-run-ai-assessment-all" is visible
+    And element ".uitest-run-ai-assessment-all" is enabled
 
-    # Teacher views AI evaluation results in rubric tab
+    # Teacher runs AI evaluation
+    When I click selector ".uitest-run-ai-assessment-all"
+    Then I wait until element ".uitest-eval-status-all-text" is visible
+    And I wait until element ".uitest-eval-status-all-text" contains text "AI analysis complete."
+
+    # Teacher views AI evaluation results in Student Rubric tab
+    When I click selector "button:contains('Student Rubric')"
     And I wait until element "#uitest-next-goal" is visible
     And I click selector "#uitest-next-goal"
     And I wait until element ".uitest-learning-goal-title" is visible

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -54,7 +54,54 @@ Feature: Evaluate student code against rubrics using AI
     And I wait until element ".uitest-ai-assessment" is visible
     Then element ".uitest-ai-assessment" contains text "Aiden has achieved Extensive or Convincing Evidence"
 
-  Scenario: Student code is evaluated by AI when teacher requests it
+  Scenario: Student code is evaluated by AI when teacher requests individual evaluation
+    Given I create a teacher-associated student named "Aiden"
+    And I am on "http://studio.code.org/home"
+    And I wait until element "#homepage-container" is visible
+    And I add the current user to the "ai-rubrics" single user experiment
+    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
+    And I wait for the page to fully load
+    And I verify progress in the header of the current page is "not_tried" for level 2
+
+    # Student runs code
+    When I ensure droplet is in text mode
+    And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
+    And I click selector "#runButton"
+    And I wait until element "#resetButton" is visible
+
+    # Teacher views student progress and floating action button
+    When I sign in as "Teacher_Aiden"
+    And I am on "http://studio.code.org/home"
+    And I wait until element "#homepage-container" is visible
+    And element "#sign_in_or_user" contains text "Teacher_Aiden"
+    And I add the current user to the "ai-rubrics" single user experiment
+    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
+    And I wait for the page to fully load
+    And element ".teacher-panel td:eq(1)" contains text "Aiden"
+    And I click selector ".teacher-panel td:eq(1)" to load a new page
+    And I wait for the page to fully load
+    #Then I verify progress in the header of the current page is "attempted_assessment" for level 2
+    And element "#ui-floatingActionButton" is visible
+
+    # Teacher views AI evaluation status in settings tab
+    When I click selector "#ui-floatingActionButton"
+    And I wait until element "#uitest-rubric-content" is visible
+    And element ".uitest-run-ai-assessment" is enabled
+
+    # Teacher runs AI evaluation
+    When I click selector ".uitest-run-ai-assessment"
+    Then I wait until element ".uitest-info-alert" is visible
+    And element ".uitest-info-alert" contains text "AI analysis complete."
+
+    # Teacher views AI evaluation results in rubric tab
+    And I wait until element "#uitest-next-goal" is visible
+    And I click selector "#uitest-next-goal"
+    And I wait until element ".uitest-learning-goal-title" is visible
+    Then element ".uitest-learning-goal-title" contains text "Sprites"
+    And I wait until element ".uitest-ai-assessment" is visible
+    Then element ".uitest-ai-assessment" contains text "Aiden has achieved Extensive or Convincing Evidence"
+
+  Scenario: Student code is evaluated by AI when teacher requests evaluation for entire class
     Given I create a teacher-associated student named "Aiden"
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-524. The "Run AI Assessment for Classroom" flow broke a few weeks back and went unnoticed due to lack of test coverage.

This PR fixes the regression (c760372fde62fc339ea37a245c292213255ef6bf), and adds a UI test to catch this kind of problem in the future (best seen in 5d80145a46b41f378802501616af5c44909435b1).

## Testing story

Added a new UI test