### PR TITLE
[Google Blockly] Retry failed code generation

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -205,6 +205,8 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       getStore().dispatch(setFailedToGenerateCode(false));
     } catch (e) {
       if (retryCount < MAX_GET_CODE_RETRIES) {
+        // Sometimes we need to wait for Google Blockly change handlers to complete
+        // before the code will generate correctly. Retry after a short delay.
         setTimeout(() => {
           return getWorkspaceCodeHelper(retryCount + 1, hiddenWorkspace);
         }, RETRY_GET_CODE_INTERVAL_MS);

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -82,7 +82,7 @@ import {
   GoogleBlocklyInstance,
 } from './types';
 import {FieldProto} from 'blockly/core/field';
-import {Options, Theme} from 'blockly';
+import {Options, Theme, Workspace} from 'blockly';
 
 const options = {
   contextMenu: true,
@@ -94,6 +94,8 @@ plugin.init(options);
 
 const INFINITE_LOOP_TRAP =
   '  executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}\n';
+const MAX_GET_CODE_RETRIES = 2;
+const RETRY_GET_CODE_INTERVAL_MS = 500;
 
 /**
  * Wrapper class for https://github.com/google/blockly
@@ -185,22 +187,33 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
 
   blocklyWrapper.loopHighlight = function () {}; // TODO
   blocklyWrapper.getWorkspaceCode = function () {
+    return getWorkspaceCodeHelper(0, this.getHiddenDefinitionWorkspace());
+  };
+
+  const getWorkspaceCodeHelper = (
+    retryCount: number,
+    hiddenWorkspace: Workspace | undefined
+  ): string => {
     let workspaceCode = '';
     try {
       workspaceCode = Blockly.JavaScript.workspaceToCode(
         Blockly.mainBlockSpace
       );
-      if (this.getHiddenDefinitionWorkspace()) {
-        workspaceCode += Blockly.JavaScript.workspaceToCode(
-          this.getHiddenDefinitionWorkspace()
-        );
+      if (hiddenWorkspace) {
+        workspaceCode += Blockly.JavaScript.workspaceToCode(hiddenWorkspace);
       }
       getStore().dispatch(setFailedToGenerateCode(false));
     } catch (e) {
-      handleCodeGenerationFailure(
-        MetricEvent.GOOGLE_BLOCKLY_GET_CODE_ERROR,
-        e as Error
-      );
+      if (retryCount < MAX_GET_CODE_RETRIES) {
+        setTimeout(() => {
+          return getWorkspaceCodeHelper(retryCount + 1, hiddenWorkspace);
+        }, RETRY_GET_CODE_INTERVAL_MS);
+      } else {
+        handleCodeGenerationFailure(
+          MetricEvent.GOOGLE_BLOCKLY_GET_CODE_ERROR,
+          e as Error
+        );
+      }
     }
     return workspaceCode;
   };


### PR DESCRIPTION
Since we've been logging google blockly code generation failures, we've theorized there is a set of errors that go away automatically after `getWorkspaceCode` is called again. We theorized this because we can't reproduce them and google blockly has event handlers that run after the workspace is set up that may not be complete by the time `getWorkspaceCode` is called.

In order to validate this theory and to hopefully clean up our logging to be real errors only, I updated `getWorkspaceCode` to retry getting code twice with a 500 ms interval between each retry. Only if all requests fail do we then log the error. I was able to validate that this fixes one known project that has a load failure until you press run or change anything. 

In the last week we saw 277 code generation errors. If this is successful this number should go down drastically.

## Testing story
Tested locally; in a normal case we never hit this code path. I also manually threw errors and confirmed only 2 retries occurred. In addition, I verified that the known failure case project is fixed by this issue. [slack thread](https://codedotorg.slack.com/archives/C05DK21DAHK/p1710351427916039)

## Follow-up work
After this is deployed and has been out for a day or so we should check if the error rate decreased, and then investigate the remaining errors.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
