### PR TITLE
CT-358: Restrict variable bubbles to the boundaries of the playspace

### DIFF
--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -24,11 +24,11 @@ export function getTextWidth(p5, text, size) {
 
 /**
  * Draws a bubble on the canvas that displays a piece of text, representing a variable name and value.
- * The bubble has a black background with a white border and white text.
- * The bubble is drawn with rounded corners. The text is horizontally and vertically centered within the bubble.
+ * The bubble is dynamically sized and has a black background with a white border/text and rounded corners.
+ * The x and y parameters determine the bubble's center, except the location will be adjusted if the bubble
+ * would overflow the canvas.
  *
- * The bubble's position is based on the x and y parameters which represent the center of the bubble.
- * The size of the bubble is dynamically calculated based on the width of the text and padding.
+ * Note: This function assumes the text provided fits within the playspace width (APP_WIDTH).
  *
  * @param {p5} p5 - The p5 instance used to draw the bubble.
  * @param {number} x - The x-coordinate of the center of the bubble.

--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -42,6 +42,26 @@ export function variableBubble(p5, x, y, text) {
   const textWidthValue = textWidth + 2 * padding;
   const textHeightValue = textSizeValue + 2 * padding;
 
+  const halfWidth = textWidthValue / 2;
+  const halfHeight = textHeightValue / 2;
+  const leftBound = x - halfWidth;
+  const rightBound = x + halfWidth;
+  const topBound = y - halfHeight;
+  const bottomBound = y + halfHeight;
+
+  // If the bubble is too close to the edge of the canvas, adjust the position so it fits.
+  if (leftBound < 0) {
+    x = halfWidth;
+  } else if (rightBound > APP_WIDTH) {
+    x = APP_WIDTH - halfWidth;
+  }
+
+  if (topBound < 0) {
+    y = halfHeight;
+  } else if (bottomBound > APP_HEIGHT) {
+    y = APP_HEIGHT - halfHeight;
+  }
+
   p5.push();
   p5.fill(colors.darkest_gray);
   p5.stroke('white');

--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -28,7 +28,7 @@ export function getTextWidth(p5, text, size) {
  * The x and y parameters determine the bubble's center, except the location will be adjusted if the bubble
  * would overflow the canvas.
  *
- * Note: This function assumes the text provided fits within the playspace width (APP_WIDTH).
+ * Note: Truncating the text so it fits within the playspace width (APP_WIDTH) should be handled before this function.
  *
  * @param {p5} p5 - The p5 instance used to draw the bubble.
  * @param {number} x - The x-coordinate of the center of the bubble.


### PR DESCRIPTION
Previous PRs have added "variable bubbles" to Sprite Lab. In the initial implementation, if a student places the center of the variable bubble close to the edges of the playspace, the bubble overflows and isn't fully visible.

This PR adjusts the bubble's x- and y-positions so it is always within the playspace's bounds. (See videos in "Testing story" below.)

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/CT-358

## Testing story

When the user drags to block to set its initial position:
https://github.com/code-dot-org/code-dot-org/assets/26844240/8bc75cb1-5b22-495f-99bb-35c5b610c59a

When the user changes the initial variable value:
https://github.com/code-dot-org/code-dot-org/assets/26844240/5ddddc3a-d5ed-4735-9588-23924645adb5

When the user changes the variable bubble inside the draw loop:
https://github.com/code-dot-org/code-dot-org/assets/26844240/5d3986be-4b82-41f4-aeba-8cbf5df366f8

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
