### PR TITLE
Removing afe banner, adding census banner, clarifying logic

### DIFF
--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -62,15 +62,15 @@ export const UnconnectedTeacherHomepage = ({
   /*
    * Determines whether the AFE banner will take premium space on the Teacher Homepage
    */
-  const shouldShowAFEBanner = true;
+  const shouldShowAFEBanner = false;
 
-  /* We are hiding the Census banner to free up space on the Teacher Homepage (November 2023)
-   * when we want to show the Census banner again remove the next line
+  /*
+   * Set to true to hide the census banner (Census banner live as of Mar 2024)
    */
-  const forceHideCensusBanner = true;
+  const forceHideCensusBanner = false;
 
   /* We are hiding the PL application banner to free up space on the Teacher Homepage (May 2023)
-   * when we want to show the Census banner again set this to true
+   * when we want to show the PL banner again set this to true
    */
   const showPLBanner = false;
 

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -139,22 +139,20 @@ describe('TeacherHomepage', () => {
   });
 
   /*
-    We have disabled the Census Teacher Banner on the Teacher Homepage (November 2023) to conserve
-    space. If we decide to show the banner again this test will need to be updated. See
-    TeacherHomepage.jsx to make the banner show.
+   * Update according to whether or not we are showing CensusBanner on TeacherHomepage
    */
-  it('does not render CensusTeacherBanner even if showCensusBanner is true', () => {
+  it('renders CensusTeacherBanner if showCensusBanner is true and forceHide is false', () => {
     const wrapper = setUp({showCensusBanner: true});
-    assert(!wrapper.find('CensusTeacherBanner').exists());
+    assert(wrapper.find('CensusTeacherBanner').exists());
   });
 
   /*
     This test will need to be updated according to whether the banner is showing,
     as determined by shouldShowAFEBanner in TeacherHomepage.jsx.
    */
-  it('renders a DonorTeacherBanner if afeEligible is true', () => {
+  it('renders a DonorTeacherBanner only if afeEligible is true and shouldShowAFEBanner', () => {
     const wrapper = setUp({afeEligible: true});
-    assert(wrapper.find('DonorTeacherBanner').exists());
+    assert(!wrapper.find('DonorTeacherBanner').exists());
   });
 
   it('renders a TeacherSections component', () => {


### PR DESCRIPTION
This is a combined update to the teacher homepage. It takes down the AFE banner and puts the census banner back up. I used logic found in https://github.com/code-dot-org/code-dot-org/pull/53621/files and https://github.com/code-dot-org/code-dot-org/pull/53612/files. I also tried to clean up some comments to make it a bit clearer around when tests are supposed to be updated (and fixed a typo on the PL line). 

Before (I logged into production/code.org so I could register with a school I knew would be AFE eligible):
<img width="1029" alt="Screenshot 2024-03-13 at 12 44 39 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/9522f1cb-b37f-418e-91c3-9824a2ce5938">

After (locally, with an existing teacher account I had):
<img width="1074" alt="Screenshot 2024-03-13 at 12 42 50 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/ba88a37d-5244-481b-a236-391f683530a4">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1569
- https://codedotorg.atlassian.net/browse/ACQ-1596

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
