### PR TITLE
[Sprite Lab] Criterion commands for new CSC module lesson 2

### DIFF
--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -260,6 +260,14 @@ export default class CoreLibrary {
     );
   }
 
+  getVariableBubbles() {
+    return this.variableBubbles;
+  }
+
+  getForegroundEffects() {
+    return this.foregroundEffects;
+  }
+
   addSpeechBubble(sprite, text, seconds = null, bubbleType = 'say') {
     // Sprites can only have one speech bubble at a time so first filter out
     // any existing speech bubbles for this sprite

--- a/apps/src/p5lab/spritelab/commands/criterionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/criterionCommands.js
@@ -618,6 +618,10 @@ export const commands = {
   // Optionally checks if the variable values have increased or decreased.
   // Since this command requires a variable bubble, it should be used in conjunction
   // with variableBubblesCreated.
+  // Example usage:
+  //   variableValueChanged(); // Checks if any watched variable changed.
+  //   variableValueChanged('increase'); // Checks if any watched variable increased.
+  //   variableValueChanged('decrease'); // Checks if any watched variable decreased.
   variableValueChanged(changeType = '') {
     const previousStudentVars = this.previous.variableBubbles;
     if (previousStudentVars) {
@@ -668,7 +672,7 @@ export const commands = {
         }
       }
     }
-    // If we reach this point, none of the watched variables changed
+    // If we reach this point, none of the watched variables changed in the specified way.
     return false;
   },
 };

--- a/apps/src/p5lab/spritelab/commands/criterionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/criterionCommands.js
@@ -583,9 +583,92 @@ export const commands = {
     return result;
   },
 
-  // Returns true if the student set a variable to any number, string, or boolean.
-  variableCreated() {
-    const result = this.studentVars.length >= 1;
-    return result;
+  // Returns true if a minimum number of foreground effects are currently active.
+  // Disregards their initial render frame.
+  foregroundEffectsActive(min = 1) {
+    return this.getForegroundEffects().length >= min;
+  },
+
+  // Returns true if a minimum number of foreground effects were first rendered
+  // this frame (e.g. using an event block)
+  foregroundEffectRenderedThisFrame(min = 1) {
+    const effects = this.getForegroundEffects();
+    const newEffects = effects.filter(
+      effect => effect.renderFrame === this.currentFrame()
+    );
+    return newEffects.length >= min;
+  },
+
+  // Returns true if a minimum number of variable bubbles are currently being drawn.
+  variableBubblesCreated(min = 1) {
+    return this.getVariableBubbles().length >= min;
+  },
+
+  // Returns true if a minimum number of watched variables have a valid value.
+  // If unset, a variable's value is an empty string.
+  variableValueSet(min = 1) {
+    const studentVars = this.getVariableBubbles();
+    const filteredVars = studentVars.filter(
+      studentVar => this.getVariableValue(studentVar.name) !== ''
+    );
+    return filteredVars.length >= min;
+  },
+
+  // Returns true if a watched variable's value changed this frame.
+  // Optionally checks if the variable values have increased or decreased.
+  // Since this command requires a variable bubble, it should be used in conjunction
+  // with variableBubblesCreated.
+  variableValueChanged(changeType = '') {
+    const previousStudentVars = this.previous.variableBubbles;
+    if (previousStudentVars) {
+      const studentVars = this.getVariableBubbles();
+      for (const studentVar of studentVars) {
+        // Find a variable with the same name in the previous student variables
+        const matchingPreviousVar = previousStudentVars.find(
+          previousVar => previousVar.name === studentVar.name
+        );
+
+        // If the variable existed, compare its value with the value of the current student variable
+        if (matchingPreviousVar) {
+          const previousValue = matchingPreviousVar.value;
+          const currentValue = this.getVariableValue(studentVar.name);
+
+          // Compare the values
+          if (previousValue !== currentValue) {
+            switch (changeType) {
+              case '':
+                // If we're not explicitly looking for an increase or decrease,
+                // any change to the value satisfies this criterion.
+                return true;
+              case 'decrease':
+                if (
+                  typeof previousValue === 'number' &&
+                  typeof currentValue === 'number' &&
+                  currentValue < previousValue
+                ) {
+                  return true;
+                }
+                break;
+              case 'increase':
+                if (
+                  typeof previousValue === 'number' &&
+                  typeof currentValue === 'number' &&
+                  currentValue > previousValue
+                ) {
+                  return true;
+                }
+                break;
+              default:
+                console.error(
+                  `Invalid argument for variableValueChanged: ${changeType}`
+                );
+                break;
+            }
+          }
+        }
+      }
+    }
+    // If we reach this point, none of the watched variables changed
+    return false;
   },
 };

--- a/apps/src/p5lab/spritelab/commands/effectCommands.js
+++ b/apps/src/p5lab/spritelab/commands/effectCommands.js
@@ -26,6 +26,7 @@ export const commands = {
         this.foregroundEffects.push({
           id,
           name: effectName,
+          renderFrame: this.currentFrame(),
           func: () => {
             this.p5.push();
             this.p5.stroke(
@@ -67,6 +68,7 @@ export const commands = {
         this.foregroundEffects.push({
           id,
           name: effectName,
+          renderFrame: this.currentFrame(),
           func: () => {
             this.p5.push();
             this.p5.noStroke();
@@ -107,6 +109,7 @@ export const commands = {
         this.foregroundEffects.push({
           id,
           name: effectName,
+          renderFrame: this.currentFrame(),
           func: () => {
             hearts.forEach(heart => {
               this.p5.push();
@@ -164,6 +167,7 @@ export const commands = {
         this.foregroundEffects.push({
           id,
           name: effectName,
+          renderFrame: this.currentFrame(),
           func: () => {
             emojis.forEach(emoji => {
               emoji.y += this.p5.pow(emoji.size, 0.25);
@@ -205,6 +209,7 @@ export const commands = {
         this.foregroundEffects.push({
           id,
           name: effectName,
+          renderFrame: this.currentFrame(),
           func: () => {
             this.p5.push();
             this.p5.noStroke();
@@ -250,6 +255,7 @@ export const commands = {
         this.foregroundEffects.push({
           id,
           name: effectName,
+          renderFrame: this.currentFrame(),
           func: () => {
             this.p5.push();
             this.p5.noStroke();
@@ -313,6 +319,7 @@ export const commands = {
         this.foregroundEffects.push({
           id,
           name: effectName,
+          renderFrame: this.currentFrame(),
           func: () => {
             this.p5.push();
             this.p5.noStroke();
@@ -357,6 +364,7 @@ export const commands = {
         this.foregroundEffects.push({
           id,
           name: effectName,
+          renderFrame: this.currentFrame(),
           func: () => {
             this.p5.push();
             this.p5.noStroke();

--- a/apps/src/p5lab/spritelab/commands/validationCommands.js
+++ b/apps/src/p5lab/spritelab/commands/validationCommands.js
@@ -222,9 +222,11 @@ export const commands = {
     this.previous.eventLogLength = this.eventLog.length;
     this.previous.printLogLength = this.printLog.length || 0;
     this.previous.soundLogLength = this.soundLog.length || 0;
+    this.previous.foregroundEffectsLength = this.foregroundEffects.length || 0;
+
+    // Store basic information about sprites.
     this.previous.sprites = [];
-    for (let i = 0; i < spriteIds.length; i++) {
-      let spriteId = spriteIds[i];
+    spriteIds.forEach(spriteId => {
       this.previous.sprites.push({
         id: spriteId,
         costume: this.nativeSpriteMap[spriteId].getAnimationLabel(),
@@ -236,7 +238,19 @@ export const commands = {
         speed: this.nativeSpriteMap[spriteId].speed,
         rotation: this.nativeSpriteMap[spriteId].rotation,
       });
-    }
+    });
+
+    // Store basic information about watched variables.
+    this.previous.variableBubbles = [];
+    const variableBubbles = this.getVariableBubbles();
+    variableBubbles.forEach(variableBubble => {
+      this.previous.variableBubbles.push({
+        ...variableBubble,
+        // Run the variable name through the JS interpreter to get its value.
+        // We need to store the previous value to validate changes between frames.
+        value: this.getVariableValue(variableBubble.name),
+      });
+    });
   },
 
   // If the student has not completed any criteria, they are "failing".


### PR DESCRIPTION
The CSC Game Development module's second lesson is ready for validation. To support this, we need to add new commands related to foreground effects and variables. This work also required:
* adding the initial render frame to an effects object (so that we could validate that an effect started in conjunction with an event)
* updating our "previous" state to track variable bubbles and their values. We need this information so that we have an efficient way to identify student variables of interest and to check for changed values.



## Links

Validation Notes Doc: https://docs.google.com/document/d/175wWAuwkDDBDxG31Ed57E7bo5gzACGQ9ZcAHSgk54Xs/edit
Jira (lessons 1-2): https://codedotorg.atlassian.net/browse/CT-405
Jira (variable bubbles): https://codedotorg.atlassian.net/browse/CT-407
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I tested this by adding temporary validation to several levels in Katie's progression according to the document above. I tested that level success or failure feedback was triggered as expected.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
