### PR TITLE
FIX #57007 and correctly define ASG tags

### DIFF
--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -140,6 +140,13 @@ frontend_device_name ||= '/dev/sda1'
       <%=indent(add_properties(frontend_properties), 6)%>
       MetricsCollection:
         - Granularity: 1Minute
+      Tags:
+        - Key: "Name"
+          Value: !Sub "Frontend-${AWS::StackName}"
+          PropagateAtLaunch: true
+        - Key: "environment"
+          Value: <%=environment%>
+          PropagateAtLaunch: true
   FrontendLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     DependsOn: FastSnapshotRestore
@@ -149,13 +156,6 @@ frontend_device_name ||= '/dev/sda1'
       IamInstanceProfile: !Ref FrontendInstanceProfile
       SecurityGroups: [!ImportValue VPC-FrontendSecurityGroup]
       KeyName: <%=ssh_key_name%>
-      Tags:
-        - Key: "Name"
-          Value: !Sub "Frontend-${AWS::StackName}"
-          PropagateAtLaunch: true
-        - Key: "environment"
-          Value: <%=environment%>
-          PropagateAtLaunch: true
       BlockDeviceMappings:
         - DeviceName: <%=frontend_device_name%>
           Ebs:


### PR DESCRIPTION
Fixes an error I missed in #57007 which failed when we attempted to deploy to production ([Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1710368205018879?thread_ts=1710366040.921109&cid=C0T0PNTM3))

"Tags" is a property of [AutoScalingGroup](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-autoscaling-autoscalinggroup.html#cfn-autoscaling-autoscalinggroup-tags), not of LaunchConfiguration

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
