### PR TITLE
Music: Separate dark mode

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -11,6 +11,8 @@ import {
   stringIsXml,
   Themes,
   ToolboxType,
+  BLOCKLY_THEME,
+  BLOCKLY_THEME_DEFAULT_DARK_MODE,
 } from '../constants';
 import {
   appendProceduresToState,
@@ -297,11 +299,16 @@ export function getField(type: string) {
  * @returns {?Blockly.Field}
  */
 // Users can change their active theme using the context menu. Use this setting, if present.
-export function getUserTheme(themeOption: string | undefined) {
+export function getUserTheme(
+  themeOption: string | undefined,
+  isDefaultDarkMode: boolean = false
+) {
+  const keyName = isDefaultDarkMode
+    ? BLOCKLY_THEME_DEFAULT_DARK_MODE
+    : BLOCKLY_THEME;
+
   return (
-    Blockly.themes[localStorage.blocklyTheme as Themes] ||
-    themeOption ||
-    cdoTheme
+    Blockly.themes[localStorage[keyName] as Themes] || themeOption || cdoTheme
   );
 }
 

--- a/apps/src/blockly/addons/contextMenu.ts
+++ b/apps/src/blockly/addons/contextMenu.ts
@@ -14,6 +14,7 @@ import {
   MenuOptionStates,
   BLOCKLY_CURSOR,
   BLOCKLY_THEME,
+  BLOCKLY_THEME_DEFAULT_DARK_MODE,
   NAVIGATION_CURSOR_TYPES,
 } from '../constants';
 import LegacyDialog from '../../code-studio/LegacyDialog';
@@ -245,7 +246,10 @@ const registerDarkMode = function (weight: number) {
       const themeName =
         baseName(currentTheme.name as Themes) +
         (isDarkTheme(scope.workspace) ? '' : dark);
-      localStorage.setItem(BLOCKLY_THEME, themeName);
+      const keyName = Blockly.isDefaultDarkMode
+        ? BLOCKLY_THEME_DEFAULT_DARK_MODE
+        : BLOCKLY_THEME;
+      localStorage.setItem(keyName, themeName);
       setAllWorkspacesTheme(Blockly.themes[themeName as Themes], currentTheme);
     },
     scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.WORKSPACE,
@@ -299,7 +303,10 @@ const registerTheme = function (name: Themes, label: string, weight: number) {
     callback: function (scope: ContextMenuRegistry.Scope) {
       const currentTheme = scope.workspace?.getTheme();
       const themeName = name + (isDarkTheme(scope.workspace) ? dark : '');
-      localStorage.setItem(BLOCKLY_THEME, themeName);
+      const keyName = Blockly.isDefaultDarkMode
+        ? BLOCKLY_THEME_DEFAULT_DARK_MODE
+        : BLOCKLY_THEME;
+      localStorage.setItem(keyName, themeName);
       setAllWorkspacesTheme(Blockly.themes[themeName as Themes], currentTheme);
     },
     scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.WORKSPACE,

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -8,6 +8,7 @@ export enum BlocklyVersion {
 
 export const ToolboxType = makeEnum('CATEGORIZED', 'UNCATEGORIZED', 'NONE');
 export const BLOCKLY_THEME = 'blocklyTheme';
+export const BLOCKLY_THEME_DEFAULT_DARK_MODE = 'blocklyThemeDefaultDarkMode';
 export const BLOCKLY_CURSOR = 'blocklyCursor';
 export const MenuOptionStates = {
   ENABLED: 'enabled',

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -674,7 +674,10 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     const optOptionsExtended = opt_options as ExtendedBlocklyOptions;
     const options = {
       ...optOptionsExtended,
-      theme: cdoUtils.getUserTheme(optOptionsExtended.theme as string),
+      theme: cdoUtils.getUserTheme(
+        optOptionsExtended.theme as string,
+        optOptionsExtended.isDefaultDarkMode
+      ),
       trashcan: false, // Don't use default trashcan.
       move: {
         wheel: true,
@@ -715,6 +718,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       ).style.height = `calc(100% - ${styleConstants['workspace-headers-height']}px)`;
     }
     blocklyWrapper.isStartMode = !!optOptionsExtended.editBlocks;
+    blocklyWrapper.isDefaultDarkMode = !!optOptionsExtended.isDefaultDarkMode;
     blocklyWrapper.isToolboxMode =
       optOptionsExtended.editBlocks === 'toolbox_blocks';
     blocklyWrapper.toolboxBlocks = options.toolbox;

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -91,6 +91,7 @@ export interface BlocklyWrapperType extends GoogleBlocklyType {
   assetUrl: (path: string) => string;
   customSimpleDialog: (config: object) => void;
   levelBlockIds: string[];
+  isDefaultDarkMode: boolean;
   isStartMode: boolean;
   isToolboxMode: boolean;
   toolboxBlocks: ToolboxDefinition | undefined;
@@ -208,6 +209,7 @@ export interface ExtendedBlocklyOptions extends BlocklyOptions {
   customSimpleDialog: (config: object) => void;
   levelBlockIds: string[];
   isBlockEditMode: boolean;
+  isDefaultDarkMode: boolean;
   editBlocks: string | undefined;
   noFunctionBlockFrame: boolean;
   useModalFunctionEditor: boolean;

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -82,6 +82,7 @@ export default class MusicBlocklyWorkspace {
       },
       readOnly: isReadOnlyWorkspace,
       useBlocklyDynamicCategories: true,
+      isDefaultDarkMode: true,
     } as BlocklyOptions);
 
     this.resizeBlockly();


### PR DESCRIPTION
Currently, when dark mode is either turned on or off using the Blockly context menu, there's no way to return to the "initial state" in which Music Lab (our first lab to have a default of dark mode) has a dark mode Blockly area while all other labs have a non-dark mode Blockly area, short of deleting a local storage object.

This issue is tracked [here](https://codedotorg.atlassian.net/browse/CT-327), and apparently a potential long-term fix is to implement a different menu which allows the selection of dark mode to be "on", "off", or "default", the latter of which would allow for returning to the "initial state" described above.

This PR proposes an interim solution, in which labs which have a default of dark mode (currently only Music Lab) have their theme tracked in a separate local storage object.  
