### PR TITLE
Music: sound selection UI tweaks

### DIFF
--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -25,6 +25,7 @@ class FieldSounds extends GoogleBlockly.Field {
     this.CURSOR = 'default';
     this.backgroundElement = null;
     this.currentFieldWidth = 0;
+    this.showingEditor = false;
   }
 
   saveState() {
@@ -69,6 +70,10 @@ class FieldSounds extends GoogleBlockly.Field {
   }
 
   showEditor_() {
+    if (this.showingEditor) {
+      return;
+    }
+
     super.showEditor_();
 
     const editor = this.dropdownCreate_();
@@ -83,6 +88,8 @@ class FieldSounds extends GoogleBlockly.Field {
       this,
       this.dropdownDispose_.bind(this)
     );
+
+    this.showingEditor = true;
   }
 
   dropdownCreate_() {
@@ -136,6 +143,7 @@ class FieldSounds extends GoogleBlockly.Field {
 
   dropdownDispose_() {
     this.newDiv_ = null;
+    this.showingEditor = false;
   }
 
   hide_() {

--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -94,7 +94,6 @@ class FieldSounds extends GoogleBlockly.Field {
     this.newDiv_.style.width = '600px';
     this.newDiv_.style.backgroundColor = color.dark_black;
     this.newDiv_.style.padding = '5px';
-    this.newDiv_.style.cursor = 'pointer';
 
     return this.newDiv_;
   }

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -83,6 +83,28 @@ export default class MusicLibrary {
     return this.folders.find(folder => folder.id === folderId) || null;
   }
 
+  // Given a folderType and a sound ID (e.g. "pack1/sound1"), return only an
+  // allowed SoundFolder containing the allowed sounds.
+  getAllowedFolderForSoundId(
+    folderType: string | undefined,
+    id: string
+  ): SoundFolder | null {
+    const lastSlashIndex = id.lastIndexOf('/');
+    const folderId = id.substring(0, lastSlashIndex);
+
+    return this.getAllowedFolderForFolderId(folderType, folderId);
+  }
+
+  // Given a folderType and a folder ID (e.g. "pack1"), return only an
+  // allowed SoundFolder containing the allowed sounds.
+  getAllowedFolderForFolderId(
+    folderType: string | undefined,
+    folderId: string
+  ): SoundFolder | null {
+    const folders = this.getAllowedSounds(folderType);
+    return folders.find(folder => folder.id === folderId) || null;
+  }
+
   // A progression step might specify a smaller set of allowed sounds.
   setAllowedSounds(allowedSounds: Sounds): void {
     this.allowedSounds = allowedSounds;

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -222,7 +222,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
   const libraryGroupPath = library.libraryJson.path;
 
   const [selectedFolder, setSelectedFolder] = useState<SoundFolder>(
-    library.getFolderForSoundId(currentValue) || folders[0]
+    folders.find(folder => folder.id === currentValue) || folders[0]
   );
   const [mode, setMode] = useState<Mode>('packs');
   const [filter, setFilter] = useState<Filter>('all');

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -304,7 +304,6 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
                 {label: 'Bass', value: 'bass'},
                 {label: 'Leads', value: 'lead'},
                 {label: 'Effects', value: 'fx'},
-                {label: 'Vocals', value: 'vocal'},
               ]}
               onChange={value => onFilterChange(value as Filter)}
               className={styles.segmentedButtons}

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -80,7 +80,6 @@ const FolderPanelRow: React.FunctionComponent<FolderPanelRowProps> = ({
       onClick={() => onSelect(folder)}
       onKeyDown={event => {
         if (event.key === 'Enter') {
-          event.nativeEvent.stopImmediatePropagation();
           onSelect(folder);
         }
       }}
@@ -165,7 +164,6 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
       onClick={() => onSelect(folder.id + '/' + sound.src)}
       onKeyDown={event => {
         if (event.key === 'Enter') {
-          event.nativeEvent.stopImmediatePropagation();
           onSelect(folder.id + '/' + sound.src);
         }
       }}

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -80,6 +80,7 @@ const FolderPanelRow: React.FunctionComponent<FolderPanelRowProps> = ({
       onClick={() => onSelect(folder)}
       onKeyDown={event => {
         if (event.key === 'Enter') {
+          event.nativeEvent.stopImmediatePropagation();
           onSelect(folder);
         }
       }}
@@ -164,6 +165,7 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
       onClick={() => onSelect(folder.id + '/' + sound.src)}
       onKeyDown={event => {
         if (event.key === 'Enter') {
+          event.nativeEvent.stopImmediatePropagation();
           onSelect(folder.id + '/' + sound.src);
         }
       }}

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -220,7 +220,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
   const libraryGroupPath = library.libraryJson.path;
 
   const [selectedFolder, setSelectedFolder] = useState<SoundFolder>(
-    folders.find(folder => folder.id === currentValue) || folders[0]
+    library.getAllowedFolderForSoundId(undefined, currentValue) || folders[0]
   );
   const [mode, setMode] = useState<Mode>('packs');
   const [filter, setFilter] = useState<Filter>('all');

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -44,6 +44,7 @@
     padding: 6px 0;
     margin: 1px 1px 6px 1px;
     overflow: hidden;
+    cursor: pointer;
 
     &:hover {
       background-color: $neutral_dark90;
@@ -100,6 +101,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    cursor: pointer;
 
     &:hover {
       background-color: $neutral_dark90;

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -24,6 +24,7 @@
     display: flex;
     flex-direction: row;
     overflow: hidden;
+    flex: 1;
     gap: 5px;
 
     .leftColumn {


### PR DESCRIPTION
Three tweaks to the sound selection UI:

- When using Blockly's keyboard navigation, pressing Enter on the `play sound` field would open the sound selection UI, but pressing Enter again would trigger an additional open.  It would be ideal if Blockly didn't try to handle additional Enter presses while we are in this UI, but in lieu of that, we now explicitly prevent additional opens.
- Fixes a bug in which the initial display of the sound selection UI would show all sounds in a folder, rather than the optional subset specified in level data.
- The cursor no longer shows as a pointer for the entire UI, but only on clickable elements.  
- Remove "vocals" filter option for now.

