### PR TITLE
Datablock Storage: index tables by project_id

### DIFF
--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -247,10 +247,7 @@ class DatablockStorageController < ApplicationController
   end
 
   # Deletes all datablock storage data for the project
-  # used in applab.js by `config.afterClearPuzzle()`
   def clear_all_data
-    # TODO: do we need an index on project_id alone for performance of this method?
-    # See: https://github.com/code-dot-org/code-dot-org/issues/57259
     DatablockStorageTable.where(project_id: @project_id).delete_all
     DatablockStorageKvp.where(project_id: @project_id).delete_all
     DatablockStorageRecord.where(project_id: @project_id).delete_all

--- a/dashboard/app/models/datablock_storage_kvp.rb
+++ b/dashboard/app/models/datablock_storage_kvp.rb
@@ -6,6 +6,10 @@
 #  key        :string(700)      not null, primary key
 #  value      :json
 #
+# Indexes
+#
+#  index_datablock_storage_kvps_on_project_id  (project_id)
+#
 class DatablockStorageKvp < ApplicationRecord
   self.primary_keys = :project_id, :key
 

--- a/dashboard/app/models/datablock_storage_record.rb
+++ b/dashboard/app/models/datablock_storage_record.rb
@@ -9,6 +9,7 @@
 #
 # Indexes
 #
+#  index_datablock_storage_records_on_project_id                 (project_id)
 #  index_datablock_storage_records_on_project_id_and_table_name  (project_id,table_name)
 #
 class DatablockStorageRecord < ApplicationRecord

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -9,6 +9,10 @@
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #
+# Indexes
+#
+#  index_datablock_storage_tables_on_project_id  (project_id)
+#
 class DatablockStorageTable < ApplicationRecord
   self.primary_keys = :project_id, :table_name
   has_many :records,

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -69,26 +69,6 @@ class DatablockStorageTable < ApplicationRecord
     end
   end
 
-  # This would require MySQL option MULTI_STATEMENTS set on the connection, which
-  # has lots of pitfalls and isn't particularly well supported with the mysql2 gem
-  # See: https://github.com/rails/rails/issues/31569
-  #
-  # def create_record_one_round_trip
-  #   channel_id_quoted = Record.connection.quote(params[:channel_id])
-  #   table_name_quoted = Record.connection.quote(params[:table_name])
-  #   json_quoted  = Record.connection.quote JSON.parse params[:json]
-  #   record_json = Record.find_by_sql(<<-SQL
-  #     BEGIN;
-  #       SELECT MIN(record_id) FROM #{Record.table_name} WHERE channel_id=#{channel_id_quoted} AND table_name=#{table_name_quoted} LIMIT 1 FOR UPDATE;
-  #       SELECT @id := IFNULL(MAX(record_id),0)+1 FROM #{Record.table_name} WHERE channel_id=#{channel_id_quoted} AND table_name=#{table_name_quoted};
-  #       INSERT INTO #{Record.table_name} VALUES (#{channel_id_quoted}, #{table_name_quoted}, @id, #{json_quoted}});
-  #     END;
-  #     SELECT * FROM #{Record.table_name} WHERE channel_id=#{channel_id_quoted} AND table_name=#{table_name_quoted} AND record_id=@id;
-  #   SQL)
-
-  #   render json: record_json
-  # end
-
   def read_records
     is_shared_table ? shared_table.records : records
   end
@@ -96,21 +76,9 @@ class DatablockStorageTable < ApplicationRecord
   def create_records(record_jsons)
     if_shared_table_copy_on_write
 
-    # BEGIN;
     DatablockStorageRecord.transaction do
-      # channel_id_quoted = Record.connection.quote(params[:channel_id])
-      # table_name_quoted = Record.connection.quote(params[:table_name])
-
-      # SELECT MIN(record_id) FROM unfirebase.records WHERE channel_id='shared' AND table_name='words' LIMIT 1 FOR UPDATE;
-      # =>
-      # DatablockStorageRecord.connection.execute("SELECT MIN(record_id) FROM #{Record.table_name} WHERE channel_id=#{channel_id_quoted} AND table_name=#{table_name_quoted} LIMIT 1 FOR UPDATE")
-      # =>
       DatablockStorageRecord.where(project_id: project_id, table_name: table_name).lock.minimum(:record_id)
 
-      # SELECT @id := IFNULL(MAX(record_id),0)+1 FROM unfirebase.records WHERE channel_id='shared' AND table_name='words';
-      # =>
-      # next_record_id = DatablockStorageRecord.connection.select_value("SELECT IFNULL(MAX(record_id),0)+1 FROM #{Record.table_name} WHERE channel_id=#{channel_id_quoted} AND table_name=#{table_name_quoted}")
-      # =>
       max_record_id = DatablockStorageRecord.where(project_id: project_id, table_name: table_name).maximum(:record_id)
       next_record_id = (max_record_id || 0) + 1
 
@@ -124,7 +92,6 @@ class DatablockStorageTable < ApplicationRecord
         # only create_record and update_record should be at risk of modifying this
         record_json['id'] = next_record_id
 
-        #   INSERT INTO unfirebase.records VALUES ('shared', 'words', @id, '{}');
         DatablockStorageRecord.create(project_id: project_id, table_name: table_name, record_id: next_record_id, record_json: record_json)
 
         cols_in_records.merge(record_json.keys)
@@ -135,7 +102,6 @@ class DatablockStorageTable < ApplicationRecord
       self.columns += (cols_in_records - columns).to_a
       save!
     end
-    # COMMIT;
   end
 
   def update_record(record_id, record_json)

--- a/dashboard/db/migrate/20240110234501_create_datablock_storage_kvps.rb
+++ b/dashboard/db/migrate/20240110234501_create_datablock_storage_kvps.rb
@@ -9,5 +9,7 @@ class CreateDatablockStorageKvps < ActiveRecord::Migration[6.1]
       t.string :key, limit: 700
       t.json :value
     end
+
+    add_index :datablock_storage_kvps, :project_id
   end
 end

--- a/dashboard/db/migrate/20240111002910_create_datablock_storage_records.rb
+++ b/dashboard/db/migrate/20240111002910_create_datablock_storage_records.rb
@@ -9,6 +9,8 @@ class CreateDatablockStorageRecords < ActiveRecord::Migration[6.1]
       t.integer :record_id
       t.json :record_json
     end
+
+    add_index :datablock_storage_records, :project_id
     add_index :datablock_storage_records, [:project_id, :table_name]
   end
 end

--- a/dashboard/db/migrate/20240111003957_create_datablock_storage_tables.rb
+++ b/dashboard/db/migrate/20240111003957_create_datablock_storage_tables.rb
@@ -10,5 +10,7 @@ class CreateDatablockStorageTables < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
+
+    add_index :datablock_storage_tables, :project_id
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -439,6 +439,7 @@ ActiveRecord::Schema.define(version: 2024_03_08_234208) do
     t.integer "project_id", null: false
     t.string "key", limit: 700, null: false
     t.json "value"
+    t.index ["project_id"], name: "index_datablock_storage_kvps_on_project_id"
   end
 
   create_table "datablock_storage_library_manifest", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
@@ -455,6 +456,7 @@ ActiveRecord::Schema.define(version: 2024_03_08_234208) do
     t.integer "record_id", null: false
     t.json "record_json"
     t.index ["project_id", "table_name"], name: "index_datablock_storage_records_on_project_id_and_table_name"
+    t.index ["project_id"], name: "index_datablock_storage_records_on_project_id"
   end
 
   create_table "datablock_storage_tables", primary_key: ["project_id", "table_name"], charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
@@ -464,6 +466,7 @@ ActiveRecord::Schema.define(version: 2024_03_08_234208) do
     t.string "is_shared_table", limit: 700
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["project_id"], name: "index_datablock_storage_tables_on_project_id"
   end
 
   create_table "delayed_jobs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
In a few cases we do a `.where(project_id: project_id)` query:
1. DatablockStorageController.get_table_names
2. DatablockStorageController.get_kvps
3. DatablockStorageController.clear_all_data

Right now this query is unindexed, which will get very expensive given the size of table we expect.

Fixes https://github.com/code-dot-org/code-dot-org/issues/57259