### PR TITLE
removed ai-rubrics-redesign from experiments

### DIFF
--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -48,8 +48,6 @@ experiments.GENDER_FEATURE_ENABLED = 'gender';
 experiments.CPA_EXPERIENCE = 'cpa_experience';
 experiments.AI_RUBRICS = 'ai-rubrics';
 experiments.NON_AI_RUBRICS = 'non-ai-rubrics';
-//Experiment for AI Rubrics redesign
-experiments.AI_RUBRICS_REDESIGN = 'ai-rubrics-redesign';
 // Experiment for showing the toggle a teacher can use to turn on AI Tutor for their section
 experiments.AI_TUTOR_ACCESS = 'ai-tutor';
 // Uses Google Blockly for a given user across labs/levels until the experiment is disabled

--- a/apps/test/unit/templates/rubrics/EvidenceLevelsTest.jsx
+++ b/apps/test/unit/templates/rubrics/EvidenceLevelsTest.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {expect} from '../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
 import EvidenceLevels from '@cdo/apps/templates/rubrics/EvidenceLevels';
-import experiments from '@cdo/apps/util/experiments';
 
 const DEFAULT_PROPS = {
   evidenceLevels: [
@@ -33,7 +32,6 @@ describe('EvidenceLevels', () => {
   });
 
   it('renders teachers view of evidence levels when the user can provide feedback', () => {
-    experiments.setEnabled('ai-rubrics-redesign', true);
     const wrapper = shallow(
       <EvidenceLevels {...DEFAULT_PROPS} canProvideFeedback={true} />
     );
@@ -41,7 +39,6 @@ describe('EvidenceLevels', () => {
     expect(
       wrapper.find('EvidenceLevelsForTeachersV2').props().canProvideFeedback
     ).to.equal(true);
-    experiments.setEnabled('ai-rubrics-redesign', false);
   });
 
   it('renders student view of evidence levels when student is viewing the rubric', () => {

--- a/apps/test/unit/templates/rubrics/RubricContentTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContentTest.jsx
@@ -4,7 +4,6 @@ import {mount, shallow} from 'enzyme';
 import sinon from 'sinon';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import RubricContent from '@cdo/apps/templates/rubrics/RubricContent';
-import experiments from '@cdo/apps/util/experiments';
 import {
   getStore,
   registerReducers,
@@ -95,7 +94,6 @@ describe('RubricContent', () => {
   });
 
   it('displays Student and Section selectors', () => {
-    experiments.setEnabled('ai-rubrics-redesign', true);
     const wrapper = mount(
       <Provider store={store}>
         <RubricContent {...defaultProps} />
@@ -103,7 +101,6 @@ describe('RubricContent', () => {
     );
     expect(wrapper.find('SectionSelector').length).to.equal(1);
     expect(wrapper.find('StudentSelector').length).to.equal(1);
-    experiments.setEnabled('ai-rubrics-redesign', false);
   });
 
   it('shows learning goals with correct props when viewing student work on non assessment level', () => {


### PR DESCRIPTION
Removed dead code left over after the AI rubric redesign. This includes:
- The ai-rubrics-redesign experiment flag
- References to the experiment flag in unit tests.

### Follow Up Work
[AITT-528](https://codedotorg.atlassian.net/browse/AITT-528) - The LearningGoal component includes dead code related to the teacher view of the rubric. Currently, only students see this component, so all code related to the teacher view needs to be removed. Because this will require detangling and potentially rebuilding parts of this component, it's being spun off into a separate task