### PR TITLE
Script to fix missing reference guides for CSD-2024

### DIFF
--- a/bin/oneoff/data_fix/missing_reference_guides.rb
+++ b/bin/oneoff/data_fix/missing_reference_guides.rb
@@ -1,12 +1,10 @@
 #!/usr/bin/env ruby
 
-# Link to reference guides for csd-2023 and csd-2024 don't work
-# The underlying root cause is that the clone for csd-2023 missed
-# some set of standard steps resulting in missing links, reference
-# guides being one of them. csd-2024 was cloned off of that resulting
-# in the same issue.
-# This script clones reference guides and links them to the appropriate
-# courses.
+# https://codedotorg.atlassian.net/browse/TEACH-840
+# CSD-2023 and CSD-2024 don't have any reference guides linked to them
+# because of an issue in the way these units were originally cloned.
+# This script clones the reference guides which were missed and links
+#  them to the appropriate courses.
 
 require_relative '../../../dashboard/config/environment'
 
@@ -14,14 +12,13 @@ def data_fix_reference_guides
   raise unless Rails.application.config.levelbuilder_mode
 
   # List of course versions to be fixed
-  course_versions_to_fix = ['csd-2023', 'csd-2024']
+  course_version_to_fix = CurriculumHelper.find_matching_course_version('csd-2024')
+
+  # Source course version with the correct set of reference guides
   source_course_version = CurriculumHelper.find_matching_course_version('csd-2022')
 
-  course_versions_to_fix.each do |course|
-    destination_course_version = CurriculumHelper.find_matching_course_version(course)
-    source_course_version&.reference_guides&.each do |reference_guide|
-      reference_guide.copy_to_course_version(destination_course_version)
-    end
+  source_course_version&.reference_guides&.each do |reference_guide|
+    reference_guide.copy_to_course_version(course_version_to_fix)
   end
 end
 

--- a/bin/oneoff/data_fix/missing_reference_guides.rb
+++ b/bin/oneoff/data_fix/missing_reference_guides.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+# Link to reference guides for csd-2023 and csd-2024 don't work
+# The underlying root cause is that the clone for csd-2023 missed
+# some set of standard steps resulting in missing links, reference
+# guides being one of them. csd-2024 was cloned off of that resulting
+# in the same issue.
+# This script clones reference guides and links them to the appropriate
+# courses.
+
+require_relative '../../../dashboard/config/environment'
+
+def data_fix_reference_guides
+  raise unless Rails.application.config.levelbuilder_mode
+
+  # List of course versions to be fixed
+  course_versions_to_fix = ['csd-2023', 'csd-2024']
+  source_course_version = CurriculumHelper.find_matching_course_version('csd-2022')
+
+  course_versions_to_fix.each do |course|
+    destination_course_version = CurriculumHelper.find_matching_course_version(course)
+    source_course_version&.reference_guides&.each do |reference_guide|
+      reference_guide.copy_to_course_version(destination_course_version)
+    end
+  end
+end
+
+data_fix_reference_guides


### PR DESCRIPTION
Issue:
Links to reference guides for CSD-2024 (https://levelbuilder-studio.code.org/courses/csd-2024/guides/) are broken.

Root cause:
The page looks for a set of reference guides that are associated with the course and results in an exception when there are no reference guides present. CSD 2023 and 2024 are expected to have reference guides, but these were incorrectly cloned from CSD-2022, which resulted in the reference guides being missing.

Fix:
This change adds an one off data fix script which will be executed on the level builder machine to clone reference guides from CSD-2022 to make a copy for 2024. We are actively not fixing 2023 because the student facing reference guides point to 2022 and having a 2023 version could cause confusion if curriculum writers edit them and students don't see the updates.

## Links

JIRA https://codedotorg.atlassian.net/browse/TEACH-840

## Testing story

Validated by executing the script locally and testing that the reference guides link for CSD 2024 work as expected.

## Deployment strategy

Script will be deployed to level builder as part of regular DTP.

## Follow-up work

Executing the script on level builder once deployed. Will use the same JIRA task to track.

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
