### PR TITLE
skip ai eval ui tests in firefox and add more debug info

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -57,6 +57,7 @@ Feature: Evaluate student code against rubrics using AI
 
   Scenario: Student code is evaluated by AI when teacher requests individual evaluation
     Given I create a teacher-associated student named "Aiden"
+    And I get debug info for the current user
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
     And I add the current user to the "ai-rubrics" single user experiment
@@ -72,6 +73,7 @@ Feature: Evaluate student code against rubrics using AI
 
     # Teacher views student progress and floating action button
     When I sign in as "Teacher_Aiden"
+    And I get debug info for the current user
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
@@ -104,6 +106,7 @@ Feature: Evaluate student code against rubrics using AI
 
   Scenario: Student code is evaluated by AI when teacher requests evaluation for entire class
     Given I create a teacher-associated student named "Aiden"
+    And I get debug info for the current user
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
     And I add the current user to the "ai-rubrics" single user experiment
@@ -122,6 +125,7 @@ Feature: Evaluate student code against rubrics using AI
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
+    And I get debug info for the current user
     And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the page to fully load

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -1,4 +1,5 @@
 # AI evaluation is stubbed out in UI tests via the /api/test/ai_proxy/assessment route.
+@no_firefox
 Feature: Evaluate student code against rubrics using AI
   # Make sure AI config files in S3 are parseable. Do this in a UI test because
   # we do not allow S3 access in unit tests. Only needs to be run in 1 browser.


### PR DESCRIPTION
1. Sometimes ai_evaluate_student_code.feature fails in firefox due to a login-related problem that seems like a familiar issue for firefox: 
* https://cucumber-logs.s3.amazonaws.com/test/test/Firefox_teacher_tools_rubrics_ai_evaluate_student_code_output.html?versionId=r4qkIeC5KNtq_mmoPchyYAe4aqbkuM7x
* ![Screenshot 2024-03-14 at 10 50 30 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/33bf00a8-1031-4c76-8e60-f6793441195d)

since we're trying hard to deflake this test right now, this PR proposes disabling the UI test in firefox until we've got the test into a more stable state.

2. in a previous PR, mark added a new ui test command to print the current user's info. this PR also adds that debug info to other scenarios. so far it looks like the user ids vary between test runs, however this logging could also be useful for matching up the RubricAiEvaluation records in the database to a particular test run.

## Testing story

Verified locally that the ui tests do not get run in firefox

verified on the test machine that user info gets printed:
![Screenshot 2024-03-14 at 11 22 44 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/48328e00-8041-4d4b-8c4b-d8427d123e6e)
