### PR TITLE
Fix Curriculum Catalog stylesheet issues

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -169,17 +169,9 @@ const CurriculumCatalog = ({
     } else {
       return (
         <div className={style.catalogContentNoResults}>
-          <img
-            className={style.noResultsImage}
-            src={CourseCatalogNoSearchResultPenguin}
-            alt=""
-          />
-          <Heading5 className={style.noResultsHeading}>
-            {i18n.noCurriculumSearchResultsHeader()}
-          </Heading5>
-          <BodyTwoText className={style.noResultsBody}>
-            {i18n.noCurriculumSearchResultsBody()}
-          </BodyTwoText>
+          <img src={CourseCatalogNoSearchResultPenguin} alt="" />
+          <Heading5>{i18n.noCurriculumSearchResultsHeader()}</Heading5>
+          <BodyTwoText>{i18n.noCurriculumSearchResultsBody()}</BodyTwoText>
         </div>
       );
     }
@@ -196,9 +188,7 @@ const CurriculumCatalog = ({
       {showAssignSuccessMessage && (
         <div className={style.assignSuccessMessageCenter}>
           <div className={style.assignSuccessMessageContainer}>
-            <BodyTwoText className={style.assignSuccessMessage}>
-              {assignSuccessMessage}
-            </BodyTwoText>
+            <BodyTwoText>{assignSuccessMessage}</BodyTwoText>
             <button
               aria-label="close success message"
               onClick={handleCloseAssignSuccessMessage}

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -103,9 +103,7 @@ const ExpandedCurriculumCatalogCard = ({
         <div className={style.expandedCardContainer}>
           <div className={style.flexDivider}>
             <div className={style.courseOfferingContainer}>
-              <Heading3 style={{marginBottom: '8px'}}>
-                {courseDisplayName}
-              </Heading3>
+              <Heading3>{courseDisplayName}</Heading3>
               <div className={style.infoContainer}>
                 <div className={style.iconWithDescription}>
                   <FontAwesome icon="user" className="fa-solid" />
@@ -117,7 +115,7 @@ const ExpandedCurriculumCatalogCard = ({
                 </div>
                 <div className={style.iconWithDescription}>
                   <FontAwesome icon="book" className="fa-solid" />
-                  <BodyTwoText className={style.subjectsText}>
+                  <BodyTwoText>
                     {i18n.topic() + ': ' + subjectsAndTopics.join(', ')}
                   </BodyTwoText>
                 </div>
@@ -126,9 +124,7 @@ const ExpandedCurriculumCatalogCard = ({
               <div className={style.centerContentContainer}>
                 <div className={style.descriptionVideoContainer}>
                   <div className={style.descriptionContainer}>
-                    <BodyTwoText className={style.descriptionText}>
-                      {description}
-                    </BodyTwoText>
+                    <BodyTwoText>{description}</BodyTwoText>
                   </div>
                   <div className={style.mediaContainer}>
                     {video ? (

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -115,7 +115,7 @@ const ExpandedCurriculumCatalogCard = ({
                 </div>
                 <div className={style.iconWithDescription}>
                   <FontAwesome icon="book" className="fa-solid" />
-                  <BodyTwoText>
+                  <BodyTwoText className={style.subjectsText}>
                     {i18n.topic() + ': ' + subjectsAndTopics.join(', ')}
                   </BodyTwoText>
                 </div>

--- a/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
@@ -135,8 +135,6 @@ $container-width: 960px;
   white-space: nowrap;
 
   > p {
-    overflow: hidden;
-    white-space: normal;
     font-size: 0.875em;
     margin: 0;
     color: $neutral_dark;
@@ -148,6 +146,10 @@ $container-width: 960px;
     align-self: flex-start;
     padding-top: 4px;
   }
+}
+
+p.subjectsText {
+  white-space: normal;
 }
 
 .infoContainer {

--- a/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
@@ -74,14 +74,18 @@ $container-width: 960px;
   width: 736px;
   padding: 16px 32px 16px 16px;
   box-sizing: border-box;
+
+  > h3 {
+    margin-bottom: 8px;
+  }
 }
 
 .descriptionContainer {
   margin-bottom: 20px;
-}
 
-.descriptionText {
-  font-size: 0.875em;
+  > p {
+    font-size: 0.875em;
+  }
 }
 
 .descriptionVideoContainer {
@@ -131,6 +135,8 @@ $container-width: 960px;
   white-space: nowrap;
 
   > p {
+    overflow: hidden;
+    white-space: normal;
     font-size: 0.875em;
     margin: 0;
     color: $neutral_dark;
@@ -228,11 +234,6 @@ $container-width: 960px;
     font-size: 14px;
     margin-bottom: 0;
   }
-}
-
-.subjectsText {
-  overflow: hidden;
-  white-space: normal;
 }
 
 .thickDivider {

--- a/apps/style/code-studio/curriculum_catalog_container.module.scss
+++ b/apps/style/code-studio/curriculum_catalog_container.module.scss
@@ -21,21 +21,21 @@ $container-width: 309px;
   width: 70%;
   margin: 3em auto;
   text-align: justify;
-}
 
-.noResultsImage {
-  display: block;
-  margin: auto;
-  width: 5em;
-}
+  img {
+    display: block;
+    margin: auto;
+    width: 5em;
+  }
 
-.noResultsHeading {
-  color: color.$teal;
-  margin: 1em 0 0 0;
-}
+  h5 {
+    color: color.$teal;
+    margin: 1em 0 0 0;
+  }
 
-.noResultsBody {
-  margin: 1em;
+  p {
+    margin: 1em;
+  }
 }
 
 .assignSuccessMessageContainer {
@@ -57,11 +57,11 @@ $container-width: 309px;
     border: none;
     font-size: 12px;
   }
-}
 
-.assignSuccessMessage {
-  margin: 16px;
-  color: color.$bootstrap_success_text;
+  p {
+    margin: 16px;
+    color: color.$bootstrap_success_text;
+  }
 }
 
 .assignSuccessMessageCenter {


### PR DESCRIPTION
As laid out in [this discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1710363328926969), @levadadenys found that based on the way the Curriculum Catalog stylesheets were set up, there would be styling conflicts with the typography components that would be resolved through the load order of stylesheets making it inconsistent. This resulted in some [eyes test changes](https://eyes.applitools.com/app/test-results/00000251691938532466/00000251691938532371/steps/3?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor).

The way to fix these issues is to either 1) set a classname for a parent element and update the styles of the given tag type within the parent's styles or 2) set a specific class name for the heading itself that included the heading tag type. I opted for option 1 since that's how much of the other curriculum catalog style sheets were set up. Now, none of the typography components used on the Curriculum Catalog page have inline-set `classNames` to set styling.

### Curriculum Catalog Card
Previous:
![old_regular_card](https://github.com/code-dot-org/code-dot-org/assets/56283563/c4f461d4-26ee-41ba-928a-9d7ad34df646)

With styling fix:
![new_regular_card](https://github.com/code-dot-org/code-dot-org/assets/56283563/288d2e29-5001-42ba-8429-20fe8438c233)

### Curriculum Catalog Expanded Card
Previous:
![old_expanded_card](https://github.com/code-dot-org/code-dot-org/assets/56283563/3b2f2f83-a6cd-4b64-bff7-74aaa84d1416)

With styling fix:
![exp](https://github.com/code-dot-org/code-dot-org/assets/56283563/f4e7cf73-6f4d-4502-9cc7-16aa5a519a3b)

### Curriculum Catalog No Results View
Previous:
![old_no_results](https://github.com/code-dot-org/code-dot-org/assets/56283563/cf013f87-1564-41d9-8aa4-70fb363d12b7)

With styling fix:
![new_no_matching](https://github.com/code-dot-org/code-dot-org/assets/56283563/e026a433-3e6a-421d-8c70-933d7f1885cc)

### Curriculum Catalog Successful Assign Message
Previous:
![old_assign_section](https://github.com/code-dot-org/code-dot-org/assets/56283563/eb3e876a-18e5-4c7a-811a-07a9a6a334a1)

With styling fix:
![new_success_assign](https://github.com/code-dot-org/code-dot-org/assets/56283563/77bf02dd-dc14-4bcb-be95-5b477fb94053)

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1710363328926969)
Failing eyes test example: [here](https://eyes.applitools.com/app/test-results/00000251691938532466/00000251691938532371/steps/3?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor)

## Testing story
Local testing.
