### PR TITLE
[Google Blockly] Remove Randomize button from bitmap field editor

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -295,7 +295,6 @@
   "blocklyKBNavOff": "Disable Keyboard Navigation",
   "blocklyMessage": "Blockly",
   "blocklyModernTheme": "Modern Theme",
-  "blocklyRandomize": "Randomize",
   "blocklyTritanopiaTheme": "Tritanopia Theme",
   "blocklyTurnOffDarkMode": "Turn off dark mode",
   "blocklyTurnOnDarkMode": "Turn on dark mode",

--- a/apps/src/blockly/addons/cdoFieldBitmap.ts
+++ b/apps/src/blockly/addons/cdoFieldBitmap.ts
@@ -25,9 +25,8 @@ export class CdoFieldBitmap extends FieldBitmap {
 
   /**
    * Show the bitmap editor dialog. The parent class provides two buttons labeled
-   * "Randomize" and "Clear" which are not translatable. In our version, we find
-   * these buttons after they are added so that we can provide translatable
-   * strings.
+   * "Randomize" and "Clear". In our version, we remove the randomize button and
+   * replace the clear button text with a translation string.
    * @param {!Event=} e Optional mouse event that triggered the field to
    *     open, or undefined if triggered programmatically.
    * @param {boolean=} _quietInput Quiet input.
@@ -42,11 +41,11 @@ export class CdoFieldBitmap extends FieldBitmap {
       '.dropdownEditor .controlButton'
     );
 
-    // Update the button text to use our translations.
+    // Remove the button or update its text to use our translations.
     buttons.forEach(button => {
       switch (button.innerHTML.trim()) {
         case 'Randomize':
-          button.innerHTML = commonI18n.blocklyRandomize();
+          button.remove();
           break;
         case 'Clear':
           button.innerHTML = commonI18n.blocklyClear();


### PR DESCRIPTION
The CSC team requested that we remove the "Randomize" button from the new bitmap field's editor as it is thought to be unnecessary and potentially confusing.

**Before:**
![image (183)](https://github.com/code-dot-org/code-dot-org/assets/43474485/31f5d172-95bf-4c81-9deb-c8ce82f2cf0c)


**After:**
<img width="420" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/ef196596-e570-493f-bee6-57480ba61e97">

Only the change to the button is relevant. Any other differences between the screenshots are unrelated.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
