### PR TITLE
[ProgressV2] Small fixes for floating scrollbar

### DIFF
--- a/apps/src/templates/sectionProgressV2/floatingScrollbar/FloatingScrollbar.jsx
+++ b/apps/src/templates/sectionProgressV2/floatingScrollbar/FloatingScrollbar.jsx
@@ -22,7 +22,7 @@ export default function FloatingScrollbar({children, childRef}) {
   const [floatScrollbar, setFloatScrollbar] = React.useState(true);
 
   const canFloat = React.useMemo(
-    () => childScrollWidth > 0 && childWidth > 0,
+    () => childScrollWidth > 0 && childWidth > 0 && scrollbarWidth > 0,
     [childScrollWidth, childWidth]
   );
 
@@ -120,6 +120,7 @@ export default function FloatingScrollbar({children, childRef}) {
       </div>
     );
   }
+  console.log('lfm', scrollbarWidth);
 
   return (
     <div className={styles.scrollingContainer}>

--- a/apps/src/templates/sectionProgressV2/floatingScrollbar/FloatingScrollbar.jsx
+++ b/apps/src/templates/sectionProgressV2/floatingScrollbar/FloatingScrollbar.jsx
@@ -21,10 +21,18 @@ export default function FloatingScrollbar({children, childRef}) {
   const [childWidth, setChildWidth] = React.useState(0);
   const [floatScrollbar, setFloatScrollbar] = React.useState(true);
 
-  const canFloat = React.useMemo(
-    () => childScrollWidth > 0 && childWidth > 0 && scrollbarWidth > 0,
-    [childScrollWidth, childWidth]
-  );
+  const canFloat = React.useMemo(() => {
+    const newCanFloat =
+      childScrollWidth > 0 && childWidth > 0 && scrollbarWidth > 0;
+    if (!newCanFloat) {
+      console.warn('FloatingScrollbar: Unable to calculate widths', {
+        childScrollWidth,
+        childWidth,
+        scrollbarWidth,
+      });
+    }
+    return newCanFloat;
+  }, [childScrollWidth, childWidth]);
 
   const childContainerResizeObserver = React.useMemo(
     () =>

--- a/apps/src/templates/sectionProgressV2/floatingScrollbar/FloatingScrollbar.jsx
+++ b/apps/src/templates/sectionProgressV2/floatingScrollbar/FloatingScrollbar.jsx
@@ -17,8 +17,8 @@ export default function FloatingScrollbar({children, childRef}) {
   const scrollRef = React.useRef();
   const childContainerRef = React.useRef();
 
-  const [childScrollWidth, setChildScrollWidth] = React.useState(0);
-  const [childWidth, setChildWidth] = React.useState(0);
+  const [childScrollWidth, setChildScrollWidth] = React.useState(1);
+  const [childWidth, setChildWidth] = React.useState(1);
   const [floatScrollbar, setFloatScrollbar] = React.useState(true);
 
   const canFloat = React.useMemo(() => {

--- a/apps/src/templates/sectionProgressV2/floatingScrollbar/FloatingScrollbar.jsx
+++ b/apps/src/templates/sectionProgressV2/floatingScrollbar/FloatingScrollbar.jsx
@@ -22,13 +22,11 @@ export default function FloatingScrollbar({children, childRef}) {
   const [floatScrollbar, setFloatScrollbar] = React.useState(true);
 
   const canFloat = React.useMemo(() => {
-    const newCanFloat =
-      childScrollWidth > 0 && childWidth > 0 && scrollbarWidth > 0;
+    const newCanFloat = childScrollWidth > 0 && childWidth > 0;
     if (!newCanFloat) {
       console.warn('FloatingScrollbar: Unable to calculate widths', {
         childScrollWidth,
         childWidth,
-        scrollbarWidth,
       });
     }
     return newCanFloat;

--- a/apps/src/templates/sectionProgressV2/floatingScrollbar/FloatingScrollbar.jsx
+++ b/apps/src/templates/sectionProgressV2/floatingScrollbar/FloatingScrollbar.jsx
@@ -128,7 +128,6 @@ export default function FloatingScrollbar({children, childRef}) {
       </div>
     );
   }
-  console.log('lfm', scrollbarWidth);
 
   return (
     <div className={styles.scrollingContainer}>

--- a/apps/src/templates/sectionProgressV2/floatingScrollbar/floating-scrollbar.module.scss
+++ b/apps/src/templates/sectionProgressV2/floatingScrollbar/floating-scrollbar.module.scss
@@ -33,3 +33,10 @@
   width: 0;
   height: 0;
 }
+
+.defaultScroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
* Only show the scrollbar if the table is on screen. If the top of the table is below the screen or the bottom of the table is above the screen, do not show the floating scrollbar.
* If we cannot calculate widths for containers or the scrollbar, now use the default state of having scrollbar at the bottom.
  * Also adds a console warning in this case so that we can debug easier to determine what we are unable to calculate. This warning is only shown once or when widths change.
* I think this should also fix the issue where the scrollbar was not showing up until the mac setting for always showing scrollbars was turned on, however, I was unable to repro locally. Because this is a timebox investigation, I put in the log line and a potential fix and will revisit if this is not fixed

## Links
[TEACH-928](https://codedotorg.atlassian.net/browse/TEACH-928)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
