### PR TITLE
Center level numbers in header row

### DIFF
--- a/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelProgressHeader.jsx
@@ -30,7 +30,9 @@ export default function ExpandedProgressColumnHeader({
           )}
         >
           {level.sublevels?.length > 0 && <FontAwesome icon="caret-down" />}
-          {lesson.relative_position + '.' + level.bubbleText}
+          <div className={styles.expandedHeaderLevelCellLevelNumber}>
+            {lesson.relative_position + '.' + level.bubbleText}
+          </div>
           {level.kind === 'assessment' && (
             <FontAwesome
               icon="star"
@@ -43,7 +45,8 @@ export default function ExpandedProgressColumnHeader({
           <div
             className={classNames(
               styles.expandedHeaderLevelCell,
-              styles.expandedHeaderExpandedLevelCell
+              styles.expandedHeaderExpandedLevelCell,
+              styles.expandedHeaderLevelCellLevelNumber
             )}
             key={lesson.id + '.' + level.id + '-h-' + sublevel.id}
           >
@@ -69,9 +72,11 @@ export default function ExpandedProgressColumnHeader({
         onClick={() => toggleExpandedChoiceLevel(level)}
       >
         {level.sublevels?.length > 0 && <FontAwesome icon="caret-right" />}
-        <div>{`${lesson.relative_position}.${
-          level.isUnplugged ? 0 : level.bubbleText
-        }`}</div>
+        <div className={styles.expandedHeaderLevelCellLevelNumber}>
+          {`${lesson.relative_position}.${
+            level.isUnplugged ? 0 : level.bubbleText
+          }`}
+        </div>
         {level.kind === 'assessment' && (
           <FontAwesome
             icon="star"

--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -292,7 +292,6 @@ $level-cell-width: 52;
 }
 
 .assessmentLevelIcon {
-  //margin-top: -2px;
   font-size: 12px;
   color: $neutral_dark60;
 }

--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -216,7 +216,7 @@ $level-cell-width: 52;
       flex-wrap: nowrap;
 
       &LevelNumber {
-        padding-top: 2px;
+        margin-top: 0.0625em;
       }
 
       &Unexpanded {

--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -203,7 +203,7 @@ $level-cell-width: 52;
       }
     }
 
-    .expandedHeaderLevelCell {
+    &LevelCell {
       width: $level-cell-width + px;
       text-align: center;
       height: 32px;
@@ -212,12 +212,16 @@ $level-cell-width: 52;
       flex-direction: row;
       align-items: center;
       justify-content: space-evenly;
-      overflow-x: hidden;
+      overflow: hidden;
       flex-wrap: nowrap;
-    }
 
-    .expandedHeaderLevelCellUnexpanded {
-      background-color: white;
+      &LevelNumber {
+        padding-top: 2px;
+      }
+
+      &Unexpanded {
+        background-color: white;
+      }
     }
 
     &ExpandedLevel {
@@ -288,6 +292,7 @@ $level-cell-width: 52;
 }
 
 .assessmentLevelIcon {
+  //margin-top: -2px;
   font-size: 12px;
   color: $neutral_dark60;
 }


### PR DESCRIPTION
The title of [the ticket](https://codedotorg.atlassian.net/browse/TEACH-918) was to "Vertically center assessment icon," but to my eye the star icon was centered pretty well already, and the level numbers were a bit above center. This change nudges them down a bit.

Before:
![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/724d807e-9fe5-44f5-aa0f-b010d0b0b18b)

After:
![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/94214095-6d13-44b2-b63f-a0dd685c6a33)
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
