### PR TITLE
[Game Design] CT-357: Handle long variable bubble labels and values

### DIFF
--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -1,3 +1,4 @@
+import {constant} from 'lodash';
 import {APP_HEIGHT, APP_WIDTH} from './constants';
 import * as colors from '@cdo/apps/util/color';
 
@@ -259,4 +260,35 @@ export function validationBar(
   p5.strokeWeight(1);
   p5.rect(x, y, width, barHeight);
   p5.pop();
+}
+
+/**
+ * Truncates the given text to fit within a specified width, adding an ellipsis if truncation occurs.
+ * This function ensures the text (such as variable labels or values) does not exceed the available space
+ * in a given context (e.g., within the variable bubble).
+ *
+ * @param {p5} p5 - The p5 instance.
+ * @param {string} text - The text to be potentially truncated.
+ * @param {number} maxWidth - The maximum width (in pixels) the text is allowed to occupy. This value should account for any desired padding or margins.
+ * @param {number} textSize - The font size (in pixels) to be used when measuring and displaying the text.
+ * @returns {string} The original text or a truncated version with an ellipsis appended if the text exceeded maxWidth.
+ */
+export function truncateText(p5, text, maxWidth, textSize) {
+  let ellipsis = '...';
+  let textWidth = getTextWidth(p5, text, textSize);
+
+  if (textWidth <= maxWidth) {
+    return text;
+  }
+
+  const ellipsisWidth = getTextWidth(p5, ellipsis, textSize);
+  maxWidth -= ellipsisWidth;
+
+  let truncatedText = text;
+  while (textWidth > maxWidth && truncatedText.length > 1) {
+    truncatedText = truncatedText.slice(0, -1);
+    textWidth = getTextWidth(p5, truncatedText, textSize);
+  }
+
+  return truncatedText + ellipsis;
 }

--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -35,12 +35,30 @@ export function getTextWidth(p5, text, size) {
  * @param {number} y - The y-coordinate of the center of the bubble.
  * @param {string} text - The text to display inside the bubble. This should represent the variable's name and value.
  */
-export function variableBubble(p5, x, y, text) {
-  const padding = 10;
-  const textSizeValue = 20;
-  const textWidth = getTextWidth(p5, text, textSizeValue);
-  const textWidthValue = textWidth + 2 * padding;
-  const textHeightValue = textSizeValue + 2 * padding;
+export function variableBubble(p5, x, y, text, config) {
+  const textWidth = getTextWidth(p5, text, config.textSize);
+  const textWidthValue = textWidth + 2 * config.padding;
+  const textHeightValue = config.textSize + 2 * config.padding;
+
+  const halfWidth = textWidthValue / 2;
+  const halfHeight = textHeightValue / 2;
+  const leftBound = x - halfWidth;
+  const rightBound = x + halfWidth;
+  const topBound = y - halfHeight;
+  const bottomBound = y + halfHeight;
+
+  // If the bubble is too close to the edge of the canvas, adjust the position so it fits.
+  if (leftBound < 0) {
+    x = halfWidth;
+  } else if (rightBound > APP_WIDTH) {
+    x = APP_WIDTH - halfWidth;
+  }
+
+  if (topBound < 0) {
+    y = halfHeight;
+  } else if (bottomBound > APP_HEIGHT) {
+    y = APP_HEIGHT - halfHeight;
+  }
 
   const halfWidth = textWidthValue / 2;
   const halfHeight = textHeightValue / 2;
@@ -65,13 +83,13 @@ export function variableBubble(p5, x, y, text) {
   p5.push();
   p5.fill(colors.darkest_gray);
   p5.stroke('white');
-  p5.strokeWeight(3);
+  p5.strokeWeight(config.strokeWeight);
   p5.rectMode(p5.CENTER);
-  p5.rect(x, y, textWidthValue, textHeightValue, 24);
+  p5.rect(x, y, textWidthValue, textHeightValue, config.strokeRadius);
 
   p5.fill('white');
   p5.noStroke();
-  p5.textSize(textSizeValue);
+  p5.textSize(config.textSize);
   p5.textAlign(p5.CENTER, p5.CENTER);
   p5.text(text, x, y);
   p5.pop();

--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -1,4 +1,3 @@
-import {constant} from 'lodash';
 import {APP_HEIGHT, APP_WIDTH} from './constants';
 import * as colors from '@cdo/apps/util/color';
 

--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -60,26 +60,6 @@ export function variableBubble(p5, x, y, text, config) {
     y = APP_HEIGHT - halfHeight;
   }
 
-  const halfWidth = textWidthValue / 2;
-  const halfHeight = textHeightValue / 2;
-  const leftBound = x - halfWidth;
-  const rightBound = x + halfWidth;
-  const topBound = y - halfHeight;
-  const bottomBound = y + halfHeight;
-
-  // If the bubble is too close to the edge of the canvas, adjust the position so it fits.
-  if (leftBound < 0) {
-    x = halfWidth;
-  } else if (rightBound > APP_WIDTH) {
-    x = APP_WIDTH - halfWidth;
-  }
-
-  if (topBound < 0) {
-    y = halfHeight;
-  } else if (bottomBound > APP_HEIGHT) {
-    y = APP_HEIGHT - halfHeight;
-  }
-
   p5.push();
   p5.fill(colors.darkest_gray);
   p5.stroke('white');

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -117,6 +117,13 @@ export default class CoreLibrary {
   }
 
   drawVariableBubbles() {
+    const config = {
+      textSize: 20,
+      padding: 10,
+      strokeWeight: 3,
+      strokeRadius: 24,
+    };
+
     this.variableBubbles.forEach(variable => {
       const {name, label, location} = variable;
       if (!name.length || !label.length || !location) {
@@ -124,10 +131,80 @@ export default class CoreLibrary {
       }
 
       const value = this.getVariableValue(name);
-      const text = `${label}: ${value}`;
+      const totalExtra = 2 * (config.padding + config.strokeWeight); // Total extra width due to padding and stroke
+      const ellipsis = '...';
 
-      // TODO: Confirm this handles shadow block locations appropriately
-      drawUtils.variableBubble(this.p5, location.x, location.y, text);
+      // Check if the value alone is too wide
+      let valueWidth =
+        drawUtils.getTextWidth(this.p5, value, config.textSize) + totalExtra;
+      if (valueWidth > APP_WIDTH) {
+        let valueToDisplay;
+        // If value exceeds APP_WIDTH, truncate the value itself
+        let truncatedValue = value;
+        let truncationNeeded = true;
+
+        while (truncationNeeded && truncatedValue.length > 0) {
+          truncatedValue = truncatedValue.slice(0, -1);
+          valueToDisplay = `${truncatedValue}${ellipsis}`;
+          let currentWidth =
+            drawUtils.getTextWidth(this.p5, valueToDisplay, config.textSize) +
+            totalExtra;
+
+          // Add ellipsis to indicate the value has been truncated, if any truncation happened
+          if (currentWidth <= APP_WIDTH) {
+            truncationNeeded = false;
+          }
+        }
+
+        // Display the truncated value without label
+        drawUtils.variableBubble(
+          this.p5,
+          location.x,
+          location.y,
+          valueToDisplay,
+          config
+        );
+        return; // Skip further processing
+      }
+
+      const fullText = `${label}: ${value}`;
+      let fullTextWidth = drawUtils.getTextWidth(
+        this.p5,
+        fullText,
+        config.textSize
+      );
+
+      let textToDisplay;
+      if (fullTextWidth > APP_WIDTH) {
+        let truncatedLabel = label;
+        let truncationNeeded = true;
+
+        while (truncationNeeded && truncatedLabel.length > 0) {
+          truncatedLabel = truncatedLabel.slice(0, -1);
+          textToDisplay = `${truncatedLabel}${ellipsis}: ${value}`;
+          let currentWidth =
+            drawUtils.getTextWidth(this.p5, textToDisplay, config.textSize) +
+            totalExtra;
+
+          if (currentWidth <= APP_WIDTH) {
+            truncationNeeded = false;
+          }
+        }
+
+        if (truncatedLabel.length === 0 && truncationNeeded) {
+          textToDisplay = `${value}`;
+        }
+      } else {
+        textToDisplay = fullText;
+      }
+
+      drawUtils.variableBubble(
+        this.p5,
+        location.x,
+        location.y,
+        textToDisplay,
+        config
+      );
     });
   }
 

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -151,7 +151,7 @@ export default class CoreLibrary {
       const value = this.getVariableValue(name);
 
       // Determine if the label needs truncation and append an ellipsis if so
-      let displayLabel =
+      const displayLabel =
         label.length > config.maxLabelLength
           ? label.slice(0, config.maxLabelLength) + '…'
           : label;
@@ -164,7 +164,7 @@ export default class CoreLibrary {
       // Truncate the value if necessary to fit within the available space
       const availableSpaceForValue =
         APP_WIDTH - totalReservedSpace - labelWidth;
-      let displayValue = drawUtils.truncateText(
+      const displayValue = drawUtils.truncateText(
         this.p5,
         `${value}`,
         availableSpaceForValue,

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -132,7 +132,11 @@ export default class CoreLibrary {
     };
 
     // Define the maximum width each part can occupy, accounting for the label/value separator
-    const separatorWidth = getTextWidth(this.p5, ': ', config.textSize);
+    const separatorWidth = drawUtils.getTextWidth(
+      this.p5,
+      ': ',
+      config.textSize
+    );
     const maxPartWidth = (APP_WIDTH - separatorWidth) / 2;
 
     this.variableBubbles.forEach(variable => {
@@ -144,13 +148,13 @@ export default class CoreLibrary {
       const value = this.getVariableValue(name);
 
       // Truncate each piece of text to fit within its maximum allowed width if necessary
-      let displayLabel = truncateText(
+      let displayLabel = drawUtils.truncateText(
         this.p5,
         label,
         maxPartWidth,
         config.textSize
       );
-      let displayValue = truncateText(
+      let displayValue = drawUtils.truncateText(
         this.p5,
         value,
         maxPartWidth,

--- a/apps/src/p5lab/utils.js
+++ b/apps/src/p5lab/utils.js
@@ -1,3 +1,5 @@
+import {getTextWidth} from './drawUtils';
+
 // NOTE: min and max are inclusive
 export function randomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -47,4 +49,21 @@ export function randomColor(p5) {
 
 export function randomColorFromPalette(palette) {
   return palette[randomInt(0, palette.length - 1)];
+}
+
+export function truncateText(p5, text, maxWidth, textSize) {
+  let truncatedText = text;
+  let textWidth = getTextWidth(p5, truncatedText, textSize);
+
+  if (textWidth <= maxWidth) return truncatedText; // No truncation needed
+
+  const ellipsisWidth = getTextWidth(p5, '...', textSize);
+  maxWidth -= ellipsisWidth; // Reserve space for ellipsis
+
+  while (textWidth > maxWidth && truncatedText.length > 1) {
+    truncatedText = truncatedText.slice(0, -1);
+    textWidth = getTextWidth(p5, truncatedText, textSize);
+  }
+
+  return truncatedText + '...';
 }

--- a/apps/src/p5lab/utils.js
+++ b/apps/src/p5lab/utils.js
@@ -1,5 +1,3 @@
-import {getTextWidth} from './drawUtils';
-
 // NOTE: min and max are inclusive
 export function randomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -49,21 +47,4 @@ export function randomColor(p5) {
 
 export function randomColorFromPalette(palette) {
   return palette[randomInt(0, palette.length - 1)];
-}
-
-export function truncateText(p5, text, maxWidth, textSize) {
-  let truncatedText = text;
-  let textWidth = getTextWidth(p5, truncatedText, textSize);
-
-  if (textWidth <= maxWidth) return truncatedText; // No truncation needed
-
-  const ellipsisWidth = getTextWidth(p5, '...', textSize);
-  maxWidth -= ellipsisWidth; // Reserve space for ellipsis
-
-  while (textWidth > maxWidth && truncatedText.length > 1) {
-    truncatedText = truncatedText.slice(0, -1);
-    textWidth = getTextWidth(p5, truncatedText, textSize);
-  }
-
-  return truncatedText + '...';
 }


### PR DESCRIPTION
The following PR:
- Moves the "magic" numbers (padding, textSizeValue, strokeRadius, etc.) into a "config" object for variable bubbles used throughout the bubble drawing code.
- Adds a `drawUtils.truncateText` function that accepts a piece of text, a maximum width, and text size and truncates the given text, if necessary, to fit within the provided width.
- Adds JSDocs for `drawVariableBubbles` in CoreLibrary.
- Adds logic to restrict the length of the label in the variable bubble to `config.maxLabelLength` (currently 30 characters).
- Adds logic to ensure the text for the value fits within the available remaining space by truncating it, if necessary.
- Note: `drawUtils.variableBubble` now accepts "displayText," which should be a string whose width is smaller than the playspace. 

The truncation behavior is demonstrated in the video below. This video features a **known edge case**: If the variable label is very long and there is a large numerical value that p5 converts to scientific notation, the scientific notation is cut off, making it look like the value is 1.2 instead of 1.2E9 or something. Do we care about this?

https://github.com/code-dot-org/code-dot-org/assets/26844240/65a7beff-9080-4280-8f09-1e1aec0b26a2

My thought is that fixing the scientific notation + large label is not a common enough case that it's worth handling separately (which would require something like using a different max character limit if we detect the value is a number in scientific notation). 

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/CT-357

## Testing story

Tested manually on a Sprite Lab level, including numerical, text, array, and boolean values (see above).

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
