### PR TITLE
Music: wait validation

### DIFF
--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -45,6 +45,8 @@ export interface LabState {
   isLoadingProjectOrLevel: boolean;
   // If the lab is loading. Can be updated by lab-specific components.
   isLoading: boolean;
+  // Whether the lab is currently running.
+  isRunning: boolean;
   // Error currently on the page, if present.
   pageError: PageError | undefined;
   // channel for the current project, or undefined if there is no current project.
@@ -67,6 +69,7 @@ const initialState: LabState = {
   initialSources: undefined,
   validationState: getInitialValidationState(),
   levelProperties: undefined,
+  isRunning: false,
 };
 
 // Thunks
@@ -238,6 +241,9 @@ const labSlice = createSlice({
   reducers: {
     setIsLoading(state, action: PayloadAction<boolean>) {
       state.isLoading = action.payload;
+    },
+    setIsRunning(state, action: PayloadAction<boolean>) {
+      state.isRunning = action.payload;
     },
     setPageError(
       state,
@@ -420,8 +426,13 @@ async function cleanUpProjectManager() {
   Lab2Registry.getInstance().clearProjectManager();
 }
 
-export const {setIsLoading, setPageError, clearPageError, setValidationState} =
-  labSlice.actions;
+export const {
+  setIsLoading,
+  setIsRunning,
+  setPageError,
+  clearPageError,
+  setValidationState,
+} = labSlice.actions;
 
 // These should not be set outside of the lab slice.
 const {setChannel, onLevelChange} = labSlice.actions;

--- a/apps/src/lab2/levelEditors/validations/EditValidations.tsx
+++ b/apps/src/lab2/levelEditors/validations/EditValidations.tsx
@@ -95,6 +95,7 @@ const EditValidations: React.FunctionComponent<EditValidationsProps> = ({
       message: '',
       next: false,
       conditions: [],
+      showOnlyWhileRunning: false,
     };
     setValidations([...validations, newValidation]);
   };

--- a/apps/src/lab2/progress/ProgressManager.ts
+++ b/apps/src/lab2/progress/ProgressManager.ts
@@ -18,6 +18,7 @@ export interface ValidationState {
   satisfied: boolean;
   message: string | null;
   index: number;
+  showOnlyWhileRunning: boolean;
 }
 
 export const getInitialValidationState: () => ValidationState = () => ({
@@ -25,6 +26,7 @@ export const getInitialValidationState: () => ValidationState = () => ({
   satisfied: false,
   message: null,
   index: 0,
+  showOnlyWhileRunning: false,
 });
 
 export default class ProgressManager {
@@ -82,6 +84,8 @@ export default class ProgressManager {
           if (!this.currentValidationState.satisfied) {
             this.currentValidationState.satisfied = validation.next;
             this.currentValidationState.message = validation.message;
+            this.currentValidationState.showOnlyWhileRunning =
+              validation.showOnlyWhileRunning;
             this.onProgressChange();
           }
           return;
@@ -112,6 +116,7 @@ export default class ProgressManager {
       // ensures that the UI is rendered fresh, and any apperance animation is
       // played again, even if it's the same message as last time.
       index: this.currentValidationState.index + 1,
+      showOnlyWhileRunning: false,
     };
 
     this.onProgressChange();

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -153,6 +153,7 @@ export interface Validation {
   message: string;
   next: boolean;
   key: string;
+  showOnlyWhileRunning: boolean;
 }
 
 // TODO: these are not all the properties of app options.

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -59,8 +59,10 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
   );
   const levelIndex = useSelector(currentLevelIndex);
   const currentLevelCount = useSelector(levelCount);
-  const {hasConditions, message, satisfied, index} = useSelector(
-    (state: {lab: LabState}) => state.lab.validationState
+  const {hasConditions, message, satisfied, index, showOnlyWhileRunning} =
+    useSelector((state: {lab: LabState}) => state.lab.validationState);
+  const isRunning = useSelector(
+    (state: {lab: LabState}) => state.lab.isRunning
   );
 
   // If there are no validation conditions, we can show the next button so long as
@@ -79,6 +81,10 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
     dispatch(navigateToNextLevel());
   }, [dispatch, beforeNextLevel]);
 
+  // Some messages should only be shown while the lab is running.
+  const messageToShow =
+    !showOnlyWhileRunning || isRunning ? message || undefined : undefined;
+
   // Don't render anything if we don't have any instructions.
   if (instructionsText === undefined) {
     return null;
@@ -87,7 +93,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
   return (
     <InstructionsPanel
       text={instructionsText}
-      message={message || undefined}
+      message={messageToShow}
       messageIndex={index}
       showNextButton={showNextButton}
       onNextPanel={onNextPanel}
@@ -148,8 +154,8 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
   };
 
   const vertical = layout === 'vertical';
-
   const canShowNextButton = showNextButton && onNextPanel;
+  const showMessage = message || canShowNextButton;
 
   return (
     <div
@@ -215,7 +221,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
             />
           </div>
         )}
-        {(message || canShowNextButton) && (
+        {showMessage && (
           <div
             key={messageIndex + ' - ' + message}
             id="instructions-feedback"

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -15,6 +15,7 @@ export const MusicConditions: ConditionNames = {
   PLAYED_SOUND_TRIGGERED: {name: 'played_sound_triggered'},
   PLAYED_SOUNDS: {name: 'played_sounds', valueType: 'number'},
   PLAYED_SOUND_ID: {name: 'played_sound_id', valueType: 'string'},
+  NOT_PLAYED_MEASURES: {name: 'not_played_measures', valueType: 'number'},
 };
 
 export default class MusicValidator extends Validator {
@@ -97,9 +98,34 @@ export default class MusicValidator extends Validator {
         });
       }
     }
+
+    /*
+    // Check for a certain number of measures not yet played.
+    const maxNumberMeasures = 8;
+    for (let numberMeasures = 1; numberMeasures <= 8; numberMeasures++) {
+      if (this.player.getCurrentPlayheadPosition() < numberMeasures + 1) {
+        this.conditionsChecker.addSatisfiedCondition({
+          name: MusicConditions.NOT_PLAYED_MEASURES.name,
+          value: numberMeasures,
+        });
+      }
+    }
+    */
   }
 
   conditionsMet(conditions: Condition[]): boolean {
+    // Take this opportunity to check any conditions that we want to reevaluate
+    // every frame, rather than can be accumulated because they stay true.
+    if (
+      conditions.length === 1 &&
+      conditions[0].name === MusicConditions.NOT_PLAYED_MEASURES.name &&
+      this.player.getCurrentPlayheadPosition() <
+        (conditions[0].value as number) + 1
+    ) {
+      return true;
+    }
+
+    // Check any accumulated success conditions.
     return this.conditionsChecker.checkRequirementConditions(conditions);
   }
 

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -98,19 +98,6 @@ export default class MusicValidator extends Validator {
         });
       }
     }
-
-    /*
-    // Check for a certain number of measures not yet played.
-    const maxNumberMeasures = 8;
-    for (let numberMeasures = 1; numberMeasures <= 8; numberMeasures++) {
-      if (this.player.getCurrentPlayheadPosition() < numberMeasures + 1) {
-        this.conditionsChecker.addSatisfiedCondition({
-          name: MusicConditions.NOT_PLAYED_MEASURES.name,
-          value: numberMeasures,
-        });
-      }
-    }
-    */
   }
 
   conditionsMet(conditions: Condition[]): boolean {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -38,6 +38,7 @@ import {
   isReadOnlyWorkspace,
   setIsLoading,
   setPageError,
+  setIsRunning,
 } from '@cdo/apps/lab2/lab2Redux';
 import Simple2Sequencer from '../player/sequencer/Simple2Sequencer';
 import AdvancedSequencer from '../player/sequencer/AdvancedSequencer';
@@ -75,6 +76,7 @@ class UnconnectedMusicView extends React.Component {
     signInState: PropTypes.oneOf(Object.values(SignInState)),
     isPlaying: PropTypes.bool,
     setIsPlaying: PropTypes.func,
+    setIsRunning: PropTypes.func,
     setCurrentPlayheadPosition: PropTypes.func,
     selectedBlockId: PropTypes.string,
     selectBlockId: PropTypes.func,
@@ -562,6 +564,7 @@ class UnconnectedMusicView extends React.Component {
     );
 
     this.props.setIsPlaying(true);
+    this.props.setIsRunning(true);
     this.props.setCurrentPlayheadPosition(this.props.startingPlayheadPosition);
     this.props.clearSelectedBlockId();
     this.props.clearSelectedTriggerId();
@@ -578,6 +581,7 @@ class UnconnectedMusicView extends React.Component {
     this.executeCompiledSong();
 
     this.props.setIsPlaying(false);
+    this.props.setIsRunning(false);
     this.props.setCurrentPlayheadPosition(this.props.startingPlayheadPosition);
   };
 
@@ -641,6 +645,7 @@ const MusicView = connect(
   }),
   dispatch => ({
     setIsPlaying: isPlaying => dispatch(setIsPlaying(isPlaying)),
+    setIsRunning: isRunning => dispatch(setIsRunning(isRunning)),
     setCurrentPlayheadPosition: currentPlayheadPosition =>
       dispatch(setCurrentPlayheadPosition(currentPlayheadPosition)),
     selectBlockId: blockId => dispatch(selectBlockId(blockId)),

--- a/dashboard/config/levels/custom/music/musiclab_intro_repeat.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_repeat.level
@@ -44,7 +44,7 @@
               "name": "played_sounds",
               "value": 3
             }
-        ],
+          ],
           "message": "Nice work.  You successfully played three sounds.",
           "next": true
         },

--- a/dashboard/config/levels/custom/music/musiclab_intro_repeat.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_repeat.level
@@ -44,9 +44,19 @@
               "name": "played_sounds",
               "value": 3
             }
-          ],
+        ],
           "message": "Nice work.  You successfully played three sounds.",
           "next": true
+        },
+        {
+          "conditions": [
+            {
+              "name": "not_played_measures",
+              "value": 6
+            }
+          ],
+          "message": "Let's listen...",
+          "showOnlyWhileRunning": true
         },
         {
           "conditions": [


### PR DESCRIPTION
This adds a new kind of validation to Music Lab which waits until playback has passed a given measure.  It allows us to show a "Let's listen..." validation message while the playback occurs, before revealing more detailed information about what's missing.  

Because of the ordering of the validations, a level success (playing three sounds simultaneously) still shows as soon as it's done.  

Because "Let's listen..." only makes sense while the program is running, a new optional `"showOnlyWhileRunning": true` parameter is used in the validation definition.

And because we don't want this particular validation to persist during a run once we pass the measure in question (that is, this validation will often start failing partway through a run), we avoid accumulating it, and rather check fresh for it each frame.

https://github.com/code-dot-org/code-dot-org/assets/2205926/904252b3-c95d-41df-a5ae-e226a6bfba0c
