### PR TITLE
Music: fix for library switching

### DIFF
--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -198,18 +198,20 @@ class FieldSounds extends GoogleBlockly.Field {
     // Add an image for the sound type.
     const soundType = this.options
       .getLibrary()
-      .getSoundForId(this.getValue()).type;
+      .getSoundForId(this.getValue())?.type;
 
-    GoogleBlockly.utils.dom.createSvgElement(
-      'image',
-      {
-        x: 6,
-        y: 3,
-        width: 15,
-        href: `/blockly/media/music/icon-${soundType}.png`,
-      },
-      this.backgroundElement
-    );
+    if (soundType) {
+      GoogleBlockly.utils.dom.createSvgElement(
+        'image',
+        {
+          x: 6,
+          y: 3,
+          width: 15,
+          href: `/blockly/media/music/icon-${soundType}.png`,
+        },
+        this.backgroundElement
+      );
+    }
 
     // Now attach the text element to the background parent.  It will
     // render on top of the background rectangle.
@@ -223,7 +225,7 @@ class FieldSounds extends GoogleBlockly.Field {
   }
 
   getText() {
-    return this.options.getLibrary().getSoundForId(this.getValue()).name;
+    return this.options.getLibrary().getSoundForId(this.getValue())?.name || '';
   }
 
   updateSize_() {


### PR DESCRIPTION
Music Lab assumes that each project will always use the sound library that it's created with, and so we don't mind some erroneous behaviour when an existing project is loaded with a different library through the `?library=` URL parameter.  That said, the `play sound` block was throwing an exception when a sound wasn't recognised, which led to some "unknown" blocks being saved.

With this change, the exception is no longer thrown, and instead the block field is rendered blank.  We should still notice this if it happens unexpectedly (and we plan to never seen this happening for end-users), but it makes internal scenarios a bit less confusing.  In fact, it means that as a project changes back and forth between libraries, all blocks maintain their internal values, and those that can be played, will.

To illustrate, here's a project loaded with the `intro2024` library:
<img width="1512" alt="Screenshot 2024-03-15 at 4 00 10 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/3c21fffe-ee07-4a74-b5d9-acdf95fc813d">

And here's the same project loaded with the `launch2024` library via URL parameter:
<img width="1512" alt="Screenshot 2024-03-15 at 3 59 43 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/4eae3195-f08c-4417-b60f-2aaa8e0073bc">

