### PR TITLE
Music: update header button behavior

### DIFF
--- a/apps/src/music/views/HeaderButtons.module.scss
+++ b/apps/src/music/views/HeaderButtons.module.scss
@@ -3,6 +3,10 @@
 
 .container {
   display: flex;
+
+  .subContainer {
+    display: flex;
+  }
 }
 
 .button {
@@ -22,6 +26,5 @@
   &Disabled {
     opacity: 50%;
     cursor: default;
-    pointer-events: none;
   }
 }

--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -10,6 +10,7 @@ import {AnalyticsContext} from '../context';
 import {MusicState} from '../redux/musicRedux';
 import moduleStyles from './undo-redo-buttons.module.scss';
 import musicI18n from '../locale';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 
 interface HeaderButtonsProps {
   onClickUndo: () => void;
@@ -25,6 +26,7 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
   onClickRedo,
   clearCode,
 }) => {
+  const canReload: boolean = !useSelector(isReadOnlyWorkspace);
   const {canUndo, canRedo} = useSelector(
     (state: {music: MusicState}) => state.music.undoStatus
   );
@@ -49,6 +51,10 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
   );
 
   const onClickStartOver = useCallback(() => {
+    if (!canReload) {
+      return;
+    }
+
     if (dialogControl) {
       dialogControl.showDialog(DialogType.StartOver, clearCode);
     }
@@ -56,7 +62,7 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
     if (analyticsReporter) {
       analyticsReporter.onButtonClicked('startOver');
     }
-  }, [dialogControl, analyticsReporter, clearCode]);
+  }, [dialogControl, analyticsReporter, clearCode, canReload]);
 
   const onFeedbackClicked = () => {
     if (analyticsReporter) {
@@ -73,7 +79,10 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
       <button
         onClick={onClickStartOver}
         type="button"
-        className={classNames(moduleStyles.button)}
+        className={classNames(
+          moduleStyles.button,
+          !canReload && moduleStyles.buttonDisabled
+        )}
       >
         <FontAwesome
           title={musicI18n.startOver()}

--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -8,7 +8,7 @@ import React, {useCallback, useContext} from 'react';
 import {useSelector} from 'react-redux';
 import {AnalyticsContext} from '../context';
 import {MusicState} from '../redux/musicRedux';
-import moduleStyles from './undo-redo-buttons.module.scss';
+import moduleStyles from './HeaderButtons.module.scss';
 import musicI18n from '../locale';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 
@@ -26,7 +26,7 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
   onClickRedo,
   clearCode,
 }) => {
-  const canReload: boolean = !useSelector(isReadOnlyWorkspace);
+  const readOnlyWorkspace: boolean = useSelector(isReadOnlyWorkspace);
   const {canUndo, canRedo} = useSelector(
     (state: {music: MusicState}) => state.music.undoStatus
   );
@@ -51,10 +51,6 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
   );
 
   const onClickStartOver = useCallback(() => {
-    if (!canReload) {
-      return;
-    }
-
     if (dialogControl) {
       dialogControl.showDialog(DialogType.StartOver, clearCode);
     }
@@ -62,7 +58,7 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
     if (analyticsReporter) {
       analyticsReporter.onButtonClicked('startOver');
     }
-  }, [dialogControl, analyticsReporter, clearCode, canReload]);
+  }, [dialogControl, analyticsReporter, clearCode]);
 
   const onFeedbackClicked = () => {
     if (analyticsReporter) {
@@ -76,40 +72,51 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
 
   return (
     <div className={moduleStyles.container}>
-      <button
-        onClick={onClickStartOver}
-        type="button"
-        className={classNames(
-          moduleStyles.button,
-          !canReload && moduleStyles.buttonDisabled
-        )}
-      >
-        <FontAwesome
-          title={musicI18n.startOver()}
-          icon="refresh"
-          className={'icon'}
-        />
-      </button>
-      <button
-        onClick={() => onClickUndoRedo('undo')}
-        type="button"
-        className={classNames(
-          moduleStyles.button,
-          !canUndo && moduleStyles.buttonDisabled
-        )}
-      >
-        <FontAwesome title={musicI18n.undo()} icon="undo" className={'icon'} />
-      </button>
-      <button
-        onClick={() => onClickUndoRedo('redo')}
-        type="button"
-        className={classNames(
-          moduleStyles.button,
-          !canRedo && moduleStyles.buttonDisabled
-        )}
-      >
-        <FontAwesome title={musicI18n.redo()} icon="redo" className={'icon'} />
-      </button>
+      {!readOnlyWorkspace && (
+        <div className={moduleStyles.subContainer}>
+          <button
+            onClick={onClickStartOver}
+            type="button"
+            className={classNames(moduleStyles.button)}
+          >
+            <FontAwesome
+              title={musicI18n.startOver()}
+              icon="refresh"
+              className={'icon'}
+            />
+          </button>
+          <button
+            onClick={() => onClickUndoRedo('undo')}
+            type="button"
+            className={classNames(
+              moduleStyles.button,
+              !canUndo && moduleStyles.buttonDisabled
+            )}
+            disabled={!canUndo}
+          >
+            <FontAwesome
+              title={musicI18n.undo()}
+              icon="undo"
+              className={'icon'}
+            />
+          </button>
+          <button
+            onClick={() => onClickUndoRedo('redo')}
+            type="button"
+            className={classNames(
+              moduleStyles.button,
+              !canRedo && moduleStyles.buttonDisabled
+            )}
+            disabled={!canRedo}
+          >
+            <FontAwesome
+              title={musicI18n.redo()}
+              icon="redo"
+              className={'icon'}
+            />
+          </button>
+        </div>
+      )}
       <button
         onClick={onFeedbackClicked}
         type="button"

--- a/apps/src/music/views/undo-redo-buttons.module.scss
+++ b/apps/src/music/views/undo-redo-buttons.module.scss
@@ -22,5 +22,6 @@
   &Disabled {
     opacity: 50%;
     cursor: default;
+    pointer-events: none;
   }
 }


### PR DESCRIPTION
This work began with the goal of just disabling the "Start Over" button for read-only workspaces, but ended up doing a couple things:

- The refresh, undo, and redo buttons are no longer shown for read-only workspaces.
- The undo and redo buttons are properly disabled when not available, taking them out of keyboard navigation.
