### PR TITLE
[Google Blockly] remove dark mode option from context menu

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -7,6 +7,7 @@ import {blocks as procedureBlocks} from '../customBlocks/googleBlockly/procedure
 import {
   BLOCK_TYPES,
   CLAMPED_NUMBER_REGEX,
+  DARK_THEME_SUFFIX,
   DEFAULT_SOUND,
   stringIsXml,
   Themes,
@@ -26,9 +27,10 @@ import {
   getProjectXml,
   processIndividualBlock,
 } from '@cdo/apps/blockly/addons/cdoXml';
-import {Block, BlockSvg, Field, WorkspaceSvg} from 'blockly';
+import {Block, BlockSvg, Field, Theme, WorkspaceSvg} from 'blockly';
 import {BlockColor, JsonBlockConfig, WorkspaceSerialization} from '../types';
 import experiments from '@cdo/apps/util/experiments';
+import {getBaseName} from '../utils';
 
 /**
  * Loads blocks to a workspace.
@@ -293,16 +295,30 @@ export function getField(type: string) {
 
 /**
  * Returns a theme object, based on the presence of an option in the browser's localStorage.
- * @param {string} type
+ * @param {?Theme} themeOption
  * @returns {?Blockly.Field}
  */
-// Users can change their active theme using the context menu. Use this setting, if present.
-export function getUserTheme(themeOption: string | undefined) {
-  return (
-    Blockly.themes[localStorage.blocklyTheme as Themes] ||
-    themeOption ||
-    cdoTheme
-  );
+export function getUserTheme(themeOption: Theme | undefined) {
+  // Today we only store the theme's base name in localStorage, which never includes 'dark'.
+  // Until March, 2024 we stored the full theme name, so we need to convert it now.
+  // getBaseName strips the 'dark' suffix from a theme name, if present.
+  const localStorageThemeBaseName = getBaseName(localStorage.blocklyTheme);
+
+  // For labs that use dark mode by default, ensure we are returning a dark theme.
+  if (themeOption?.name.endsWith(DARK_THEME_SUFFIX)) {
+    return localStorageThemeBaseName
+      ? Blockly.themes[
+          (localStorageThemeBaseName + DARK_THEME_SUFFIX) as Themes
+        ]
+      : themeOption;
+  } else {
+    // For all other labs, return a light mode theme.
+    return (
+      Blockly.themes[localStorageThemeBaseName as Themes] ||
+      themeOption ||
+      cdoTheme
+    );
+  }
 }
 
 /**

--- a/apps/src/blockly/addons/contextMenu.ts
+++ b/apps/src/blockly/addons/contextMenu.ts
@@ -15,11 +15,11 @@ import {
   BLOCKLY_CURSOR,
   BLOCKLY_THEME,
   NAVIGATION_CURSOR_TYPES,
+  DARK_THEME_SUFFIX,
 } from '../constants';
 import LegacyDialog from '../../code-studio/LegacyDialog';
 import experiments from '@cdo/apps/util/experiments';
-
-const dark = 'dark';
+import {getBaseName} from '../utils';
 
 // Some options are only available to levelbuilders via start mode.
 // Literal strings are used for display text instead of translatable strings
@@ -224,37 +224,6 @@ const registerCursor = function (cursorType: string, weight: number) {
   GoogleBlockly.ContextMenuRegistry.registry.register(cursorOption);
 };
 
-/**
- * Toggle workspace theme between light/dark components
- */
-const registerDarkMode = function (weight: number) {
-  const toggleDarkModeOption = {
-    displayText: function (scope: ContextMenuRegistry.Scope) {
-      return scope.workspace && isDarkTheme(scope.workspace)
-        ? commonI18n.blocklyTurnOffDarkMode()
-        : commonI18n.blocklyTurnOnDarkMode();
-    },
-    preconditionFn: function () {
-      return MenuOptionStates.ENABLED;
-    },
-    callback: function (scope: ContextMenuRegistry.Scope) {
-      if (!scope.workspace) {
-        return;
-      }
-      const currentTheme = scope.workspace.getTheme();
-      const themeName =
-        baseName(currentTheme.name as Themes) +
-        (isDarkTheme(scope.workspace) ? '' : dark);
-      localStorage.setItem(BLOCKLY_THEME, themeName);
-      setAllWorkspacesTheme(Blockly.themes[themeName as Themes], currentTheme);
-    },
-    scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.WORKSPACE,
-    id: 'toggleDarkMode',
-    weight,
-  };
-  GoogleBlockly.ContextMenuRegistry.registry.register(toggleDarkModeOption);
-};
-
 const themes = [
   {
     name: Themes.MODERN,
@@ -297,9 +266,10 @@ const registerTheme = function (name: Themes, label: string, weight: number) {
       }
     },
     callback: function (scope: ContextMenuRegistry.Scope) {
+      localStorage.setItem(BLOCKLY_THEME, name);
       const currentTheme = scope.workspace?.getTheme();
-      const themeName = name + (isDarkTheme(scope.workspace) ? dark : '');
-      localStorage.setItem(BLOCKLY_THEME, themeName);
+      const themeName =
+        name + (isDarkTheme(currentTheme) ? DARK_THEME_SUFFIX : '');
       setAllWorkspacesTheme(Blockly.themes[themeName as Themes], currentTheme);
     },
     scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.WORKSPACE,
@@ -421,15 +391,13 @@ function hasShadowChildren(block: Block) {
 }
 
 function isCurrentTheme(theme: Themes, workspace: WorkspaceSvg | undefined) {
-  return baseName(workspace?.getTheme().name as Themes) === baseName(theme);
+  return (
+    getBaseName(workspace?.getTheme().name as Themes) === getBaseName(theme)
+  );
 }
 
-function isDarkTheme(workspace: WorkspaceSvg | undefined) {
-  return workspace?.getTheme().name.includes(dark);
-}
-
-function baseName(themeName: Themes) {
-  return themeName.replace(dark, '');
+function isDarkTheme(theme: Theme | undefined) {
+  return theme?.name.includes(DARK_THEME_SUFFIX);
 }
 
 function setAllWorkspacesTheme(
@@ -519,6 +487,5 @@ function registerCustomWorkspaceOptions() {
   // sorted in the order listed here. The ++ incrementation happens after the value is accessed.
   registerKeyboardNavigation(nextWeight++);
   registerAllCursors(nextWeight++, NAVIGATION_CURSOR_TYPES);
-  registerDarkMode(nextWeight++);
   registerThemes(nextWeight++, themes);
 }

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -28,6 +28,8 @@ export enum Themes {
   TRITANOPIA_DARK = 'cdotritanopiadark',
 }
 
+export const DARK_THEME_SUFFIX = 'dark';
+
 export enum BlockStyles {
   DEFAULT = 'default',
   SETUP = 'setup_blocks',

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -608,7 +608,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   // We used to refer to these as "readOnlyBlockSpaces", which was confusing with normal,
   // read only workspaces.
   blocklyWrapper.createEmbeddedWorkspace = function (container, xml, options) {
-    const theme = cdoUtils.getUserTheme(options.theme as string) as Theme;
+    const theme = cdoUtils.getUserTheme(options.theme as Theme);
     const workspace = new Blockly.WorkspaceSvg({
       readOnly: true,
       theme: theme,
@@ -674,7 +674,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     const optOptionsExtended = opt_options as ExtendedBlocklyOptions;
     const options = {
       ...optOptionsExtended,
-      theme: cdoUtils.getUserTheme(optOptionsExtended.theme as string),
+      theme: cdoUtils.getUserTheme(optOptionsExtended.theme as Theme),
       trashcan: false, // Don't use default trashcan.
       move: {
         wheel: true,

--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -5,6 +5,7 @@ import {getStore} from '@cdo/apps/redux';
 import {setFailedToGenerateCode} from '@cdo/apps/redux/blockly';
 import MetricsReporter from '@cdo/apps/lib/metrics/MetricsReporter';
 import {MetricEvent} from '@cdo/apps/lib/metrics/events';
+import {DARK_THEME_SUFFIX, Themes} from './constants';
 
 type xmlAttribute = string | null;
 
@@ -143,5 +144,12 @@ export function handleCodeGenerationFailure(
       errorMessage: error.message,
       stackTrace: error.stack,
     });
+  }
+}
+
+// Returns the current theme name without the 'dark' suffix, if present.
+export function getBaseName(themeName: Themes) {
+  if (themeName) {
+    return themeName.replace(DARK_THEME_SUFFIX, '');
   }
 }


### PR DESCRIPTION
## Background and Context

Last month, @breville documented an issue he described as an "endless toggle" problem related to themes in Google Blockly labs:

> Repro:
> 1. visit https://studio.code.org/projectbeats
>   * choose Turn off dark mode.
>   * choose Turn on dark mode.
> 2. visit https://studio.code.org/projects/spritelab
>   * observe that it's unexpectedly dark mode.
>   * choose Turn off dark mode.
> 3. visit visit https://studio.code.org/projectbeats again
>   * observe that it's unexpectedly light mode.

We want to move towards greater consistency between our Blockly labs, but having one lab with mostly dark components makes it less straight-forward. While this was sharing of theme preferences was intentional, he also pointed out that it created the potential for a "partial dark mode" experience that was potentially undesired:
<img width="50%" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/9dfb68a9-5072-43c6-9afa-17a8927904ca"><img width="50%" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/7e8d80c8-c8ff-4002-86bf-6cc1bc42d62a">


**Option 1: Separate storage entries**

As a potential fix, Brendan proposed that we create separate state to track theme preferences in labs with dark mode as the default:
* https://github.com/code-dot-org/code-dot-org/pull/57256

This solves the "endless toggle" problem, but doubles the work for a user who wants an accessible block theme in both types of labs. It also adds an additional thing to `localStorage` which isn't our desired long-term solution. (Ticket for that: https://codedotorg.atlassian.net/browse/CT-77)

**Option 2: "Lab default" theme option**
As a counter-proposal, I suggested that we could simply add a new option to the context menu to revert to the lab's default theme (effectively deleting the `localStorage` entry). This can potentially solve the "endless toggle" problem, but it puts the onus on the effected user to figure out how. This was not drafted in a pull request.

Neither of these two proposals address the second problem: It is still possible to get into a "partial dark mode" state.

**Option 3: Remove dark mode toggling**
Finally, @ebeastlake proposed that turn off dark and light mode options for all Google Blockly labs until we can fully support dark/light mode for the full platform (not just the Blockly workspace). This effectively hides a partially-built feature and solves both of the problems that Brendan raised. This pull request implements Emily's suggested solution.

Full Slack thread: https://codedotorg.slack.com/archives/C05DK21DAHK/p1707716345562319

## Technical Details
### Context Menu updates
In this branch, we remove the completely remove option that toggles dark mode (ie. the dark and light versions of our 5 types of themes). 
When a user selects another theme via context menu, we only save the base name (excluding "dark), which describes the user's preferences for block styles.

### Inject Updates
Upon creating a workspace, we will always set the theme to one that matches the light/dark default of the lab. For example, if a user has a saved `'cdohighcontrastdark'` in `localStorage`, we will use the dark high contrast theme for Music Lab, but the standard (light) high contrast theme for other labs. If a user has saved `'cdomodern'` (our light default theme), we will still load Music Lab with the default dark theme. Needing to get the base name is effectively backwards-compatibility stuff for people who have a saved option. 

### Other cleanup
* `getUserTheme`'s `themeOption` parameter was incorrectly listed as a string. Updated to use the `Theme` type.
* A constant for the string `'dark'` was moved to a shared constants file.
* The helper function to get a theme's base name was moved out of the context menu file and into utils.
* The helper function `isDarkTheme` was refactored to take a theme argument rather than a workspace. This better matches the purpose of the function and we were already accessing the theme in the same way outside of this scope.

These changes make it so that users will always see a dark theme in Music Lab (our only dark-default Blockly lab) and a light theme elsewhere. Users can still select between our modern block styles, high contrast block styles, or any of our three block themes for users with limited color vision.


## Links

Slack thread: https://codedotorg.slack.com/archives/C05DK21DAHK/p1707716345562319

## Testing story

Before making any changes to my branch, I opened Music Lab and set the theme to dark/protanopia. After making the changes, I opened Music Lab in another tab and saw that it the theme had not change. I opened Sprite Lab and saw that it was using light/protanopia. I then manually updated my local storage entry to several other potential light/dark options and observed that for each case the workspace was loaded with a theme that matched the lab's other components.
<img width="50%" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/12e07890-9bd2-484b-910e-1276212ffb64"><img width="60%" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/8abdf32c-f2c1-4905-851b-afed41242331">


I confirmed that option to toggle dark mode was removed from the context menu. I confirmed that we are now only storing the theme's base name in `localStorage`.

## Follow-up work

* Move theme preferences out of `localStorage` ([Jira issue](https://codedotorg.atlassian.net/browse/CT-77))
* Improve discoverability of accessibility features ([Google Doc](https://docs.google.com/document/d/1KeyWlKz7ma-7Oc7ICAtIbreuNUFnJTN10c2pQi3pa0U/edit#heading=h.qi8xxyq72bct))
* (Long-term) Eventually build support for toggling dark mode on/off in our labs ([Figma board](https://www.figma.com/file/hExjmRsMv3jseWOIMjLbj0/Dark-Mode?type=design&node-id=1038-8033&mode=design&t=XyLwWNyi0tCESRRl-0))

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
