### PR TITLE
Update text on congrats page after personalizing certificate

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -475,7 +475,7 @@
   "congratsCertificateShare": "Share your achievement",
   "congratsCertificateShareMessage": "Share your achievement with others and encourage them to participate.",
   "congratsCertificateThanks": "Thanks for submitting!",
-  "congratsCertificateContinue": "Now, keep going with our other courses, or see more options to Learn beyond an Hour below.",
+  "congratsCertificateContinue": "Now, see options below to keep going with our other courses.",
   "congratsNextLevelHeading": "Graduate to the next level",
   "congratsSelfPacedPlTitle": "Explore more self-paced professional learning modules",
   "congratsSelfPacedPlDescription": "Keep learning with our robust selection of self-paced professional learning modules. Our self-paced learning works in tandem with our curriculum so you can empower yourself and your students at the pace that’s best for you.",


### PR DESCRIPTION
Updates the text after personalizing a certificate to not reference an hour of code. I decided to update the existing text rather than create a new string to avoid un-translating the page, but I'm open to push back there!

<img width="1048" alt="Screenshot 2024-03-15 at 9 44 37 AM" src="https://github.com/code-dot-org/code-dot-org/assets/46464143/2786e93a-680c-484f-bfbd-83580f46dccf">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
