### PR TITLE
[Design2-102] DSCO - Typography - Update docs, and check how custom styles are set across the project

### DIFF
--- a/apps/src/aichat/views/ChatMessage.tsx
+++ b/apps/src/aichat/views/ChatMessage.tsx
@@ -108,11 +108,7 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({message}) => {
 
       {isAssistant(message.role) && (
         <div className={moduleStyles.assistantMessageContainer}>
-          <Typography
-            className={moduleStyles.messageHeaderContainer}
-            semanticTag="h5"
-            visualAppearance="heading-xs"
-          >
+          <Typography semanticTag="h5" visualAppearance="heading-xs">
             {botTitle} ({message.role})
           </Typography>
           {displayAssistantMessage(message.status, message.chatMessageText)}

--- a/apps/src/aichat/views/chatMessage.module.scss
+++ b/apps/src/aichat/views/chatMessage.module.scss
@@ -12,6 +12,10 @@
 
 .assistantMessageContainer {
     margin: 0 50px 15px 0;
+
+    h5 {
+        margin: 5px 0 5px 0;
+    }
 }
 
 .userMessage {
@@ -28,8 +32,4 @@
 
 .tooPersonalMessage {
     background-color: $lightest_yellow;
-}
-
-.messageHeaderContainer {
-    margin: 5px 0 5px 0;
 }

--- a/apps/src/componentLibrary/typography/README.md
+++ b/apps/src/componentLibrary/typography/README.md
@@ -17,7 +17,7 @@ The long explanation [can be found here](https://github.com/code-dot-org/code-do
 Since we're using scss modules and classnames inside, **to overwrite the styles of the components, you need to make sure 
 overwriting styles has highest styles priority**.
 
-Here's some examples:
+Here are some examples:
 
 ```javascript
  // Assuming we want to make h1 element that will look like h5 with a different color than Typography's default.
@@ -38,7 +38,7 @@ Here's some examples:
 //     </style>
 
             <div className={scssModule.parentDiv}>
-                <Heading1 visualAppearance="heading-lg">
+                <Heading1 visualAppearance="heading-sm">
                     Some Heading
                 </Heading1>
             </div>
@@ -52,7 +52,7 @@ Here's some examples:
 //     </style>
 
             <div>
-                <Heading1 visualAppearance="heading-lg" className={scssModule.customHeadingStyle}>
+                <Heading1 visualAppearance="heading-sm" className={scssModule.customHeadingStyle}>
                     Some Heading
                 </Heading1>
             </div>
@@ -91,4 +91,4 @@ import Typography from './../componentLibrary/typography';
 
 ```
 
-For guidelines on how to use these components and the features they offer, [visit Storybook](http://localhost:9001/?path=/story/typography-component--body-one).
+For guidelines on how to use these components and the features they offer, [visit Storybook](http://localhost:9001/?path=/story/designsystem-typography--all-typography-elements).

--- a/apps/src/componentLibrary/typography/README.md
+++ b/apps/src/componentLibrary/typography/README.md
@@ -14,31 +14,10 @@ Short explanation is that we in order to use semantic tags correctly we might wa
 The long explanation [can be found here](https://github.com/code-dot-org/code-dot-org/pull/51116#discussion_r1159915772)
 
 ### Additional styling / rewriting existing styles of the components
-Since we're using scss modules and classnames inside, to overwrite the styles of the components, you need to make sure 
-overwriting styles has highest styles priority. Here's some examples:
+Since we're using scss modules and classnames inside, **to overwrite the styles of the components, you need to make sure 
+overwriting styles has highest styles priority**.
 
-```javascript
- // Assuming we want to make h1 element that will look like h1 with a different color than Typography's default.
-    <div>
-        <Heading1>
-            Some Heading
-        </Heading1>
-    </div>
-
-// Just add any classname style in your scss module to the Heading1.
-//     <style>
-//     .heading1Style {
-//       color: #f00;
-//     }
-//     </style>
-
-    <div>
-        <Heading1 className={scssModule.heading1Style}>
-            Some Heading
-        </Heading1>
-    </div>
-
-```
+Here's some examples:
 
 ```javascript
  // Assuming we want to make h1 element that will look like h5 with a different color than Typography's default.
@@ -52,8 +31,9 @@ overwriting styles has highest styles priority. Here's some examples:
 
 //     <style>
 //     .parentDiv {
-//     h1 {
+//       h1 {
 //         color: #f00;
+//       }
 //     }
 //     </style>
 
@@ -77,7 +57,7 @@ overwriting styles has highest styles priority. Here's some examples:
                 </Heading1>
             </div>
 
-// 2. Use inline styles:
+// 2. (Not recomended since we're trying to avoid inline stlyes) Use inline styles:
             <div>
                 <Heading1 visualAppearance="heading-lg" style={{color: '#f00'}}>
                     Some Heading
@@ -85,6 +65,8 @@ overwriting styles has highest styles priority. Here's some examples:
             </div>
 
 ```
+
+***Always relly on css selector priority, not the order of stylesheets being loaded.*** (Since order of stylesheets load can be changed almost randomly [example here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1710363328926969))
 
 
 

--- a/apps/src/lab2/levelEditors/validations/EditValidations.tsx
+++ b/apps/src/lab2/levelEditors/validations/EditValidations.tsx
@@ -107,11 +107,7 @@ const EditValidations: React.FunctionComponent<EditValidationsProps> = ({
         name="level[validations]"
         value={JSON.stringify(validations)}
       />
-      <Typography
-        semanticTag="p"
-        visualAppearance="body-three"
-        className={moduleStyles.title}
-      >
+      <Typography semanticTag="p" visualAppearance="body-three">
         Edit validations for this level. Currently only supported by Lab2 labs.
         <br />
         NOTE: Validations are checked in the order they are listed. The first

--- a/apps/src/lab2/levelEditors/validations/edit-validations.module.scss
+++ b/apps/src/lab2/levelEditors/validations/edit-validations.module.scss
@@ -14,16 +14,17 @@
   border-radius: 4px;
   margin: 20px 0;
   padding: 20px 10px;
+
+  .validationTitle {
+    padding-bottom: 10px;
+    padding-right: 10px;
+  }
 }
 
 .message {
   width: 90%;
 }
 
-.validationTitle {
-  padding-bottom: 10px;
-  padding-right: 10px;
-}
 
 .label {
   padding-right: 10px;

--- a/apps/src/templates/certificates/certificate_batch.module.scss
+++ b/apps/src/templates/certificates/certificate_batch.module.scss
@@ -264,7 +264,7 @@ a.linkButton {
   height: 247px;
 }
 
-.textCenter {
+h3.textCenter {
   text-align: center;
 }
 

--- a/apps/src/templates/certificates/congrats.module.scss
+++ b/apps/src/templates/certificates/congrats.module.scss
@@ -6,7 +6,7 @@
   margin-top: 50px;
 }
 
-.header {
+h1.header {
   color: $neutral_dark;
 }
 
@@ -26,7 +26,7 @@
   width: 50%;
 }
 
-.heading {
+h1.heading {
   width: 100%;
 }
 
@@ -36,7 +36,7 @@
   width: 100%;
 }
 
-.mobileHeading {
+h1.mobileHeading {
   font-size: 24px;
   line-height: 1.5;
 }
@@ -69,9 +69,9 @@
 .confetti {
   top: 100px;
 }
-.enterName {
-  font-weight: bold !important;
-  margin: 0 !important;
+p.enterName {
+  font-weight: bold;
+  margin: 0;
 }
 
 .inputButtonContainer {

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -1109,12 +1109,12 @@ button.infoAlertRight {
   gap: 1rem;
 }
 
-.detailsVisible {
+p.detailsVisible {
   display: inline;
   padding-inline-end: 1rem;
 }
 
-.detailsHidden {
+p.detailsHidden {
   display: none;
 }
 

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -759,7 +759,7 @@ p.aiFeedbackRadioBoxText {
   gap: 0.5rem;
 }
 
-.aiFeedbackReceived {
+em.aiFeedbackReceived {
   i {
     margin-right: 0.5rem;
   }

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -554,7 +554,7 @@ p.errorMessage {
   }
 }
 
-.aiAssessmentScoreText {
+p.aiAssessmentScoreText {
   strong::after {
     content: ' ';
   }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [Design2-102] DSCO - Typography - Update docs, and check how custom styles are set across the project

When updating storybook, we discovered that for some reason order of loaded stylesheets has changed and it activated the styles that weren't active before (because they had the same priority as the `TypographyElements` styles). More info about it in [this slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1710363328926969).

When developing [TypographyElements for Designs system](https://github.com/code-dot-org/code-dot-org/tree/staging/apps/src/componentLibrary/typography) we used .classNames to style `TypographyElements` which means that in order to add customStyles for `TypographyElement` - one need to set this styles via higher priority css selector. We have this info in the [Readme.md](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/componentLibrary/typography/README.md)
```
// 1. (Recomended) We can use scss module for 
//      a) set a classname for a parent element and update h1 in that style

//     <style>
//     .parentDiv {
//     h1 {
//         color: #f00;
//     }
//     </style>

            <div className={scssModule.parentDiv}>
                <Heading1 visualAppearance="heading-lg">
                    Some Heading
                </Heading1>
            </div>

//      b) set a specific classname for a heading itself

//     <style>
//     h1.customHeadingStyle {
//          color: #f00;
//     }
//     </style>

            <div>
                <Heading1 visualAppearance="heading-lg" className={scssModule.customHeadingStyle}>
                    Some Heading
                </Heading1>
            </div>
```


However, there also was a misleading comment in that Readme as well:
```
// Just add any classname style in your scss module to the Heading1.
//     <style>
//     .heading1Style {
//       color: #f00;
//     }
//     </style>

    <div>
        <Heading1 className={scssModule.heading1Style}>
            Some Heading
        </Heading1>
    </div>
```

More info in [this slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1710444243762939).


This PR updates documentation removing potentially misleading statement.
Also, I've looked through all of our 'React based' `TypographyElements` usages, located and updated/fixed 7 potential issues. Ideally this PR won't make any visual difference, but it's possible that there'll be some (and if it'll be it should be the desired/actual coded styles for that screens). In general, it might be better to deploy this PR carefully, if possible - even as a separate build, but not necessary.

To sum it up:
* If you're working now, or planning to work with TypographyElements in the future, make sure your custom styles selector will have a higher priority over TypographyElements  styles.
* **Always make sure you rely on css selectors priority, not stylesheet load order(it can change almost randomly).**

## Links
- jira ticket: [DESIGN2-102](https://codedotorg.atlassian.net/browse/DESIGN2-102)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
