### PR TITLE
skip ai eval ui test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -1,3 +1,4 @@
+@skip
 # AI evaluation is stubbed out in UI tests via the /api/test/ai_proxy/assessment route.
 @no_firefox
 Feature: Evaluate student code against rubrics using AI


### PR DESCRIPTION
This will skip the ai_evaluate_student_code ui test pending an investigation into an error that is causing incorrect AI evaluations to be retrieved from the backend.