### PR TITLE
Lab2: add validation messages to loc pipeline

### DIFF
--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -173,6 +173,15 @@ module I18n
                 end
               end
 
+              # Lab2 Validations
+              if level.uses_lab2? && level.try(:validations)
+                validations = level.validations
+                i18n_strings['validations'] = Hash.new unless validations.empty?
+                validations.each do |validation|
+                  i18n_strings['validations'][validation['key']] = validation['message']
+                end
+              end
+
               level_xml = Nokogiri::XML(level.to_xml, &:noblanks)
               blocks = level_xml.xpath('//blocks').first
               if blocks
@@ -383,6 +392,7 @@ module I18n
               long_instructions
               short_instructions
               teacher_markdown
+              validations
             )
 
             redactable = i18n_strings.select do |key, _|

--- a/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
@@ -615,8 +615,6 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
       }
     ]
 
-    p level.validations
-
     expected_result = {
       'validations' => {
         'validation-1' => 'message-1',

--- a/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
@@ -595,6 +595,42 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     assert_equal expected_result, sync_in_instance.send(:get_i18n_strings, level)
   end
 
+  def test_i18n_strings_collection_for_level_validations
+    sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
+
+    level = FactoryBot.build(:music)
+
+    level.validations = [
+      {
+        'conditions' => [{'name' => 'condition-1', 'value' => 1}],
+        'message' => 'message-1',
+        'next' => true,
+        'key' => 'validation-1'
+      },
+      {
+        'conditions' => [],
+        'message' => 'message-2',
+        'next' => false,
+        'key' => 'validation-2',
+      }
+    ]
+
+    p level.validations
+
+    expected_result = {
+      'validations' => {
+        'validation-1' => 'message-1',
+        'validation-2' => 'message-2'
+      }
+    }
+
+    assert_equal expected_result, sync_in_instance.send(:get_i18n_strings, level)
+
+    level.validations = []
+    expected_result = {}
+    assert_equal expected_result, sync_in_instance.send(:get_i18n_strings, level)
+  end
+
   def test_yml_file_writting
     sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
 
@@ -629,6 +665,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
       'long_instructions'  => 'expected_long_instructions',
       'teacher_markdown'   => 'expected_teacher_markdown',
       'authored_hints'     => 'expected_authored_hints',
+      'validations'        => 'expected_validations',
       'contained levels'   => [
         {
           'unexpected_key'     => 'unexpected_value',
@@ -648,6 +685,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
       'long_instructions'  => 'expected_long_instructions',
       'teacher_markdown'   => 'expected_teacher_markdown',
       'authored_hints'     => 'expected_authored_hints',
+      'validations'        => 'expected_validations',
       'contained levels'   => [
         {
           'short_instructions' => 'expected_short_instructions',

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -727,6 +727,20 @@ class Level < ApplicationRecord
     end
   end
 
+  def localized_validations
+    if should_localize?
+      validations.each do |validation|
+        validation['message'] = I18n.t(
+          validation["key"],
+          scope: [:data, :validations, name],
+          default: validation["message"],
+          smart: true
+        )
+      end
+    end
+    validations
+  end
+
   # There's a bit of trickery here. We consider a level to be
   # hint_prompt_enabled for the sake of the level editing experience if any of
   # the scripts associated with the level are hint_prompt_enabled.
@@ -792,6 +806,8 @@ class Level < ApplicationRecord
     properties_camelized[:appName] = game&.app
     properties_camelized[:useRestrictedSongs] = game.use_restricted_songs?
     properties_camelized[:usesProjects] = try(:is_project_level) || channel_backed?
+    # Localized properties
+    properties_camelized["validations"] = localized_validations if properties_camelized["validations"]
     properties_camelized
   end
 

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -729,7 +729,8 @@ class Level < ApplicationRecord
 
   def localized_validations
     if should_localize?
-      validations.each do |validation|
+      validations_clone = validations.map(&:clone)
+      validations_clone.each do |validation|
         validation['message'] = I18n.t(
           validation["key"],
           scope: [:data, :validations, name],
@@ -737,8 +738,10 @@ class Level < ApplicationRecord
           smart: true
         )
       end
+      validations_clone
+    else
+      validations
     end
-    validations
   end
 
   # There's a bit of trickery here. We consider a level to be


### PR DESCRIPTION
Add Lab2 validation messages to the localization pipeline. This will be necessary for localizing Music Lab ahead of our May marketing launch.

Note that while I tested this with the music-intro-2024 script, the content in that script won't actually be added to the production loc pipeline until we manually add it to the list of translatable units. We'll do that once all localization support is in place and the strings are finalized (https://codedotorg.atlassian.net/browse/LABS-569).

## Links

https://codedotorg.atlassian.net/browse/LABS-548

## Testing story

Tested this end to end by running the i18n test sync locally. Details below -

**Sync In** produces a source file like this:

<img width="1810" alt="Screenshot 2024-03-15 at 10 17 52 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/e91c4bd9-9f29-4790-a921-1fc9bacc8d8e">

After running **Sync Up**, we can view and translate the content in Crowdin (these are pseudo-translations for testing purposes):

<img width="1963" alt="Screenshot 2024-03-15 at 10 20 26 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/e5268bc4-2648-4dc7-af68-4c8fdfb37efe">

**Sync Down** and **Sync Out** produces output files like this:

<img width="1267" alt="Screenshot 2024-03-15 at 10 28 36 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/d9e5c5c6-88fd-4822-b715-32394ad8413f">

And finally we see the translated content when running the lab in a different locale:

<img width="1510" alt="Screenshot 2024-03-15 at 10 32 09 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/e1c8388c-f429-4b90-9bbf-0bc2b88775ff">
