### PR TITLE
Fix a Few More Violations of `Style/HashEachMethods`

### DIFF
--- a/dashboard/app/views/notes/index.html.haml
+++ b/dashboard/app/views/notes/index.html.haml
@@ -1,4 +1,4 @@
-- @slides.values.each do |slide|
+- @slides.each_value do |slide|
   .note
     = image_tag(slide[:image])
     %p= slide[:text]

--- a/dashboard/app/views/shared/_school_info.html.haml
+++ b/dashboard/app/views/shared/_school_info.html.haml
@@ -17,7 +17,7 @@
       .question School Country
       %select#school-country.form-control{name: "#{form_name}[country]", type: "select", required: false}
         %option{value: "", selected: true, disabled: true}
-        - COUNTRY_CODE_TO_COUNTRY_NAME.keys.each do |code|
+        - COUNTRY_CODE_TO_COUNTRY_NAME.each_key do |code|
           %option{value: code}= country_name_from_code(code)
 
     .form-group

--- a/pegasus/sites.v3/code.org/views/school_info.haml
+++ b/pegasus/sites.v3/code.org/views/school_info.haml
@@ -10,7 +10,7 @@
       %span{style: "color:#c00; font-family: var(--main-font); font-weight: var(--semi-bold-font-weight); font-size:20px"} *
       %select#school-country.form-control{name: "country_s", type: "select", required: false}
         %option{value: "", selected: true, disabled: true}
-        - COUNTRY_CODE_TO_COUNTRY_NAME.keys.each do |code|
+        - COUNTRY_CODE_TO_COUNTRY_NAME.each_key do |code|
           %option{value: code}= country_name_from_code(code)
 
     .form-group


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/57279, which reenabled this rule. Looks like I missed a few instances of `(keys|values).each`, presumably because they were added to the staging branch between creation and merge of that PR.

These fixes were applied manually.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
