### PR TITLE
Moved keep working in dialog

### DIFF
--- a/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
+++ b/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
@@ -69,11 +69,6 @@ export default function MoreDetailsDialog({hasValidation, onClose}) {
             i18n.validated(),
             i18n.progressLegendDetailsValidated()
           )}
-        {renderItem(
-          ITEM_TYPE.KEEP_WORKING,
-          i18n.markedAsKeepWorking(),
-          i18n.progressLegendDetailsKeepGoing()
-        )}
         <Heading6>{i18n.teacherActions()}</Heading6>
         {renderItem(
           ITEM_TYPE.NEEDS_FEEDBACK,
@@ -84,6 +79,11 @@ export default function MoreDetailsDialog({hasValidation, onClose}) {
           ITEM_TYPE.FEEDBACK_GIVEN,
           i18n.feedbackGiven(),
           i18n.progressLegendDetailsFeedbackGiven()
+        )}
+        {renderItem(
+          ITEM_TYPE.KEEP_WORKING,
+          i18n.markedAsKeepWorking(),
+          i18n.progressLegendDetailsKeepGoing()
         )}
         <Heading6>{i18n.levelTypes()}</Heading6>
         {renderItem(


### PR DESCRIPTION
Moved the `keep working` icon to the Teacher Actions portion.

<img width="989" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/e33bfb84-be3c-40f8-906d-d8fde3efd406">

Note that this matches the Icon Key on the page:

<img width="1099" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/2e84e30d-2b25-4e95-953a-d2374db660c6">



## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-939)

## Testing story

Tested locally on my browser.  Eventually an Eyes test could be put to use here.
