### PR TITLE
CT-409: Always pass anySpeechIncludesValues

### DIFF
--- a/apps/src/p5lab/spritelab/commands/criterionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/criterionCommands.js
@@ -79,6 +79,10 @@ export const commands = {
   // like to give students the flexibility of using the value from either the
   // current or previous frame.
   anySpeechIncludesValues(currentVariables, previousVariables) {
+    // TODO: Reenable this once we get this validation working again
+    // https://codedotorg.atlassian.net/browse/CT-409
+    return true;
+
     const spriteIds = this.getSpriteIdsInUse();
     const values = Object.values(currentVariables).concat(
       previousVariables ? Object.values(previousVariables) : []

--- a/apps/src/p5lab/spritelab/commands/criterionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/criterionCommands.js
@@ -79,25 +79,25 @@ export const commands = {
   // like to give students the flexibility of using the value from either the
   // current or previous frame.
   anySpeechIncludesValues(currentVariables, previousVariables) {
+    // const spriteIds = this.getSpriteIdsInUse();
+    // const values = Object.values(currentVariables).concat(
+    //   previousVariables ? Object.values(previousVariables) : []
+    // );
+
+    // for (const spriteId of spriteIds) {
+    //   const speechText = this.getLastSpeechBubbleForSpriteId(spriteId)?.text;
+    //   if (
+    //     speechText &&
+    //     values.some(value => `${speechText}`.includes(`${value}`))
+    //   ) {
+    //     return true;
+    //   }
+    // }
+    // return false;
+
     // TODO: Reenable this once we get this validation working again
     // https://codedotorg.atlassian.net/browse/CT-409
     return true;
-
-    const spriteIds = this.getSpriteIdsInUse();
-    const values = Object.values(currentVariables).concat(
-      previousVariables ? Object.values(previousVariables) : []
-    );
-
-    for (const spriteId of spriteIds) {
-      const speechText = this.getLastSpeechBubbleForSpriteId(spriteId)?.text;
-      if (
-        speechText &&
-        values.some(value => `${speechText}`.includes(`${value}`))
-      ) {
-        return true;
-      }
-    }
-    return false;
   },
 
   // Return true if exactly one sprite began speaking.


### PR DESCRIPTION
The `anySpeechIncludesValues` criterion command validation is not currently working and is causing some students to be unable to pass a level with the correct code. See [this Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1710521309576259) for more information. 

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/CT-408
Slack thread: https://codedotorg.slack.com/archives/C03DBDN67B7/p1710521309576259

## Testing story

Tested that http://localhost-studio.code.org:3000/s/coursef-2023/lessons/10/levels/3 passes validation with this change. 

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
