### PR TITLE
[ProgressV2] Fix adding students throwing fatal error

### DIFF
--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -17,12 +17,13 @@ function SectionProgressV2({
   unitData,
   isLoadingProgress,
   isRefreshingProgress,
+  isLevelProgressLoaded,
 }) {
   const [expandedLessonIds, setExpandedLessons] = React.useState([]);
 
   const levelDataInitialized = React.useMemo(() => {
-    return unitData && !isLoadingProgress && !isRefreshingProgress;
-  }, [unitData, isLoadingProgress, isRefreshingProgress]);
+    return unitData && isLevelProgressLoaded;
+  }, [unitData, isLevelProgressLoaded]);
 
   React.useEffect(() => {
     if (!unitData && !isLoadingProgress && !isRefreshingProgress) {
@@ -66,6 +67,7 @@ SectionProgressV2.propTypes = {
   unitData: unitDataPropType,
   isLoadingProgress: PropTypes.bool.isRequired,
   isRefreshingProgress: PropTypes.bool.isRequired,
+  isLevelProgressLoaded: PropTypes.bool.isRequired,
 };
 
 export default connect(state => ({
@@ -74,4 +76,8 @@ export default connect(state => ({
   unitData: getCurrentUnitData(state),
   isLoadingProgress: state.sectionProgress.isLoadingProgress,
   isRefreshingProgress: state.sectionProgress.isRefreshingProgress,
+  isLevelProgressLoaded:
+    !!state.sectionProgress.studentLevelProgressByUnit[
+      state.unitSelection.scriptId
+    ],
 }))(SectionProgressV2);


### PR DESCRIPTION
Crash was caused by trying to get data from `studentLevelProgressByUnit` for a student that was just added, but progress data was not loaded. 

This PR:
* Filters all students that don't have progress data loaded from the table
* Async loads progress data again when student progress data is not found
* Only show skeleton if data is not loaded, even if data is getting refreshed

## Links
https://codedotorg.atlassian.net/browse/TEACH-938
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
