### PR TITLE
Fix skip link on explore modules on code.org/csc

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/csc/index.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csc/index.haml
@@ -50,7 +50,7 @@ theme: responsive_full_width
         %span •
         =hoc_s(:teacher_label_csc)
 
-%section.bg-neutral-light.centered
+%section#csc-modules.bg-neutral-light.centered
   .wrapper
     %h2=hoc_s(:csc_explore_curriculum)
     %p=hoc_s(:csc_explore_desc)


### PR DESCRIPTION
Fixes the skip link to https://code.org/educate/csc#csc-modules on the CSC page. 

**Jira ticket:** [ACQ-1606](https://codedotorg.atlassian.net/browse/ACQ-1606)

----


https://github.com/code-dot-org/code-dot-org/assets/9256643/823a3674-cdad-4cff-80af-c1d668c73323

