### PR TITLE
[Google Blockly] Fix bug in blockSpaceToCode

### DIFF
--- a/apps/src/blockly/addons/cdoGenerator.ts
+++ b/apps/src/blockly/addons/cdoGenerator.ts
@@ -40,7 +40,7 @@ export default function initializeGenerator(
       code.push(blocklyWrapper.JavaScript.blockToCode(block));
     });
     let result = code.join('\n');
-    result = generator.finish(code);
+    result = generator.finish(result);
     return result;
   };
 


### PR DESCRIPTION
When converting from javascript to TypeScript I didn't pass the correct variable to `generator.finish`. I passed the original array `code` instead of the stringified `result`. This caused an error if the code was an array with more than one value, as it would get stringified later on with a `,`, which caused code generation to fail.

[PR where I made the mistake](https://github.com/code-dot-org/code-dot-org/pull/56805/files#diff-188d1ce24ff6fffe4a2cef0045a8dc561b70367b85180965682c8c6fab563835L40)

## Links

- [slack discussion](https://codedotorg.slack.com/archives/C05DK21DAHK/p1710532733321179)
- [jira ticket](https://codedotorg.atlassian.net/browse/CT-410)

## Testing story
Tested locally. The bounce level where this failed before no longer fails to generate code if you have a duplicate "when..." block.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
