### PR TITLE
Music: delay showing non-success validation

### DIFF
--- a/apps/src/lab2/progress/ProgressManager.ts
+++ b/apps/src/lab2/progress/ProgressManager.ts
@@ -76,8 +76,8 @@ export default class ProgressManager {
 
     // Go through each validation to see if we have a match.
     for (const validation of this.currentValidations) {
-      // If it's not a next validation, then make sure the lab-specific validator
-      // is ready for it.
+      // If it's a non-successful validation (i.e. validation.next is false), then
+      // make sure the lab-specific validator is ready for it.
       if (this.validator.shouldCheckNextConditionsOnly() && !validation.next) {
         continue;
       }

--- a/apps/src/lab2/progress/ProgressManager.ts
+++ b/apps/src/lab2/progress/ProgressManager.ts
@@ -7,6 +7,7 @@ import {Condition, Validation} from '@cdo/apps/lab2/types';
 // the validation works is up to the implementor.
 export abstract class Validator {
   abstract shouldCheckConditions(): boolean;
+  abstract shouldCheckNextConditionsOnly(): boolean;
   abstract checkConditions(): void;
   abstract conditionsMet(conditions: Condition[]): boolean;
   abstract clear(): void;
@@ -75,6 +76,12 @@ export default class ProgressManager {
 
     // Go through each validation to see if we have a match.
     for (const validation of this.currentValidations) {
+      // If it's not a next validation, then make sure the lab-specific validator
+      // is ready for it.
+      if (this.validator.shouldCheckNextConditionsOnly() && !validation.next) {
+        continue;
+      }
+
       if (validation.conditions) {
         // Ask the lab-specific validator if this validation's
         // conditions are met.

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -21,6 +21,7 @@ export default class MusicValidator extends Validator {
   constructor(
     private readonly getIsPlaying: () => boolean,
     private readonly getPlaybackEvents: () => PlaybackEvent[],
+    private readonly getValidationTimeout: () => number,
     private readonly player: MusicPlayer,
     private readonly conditionsChecker: ConditionsChecker = new ConditionsChecker(
       Object.values(MusicConditions).map(condition => condition.name)
@@ -31,6 +32,12 @@ export default class MusicValidator extends Validator {
 
   shouldCheckConditions() {
     return this.getIsPlaying();
+  }
+
+  shouldCheckNextConditionsOnly() {
+    return (
+      this.player.getCurrentPlayheadPosition() < this.getValidationTimeout()
+    );
   }
 
   checkConditions() {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -118,6 +118,7 @@ class UnconnectedMusicView extends React.Component {
     this.musicValidator = new MusicValidator(
       this.getIsPlaying,
       this.getPlaybackEvents,
+      this.getValidationTimeout,
       this.player
     );
 
@@ -319,6 +320,17 @@ class UnconnectedMusicView extends React.Component {
 
   getIsPlaying = () => {
     return this.props.isPlaying;
+  };
+
+  getValidationTimeout = () => {
+    // The level can specify a desired timeout, in measures, before it starts showing
+    // non-"next" validation messages.  If a timeout is not specified, default to 2,
+    // which allows for one measure of playback.  That said, if we're already past the
+    // last measure of music, then non-"next" validation messages can start showing.
+    return Math.min(
+      this.props.levelData?.validationTimeout || 2,
+      this.sequencer.getLastMeasure()
+    );
   };
 
   getPlaybackEvents = () => {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -323,9 +323,9 @@ class UnconnectedMusicView extends React.Component {
   };
 
   getValidationTimeout = () => {
-    // The level can specify a desired timeout, in measures, before it starts showing
+    // The level can specify a desired timeout, in measures, when it starts showing
     // non-"next" validation messages.  If a timeout is not specified, default to 2,
-    // which allows for one measure of playback.  That said, if we're already past the
+    // which allows for one measure of playback.  That said, if we're already at the
     // last measure of music, then non-"next" validation messages can start showing.
     return Math.min(
       this.props.levelData?.validationTimeout || 2,

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -323,14 +323,18 @@ class UnconnectedMusicView extends React.Component {
   };
 
   getValidationTimeout = () => {
-    // The level can specify a desired timeout, in measures, when it starts showing
-    // non-"next" validation messages.  If a timeout is not specified, default to 2,
-    // which allows for one measure of playback.  That said, if we're already at the
-    // last measure of music, then non-"next" validation messages can start showing.
-    return Math.min(
-      this.props.levelData?.validationTimeout || 2,
-      this.sequencer.getLastMeasure()
-    );
+    // The level can specify a desired timeout, in measures, when we can start showing
+    // non-success validation messages.  That said, if we've just completed playing the
+    // last measure before reaching that specified value, we can start showing the
+    // messages.
+    // If no timeout is specified, then we can starting showing the non-success messages
+    // at measure 2.
+    return this.props.levelData?.validationTimeout
+      ? Math.min(
+          this.props.levelData?.validationTimeout,
+          this.sequencer.getLastMeasure()
+        )
+      : 2;
   };
 
   getPlaybackEvents = () => {

--- a/dashboard/config/levels/custom/music/musiclab_intro_repeat.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_repeat.level
@@ -36,7 +36,8 @@
           ]
         },
         "type": "flyout"
-      }
+      },
+      "validationTimeout": 6
     },
     "instructions_important": "false",
     "hide_share_and_remix": "true",


### PR DESCRIPTION
With this change, a Music Lab level can provide a `validationTimeout` specifying the measure at which non-success validation messages can start appearing.  That said, if this timeout has been specified but the playhead has already completed the final scheduled measure, non-success validation messages can start appearing at that point.

If the level does not provide this value, non-success validation messages can start appearing after the first measure has completed.  This creates a moment of anticipation before seeing initial feedback.

Success validation messages will continue to be shown as soon as they are available.

## Use cases

#### musiclab_intro_repeat

https://github.com/code-dot-org/code-dot-org/assets/2205926/3018c48b-95c4-481e-aa39-f11f93bf0e01

The initial use case is the level in which we want to give the user the opportunity to repeat three sounds before non-success validation messages are shown.  Four scenarios are demonstrated:
- If the user plays three 2-measure sounds, then they will see the success validation messages before any non-success ones have the chance to be shown.  
- If the user plays three short sounds, they will see the success validation message as soon as they start playing the third sound.
- If the user plays two short sounds, they will see the success validation message as soon as the second measure completes.  Despite the playhead not yet reaching the specified timeout value, there are no more scheduled measures to play.  
- If the user plays three very long sounds, they will see non-success validation messages shown, but not until they reach measure 6.

By limiting the sounds for this level to only be those that are 2 measures long, we could always deliver the first option.

#### musiclab_intro_trigger

https://github.com/code-dot-org/code-dot-org/assets/2205926/dd57a022-fb82-413d-9568-8ee559e88b63

Another potential use case is the level in which we want the user to play a triggered sound.  In this implementation, they will see a non-success validation message after the first measure has played, which is the default when the level does not specify a timeout.  We could build support for the level to delay the display of this message until a certain timeout, even though there are no other scheduled sounds, but I've held off on that for now.

## Related

This is an alternative to the idea sketched out in https://github.com/code-dot-org/code-dot-org/pull/57286.  In this approach, the timeout mangement is Music Lab-specific, and is inspired by earlier labs' timeout systems.  