### PR TITLE
Music: fix small layout issue

### DIFF
--- a/apps/src/music/views/music-view.module.scss
+++ b/apps/src/music/views/music-view.module.scss
@@ -26,6 +26,7 @@ $default-spacing: 2px;
   flex-direction: row;
   max-height: calc(100% - $timeline-area-height);
   gap: $default-spacing;
+  overflow: hidden;
 }
 
 .playArea {


### PR DESCRIPTION
The fixes the layout so that it doesn't shift in a subtle but annoying way.

When the instructions were cropped by a feedback message, because the window was not particular high, as shown in the screenshot, the `work-area` would grow by 2px and the `play-area` would shrink by the same.  This two pixel shift could happen repeatedly as feedback appeared and disappeared.

With this fix, the two areas maintain their desired size at all times.  

<img width="1512" alt="Screenshot 2024-03-18 at 8 14 32 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/ce21cbdd-0b25-458c-89ce-713aa6397d49">
