### PR TITLE
Rename sharing project events from 'Finish' button

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -177,7 +177,8 @@ const EVENTS = {
   SHARING_CLOSE_ESCAPE: 'User Clicks X Or Esc Button In Project Share Dialog',
 
   // Project sharing via 'Finish' button
-  FINISH_SHARING_LINK_COPY: 'User Clicks Project Copy Link In Finish Congrats Dialog',
+  FINISH_SHARING_LINK_COPY:
+    'User Clicks Project Copy Link In Finish Congrats Dialog',
   FINISH_SHARING_PUBLISH: 'User Clicks Publish In Finish Congrats Dialog',
   FINISH_SHARING_FB: 'User Clicks Facebook Icon In Finish Congrats Dialog',
   FINISH_SHARING_TWITTER: 'User Clicks Twitter Icon In Finish Congrats Dialog',

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -177,10 +177,10 @@ const EVENTS = {
   SHARING_CLOSE_ESCAPE: 'User Clicks X Or Esc Button In Project Share Dialog',
 
   // Project sharing via 'Finish' button
-  FINISH_SHARING_LINK_COPY: 'User Clicks Project Copy Link In Share Dialog',
-  FINISH_SHARING_PUBLISH: 'User Clicks Publish In Project Share Dialog',
-  FINISH_SHARING_FB: 'User Clicks Facebook Icon In Project Share Dialog',
-  FINISH_SHARING_TWITTER: 'User Clicks Twitter Icon In Project Share Dialog',
+  FINISH_SHARING_LINK_COPY: 'User Clicks Project Copy Link In Finish Congrats Dialog',
+  FINISH_SHARING_PUBLISH: 'User Clicks Publish In Finish Congrats Dialog',
+  FINISH_SHARING_FB: 'User Clicks Facebook Icon In Finish Congrats Dialog',
+  FINISH_SHARING_TWITTER: 'User Clicks Twitter Icon In Finish Congrats Dialog',
   FINISH_SHARING_LINK_SEND_TO_PHONE:
     'User Clicks Send To Phone In Finish Congrats Dialog',
   FINISH_BUTTON_CERTIFICATE:


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the names of sharing project events from the dialog that is displayed after a user clicks on the 'Finish' button on the last level of a progerssion. This is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/57127.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
