### PR TITLE
[Google Blockly] only use cache for dropdown fields on actual behavior blocks

### DIFF
--- a/apps/src/blockly/addons/cdoFieldDropdown.ts
+++ b/apps/src/blockly/addons/cdoFieldDropdown.ts
@@ -37,12 +37,13 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
    * by quotes in xml.
    */
   doClassValidation_(newValue?: string) {
+    const sourceBlock = this.getSourceBlock();
     if (newValue === EMPTY_OPTION) {
       return newValue;
     } else {
       // For behavior picker blocks, we need to regenerate menu options each time,
       // in case a behavior has been renamed.
-      const useCache = this.name !== 'BEHAVIOR';
+      const useCache = sourceBlock?.type === 'gamelab_behaviorPicker';
       for (const option of this.getOptions(useCache, newValue)) {
         if (option[1] === newValue) {
           return newValue;
@@ -51,11 +52,11 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
         }
       }
 
-      if (this.sourceBlock_) {
+      if (sourceBlock) {
         console.warn(
           "Cannot set the dropdown's value to an unavailable option." +
             ' Block type: ' +
-            this.sourceBlock_.type +
+            sourceBlock.type +
             ', Field name: ' +
             this.name +
             ', Value: ' +
@@ -79,9 +80,10 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
    */
   getOptions(useCache?: boolean, newValue?: string) {
     const options = super.getOptions(useCache);
+    const sourceBlock = this.getSourceBlock();
 
     // Behavior pickers do not populate correctly until the workspace has been loaded.
-    if (this.name === 'BEHAVIOR' && newValue) {
+    if (sourceBlock?.type === 'gamelab_behaviorPicker' && newValue) {
       // Check whether the initial newValue option already exists
       const optionExists = options.some(option => option[0] === newValue);
       // The hidden workspace is created after the main workspace flyout is populated.

--- a/apps/src/blockly/addons/cdoFieldDropdown.ts
+++ b/apps/src/blockly/addons/cdoFieldDropdown.ts
@@ -3,7 +3,7 @@ import GoogleBlockly, {
   FieldDropdownValidator,
   MenuGeneratorFunction,
 } from 'blockly/core';
-import {EMPTY_OPTION} from '../constants';
+import {BLOCK_TYPES, EMPTY_OPTION} from '../constants';
 import {
   printerStyleNumberRangeToList,
   numberListToString,
@@ -43,7 +43,7 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     } else {
       // For behavior picker blocks, we need to regenerate menu options each time,
       // in case a behavior has been renamed.
-      const useCache = sourceBlock?.type === 'gamelab_behaviorPicker';
+      const useCache = sourceBlock?.type === BLOCK_TYPES.behaviorPicker;
       for (const option of this.getOptions(useCache, newValue)) {
         if (option[1] === newValue) {
           return newValue;
@@ -83,7 +83,7 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     const sourceBlock = this.getSourceBlock();
 
     // Behavior pickers do not populate correctly until the workspace has been loaded.
-    if (sourceBlock?.type === 'gamelab_behaviorPicker' && newValue) {
+    if (sourceBlock?.type === BLOCK_TYPES.behaviorPicker && newValue) {
       // Check whether the initial newValue option already exists
       const optionExists = options.some(option => option[0] === newValue);
       // The hidden workspace is created after the main workspace flyout is populated.

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -114,6 +114,7 @@ export enum BLOCK_TYPES {
   procedureDefinition = 'procedures_defnoreturn',
   whenRun = 'when_run',
   behaviorGet = 'gamelab_behavior_get',
+  behaviorPicker = 'gamelab_behaviorPicker',
   spriteParameterGet = 'sprite_parameter_get',
   procedureCall = 'procedures_callnoreturn',
   variableGet = 'variables_get',


### PR DESCRIPTION
@onlinecsteacher reported on Slack that on level edit pages we were showing a bad preview for behavior dropdown fields like this green one:

![Screenshot 2024-03-15 at 4 20 55 PM](https://github.com/code-dot-org/code-dot-org/assets/43474485/3377a45e-e1f7-4d34-a6e6-4f5a1a405153)

This block looks just like the `behaviorPicker` which dynamically creates a menu of options based on behavior definition blocks found on the hidden workspace. While the field name is `'BEHAVIOR'`, this is not the same block. In fact, there are several custom blocks with fields named like this that are standard (not dynamic) dropdown fields. The options on these blocks look like `['wandering', 'new Behavior(wandering, [])']`
Because of some oversimplified logic, we were calling `getOptions` with `useCache = true` on these blocks, which had some additional logic only intended for behavior picker blocks. With these other blocks, because the hidden workspace wasn't being loaded on edit pages, we'd call `options.push([newValue, newValue])` which meant the block would get an option like `['new Behavior(wandering, [])', 'new Behavior(wandering, [])']`. This is why levelbuilders were seeing the actual field value instead of its user-friendly label. 

I updated the logic to only do any of this for blocks that have the correct type.
Now the field shows the expected label:

<img width="918" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/be7b1ca8-bce7-4014-a572-da80c1498ce2">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

`behaviorPicker` is a custom input type that can theoretically be added to any block. Today it is only used on one block, but if that changes, we'd have to strengthen this revised logic. Because levelbuilders otherwise have the ability to make new blocks, we may want to address this sooner than later. For example, if a levelbuilder cloned the block into another pool it wouldn't work quite right.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
