### PR TITLE
P20-773: Fix student count when sync students & sections from an LMS integration

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -280,9 +280,13 @@ class LtiV1Controller < ApplicationController
 
       # Report which sections were updated
       nrps_sections.each do |section_id, section|
+        student_count = section[:members].count do |member|
+          member[:roles].include?(Policies::Lti::CONTEXT_LEARNER_ROLE)
+        end
+
         result[:all][section_id] = {
           name: section[:name],
-          size: section[:members].size,
+          size: student_count,
         }
       end
     end

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -552,6 +552,50 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test 'sync_course as json - syncs and returns course sections data' do
+    lti_course_context_id = SecureRandom.uuid
+    lti_course_resource_link_id = SecureRandom.uuid
+    lti_course_nrps_url = 'https://example.com/nrps'
+
+    user = create :teacher, :with_lti_auth
+    lti_integration = create :lti_integration
+    create(
+      :lti_course,
+      lti_integration: lti_integration,
+      context_id: lti_course_context_id,
+      resource_link_id: lti_course_resource_link_id,
+      nrps_url: lti_course_nrps_url
+    )
+
+    LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course_nrps_url, lti_course_resource_link_id)
+    Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
+    Services::Lti.expects(:sync_course_roster).returns(true)
+
+    sign_in user
+
+    assert_no_difference 'LtiCourse.count' do
+      get '/lti/v1/sync_course', params: {
+        lti_integration_id: lti_integration.id,
+        deployment_id: 'foo',
+        context_id: lti_course_context_id,
+        rlid: lti_course_resource_link_id,
+        nrps_url: lti_course_nrps_url
+      }, as: :json
+    end
+
+    expected_sections_data = {
+      'all' => {
+        '1' => {'name' => 'Section 1', 'size' => 3},
+        '2' => {'name' => 'Section 2', 'size' => 3},
+        '3' => {'name' => 'Section 3', 'size' => 3}
+      },
+      'changed' => {},
+    }
+
+    assert_response :ok
+    assert_equal expected_sections_data, JSON.parse(response.body)
+  end
+
   test 'sync - should not sync given no changes' do
     had_changes = false
     user = create :teacher, :with_lti_auth


### PR DESCRIPTION
## Summary
Counts only course section members with the role `http://purl.imsglobal.org/vocab/lis/v2/membership#Learner`.

> Learner: A participant who engages with learning content. Often referred to as a student in many educational contexts.

## NRPS response
```json
{
  "id": "https://codeorg.instructure.com/api/lti/courses/129/names_and_roles",
  "context": {
    "id": "********************************",
    "label": "20-21",
    "title": "20-21 AP CSP Code.org Curriculum"
  },
  "members": [
    {
      "status": "Active",
      "user_id": "********************************",
      "lti11_legacy_user_id": "********************************",
      "roles": ["http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor"]
    }, {
      "status": "Active",
      "user_id": "********************************",
      "lti11_legacy_user_id": "********************************",
      "roles": ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"]
    }
  ]
}
```

## Screenshots
| Before | After |
| ------ | ----- |
| <img width="1124" alt="before" src="https://github.com/code-dot-org/code-dot-org/assets/11708250/b06cb341-df39-4ef8-a102-c65a8024b926"> | <img width="1124" alt="after" src="https://github.com/code-dot-org/code-dot-org/assets/11708250/e9e108a4-ec3e-46a6-89ea-638986853400"> |

## Links
- JIRA ticket: [P20-773](https://codedotorg.atlassian.net/browse/P20-773)