### PR TITLE
[Google Blockly] extend dropdown field class for behavior picker input

### DIFF
--- a/apps/src/blockly/addons/cdoFieldBehaviorPicker.ts
+++ b/apps/src/blockly/addons/cdoFieldBehaviorPicker.ts
@@ -1,0 +1,86 @@
+import CdoFieldDropdown from './cdoFieldDropdown';
+import {
+  FieldDropdownConfig,
+  FieldDropdownValidator,
+  MenuGeneratorFunction,
+} from 'blockly/core';
+import {EMPTY_OPTION} from '../constants';
+
+type CustomMenuGenerator = CustomMenuOption[] | MenuGeneratorFunction;
+type CustomMenuOption = [string, string];
+
+export default class CdoFieldBehaviorPicker extends CdoFieldDropdown {
+  constructor(
+    menuGenerator?: CustomMenuGenerator,
+    validator?: FieldDropdownValidator,
+    config?: FieldDropdownConfig
+  ) {
+    super(menuGenerator, validator, config);
+  }
+
+  /**
+   * Ensure that the input value is a valid language-neutral option.
+   * @param newValue The input value.
+   * @returns A valid language-neutral option, or null if invalid.
+   * @override Add special case for '???' and accommodate valid initial values that are not surrounded
+   * by quotes in xml.
+   */
+  doClassValidation_(newValue?: string): string | null {
+    const sourceBlock = this.getSourceBlock();
+    if (newValue === EMPTY_OPTION) {
+      return newValue;
+    } else {
+      // For behavior picker blocks, we need to regenerate menu options each time,
+      // in case a behavior has been renamed.
+      const useCache = false;
+      for (const option of this.getOptions(useCache, newValue)) {
+        if (option[1] === newValue) {
+          return newValue;
+        } else if (option[1] === `"${newValue}"`) {
+          return `"${newValue}"`;
+        }
+      }
+
+      if (sourceBlock) {
+        console.warn(
+          "Cannot set the dropdown's value to an unavailable option." +
+            ' Block type: ' +
+            sourceBlock.type +
+            ', Field name: ' +
+            this.name +
+            ', Value: ' +
+            newValue
+        );
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Return a list of the options for this dropdown.
+   *
+   * @param useCache For dynamic options, whether or not to use the cached
+   *     options or to re-generate them.
+   * @param {string} newValue The new value to be checked and potentially added
+   *     to the options list (behaviorPicker blocks only).
+   * @returns A non-empty array of option tuples:
+   *     (human-readable text or image, language-neutral name).
+   * @throws {TypeError} If generated options are incorrectly structured.
+   */
+  getOptions(useCache?: boolean, newValue?: string) {
+    const options = super.getOptions(useCache);
+
+    // Behavior pickers do not populate correctly until the workspace has been loaded.
+    if (newValue) {
+      // Check whether the initial newValue option already exists
+      const optionExists = options.some(option => option[0] === newValue);
+      // The hidden workspace is created after the main workspace flyout is populated.
+      const loadingFinished = Blockly.getHiddenDefinitionWorkspace();
+      if (!optionExists && !loadingFinished) {
+        // Assume initial value is valid and add it to the menu if not yet present.
+        options.push([newValue, newValue]);
+      }
+    }
+    return options;
+  }
+}

--- a/apps/src/blockly/addons/cdoFieldDropdown.ts
+++ b/apps/src/blockly/addons/cdoFieldDropdown.ts
@@ -3,7 +3,7 @@ import GoogleBlockly, {
   FieldDropdownValidator,
   MenuGeneratorFunction,
 } from 'blockly/core';
-import {BLOCK_TYPES, EMPTY_OPTION} from '../constants';
+import {EMPTY_OPTION} from '../constants';
 import {
   printerStyleNumberRangeToList,
   numberListToString,
@@ -41,10 +41,7 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     if (newValue === EMPTY_OPTION) {
       return newValue;
     } else {
-      // For behavior picker blocks, we need to regenerate menu options each time,
-      // in case a behavior has been renamed.
-      const useCache = sourceBlock?.type === BLOCK_TYPES.behaviorPicker;
-      for (const option of this.getOptions(useCache, newValue)) {
+      for (const option of this.getOptions(true)) {
         if (option[1] === newValue) {
           return newValue;
         } else if (option[1] === `"${newValue}"`) {
@@ -65,35 +62,6 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
       }
       return null;
     }
-  }
-
-  /**
-   * Return a list of the options for this dropdown.
-   *
-   * @param useCache For dynamic options, whether or not to use the cached
-   *     options or to re-generate them.
-   * @param {string} newValue The new value to be checked and potentially added
-   *     to the options list (behaviorPicker blocks only).
-   * @returns A non-empty array of option tuples:
-   *     (human-readable text or image, language-neutral name).
-   * @throws {TypeError} If generated options are incorrectly structured.
-   */
-  getOptions(useCache?: boolean, newValue?: string) {
-    const options = super.getOptions(useCache);
-    const sourceBlock = this.getSourceBlock();
-
-    // Behavior pickers do not populate correctly until the workspace has been loaded.
-    if (sourceBlock?.type === BLOCK_TYPES.behaviorPicker && newValue) {
-      // Check whether the initial newValue option already exists
-      const optionExists = options.some(option => option[0] === newValue);
-      // The hidden workspace is created after the main workspace flyout is populated.
-      const loadingFinished = Blockly.getHiddenDefinitionWorkspace();
-      if (!optionExists && !loadingFinished) {
-        // Assume initial value is valid and add it to the menu if not yet present.
-        options.push([newValue, newValue]);
-      }
-    }
-    return options;
   }
 
   /**

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -114,7 +114,6 @@ export enum BLOCK_TYPES {
   procedureDefinition = 'procedures_defnoreturn',
   whenRun = 'when_run',
   behaviorGet = 'gamelab_behavior_get',
-  behaviorPicker = 'gamelab_behaviorPicker',
   spriteParameterGet = 'sprite_parameter_get',
   procedureCall = 'procedures_callnoreturn',
   variableGet = 'variables_get',

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -12,6 +12,7 @@ import {BlocklyVersion, WORKSPACE_EVENTS} from '@cdo/apps/blockly/constants';
 import styleConstants from '@cdo/apps/styleConstants';
 import * as utils from '@cdo/apps/utils';
 import initializeCdoConstants from './addons/cdoConstants';
+import CdoFieldBehaviorPicker from './addons/cdoFieldBehaviorPicker';
 import CdoFieldButton from './addons/cdoFieldButton';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
 import CdoFieldToggle from './addons/cdoFieldToggle';
@@ -335,6 +336,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   blocklyWrapper.FieldImageDropdown = CdoFieldImageDropdown;
   blocklyWrapper.FieldToggle = CdoFieldToggle;
   blocklyWrapper.FieldFlyout = CdoFieldFlyout;
+  blocklyWrapper.FieldBehaviorPicker = CdoFieldBehaviorPicker;
 
   blocklyWrapper.blockly_.registry.register(
     blocklyWrapper.blockly_.registry.Type.FLYOUTS_VERTICAL_TOOLBOX,

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -39,6 +39,7 @@ import {IProcedureBlock, IProcedureModel} from 'blockly/core/procedures';
 import BlockSvgFrame from './addons/blockSvgFrame';
 import {ToolboxDefinition} from 'blockly/core/utils/toolbox';
 import CdoFieldVariable from './addons/cdoFieldVariable';
+import CdoFieldBehaviorPicker from './addons/cdoFieldBehaviorPicker';
 
 export interface BlockDefinition {
   category: string;
@@ -83,6 +84,7 @@ export interface BlocklyWrapperType extends GoogleBlocklyType {
     onMainBlockSpaceCreated: (callback: () => void) => void;
   };
 
+  FieldBehaviorPicker: typeof CdoFieldBehaviorPicker;
   FieldButton: typeof CdoFieldButton;
   FieldImageDropdown: typeof CdoFieldImageDropdown;
   FieldToggle: typeof CdoFieldToggle;

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -333,7 +333,7 @@ const customInputTypes = {
   },
   behaviorPicker: {
     addInput(blockly, block, inputConfig, currentInputRow) {
-      const dropdownField = new Blockly.FieldDropdown(
+      const dropdownField = new Blockly.FieldBehaviorPicker(
         Blockly.customBlocks.getAllBehaviorOptions
       );
       currentInputRow


### PR DESCRIPTION
Earlier this week, we fixed a bug that stemmed from custom dropdown logic for behaviors. We have a handful of static dropdown fields that list some behaviors as well as one custom `behaviorPicker` input. Each of these use the name `BEHAVIOR` for their field, which we were incorrectly using to determine how we should generate the menu of options. That was fixed here:
* https://github.com/code-dot-org/code-dot-org/pull/57337

As of the merging of the branch above, we now look at the actual block type. This works for now because only one block type uses the `behaviorPicker` and that block only has one dropdown field. However, this means that levelbuilders would be unable to reuse this custom input type for other new blocks without an engineer. This isn't a precedent we want to set.

To handle this better, we can extend the `CdoFieldDropdown` class and be sure to use it only where needed. This way, behavior picker fields are technically different than dropdown fields and we don't need to make any attempt to guess how they should work based upon block configuration. This would allow a levelbuilder to create a new behavior picker block with any type and any field name they choose.

After extending the class, I was able to remove a significant amount custom logic from the base class, including the entire `getOptions` override.

There are no UI changes here.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I checked the original behavior picker block, several behavior dropdown field blocks, and a few other random blocks with dropdown fields and didn't notice any regressions.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
