### PR TITLE
[Sprite Lab] move constants into function scope

### DIFF
--- a/dashboard/config/blocks/GamelabJr/gamelab_layoutGrid.js
+++ b/dashboard/config/blocks/GamelabJr/gamelab_layoutGrid.js
@@ -1,8 +1,7 @@
-var SPRITE_SIZE = 25;
-var MIN_XY = SPRITE_SIZE / 2 + 5;
-var MAX_XY = 400 - MIN_XY;
-
 function layoutGrid() {
+  var SPRITE_SIZE = 25;
+  var MIN_XY = SPRITE_SIZE / 2 + 5;
+  var MAX_XY = 400 - MIN_XY;
   var spriteIds = getSpriteIdsInUse();
   var count = spriteIds.length;
   var numRows = Math.ceil(Math.sqrt(count));

--- a/dashboard/config/blocks/ParticlesBlocks/ParticlesBlocks_statesOfMatter2.js
+++ b/dashboard/config/blocks/ParticlesBlocks/ParticlesBlocks_statesOfMatter2.js
@@ -14,42 +14,45 @@ function filterSprites(costume) {
 
 //Equivalent of layoutAsGrid({costume: costume})
 function helperGrid(costume) {
-    spriteIds = filterSprites(costume);
-    count = spriteIds.length;
-    //Now this is essentially the same code as layoutGrid block
-    var numRows = Math.ceil(Math.sqrt(count));
-    var numCols = Math.ceil(count / numRows);
-    for (var i = 0; i < count; i++) {
-      var spriteIdArg = {id: spriteIds[i]};
-      var row = Math.floor(i / numCols);
-      var col = i % numCols;
-      var colFraction = col / (numCols - 1) || 0;
-      var x = MIN_XY + colFraction * (MAX_XY - MIN_XY);
-      var rowFraction = row / (numRows - 1) || 0;
-      var y = MIN_XY + rowFraction * (MAX_XY - MIN_XY);
+  var SPRITE_SIZE = 25;
+  var MIN_XY = SPRITE_SIZE / 2 + 5;
+  var MAX_XY = 400 - MIN_XY;
+  spriteIds = filterSprites(costume);
+  count = spriteIds.length;
+  //Now this is essentially the same code as layoutGrid block
+  var numRows = Math.ceil(Math.sqrt(count));
+  var numCols = Math.ceil(count / numRows);
+  for (var i = 0; i < count; i++) {
+    var spriteIdArg = {id: spriteIds[i]};
+    var row = Math.floor(i / numCols);
+    var col = i % numCols;
+    var colFraction = col / (numCols - 1) || 0;
+    var x = MIN_XY + colFraction * (MAX_XY - MIN_XY);
+    var rowFraction = row / (numRows - 1) || 0;
+    var y = MIN_XY + rowFraction * (MAX_XY - MIN_XY);
 
-      jumpTo(spriteIdArg, {x: x, y: y});
-    }
+    jumpTo(spriteIdArg, {x: x, y: y});
+  }
 }
 
 function statesOfMatter2(costume, behaviorStr) {
-    //For Validation
-    if(typeof checkValidation === 'function' && checkValidation()) {
-      var newBlockObj = {
-        blockName: 'statesOfMatter',
-        costume: costume,
-        matter: behaviorStr
-      };
-      addParticlesBlock(newBlockObj);
-    }
-  
+  //For Validation
+  if(typeof checkValidation === 'function' && checkValidation()) {
+    var newBlockObj = {
+      blockName: 'statesOfMatter',
+      costume: costume,
+      matter: behaviorStr
+    };
+    addParticlesBlock(newBlockObj);
+  }
+
   if(behaviorStr == "solid"){
     helperGrid(costume);
     addBehaviorSimple(({costume: costume}), new Behavior(wobbling, []));
   } else if(behaviorStr == "liquid"){
     var liquidSprites = filterSprites(costume);
     for(var i = 0; i < liquidSprites.length; i++) {
-    	setProp(({id: liquidSprites[i]}), "y", math_random_int(0, 151));
+      setProp(({id: liquidSprites[i]}), "y", math_random_int(0, 151));
     }
     addBehaviorSimple(({costume: costume}), new Behavior(liquid2, []));
   } else if(behaviorStr == "gas"){

--- a/dashboard/config/libraries/zParticlesModule.interpreted.js
+++ b/dashboard/config/libraries/zParticlesModule.interpreted.js
@@ -18,22 +18,25 @@ function filterSprites(costume) {
 
 //Equivalent of layoutAsGrid({costume: costume})
 function helperGrid(costume) {
-    spriteIds = filterSprites(costume);
-    count = spriteIds.length;
-    //Now this is essentially the same code as layoutGrid block
-    var numRows = Math.ceil(Math.sqrt(count));
-    var numCols = Math.ceil(count / numRows);
-    for (var i = 0; i < count; i++) {
-      var spriteIdArg = {id: spriteIds[i]};
-      var row = Math.floor(i / numCols);
-      var col = i % numCols;
-      var colFraction = col / (numCols - 1) || 0;
-      var x = MIN_XY + colFraction * (MAX_XY - MIN_XY);
-      var rowFraction = row / (numRows - 1) || 0;
-      var y = MIN_XY + rowFraction * (MAX_XY - MIN_XY);
+  var SPRITE_SIZE = 25;
+  var MIN_XY = SPRITE_SIZE / 2 + 5;
+  var MAX_XY = 400 - MIN_XY;
+  spriteIds = filterSprites(costume);
+  count = spriteIds.length;
+  //Now this is essentially the same code as layoutGrid block
+  var numRows = Math.ceil(Math.sqrt(count));
+  var numCols = Math.ceil(count / numRows);
+  for (var i = 0; i < count; i++) {
+    var spriteIdArg = {id: spriteIds[i]};
+    var row = Math.floor(i / numCols);
+    var col = i % numCols;
+    var colFraction = col / (numCols - 1) || 0;
+    var x = MIN_XY + colFraction * (MAX_XY - MIN_XY);
+    var rowFraction = row / (numRows - 1) || 0;
+    var y = MIN_XY + rowFraction * (MAX_XY - MIN_XY);
 
-      jumpTo(spriteIdArg, {x: x, y: y});
-    }
+    jumpTo(spriteIdArg, {x: x, y: y});
+  }
 }
 
 
@@ -67,12 +70,12 @@ function setupParticlesValidation() {
   //function block may have already created these objects, so this checks to make sure
   //we don't accidentally overwrite them.
   if(!validationProps.particles) {
-  	validationProps.particles = {};
-  	validationProps.particles.blocks = [];
+    validationProps.particles = {};
+    validationProps.particles.blocks = [];
   }
   if(!validationProps.particles.previous) {
-  	validationProps.particles.previous = {};
-  	validationProps.particles.previous.blocks = [];
+    validationProps.particles.previous = {};
+    validationProps.particles.previous.blocks = [];
   }
   return true;
 }


### PR DESCRIPTION
Some variable levels make use of an interpreted helper library which looks for student-created variables on the interpreter's global `window` scope. During the discussion of one variable bug on Friday, it was observed that this variable log had additional unexpected values. Some of these were due invisible blocks that were getting accidentally enabled (https://github.com/code-dot-org/code-dot-org/pull/57346), but others were showing up due to variables that were defined in block helper code at the global level: 
![Screenshot 2024-03-15 at 11 00 51 AM](https://github.com/code-dot-org/code-dot-org/assets/43474485/1207fd3c-b043-49f8-adc7-b5b6bd5f9166)
With additional logging, we found that the values shown above correspond to these labels:
```
{
    "SPRITE_SIZE": 25,
    "MIN_XY": 17.5,
    "MAX_XY": 382.5,
    "count": 0,
    "score": 0
}
```

This was impacting levels where we checked that students had created variables by looking at `Object.keys(varLog).length > 0`. Because of these extra variables on the window, the student was always passing that criterion.
The first 3 of these come from the helper code of the `layoutGrid` block of all places. (The other two (count and score) again were coming from mishandled hidden blocks.) 

Apparently, whether a variable is declared somewhere like this or by the code generated from the student's blocks, it ends up in the same place on the window. We can pull these variables out of the global scope and into the block's main function. Because all interpreted code like this is just concatenated, it is possible for one block's code to reference global variables and functions from another block. I noticed that the block `ParticlesBlocks_statesOfMatter2` and the library `zParticlesModule` were accessing `MIN_XY` and `MAX_XY` directly, so I re-defined these constants in those files too.

Note that the diff here shows some minor changes to formatting that was automatically applied by levelbuilder. The only important differences here related directly to `SPRITE_SIZE`, `MIN_XY`, and `MAX_XY`.

## Links

Jira: https://codedotorg.atlassian.net/browse/CT-417
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I confirmed via logging that the refactored variables were no longer showing up in `varLog`. 
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/3b32a4b3-1441-416c-ac71-d182d730cd04)

Note that the criterion still passes on this branch because other variables from hidden blocks are still showing up. Once both branches are merged, it is assumed that this criterion will work as expected.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->
We definitely need a stronger way to find and check student variables, and that work is being tracked here: https://codedotorg.atlassian.net/browse/CT-418
## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
