### PR TITLE
[ProgressV2] Speed up teacher_dashboard initial load by removing validCourseOfferings

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -38,7 +38,6 @@ const scriptData = JSON.parse(script.dataset.dashboard);
 const {
   section,
   sections,
-  validCourseOfferings,
   localeCode,
   hasSeenStandardsReportInfo,
   coursesWithProgress,
@@ -68,7 +67,6 @@ $(document).ready(function () {
   store.dispatch(setRosterProvider(section.login_type));
   store.dispatch(setRosterProviderName(section.login_type_name));
   store.dispatch(setLoginType(section.login_type));
-  store.dispatch(setCourseOfferings(validCourseOfferings));
   store.dispatch(setLocaleCode(localeCode));
 
   // DCDO Flag - show/hide Lock Section field

--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -13,7 +13,6 @@ import teacherSections, {
   selectSection,
   setRosterProvider,
   setRosterProviderName,
-  setCourseOfferings,
   setShowLockSectionField, // DCDO Flag - show/hide Lock Section field
   setStudentsForCurrentSection,
   sectionProviderName,

--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
@@ -18,38 +18,25 @@ import Button from '../Button';
 import DropdownButton from '../DropdownButton';
 import {disabledBubblesSupportArticle} from '@cdo/apps/code-studio/disabledBubbles';
 
-class TeacherDashboardHeader extends React.Component {
-  static propTypes = {
-    sections: PropTypes.arrayOf(sectionShape).isRequired,
-    selectedSection: sectionShape.isRequired,
-    openEditSectionDialog: PropTypes.func.isRequired,
-    assignmentName: PropTypes.string,
-    asyncLoadCourseOfferings: PropTypes.func.isRequired,
-  };
+function TeacherDashboardHeader({
+  sections,
+  selectedSection,
+  assignmentName,
+  openEditSectionDialog,
+  asyncLoadCourseOfferings,
+}) {
+  React.useEffect(() => {
+    asyncLoadCourseOfferings();
+  }, [asyncLoadCourseOfferings]);
 
-  constructor(props) {
-    super(props);
-    this.getDropdownOptions = this.getDropdownOptions.bind(this);
-  }
-
-  componentDidMount() {
-    this.props.asyncLoadCourseOfferings();
-  }
-
-  getDropdownOptions(optionMetricName) {
-    let self = this;
-
-    let options = self.props.sections.map(function (section, i) {
+  const getDropdownOptions = optionMetricName => {
+    let options = sections.map(function (section, i) {
       let optionOnClick = () => {
-        switchToSection(section.id, self.props.selectedSection.id);
-        recordSwitchToSection(
-          section.id,
-          self.props.selectedSection.id,
-          optionMetricName
-        );
+        switchToSection(section.id, selectedSection.id);
+        recordSwitchToSection(section.id, selectedSection.id, optionMetricName);
       };
       let icon = undefined;
-      if (section.id === self.props.selectedSection.id) {
+      if (section.id === selectedSection.id) {
         icon = <FontAwesome icon="check" />;
       }
       return (
@@ -59,9 +46,9 @@ class TeacherDashboardHeader extends React.Component {
       );
     });
     return options;
-  }
+  };
 
-  lockedSectionNotification = ({restrictSection, loginType}) =>
+  const lockedSectionNotification = ({restrictSection, loginType}) =>
     restrictSection &&
     loginType !==
       (SectionLoginType.google_classroom || SectionLoginType.clever) && (
@@ -73,7 +60,7 @@ class TeacherDashboardHeader extends React.Component {
       />
     );
 
-  progressNotSavingNotification() {
+  const progressNotSavingNotification = () => {
     return (
       <Notification
         type={NotificationType.failure}
@@ -89,68 +76,72 @@ class TeacherDashboardHeader extends React.Component {
         dismissable={false}
       />
     );
-  }
+  };
   /**
    * Returns the URL to the correct section to be edited
    */
-  editRedirectUrl = sectionId => {
+  const editRedirectUrl = sectionId => {
     return '/sections/' + sectionId + '/edit';
   };
 
-  render() {
-    return (
-      <div style={styles.headerContainer}>
-        <SmallChevronLink
-          href="/home#classroom-sections"
-          text={i18n.viewAllSections()}
-          iconBefore
-          style={styles.linkPadding}
-        />
-        <this.lockedSectionNotification
-          restrictSection={this.props.selectedSection.restrictSection}
-          loginType={this.props.selectedSection.loginType}
-        />
-        {this.props.selectedSection.postMilestoneDisabled && (
-          <this.progressNotSavingNotification />
-        )}
-        <div style={styles.header}>
-          <div>
-            <h1>{this.props.selectedSection.name}</h1>
-            {this.props.assignmentName && (
-              <div id="assignment-name">
-                <span style={styles.sectionPrompt}>
-                  {i18n.assignedToWithColon()}{' '}
-                </span>
-                {this.props.assignmentName}
-              </div>
-            )}
-          </div>
-          <div style={styles.rightColumn}>
-            <div style={styles.buttonSection}>
-              <Button
-                __useDeprecatedTag
-                href={this.editRedirectUrl(this.props.selectedSection.id)}
-                className="edit-section-details-link"
-                icon="gear"
-                size="narrow"
-                color="gray"
-                text={i18n.editSectionDetails()}
-                style={styles.buttonWithMargin}
-              />
-              <DropdownButton
-                size="narrow"
-                color="gray"
-                text={i18n.switchSection()}
-              >
-                {this.getDropdownOptions('from_button_switch_section')}
-              </DropdownButton>
+  return (
+    <div style={styles.headerContainer}>
+      <SmallChevronLink
+        href="/home#classroom-sections"
+        text={i18n.viewAllSections()}
+        iconBefore
+        style={styles.linkPadding}
+      />
+      {lockedSectionNotification({
+        restrictSection: selectedSection.restrictSection,
+        loginType: selectedSection.loginType,
+      })}
+      {selectedSection.postMilestoneDisabled && progressNotSavingNotification()}
+      <div style={styles.header}>
+        <div>
+          <h1>{selectedSection.name}</h1>
+          {assignmentName && (
+            <div id="assignment-name">
+              <span style={styles.sectionPrompt}>
+                {i18n.assignedToWithColon()}{' '}
+              </span>
+              {assignmentName}
             </div>
+          )}
+        </div>
+        <div style={styles.rightColumn}>
+          <div style={styles.buttonSection}>
+            <Button
+              __useDeprecatedTag
+              href={editRedirectUrl(selectedSection.id)}
+              className="edit-section-details-link"
+              icon="gear"
+              size="narrow"
+              color="gray"
+              text={i18n.editSectionDetails()}
+              style={styles.buttonWithMargin}
+            />
+            <DropdownButton
+              size="narrow"
+              color="gray"
+              text={i18n.switchSection()}
+            >
+              {getDropdownOptions('from_button_switch_section')}
+            </DropdownButton>
           </div>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
+
+TeacherDashboardHeader.propTypes = {
+  sections: PropTypes.arrayOf(sectionShape).isRequired,
+  selectedSection: sectionShape.isRequired,
+  openEditSectionDialog: PropTypes.func.isRequired,
+  assignmentName: PropTypes.string,
+  asyncLoadCourseOfferings: PropTypes.func.isRequired,
+};
 
 const styles = {
   sectionPrompt: {
@@ -184,18 +175,20 @@ const styles = {
 export const UnconnectedTeacherDashboardHeader = TeacherDashboardHeader;
 
 export default connect(
-  state => {
+  state => ({
     // In most cases, filtering out hidden sections is done on the backend.
     // However in this case, we need hidden sections in the redux tree in case
     // the selected section is hidden.
-    let sections = sortedSectionsList(state.teacherSections.sections).filter(
+    sections: sortedSectionsList(state.teacherSections.sections).filter(
       section => !section.hidden
-    );
-    let selectedSectionId = state.teacherSections.selectedSectionId;
-    let selectedSection = state.teacherSections.sections[selectedSectionId];
-    let assignmentName = getAssignmentName(state, selectedSectionId);
-    return {sections, selectedSection, assignmentName};
-  },
+    ),
+    selectedSection:
+      state.teacherSections.sections[state.teacherSections.selectedSectionId],
+    assignmentName: getAssignmentName(
+      state,
+      state.teacherSections.selectedSectionId
+    ),
+  }),
   dispatch => {
     return {
       openEditSectionDialog: id => dispatch(beginEditingSection(id)),

--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import SmallChevronLink from '../SmallChevronLink';
 import {
+  asyncLoadCourseOfferings,
   beginEditingSection,
   getAssignmentName,
   sortedSectionsList,
@@ -23,12 +24,18 @@ class TeacherDashboardHeader extends React.Component {
     selectedSection: sectionShape.isRequired,
     openEditSectionDialog: PropTypes.func.isRequired,
     assignmentName: PropTypes.string,
+    asyncLoadCourseOfferings: PropTypes.func.isRequired,
   };
 
   constructor(props) {
     super(props);
     this.getDropdownOptions = this.getDropdownOptions.bind(this);
   }
+
+  componentDidMount() {
+    this.props.asyncLoadCourseOfferings();
+  }
+
   getDropdownOptions(optionMetricName) {
     let self = this;
 
@@ -192,6 +199,7 @@ export default connect(
   dispatch => {
     return {
       openEditSectionDialog: id => dispatch(beginEditingSection(id)),
+      asyncLoadCourseOfferings: () => dispatch(asyncLoadCourseOfferings()),
     };
   }
 )(TeacherDashboardHeader);

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -447,6 +447,14 @@ export const asyncLoadSectionData = id => dispatch => {
     });
 };
 
+export const asyncLoadCourseOfferings = () => dispatch => {
+  fetchJSON('/dashboardapi/sections/valid_course_offerings')
+    .then(offerings => dispatch(setCourseOfferings(offerings)))
+    .catch(err => {
+      console.error(err.message);
+    });
+};
+
 /**
  * Load coteacher invites
  */

--- a/apps/test/unit/templates/teacherDashboard/TeacherDashboardHeaderTest.js
+++ b/apps/test/unit/templates/teacherDashboard/TeacherDashboardHeaderTest.js
@@ -50,6 +50,7 @@ const DEFAULT_PROPS = {
   selectedSection: MOCK_SECTIONS[0],
   assignmentName: MOCK_SCRIPT.name,
   openEditSectionDialog: () => {},
+  asyncLoadCourseOfferings: () => {},
 };
 
 describe('TeacherDashboardHeader', () => {

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -6,7 +6,6 @@
   teacher_dashboard_data[:sections] = @sections
   teacher_dashboard_data[:section] = @section_summary
   teacher_dashboard_data[:coursesWithProgress] = CourseVersion.courses_for_unit_selector(@section.participant_unit_ids)
-  teacher_dashboard_data[:validCourseOfferings] = CourseOffering.assignable_course_offerings_info(current_user, @locale_code)
   teacher_dashboard_data[:currentUserId] = @current_user.id
   teacher_dashboard_data[:hasSeenStandardsReportInfo] = @current_user.has_seen_standards_report_info_dialog || false
   teacher_dashboard_data[:userName] = @current_user.short_name


### PR DESCRIPTION
Part of an effort to improve loading times of the teacher dashboard by removing items by `data-dashboard` script tag.

This removes `validCourseOfferings` from the initial load and moves it async. This is only used to show the course in the section header. 

While loading, the assigned course will not show up and will appear when loaded. See recording.

https://github.com/code-dot-org/code-dot-org/assets/25193259/f223e10e-ae3f-4478-8169-87307ae127ab


This PR also:
* Refactors `TeacherDashboardHeader` to be a functional component
* Refactors `TeacherDashboardHeader` redux connect statement to align with other components

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[TEACH-841](https://codedotorg.atlassian.net/browse/TEACH-841)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
