### PR TITLE
[Game Design] Follow-up: Handle variable bubble scientific notation

### DIFF
--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -10,6 +10,7 @@ import {
   displayWorkspaceAlert,
 } from '../../code-studio/projectRedux';
 import msg from '@cdo/locale';
+import {formatForPlayspace} from '../utils';
 
 export default class CoreLibrary {
   constructor(p5, jsInterpreter) {
@@ -131,7 +132,7 @@ export default class CoreLibrary {
       padding: 10,
       strokeWeight: 3,
       strokeRadius: 24,
-      maxLabelLength: 30, // Maximum number of characters to display in the label
+      maxLabelLength: 20, // Maximum number of characters to display in the label
     };
 
     // Calculate the width for the label and value separator (colon and space)
@@ -166,7 +167,7 @@ export default class CoreLibrary {
         APP_WIDTH - totalReservedSpace - labelWidth;
       const displayValue = drawUtils.truncateText(
         this.p5,
-        `${value}`,
+        formatForPlayspace(value),
         availableSpaceForValue,
         config.textSize
       );

--- a/apps/src/p5lab/utils.js
+++ b/apps/src/p5lab/utils.js
@@ -48,3 +48,8 @@ export function randomColor(p5) {
 export function randomColorFromPalette(palette) {
   return palette[randomInt(0, palette.length - 1)];
 }
+
+export function formatForPlayspace(value) {
+  const isScientific = typeof value === 'number' && Math.abs(value) >= 1e21;
+  return isScientific ? value.toPrecision(2) : `${value}`;
+}

--- a/apps/test/unit/p5lab/utilsTest.js
+++ b/apps/test/unit/p5lab/utilsTest.js
@@ -1,0 +1,35 @@
+import {expect} from '../../util/reconfiguredChai';
+import {formatForPlayspace} from './formatForPlayspace';
+
+describe('formatForPlayspace', function () {
+  it('formats large numbers in scientific notation with 2 significant digits', function () {
+    expect(formatForPlayspace(1e21)).to.equal('1.0e+21');
+    expect(formatForPlayspace(-1e23)).to.equal('-1.0e+23');
+  });
+
+  it('returns small numbers as-is but as a string', function () {
+    expect(formatForPlayspace(123)).to.equal('123');
+    expect(formatForPlayspace(-456.789)).to.equal('-456.789');
+  });
+
+  it('converts boolean values to their string representations', function () {
+    expect(formatForPlayspace(true)).to.equal('true');
+    expect(formatForPlayspace(false)).to.equal('false');
+  });
+
+  it('returns string values unchanged', function () {
+    expect(formatForPlayspace('hello')).to.equal('hello');
+    expect(formatForPlayspace('12345')).to.equal('12345');
+  });
+
+  it('converts arrays to strings', function () {
+    expect(formatForPlayspace([1, 2, 3])).to.equal('1,2,3');
+    expect(formatForPlayspace(['a', 'b', 'c'])).to.equal('a,b,c');
+  });
+
+  it('handles special number cases', function () {
+    expect(formatForPlayspace(NaN)).to.equal('NaN');
+    expect(formatForPlayspace(Infinity)).to.equal('Infinity');
+    expect(formatForPlayspace(-Infinity)).to.equal('-Infinity');
+  });
+});

--- a/apps/test/unit/p5lab/utilsTest.js
+++ b/apps/test/unit/p5lab/utilsTest.js
@@ -1,5 +1,5 @@
+import {formatForPlayspace} from '@cdo/apps/p5lab/utils';
 import {expect} from '../../util/reconfiguredChai';
-import {formatForPlayspace} from './formatForPlayspace';
 
 describe('formatForPlayspace', function () {
   it('formats large numbers in scientific notation with 2 significant digits', function () {


### PR DESCRIPTION
This PR is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/57285.

The video in the original PR (linked above) shows a known edge case: If the variable label is very long and there is a large numerical value that p5 converts to scientific notation, the scientific notation is cut off, making it look like the value is 1.2 instead of 1.2E9 or something. See the screenshot below.

<img width="891" alt="Screenshot 2024-03-19 at 1 47 35 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/d0a7e1e5-ce87-418c-9990-9e8c848ec0ae">


This PR reduces the severity of the bug described above in two ways:
- It shortens the `maxLabelLength` from 30 characters to 20. I did this because, at 30 characters, using wide characters will still overflow the playspace. At 20 label characters, even with a string of `w`s, it's clear that the value is in scientific notation even if the exponent isn't always on screen (see below). cc @samantha-code 
- It introduces a new `formatForPlayspace` util that will take large numbers and render them using only two units of precision before the exponent. 

<img width="218" alt="Screenshot 2024-03-18 at 11 11 34 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/1c7073e4-e4e1-4b33-bf27-e189347c4af8">

Note: I say reduces, not solves, because if the label uses sufficiently wide characters and/or the exponent gets sufficiently large, there is still part of the number that may not be visible.

## Links

Jira ticket: None
Previous PR: https://github.com/code-dot-org/code-dot-org/pull/57285

## Testing story

Tested locally.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
