### PR TITLE
Update top_skinny_banner view to work with and without a url

### DIFF
--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -586,34 +586,31 @@ aside.top-skinny-banner {
   &.light-theme {
     background: var(--neutral_dark10);
 
-    a > *,
-    button > i {
-      color: var(--neutral_dark);
+    & * {
+      color: var(--neutral_dark) !important;
     }
   }
 
-  & a {
+  & * {
+    color: var(--neutral_white);
+  }
+
+  & .content-wrapper {
     width: 100%;
     padding: 1rem;
     display: flex;
     justify-content: center;
     gap: 0.5rem;
 
-    & > * {
-      color: var(--neutral_white);
-    }
-
     & > i {
       margin-top: 2px;
     }
 
-    & > p {
-      margin-bottom: 0;
+    & > a {
       text-decoration: none;
-    }
+      font-weight: var(--normal-font-weight);
 
-    &:hover {
-      & > p {
+      &:hover {
         text-decoration: underline;
       }
     }
@@ -639,10 +636,6 @@ aside.top-skinny-banner {
       &:not(:focus-visible) {
         outline: none;
       }
-    }
-
-    & > i {
-      color: var(--neutral_white);
     }
   }
 }

--- a/pegasus/sites.v3/code.org/views/top_skinny_banner.haml
+++ b/pegasus/sites.v3/code.org/views/top_skinny_banner.haml
@@ -1,8 +1,12 @@
 %aside.top-skinny-banner{class: light_theme ? "light-theme" : "", id: banner_id}
-  %a{href: banner_url}
+  .content-wrapper
     %i{class: "#{banner_icon}"}
-    %p.body-two
-      = banner_text
+    - if banner_url
+      %a.body-two.no-margin-bottom{href: banner_url}
+        = banner_text
+    - else
+      %p.body-two.no-margin-bottom
+        = banner_text
   %button{aria:{label: hoc_s(:call_to_action_hide_banner)}}
     %i{class: "fa fa-xmark"}
 


### PR DESCRIPTION
Refactors the `top_skinny_banner.haml` view so it works with or without a URL. Set `banner_url: false` where the view is used. The entire banner is no longer a link, and now only the text will link, or not link.

**Jira ticket:** [ACQ-1648](https://codedotorg.atlassian.net/browse/ACQ-1648)

----

## With url

https://github.com/code-dot-org/code-dot-org/assets/9256643/bee8442f-92c0-40b4-85fe-8e8a0da70c0c


## Without url

https://github.com/code-dot-org/code-dot-org/assets/9256643/9831bea4-ae45-4ba9-aa04-ed20fbd6c7e4

