### PR TITLE
Split Up Name Argument in `Cdo::Metrics.put`

### DIFF
--- a/lib/cdo/app_server_hooks.rb
+++ b/lib/cdo/app_server_hooks.rb
@@ -28,7 +28,7 @@ module Cdo
 
     def self.after_fork(host:)
       require 'cdo/aws/metrics'
-      Cdo::Metrics.put('App Server/WorkerBoot', 1, Host: host)
+      Cdo::Metrics.put('App Server', 'WorkerBoot', 1, Host: host)
 
       # Statsig is initialized here for managed environments. For development, it is
       # intialized in config/initializers/statsig.rb

--- a/lib/cdo/app_server_metrics.rb
+++ b/lib/cdo/app_server_metrics.rb
@@ -52,7 +52,8 @@ module Cdo
     def collect_metrics(*_)
       collect_listener_stats.each do |name, value|
         Cdo::Metrics.put(
-          "#{@namespace}/#{name}",
+          @namespace,
+          name,
           value,
           @dimensions,
           storage_resolution: 1,

--- a/lib/cdo/aws/metrics.rb
+++ b/lib/cdo/aws/metrics.rb
@@ -65,8 +65,7 @@ module Cdo
     # @param [Hash{Symbol => String}] dimensions
     # @param [Hash] options Additional keyword arguments to be merged
     #  into the {Aws::CloudWatch::Types::MetricDatum} object.
-    def self.put(name, value, dimensions, **options)
-      namespace, metric_name = name.split('/', 2)
+    def self.put(namespace, metric_name, value, dimensions, **options)
       metric = {
         metric_name: metric_name,
         dimensions: dimensions.map {|k, v| {name: k, value: v}},

--- a/lib/cdo/data/logging/infrastructure_logger.rb
+++ b/lib/cdo/data/logging/infrastructure_logger.rb
@@ -20,10 +20,9 @@ module Infrastructure
       unless @enabled
         return
       end
-      metric_name = "#{CLOUD_WATCH_NAMESPACE}/#{metric_name}"
       metric_value = 1 if metric_value.nil?
       dimensions = extra_dimensions.nil? ? extra_dimensions : extra_dimensions.merge(@dimensions)
-      Cdo::Metrics.put(metric_name, metric_value, dimensions)
+      Cdo::Metrics.put(CLOUD_WATCH_NAMESPACE, metric_name, metric_value, dimensions)
     end
 
     def self.flush

--- a/lib/cdo/lighthouse.rb
+++ b/lib/cdo/lighthouse.rb
@@ -56,7 +56,7 @@ module Lighthouse
 
     perf = (JSON.parse(json).dig('categories', 'performance', 'score') * 100).to_i
     ChatClient.log "#{url} Page Speed: <a href='#{html_url}'>#{perf}</a>"
-    Cdo::Metrics.put 'Website/PageSpeed', perf,
+    Cdo::Metrics.put 'Website', 'PageSpeed', perf,
       Environment: CDO.rack_env, URL: url.to_s
   rescue => exception
     ChatClient.log "Page speed report failed: #{exception}"

--- a/lib/test/cdo/aws/test_metrics.rb
+++ b/lib/test/cdo/aws/test_metrics.rb
@@ -7,7 +7,7 @@ class CdoMetricsTest < Minitest::Test
   end
 
   def test_put
-    Cdo::Metrics.put('App Server/WorkerBoot', 1, {Host: 'localhost.code.org'})
+    Cdo::Metrics.put('App Server', 'WorkerBoot', 1, {Host: 'localhost.code.org'})
     Cdo::Metrics.flush!
     refute_empty Cdo::Metrics.client.api_requests
     assert_equal(

--- a/lib/test/cdo/test_app_server_metrics.rb
+++ b/lib/test/cdo/test_app_server_metrics.rb
@@ -23,7 +23,7 @@ class AppServerMetricsTest < Minitest::Test
   def expect_metrics(*metrics)
     @sequence ||= sequence('metrics')
     metrics.each do |name, value|
-      Cdo::Metrics.expects(:put).with("App Server/#{name}", value, {}, {storage_resolution: 1, unit: 'Count'}).in_sequence(@sequence)
+      Cdo::Metrics.expects(:put).with("App Server", name, value, {}, {storage_resolution: 1, unit: 'Count'}).in_sequence(@sequence)
     end
   end
 


### PR DESCRIPTION
Our `Cdo::Metrics` helper currently has three methods for logging metrics data: `push`, `put`, and `put_metric`. Both `push` and `put_metric` expect you to define the namespace and metric name as separate strings, but `put` expects you to put them both in a single string separated by a `/`. Unfortunately (and I think unintentionally), this precludes us from being able to use namspaces which themselves have a `/` in them. Not only do `push` and `put_metric` allow that kind of formatting, but we are indeed [taking advantage of that functionality](https://github.com/code-dot-org/code-dot-org/blob/b3dcd016d5cb17c696e0fc9e6436f87ad5a1e2a2/bin/cron/report_activejob_metrics#L7-L12)

Because I don't think we have a specific reason to disallow `/` in the namespace and because the specific implementation of the `put` method does not appear to be actually saving us from a significant amount of complexity, I propose that we refactor the method to be more in line with the other methods in the class.

Thoughts? Concerns? Any specific context as to why we originally implemented it this way that I'm missing?

## Testing story

Updated one unit test to reflect this change; relying on other unit tests to verify no unexpected side effects.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
