### PR TITLE
Adds five amplitude events for school info interstitial

### DIFF
--- a/apps/src/lib/ui/SchoolInfoInterstitial.jsx
+++ b/apps/src/lib/ui/SchoolInfoInterstitial.jsx
@@ -10,23 +10,11 @@ import SchoolInfoInputs, {
   SCHOOL_TYPES_HAVING_NCES_SEARCH,
   SCHOOL_TYPES_HAVING_NAMES,
 } from '../../templates/SchoolInfoInputs';
-import firehoseClient from '../util/firehose';
 import {combineReducers, createStore} from 'redux';
 import mapboxReducer, {setMapboxAccessToken} from '@cdo/apps/redux/mapbox';
 import fontConstants from '@cdo/apps/fontConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
-
-const FIREHOSE_EVENTS = {
-  // Interstitial is displayed to the teacher.
-  SHOW: 'show',
-  // Teacher clicked "Save"
-  SUBMIT: 'submit',
-  // School information saved successfully
-  SAVE_SUCCESS: 'save_success',
-  // School information failed to save
-  SAVE_FAILURE: 'save_failure',
-};
 
 const store = createStore(
   combineReducers({
@@ -96,21 +84,6 @@ export default class SchoolInfoInterstitial extends React.Component {
     }
   }
 
-  logEvent(eventName, data = {}) {
-    firehoseClient.putRecord({
-      study: 'school_info_interstitial',
-      study_group: 'control',
-      event: eventName,
-      // Send "has NCES id" as data_int
-      data_int:
-        this.state.ncesSchoolId && this.state.ncesSchoolId !== '-1' ? 1 : 0,
-      data_json: JSON.stringify({
-        isComplete: SchoolInfoInterstitial.isSchoolInfoComplete(this.state),
-        ...data,
-      }),
-    });
-  }
-
   static isSchoolInfoComplete(state) {
     if (!state.country) {
       return false;
@@ -136,7 +109,6 @@ export default class SchoolInfoInterstitial extends React.Component {
   }
 
   componentDidMount() {
-    this.logEvent(FIREHOSE_EVENTS.SHOW);
     analyticsReporter.sendEvent(EVENTS.SCHOOL_INTERSTITIAL_SHOW);
   }
 
@@ -242,11 +214,11 @@ export default class SchoolInfoInterstitial extends React.Component {
     if (!isValid) {
       return;
     }
-    this.logEvent(FIREHOSE_EVENTS.SUBMIT, {
-      attempt: this.state.showSchoolInfoUnknownError ? 2 : 1,
-    });
-
     analyticsReporter.sendEvent(EVENTS.SCHOOL_INTERSTITIAL_SUBMIT, {
+      hasNcesId:
+        this.state.ncesSchoolId && this.state.ncesSchoolId !== '-1'
+          ? 'true'
+          : 'false',
       attempt: this.state.showSchoolInfoUnknownError ? 2 : 1,
     });
 
@@ -262,10 +234,6 @@ export default class SchoolInfoInterstitial extends React.Component {
       },
     })
       .done(() => {
-        this.logEvent(FIREHOSE_EVENTS.SAVE_SUCCESS, {
-          attempt: this.state.showSchoolInfoUnknownError ? 2 : 1,
-        });
-
         analyticsReporter.sendEvent(EVENTS.SCHOOL_INTERSTITIAL_SAVE_SUCCESS, {
           attempt: this.state.showSchoolInfoUnknownError ? 2 : 1,
         });
@@ -273,10 +241,6 @@ export default class SchoolInfoInterstitial extends React.Component {
         this.props.onClose();
       })
       .fail(() => {
-        this.logEvent(FIREHOSE_EVENTS.SAVE_FAILURE, {
-          attempt: this.state.showSchoolInfoUnknownError ? 2 : 1,
-        });
-
         analyticsReporter.sendEvent(EVENTS.SCHOOL_INTERSTITIAL_SAVE_FAILURE, {
           attempt: this.state.showSchoolInfoUnknownError ? 2 : 1,
         });

--- a/apps/src/lib/ui/SchoolInfoInterstitial.jsx
+++ b/apps/src/lib/ui/SchoolInfoInterstitial.jsx
@@ -14,6 +14,8 @@ import firehoseClient from '../util/firehose';
 import {combineReducers, createStore} from 'redux';
 import mapboxReducer, {setMapboxAccessToken} from '@cdo/apps/redux/mapbox';
 import fontConstants from '@cdo/apps/fontConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 const FIREHOSE_EVENTS = {
   // Interstitial is displayed to the teacher.
@@ -135,6 +137,7 @@ export default class SchoolInfoInterstitial extends React.Component {
 
   componentDidMount() {
     this.logEvent(FIREHOSE_EVENTS.SHOW);
+    analyticsReporter.sendEvent(EVENTS.SCHOOL_INTERSTITIAL_SHOW);
   }
 
   buildSchoolData() {
@@ -243,6 +246,10 @@ export default class SchoolInfoInterstitial extends React.Component {
       attempt: this.state.showSchoolInfoUnknownError ? 2 : 1,
     });
 
+    analyticsReporter.sendEvent(EVENTS.SCHOOL_INTERSTITIAL_SUBMIT, {
+      attempt: this.state.showSchoolInfoUnknownError ? 2 : 1,
+    });
+
     const schoolData = this.buildSchoolData();
     const {formUrl, authTokenName, authTokenValue} = this.props.scriptData;
     $.post({
@@ -259,10 +266,18 @@ export default class SchoolInfoInterstitial extends React.Component {
           attempt: this.state.showSchoolInfoUnknownError ? 2 : 1,
         });
 
+        analyticsReporter.sendEvent(EVENTS.SCHOOL_INTERSTITIAL_SAVE_SUCCESS, {
+          attempt: this.state.showSchoolInfoUnknownError ? 2 : 1,
+        });
+
         this.props.onClose();
       })
       .fail(() => {
         this.logEvent(FIREHOSE_EVENTS.SAVE_FAILURE, {
+          attempt: this.state.showSchoolInfoUnknownError ? 2 : 1,
+        });
+
+        analyticsReporter.sendEvent(EVENTS.SCHOOL_INTERSTITIAL_SAVE_FAILURE, {
           attempt: this.state.showSchoolInfoUnknownError ? 2 : 1,
         });
 
@@ -278,6 +293,7 @@ export default class SchoolInfoInterstitial extends React.Component {
   };
 
   dismissSchoolInfoForm = () => {
+    analyticsReporter.sendEvent(EVENTS.SCHOOL_INTERSTITIAL_DISMISS);
     this.setState({isOpen: false});
     this.props.onClose();
   };

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -18,6 +18,13 @@ const EVENTS = {
   CONFIRM_SCHOOL_CLICKED: 'Confirm School Clicked',
   UPDATE_SCHOOL_CLICKED: 'Update School Clicked',
 
+  // School Interstitial
+  SCHOOL_INTERSTITIAL_SHOW: 'School Interstitial Shown',
+  SCHOOL_INTERSTITIAL_SUBMIT: 'School Interstitial Submitted',
+  SCHOOL_INTERSTITIAL_SAVE_SUCCESS: 'School Interstitial Save Success',
+  SCHOOL_INTERSTITIAL_SAVE_FAILURE: 'School Interstitial Save Failure',
+  SCHOOL_INTERSTITIAL_DISMISS: 'School Interstitial Dismissed',
+
   // Course/Unit info
   COURSE_OVERVIEW_PAGE_VISITED_BY_TEACHER_EVENT:
     'Course Overview Page Visited By Teacher',


### PR DESCRIPTION
This adds 4 Amplitude events to mirror the existing firehose events (show, submit, save success, save fail) and another for dismissal of the dialog.

Followup: Also removes the firehose events.

<img width="397" alt="Screenshot 2024-03-19 at 2 25 51 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/d30c4ed4-be5e-4498-a240-e920699de84a">

<img width="408" alt="Screenshot 2024-03-19 at 2 26 04 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/50cef5be-2755-418f-a45b-508f902e6763">

<img width="395" alt="Screenshot 2024-03-19 at 2 26 54 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/bf9151f2-89e3-4f76-89f9-1612c93e852e">

<img width="602" alt="Screenshot 2024-03-19 at 3 07 55 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/eb11b881-852a-4e93-942c-60a12e18a56c">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1483

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
