### PR TITLE
Fix login info page styling

### DIFF
--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -119,7 +119,7 @@ function TeacherDashboard({
         />
         <Route
           path={TeacherDashboardPath.loginInfo}
-          component={props => (
+          component={props => applyV1TeacherDashboardWidth(
             <SectionLoginInfo
               studioUrlPrefix={studioUrlPrefix}
               sectionProviderName={sectionProviderName}

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -119,12 +119,14 @@ function TeacherDashboard({
         />
         <Route
           path={TeacherDashboardPath.loginInfo}
-          component={props => applyV1TeacherDashboardWidth(
-            <SectionLoginInfo
-              studioUrlPrefix={studioUrlPrefix}
-              sectionProviderName={sectionProviderName}
-            />
-          )}
+          component={props =>
+            applyV1TeacherDashboardWidth(
+              <SectionLoginInfo
+                studioUrlPrefix={studioUrlPrefix}
+                sectionProviderName={sectionProviderName}
+              />
+            )
+          }
         />
         <Route
           path={TeacherDashboardPath.standardsReport}

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -4085,10 +4085,8 @@ a {
   }
 }
 
-#teacher-dashboard::after {
-  content: "";
-  clear: both;
-  display: table;
+#teacher-dashboard {
+  overflow: auto;
 }
 
 #lti-integration-portal {

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -4085,6 +4085,12 @@ a {
   }
 }
 
+#teacher-dashboard::after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
 #lti-integration-portal {
   $signup-info-background: #f7f7f7;
   $signup-info-border-color: #e5e5e5;


### PR DESCRIPTION
Putting the v1 margins back onto the login info page was missed in #56756. This change fixes that and also adds `overflow:auto` to the `#teacher-dashboard` div so that the floated login cards don't bleed into the footer.

Before:
<img width="1061" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/4108328/e7ce743e-26ae-4d68-a1a9-bd9a0d802cb5">


After:
<img width="1061" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/4108328/72e4eea4-1180-4087-8495-3e4d8d416ff9">

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
