### PR TITLE
[Sprite Lab] refactor getVariableValue

### DIFF
--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -148,7 +148,8 @@ export default class CoreLibrary {
         return;
       }
 
-      const value = this.getVariableValue(name);
+      // Use variable value or empty string (if undefined).
+      const value = this.getVariableValue(name, '');
 
       // Determine if the label needs truncation and append an ellipsis if so
       const displayLabel =
@@ -182,7 +183,7 @@ export default class CoreLibrary {
     });
   }
 
-  getVariableValue(variableName) {
+  getVariableValue(variableName, defaultValue) {
     if (!this.jsInterpreter) {
       console.error('JS Interpreter not set in CoreLibrary');
       return;
@@ -192,7 +193,7 @@ export default class CoreLibrary {
       // Blockly does not execute code or track the runtime values of variables, so we need to
       // evaluate the variable's value using the JSInterpreter.
       const result = this.jsInterpreter.evaluateWatchExpression(variableName);
-      return typeof result === 'undefined' ? '' : result;
+      return typeof result === 'undefined' ? defaultValue : result;
     } catch (e) {
       console.error(`Error evaluating variable '${variableName}': ${e}`);
       return '';

--- a/apps/src/p5lab/spritelab/commands/criterionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/criterionCommands.js
@@ -60,7 +60,7 @@ export const commands = {
     const spriteIds = this.getSpriteIdsInUse();
     return (
       spriteIds.filter(id => this.getLastSpeechBubbleForSpriteId(id)).length >=
-      1
+      min
     );
   },
 

--- a/apps/src/p5lab/spritelab/commands/criterionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/criterionCommands.js
@@ -548,11 +548,12 @@ export const commands = {
   },
 
   // Returns true if a minimum number of watched variables have a valid value.
-  // If unset, a variable's value is an empty string.
+  // If unset, a variable's value is undefined.
   variableValueSet(min = 1) {
     const studentVars = this.getVariableBubbles();
     const filteredVars = studentVars.filter(
-      studentVar => this.getVariableValue(studentVar.name) !== ''
+      studentVar =>
+        typeof this.getVariableValue(studentVar.name) !== 'undefined'
     );
     return filteredVars.length >= min;
   },

--- a/apps/src/p5lab/spritelab/commands/validationCommands.js
+++ b/apps/src/p5lab/spritelab/commands/validationCommands.js
@@ -246,9 +246,10 @@ export const commands = {
     variableBubbles.forEach(variableBubble => {
       this.previous.variableBubbles.push({
         ...variableBubble,
-        // Run the variable name through the JS interpreter to get its value.
+        // Run the variable name through the JS interpreter to get its value,
+        // using an empty string for undefined variables.
         // We need to store the previous value to validate changes between frames.
-        value: this.getVariableValue(variableBubble.name),
+        value: this.getVariableValue(variableBubble.name, ''),
       });
     });
   },


### PR DESCRIPTION
This a quick refactor of `getVariableValue`. It adds an optional parameter, which if provided, overrides any returned `undefined` values. This function was created for variable bubbles which use an empty string instead of "undefined", but there are other cases where we want the unmodified values such as validation.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
