### PR TITLE
Add a .white utility class for use on text elements

### DIFF
--- a/pegasus/sites.v3/code.org/public/about/careers/engineering.haml
+++ b/pegasus/sites.v3/code.org/public/about/careers/engineering.haml
@@ -11,9 +11,9 @@ theme: responsive_full_width
     .flex-container
       .text-wrapper.col-60.flex-container.align-items-center
         .hero-banner-basic__content
-          %h1{style: "color: white"}
+          %h1.white
             =hoc_s(:engineering_hero_heading)
-          %p{style: "color: white"}
+          %p.white
             =hoc_s(:engineering_hero_desc)
           %a{href: "/about/careers#roles", class: "link-button", target: "_blank", rel: "noopener noreferrer", aria:{label: hoc_s("call_to_action_open_positions")}}
             =hoc_s(:call_to_action_open_positions)

--- a/pegasus/sites.v3/code.org/public/accessibility.haml
+++ b/pegasus/sites.v3/code.org/public/accessibility.haml
@@ -11,9 +11,9 @@ theme: responsive_full_width
     .flex-container.align-items-center.gap-2
       .text-wrapper.col-50
         .hero-banner-basic__content
-          %h1{style: "color: white"}
+          %h1.white
             =hoc_s(:accessibility_hero_heading)
-          %p{style: "color: white"}
+          %p.white
             =hoc_s(:accessibility_hero_desc)
       .col-45
         %img{src: "/images/accessibility/accessibility-illustration-header.png", alt: "", style: "width: 100%"}

--- a/pegasus/sites.v3/code.org/public/administrators.haml
+++ b/pegasus/sites.v3/code.org/public/administrators.haml
@@ -30,9 +30,9 @@ theme: responsive_full_width
 
 %section.bg-pattern-dark
   .wrapper.centered
-    %h2{style: "color: var(--neutral_white)"}
+    %h2.white
       =hoc_s(:admins_page_district_program_header)
-    %p{style: "color: var(--neutral_white)"}
+    %p.white
       =hoc_s(:admins_page_district_program_desc)
     .button-wrapper.centered
       %a.link-button{href: "/districts"}
@@ -50,14 +50,14 @@ theme: responsive_full_width
 
 %section.pathways.bg-neutral-dark
   .wrapper
-    %h2.centered{style: "color: var(--neutral_white)"}
+    %h2.centered.white
       =hoc_s(:curriculum_pathway_heading)
-    %p.centered{style: "color: var(--neutral_white); margin-bottom: 3rem"}
+    %p.centered.white{style: "margin-bottom: 3rem"}
       =hoc_s(:curriculum_pathway_desc)
     = view :curriculum_pathway
     %hr.light
     %div.centered
-      %h3{style: "color: var(--neutral_white)"}
+      %h3.white
         =hoc_s(:teach_page_free_curriculum_heading_02)
       .button-wrapper.centered
         %a.link-button{href: "/educate/curriculum/elementary-school"}

--- a/pegasus/sites.v3/code.org/public/ai/how-ai-works.haml
+++ b/pegasus/sites.v3/code.org/public/ai/how-ai-works.haml
@@ -9,8 +9,8 @@ theme: responsive_full_width
 %section.hero-banner-basic
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}=hoc_s(:how_ai_works_hero_heading)
-      %p.body-one{style: "color: white"}=hoc_s(:how_ai_works_hero_desc)
+      %h1.white=hoc_s(:how_ai_works_hero_heading)
+      %p.body-one.white=hoc_s(:how_ai_works_hero_desc)
     %figure
       %img{src: "/images/banners/ai-bot-artist-w-trophy.png", alt: ""}
 

--- a/pegasus/sites.v3/code.org/public/ai/index.haml
+++ b/pegasus/sites.v3/code.org/public/ai/index.haml
@@ -17,8 +17,8 @@ theme: responsive_full_width
 %section.hero-banner-basic.bg-neutral-dark{style: "display: block !important"}
   .wrapper
     .text-wrapper.col-60
-      %h1{style: "color: white"}=hoc_s(:ai_hero_heading)
-      %p.body-one{style: "color: white"}=hoc_s(:ai_hero_desc)
+      %h1.white=hoc_s(:ai_hero_heading)
+      %p.body-one.white=hoc_s(:ai_hero_desc)
     %figure.col-33{style: "float: right"}
       %img.fade-in-out{src: "/images/banners/ai-bot-wizard.svg", alt: "", style: "z-index: 10"}
       %img{src: "/images/banners/ai-bot-default.svg", alt: "", style: "position: relative;"}

--- a/pegasus/sites.v3/code.org/public/ai/pl/101/index.haml
+++ b/pegasus/sites.v3/code.org/public/ai/pl/101/index.haml
@@ -11,10 +11,10 @@ theme: responsive_full_width
 %section.hero-banner-basic.hero-ai-pl-webinar{style: "display: block !important"}
   .wrapper
     .text-wrapper.col-75
-      %h1{style: "color: white"}=hoc_s(:ai_pl_101_hero_heading)
-      %p.body-one{style: "color: white"}=hoc_s(:ai_pl_101_hero_desc)
+      %h1.white=hoc_s(:ai_pl_101_hero_heading)
+      %p.body-one.white=hoc_s(:ai_pl_101_hero_desc)
       .hero-ai-pl-webinar__by
-        %span{style: "color: white"}=hoc_s(:ai_pl_101_hero_presented)
+        %span.white=hoc_s(:ai_pl_101_hero_presented)
         .hero-ai-pl-webinar__list
           %img{src: "/images/ai/pl/101/code--w.png", height: "24px", alt: "CODE"}
           %img{src: "/images/ai/pl/101/ets--w.png", height: "26px", alt: "ETS"}

--- a/pegasus/sites.v3/code.org/public/blockchain.haml
+++ b/pegasus/sites.v3/code.org/public/blockchain.haml
@@ -9,8 +9,8 @@ theme: responsive_full_width
 %section.hero-banner-basic.bg-neutral-dark
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}=hoc_s(:blockchain_hero_heading)
-      %p.body-one{style: "color: white"}=hoc_s(:blockchain_hero_desc)
+      %h1.white=hoc_s(:blockchain_hero_heading)
+      %p.body-one.white=hoc_s(:blockchain_hero_desc)
     %figure
       %img{src: "/images/banners/blockchain-laptop-silver.png", alt: ""}
     .clear

--- a/pegasus/sites.v3/code.org/public/curriculum/computer-vision.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/computer-vision.haml
@@ -9,9 +9,9 @@ theme: responsive_full_width
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}
+      %h1.white
         =hoc_s(:csa_ai_page_hero_title)
-      %p{style: "color: white"}
+      %p.white
         =hoc_s(:csa_ai_page_hero_description, markdown: :inline, locals: {csa_url: "https://apcentral.collegeboard.org/media/pdf/ap-computer-science-a-course-and-exam-description.pdf?course=ap-computer-science-a"})
       %a.link-button.white{href: CDO.studio_url("/s/csa-software-engineering")}
         =hoc_s(:call_to_action_explore_course)

--- a/pegasus/sites.v3/code.org/public/dance.haml
+++ b/pegasus/sites.v3/code.org/public/dance.haml
@@ -20,7 +20,7 @@ theme: responsive_full_width
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}
+      %h1.white
         =hoc_s(:dance_hero_heading)
     %figure
       %img{src: "/images/dance-hoc/dance-party-characters-banner.png", alt: ""}

--- a/pegasus/sites.v3/code.org/public/districts.haml
+++ b/pegasus/sites.v3/code.org/public/districts.haml
@@ -25,9 +25,9 @@ theme: responsive_full_width
 %section.hero-banner-basic.bg-neutral-dark{style: "display: block !important"}
   .wrapper
     .text-wrapper
-      %h1{style: "color: white"} Code.org District Program
-      %p.heading-sm{style: "color: white"} Bring computer science to your district.
-      %p.no-margin-bottom{style: "color: white"} Learn how Code.org can help teach your students the skills of the future!
+      %h1.white Code.org District Program
+      %p.heading-sm.white Bring computer science to your district.
+      %p.no-margin-bottom.white Learn how Code.org can help teach your students the skills of the future!
     .clear
     %img{src: "shared/images/banners/admins-hero-students-at-computers.png", alt: ""}
 

--- a/pegasus/sites.v3/code.org/public/educate/csa.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csa.haml
@@ -9,9 +9,9 @@ theme: responsive_full_width
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}
+      %h1.white
         =hoc_s(:curriculum_name_csa)
-      %p.has-external-link{style: "color: white"}
+      %p.has-external-link.white
         =hoc_s(:csa_page_top_desc, markdown: :inline, locals: {csa_url: "https://apcentral.collegeboard.org/media/pdf/ap-computer-science-a-course-and-exam-description.pdf?course=ap-computer-science-a"})
       %a.link-button.white{href: CDO.studio_url("/courses/csa?viewAs=Instructor")}
         =hoc_s(:call_to_action_explore_course)

--- a/pegasus/sites.v3/code.org/public/educate/csc/index.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csc/index.haml
@@ -9,9 +9,9 @@ theme: responsive_full_width
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}
+      %h1.white
         =hoc_s(:curriculum_name_csc)
-      %p{style: "color: white"}
+      %p.white
         =hoc_s(:csc_page_top_desc)
       %a.link-button.white{href: "#csc-modules"}
         =hoc_s(:call_to_action_explore_modules)

--- a/pegasus/sites.v3/code.org/public/educate/csd/index.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csd/index.haml
@@ -11,9 +11,9 @@ theme: responsive_full_width
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}
+      %h1.white
         =hoc_s(:curriculum_name_csd)
-      %p{style: "color: white"}
+      %p.white
         =hoc_s(:csd_page_top_desc)
       %a.link-button{href: "#pick-a-course"}
         =hoc_s(:call_to_action_explore_curriculum_options)

--- a/pegasus/sites.v3/code.org/public/educate/csf.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csf.haml
@@ -9,9 +9,9 @@ theme: responsive_full_width
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}
+      %h1.white
         =hoc_s(:curriculum_name_csf)
-      %p{style: "color: white"}
+      %p.white
         =hoc_s(:csf_page_top_desc)
       %a.link-button.white{href: "#pick-a-course"}
         =hoc_s(:call_to_action_explore_courses)

--- a/pegasus/sites.v3/code.org/public/educate/csp.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csp.haml
@@ -9,9 +9,9 @@ theme: responsive_full_width
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}
+      %h1.white
         =hoc_s(:curriculum_name_csp)
-      %p{style: "color: white"}
+      %p.white
         =hoc_s(:csp_page_top_desc)
       %a.link-button.white{href: CDO.studio_url("/courses/csp?viewAs=Instructor")}
         =hoc_s(:call_to_action_explore_course)

--- a/pegasus/sites.v3/code.org/public/educate/professional-development-online.haml
+++ b/pegasus/sites.v3/code.org/public/educate/professional-development-online.haml
@@ -14,8 +14,8 @@ theme: responsive_full_width
 %section.hero-banner-basic.bg-neutral-dark
   .wrapper.flex-container.align-items-center
     .text-wrapper
-      %h1{style: "color: white"}=hoc_s(:self_paced_pl_hero_heading)
-      %p.body-one{style: "color: white"}=hoc_s(:self_paced_pl_hero_desc)
+      %h1.white=hoc_s(:self_paced_pl_hero_heading)
+      %p.body-one.white=hoc_s(:self_paced_pl_hero_desc)
     %img{src: "../shared/images/banners/self-paced-pl-hero.png", alt: ""}
 
 %section

--- a/pegasus/sites.v3/code.org/public/educate/resources/videos.haml
+++ b/pegasus/sites.v3/code.org/public/educate/resources/videos.haml
@@ -14,9 +14,9 @@ video_player: true
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}
+      %h1.white
         =hoc_s(:video_library_page_main_title)
-      %p{style: "color: white"}
+      %p.white
         =hoc_s(:video_library_page_hero_description)
     %figure
       %img{src: "/images/banners/video-logo.png", alt: ""}

--- a/pegasus/sites.v3/code.org/public/help.haml
+++ b/pegasus/sites.v3/code.org/public/help.haml
@@ -52,9 +52,9 @@ theme: responsive_full_width
 
 %section.speak-for-cs.bg-neutral-dark
   .wrapper.centered
-    %h2{style: "color: white"}
+    %h2.white
       =hoc_s(:help_page_speak_for_cs_heading)
-    %p{style: "color: white"}
+    %p.white
       =hoc_s(:help_page_speak_for_cs_desc)
     %a.link-button.has-external-link{href: "https://advocacy.code.org", target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_learn_about_advocacy)
@@ -70,9 +70,9 @@ theme: responsive_full_width
       %img{src: "/images/help-page-shop-01.png", alt: ""}
       %img{src: "/images/help-page-shop-02.png", alt: ""}
     .text-wrapper
-      %h2{style: "color: white"}
+      %h2.white
         =hoc_s(:shop_code_dot_org_heading)
-      %p{style: "color: white"}
+      %p.white
         =hoc_s(:shop_code_dot_org_desc)
       %a.link-button.has-external-link{href: "https://store.code.org", target: "_blank", rel: "noopener noreferrer"}
         =hoc_s(:call_to_action_visit_store)

--- a/pegasus/sites.v3/code.org/public/maker/index.haml
+++ b/pegasus/sites.v3/code.org/public/maker/index.haml
@@ -16,8 +16,8 @@ theme: responsive_full_width
   .wrapper
     %div.flex-container
       %div.text-wrapper.col-50
-        %h1{style: "color: white"} Become a Maker
-        %p{style: "color: white"} Explore your creativity with physical computing.
+        %h1.white Become a Maker
+        %p.white Explore your creativity with physical computing.
       %div.col-30.flex-container.justify-end
         %img{src: "/images/maker/maker-skinny-banner-img-left.svg", alt: ""}
         %img{src: "/images/maker/maker-skinny-banner-img-right.svg", alt: ""}

--- a/pegasus/sites.v3/code.org/public/minecraft.haml
+++ b/pegasus/sites.v3/code.org/public/minecraft.haml
@@ -9,7 +9,7 @@ theme: responsive_full_width
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}
+      %h1.white
         =hoc_s(:minecraft_hero_heading)
     %figure
       %img{src: "/images/mc/minecraft-banner-figures.png", alt: ""}

--- a/pegasus/sites.v3/code.org/public/naipi.haml
+++ b/pegasus/sites.v3/code.org/public/naipi.haml
@@ -9,7 +9,7 @@ theme: responsive_full_width
 %section.hero-banner-basic
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}
+      %h1.white
         =hoc_s(:naipi_page_heading)
 
 %section

--- a/pegasus/sites.v3/code.org/public/professional-learning/international.haml
+++ b/pegasus/sites.v3/code.org/public/professional-learning/international.haml
@@ -12,9 +12,9 @@ set_dir: true
 %section.hero-banner-basic
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}
+      %h1.white
         =hoc_s("intl_pl_page.heading")
-      %p.body-one{style: "color: white"}
+      %p.body-one.white
         =hoc_s("intl_pl_page.desc")
     %figure
       %img{src: "/images/banners/intl-pl-globe.png", alt: ""}

--- a/pegasus/sites.v3/code.org/public/youngwomen.haml
+++ b/pegasus/sites.v3/code.org/public/youngwomen.haml
@@ -13,9 +13,9 @@ theme: responsive_full_width
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper
-      %h1{style: "color: white"}
+      %h1.white
         =hoc_s(:yw_page_top_heading)
-      %p.body-one{style: "color: white"}
+      %p.body-one.white
         =hoc_s(:yw_page_top_desc)
       - if !applications_closed
         %a.link-button.white.has-external-link{href: "https://docs.google.com/forms/d/e/1FAIpQLScKoT8ttOeWU3mWp_fDaFV0qQ5niXk3tSi1INALHhGWFQtVjw/viewform", target: "_blank", rel: "noopener noreferrer"}

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -122,7 +122,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* Use this class on text elements to turn them white */
-h1, h2, h3, h4, h5, h6, p, figcaption, a:not(.link-button) {
+h1, h2, h3, h4, h5, h6, p, figcaption, span, a:not(.link-button) {
   &.white {
     color: var(--neutral_white) !important;
   }

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -122,7 +122,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* Use this class on text elements to turn them white */
-h1, h2, h3, h4, h5, h6, p, figcaption, a {
+h1, h2, h3, h4, h5, h6, p, figcaption, a:not(.link-button) {
   &.white {
     color: var(--neutral_white) !important;
   }

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -121,6 +121,13 @@ h1, h2, h3, h4, h5, h6 {
   text-wrap: balance;
 }
 
+/* Use this class on text elements to turn them white */
+h1, h2, h3, h4, h5, h6, p, figcaption, a {
+  &.white {
+    color: var(--neutral_white) !important;
+  }
+}
+
 p {
   line-height: 1.48;
   margin-bottom: 1em;


### PR DESCRIPTION
Adds a `.white` class for use on text elements and links, except for links styled as buttons using the `.link-button` class. This cuts down on the need for custom styles or inline styles on text elements that need to be white on a dark background. 

I updated the places that were doing this with inline styles in this PR too.

**Jira ticket:** [ACQ-1647](https://codedotorg.atlassian.net/browse/ACQ-1647)