### PR TITLE
Truncates the callouts_seen session data.

### DIFF
--- a/dashboard/lib/client_state.rb
+++ b/dashboard/lib/client_state.rb
@@ -96,8 +96,15 @@ class ClientState
 
   # Adds callout_key to the set of callouts seen in the current user session.
   def add_callout_seen(callout_key)
-    session[:callouts_seen] ||= Set.new
-    session[:callouts_seen].add(callout_key)
+    session[:callouts_seen] ||= []
+    # Ensure all old states that are using a Set are converted to an Array
+    session[:callouts_seen] = session[:callouts_seen].to_a
+    # Deletes a key if it exists (does nothing if not)
+    session[:callouts_seen].delete(callout_key)
+    # Append to the end of the list
+    session[:callouts_seen] << callout_key
+    # Rotate the list to only a certain number of the newest items
+    session[:callouts_seen].shift(session[:callouts_seen].length - 20) if session[:callouts_seen].length > 20
   end
 
   private

--- a/dashboard/test/helpers/application_helper_test.rb
+++ b/dashboard/test/helpers/application_helper_test.rb
@@ -146,6 +146,36 @@ class ApplicationHelperTest < ActionView::TestCase
     refute client_state.callout_seen? 'callout2'
   end
 
+  test 'callout_seen only has a truncated list' do
+    refute client_state.callout_seen? 'callout'
+    client_state.add_callout_seen 'callout'
+    25.times do |i|
+      client_state.add_callout_seen "callout_#{i}"
+    end
+    assert client_state.callout_seen? 'callout_24'
+    refute client_state.callout_seen? 'callout'
+  end
+
+  test 'callout_seen maintains most recently used order' do
+    refute client_state.callout_seen? 'callout'
+    client_state.add_callout_seen 'callout'
+    assert client_state.callout_seen? 'callout'
+    10.times do |i|
+      client_state.add_callout_seen "callout_#{i}"
+    end
+    assert client_state.callout_seen? 'callout'
+    client_state.add_callout_seen 'callout'
+    10.times do |i|
+      client_state.add_callout_seen "callout_#{i + 10}"
+    end
+    assert client_state.callout_seen? 'callout'
+    client_state.add_callout_seen 'callout'
+    10.times do |i|
+      client_state.add_callout_seen "callout_#{i + 10}"
+    end
+    assert client_state.callout_seen? 'callout'
+  end
+
   test 'client state with invalid cookie' do
     sl = create :script_level
     cookies[:progress] = '&*%$% mangled #$#$$'


### PR DESCRIPTION
**What**: The `callouts_seen` session key stores a list of keys that list the "callouts" (which describe sections of the screen to new users) the current session holder has seen.

**Problem**: The session data as a whole can only be 4096 bytes (4 KiB) in size and that is after the serialization and encryption is performed. Generally the encryption doubles the size of the raw session data leaving only around 2KiB for actual data. **_A guest account cannot even get through half of the Express course before the site 500s on them!_**

**Reason**: The `callouts_seen` is an unbounded list represented as a serialized ruby `Set` object and the data is maintained via the `add_callout_seen` method in `dashboard/lib/client_state.rb`. Generally, when we see the error in real life, this list has 48 or more items. When it goes past this, the data is too large and Rails' ActionPack library raises a `CookieOverflow` error.

**Solution**: Just serialize as an Array to maintain an ordered list and then add logic to cap the items to the newest 20 (or agreed upon number). Ensure existing items get moved to the end of the list to maintain a most recently seen order.

**Drawback**: We 'forget' callouts we haven't seen in a while, which just causes the callouts to happen again. But I can go an hour or two before I roll the list around, and in that case, seeing a helpful hint again isn't the worst thing. This implementation of an `Array` vs. `Set` means that looking up the existing key requires scanning the entire list. (A `Set` in ruby is just a glorified `Hash` honestly) However, since the `Array` is capped at a small value and it's an in-memory list, I'm not too worried about the performance relative to, say, a database query.

## Case Study

Let's look at the raw data size as I go through the site as a guest user. I will just create a couple of projects, play around in them, and start going through the recent Express 2023 course.

* `0B` - Clearing my cookies and starting from a fresh cookie state.
* `658B` - Initial cookie data.
* `964B` - I go and play around with an Artist level
* `1078B` - I play around with Sprite Lab
* `1538B` - I go and start the Express course
* `1702B` - Lesson 1 Level 3
* `1794B` - Lesson 1 Level 4 (just 1 callout was added for 92 bytes)
* `1958B` - Lesson 1 Level 7
* `2050B` - Lesson 2 Level 6 (**50% of our cookie budget is almost gone**)
* `2132B` - Lesson 2 Level 10
* `2214B` - Lesson 3 Level 2
* `2306B` - Lesson 3 Level 8
* `2326B` - Lesson 4 Level 2
* ...
* `3012B` - Lesson 7 Level 13
* ...
* `3556B` - Lesson 9 Level 13
* ...
* `3894B` - Lesson 13 (minecraft) Level 1 (**Less than 300 bytes left**)
* ...
* `4118B` - Lesson 13 Level 6
* Any new callout: **CookieOverflow** and a 500 error. (session has 50 callouts)

So, I cannot reasonably finish the Express course without creating an account. Each callout seems to add around 70 bytes or more to the session.

## Real Errors

[HoneyBadger 1](https://app.honeybadger.io/projects/3240/faults/105782184) - 48 callouts
[HoneyBadger 2](https://app.honeybadger.io/projects/3240/faults/105683558) - 50 callouts
[HoneyBadger 3](https://app.honeybadger.io/projects/3240/faults/105681203) - 48 callouts

So generally, our CookieOverflow errors contain `callouts_seen` with 48+ callouts. A rolling list capped at 20 seems very reasonable. This isn't a comprehensive examination... there could be other situations that cause the CookieOverflow that would still be limited by this value of '20', but it seems like the most prevalent cause.

It seems to happen very rarely if at all... but a logged in user will fail with a `CookieOverflow` after around 150-160 callouts.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- related jira ticket: [TEACH-228](https://codedotorg.atlassian.net/browse/TEACH-228)

## Testing

* Ran existing unit tests (there's only 1!!).
* Added unit tests and ran with old implementation to see red status.
* Added two unit tests to check for 1. truncation and 2. that entries re-seen do not get predictably truncated.
* The implementation still passes the existing unit test which just looks for the existence of the newly added key in the list.
* Manually took a failing CookieOverflow session and saw that it did not 500 error on a reload.
* Manually visited my development instance (where I am instrumenting ActionPack) to see that the session data size stabilized.

## Deployment strategy

This implementation performs a somewhat redundant `to_a` on the session value for `callouts_seen` since we must handle seeing a serialized `Set` from old sessions. Afterward, old sessions will have been converted to an `Array` serialization just fine.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
