### PR TITLE
Datablock Storage: channel_exists => project_has_data

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -807,7 +807,7 @@ Applab.init = function (config) {
 };
 
 async function initDataTab(levelOptions) {
-  const channelExists = await Applab.storage.channelExists();
+  const projectHasData = await Applab.storage.projectHasData();
   if (levelOptions.dataTables) {
     Applab.storage.populateTable(levelOptions.dataTables).catch(outputError);
   }
@@ -820,7 +820,7 @@ async function initDataTab(levelOptions) {
   }
   if (levelOptions.dataLibraryTables) {
     const libraryManifest = await Applab.storage.getLibraryManifest();
-    if (!channelExists) {
+    if (!projectHasData) {
       const tables = levelOptions.dataLibraryTables.split(',');
       tables.forEach(table => {
         const datasetInfo = getDatasetInfo(table, libraryManifest.tables);

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -372,12 +372,14 @@ DatablockStorage.getColumnsForTable = function (tableName) {
   return getColumnsForTable({tableName});
 };
 
-// @return {Promise<boolean>} whether the project channelID exists
-DatablockStorage.channelExists = function () {
-  return _fetch('channel_exists', 'GET', {});
+// @return {Promise<boolean>} whether the project has any data in it
+DatablockStorage.projectHasData = function () {
+  return _fetch('project_has_data', 'GET', {}).then(response =>
+    response.json()
+  );
 };
 
-// deletes all datablock storage data for this channel,
+// deletes all datablock storage data for this project,
 // used only one place, applab.js config.afterClearPuzzle()
 DatablockStorage.clearAllData = function (onSuccess, onError) {
   _fetch('clear_all_data', 'DELETE', {}).then(onSuccess, onError);

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -77,7 +77,7 @@ FirebaseStorage.getColumnsForTable = function (tableName, tableType) {
 /**
  * @return {Promise<boolean>} whether the project channel exists
  */
-FirebaseStorage.channelExists = function () {
+FirebaseStorage.projectHasData = function () {
   return getProjectDatabase()
     .once('value')
     .then(snapshot => snapshot.val() !== null);

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -18,7 +18,7 @@
 # - datablock_storage_library_manifest.rb
 #
 # Methods are broken into sections, for example the Key-Value-Pair API, Table API,
-# Table Column API, Table Record API, Library Manifest API & Channel API
+# Table Column API, Table Record API, Library Manifest API & Project API
 #
 # More details can be found in the PR that initially created Datablock Storage:
 # https://github.com/code-dot-org/code-dot-org/pull/56279
@@ -276,12 +276,13 @@ class DatablockStorageController < ApplicationController
   end
 
   ##########################################################
-  #   Channel API                                          #
+  #   Project API                                          #
   ##########################################################
 
-  # Returns true if validation checks pass
-  def channel_exists
-    render json: true
+  # Returns true if there is any data for the project
+  def project_has_data
+    is_there_data = DatablockStorageTable.exists?(project_id: @project_id) || DatablockStorageKvp.exists?(project_id: @project_id)
+    render json: is_there_data
   end
 
   # Deletes all datablock storage data for the project

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1159,8 +1159,8 @@ Dashboard::Application.routes.draw do
         get :get_library_manifest
         put :set_library_manifest
 
-        # Datablock Storage: Channel API
-        get :channel_exists
+        # Datablock Storage: Project API
+        get :project_has_data
         delete :clear_all_data
 
         # TODO: post-firebase-cleanup, remove

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -695,6 +695,44 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
     assert_equal CSV_DATA, @response.body
   end
 
+  test "project_has_data" do
+    get _url(:project_has_data)
+    assert_response :success
+    assert_equal false, JSON.parse(@response.body)
+
+    create_bob_record
+
+    get _url(:project_has_data)
+    assert_response :success
+    assert_equal true, JSON.parse(@response.body)
+
+    delete _url(:delete_table), params: {
+      table_name: 'mytable',
+    }
+
+    get _url(:project_has_data)
+    assert_response :success
+    assert_equal false, JSON.parse(@response.body)
+
+    post _url(:set_key_value), params: {
+      key: 'name',
+      value: 'bob'.to_json,
+    }
+
+    get _url(:project_has_data)
+    assert_response :success
+    assert_equal true, JSON.parse(@response.body)
+
+    delete _url(:delete_key_value), params: {
+      key: 'name',
+    }
+    assert_response :success
+
+    get _url(:project_has_data)
+    assert_response :success
+    assert_equal false, JSON.parse(@response.body)
+  end
+
   test "clear_all_data" do
     create_bob_record
     set_and_get_key_value('somekey', 5)


### PR DESCRIPTION
1. Rename channel_exists => project_has_data
2. Implement DatablockStorageController.project_has_data around the new semantic
3. Add new controller test for project_has_data

Fixes [#56632](https://github.com/code-dot-org/code-dot-org/issues/56632): after this change we see stock tables being populated when specified by levelbuilder.

Co-authored-by: Cassi Brenci <cnbrenci@users.noreply.github.com>