### PR TITLE
Music: optional vocals filter

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -23,6 +23,9 @@ export default class MusicLibrary {
   private bpm: number | undefined;
   private key: Key | undefined;
 
+  // Whether this library contains vocals.
+  private hasVocals: boolean;
+
   constructor(name: string, libraryJson: LibraryJson) {
     this.name = name;
     this.libraryJson = libraryJson;
@@ -42,6 +45,8 @@ export default class MusicLibrary {
     if (libraryJson.key) {
       this.key = Key[libraryJson.key.toUpperCase() as keyof typeof Key];
     }
+
+    this.hasVocals = !!libraryJson.hasVocals;
   }
 
   getDefaultSound(): string | undefined {
@@ -154,6 +159,10 @@ export default class MusicLibrary {
   getKey(): Key | undefined {
     return this.key;
   }
+
+  getHasVocals(): boolean {
+    return this.hasVocals;
+  }
 }
 
 export const LibraryValidator: ResponseValidator<LibraryJson> = response => {
@@ -223,6 +232,7 @@ export type LibraryJson = {
   path: string;
   bpm?: number;
   key?: string;
+  hasVocals?: boolean;
   defaultSound?: string;
   folders: SoundFolder[];
   instruments: SoundFolder[];

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -279,6 +279,18 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
     );
   }
 
+  const typeButtons = [
+    {label: 'All', value: 'all'},
+    {label: 'Beats', value: 'beat'},
+    {label: 'Bass', value: 'bass'},
+    {label: 'Leads', value: 'lead'},
+    {label: 'Effects', value: 'fx'},
+  ];
+
+  if (library.getHasVocals()) {
+    typeButtons.push({label: 'Vocals', value: 'vocal'});
+  }
+
   return (
     <FocusLock>
       <div id="sounds-panel" className={styles.soundsPanel} aria-modal>
@@ -297,13 +309,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
 
             <SegmentedButtons
               selectedButtonValue={filter}
-              buttons={[
-                {label: 'All', value: 'all'},
-                {label: 'Beats', value: 'beat'},
-                {label: 'Bass', value: 'bass'},
-                {label: 'Leads', value: 'lead'},
-                {label: 'Effects', value: 'fx'},
-              ]}
+              buttons={typeButtons}
               onChange={value => onFilterChange(value as Filter)}
               className={styles.segmentedButtons}
             />


### PR DESCRIPTION
A library can now specify whether it has vocals, with `"hasVocals": true`, and then the sound selection UI will offer "Vocals" as an option.
