### PR TITLE
Datablock Storage: use square corners for [Data] to visually flag "in experiment"

### DIFF
--- a/apps/src/applab/PlaySpaceHeader.jsx
+++ b/apps/src/applab/PlaySpaceHeader.jsx
@@ -9,6 +9,7 @@ import {actions} from './redux/applab';
 import {connect} from 'react-redux';
 import ScreenSelector from './ScreenSelector';
 import ToggleGroup from '../templates/ToggleGroup';
+import {isDatablockStorage} from '../storage/storage';
 
 class PlaySpaceHeader extends React.Component {
   static propTypes = {
@@ -27,6 +28,22 @@ class PlaySpaceHeader extends React.Component {
     onScreenCreate: PropTypes.func.isRequired,
     onInterfaceModeChange: PropTypes.func.isRequired,
   };
+
+  // Visually flag that a project is part of the Datablock Storage experiment
+  // by squaring the otherwise rounded-on-the-right corners of the [Data] tab.
+  //
+  // Why? We are gradually rolling out Datablock Storage in a small percentage
+  // of Applab projects. For bug triage, we need a quick way for CS to identify
+  // projects using Datablock Storage that is likely to be recognizable even if
+  // screenshots are taken with a cell phone, or cropped.
+  //
+  // TODO: post-firebase-cleanup, remove this method, #56994
+  squareCornersIfUsingDatablockStorage() {
+    const STYLE_TO_FLAG_DATABLOCK_STORAGE = {
+      borderRadius: 0,
+    };
+    return isDatablockStorage() ? STYLE_TO_FLAG_DATABLOCK_STORAGE : {};
+  }
 
   render() {
     let leftSide, rightSide;
@@ -57,6 +74,7 @@ class PlaySpaceHeader extends React.Component {
               type="button"
               id="dataModeButton"
               value={ApplabInterfaceMode.DATA}
+              style={this.squareCornersIfUsingDatablockStorage()}
             >
               {msg.dataMode()}
             </button>


### PR DESCRIPTION
Visually flag that a project is part of the Datablock Storage experiment by squaring the otherwise rounded-on-the-right corners of the [Data] tab.

Why? We are gradually rolling out Datablock Storage in a small percentage of Applab projects. For bug triage, we need a quick way for CS to identify projects using Datablock Storage that is likely to be recognizable even if screenshots are taken with a cell phone, or cropped.

Applab Project is using Datablock Storage (experimental condition):
<img width="417" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/b8cf6ff5-7fa6-4820-a911-f4cb2ef5d29d">

Applab Project is NOT using Datablock Storage (regular condition):
<img width="417" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/dffcd52e-367c-4d0c-8970-423f75bff98b">