### PR TITLE
Datablock Storage: DB migrations

### DIFF
--- a/dashboard/db/migrate/20240110234501_create_datablock_storage_kvps.rb
+++ b/dashboard/db/migrate/20240110234501_create_datablock_storage_kvps.rb
@@ -1,0 +1,15 @@
+class CreateDatablockStorageKvps < ActiveRecord::Migration[6.1]
+  def change
+    # We use utf8mb4 because we want .string to support emoji
+    create_table :datablock_storage_kvps, primary_key: [:project_id, :key], charset: 'utf8mb4', collation: 'utf8mb4_bin' do |t|
+      t.integer :project_id
+      # this is part of the composite primary_key and max key length in mysql is 3072 bytes,
+      # so 700 * 4-bytes per utf8 character. This also slightly exceeds the existing Firebase
+      # data's max key length.
+      t.string :key, limit: 700
+      t.json :value
+    end
+
+    add_index :datablock_storage_kvps, :project_id
+  end
+end

--- a/dashboard/db/migrate/20240111002910_create_datablock_storage_records.rb
+++ b/dashboard/db/migrate/20240111002910_create_datablock_storage_records.rb
@@ -1,0 +1,16 @@
+class CreateDatablockStorageRecords < ActiveRecord::Migration[6.1]
+  def change
+    # We use utf8mb4 because we want .table_name to support emoji
+    create_table :datablock_storage_records, primary_key: [:project_id, :table_name, :record_id], charset: 'utf8mb4', collation: 'utf8mb4_bin' do |t|
+      t.integer :project_id
+      # this is part of the composite primary_key for datablock_storage_tables
+      # and max key length in mysql is 3072 bytes, so 700 * 4-bytes per utf8 character
+      t.string :table_name, limit: 700
+      t.integer :record_id
+      t.json :record_json
+    end
+
+    add_index :datablock_storage_records, :project_id
+    add_index :datablock_storage_records, [:project_id, :table_name]
+  end
+end

--- a/dashboard/db/migrate/20240111003957_create_datablock_storage_tables.rb
+++ b/dashboard/db/migrate/20240111003957_create_datablock_storage_tables.rb
@@ -1,0 +1,16 @@
+class CreateDatablockStorageTables < ActiveRecord::Migration[6.1]
+  def change
+    # We use utf8mb4 because we want .table_name to support emoji
+    create_table :datablock_storage_tables, primary_key: [:project_id, :table_name], charset: 'utf8mb4', collation: 'utf8mb4_bin' do |t|
+      t.integer :project_id
+      # this is part of the composite primary_key and max key length in mysql is 3072 bytes * 4-bytes per utf8 character
+      t.string :table_name, limit: 700
+      t.json :columns
+      t.string :is_shared_table, limit: 700
+
+      t.timestamps
+    end
+
+    add_index :datablock_storage_tables, :project_id
+  end
+end

--- a/dashboard/db/migrate/20240215100626_create_project_use_datablock_storages.rb
+++ b/dashboard/db/migrate/20240215100626_create_project_use_datablock_storages.rb
@@ -1,0 +1,13 @@
+# TODO: post-firebase-cleanup, drop this table: #56994
+#
+# This is a temporary table that allows some projects to be in Firebase, and some
+# to be in Datablock storage. Once all projects migrated to Datablock storage,
+# we can remove this table.
+class CreateProjectUseDatablockStorages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :project_use_datablock_storages do |t|
+      t.integer :project_id, null: false, index: true
+      t.boolean :use_datablock_storage, default: false, null: false
+    end
+  end
+end

--- a/dashboard/db/migrate/20240216053618_create_datablock_storage_library_manifest.rb
+++ b/dashboard/db/migrate/20240216053618_create_datablock_storage_library_manifest.rb
@@ -1,0 +1,12 @@
+require 'firebase'
+
+class CreateDatablockStorageLibraryManifest < ActiveRecord::Migration[6.1]
+  def change
+    create_table :datablock_storage_library_manifest do |t|
+      t.json :library_manifest
+      t.integer :singleton_guard, null: false
+      t.timestamps
+    end
+    add_index :datablock_storage_library_manifest, :singleton_guard, unique: true
+  end
+end

--- a/dashboard/db/migrate/20240216071353_seed_datasets_from_firebase.rb
+++ b/dashboard/db/migrate/20240216071353_seed_datasets_from_firebase.rb
@@ -1,0 +1,60 @@
+# This pre-seeds the Data Library from Firebase,
+# including the datasets, and the library manifest.
+#
+# TODO: post-firebase-cleanup, remove this migration (=turn it into a NoOp)
+# as soon as firebase is outdated, we shouldn't be running this anymore. We
+# may require anothe way to seed this data at that point: #56994
+class SeedDatasetsFromFirebase < ActiveRecord::Migration[6.1]
+  def up
+    seed_manifest_from_firebase
+    seed_tables_from_firebase
+  rescue => exception
+    message = <<~LOG
+      Failed to seed datablock storage library from Firebase: #{exception.message}
+
+      Traceback:
+      #{exception.backtrace.join("\n")}
+
+      This isn't necessarily an error, unless you really want to get the Firebase
+      'Data Library' data. If its after June 2024, this code should have
+      been removed, somebody forgot to do the `TODO: post-firebase-cleanup`.
+    LOG
+    Rails.logger.warn message
+    puts message
+  end
+
+  def down
+    DatablockStorageLibraryManifest.instance.destroy
+    DatablockStorageTable.where(project_id: DatablockStorageTable::SHARED_TABLE_PROJECT_ID).destroy_all
+  end
+
+  private
+
+  def firebase_get(path)
+    raise "CDO.firebase_shared_secret not defined" unless CDO.firebase_shared_secret
+    firebase = Firebase::Client.new 'https://cdo-v3-shared.firebaseio.com/', CDO.firebase_shared_secret
+    response = firebase.get(path)
+    raise "Error fetching #{path} from Firebase: #{response.code}" unless response.success?
+    response.body
+  end
+
+  def seed_manifest_from_firebase
+    db = DatablockStorageLibraryManifest.instance
+    raise "Library manifest already exists, not re-seeding" unless db.library_manifest['tables']&.length&.< 1
+    firebase_manifest = firebase_get('/v3/channels/shared/metadata/manifest')
+    puts "Seeding library manifest from Firebase with #{firebase_manifest['tables']&.length} shared tables"
+    db.update!(library_manifest: firebase_manifest)
+  end
+
+  def seed_tables_from_firebase
+    raise "There are already shared_tables / datasets, not re-seeding" unless DatablockStorageTable.get_shared_table_names.empty?
+    firebase_tables = firebase_get('/v3/channels/shared/storage/tables')
+    # Firebase's JSON format is a little different, in particular in stores
+    # each record not as a JSON object, but as a JSON string
+    firebase_tables.each do |table_name, firebase_table|
+      table = firebase_table['records'].filter_map {|record| JSON.parse(record) if record.is_a?(String)}
+      puts "Seeding shared table from Firebase: '#{table_name}' (#{table.length} records)"
+      DatablockStorageTable.populate_tables(DatablockStorageTable::SHARED_TABLE_PROJECT_ID, {table_name => table})
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -435,6 +435,40 @@ ActiveRecord::Schema.define(version: 2024_03_08_234208) do
     t.index ["name"], name: "index_data_docs_on_name"
   end
 
+  create_table "datablock_storage_kvps", primary_key: ["project_id", "key"], charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.string "key", limit: 700, null: false
+    t.json "value"
+    t.index ["project_id"], name: "index_datablock_storage_kvps_on_project_id"
+  end
+
+  create_table "datablock_storage_library_manifest", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.json "library_manifest"
+    t.integer "singleton_guard", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["singleton_guard"], name: "index_datablock_storage_library_manifest_on_singleton_guard", unique: true
+  end
+
+  create_table "datablock_storage_records", primary_key: ["project_id", "table_name", "record_id"], charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.string "table_name", limit: 700, null: false
+    t.integer "record_id", null: false
+    t.json "record_json"
+    t.index ["project_id", "table_name"], name: "index_datablock_storage_records_on_project_id_and_table_name"
+    t.index ["project_id"], name: "index_datablock_storage_records_on_project_id"
+  end
+
+  create_table "datablock_storage_tables", primary_key: ["project_id", "table_name"], charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.string "table_name", limit: 700, null: false
+    t.json "columns"
+    t.string "is_shared_table", limit: 700
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["project_id"], name: "index_datablock_storage_tables_on_project_id"
+  end
+
   create_table "delayed_jobs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
@@ -1567,6 +1601,12 @@ ActiveRecord::Schema.define(version: 2024_03_08_234208) do
     t.datetime "updated_at", null: false
     t.index ["storage_app_id", "object_version_id"], name: "index_project_commits_on_storage_app_id_and_object_version_id", unique: true
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
+  end
+
+  create_table "project_use_datablock_storages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.boolean "use_datablock_storage", default: false, null: false
+    t.index ["project_id"], name: "index_project_use_datablock_storages_on_project_id"
   end
 
   create_table "projects", id: :integer, charset: "utf8mb4", force: :cascade do |t|


### PR DESCRIPTION
This PR splits the DB migrations out from the main Datablock Storage PR: #56279 

@bethanyaconnor suggested we apply the migrations first, so that if a quick revert is required on #56279 we won't have to be tweezering out NOT reverting the DB migrations.

Co-authored-by: Cassi Brenci <cassi.brenci@code.org>