### PR TITLE
Music: italic vocals

### DIFF
--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -170,6 +170,14 @@ class FieldSounds extends GoogleBlockly.Field {
       height: 20,
     });
 
+    const soundType = this.options
+      .getLibrary()
+      .getSoundForId(this.getValue())?.type;
+
+    if (soundType === 'vocal') {
+      textElement.setAttribute('font-style', 'italic');
+    }
+
     // Attach the actual text.
     textElement.appendChild(document.createTextNode(fieldText));
 
@@ -204,10 +212,6 @@ class FieldSounds extends GoogleBlockly.Field {
     );
 
     // Add an image for the sound type.
-    const soundType = this.options
-      .getLibrary()
-      .getSoundForId(this.getValue())?.type;
-
     if (soundType) {
       GoogleBlockly.utils.dom.createSvgElement(
         'image',

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -173,7 +173,14 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
     >
       <div className={styles.soundRowLeft}>
         <img src={typeIconPath} className={styles.typeIcon} alt="" />
-        <div className={styles.name}>{sound.name}</div>
+        <div
+          className={classNames(
+            styles.name,
+            sound.type === 'vocal' && styles.nameVocal
+          )}
+        >
+          {sound.name}
+        </div>
       </div>
       {showingSoundsOnly && (
         <div className={styles.soundRowMiddle}>

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -132,9 +132,12 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+
+        &Vocal {
+          font-style: italic;
+        }
       }
     }
-
 
     &Middle {
       font-size: 11px;


### PR DESCRIPTION
The sound selection UI now shows the names of sounds of type `"vocal"` in _italics_.  The `play sound` block's custom field _matches_.

Our libraries are going to feature the lyrics in these names, and they sometimes are truncated with ellipses, so this is a way to have them read differently to the other names.

<img width="666" alt="Screenshot 2024-03-21 at 12 11 14 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/0ec6fedd-8163-47a2-9402-4395ed65ad15">
