### PR TITLE
[Google Blockly] add all blocks undeletable option to start mode

### DIFF
--- a/apps/src/blockly/addons/contextMenu.ts
+++ b/apps/src/blockly/addons/contextMenu.ts
@@ -164,6 +164,38 @@ const registerUnshadow = function (weight: number) {
   GoogleBlockly.ContextMenuRegistry.registry.register(unshadowOption);
 };
 
+const registerAllBlocksUndeletable = function (weight: number) {
+  const workspaceBlocksUndeletableOption = {
+    displayText: function (scope: ContextMenuRegistry.Scope) {
+      return 'Make ALL Blocks Undeletable';
+    },
+    preconditionFn: function (scope: ContextMenuRegistry.Scope) {
+      if (Blockly.isStartMode) {
+        if (
+          scope.workspace?.getAllBlocks().every(block => !block.isDeletable())
+        ) {
+          return MenuOptionStates.DISABLED;
+        }
+        return MenuOptionStates.ENABLED;
+      }
+      return MenuOptionStates.HIDDEN;
+    },
+    callback: function (scope: ContextMenuRegistry.Scope) {
+      if (scope.workspace) {
+        scope.workspace
+          .getAllBlocks()
+          .forEach(block => block.setDeletable(false));
+      }
+    },
+    scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+    id: 'workspaceBlocksUndeletable',
+    weight,
+  };
+  GoogleBlockly.ContextMenuRegistry.registry.register(
+    workspaceBlocksUndeletableOption
+  );
+};
+
 const registerKeyboardNavigation = function (weight: number) {
   const keyboardNavigationOption = {
     displayText: function (scope: ContextMenuRegistry.Scope) {
@@ -488,4 +520,5 @@ function registerCustomWorkspaceOptions() {
   registerKeyboardNavigation(nextWeight++);
   registerAllCursors(nextWeight++, NAVIGATION_CURSOR_TYPES);
   registerThemes(nextWeight++, themes);
+  registerAllBlocksUndeletable(nextWeight++);
 }


### PR DESCRIPTION
Request from @onlinecsteacher:
> It would be so handy to be able to render all starter code blocks on a page undeleteable without having to update the XML for each one (or repeatedly right click and select from a dropdown)
In these levels we’re asking students to make minor changes to the code. They don’t have a toolbox because the code already exists but we don’t want them to delete the blocks:
https://levelbuilder-studio.code.org/s/pilot-k5-game-design/lessons/2/levels/11
I made the blocks in Levels C and D undeleteable but it takes a while

For a potential quick-win for our levelbuilders, we can add a custom context menu option under the workspace scope to handle this. This option only shows in start mode (and toolbox mode is excluded since you wouldn't want to allow students to create infinite undeletable blocks). Unless every block is already undeletable, the option is enabled. I confirmed that this works as expected and results in a `deletable="false"` attribute being added to each block element in the Start Blocks XML on the level edit page. The option does not show on any student-facing view.


https://github.com/code-dot-org/code-dot-org/assets/43474485/a8701fa5-121f-4bd5-8f9c-6a2061c74cd5


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
