### PR TITLE
feat(lms): add support for teacher account creation and co-teacher support on sync

### DIFF
--- a/dashboard/app/controllers/api/v1/section_instructors_controller.rb
+++ b/dashboard/app/controllers/api/v1/section_instructors_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::SectionInstructorsController < Api::V1::JSONApiController
     authorize! :manage, section
 
     begin
-      si = section.add_instructor(params.require(:email), current_user)
+      si = section.invite_instructor(params.require(:email), current_user)
       render json: si, serializer: Api::V1::SectionInstructorSerializer
     rescue ArgumentError => exception
       render json: {error: exception.message}, status: :bad_request

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -71,7 +71,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
     return head :bad_request unless section.persisted?
 
     # Add all coteachers specified in params
-    params[:instructor_emails]&.each {|instructor_email| section.add_instructor(instructor_email, current_user)}
+    params[:instructor_emails]&.each {|instructor_email| section.invite_instructor(instructor_email, current_user)}
 
     # TODO: Move to an after_create step on Section model when old API is fully deprecated
     current_user.assign_script @unit if @unit
@@ -116,7 +116,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
     end
 
     # Add all coteachers specified in params
-    params[:instructor_emails]&.each {|instructor_email| section.add_instructor(instructor_email, current_user)}
+    params[:instructor_emails]&.each {|instructor_email| section.invite_instructor(instructor_email, current_user)}
 
     render json: section.summarize
   end

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -570,9 +570,9 @@ class Section < ApplicationRecord
 
   # Adds an instructor to the section
   # If the instructor was previously deleted, restore the instructor
-  # If the instructor was invited or inactive, reactive the instructor
+  # Make the instructor active if they had a different status
   # If the instructor did not previously exist, create the section instructor relationship
-  # Returns true if the instructor could be added, false otherwise
+  # Returns true if successful
   def add_instructor(user)
     transaction do
       Follower.find_by(section: self, student_user: user)&.destroy

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -573,31 +573,24 @@ class Section < ApplicationRecord
   # If the instructor was invited or inactive, reactive the instructor
   # If the instructor did not previously exist, create the section instructor relationship
   # Returns true if the instructor could be added, false otherwise
-  public def add_instructor(user)
-    return false unless user.teacher?
-
-    Follower.find_by(section: self, student_user: user)&.destroy
-
-    si = SectionInstructor.with_deleted.find_by(instructor: user, section_id: id)
-    if si.blank?
-      SectionInstructor.create!(section_id: id, instructor: user, status: :active)
-    elsif si.deleted?
-      si.restore
-      si.status = :active
-      si.save!
-    elsif si.status != 'active'
-      si.status = :active
-      si.save!
+  def add_instructor(user)
+    transaction do
+      Follower.find_by(section: self, student_user: user)&.destroy
+      si = SectionInstructor.with_deleted.find_or_initialize_by(instructor: user, section_id: id)
+      si.restore if si.deleted?
+      si.active!
     end
 
     true
   end
 
-  public def remove_instructor(user)
-    SectionInstructor.find_by(instructor: user, section_id: id)&.destroy
+  # Removes an instructor
+  # Note: Will not remove the primary instructor to prevent orphaned sections
+  def remove_instructor(user)
+    SectionInstructor.find_by(instructor: user, section_id: id)&.destroy unless self.user == user
   end
 
-  public def invite_instructor(email, current_user)
+  def invite_instructor(email, current_user)
     instructor = User.find_by!(email: email, user_type: :teacher)
     raise ArgumentError.new('inviting self') if instructor == current_user
 

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -190,14 +190,14 @@ module Services
         )
         had_changes ||= (user.new_record? || user.changed?)
         user.save!
-        if account_type == ::User::TYPE_STUDENT
-          add_student_result = section.add_student(user)
-          had_changes ||= add_student_result == Section::ADD_STUDENT_SUCCESS
-          current_students.add(user.id)
-        else
+        if account_type == ::User::TYPE_TEACHER
           add_instructor_result = section.add_instructor(user)
           had_changes ||= add_instructor_result
           current_teachers.add(user.id)
+        else
+          add_student_result = section.add_student(user)
+          had_changes ||= add_student_result == Section::ADD_STUDENT_SUCCESS
+          current_students.add(user.id)
         end
       end
 

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -317,7 +317,7 @@ class Services::LtiTest < ActiveSupport::TestCase
     assert_equal user.user_type, User::TYPE_STUDENT
   end
 
-  test 'should create a teacher user if LTI does not provide email despite instructor role' do
+  test 'should create a student user if LTI does not provide email despite instructor role' do
     Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
     @nrps_teacher[:message].first.delete(@custom_claims_key)
 

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -451,7 +451,7 @@ class Services::LtiTest < ActiveSupport::TestCase
 
     co_teacher_si.reload
 
-    assert_equal 3, lti_section.followers.length
+    assert_equal 2, lti_section.followers.length
     assert_equal true, co_teacher_si.deleted?
   end
 

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -905,13 +905,6 @@ class SectionTest < ActiveSupport::TestCase
     assert_equal 1, section.instructors.length
   end
 
-  test 'add_instructor returns false if not an instructor' do
-    section = create(:section)
-    user = create :student
-
-    assert_equal false, section.add_instructor(user)
-  end
-
   test 'add_instructor returns true and adds the teacher if not previously a co-teacher' do
     section = create(:section)
     user = create :teacher
@@ -961,6 +954,17 @@ class SectionTest < ActiveSupport::TestCase
     si.reload
 
     assert_equal true, si.deleted?
+  end
+
+  test 'remove_instructor does not remove the primary teacher' do
+    user = create :teacher
+    section = create(:section, user: user)
+
+    si = SectionInstructor.find_by(instructor: user, section_id: section.id)
+    section.remove_instructor(user)
+    si.reload
+
+    assert_equal false, si.deleted?
   end
 
   def set_up_code_review_groups

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -909,9 +909,7 @@ class SectionTest < ActiveSupport::TestCase
     section = create(:section)
     user = create :teacher
 
-    result = section.add_instructor(user)
-
-    assert_equal true, result
+    assert section.add_instructor(user)
     assert_equal user, section.section_instructors.last.instructor
   end
 
@@ -964,7 +962,7 @@ class SectionTest < ActiveSupport::TestCase
     section.remove_instructor(user)
     si.reload
 
-    assert_equal false, si.deleted?
+    refute si.deleted?
   end
 
   def set_up_code_review_groups


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This PR adds the following features:

1. Upon section sync, create teacher accounts if the LMS provides the e-mail address and the LMS indicates the user is a teacher. If not, a student account is created. If the user is a teacher on the LMS but a student account is created in this process, the teacher will be upgraded to a teacher account when the user first logs in via the upgrade teacher pathway.
2. Upon section sync, add co-teachers into the section.
3. Downgrade co-teacher to student in a section based on LMS response
4. Upgrade students to co-teacher in a section based on LMS response

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-603)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

### Scenario 1: Create new Code.org teacher account via section sync

"Stephen Student9" is a brand new account on Canvas. Code.org will create a brand new account on Code.org as a teacher and add the user as co-teacher.

[Create teacher account via sync.webm](https://github.com/code-dot-org/code-dot-org/assets/538214/91d5ac4d-fa58-4fec-b287-89c9105119d2)

### Scenario 2: Downgrade co-teachers to students

On canvas, change the role of students 3, 4, and 5 to student.

[Downgrade co-teachers to student.webm](https://github.com/code-dot-org/code-dot-org/assets/538214/826dd34e-2d14-40ba-9cbf-a2d46f54d4e1)

### Scenario 3: Upgrade students to co-teachers

On canvas, change the role of student 3 and 4 to teacher.

[Upgrade student to co-teacher.webm](https://github.com/code-dot-org/code-dot-org/assets/538214/dd98c7f3-6637-459f-ae72-8239e659502d)


### Scenario 4: Transfer a student from one Canvas section to becoming a teacher in a different Canvas section


[transfer student.webm](https://github.com/code-dot-org/code-dot-org/assets/538214/48fa7b6d-5e86-4c62-802f-a262d6c33baa)


### Scenario 5: Transfer a teacher from one Canvas section to becoming a student in a different Canvas section


[transfer teacher.webm](https://github.com/code-dot-org/code-dot-org/assets/538214/c3e4ad25-c71e-4732-8e79-2bd992546f06)


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

- https://codedotorg.atlassian.net/browse/P20-804

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
