### PR TITLE
Add Issuer column to the lti_user_identities table

### DIFF
--- a/dashboard/app/models/lti_user_identity.rb
+++ b/dashboard/app/models/lti_user_identity.rb
@@ -9,10 +9,12 @@
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  deleted_at         :datetime
+#  issuer             :string(255)      not null
 #
 # Indexes
 #
 #  index_lti_user_identities_on_deleted_at          (deleted_at)
+#  index_lti_user_identities_on_issuer              (issuer)
 #  index_lti_user_identities_on_lti_integration_id  (lti_integration_id)
 #  index_lti_user_identities_on_subject             (subject)
 #  index_lti_user_identities_on_user_id             (user_id)

--- a/dashboard/db/migrate/20240320051410_add_issuer_to_lti_user_identities.rb
+++ b/dashboard/db/migrate/20240320051410_add_issuer_to_lti_user_identities.rb
@@ -1,0 +1,7 @@
+class AddIssuerToLtiUserIdentities < ActiveRecord::Migration[6.1]
+  def change
+    add_column :lti_user_identities, :issuer, :string
+    change_column_null :lti_user_identities, :issuer, false
+    add_index :lti_user_identities, :issuer
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -993,7 +993,7 @@ ActiveRecord::Schema.define(version: 2024_03_20_051410) do
     t.index ["user_id"], name: "index_pd_applications_on_user_id"
   end
 
-  create_table "pd_applications_status_logs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications_status_logs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "pd_application_id", null: false
     t.string "status", null: false
     t.datetime "timestamp", null: false

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_08_234208) do
+ActiveRecord::Schema.define(version: 2024_03_20_051410) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -867,7 +867,9 @@ ActiveRecord::Schema.define(version: 2024_03_08_234208) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "deleted_at"
+    t.string "issuer", null: false
     t.index ["deleted_at"], name: "index_lti_user_identities_on_deleted_at"
+    t.index ["issuer"], name: "index_lti_user_identities_on_issuer"
     t.index ["lti_integration_id"], name: "index_lti_user_identities_on_lti_integration_id"
     t.index ["subject"], name: "index_lti_user_identities_on_subject"
     t.index ["user_id"], name: "index_lti_user_identities_on_user_id"
@@ -991,7 +993,7 @@ ActiveRecord::Schema.define(version: 2024_03_08_234208) do
     t.index ["user_id"], name: "index_pd_applications_on_user_id"
   end
 
-  create_table "pd_applications_status_logs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications_status_logs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "pd_application_id", null: false
     t.string "status", null: false
     t.datetime "timestamp", null: false


### PR DESCRIPTION
## Story
Currently, our `lti_user_identities` table has the following columns: `id`, `subject`,  `lti_integration_id`,  `user_id`,  `created_at`, `updated_at`, and `deleted_at`. 

When searching for a user through the `lti_user_identities` table using the content of an LTI's JWT, only the `subject` is present. 
The `subject` is only guaranteed to be unique within an LMS and we could have a situation where two users, from different LMSs, have the same `subject`.

To avoid collision we need to add another column to the `lti_user_identities` table to store the issuer of an LTI Identity.

## Changes
This PR includes a migration to the `lti_user_identities` where:
-  A new column `issuer` is added.
- The new column can not be null
-  It is indexed since it will be primarily used for querying the `lti_user_identities` table.

## Links
- Jira ticket: [P20-789](https://codedotorg.atlassian.net/browse/P20-789)

## Follow-up work
- Modifying the existing LTI code to store the issuer each time a user identity is created.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
