### PR TITLE
Split up PanelsView for reuse

### DIFF
--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -24,7 +24,7 @@ import ProgressContainer from '../progress/ProgressContainer';
 import {AppName} from '../types';
 import moduleStyles from './lab-views-renderer.module.scss';
 import {DEFAULT_THEME, Theme, ThemeContext} from './ThemeWrapper';
-import PanelsView from '@cdo/apps/panels/PanelsView';
+import PanelsLabView from '@cdo/apps/panels/PanelsLabView';
 import Weblab2View from '@cdo/apps/weblab2/Weblab2View';
 import Loading from './Loading';
 
@@ -94,7 +94,7 @@ const appsProperties: {[appName in AppName]?: AppProperties} = {
   },
   panels: {
     backgroundMode: false,
-    node: <PanelsView />,
+    node: <PanelsLabView />,
   },
   weblab2: {
     backgroundMode: false,

--- a/apps/src/panels/PanelsLabView.tsx
+++ b/apps/src/panels/PanelsLabView.tsx
@@ -1,0 +1,60 @@
+// Panels
+//
+// This is a React client for a panels level.  Note that this is
+// only used for levels that use Lab2.
+
+import React, {useCallback} from 'react';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {
+  sendSuccessReport,
+  navigateToNextLevel,
+} from '@cdo/apps/code-studio/progressRedux';
+import {PanelsLevelData} from './types';
+import PanelsView from './PanelsView';
+import useWindowSize from '../util/hooks/useWindowSize';
+
+const appName = 'panels';
+
+const PanelsLabView: React.FunctionComponent = () => {
+  const dispatch = useAppDispatch();
+
+  const levelData = useAppSelector(
+    state => state.lab.levelProperties?.levelData
+  );
+  const currentAppName = useAppSelector(
+    state => state.lab.levelProperties?.appName
+  );
+
+  const onContinue = useCallback(
+    (nextUrl?: string) => {
+      if (nextUrl) {
+        // This is a short-term solution for the Music Lab progression in incubation.  We will not attempt
+        // to send a success report for a level that uses this feature.
+        window.location.href = nextUrl;
+      } else {
+        dispatch(sendSuccessReport(appName));
+        dispatch(navigateToNextLevel());
+      }
+    },
+    [dispatch]
+  );
+
+  const panels = (levelData as PanelsLevelData | undefined)?.panels;
+
+  const [windowWidth, windowHeight] = useWindowSize();
+
+  if (!panels || currentAppName !== appName) {
+    return <div />;
+  }
+
+  return (
+    <PanelsView
+      panels={panels}
+      onContinue={onContinue}
+      targetWidth={windowWidth}
+      targetHeight={windowHeight}
+    />
+  );
+};
+
+export default PanelsLabView;

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -1,109 +1,43 @@
-// Panels
-//
-// This is a React client for a panels level.  Note that this is
-// only used for levels that use Lab2.
-
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useLayoutEffect,
-  useState,
-} from 'react';
-import {useSelector} from 'react-redux';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
-import {
-  sendSuccessReport,
-  navigateToNextLevel,
-} from '@cdo/apps/code-studio/progressRedux';
-import {LabState} from '@cdo/apps/lab2/lab2Redux';
-import {PanelsLevelData} from './types';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import styles from './panels.module.scss';
+import EnhancedSafeMarkdown from '../templates/EnhancedSafeMarkdown';
 import classNames from 'classnames';
-import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
-import {currentLevelIndex} from '@cdo/apps/code-studio/progressReduxSelectors';
-const commonI18n = require('@cdo/locale');
+import {commonI18n} from '../types/locale';
+import FontAwesome from '../templates/FontAwesome';
+import {Panel} from './types';
 
-function useWindowSize() {
-  const [size, setSize] = useState([
-    document.documentElement.clientWidth,
-    document.documentElement.clientHeight,
-  ]);
-  useLayoutEffect(() => {
-    function updateSize() {
-      const width = document.documentElement.clientWidth;
-      const height = document.documentElement.clientHeight;
-      setSize([width, height]);
-    }
-    window.addEventListener('resize', updateSize);
-    updateSize();
-    return () => window.removeEventListener('resize', updateSize);
-  }, []);
-  return size;
+// Leave a margin to the left and the right of the panels, to the edges
+// of the screen.
+const horizontalMargin = 40;
+
+// Leave a vertical margin above and below the panels, to the edges of the
+// screen.
+const verticalMargin = 50;
+
+// We need room below the panels content for the children passed in.  This area
+// can contain things like a Continue button.
+const childrenAreaHeight = 70;
+
+interface PanelsProps {
+  panels: Panel[];
+  onContinue: (nextUrl?: string) => void;
+  targetWidth: number;
+  targetHeight: number;
+  resetOnChange?: boolean;
 }
 
-const PanelsView: React.FunctionComponent = () => {
-  const dispatch = useAppDispatch();
-
-  const appName = 'panels';
-
-  const levelData = useSelector(
-    ({lab}: {lab: LabState}) => lab.levelProperties?.levelData
-  );
-  const currentAppName = useSelector(
-    ({lab}: {lab: LabState}) => lab.levelProperties?.appName
-  );
-  const levelIndex = useSelector(currentLevelIndex);
-
-  const [levelPanels, setLevelPanels] = useState<PanelsLevelData | null>(null);
+/**
+ * View that renders a set of panels with an image and text. Used in the Lab2 panels level type.
+ */
+const PanelsView: React.FunctionComponent<PanelsProps> = ({
+  panels,
+  onContinue,
+  targetWidth,
+  targetHeight,
+  resetOnChange = true,
+}) => {
   const [currentPanel, setCurrentPanel] = useState(0);
 
-  // Go back to the first panel whenever a level switch occurs.
-  useEffect(() => {
-    setCurrentPanel(0);
-  }, [levelIndex]);
-
-  useEffect(() => {
-    if (currentAppName === appName && levelData) {
-      setLevelPanels(levelData as PanelsLevelData);
-    }
-  }, [currentAppName, levelData]);
-
-  const handleButtonClick = useCallback(() => {
-    if (levelPanels?.panels) {
-      const nextUrl = levelPanels.panels[currentPanel].nextUrl;
-
-      if (currentPanel < levelPanels.panels.length - 1) {
-        setCurrentPanel(currentPanel + 1);
-      } else if (nextUrl) {
-        // This is a short-term solution for the Music Lab progression in incubation.  We will not attempt
-        // to send a success report for a level that uses this feature.
-        window.location.href = nextUrl;
-      } else {
-        dispatch(sendSuccessReport(appName));
-        dispatch(navigateToNextLevel());
-      }
-    }
-  }, [levelPanels, currentPanel, dispatch]);
-
-  const handleBubbleClick = (index: number) => {
-    setCurrentPanel(index);
-  };
-
-  // Leave a margin to the left and the right of the panels, to the edges
-  // of the screen.
-  const horizontalMargin = 40;
-
-  // Leave a vertical margin above and below the panels, to the edges of the
-  // screen.
-  const verticalMargin = 50;
-
-  // We need room below the panels content for the children passed in.  This area
-  // can contain things like a Continue button.
-  const childrenAreaHeight = 70;
-
-  let [targetWidth, targetHeight] = useWindowSize();
   targetWidth -= horizontalMargin * 2;
   targetHeight -= verticalMargin * 2 + childrenAreaHeight;
 
@@ -123,13 +57,37 @@ const PanelsView: React.FunctionComponent = () => {
     return [width, height];
   }, [targetWidth, targetHeight]);
 
-  if (!levelPanels?.panels) {
-    return <div />;
+  const handleButtonClick = useCallback(() => {
+    if (currentPanel < panels.length - 1) {
+      setCurrentPanel(currentPanel + 1);
+    } else {
+      onContinue(panels[currentPanel].nextUrl);
+    }
+  }, [panels, currentPanel, onContinue]);
+
+  const handleBubbleClick = (index: number) => {
+    setCurrentPanel(index);
+  };
+
+  // Reset to first panel whenever panels content changes if specified.
+  useEffect(() => {
+    if (resetOnChange) {
+      setCurrentPanel(0);
+    }
+    // Reset to last panel if number of panels has reduced
+    if (currentPanel >= panels.length) {
+      setCurrentPanel(panels.length - 1);
+    }
+  }, [panels, resetOnChange, currentPanel]);
+
+  const panel = panels[currentPanel];
+  if (!panel) {
+    return null;
   }
 
   const showSmallText = height < 300;
   const textLayoutClass =
-    levelPanels.panels[currentPanel].layout === 'text-bottom-left'
+    panel.layout === 'text-bottom-left'
       ? styles.markdownTextBottomLeft
       : styles.markdownTextTopRight;
 
@@ -143,11 +101,11 @@ const PanelsView: React.FunctionComponent = () => {
         <div
           className={styles.image}
           style={{
-            backgroundImage: `url("${levelPanels.panels[currentPanel].imageUrl}")`,
+            backgroundImage: `url("${panel.imageUrl}")`,
           }}
         />
         <EnhancedSafeMarkdown
-          markdown={levelPanels.panels[currentPanel]?.text}
+          markdown={panel.text}
           className={classNames(
             styles.markdownText,
             showSmallText && styles.markdownTextSmall,
@@ -165,13 +123,13 @@ const PanelsView: React.FunctionComponent = () => {
           onClick={handleButtonClick}
           className={styles.button}
         >
-          {currentPanel < levelPanels.panels.length - 1
+          {currentPanel < panels.length - 1
             ? commonI18n.next()
             : commonI18n.continue()}
         </button>
-        {levelPanels.panels.length > 1 && (
+        {panels.length > 1 && (
           <div id="panels-bubbles">
-            {Array.from(Array(levelPanels.panels.length).keys()).map(index => {
+            {Array.from(Array(panels.length).keys()).map(index => {
               return (
                 <FontAwesome
                   key={index}

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -74,11 +74,14 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
     if (resetOnChange) {
       setCurrentPanel(0);
     }
-    // Reset to last panel if number of panels has reduced
+  }, [panels, resetOnChange]);
+
+  // Reset to last panel if number of panels has reduced
+  useEffect(() => {
     if (currentPanel >= panels.length) {
       setCurrentPanel(panels.length - 1);
     }
-  }, [panels, resetOnChange, currentPanel]);
+  }, [currentPanel, panels]);
 
   const panel = panels[currentPanel];
   if (!panel) {

--- a/apps/src/panels/types.ts
+++ b/apps/src/panels/types.ts
@@ -1,12 +1,13 @@
 // The level data for a panels level that doesn't require
 // reloads between levels.
 export interface PanelsLevelData {
-  panels: [
-    {
-      imageUrl: string;
-      text: string;
-      nextUrl?: string;
-      layout?: string;
-    }
-  ];
+  panels: Panel[];
+}
+
+export interface Panel {
+  imageUrl: string;
+  text: string;
+  nextUrl?: string;
+  layout?: string;
+  key: string;
 }

--- a/apps/src/panels/types.ts
+++ b/apps/src/panels/types.ts
@@ -8,6 +8,8 @@ export interface Panel {
   imageUrl: string;
   text: string;
   nextUrl?: string;
-  layout?: string;
+  layout?: PanelLayout;
   key: string;
 }
+
+export type PanelLayout = 'text-bottom-left' | 'text-top-right';

--- a/apps/src/panels/types.ts
+++ b/apps/src/panels/types.ts
@@ -4,6 +4,8 @@ export interface PanelsLevelData {
   panels: Panel[];
 }
 
+export type PanelLayout = 'text-bottom-left' | 'text-top-right';
+
 export interface Panel {
   imageUrl: string;
   text: string;
@@ -11,5 +13,3 @@ export interface Panel {
   layout?: PanelLayout;
   key: string;
 }
-
-export type PanelLayout = 'text-bottom-left' | 'text-top-right';

--- a/apps/src/util/hooks/useWindowSize.ts
+++ b/apps/src/util/hooks/useWindowSize.ts
@@ -1,0 +1,22 @@
+import {useLayoutEffect, useState} from 'react';
+
+/**
+ * Hook for getting the window size.
+ */
+export default function useWindowSize() {
+  const [size, setSize] = useState([
+    document.documentElement.clientWidth,
+    document.documentElement.clientHeight,
+  ]);
+  useLayoutEffect(() => {
+    function updateSize() {
+      const width = document.documentElement.clientWidth;
+      const height = document.documentElement.clientHeight;
+      setSize([width, height]);
+    }
+    window.addEventListener('resize', updateSize);
+    updateSize();
+    return () => window.removeEventListener('resize', updateSize);
+  }, []);
+  return size;
+}


### PR DESCRIPTION
Splits up the existing `PanelsView` into a `PanelsView` component that is Lab2-agnostic and just renders a set panels, and a `PanelsLabView` container that pulls the data from Lab2 and renders the view. This is a prefactor for reusing this view on the levelbuilder edit page for live previewing panels content.

## Testing story

Tested locally. No change to existing panels levels.