### PR TITLE
OneTrust libraries should use the same domain

### DIFF
--- a/shared/haml/onetrust_cookie_scripts.haml
+++ b/shared/haml/onetrust_cookie_scripts.haml
@@ -5,20 +5,22 @@
 -# The OneTrust config to load should be passed in.
 - domain ||= nil
 :ruby
-  auto_block_src = {
+  one_trust_domains = {
     'code.org' => {
-      'test' => 'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d-test/OtAutoBlock.js',
-      'prod' => 'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d/OtAutoBlock.js',
+      'test' => '27cca70a-7db3-4852-9ef0-a6660fd0977d-test',
+      'prod' => '27cca70a-7db3-4852-9ef0-a6660fd0977d',
     },
     'hourofcode.com' => {
-      'test' => 'https://cdn.cookielaw.org/consent/7c79c547-a2fc-4998-9b21-0c7a5e67e345-test/OtAutoBlock.js',
-      'prod' => 'https://cdn.cookielaw.org/consent/7c79c547-a2fc-4998-9b21-0c7a5e67e345/OtAutoBlock.js',
+      'test' => '7c79c547-a2fc-4998-9b21-0c7a5e67e345-test',
+      'prod' => '7c79c547-a2fc-4998-9b21-0c7a5e67e345',
     }
   }
 -# Don't add the libraries if the feature is 'off' or an unknown
 -# domain was given.
-- if cookie_script_env != 'off' &&  auto_block_src[domain].present?
-  %script{src: auto_block_src[domain][cookie_script_env], type: 'text/javascript'}
-  %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '27cca70a-7db3-4852-9ef0-a6660fd0977d'}
+- one_trust_domain = one_trust_domains.dig(domain, cookie_script_env)
+- if cookie_script_env != 'off' && one_trust_domain.present?
+  - auto_block_src = "https://cdn.cookielaw.org/consent/#{one_trust_domain}/OtAutoBlock.js"
+  %script{src: auto_block_src, type: 'text/javascript'}
+  %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => one_trust_domain}
   :javascript
     function OptanonWrapper() { }


### PR DESCRIPTION
Users visting https://hourofcode.com/uk in the UK were reporting that the OneTrust banner was making the screen go grey and making the UI un-clickable. When reproducing the issue locally, I noticed that hourofcode.com was trying to run the banner code intended for the code.org domain. This PR makes sure that `otSDKStub.js` and `OtAutoBlock.js` are using the same, correct domain.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/P20-794)
* [PR which introduced this bug](https://github.com/code-dot-org/code-dot-org/pull/57101/files)

## Testing story
Opened the following URLs, verified the correct domains were used, and the website still work properly:
* http://localhost.hourofcode.com:3000/uk?otreset=true&otgeo=gb&onetrust_cookie_scripts=prod
* http://localhost.hourofcode.com:3000/uk?otreset=true&otgeo=gb&onetrust_cookie_scripts=test
* http://localhost.hourofcode.com:3000/uk?otreset=true&otgeo=gb&onetrust_cookie_scripts=off
---
* http://localhost-studio.code.org:3000/s/dance-2019/lessons/1/levels/2?otreset=true&otgeo=gb&onetrust_cookie_scripts=prod
* http://localhost-studio.code.org:3000/s/dance-2019/lessons/1/levels/2?otreset=true&otgeo=gb&onetrust_cookie_scripts=test
* http://localhost-studio.code.org:3000/s/dance-2019/lessons/1/levels/2?otreset=true&otgeo=gb&onetrust_cookie_scripts=off
---
* http://localhost.code.org:3000/index?otreset=true&otgeo=gb&onetrust_cookie_scripts=prod
* http://localhost.code.org:3000/index?otreset=true&otgeo=gb&onetrust_cookie_scripts=test
* http://localhost.code.org:3000/index?otreset=true&otgeo=gb&onetrust_cookie_scripts=off


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
