### PR TITLE
Make updated pages work with RTL languages

### DIFF
--- a/pegasus/sites.v3/code.org/public/about/index.haml
+++ b/pegasus/sites.v3/code.org/public/about/index.haml
@@ -4,6 +4,7 @@ nav: about_nav
 video_player: true
 theme: responsive
 style_min: true
+set_dir: true
 ---
 
 - facebook = {:u=>'https://youtu.be/mTGSiB4kB18'}

--- a/pegasus/sites.v3/code.org/public/professional-learning/international-partners.haml
+++ b/pegasus/sites.v3/code.org/public/professional-learning/international-partners.haml
@@ -1,6 +1,5 @@
 ---
 theme: responsive_full_width
-set_dir: true
 ---
 
 :ruby

--- a/pegasus/sites.v3/code.org/public/professional-learning/international.haml
+++ b/pegasus/sites.v3/code.org/public/professional-learning/international.haml
@@ -1,6 +1,5 @@
 ---
 theme: responsive_full_width
-set_dir: true
 ---
 
 :ruby

--- a/pegasus/sites.v3/code.org/themes/responsive_full_width.haml
+++ b/pegasus/sites.v3/code.org/themes/responsive_full_width.haml
@@ -1,6 +1,6 @@
 !!! 5
 
-- if @header['set_dir']
+- if ! @header['set_dir']
   - dir = language_dir_class
 
 %html{dir: dir}


### PR DESCRIPTION
Adds logic to set a `dir` attribute on the html tag of updated pages that use the `responsive_full_width` theme (this is all of the pages that have been redesigned/refactored). This adds Right To Left language support on these pages automatically so the layout is mirrored correctly for RTL languages.

Eventually we'll want to add this site-wide, but for now this a good compromise since it may break the RTL layout on some legacy pages.

**Note:** some elements may break for RTL, like the old video carousels, but the majority of things should be ok. Jorge said it's ok for the video carousels to break for now. 

**Jira ticket:** [ACQ-1651](https://codedotorg.atlassian.net/browse/ACQ-1651)

----

## Example on https://code.org/csd
| LTR | RTL |
| ----- | ----- |
| <img width="1546" alt="LTR" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/eccaddbc-d594-4450-a42d-77222becd832"> | <img width="1546" alt="RTL" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/95d11e64-ffdb-40ce-b454-7f7cea78140f"> |

