### PR TITLE
Fix to load behavior picker blocks from xml correctly

### DIFF
--- a/apps/src/blockly/addons/cdoFieldBehaviorPicker.ts
+++ b/apps/src/blockly/addons/cdoFieldBehaviorPicker.ts
@@ -75,7 +75,7 @@ export default class CdoFieldBehaviorPicker extends CdoFieldDropdown {
       // Check whether the initial newValue option already exists
       const optionExists = options.some(option => option[0] === newValue);
       // The hidden workspace is created after the main workspace flyout is populated.
-      const loadingFinished = Blockly.getHiddenDefinitionWorkspace();
+      const loadingFinished = Blockly.hasLoadedBlocks;
       if (!optionExists && !loadingFinished) {
         // Assume initial value is valid and add it to the menu if not yet present.
         options.push([newValue, newValue]);

--- a/apps/src/blockly/addons/cdoFieldBehaviorPicker.ts
+++ b/apps/src/blockly/addons/cdoFieldBehaviorPicker.ts
@@ -70,11 +70,11 @@ export default class CdoFieldBehaviorPicker extends CdoFieldDropdown {
   getOptions(useCache?: boolean, newValue?: string) {
     const options = super.getOptions(useCache);
 
-    // Behavior pickers do not populate correctly until the workspace has been loaded.
+    // Behavior pickers do not populate correctly until the hidden workspace has been loaded
+    // with blocks.
     if (newValue) {
       // Check whether the initial newValue option already exists
       const optionExists = options.some(option => option[0] === newValue);
-      // The hidden workspace is created after the main workspace flyout is populated.
       const loadingFinished = Blockly.hasLoadedBlocks;
       if (!optionExists && !loadingFinished) {
         // Assume initial value is valid and add it to the menu if not yet present.

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -43,6 +43,8 @@ export function loadBlocksToWorkspace(
   source: string,
   includeHiddenDefinitions = true
 ) {
+  // Reset hasLoadedBlocks to false so we can accurately track if blocks have been loaded.
+  // This function may be called multiple times to reload blocks (ex. when starting over).
   Blockly.hasLoadedBlocks = false;
   const embedded = Blockly.isEmbeddedWorkspace(workspace);
   const {mainSource, hiddenDefinitionSource} = prepareSourcesForWorkspaces(

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -43,6 +43,7 @@ export function loadBlocksToWorkspace(
   source: string,
   includeHiddenDefinitions = true
 ) {
+  Blockly.hasLoadedBlocks = false;
   const embedded = Blockly.isEmbeddedWorkspace(workspace);
   const {mainSource, hiddenDefinitionSource} = prepareSourcesForWorkspaces(
     source,

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -54,6 +54,7 @@ export function loadBlocksToWorkspace(
   }
   Blockly.serialization.workspaces.load(mainSource, workspace);
   positionBlocksOnWorkspace(workspace);
+  Blockly.hasLoadedBlocks = true;
 }
 
 /**

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -669,6 +669,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   };
 
   blocklyWrapper.inject = function (container, opt_options) {
+    blocklyWrapper.hasLoadedBlocks = false;
     if (!opt_options) {
       opt_options = {};
     }

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -669,6 +669,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   };
 
   blocklyWrapper.inject = function (container, opt_options) {
+    // Set the default value for hasLoadedBlocks to false.
     blocklyWrapper.hasLoadedBlocks = false;
     if (!opt_options) {
       opt_options = {};

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -114,6 +114,7 @@ export interface BlocklyWrapperType extends GoogleBlocklyType {
   BlockValueType: {[key: string]: string};
   SNAP_RADIUS: number;
   Variables: ExtendedVariables;
+  hasLoadedBlocks: boolean;
 
   wrapReadOnlyProperty: (propertyName: string) => void;
   wrapSettableProperty: (propertyName: string) => void;


### PR DESCRIPTION
@onlinecsteacher found an [issue](https://codedotorg.slack.com/archives/C05DMS18MEX/p1710952615656619) where behavior picker blocks would not persist their choice in start blocks, ex if you select `wandering` it will reload as `driving with arrow keys` (this first choice in the list). This is because of some intricacies of how the behavior picker works. The behavior picker needs all the behaviors to be loaded into the hidden workspace to get the appropriate list of options. If it sees an option it doesn't know about, we usually will reject it and end up with the first option in the list. We did have an exception to this to allow for any option while loading, to enable behavior picker blocks in an uncategorized toolbox. However, that check was only that the hidden workspace exists, not that blocks have been loaded to it. What is happening in this situation is the hidden definition workspace exists, and we've started loading blocks. Since we have xml blocks (all start blocks are xml), we convert all the blocks to json first via an unheaded workspace. When we try to assign the behavior picker value, we think that we should be loaded and therefore do not allow an unknown option.

The fix for this was to add a `hasLoadedBlocks` flag to the google blockly wrapper and use that to decide if we should allow unknown behavior options in the behavior picker.

Most of the time behavior pickers seem to be set to `driving with arrow keys` in the start blocks, which is why we are only just discovering this issue. This block also isn't widely used.

## Links
- [slack thread](https://codedotorg.slack.com/archives/C05DMS18MEX/p1710952615656619)

## Testing story
Tested locally. I tested that behavior pickers set via start blocks now load correctly both in start mode and for users in normal mode.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
