### PR TITLE
fix(eyes): wait for fade animation to complete before snapshotting

### DIFF
--- a/dashboard/test/ui/features/eyes.feature
+++ b/dashboard/test/ui/features/eyes.feature
@@ -7,6 +7,7 @@ Background:
 Scenario:
   When I open my eyes to test "multi"
   Given I am on "http://studio.code.org/s/course1/lessons/2/levels/2?noautoplay=true"
+  And The header is finished animating
   Then element ".submitButton" is visible
   And I see no difference for "level load"
   And I close my eyes
@@ -14,6 +15,7 @@ Scenario:
 Scenario:
   When I open my eyes to test "match"
   Given I am on "http://studio.code.org/s/course1/lessons/14/levels/13?noautoplay=true"
+  And The header is finished animating
   Then element ".submitButton" is visible
   And I see no difference for "level load"
   And I close my eyes
@@ -21,6 +23,7 @@ Scenario:
 Scenario:
   When I open my eyes to test "text-only match"
   Given I am on "http://studio.code.org/s/course3/lessons/10/levels/2?noautoplay=true"
+  And The header is finished animating
   Then element ".submitButton" is visible
   And I see no difference for "level load"
   And I close my eyes
@@ -28,6 +31,7 @@ Scenario:
 Scenario:
   When I open my eyes to test "text compression"
   Given I am on "http://studio.code.org/s/allthethings/lessons/16/levels/1?noautoplay=true"
+  And The header is finished animating
   And I see no difference for "level load"
   And I set text compression dictionary to "pitter\npatter\n"
   And I see no difference for "simple substitution"
@@ -36,6 +40,7 @@ Scenario:
 Scenario:
   When I open my eyes to test "pixelation with range"
   Given I am on "http://studio.code.org/s/allthethings/lessons/17/levels/2?noautoplay=true"
+  And The header is finished animating
   And I see no difference for "level load"
   And I close my eyes
 
@@ -50,6 +55,7 @@ Scenario:
 
   Then I am on "http://studio.code.org/s/allthethings/lessons/2/levels/1/lang/ar-sa"
   And I wait for the page to fully load
+  And The header is finished animating
   And I see no difference for "maze RTL"
   Given I am on "http://studio.code.org/reset_session/lang/en"
   And I wait for 2 seconds
@@ -58,6 +64,7 @@ Scenario:
 Scenario:
   When I open my eyes to test "star wars RTL"
   Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/15/lang/ar-sa?noautoplay=true"
+  And The header is finished animating
   And I wait to see ".header_user"
   And I wait to see "#runButton"
   # close the video dialog, because the noautoplay param may be lost in the

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -67,6 +67,14 @@ And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?$/) do |
   @eyes.stitch_mode = Applitools::STITCH_MODE[:css]
 end
 
+And(/^The header is finished animating$/) do
+  wait_for_jquery
+
+  wait_until do
+    @browser.execute_script('return $("#header_middle_content").css("opacity") === \'1\'') == true
+  end
+end
+
 def ensure_eyes_available
   return if @eyes
   @eyes = Applitools::Selenium::Eyes.new


### PR DESCRIPTION
Currently, the eyes tests performs a visual comparison against a baseline stored on Applitool. For the pages that are currently being tested, the header has a CSS opacity fade in that transitions from 0% to 100% in 400ms. If eyes snapshots anytime during the animation, the test will fail. 

Typically, the normal operation of the setup steps will have resulted in the fade animation to have already completed. However, if eyes runs faster than normal, it is possible for eyes to snapshot during the animation. To resolve this, wait for the animation to have completed before snapshotting.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Passing eyes run against the `test` baseline: https://eyes.applitools.com/app/test-results/00000251690201644466/?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110

I executed the tests via Selenium and Eyes using:

```
./runner.rb --eyes --feature features/eyes.feature
```

Result:

```
[eyes] Starting UI tests for Firefox_eyes_eyes
[eyes] cucumber features/eyes.feature  -S -t 'not @skip' -t @eyes -t 'not @only_mobile' -t 'not @only_phone' -t 'not @only_one_browser' -t 'not @chrome' -t 'not @no_firefox' -t 'not @webpurify' -t 'not @pegasus_db_access' -t 'not @dashboard_db_access'
[eyes] UI tests for Firefox_eyes_eyes succeeded (6:51 minutes, 7 passed)
[eyes] Starting UI tests for Safari_eyes_eyes
[eyes] cucumber features/eyes.feature  -S -t 'not @skip' -t @eyes -t 'not @only_mobile' -t 'not @only_phone' -t 'not @only_one_browser' -t 'not @chrome' -t 'not @no_safari' -t 'not @webpurify' -t 'not @pegasus_db_access' -t 'not @dashboard_db_access'
[eyes] UI tests for Safari_eyes_eyes succeeded (7:05 minutes, 7 passed)
[eyes] Starting UI tests for Chrome_eyes_eyes
[eyes] cucumber features/eyes.feature  -S -t 'not @skip' -t @eyes -t 'not @only_mobile' -t 'not @only_phone' -t 'not @only_one_browser' -t 'not @no_chrome' -t 'not @webpurify' -t 'not @pegasus_db_access' -t 'not @dashboard_db_access'
[eyes] UI tests for Chrome_eyes_eyes succeeded (7:36 minutes, 7 passed)
```

### Evidence of opacity changing

The script execution returned false indicating an opacity value of less than 100%. This can result in a visual difference if the opacity value doesn't become 100% by the time the snapshot.

![Screenshot from 2024-03-20 14-28-10](https://github.com/code-dot-org/code-dot-org/assets/538214/41b83443-199c-4b37-838a-f4c4c628275c)


### Local tests against Selenium & Eyes

![Screenshot from 2024-03-20 14-24-53](https://github.com/code-dot-org/code-dot-org/assets/538214/182595f7-e91d-417f-a91e-40e8d12570f5)


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy


## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
