### PR TITLE
Remove null ID elements from Applab design html

### DIFF
--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -1227,6 +1227,7 @@ function sanitizeLevelDom(levelDom) {
     '#codeApp',
     '#visualizationColumn',
     '#visualizationResizeBar',
+    '#null',
     '.editor-column',
   ];
 


### PR DESCRIPTION
We received a few tickets ([1](https://codeorg.zendesk.com/agent/tickets/491450), [2](https://codeorg.zendesk.com/agent/tickets/491363)) where students were seeing extraneous elements in their design mode HTML, all with an ID of "null". In one of these cases there were thousands of these extra elements, causing the page to run out of memory and crash. It's still unclear why/how these elements are getting added, but this should at least filter them out and log if we see this again.

Before:
<img width="1509" alt="Screenshot 2024-03-20 at 3 04 06 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/f3642b6b-794b-4af3-ad35-90ea1a10458e">

After:
<img width="757" alt="Screenshot 2024-03-20 at 3 23 38 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/80d08b2e-cf08-4c88-b40d-37f22c788513">

## Testing story

Tested with affected student projects code (copied to S3 bucket of a local test project).