### PR TITLE
changed string for V1 and V2 progress view toggle

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2572,7 +2572,7 @@
   "summaryView": "Summary View",
   "support": "Support",
   "switchSection": "Switch section:",
-  "switchToNewProgressView": "Switch to new progress view",
+  "switchToNewProgressView": "Try out new progress view (beta)",
   "switchToOldProgressView": "Switch to old progress view",
   "syncClever": "Sync students from Clever",
   "syncGoogleClassroom": "Sync students from Google Classroom",

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
@@ -22,7 +22,7 @@ import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSection
 
 import {expect} from '../../../util/reconfiguredChai';
 
-const V1_PAGE_LINK_TEXT = 'Switch to new progress view';
+const V1_PAGE_LINK_TEXT = 'Try out new progress view (beta)';
 const V2_PAGE_LINK_TEXT = 'Switch to old progress view';
 const V1_TEST_ID = 'section-progress-v1';
 const V2_TEST_ID = 'section-progress-v2';


### PR DESCRIPTION
Changed string for link to new progress view:

<img width="1214" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/210db15d-939f-436e-8413-7a2e3eea44fa">

Previously this is what it looked like:
<img width="1212" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/ae3c0e6f-9a77-47d7-bdc3-4ccedfd150a6">



## Links

[Ticket](https://codedotorg.atlassian.net/browse/TEACH-958)

## Testing story

- Modified existing test
