### PR TITLE
Webpack HMR follow-up: allow localhost.code.org, remove one error overlay layer

### DIFF
--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -693,7 +693,8 @@ function createWebpackConfig({
     ],
     devServer: envConstants.HOT
       ? {
-          allowedHosts: ['localhost-studio.code.org'],
+          allowedHosts: ['localhost-studio.code.org', 'localhost.code.org'],
+          client: {overlay: false},
           port: WEBPACK_DEV_SERVER_PORT,
           proxy: [
             {


### PR DESCRIPTION
A couple of follow-ups to https://github.com/code-dot-org/code-dot-org/pull/56882:
- silences errors observed when accessing pegasus (ie, localhost.code.org) pages on port 3000
- removes one of two error overlays, which were introduced by this PR

I'm not (at a glance) sure where the other error overlay comes from, but we could dig into it further.

I'm also admittedly getting a little bit turned around about why we need to add localhost.code.org as an allowedHost though -- if you're using port 3000, why is pegasus hitting port 9000/webpack dev server at all?

![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/9fc357cb-2cb4-4f11-a508-fa3aeddbdec5)

## Links

- Slack thread: https://codedotorg.slack.com/archives/C046G4TRLEN/p1710959415427739

## Testing story

Tested manually that I only saw 1 error overlay instead of 2 after throwing an error in some pegasus JS code. Also saw the error that Kelby described no longer appear.