### PR TITLE
Revert change in get_user LTI query back to use authentication options

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -135,7 +135,7 @@ class LtiV1Controller < ApplicationController
       message_type = decoded_jwt[:'https://purl.imsglobal.org/spec/lti/claim/message_type']
       return wrong_resource_type unless message_type == 'LtiResourceLinkRequest'
 
-      user = Queries::Lti.get_user(decoded_jwt[:sub])
+      user = Queries::Lti.get_user(decoded_jwt)
       target_link_uri = decoded_jwt[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri']
 
       launch_context = decoded_jwt[Policies::Lti::LTI_CONTEXT_CLAIM]

--- a/dashboard/lib/queries/lti.rb
+++ b/dashboard/lib/queries/lti.rb
@@ -2,8 +2,9 @@ require 'policies/lti'
 require 'authentication_option'
 
 class Queries::Lti
-  def self.get_user(user_id)
-    LtiUserIdentity.find_by(subject: user_id)&.user
+  def self.get_user(id_token)
+    auth_id = Services::Lti::AuthIdGenerator.new(id_token).call
+    User.find_by_credential(type: AuthenticationOption::LTI_V1, id: auth_id)
   end
 
   # Returns the LTI user id for a particular code.org user and LTI integration
@@ -21,7 +22,7 @@ class Queries::Lti
       aud: client_id,
       iss: issuer,
     }
-    get_user(id_token[:sub])
+    get_user(id_token)
   end
 
   def self.get_deployment(lti_integration_id, deployment_id)

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -33,8 +33,7 @@ module Services
       auth_option = user.authentication_options.find(&:lti?)
       issuer, client_id, subject = auth_option.authentication_id.split('|')
       lti_integration = Queries::Lti.get_lti_integration(issuer, client_id)
-      identity = LtiUserIdentity.new(user: user, subject: subject, lti_integration: lti_integration)
-      identity.save!
+      LtiUserIdentity.create(user: user, subject: subject, lti_integration: lti_integration)
     end
 
     def self.create_lti_integration(

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -487,7 +487,6 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     ao.save!
 
     deployment = LtiDeployment.create(deployment_id: @deployment_id, lti_integration_id: @integration.id)
-    create :lti_user_identity, user: user, subject: payload[:sub]
     assert deployment
     post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
 

--- a/dashboard/test/lib/queries/lti_test.rb
+++ b/dashboard/test/lib/queries/lti_test.rb
@@ -15,9 +15,8 @@ class Services::LtiTest < ActiveSupport::TestCase
       authentication_id: Services::Lti::AuthIdGenerator.new(id_token).call,
       credential_type: AuthenticationOption::LTI_V1,
     )
-    create :lti_user_identity, user: user, subject: id_token[:sub]
 
-    assert_equal user, Queries::Lti.get_user(id_token[:sub])
+    assert_equal user, Queries::Lti.get_user(id_token)
   end
 
   test 'finds a code.org user given LTI integration creds and an NRPS member response' do
@@ -34,7 +33,6 @@ class Services::LtiTest < ActiveSupport::TestCase
       authentication_id: Services::Lti::AuthIdGenerator.new(id_token).call,
       credential_type: AuthenticationOption::LTI_V1,
     )
-    create :lti_user_identity, user: user, subject: lms_user_id
     mock_nrps_member = {
       user_id: lms_user_id,
     }

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -351,7 +351,6 @@ class Services::LtiTest < ActiveSupport::TestCase
     auth_id = "#{@lti_integration[:issuer]}|#{@lti_integration[:client_id]}|user-id-1"
     user = create :teacher
     create :lti_authentication_option, user: user, authentication_id: auth_id
-    create :lti_user_identity, lti_integration: @lti_integration, user: user, subject: 'user-id-1'
 
     section = create :section, user: user
 


### PR DESCRIPTION
In PR #57190 we switch the `get_user` LTI query from using User's Authentication Options to using the `lti_user_identities` table.

After a second thought, we realized we would have to add the `issuer` to the `lti_user_identities` table duplicating data stored in other tables, making the introduced changes less advantageous than we first thought.

In addition, the previous implementation follows our Authentication Options pattern for other methods such as Google, Clever, etc. where given an authentication credential we always try to find the Authentication Options that match the credentials.

This PR rolls back to the previous implementation and reverts the changes to the unit tests that used the `get_user` LTI query.

## Links

## Testing story

## Deployment strategy

## Follow-up work


## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
