### PR TITLE
Music: update libraries

### DIFF
--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -48,7 +48,7 @@ export const BlockMode = {
 // For reference, events look like this:
 // events: [{src: 'sound_1', tick: 3}]
 export const DEFAULT_PATTERN = {
-  kit: 'glitch',
+  kit: 'drums',
   events: [],
 };
 

--- a/apps/static/music/music-library-intro2024.json
+++ b/apps/static/music/music-library-intro2024.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:164afe096a11f1e21855cf0d4f564ad8b9f00d3e606f5f6d65bb65fd6836a700
-size 19651
+oid sha256:4c8fd76ef91111c47ccbb93f7eeb5c70a038619490d9062102827013f782d2fc
+size 19763

--- a/apps/static/music/music-library-launch2024.json
+++ b/apps/static/music/music-library-launch2024.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4a8aed762b1358eb9b5cb907dbe90a597e10d314a560b7c5862d987faa6833a
-size 31832
+oid sha256:6d8786733e3bebbeef33f25e4e11c3656f8c480d0644db3f4bd033bfdadc9cc7
+size 31831

--- a/apps/static/music/music-library-launch2024.json
+++ b/apps/static/music/music-library-launch2024.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f62f9ecadced2ac418bb5b1b886d8981858d1874368600ff20043c2fd6ed439
-size 27325
+oid sha256:b4a8aed762b1358eb9b5cb907dbe90a597e10d314a560b7c5862d987faa6833a
+size 31832


### PR DESCRIPTION
Some small updates to the music libraries:

- reorder drumkits
- alphabetize the sounds in packs again
- only one instance of `5nare` drum, in the Glitch kit

And a tiny code change to default to the regular drum kit.

The libraries have already been updated on S3.  The copies here serve as historic snapshots.