### PR TITLE
[Sprite Lab] wall sprites don't push each other

### DIFF
--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -420,6 +420,8 @@ export default class CoreLibrary {
       }
     }
     if (typeof spriteArg.group === 'string') {
+      // The group property is undefined for sprites unless explicitly set.
+      // We're using '' as a way to signal that we want to return the ones without a group.
       if (spriteArg.group === '') {
         return Object.values(this.nativeSpriteMap).filter(
           sprite => !sprite.group

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -419,7 +419,12 @@ export default class CoreLibrary {
         );
       }
     }
-    if (spriteArg.group) {
+    if (typeof spriteArg.group === 'string') {
+      if (spriteArg.group === '') {
+        return Object.values(this.nativeSpriteMap).filter(
+          sprite => !sprite.group
+        );
+      }
       return Object.values(this.nativeSpriteMap).filter(
         sprite => sprite.group === spriteArg.group
       );

--- a/apps/src/p5lab/spritelab/commands/spriteCommands.js
+++ b/apps/src/p5lab/spritelab/commands/spriteCommands.js
@@ -178,6 +178,7 @@ export const commands = {
         }
         default:
       }
+      spriteOptions.group = 'effects';
       const spriteId = this.addSprite(spriteOptions);
       const sprite = this.getSpriteArray({id: spriteId})[0];
       this.addBehavior(sprite, {

--- a/dashboard/config/libraries/zGameDev.interpreted.js
+++ b/dashboard/config/libraries/zGameDev.interpreted.js
@@ -1,32 +1,16 @@
 var GRID_SIZE = 8;
 var CELL_SIZE = 400 / GRID_SIZE;
-var GRAVITY = -0.5;
+var GRAVITY = -0.25;
 
 setDefaultSpriteSize(CELL_SIZE);
 
 // Handles sprite interactions every frame.
 function gameDevLoop() {
   collide('collide', {group: 'players'}, {group: 'walls'});
-  collide('collide', {group: 'objects'}, {group: 'walls'});
-  collide('collide', {group: 'enemies'}, {group: 'walls'});
-  collide("collide", ({costume: "all"}), ({group: "walls"}));
- 
-  edgesCollide({group: 'players'});
-  edgesCollide({group: 'enemies'});
-  edgesCollide({group: 'objects'});
-  gravity({group: 'players'}, GRAVITY);
-  gravity({group: 'enemies'}, GRAVITY);
-//  addBehaviorSimple({group: 'players'}, new Behavior(movingLeftAndRight, []));
-}
+  collide('collide', {group: ''}, {group: 'walls'});
 
-// A behavior to make a sprite move left and right with arrow keys.
-// function movingLeftAndRight(this_sprite) {
-//  if (isKeyPressed('left') || isKeyPressed('a')) {
-//    moveInDirection(this_sprite, getProp(this_sprite, 'speed'), 'West');
-//  }
-//  if (isKeyPressed('right') || isKeyPressed('d')) {
-//    moveInDirection(this_sprite, getProp(this_sprite, 'speed'), 'East');
-//  }
-//}
+  edgesCollide({group: 'players'});
+  gravity({group: 'players'}, GRAVITY);
+}
 
 other.push(gameDevLoop);


### PR DESCRIPTION
Sprites in the new Game Design lessons have a explicitly set `group` property in order simplify handling of sprite collisions, gravity, and jumping. It is desired that sprites in the `walls` group block all other sprites from moving and prevent them from overlapping. It's important that wall sprites not block other wall sprites or they will be pushed away. This adds the ability to get the list of sprites with no group so that the helper library can automatically have wall sprites block them. 

Before: 
![2024-03-21 11-57-21 2024-03-21 11_58_11](https://github.com/code-dot-org/code-dot-org/assets/43474485/2cbb12bb-54c2-41f9-b9da-3be54c677048)

After:

![2024-03-21 12-00-49 2024-03-21 12_01_20](https://github.com/code-dot-org/code-dot-org/assets/43474485/f3ab7c6c-5a1c-42fe-99d8-85a356d5ee37)


As the levels have been iterated upon, a couple other groups ("enemies", "objects") have been removed so I've cleaned up references to them in the helper library.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
