### PR TITLE
Add strings for Coding with AI page

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10418,7 +10418,7 @@
         answer: "Due to the flexibility of these lessons, you could choose to teach these lessons in any order, in sequence, spread out over multiple weeks, or back-to-back within one week."
       answer_keys:
         question: "How can I access answer keys?"
-        answer: "With an approved teacher account, you can find answer keys in a blue "Teacher Only” panel that shows in the online lessons and activities. If you need an approved teacher account, you can apply for access to protected teacher-only materials (answer keys, etc) through [this form](%{form_url}). Please keep in mind that it may take 3-5 business days to verify your account."
+        answer: "With an approved teacher account, you can find answer keys in a blue \"Teacher Only\" panel that shows in the online lessons and activities. If you need an approved teacher account, you can apply for access to protected teacher-only materials (answer keys, etc) through [this form](%{form_url}). Please keep in mind that it may take 3-5 business days to verify your account."
       standards:
         question: "Is this module mapped to standards?"
         answer: "Yes, the Coding with AI curriculum is mapped to the [CSTA K-12 Standards](%{csta_url}) and the [AI for K-12 Guidelines](%{k12_url})."

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10349,7 +10349,7 @@
       languages: "English"
     support:
       heading: "Resources to support you every step of the way"
-      desc: "Get access to materials that will help you teach computer science with confidence—even without prior CS teaching experience—when you create a *free* Code.org account."
+      desc: "Get access to materials that will help you teach computer science with confidence—even without prior CS teaching experience—when you create a **free** Code.org account."
       button: "Create a free account"
     lessons:
       heading: "Lessons in this course"
@@ -10363,7 +10363,7 @@
       lesson_02:
         overline: "Lesson 2"
         title: "AI as Your Ideation Partner for Programming Prep"
-        desc: "How can AI assist in during the initial stages of the programming process, and what ethical considerations should be noted?"
+        desc: "How can AI assist during the initial stages of the programming process, and what ethical considerations should be noted?"
         aria_label: "View AI as Your Ideation Partner for Programming Prep lesson"
       lesson_03:
         overline: "Lesson 3"
@@ -10396,7 +10396,7 @@
         desc: "This series of short videos and accompanying lessons will introduce you and your students to how artificial intelligence works and why it matters."
         button: "View lessons"
         aria_label: "View How AI Works lessons"
-      dance_party:
+      ai_101:
         overline: "Professional Learning"
         title: "AI 101 for Teachers"
         desc: "Discover the groundbreaking world of AI and its transformative potential in education with our foundational online learning series for teachers."
@@ -10412,13 +10412,13 @@
         answer: "There are no required prerequisites, but you may choose to teach one or more of the [How AI Works lessons](%{ai_url}) before these to provide additional context about chatbots and large language models, algorithmic bias, and ethical considerations of AI."
       tools:
         question: "What tools and setup are required for teaching this module?"
-        answer: "Students need to have their own devices to type on. They also need access to Bing, Bard, ChatGPT, or some other general chatbot on their computers. Check with your principal or IT department to make sure students can access one of these LLMs."
+        answer: "Students need to have their own devices to type on. They also need access to Bing, Bard, ChatGPT, or some other general chatbot on their computers. Check with your principal or IT department to make sure students can access one of these LLMs (Large Language Models)."
       timing:
         question: "What is the recommended timing for teaching this module?"
         answer: "Due to the flexibility of these lessons, you could choose to teach these lessons in any order, in sequence, spread out over multiple weeks, or back-to-back within one week."
       answer_keys:
         question: "How can I access answer keys?"
-        answer: "With an approved teacher account, you can find answer keys in a blue "Teacher Only” panel that shows in the online lessons and activities.If you need an approved teacher account, you can apply for access to protected teacher-only materials (answer keys, etc) through [this form](%{form_url}). Please keep in mind that it may take 3-5 business days to verify your account."
+        answer: "With an approved teacher account, you can find answer keys in a blue "Teacher Only” panel that shows in the online lessons and activities. If you need an approved teacher account, you can apply for access to protected teacher-only materials (answer keys, etc) through [this form](%{form_url}). Please keep in mind that it may take 3-5 business days to verify your account."
       standards:
         question: "Is this module mapped to standards?"
         answer: "Yes, the Coding with AI curriculum is mapped to the [CSTA K-12 Standards](%{csta_url}) and the [AI for K-12 Guidelines](%{k12_url})."

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10321,6 +10321,123 @@
   csa_ai_page_faq_answer_11_list_03: "**Goal 3:** Deepen understanding of how AI models are trained and integrated into programs."
   csa_ai_page_faq_answer_11_02: "For more information about the values that guided our work, please see our [curriculum values](%{curriculum_values_url})."
 
+  coding_with_ai_page:
+    heading: "Coding with AI"
+    desc: "The Coding with AI unit teaches strategies for using AI to simplify complex concepts, guide problem-solving, and even generate code, empowering students to become informed and ethical future coders."
+    button: "Explore unit"
+    empower:
+      heading: "Empower students to become confident, ethical coders"
+      desc: "Teach students how AI can become an effective support tool with this versatile, language-neutral unit."
+      language:
+        title: "Language agnostic"
+        desc: "Tailored for universal relevance, this unit goes beyond specific programming languages, focusing on foundational AI and coding principles and challenges."
+      flexbile:
+        title: "Flexible course structure"
+        desc: "Beyond the introductory lesson, this unit is designed to be flexible. You can teach each lesson on it's own or in the order that suits your classroom learning goals."
+      support:
+        title: "AI as a support tool"
+        desc: "This unit is an ideal add-on to any language-specific instruction, helping you teach how AI can be used as a support tool and equip students with future-ready skills."
+    glance:
+      grades: "6-12"
+      level: "Beginner"
+      duration: "Five 45 minutes lessons"
+      devices: "Laptop, Chromebook"
+      topics: "Artificial Intelligence, Programming"
+      tools: "Any AI tool (ChatGPT, Bard, etc)"
+      professional_learning: "None"
+      accessibility_features: "Text-to-speech, Closed captioning, Immersive reader"
+      languages: "English"
+    support:
+      heading: "Resources to support you every step of the way"
+      desc: "Get access to materials that will help you teach computer science with confidence—even without prior CS teaching experience—when you create a *free* Code.org account."
+      button: "Create a free account"
+    lessons:
+      heading: "Lessons in this course"
+      desc: "With the exception of lesson 1, the lessons in this course are flexible and can be taught in any order!"
+      button: "View lesson plan"
+      lesson_01:
+        overline: "Lesson 1"
+        title: "Introduction to Coding with AI"
+        desc: "How can AI support code development and what ethical considerations should be addressed when using AI in coding?"
+        aria_label: "View Introduction to Coding with AI lesson"
+      lesson_02:
+        overline: "Lesson 2"
+        title: "AI as Your Ideation Partner for Programming Prep"
+        desc: "How can AI assist in during the initial stages of the programming process, and what ethical considerations should be noted?"
+        aria_label: "View AI as Your Ideation Partner for Programming Prep lesson"
+      lesson_03:
+        overline: "Lesson 3"
+        title: "Navigating Algorithms with the Help of AI"
+        desc: "How can AI enhance your ability to develop and understand algorithms, and what ethical considerations should be noted?"
+        aria_label: "View Navigating Algorithms with the Help of AI lesson"
+      lesson_04:
+        overline: "Lesson 4"
+        title: "AI as Your Debugging Partner"
+        desc: "How does integrating AI into the debugging process impact the balance between a programmer's creativity and problem-solving efficiency?"
+        aria_label: "View AI as Your Debugging Partner lesson"
+      lesson_05:
+        overline: "Lesson 5"
+        title: "Beyond the Finished Code"
+        desc: "How can AI tools ethically enhance the functionality of a finished program?"
+        aria_label: "View Beyond the Finished Code lesson"
+    learn_more:
+      heading: "Learn more about Artificial Intelligence"
+      subheading: "Discover our extensive AI resources"
+      desc: "We're rapidly expanding our AI offerings, including robust AI-focused curriculum, professional learning, educational videos, and more! Explore everything we have to offer and find what's right for you."
+      button: "Explore AI resources"
+      dance_party:
+        overline: "Grades 3-12"
+        title: "Dance Party: AI Edition"
+        desc: "Learn about artificial intelligence (AI) concepts to create your own virtual dance party showcasing today's top artists."
+        button: "Explore Dance Party AI"
+      how_ai_works:
+        overline: "Grades 6-12"
+        title: "How AI Works"
+        desc: "This series of short videos and accompanying lessons will introduce you and your students to how artificial intelligence works and why it matters."
+        button: "View lessons"
+        aria_label: "View How AI Works lessons"
+      dance_party:
+        overline: "Professional Learning"
+        title: "AI 101 for Teachers"
+        desc: "Discover the groundbreaking world of AI and its transformative potential in education with our foundational online learning series for teachers."
+        button: "Watch videos"
+        aria_label: "Watch AI 101 for Teachers videos"
+    faq:
+      heading: "Frequently asked questions"
+      programming_laguage:
+        question: "What programming language is the module for?"
+        answer: "None! This module is intentionally designed to be language-agnostic so you can incorporate these lessons into your existing curriculum."
+      prerequisites:
+        question: "What are the prerequisites for this module?"
+        answer: "There are no required prerequisites, but you may choose to teach one or more of the [How AI Works lessons](%{ai_url}) before these to provide additional context about chatbots and large language models, algorithmic bias, and ethical considerations of AI."
+      tools:
+        question: "What tools and setup are required for teaching this module?"
+        answer: "Students need to have their own devices to type on. They also need access to Bing, Bard, ChatGPT, or some other general chatbot on their computers. Check with your principal or IT department to make sure students can access one of these LLMs."
+      timing:
+        question: "What is the recommended timing for teaching this module?"
+        answer: "Due to the flexibility of these lessons, you could choose to teach these lessons in any order, in sequence, spread out over multiple weeks, or back-to-back within one week."
+      answer_keys:
+        question: "How can I access answer keys?"
+        answer: "With an approved teacher account, you can find answer keys in a blue "Teacher Only” panel that shows in the online lessons and activities.If you need an approved teacher account, you can apply for access to protected teacher-only materials (answer keys, etc) through [this form](%{form_url}). Please keep in mind that it may take 3-5 business days to verify your account."
+      standards:
+        question: "Is this module mapped to standards?"
+        answer: "Yes, the Coding with AI curriculum is mapped to the [CSTA K-12 Standards](%{csta_url}) and the [AI for K-12 Guidelines](%{k12_url})."
+    resources:
+      heading: "Additional resources"
+      desc: "From diverse curriculum offerings, to short educational videos, explore all the things Code.org has to offer."
+      catalog:
+        title: "Curriculum Catalog"
+        desc: "Comprehensive curriculum offerings for every grade and experience level featuring robust structured and self-paced learning options."
+        button: "Explore the catalog"
+      videos:
+        title: "Explore Videos"
+        desc: "We offer a growing library of educational videos for use by educators worldwide, online or in classrooms."
+        button: "View video library"
+      support:
+        title: "Get Support"
+        desc: "Our customer support team is ready to answer your questions. Email us at [support@code.org](%{email_url}) or check out our support center, which offers useful guides and answers!"
+        button: "Visit our support center"
+
   video_library_page_main_title: "Educational short videos"
   video_library_page_hero_description: "Code.org's growing library of educational videos is available for re-use by educators worldwide, online or in classrooms. Our goal is to amplify our efforts beyond our own curriculum's reach."
   video_library_page_title_ai_works: "How AI Works"


### PR DESCRIPTION
Adds strings for the new https://code.org/curriculum/coding-with-ai page.

**Jira tickets:** [This PR](https://codedotorg.atlassian.net/browse/ACQ-1653) • [Parent ticket](https://codedotorg.atlassian.net/browse/ACQ-1504)