### PR TITLE
Direct to congrats page on script completion

### DIFF
--- a/dashboard/app/controllers/congrats_controller.rb
+++ b/dashboard/app/controllers/congrats_controller.rb
@@ -50,7 +50,7 @@ class CongratsController < ApplicationController
       # The order of this conditional is important. During HoC, we generally want to avoid
       # hitting the database, so we check if the unit is an HoC unit first.
       @certificate_data =
-        if curriculum&.hoc? || curriculum&.csf? || Policies::ScriptActivity.completed?(current_user, curriculum)
+        if Policies::ScriptActivity.can_view_congrats_page?(current_user, curriculum)
           [{
             courseName: @course_name,
             courseTitle: curriculum.localized_title,

--- a/dashboard/app/helpers/script_levels_helper.rb
+++ b/dashboard/app/helpers/script_levels_helper.rb
@@ -44,16 +44,6 @@ module ScriptLevelsHelper
     video_info_response
   end
 
-  def script_completion_redirect(script)
-    if script.hoc?
-      script.hoc_finish_url
-    elsif script.csf?
-      script.csf_finish_url
-    else
-      root_path
-    end
-  end
-
   def tracking_pixel_url(script)
     if script.name == Unit::HOC_2013_NAME
       CDO.code_org_url '/api/hour/begin_codeorg.png'

--- a/dashboard/app/helpers/script_levels_helper.rb
+++ b/dashboard/app/helpers/script_levels_helper.rb
@@ -44,6 +44,14 @@ module ScriptLevelsHelper
     video_info_response
   end
 
+  def script_completion_redirect(user, script)
+    if Policies::ScriptActivity.can_view_congrats_page?(user, script)
+      script.finish_url
+    else
+      script_path(script)
+    end
+  end
+
   def tracking_pixel_url(script)
     if script.name == Unit::HOC_2013_NAME
       CDO.code_org_url '/api/hour/begin_codeorg.png'

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -605,7 +605,7 @@ class Lesson < ApplicationRecord
     end
     next_level = next_level_for_lesson_extras(user)
     next_level ?
-      build_script_level_path(next_level) : script.finish_url
+      build_script_level_path(next_level) : script_completion_redirect(user, script)
   end
 
   def next_level_number_for_lesson_extras(user)

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -605,7 +605,7 @@ class Lesson < ApplicationRecord
     end
     next_level = next_level_for_lesson_extras(user)
     next_level ?
-      build_script_level_path(next_level) : script_completion_redirect(script)
+      build_script_level_path(next_level) : script.finish_url
   end
 
   def next_level_number_for_lesson_extras(user)

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -178,7 +178,7 @@ class ScriptLevel < ApplicationRecord
     elsif script.pl_course?
       return build_script_level_path(level_to_follow) if level_to_follow
       next_unit = script.next_unit(user)
-      next_unit ? script_path(next_unit) : script.finish_url
+      next_unit ? script_path(next_unit) : script_completion_redirect(user, script)
     elsif bubble_choice? && !bubble_choice_parent
       # Redirect user back to the BubbleChoice activity page from sublevels.
       build_script_level_path(self)
@@ -197,7 +197,7 @@ class ScriptLevel < ApplicationRecord
           script_path(script) + "?completedLessonNumber=#{lesson.relative_position}"
         end
       else
-        level_to_follow ? build_script_level_path(level_to_follow) : script.finish_url
+        level_to_follow ? build_script_level_path(level_to_follow) : script_completion_redirect(user, script)
       end
     end
   end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -178,7 +178,7 @@ class ScriptLevel < ApplicationRecord
     elsif script.pl_course?
       return build_script_level_path(level_to_follow) if level_to_follow
       next_unit = script.next_unit(user)
-      next_unit ? script_path(next_unit) : script_completion_redirect(script)
+      next_unit ? script_path(next_unit) : script.finish_url
     elsif bubble_choice? && !bubble_choice_parent
       # Redirect user back to the BubbleChoice activity page from sublevels.
       build_script_level_path(self)
@@ -197,7 +197,7 @@ class ScriptLevel < ApplicationRecord
           script_path(script) + "?completedLessonNumber=#{lesson.relative_position}"
         end
       else
-        level_to_follow ? build_script_level_path(level_to_follow) : script_completion_redirect(script)
+        level_to_follow ? build_script_level_path(level_to_follow) : script.finish_url
       end
     end
   end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2024_04_12_134643) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
-  create_table "ai_tutor_interaction_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "ai_tutor_interaction_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "ai_tutor_interaction_id", null: false
     t.integer "user_id", null: false
     t.boolean "thumbs_up"
@@ -453,7 +453,7 @@ ActiveRecord::Schema.define(version: 2024_04_12_134643) do
     t.index ["project_id"], name: "index_datablock_storage_kvps_on_project_id"
   end
 
-  create_table "datablock_storage_library_manifest", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "datablock_storage_library_manifest", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.json "library_manifest"
     t.integer "singleton_guard", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -876,7 +876,7 @@ ActiveRecord::Schema.define(version: 2024_04_12_134643) do
     t.index ["lti_integration_id"], name: "index_lti_deployments_on_lti_integration_id"
   end
 
-  create_table "lti_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "lti_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "satisfied", null: false
     t.string "locale"
@@ -1635,7 +1635,7 @@ ActiveRecord::Schema.define(version: 2024_04_12_134643) do
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
   end
 
-  create_table "project_use_datablock_storages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "project_use_datablock_storages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "project_id", null: false
     t.boolean "use_datablock_storage", default: false, null: false
     t.index ["project_id"], name: "index_project_use_datablock_storages_on_project_id"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2024_04_12_134643) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
-  create_table "ai_tutor_interaction_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "ai_tutor_interaction_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "ai_tutor_interaction_id", null: false
     t.integer "user_id", null: false
     t.boolean "thumbs_up"
@@ -453,7 +453,7 @@ ActiveRecord::Schema.define(version: 2024_04_12_134643) do
     t.index ["project_id"], name: "index_datablock_storage_kvps_on_project_id"
   end
 
-  create_table "datablock_storage_library_manifest", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "datablock_storage_library_manifest", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.json "library_manifest"
     t.integer "singleton_guard", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -876,7 +876,7 @@ ActiveRecord::Schema.define(version: 2024_04_12_134643) do
     t.index ["lti_integration_id"], name: "index_lti_deployments_on_lti_integration_id"
   end
 
-  create_table "lti_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "satisfied", null: false
     t.string "locale"
@@ -1635,7 +1635,7 @@ ActiveRecord::Schema.define(version: 2024_04_12_134643) do
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
   end
 
-  create_table "project_use_datablock_storages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "project_use_datablock_storages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "project_id", null: false
     t.boolean "use_datablock_storage", default: false, null: false
     t.index ["project_id"], name: "index_project_use_datablock_storages_on_project_id"

--- a/dashboard/lib/policies/script_activity.rb
+++ b/dashboard/lib/policies/script_activity.rb
@@ -12,6 +12,7 @@ class Policies::ScriptActivity
 
     return true if script.hoc?
     return true if script.csf?
+    return true if script.csc?
 
     completed?(user, script)
   end

--- a/dashboard/lib/policies/script_activity.rb
+++ b/dashboard/lib/policies/script_activity.rb
@@ -6,4 +6,13 @@ class Policies::ScriptActivity
     return false unless user_script
     !!user_script.completed_at || user.completed_progression_levels?(script)
   end
+
+  def self.can_view_congrats_page?(user, script)
+    return false unless script
+
+    return true if script.hoc?
+    return true if script.csf?
+
+    completed?(user, script)
+  end
 end

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1095,22 +1095,22 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test 'end of HoC for a user is HOC endpoint' do
     stubs(:current_user).returns(@student)
-    assert_equal('//test.code.org/api/hour/finish/hourofcode', script_completion_redirect(Unit.find_by_name(Unit::HOC_NAME)))
+    assert_equal('//test.code.org/api/hour/finish/hourofcode', Unit.find_by_name(Unit::HOC_NAME).finish_url)
   end
 
   test 'post script redirect is HOC endpoint' do
     stubs(:current_user).returns(nil)
-    assert_equal('//test.code.org/api/hour/finish/hourofcode', script_completion_redirect(Unit.find_by_name(Unit::HOC_NAME)))
+    assert_equal('//test.code.org/api/hour/finish/hourofcode', Unit.find_by_name(Unit::HOC_NAME).finish_url)
   end
 
   test 'post script redirect is frozen endpoint' do
     stubs(:current_user).returns(nil)
-    assert_equal('//test.code.org/api/hour/finish/frozen', script_completion_redirect(Unit.find_by_name(Unit::FROZEN_NAME)))
+    assert_equal('//test.code.org/api/hour/finish/frozen', Unit.find_by_name(Unit::FROZEN_NAME).finish_url)
   end
 
   test 'post script redirect is starwars endpoint' do
     stubs(:current_user).returns(nil)
-    assert_equal('//test.code.org/api/hour/finish/starwars', script_completion_redirect(Unit.find_by_name(Unit::STARWARS_NAME)))
+    assert_equal('//test.code.org/api/hour/finish/starwars', Unit.find_by_name(Unit::STARWARS_NAME).finish_url)
   end
 
   test "show redirects admins to root" do

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -70,7 +70,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
-    assert_cached_queries(10) do
+    assert_cached_queries(11) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -62,13 +62,31 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "post milestone passing" do
+  test "post milestone passing last level of progression" do
     student = create :student
     sign_in student
 
     sl = create(:script, :with_levels, levels_count: 3).script_levels[2]
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
+    setup_script_cache
+    assert_cached_queries(10) do
+      post milestone_path(
+        user_id: student.id,
+        script_level_id: sl.id
+      ), params: params
+      assert_response :success
+    end
+  end
+
+  test "post milestone passing middle level of progression" do
+    student = create :student
+    sign_in student
+
+    sl = create(:script, :with_levels, levels_count: 3).script_levels[1]
+    params = {program: 'fake program', testResult: 100, result: 'true'}
+
+    setup_script_cache
     assert_cached_queries(9) do
       post milestone_path(
         user_id: student.id,

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -172,7 +172,7 @@ class LessonTest < ActiveSupport::TestCase
     create :script_level, script: script, lesson: lesson2
 
     assert_match (/\/s\/bogus-script-\d+\/lessons\/2\/levels\/1/), lesson1.next_level_path_for_lesson_extras(@student)
-    assert_equal '/', lesson2.next_level_path_for_lesson_extras(@student)
+    assert_equal "/s/#{script.name}", lesson2.next_level_path_for_lesson_extras(@student)
   end
 
   test "next_level_path_for_lesson_extras show unit overview" do


### PR DESCRIPTION
This PR does a handful of things:
- When finishing the last level of a unit, if the user can view the congrats page, they are directed to the congrats page
- When the user hasn't finished the whole unit, the user is directed back to the unit overview page rather than the homepage. I figured this was a good change -- let me know if anyone disagrees
- Allows any user to view certificates for CSC units

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
