### PR TITLE
feat(signup): move email from backend session cache to browser session storage

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_sign_up.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {trySetSessionStorage} from '@cdo/apps/utils';
 
 $(document).ready(() => {
   analyticsReporter.sendEvent(EVENTS.SIGN_UP_STARTED_EVENT);
@@ -22,6 +23,23 @@ $(document).ready(() => {
     });
   document.getElementById('facebook-sign-in').addEventListener('click', () => {
     logUserLoginType('facebook');
+  });
+
+  $('#new_user').on('submit', function (event) {
+    event.preventDefault();
+
+    const emailAddress = $('#user_email').val();
+    const expirationDate = new Date();
+    expirationDate.setHours(expirationDate.getHours() + 3);
+
+    const signupFormData = {
+      emailAddress,
+      expiration: expirationDate.getTime(),
+    };
+
+    trySetSessionStorage('signup-form', JSON.stringify(signupFormData));
+
+    this.submit();
   });
 });
 

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -21,7 +21,7 @@
   = form_for(@user, url: registration_path(@user), html: {class: "finish-signup"}) do |f|
     .row
       .span10
-        %p
+        %p{id: "signup-description"}
           - if Policies::Lti.lti? @user
             - issuer_url = Policies::Lti.issuer @user
             - issuer_name = Policies::Lti.issuer_name issuer_url

--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -4,6 +4,10 @@ class Policies::User
   def self.user_attributes(user)
     attributes = user.attributes
     authentication_options = user.authentication_options.map {|ao| ao.attributes.compact}
+
+    # Remove the plaintext email from the session cache
+    attributes.delete("email")
+
     attributes.merge('authentication_options_attributes' => authentication_options).compact
   end
 end


### PR DESCRIPTION
Currently, the signup flow is a two page process where email and password is collected on the first page and additional metadata on the second. This results in the email being stored in the backend session cache.

Instead, we can temporarily store the email in the browser session storage. The handling of invalid or missing states will be consistent with the existing backend behavior (cancel and return to first page).

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
