### PR TITLE
Removing unused hidden field from account sign up

### DIFF
--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -34,7 +34,6 @@
           = link_to t('cancel'), users_cancel_path
 
     = f.hidden_field :locale, value: locale
-    = f.hidden_field :encrypted_password
     - if @user.errors.any?
       .row
         .span8


### PR DESCRIPTION
When a user is creating a new account using the email+password combo they visit 2 pages:
1. Type and email and password
2. Select user type, display name, age, etc.

Since the 2nd page needs to know what the user typed for their email and password, that was passed along as hidden <input> fields when this flow was first created. However, for years now, we cache the email & password on the server-side, thus we don't need to be exposing the encrypted or plaintext values to the user's browser.

This PR removes the hidden `encrypted_password` <input> field because it is a security vulnerability to be exposing it in the browser.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/P20-729)

## Testing story
* Manual testing. Created new student and teacher accounts. I could log out and log back in successfully.

