### PR TITLE
Do not update statsig user data on staging

### DIFF
--- a/apps/src/lib/util/StatsigReporter.js
+++ b/apps/src/lib/util/StatsigReporter.js
@@ -50,8 +50,9 @@ class StatsigReporter {
       this.log(
         `User properties: userId: ${formattedUserId}, userType: ${userType}, signInState: ${!!userId}`
       );
+    } else {
+      await Statsig.updateUser(user);
     }
-    await Statsig.updateUser(user);
   }
 
   sendEvent(eventName, payload) {


### PR DESCRIPTION
Staging is getting a race condition failure because we're not using a staging server for Statsig but the userproperties is getting called to update. This pulls the userUpdate call into the same logic as initialize, so we will never try to update a user if we haven't called initialize first. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
