### PR TITLE
Create WYSIWYG editor for Panels levels

### DIFF
--- a/apps/src/lab2/levelEditors/panels/EditPanels.tsx
+++ b/apps/src/lab2/levelEditors/panels/EditPanels.tsx
@@ -134,7 +134,7 @@ const EditPanels: React.FunctionComponent<EditPanelsProps> = ({
           type="button"
           onClick={addPanel}
           text="Add Panel"
-          color="grey"
+          color="gray"
           icon="plus"
         />
       </div>

--- a/apps/src/lab2/levelEditors/panels/EditPanels.tsx
+++ b/apps/src/lab2/levelEditors/panels/EditPanels.tsx
@@ -1,0 +1,280 @@
+import {Panel, PanelLayout} from '@cdo/apps/panels/types';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import moduleStyles from './edit-panels.module.scss';
+import PanelsView from '@cdo/apps/panels/PanelsView';
+import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
+import {
+  BodyThreeText,
+  Heading3,
+  Heading5,
+} from '@cdo/apps/componentLibrary/typography';
+import {createUuid} from '@cdo/apps/utils';
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
+import classNames from 'classnames';
+import ImageInput from '@cdo/apps/lib/levelbuilder/ImageInput';
+import Button from '@cdo/apps/templates/Button';
+
+const createKey = (levelName: string) => levelName + '-' + createUuid();
+
+function sanitizePanels(panels: Panel[], levelName: string) {
+  return panels.map(panel => {
+    return {
+      ...panel,
+      key: panel.key || createKey(levelName),
+    };
+  });
+}
+
+interface EditPanelsProps {
+  initialPanels: Panel[];
+  levelName: string;
+}
+
+/**
+ * Editor for the Lab2 panels level type on the level edit page.
+ */
+const EditPanels: React.FunctionComponent<EditPanelsProps> = ({
+  initialPanels,
+  levelName,
+}) => {
+  const [panels, setPanels] = useState<Panel[]>(
+    sanitizePanels(initialPanels, levelName)
+  );
+  const [toastMessage, setToastMessage] = useState('');
+  const [toastIndex, setToastIndex] = useState(0);
+
+  const updatePanel = useCallback(
+    (panel: Panel, index: number) => {
+      setPanels([...panels.slice(0, index), panel, ...panels.slice(index + 1)]);
+    },
+    [panels]
+  );
+
+  const addPanel = useCallback(() => {
+    setPanels([...panels, {text: '', imageUrl: '', key: createKey(levelName)}]);
+  }, [panels, levelName]);
+
+  const movePanel = useCallback(
+    (key: string, direction: 'up' | 'down') => {
+      const index = panels.findIndex(panel => {
+        return panel.key === key;
+      });
+
+      if (index === -1) {
+        return;
+      }
+
+      const newIndex = direction === 'up' ? index - 1 : index + 1;
+      if (newIndex < 0 || newIndex >= panels.length) {
+        return;
+      }
+      const newPanels = [...panels];
+      const temp = newPanels[index];
+      newPanels[index] = newPanels[newIndex];
+      newPanels[newIndex] = temp;
+      setPanels(newPanels);
+    },
+    [panels]
+  );
+
+  const deletePanel = useCallback(
+    (key: string) => {
+      setPanels(panels.filter(panel => panel.key !== key));
+    },
+    [panels]
+  );
+
+  const onContinue = useCallback((nextUrl?: string) => {
+    if (nextUrl) {
+      setToastMessage(`Redirecting to ${nextUrl}`);
+    } else {
+      setToastMessage('Navigating to next level');
+    }
+    // Force a refresh
+    setToastIndex(t => t + 1);
+  }, []);
+
+  return (
+    <div className={moduleStyles.container}>
+      <input
+        type="hidden"
+        id="level_panels"
+        name="level[panels]"
+        value={JSON.stringify(panels)}
+      />
+      <Heading3>Preview</Heading3>
+      <div className={moduleStyles.panelsContainer}>
+        <Toast message={toastMessage} index={toastIndex} />
+        <div className={moduleStyles.fullSizeContainer}>
+          <PanelsView
+            panels={panels}
+            onContinue={onContinue}
+            targetWidth={1920}
+            targetHeight={1080}
+            resetOnChange={false}
+          />
+        </div>
+      </div>
+      <div className={moduleStyles.panelEditors}>
+        {panels.map((panel, index) => (
+          <EditPanel
+            key={index}
+            panel={panel}
+            index={index}
+            updatePanel={updatePanel}
+            movePanel={movePanel}
+            deletePanel={deletePanel}
+            last={index === panels.length - 1}
+          />
+        ))}
+      </div>
+      <div className={moduleStyles.addButtonContainer}>
+        <Button
+          type="button"
+          onClick={addPanel}
+          text="Add Panel"
+          color="grey"
+          icon="plus"
+        />
+      </div>
+    </div>
+  );
+};
+
+interface EditPanelProps {
+  panel: Panel;
+  index: number;
+  updatePanel: (panel: Panel, index: number) => void;
+  movePanel: (key: string, direction: 'up' | 'down') => void;
+  deletePanel: (key: string) => void;
+  last?: boolean;
+}
+
+const EditPanel: React.FunctionComponent<EditPanelProps> = ({
+  panel,
+  index,
+  updatePanel,
+  movePanel,
+  deletePanel,
+  last = false,
+}) => {
+  return (
+    <div className={moduleStyles.panelEditor}>
+      <div className={moduleStyles.fieldRow}>
+        <Heading5 className={moduleStyles.panelHeader}>
+          Panel {index + 1}
+        </Heading5>
+        {index !== 0 && (
+          <button
+            type="button"
+            className={moduleStyles.button}
+            onClick={() => movePanel(panel.key, 'up')}
+          >
+            <FontAwesomeV6Icon iconName="arrow-up" />
+          </button>
+        )}
+        {!last && (
+          <button
+            type="button"
+            className={moduleStyles.button}
+            onClick={() => movePanel(panel.key, 'down')}
+          >
+            <FontAwesomeV6Icon iconName="arrow-down" />
+          </button>
+        )}
+        <button
+          type="button"
+          className={moduleStyles.deleteButton}
+          onClick={() => deletePanel(panel.key)}
+        >
+          <FontAwesomeV6Icon iconName="trash" />
+        </button>
+      </div>
+      <div className={moduleStyles.fieldRow}>
+        <label htmlFor={panel.text}>Text</label>
+        <textarea
+          className={moduleStyles.textarea}
+          name={panel.text}
+          value={panel.text}
+          onChange={e => updatePanel({...panel, text: e.target.value}, index)}
+        />
+        <SimpleDropdown
+          labelText="Position"
+          name="position"
+          size="s"
+          onChange={e =>
+            updatePanel(
+              {...panel, layout: e.target.value as PanelLayout},
+              index
+            )
+          }
+          selectedValue={panel.layout}
+          items={[
+            {value: 'text-top-right', text: 'Top Right'},
+            {value: 'text-bottom-left', text: 'Bottom Left'},
+          ]}
+        />
+      </div>
+      <div className={moduleStyles.fieldRow}>
+        <ImageInput
+          initialImageUrl={panel.imageUrl}
+          updateImageUrl={imageUrl => {
+            updatePanel({...panel, imageUrl: imageUrl}, index);
+          }}
+        />
+      </div>
+      {last && (
+        <div className={moduleStyles.fieldRow}>
+          <label htmlFor={panel.nextUrl}>
+            {'Redirect URL (leave blank to continue to next level)'}
+          </label>
+          <input
+            name={panel.nextUrl}
+            value={panel.nextUrl}
+            onChange={e =>
+              updatePanel(
+                {...panel, nextUrl: e.target.value || undefined},
+                index
+              )
+            }
+          />
+        </div>
+      )}
+      <hr />
+    </div>
+  );
+};
+
+const Toast: React.FunctionComponent<{message: string; index: number}> = ({
+  message,
+  index,
+}) => {
+  const [show, setShow] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  // Use index to force a refresh
+  useEffect(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+    }
+    setShow(true);
+    timeoutRef.current = window.setTimeout(() => setShow(false), 3000);
+  }, [index]);
+
+  return (
+    <div className={moduleStyles.toastOverlay} key={index}>
+      <div
+        className={classNames(
+          moduleStyles.toast,
+          show && message && moduleStyles.toastShow
+        )}
+      >
+        <BodyThreeText className={moduleStyles.toastMessage}>
+          {message}
+        </BodyThreeText>
+      </div>
+    </div>
+  );
+};
+
+export default EditPanels;

--- a/apps/src/lab2/levelEditors/panels/EditPanels.tsx
+++ b/apps/src/lab2/levelEditors/panels/EditPanels.tsx
@@ -119,7 +119,7 @@ const EditPanels: React.FunctionComponent<EditPanelsProps> = ({
       <div className={moduleStyles.panelEditors}>
         {panels.map((panel, index) => (
           <EditPanel
-            key={index}
+            key={panel.key}
             panel={panel}
             index={index}
             updatePanel={updatePanel}

--- a/apps/src/lab2/levelEditors/panels/EditPanels.tsx
+++ b/apps/src/lab2/levelEditors/panels/EditPanels.tsx
@@ -43,9 +43,10 @@ const EditPanels: React.FunctionComponent<EditPanelsProps> = ({
   const [toastMessage, setToastMessage] = useState('');
   const [toastIndex, setToastIndex] = useState(0);
 
+  // Update a panel. Replaces a panel with the given key with the new panel.
   const updatePanel = useCallback(
-    (panel: Panel, index: number) => {
-      setPanels([...panels.slice(0, index), panel, ...panels.slice(index + 1)]);
+    (panel: Panel) => {
+      setPanels(panels.map(p => (p.key === panel.key ? panel : p)));
     },
     [panels]
   );
@@ -144,7 +145,7 @@ const EditPanels: React.FunctionComponent<EditPanelsProps> = ({
 interface EditPanelProps {
   panel: Panel;
   index: number;
-  updatePanel: (panel: Panel, index: number) => void;
+  updatePanel: (panel: Panel) => void;
   movePanel: (key: string, direction: 'up' | 'down') => void;
   deletePanel: (key: string) => void;
   last?: boolean;
@@ -196,17 +197,17 @@ const EditPanel: React.FunctionComponent<EditPanelProps> = ({
           className={moduleStyles.textarea}
           name={panel.text}
           value={panel.text}
-          onChange={e => updatePanel({...panel, text: e.target.value}, index)}
+          onChange={e => updatePanel({...panel, text: e.target.value})}
         />
         <SimpleDropdown
           labelText="Position"
           name="position"
           size="s"
           onChange={e =>
-            updatePanel(
-              {...panel, layout: e.target.value as PanelLayout},
-              index
-            )
+            updatePanel({
+              ...panel,
+              layout: e.target.value as PanelLayout,
+            })
           }
           selectedValue={panel.layout}
           items={[
@@ -219,7 +220,7 @@ const EditPanel: React.FunctionComponent<EditPanelProps> = ({
         <ImageInput
           initialImageUrl={panel.imageUrl}
           updateImageUrl={imageUrl => {
-            updatePanel({...panel, imageUrl: imageUrl}, index);
+            updatePanel({...panel, imageUrl: imageUrl});
           }}
         />
       </div>
@@ -232,10 +233,7 @@ const EditPanel: React.FunctionComponent<EditPanelProps> = ({
             name={panel.nextUrl}
             value={panel.nextUrl}
             onChange={e =>
-              updatePanel(
-                {...panel, nextUrl: e.target.value || undefined},
-                index
-              )
+              updatePanel({...panel, nextUrl: e.target.value || undefined})
             }
           />
         </div>

--- a/apps/src/lab2/levelEditors/panels/edit-panels.module.scss
+++ b/apps/src/lab2/levelEditors/panels/edit-panels.module.scss
@@ -1,0 +1,122 @@
+@import '../../../mixins.scss';
+@import 'color.scss';
+
+.container {
+  display: flex;
+  flex-direction: column;
+}
+
+.panelsContainer {
+  position: relative;
+  height: 540px;
+  background-color: #121212;
+  margin-bottom: 25px;
+}
+
+.fullSizeContainer {
+  position: relative;
+  width: 1920px;
+  height: 1080px;
+  transform: scale(0.5) translateX(-50%) translateY(-50%);
+}
+
+.panelEditors {
+  overflow-y: scroll;
+  padding: 20px;
+  border-radius: 4px;
+  margin-bottom: 25px;
+  resize: vertical;
+  height: 300px;
+  background-color: rgba($neutral_dark10, 0.5);
+}
+
+.panelEditor {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 20px;
+}
+
+.fieldRow {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  gap: 20px;
+  margin-bottom: 10px;
+}
+
+.textarea {
+  flex: 1;
+}
+
+.imageUrlInput {
+  width: 700px;
+}
+
+.panelHeader {
+  margin: 0;
+}
+
+.addButtonContainer {
+  display: flex;
+  justify-content: center;
+}
+
+%button,
+.button {
+  @include remove-button-styles;
+  transition: color 0.1s ease;
+
+  &:hover {
+    color: $neutral_dark40;
+  }
+}
+
+.deleteButton {
+  @extend %button;
+  &:hover {
+    color: $product_negative_default;
+  }
+}
+
+.addPanelButton {
+  @extend %button;
+  margin: auto;
+}
+
+@keyframes fade-out-toast {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.toastOverlay {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
+}
+
+.toast {
+  margin: 100px auto auto auto;
+  z-index: 100;
+  opacity: 0;
+  background-color: $brand_primary_default;
+  border: 2px $brand_primary_light solid;
+  border-radius: 4px;
+  padding: 10px;
+
+  &Show {
+    animation: fade-out-toast 3s;
+  }
+}
+
+.toastMessage {
+  color: $neutral_light;
+  margin-bottom: 0;
+}

--- a/apps/src/panels/PanelsLabView.tsx
+++ b/apps/src/panels/PanelsLabView.tsx
@@ -9,7 +9,7 @@ import {
   sendSuccessReport,
   navigateToNextLevel,
 } from '@cdo/apps/code-studio/progressRedux';
-import {PanelsLevelData} from './types';
+import {PanelsLevelData, PanelsLevelProperties} from './types';
 import PanelsView from './PanelsView';
 import useWindowSize from '../util/hooks/useWindowSize';
 
@@ -18,8 +18,11 @@ const appName = 'panels';
 const PanelsLabView: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
 
-  const levelData = useAppSelector(
-    state => state.lab.levelProperties?.levelData
+  const panels = useAppSelector(
+    state =>
+      (state.lab.levelProperties as PanelsLevelProperties | undefined)
+        ?.panels ||
+      (state.lab.levelProperties?.levelData as PanelsLevelData)?.panels
   );
   const currentAppName = useAppSelector(
     state => state.lab.levelProperties?.appName
@@ -38,8 +41,6 @@ const PanelsLabView: React.FunctionComponent = () => {
     },
     [dispatch]
   );
-
-  const panels = (levelData as PanelsLevelData | undefined)?.panels;
 
   const [windowWidth, windowHeight] = useWindowSize();
 

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -79,7 +79,7 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
   // Reset to last panel if number of panels has reduced
   useEffect(() => {
     if (currentPanel >= panels.length) {
-      setCurrentPanel(panels.length - 1);
+      setCurrentPanel(Math.max(panels.length - 1, 0));
     }
   }, [currentPanel, panels]);
 

--- a/apps/src/panels/types.ts
+++ b/apps/src/panels/types.ts
@@ -1,6 +1,12 @@
+import {LevelProperties} from '../lab2/types';
+
 // The level data for a panels level that doesn't require
 // reloads between levels.
 export interface PanelsLevelData {
+  panels: Panel[];
+}
+
+export interface PanelsLevelProperties extends LevelProperties {
   panels: Panel[];
 }
 

--- a/apps/src/sites/studio/pages/levels/editors/fields/_panels.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_panels.js
@@ -1,0 +1,16 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import EditPanels from '@cdo/apps/lab2/levelEditors/panels/EditPanels';
+
+$(document).ready(function () {
+  const initialPanels = getScriptData('panels');
+  const levelName = document.querySelector('script[data-levelname]')?.dataset
+    ?.levelname;
+
+  ReactDOM.render(
+    <EditPanels initialPanels={initialPanels} levelName={levelName} />,
+    document.getElementById('panels-container')
+  );
+});

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -135,6 +135,7 @@ const INTERNAL_ENTRIES = {
   'levels/editors/fields/_callouts': './src/sites/studio/pages/levels/editors/fields/_callouts.js',
   'levels/editors/fields/_droplet': './src/sites/studio/pages/levels/editors/fields/_droplet.js',
   'levels/editors/fields/_grid': './src/sites/studio/pages/levels/editors/fields/_grid.js',
+  'levels/editors/fields/_panels': './src/sites/studio/pages/levels/editors/fields/_panels.js',
   'levels/editors/fields/_poetry_fields': './src/sites/studio/pages/levels/editors/fields/_poetry_fields.js',
   'levels/editors/fields/_preload_assets': './src/sites/studio/pages/levels/editors/fields/_preload_assets.js',
   'levels/editors/fields/_special_level_types': './src/sites/studio/pages/levels/editors/fields/_special_level_types.js',

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -573,7 +573,7 @@ class LevelsController < ApplicationController
     # Parse a few specific JSON fields used by modern (Lab2) labs so that they are
     # stored in the database as a first-order member of the properties JSON, rather
     # than simply as a string of JSON belonging to a single property.
-    [:level_data, :initial_ai_customizations, :validations].each do |key|
+    [:level_data, :initial_ai_customizations, :validations, :panels].each do |key|
       level_params[key] = JSON.parse(level_params[key]) if level_params[key]
     end
     # Delete validations from level data if present. We'll use the validations in level properties instead.

--- a/dashboard/app/models/levels/panels.rb
+++ b/dashboard/app/models/levels/panels.rb
@@ -30,6 +30,7 @@ class Panels < Level
     submittable
     background
     level_data
+    panels
   )
 
   def self.create_from_level_builder(params, level_params)

--- a/dashboard/app/views/levels/editors/_panels.html.haml
+++ b/dashboard/app/views/levels/editors/_panels.html.haml
@@ -1,2 +1,2 @@
-= render partial: 'levels/editors/fields/level_data', locals: {f: f}
+= render partial: 'levels/editors/fields/panels', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_panels.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_panels.html.haml
@@ -1,0 +1,8 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#panels-container"}}
+  Panels
+
+#panels-container.in.collapse
+
+- content_for :body_scripts do
+  %script{src: webpack_asset_path('js/levels/editors/fields/_panels.js'),
+        data: {panels: (@level.properties['panels'] || @level.properties.dig('level_data', 'panels') || []).to_json, levelname: @level.name}}


### PR DESCRIPTION
This adds a live previewing, WYSIWYG editor for the "panels" level type in levelbuilder. Because this editor is in React, we can use the `PanelsView` component directly and render the experience as the user would see it in the level.

This also silently saves `panels` data to level properties instead of `levelData` for the purposes of localization, similar to https://github.com/code-dot-org/code-dot-org/pull/57211. The motivation here again is to make the data more easily accessible and translatable.

Editing an existing Panels level:

https://github.com/code-dot-org/code-dot-org/assets/85528507/c53bb985-77bf-4702-9327-772023897fe3

Creating Panels from scratch:

https://github.com/code-dot-org/code-dot-org/assets/85528507/e050e41c-ad48-4210-82d4-61454e000a1d

## Testing story

Tested editing existing panels levels in the music lab intro progression, and creating new panels levels from scratch.