### PR TITLE
Handle no toolbox levels created via Google Blockly

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2841,7 +2841,8 @@ StudioApp.prototype.handleUsingBlockly_ = function (config) {
 
   // If levelbuilder provides an empty toolbox, some apps (like artist)
   // replace it with a full toolbox. I think some levels may depend on this
-  // behavior. We want a way to specify no toolbox, which is <xml></xml>
+  // behavior. We want a way to specify no toolbox, which is <xml></xml>.
+  // Google Blockly may also add a xmlns attribute to this xml.
   if (config.level.toolbox) {
     // Update CDO Blockly XML so it is compatible with mainline Google Blockly
     // (Nothing is changed if we are using CDO Blockly.)
@@ -2850,13 +2851,14 @@ StudioApp.prototype.handleUsingBlockly_ = function (config) {
     );
 
     const toolboxWithoutWhitespace = config.level.toolbox.replace(/\s/g, '');
-    // An empty toolbox should be treated as no toolbox.
+    const emptyToolboxOptionsWithoutWhitespace = [
+      '<xml></xml>',
+      '<xml/>',
+      '<xmlxmlns="https://developers.google.com/blockly/xml"/>',
+      '<xmlxmlns="https://developers.google.com/blockly/xml"></xml>',
+    ];
     if (
-      toolboxWithoutWhitespace === '<xml></xml>' ||
-      toolboxWithoutWhitespace === '<xml/>' ||
-      // Google Blockly always adds the xmlns attribute.
-      toolboxWithoutWhitespace ===
-        '<xmlxmlns="https://developers.google.com/blockly/xml"/>'
+      emptyToolboxOptionsWithoutWhitespace.includes(toolboxWithoutWhitespace)
     ) {
       config.level.toolbox = undefined;
     }

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2850,9 +2850,13 @@ StudioApp.prototype.handleUsingBlockly_ = function (config) {
     );
 
     const toolboxWithoutWhitespace = config.level.toolbox.replace(/\s/g, '');
+    // An empty toolbox should be treated as no toolbox.
     if (
       toolboxWithoutWhitespace === '<xml></xml>' ||
-      toolboxWithoutWhitespace === '<xml/>'
+      toolboxWithoutWhitespace === '<xml/>' ||
+      // Google Blockly always adds the xmlns attribute.
+      toolboxWithoutWhitespace ===
+        '<xmlxmlns="https://developers.google.com/blockly/xml"/>'
     ) {
       config.level.toolbox = undefined;
     }


### PR DESCRIPTION
We found an issue where levels edited with Google Blockly that were supposed to have no toolbox ended up with a tiny blank toolbox. The underlying issue is if you create an empty toolbox via Google Blockly instead of saving `<xml />` as the toolbox blocks, `<xml xmlns="https://developers.google.com/blockly/xml"/>` is saved. This is an issue because we manually turned `<xml />` into an `undefined` toolbox to avoid this tiny empty toolbox. The quick fix for this was to also turn the version with the xmlns attribute into an `undefined` toolbox.

This is still a bit brittle, because if this attribute changes we could end up in the same situation again. We may want to use a regular expression instead.

## Links

- jira ticket: [CT-402](https://codedotorg.atlassian.net/browse/CT-402)


## Testing story
Tested locally that the new version of no toolbox works.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
