### PR TITLE
Fix reference for renamed method to be the new name

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -534,9 +534,9 @@ class ProjectsController < ApplicationController
     return if redirect_under_13_without_tos_teacher(@level)
     # TODO: post-firebase-cleanup, remove both branches of this conditional: #56994
     if params[:script_call]
-      render js: "#{params[:script_call]}(#{firebase_options.to_json});"
+      render js: "#{params[:script_call]}(#{datablock_storage_options.to_json});"
     else
-      render json: firebase_options
+      render json: datablock_storage_options
     end
   end
 


### PR DESCRIPTION
Honeybadger error showed up after DTP: https://app.honeybadger.io/projects/3240/faults/105874856/01HSHNHCTR8X7CJJ8NZJBB2X2M?q=occurred.after%3A%221+hours+ago%22

Bug is from this pr #56279

I believe there is no user impact. I'm able to successfully export an applab project without seeing any error, and my project works after it's been exported. I believe the only effect of this bug is that firebase options don't get included in the exported project which is fine because we don't support execution of the data functions in exported projects anyway.

## Testing story

I can repro the 500 error in prod on one of my projects with this URL:  https://studio.code.org/projects/applab/gqD0R_uAxZXeExUWMZDCGfAjSgyQIZknpKGr9VJ3_bE/export_config?script_call=setExportConfig

With the fix, http://localhost-studio.code.org:3000/projects/applab/TP3c4-GKEI4pvQ5HayE-1w/export_config?script_call=setExportConfig is successful.