### PR TITLE
Speed up the Dashboard test env loading

### DIFF
--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -4,6 +4,10 @@ require 'webmock/minitest'
 class LevelsHelperTest < ActionView::TestCase
   include Devise::Test::ControllerHelpers
 
+  setup_all do
+    I18n.load_path += Dir[Rails.root.join('config/locales/block_categories.it-IT.*')]
+  end
+
   def sign_in(user)
     user.reload
     # override the default sign_in helper because we don't actually have a request or anything here

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -33,6 +33,8 @@ CDO.stubs(:rack_env).returns(:test) if defined? CDO
 Rails.application.reload_routes! if defined?(Rails) && defined?(Rails.application)
 
 require File.expand_path('../../config/environment', __FILE__)
+# Loads only English i18n files to speed up the env loading
+I18n.load_path.select! {|path| path.match?(/en-US|en\./)}
 I18n.load_path += Dir[Rails.root.join('test', 'en.yml')]
 I18n.backend.reload!
 I18n.fallbacks[:'te-ST'] = [:'te-ST', :'en-US', :en]


### PR DESCRIPTION
The Dashboard test env loads 5.6 times faster with English i18n files only:
| Before  | After |
| ------- | ----- |
| ![before](https://github.com/code-dot-org/code-dot-org/assets/11708250/c93643c8-ae18-48a4-84c0-327c74bc60fd) | ![after](https://github.com/code-dot-org/code-dot-org/assets/11708250/578d6f60-9d38-4a5a-a1ea-7416a647d6ee) |
