### PR TITLE
[Google Blockly] extend FieldImageDropdown for costume and background pickers

### DIFF
--- a/apps/src/blockly/addons/cdoFieldAnimationDropdown.ts
+++ b/apps/src/blockly/addons/cdoFieldAnimationDropdown.ts
@@ -1,0 +1,38 @@
+import {CdoFieldImageDropdown} from './cdoFieldImageDropdown';
+import {MenuOption} from 'blockly';
+
+interface ButtonConfig {
+  text: string;
+  action: () => void;
+}
+
+export default class CdoFieldAnimationDropdown extends CdoFieldImageDropdown {
+  constructor(
+    menuGenerator: MenuOption[] | (() => MenuOption[]),
+    width: number,
+    height: number,
+    buttons: ButtonConfig[] | undefined
+  ) {
+    super(menuGenerator, width, height, buttons);
+  }
+
+  /**
+   * @override
+   * Ensure that the input value is a valid language-neutral option.
+   * The first change we made from the parent method is to not use the cache,
+   * as the list of options can change. The second is to remove a warning if the
+   * value is invalid. We do this because levelbuilders frequently edit level
+   * animations after setting the block XML and we want to avoid a flood
+   * of console warnings.
+   *
+   * @param newValue The input value.
+   * @returns A valid language-neutral option, or null if invalid.
+   */
+  doClassValidation_(newValue: string) {
+    const options = this.getOptions(false); // false = do not use cache
+
+    const isValueValid = options.some(option => option[1] === newValue);
+
+    return isValueValid ? newValue : null;
+  }
+}

--- a/apps/src/blockly/addons/cdoFieldImageDropdown.ts
+++ b/apps/src/blockly/addons/cdoFieldImageDropdown.ts
@@ -93,7 +93,8 @@ export class CdoFieldImageDropdown extends FieldGridDropdown {
         buttonElement.innerHTML = button.text;
         buttonElement.addEventListener('click', button.action);
         buttonElement.addEventListener('click', () =>
-          Blockly.DropDownDiv.hideIfOwner(this, true)
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          Blockly.DropDownDiv.hideIfOwner(this as any, true)
         );
         const menuItem = new Blockly.MenuItem(buttonElement, '');
         menuItem.setRole(Blockly.utils.aria.Role.OPTION);
@@ -141,42 +142,10 @@ export class CdoFieldImageDropdown extends FieldGridDropdown {
     (this as any).updateColumnsStyling_();
 
     Blockly.DropDownDiv.showPositionedByField(
-      this,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this as any,
       this.dropdownDispose_.bind(this)
     );
-  }
-
-  /**
-   * @override
-   * Ensure that the input value is a valid language-neutral option.
-   * The only change we made from the parent method is to not use the cache,
-   * as the list of options can change.
-   *
-   * @param newValue The input value.
-   * @returns A valid language-neutral option, or null if invalid.
-   */
-  doClassValidation_(newValue: string) {
-    /* Begin CDO Customization */
-    const options = this.getOptions(false); // false = do not use cache
-    /* End CDO Customization */
-
-    const isValueValid = options.some(option => option[1] === newValue);
-
-    if (!isValueValid) {
-      if (this.sourceBlock_) {
-        console.warn(
-          "Cannot set the dropdown's value to an unavailable option." +
-            ' Block type: ' +
-            this.sourceBlock_.type +
-            ', Field name: ' +
-            this.name +
-            ', Value: ' +
-            newValue
-        );
-      }
-      return null;
-    }
-    return newValue;
   }
 }
 

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -12,6 +12,7 @@ import {BlocklyVersion, WORKSPACE_EVENTS} from '@cdo/apps/blockly/constants';
 import styleConstants from '@cdo/apps/styleConstants';
 import * as utils from '@cdo/apps/utils';
 import initializeCdoConstants from './addons/cdoConstants';
+import CdoFieldAnimationDropdown from './addons/cdoFieldAnimationDropdown';
 import CdoFieldBehaviorPicker from './addons/cdoFieldBehaviorPicker';
 import CdoFieldButton from './addons/cdoFieldButton';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
@@ -337,6 +338,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   blocklyWrapper.FieldToggle = CdoFieldToggle;
   blocklyWrapper.FieldFlyout = CdoFieldFlyout;
   blocklyWrapper.FieldBehaviorPicker = CdoFieldBehaviorPicker;
+  blocklyWrapper.FieldAnimationDropdown = CdoFieldAnimationDropdown;
 
   blocklyWrapper.blockly_.registry.register(
     blocklyWrapper.blockly_.registry.Type.FLYOUTS_VERTICAL_TOOLBOX,

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -22,6 +22,7 @@ import {
   WORKSPACE_EVENTS,
 } from './constants';
 import {Field, FieldProto} from 'blockly/core/field';
+import CdoFieldAnimationDropdown from './addons/cdoFieldAnimationDropdown';
 import CdoFieldButton from './addons/cdoFieldButton';
 import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
 import CdoFieldToggle from './addons/cdoFieldToggle';
@@ -87,6 +88,7 @@ export interface BlocklyWrapperType extends GoogleBlocklyType {
   FieldBehaviorPicker: typeof CdoFieldBehaviorPicker;
   FieldButton: typeof CdoFieldButton;
   FieldImageDropdown: typeof CdoFieldImageDropdown;
+  FieldAnimationDropdown: typeof CdoFieldAnimationDropdown;
   FieldToggle: typeof CdoFieldToggle;
   FieldFlyout: typeof CdoFieldFlyout;
   FieldBitmap: typeof CdoFieldBitmap;

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -197,7 +197,7 @@ const customInputTypes = {
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(
-          new Blockly.FieldImageDropdown(costumeList, 32, 32, buttons),
+          new Blockly.FieldAnimationDropdown(costumeList, 32, 32, buttons),
           inputConfig.name
         );
     },
@@ -226,7 +226,7 @@ const customInputTypes = {
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(
-          new Blockly.FieldImageDropdown(backgroundList, 40, 40, buttons),
+          new Blockly.FieldAnimationDropdown(backgroundList, 40, 40, buttons),
           inputConfig.name
         );
     },


### PR DESCRIPTION
Similar to:
* https://github.com/code-dot-org/code-dot-org/pull/57344

A common levelbuilder practice is to edit the Animation JSON for a level after the blocks are set. This causes a flood of warnings in the console about an unavailable option in the image dropdown field. Since we already handle this gracefully and the curriculum team understands how it works, it feels reasonable to skip this warning. 

Removing this warning from all image dropdowns didn't feel ideal. This field type is used in Flappy, Bounce, Artist, and Play Lab, but it's only in Sprite Lab where the animations can be changed. Some of these labs aren't even migrated yet, and it could be helpful to have those warnings in place once that work is begun. For this reason I decided to extend the class specifically for the blocks that deal with dynamic animations, ie. `behaviorPicker` and `costumePicker` custom input type.

The last time we added an override to `CdoFieldImageDropdown` was also related to these blocks. https://github.com/code-dot-org/code-dot-org/pull/55912
We needed to add an override for `doClassValidation` to not cache the options list so that recently added animations would be usable in the function editor workspace. At the time, we decided it should be fine to do this for all image dropdowns, but acknowledged it was potentially overkill for cases where the list of images is static: https://github.com/code-dot-org/code-dot-org/pull/55912#discussion_r1465049544

The new class preserves our previous override, but without the warning. The warning _is_ part of the original `FieldGridDropdown` from the Blockly plugin, so it seems like we can also remove the `doClassValidation` override from `CdoFieldImageDropdown`. 

The same warning also exists in our custom classes `FieldBehaviorPicker` and `FieldDropdown`. I think it’s probably fine to leave those for now since we’d be less likely to find that the options have swapped out from under us in those cases.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
## Links

Slack thread: https://codedotorg.slack.com/archives/C05DK21DAHK/p1711047168603369

## Testing story

I tested this by first confirming that sprite/background blocks were indeed using the new field type as expected. I tested general use, including adding animations from within the function editor to ensure that our previous fix was still working. I also observed that the warnings were gone in a level that previously had them.
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/890d5f08-50cc-4ecc-bfad-f0ebef341297)![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/0d4e9633-369d-455a-9dc3-f489b438a3c2)

I also tested a Bounce level that uses our custom image dropdown and saw no regressions. By manually setting an invalid value into the start blocks of the level, I was able to see the console warning as before, now being produced by the super/plugin class:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/e48b1bbd-5df9-48a0-8823-924a8aec54e0)![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/40007681-e056-41e6-a7d2-877c4621242d)



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
