### PR TITLE
Revert "Revert "Datablock Storage: replace firebase for applab data features (#56279)"

### DIFF
--- a/apps/src/applab/Exporter.js
+++ b/apps/src/applab/Exporter.js
@@ -89,9 +89,9 @@ const APP_OPTIONS_ALLOWLIST = {
   hideSource: true,
   share: true,
   labUserId: false,
-  firebaseName: false,
-  firebaseAuthToken: false,
-  firebaseChannelIdSuffix: false,
+  firebaseName: false, // TODO: post-firebase-cleanup: #56994
+  firebaseAuthToken: false, // TODO: post-firebase-cleanup: #56994
+  firebaseChannelIdSuffix: false, // TODO: post-firebase-cleanup: #56994
   isSignedIn: true,
   pinWorkspaceToBottom: true,
   hasVerticalScrollbars: true,

--- a/apps/src/applab/PlaySpaceHeader.jsx
+++ b/apps/src/applab/PlaySpaceHeader.jsx
@@ -9,6 +9,7 @@ import {actions} from './redux/applab';
 import {connect} from 'react-redux';
 import ScreenSelector from './ScreenSelector';
 import ToggleGroup from '../templates/ToggleGroup';
+import {isDatablockStorage} from '../storage/storage';
 
 class PlaySpaceHeader extends React.Component {
   static propTypes = {
@@ -27,6 +28,22 @@ class PlaySpaceHeader extends React.Component {
     onScreenCreate: PropTypes.func.isRequired,
     onInterfaceModeChange: PropTypes.func.isRequired,
   };
+
+  // Visually flag that a project is part of the Datablock Storage experiment
+  // by squaring the otherwise rounded-on-the-right corners of the [Data] tab.
+  //
+  // Why? We are gradually rolling out Datablock Storage in a small percentage
+  // of Applab projects. For bug triage, we need a quick way for CS to identify
+  // projects using Datablock Storage that is likely to be recognizable even if
+  // screenshots are taken with a cell phone, or cropped.
+  //
+  // TODO: post-firebase-cleanup, remove this method, #56994
+  squareCornersIfUsingDatablockStorage() {
+    const STYLE_TO_FLAG_DATABLOCK_STORAGE = {
+      borderRadius: 0,
+    };
+    return isDatablockStorage() ? STYLE_TO_FLAG_DATABLOCK_STORAGE : {};
+  }
 
   render() {
     let leftSide, rightSide;
@@ -57,6 +74,7 @@ class PlaySpaceHeader extends React.Component {
               type="button"
               id="dataModeButton"
               value={ApplabInterfaceMode.DATA}
+              style={this.squareCornersIfUsingDatablockStorage()}
             >
               {msg.dataMode()}
             </button>

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -1863,7 +1863,7 @@ applabCommands.getColumn = function (opts) {
   apiValidateType(opts, 'getColumn', 'table', opts.table, 'string');
   apiValidateType(opts, 'getColumn', 'column', opts.column, 'string');
 
-  Applab.storage.readRecords(
+  Applab.storage.getColumn(
     opts.table,
     opts.column,
     handleGetColumn.bind(this, opts),

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -1865,25 +1865,24 @@ applabCommands.getColumn = function (opts) {
 
   Applab.storage.readRecords(
     opts.table,
-    {},
+    opts.column,
     handleGetColumn.bind(this, opts),
     handleGetColumnError.bind(this, opts)
   );
 };
 
-var handleGetColumn = function (opts, records) {
-  let columnList = [];
+var handleGetColumn = function (opts, columnValues) {
   let columnName = opts.column;
   let tableName = opts.table;
-  if (records === null) {
+  if (columnValues === null) {
     outputError(i18n.tableDoesNotExistError({tableName}));
   } else {
-    records.forEach(row => columnList.push(row[opts.column]));
-    if (columnList.every(element => element === undefined)) {
+    if (columnValues.every(element => element === undefined)) {
       outputError(i18n.columnDoesNotExistError({columnName, tableName}));
     }
   }
-  opts.callback(columnList);
+
+  opts.callback(columnValues);
 };
 
 var handleGetColumnError = function (opts, message) {

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -46,10 +46,10 @@
  * @property {boolean} hideSource
  * @property {string} share
  * @property {string} labUserId
- * @property {string} firebaseName
- * @property {string} firebaseSharedAuthToken
- * @property {string} firebaseAuthToken
- * @property {string} firebaseChannelIdSuffix
+ * @property {string} firebaseName // TODO: post-firebase-cleanup: #56994
+ * @property {string} firebaseSharedAuthToken // TODO: post-firebase-cleanup: #56994
+ * @property {string} firebaseAuthToken // TODO: post-firebase-cleanup: #56994
+ * @property {string} firebaseChannelIdSuffix // TODO: post-firebase-cleanup: #56994
  * @property {boolean} isSignedIn
  * @property {boolean} pinWorkspaceToBottom
  * @property {boolean} hasVerticalScrollbars

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -31,7 +31,7 @@ var p5GroupWrapper = require('./P5GroupWrapper');
 var gamelabCommands = require('./gamelab/commands');
 import {initializeSubmitHelper, onSubmitComplete} from '@cdo/apps/submitHelper';
 var dom = require('@cdo/apps/dom');
-import {initFirebaseStorage} from '@cdo/apps/storage/firebaseStorage';
+import {initStorage, FIREBASE_STORAGE} from '../storage/storage';
 import {getStore} from '@cdo/apps/redux';
 import {
   allAnimationsSingleFrameSelector,
@@ -254,7 +254,8 @@ export default class P5Lab {
     config.usesAssets = true;
 
     this.studioApp_.labUserId = config.labUserId;
-    this.studioApp_.storage = initFirebaseStorage({
+    // TODO: unfirebase, convert to datablock storage: #56995
+    this.studioApp_.storage = initStorage(FIREBASE_STORAGE, {
       channelId: config.channel,
       firebaseName: config.firebaseName,
       firebaseAuthToken: config.firebaseAuthToken,

--- a/apps/src/storage/GetColumnParamPicker.jsx
+++ b/apps/src/storage/GetColumnParamPicker.jsx
@@ -5,6 +5,7 @@ import color from '../util/color';
 import {getStore} from '@cdo/apps/redux';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import fontConstants from '@cdo/apps/fontConstants';
+import {isFirebaseStorage} from './storage';
 
 export const ParamType = {
   TABLE: 'TABLE',
@@ -24,11 +25,13 @@ export default class GetColumnParamPicker extends React.Component {
   componentDidMount() {
     if (this.props.param === ParamType.COLUMN) {
       const reduxState = getStore().getState();
+      // TODO: post-firebase-cleanup, remove this conditional: #56994
+      // Only firebase needs tableType, datablock storage checks on the backend
+      const tableType = isFirebaseStorage()
+        ? reduxState.data.tableListMap[this.props.table]
+        : undefined;
       Applab.storage
-        .getColumnsForTable(
-          this.props.table,
-          reduxState.data.tableListMap[this.props.table]
-        )
+        .getColumnsForTable(this.props.table, tableType)
         .then(columns => this.setState({columns: columns}));
     }
   }

--- a/apps/src/storage/dataBrowser/AddKeyRow.jsx
+++ b/apps/src/storage/dataBrowser/AddKeyRow.jsx
@@ -1,5 +1,4 @@
 /** @overview Component for adding a key/value pair row. */
-import FirebaseStorage from '../firebaseStorage';
 import PendingButton from '../../templates/PendingButton';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -8,6 +7,8 @@ import dataStyles from './data-styles.module.scss';
 import classNames from 'classnames';
 import {WarningType} from '../constants';
 import msg from '@cdo/locale';
+import {refreshCurrentDataView} from './loadDataForView';
+import {storageBackend} from '../storage';
 
 const INITIAL_STATE = {
   isAdding: false,
@@ -41,10 +42,13 @@ class AddKeyRow extends React.Component {
           this.state.value,
           /* allowUnquotedStrings */ false
         );
-        FirebaseStorage.setKeyValue(
+        storageBackend().setKeyValue(
           this.state.key,
           value,
-          () => this.setState(INITIAL_STATE),
+          () => {
+            this.setState(INITIAL_STATE);
+            refreshCurrentDataView();
+          },
           err => {
             if (
               err.type === WarningType.KEY_INVALID ||

--- a/apps/src/storage/dataBrowser/AddTableRow.jsx
+++ b/apps/src/storage/dataBrowser/AddTableRow.jsx
@@ -1,4 +1,5 @@
-import FirebaseStorage from '../firebaseStorage';
+import {storageBackend} from '../storage';
+import {refreshCurrentDataView} from './loadDataForView';
 import PendingButton from '../../templates/PendingButton';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -38,10 +39,13 @@ class AddTableRow extends React.Component {
         castValue(inputString, /* allowUnquotedStrings */ false)
       );
       this.setState({isAdding: true});
-      FirebaseStorage.createRecord(
+      storageBackend().createRecord(
         this.props.tableName,
         record,
-        () => this.setState(INITIAL_STATE),
+        () => {
+          refreshCurrentDataView();
+          this.setState(INITIAL_STATE);
+        },
         msg => console.warn(msg)
       );
     } catch (e) {

--- a/apps/src/storage/dataBrowser/DataOverview.jsx
+++ b/apps/src/storage/dataBrowser/DataOverview.jsx
@@ -4,7 +4,8 @@
  * a new data table.
  */
 import {DataView, WarningType} from '../constants';
-import FirebaseStorage from '../firebaseStorage';
+import {storageBackend} from '../storage';
+import {refreshCurrentDataView} from './loadDataForView';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {changeView, showWarning} from '../redux/data';
@@ -26,9 +27,12 @@ class DataOverview extends React.Component {
   };
 
   onTableAdd = tableName => {
-    FirebaseStorage.createTable(
+    storageBackend().createTable(
       tableName,
-      () => this.props.onViewChange(DataView.TABLE, tableName),
+      () => {
+        refreshCurrentDataView();
+        this.props.onViewChange(DataView.TABLE, tableName);
+      },
       error => {
         if (
           error.type &&

--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -5,7 +5,7 @@ import AddTableRow from './AddTableRow';
 import EditTableRow from './EditTableRow';
 import ColumnHeader from './ColumnHeader';
 import DataEntryError from './DataEntryError';
-import FirebaseStorage from '../firebaseStorage';
+import {storageBackend} from '../storage';
 import FontAwesome from '../../templates/FontAwesome';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -17,6 +17,7 @@ import msg from '@cdo/locale';
 import {WarningType} from '../constants';
 import style from './data-table.module.scss';
 import classNames from 'classnames';
+import {refreshCurrentDataView} from './loadDataForView';
 
 const MAX_ROWS_PER_PAGE = 500;
 
@@ -59,10 +60,11 @@ class DataTable extends React.Component {
     this.setState({pendingAdd: true});
     // Show the spinner icon before updating the data.
     setTimeout(() => {
-      FirebaseStorage.addColumn(
+      storageBackend().addColumn(
         this.props.tableName,
         columnName,
         () => {
+          refreshCurrentDataView();
           this.setState({
             editingColumn: columnName,
             pendingAdd: false,
@@ -82,10 +84,10 @@ class DataTable extends React.Component {
     });
     // Show the spinner icon before updating the data.
     setTimeout(() => {
-      FirebaseStorage.deleteColumn(
+      storageBackend().deleteColumn(
         this.props.tableName,
         columnToRemove,
-        this.resetColumnState,
+        this.onColumnChanged,
         error => {
           console.warn(error);
           this.resetColumnState();
@@ -107,11 +109,11 @@ class DataTable extends React.Component {
     // Show the spinner icon before updating the data.
     setTimeout(() => {
       if (this.props.tableName) {
-        FirebaseStorage.renameColumn(
+        storageBackend().renameColumn(
           this.props.tableName,
           oldName,
           newName,
-          this.resetColumnState,
+          this.onColumnChanged,
           error => {
             console.warn(error);
             this.resetColumnState();
@@ -122,6 +124,11 @@ class DataTable extends React.Component {
         this.resetColumnState();
       }
     }, 0);
+  };
+
+  onColumnChanged = () => {
+    refreshCurrentDataView();
+    this.resetColumnState();
   };
 
   resetColumnState = () => {
@@ -147,11 +154,11 @@ class DataTable extends React.Component {
     });
     // Show the spinner icon before updating the data.
     setTimeout(() => {
-      FirebaseStorage.coerceColumn(
+      storageBackend().coerceColumn(
         this.props.tableName,
         columnName,
         columnType,
-        this.resetColumnState,
+        this.onColumnChanged,
         err => {
           if (err.type === WarningType.CANNOT_CONVERT_COLUMN_TYPE) {
             this.props.onShowWarning(err.msg);

--- a/apps/src/storage/dataBrowser/EditKeyRow.jsx
+++ b/apps/src/storage/dataBrowser/EditKeyRow.jsx
@@ -1,5 +1,4 @@
 /** @overview Component for editing a key/value pair row. */
-import FirebaseStorage from '../firebaseStorage';
 import PropTypes from 'prop-types';
 import React from 'react';
 import PendingButton from '../../templates/PendingButton';
@@ -7,6 +6,8 @@ import {castValue, displayableValue, editableValue} from './dataUtils';
 import dataStyles from './data-styles.module.scss';
 import classNames from 'classnames';
 import msg from '@cdo/locale';
+import {refreshCurrentDataView} from './loadDataForView';
+import {storageBackend} from '../storage';
 
 const INITIAL_STATE = {
   isDeleting: false,
@@ -49,10 +50,10 @@ class EditKeyRow extends React.Component {
         this.state.newValue,
         /* allowUnquotedStrings */ false
       );
-      FirebaseStorage.setKeyValue(
+      storageBackend().setKeyValue(
         this.props.keyName,
         newValue,
-        this.resetState,
+        this.onKeyValueChanged,
         msg => console.warn(msg)
       );
     } catch (e) {
@@ -61,17 +62,21 @@ class EditKeyRow extends React.Component {
     }
   };
 
-  resetState = () => {
+  onKeyValueChanged = () => {
     // Deleting a key/value pair could cause this component to become unmounted.
     if (this.isMounted_) {
       this.setState(INITIAL_STATE);
     }
+
+    refreshCurrentDataView();
   };
 
   handleDelete = () => {
     this.setState({isDeleting: true});
-    FirebaseStorage.deleteKeyValue(this.props.keyName, this.resetState, msg =>
-      console.warn(msg)
+    storageBackend().deleteKeyValue(
+      this.props.keyName,
+      this.onKeyValueChanged,
+      msg => console.warn(msg)
     );
   };
 

--- a/apps/src/storage/dataBrowser/EditTableListRow.jsx
+++ b/apps/src/storage/dataBrowser/EditTableListRow.jsx
@@ -1,11 +1,12 @@
 import ConfirmDeleteButton from './ConfirmDeleteButton';
 import {DataView} from '../constants';
 import EditLink from './EditLink';
-import FirebaseStorage from '../firebaseStorage';
 import PropTypes from 'prop-types';
 import React from 'react';
 import dataStyles from './data-styles.module.scss';
 import msg from '@cdo/locale';
+import {refreshCurrentDataView} from './loadDataForView';
+import {storageBackend, isFirebaseStorage} from '../storage';
 
 class EditTableListRow extends React.Component {
   static propTypes = {
@@ -19,7 +20,19 @@ class EditTableListRow extends React.Component {
   };
 
   handleDelete = () => {
-    FirebaseStorage.deleteTable(this.props.tableName, this.props.tableType);
+    // TODO: post-firebase-cleanup, remove this conditional: #56994
+    if (isFirebaseStorage()) {
+      storageBackend().deleteTable(
+        this.props.tableName,
+        this.props.tableType,
+        refreshCurrentDataView
+      );
+    } else {
+      storageBackend().deleteTable(
+        this.props.tableName,
+        refreshCurrentDataView
+      );
+    }
   };
 
   render() {

--- a/apps/src/storage/dataBrowser/EditTableRow.jsx
+++ b/apps/src/storage/dataBrowser/EditTableRow.jsx
@@ -1,4 +1,3 @@
-import FirebaseStorage from '../firebaseStorage';
 import PropTypes from 'prop-types';
 import React from 'react';
 import PendingButton from '../../templates/PendingButton';
@@ -7,6 +6,8 @@ import dataStyles from './data-styles.module.scss';
 import classNames from 'classnames';
 import _ from 'lodash';
 import msg from '@cdo/locale';
+import {refreshCurrentDataView} from './loadDataForView';
+import {storageBackend} from '../storage';
 
 const INITIAL_STATE = {
   isDeleting: false,
@@ -57,10 +58,10 @@ class EditTableRow extends React.Component {
         castValue(inputString, /* allowUnquotedStrings */ false)
       );
       this.setState({isSaving: true});
-      FirebaseStorage.updateRecord(
+      storageBackend().updateRecord(
         this.props.tableName,
         newRecord,
-        this.resetState,
+        this.onRecordChanged,
         msg => console.warn(msg)
       );
     } catch (e) {
@@ -69,11 +70,13 @@ class EditTableRow extends React.Component {
     }
   };
 
-  resetState = () => {
+  onRecordChanged = () => {
     // Deleting a row may have caused this component to become unmounted.
     if (this.isMounted_) {
       this.setState(INITIAL_STATE);
     }
+
+    refreshCurrentDataView();
   };
 
   handleEdit = () => {
@@ -85,10 +88,10 @@ class EditTableRow extends React.Component {
 
   handleDelete = () => {
     this.setState({isDeleting: true});
-    FirebaseStorage.deleteRecord(
+    storageBackend().deleteRecord(
       this.props.tableName,
       this.props.record,
-      this.resetState,
+      this.onRecordChanged,
       msg => console.warn(msg)
     );
   };

--- a/apps/src/storage/dataBrowser/loadDataForView.js
+++ b/apps/src/storage/dataBrowser/loadDataForView.js
@@ -77,8 +77,8 @@ export function loadDataForView(storage, view, oldTableName, newTableName) {
       if (isFirebaseStorage()) {
         // Firebase
         storage.subscribeToListOfProjectTables(
-          tableName =>
-            getStore().dispatch(addTableName(tableName, tableType.PROJECT)),
+          (tableName, tableType) =>
+            getStore().dispatch(addTableName(tableName, tableType)),
           tableName => getStore().dispatch(deleteTableName(tableName))
         );
       } else {

--- a/apps/src/storage/dataBrowser/loadDataForView.js
+++ b/apps/src/storage/dataBrowser/loadDataForView.js
@@ -1,0 +1,98 @@
+import {getStore} from '../../redux';
+import {DataView} from '../constants';
+import {
+  tableType,
+  addTableName,
+  deleteTableName,
+  updateTableColumns,
+  updateTableRecords,
+  updateKeyValueData,
+  updateTableList,
+} from '../redux/data';
+import {isDatablockStorage, isFirebaseStorage} from '../storage';
+
+let lastView;
+let lastTableName;
+let lastStorage;
+
+export function refreshCurrentDataView() {
+  // TODO: post-firebase-cleanup, remove if guard, but keep the contents: #56994
+  if (isDatablockStorage()) {
+    loadDataForView(lastStorage, lastView, null, lastTableName);
+  }
+}
+
+/**
+ * Given a particular view in the data sets browser, invoke appropriate
+ * commands to the storageBackend() loading the data needed for that view.
+ * @param {StorageBackend} storage - firebaseStorage or datablockStorage
+ * @param {DataView} view
+ * @param {string} oldTableName - a previously subscribed table name, for firebase to unsubscribe
+ * @param {string} newTableName - name of the table being displayed, if any
+ */
+export function loadDataForView(storage, view, oldTableName, newTableName) {
+  // TODO: post-firebase-cleanup, remove oldTableName: #56994
+
+  // Save for later use in refreshCurrentDataView()
+  lastView = view;
+  lastTableName = newTableName;
+  lastStorage = storage;
+
+  if (!getStore().getState().pageConstants.hasDataMode) {
+    throw new Error('onDataViewChange triggered without data mode enabled');
+  }
+
+  // TODO: post-firebase-cleanup, remove this conditional: #56994
+  if (isFirebaseStorage()) {
+    storage.unsubscribeFromKeyValuePairs();
+    if (oldTableName) {
+      storage.unsubscribeFromTable(oldTableName);
+    }
+  }
+
+  switch (view) {
+    case DataView.PROPERTIES: {
+      // Triggered when the Key Value Pairs tab is brought up
+      storage.getKeyValuePairs(keyValueData => {
+        getStore().dispatch(updateKeyValueData(keyValueData));
+      });
+      return;
+    }
+    case DataView.TABLE: {
+      // Triggered when we browse a specific table
+      storage.loadTable(
+        newTableName,
+        columnNames =>
+          getStore().dispatch(updateTableColumns(newTableName, columnNames)),
+        records =>
+          getStore().dispatch(updateTableRecords(newTableName, records))
+      );
+      return;
+    }
+    case DataView.OVERVIEW: {
+      // Initialize redux's list of tables from firebase, and keep it up to date as
+      // new tables are added and removed.
+
+      // TODO: post-firebase-cleanup, remove this conditional: #56994
+      if (isFirebaseStorage()) {
+        // Firebase
+        storage.subscribeToListOfProjectTables(
+          tableName =>
+            getStore().dispatch(addTableName(tableName, tableType.PROJECT)),
+          tableName => getStore().dispatch(deleteTableName(tableName))
+        );
+      } else {
+        // Datablock Storage
+        storage.getTableNames().then(tableNames => {
+          const tableListMap = Object.fromEntries(
+            tableNames.map(tableName => [tableName, tableType.PROJECT])
+          );
+          getStore().dispatch(updateTableList(tableListMap));
+        });
+      }
+      return;
+    }
+    default:
+      return;
+  }
+}

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -1,0 +1,404 @@
+import _ from 'lodash';
+
+// DatablockStorage powers the "Data" tab in App Lab and Game Lab, including the
+// datasets library, and the data blocks such as `readRecords` and `getKeyValue`.
+//
+// DatablockStorage.* methods are thin wrappers over the corresponding methods
+// found in apps/controllers/datablock_storage_controller.rb
+//
+// See datablock_storage_controller.rb for more detailed documentation.
+
+const DatablockStorage = {};
+let channelId = undefined;
+
+export function initDatablockStorage({channelId: _channelId}) {
+  channelId = _channelId;
+  return DatablockStorage;
+}
+
+function urlFor(func_name) {
+  return `/datablock_storage/${channelId}/` + func_name;
+}
+
+async function _fetch(path, method, params) {
+  let response;
+  if (method.toUpperCase() === 'GET') {
+    response = await fetch(urlFor(path) + '?' + new URLSearchParams(params), {
+      method: 'GET',
+    });
+  } else {
+    response = await fetch(urlFor(path), {
+      method,
+      body: JSON.stringify(params),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      credentials: 'same-origin',
+    });
+  }
+  if (!response.ok) {
+    throw await response.json();
+  }
+  return response;
+}
+
+async function getKeyValue(key) {
+  const response = await _fetch('get_key_value', 'GET', {key});
+  const json = await response.json();
+  return json === null ? undefined : json;
+}
+
+DatablockStorage.getKeyValue = function (key, onSuccess, onError) {
+  return getKeyValue(key).then(onSuccess, onError);
+};
+
+DatablockStorage.setKeyValue = function (key, value, onSuccess, onError) {
+  value = value === undefined ? null : value;
+  _fetch('set_key_value', 'POST', {
+    key,
+    value: JSON.stringify(value),
+  }).then(onSuccess, onError);
+};
+
+async function createRecord(tableName, record) {
+  const response = await _fetch('create_record', 'POST', {
+    table_name: tableName,
+    record_json: JSON.stringify(record),
+  });
+  return await response.json();
+}
+
+DatablockStorage.createRecord = function (
+  tableName,
+  record,
+  onSuccess,
+  onError
+) {
+  createRecord(tableName, record).then(onSuccess, onError);
+};
+
+DatablockStorage.updateRecord = function (
+  tableName,
+  record,
+  onSuccess,
+  onError
+) {
+  _fetch('update_record', 'PUT', {
+    table_name: tableName,
+    record_id: record.id,
+    record_json: JSON.stringify(record),
+  })
+    .then(response => response.json())
+    .then(record => {
+      onSuccess(record, !!record);
+    }, onError);
+};
+
+/**
+ * Returns true if record matches the given search parameters, which are a map
+ * from key name to expected value.
+ */
+function matchesSearch(record, searchParams) {
+  let matches = true;
+  Object.keys(searchParams || {}).forEach(key => {
+    matches = matches && record[key] === searchParams[key];
+  });
+  return matches;
+}
+
+function filterRecords(recordList, searchParams) {
+  return recordList.filter(record => {
+    return matchesSearch(record, searchParams);
+  });
+}
+
+async function readRecords({
+  tableName,
+  searchParams = false,
+  isSharedTable = false,
+}) {
+  const response = await _fetch('read_records', 'GET', {
+    table_name: tableName,
+    is_shared_table: isSharedTable,
+  });
+  const json = await response.json();
+  return searchParams ? filterRecords(json, searchParams) : json;
+}
+
+DatablockStorage.readRecords = function (
+  tableName,
+  searchParams,
+  onSuccess,
+  onError
+) {
+  return readRecords({tableName, searchParams}).then(onSuccess, onError);
+};
+
+DatablockStorage.deleteRecord = function (
+  tableName,
+  record,
+  onSuccess,
+  onError
+) {
+  _fetch('delete_record', 'DELETE', {
+    table_name: tableName,
+    record_id: record.id,
+  }).then(onSuccess, onError);
+};
+
+async function getTableNames({isSharedTable = false} = {}) {
+  const response = await _fetch('get_table_names', 'GET', {
+    is_shared_table: isSharedTable,
+  });
+  return await response.json();
+}
+
+// This is only called if isDatablockStorage()
+DatablockStorage.getTableNames = function () {
+  return getTableNames();
+};
+
+function loadTableAndColumns({
+  tableName,
+  isSharedTable,
+  onColumnsChanged,
+  onRecordsChanged,
+}) {
+  readRecords({tableName, isSharedTable}).then(records => {
+    getColumnsForTable({tableName, isSharedTable}).then(onColumnsChanged);
+
+    // DataTableView.getTableJson() expects an array of JSON strings
+    // which it then parses as JSON, and then stringifies again 🙈
+    // see: https://github.com/code-dot-org/code-dot-org/blob/208ed1f6733ca2524cc91bdfa696ba98c3250f47/apps/src/storage/dataBrowser/DataTableView.jsx/#L89-L93
+    //
+    // This is a relic of how our F*rebase records were stored
+    // and a future improvement might be to optimize this.
+    const recordStrings = records.map(record => JSON.stringify(record));
+    onRecordsChanged(recordStrings);
+  });
+}
+
+DatablockStorage.loadTable = function (
+  tableName,
+  onColumnsChanged,
+  onRecordsChanged
+) {
+  loadTableAndColumns({
+    tableName,
+    isSharedTable: false,
+    onColumnsChanged,
+    onRecordsChanged,
+  });
+};
+
+DatablockStorage.getKeyValuePairs = function (onKeyValuePairsChanged) {
+  _fetch('get_key_values', 'GET', {})
+    .then(response => response.json())
+    .then(json => {
+      onKeyValuePairsChanged(_.mapValues(json, value => JSON.stringify(value)));
+    });
+};
+
+DatablockStorage.previewSharedTable = function (
+  sharedTableName,
+  onColumnsChanged,
+  onRecordsChanged
+) {
+  loadTableAndColumns({
+    tableName: sharedTableName,
+    isSharedTable: true,
+    onColumnsChanged,
+    onRecordsChanged,
+  });
+};
+
+DatablockStorage.createTable = function (tableName, onSuccess, onError) {
+  _fetch('create_table', 'POST', {
+    table_name: tableName,
+  }).then(onSuccess, onError);
+};
+
+DatablockStorage.deleteTable = function (tableName, onSuccess, onError) {
+  _fetch('delete_table', 'DELETE', {
+    table_name: tableName,
+  }).then(onSuccess, onError);
+};
+
+DatablockStorage.clearTable = function (tableName, onSuccess, onError) {
+  _fetch('clear_table', 'DELETE', {
+    table_name: tableName,
+  }).then(onSuccess, onError);
+};
+
+DatablockStorage.importCsv = function (
+  tableName,
+  tableDataCsv,
+  onSuccess,
+  onError
+) {
+  _fetch('import_csv', 'POST', {
+    table_name: tableName,
+    table_data_csv: tableDataCsv,
+  }).then(onSuccess, onError);
+};
+
+DatablockStorage.exportCsvUrl = function (tableName) {
+  return (
+    urlFor('export_csv') + '?' + new URLSearchParams({table_name: tableName})
+  );
+};
+
+DatablockStorage.addColumn = function (
+  tableName,
+  columnName,
+  onSuccess,
+  onError
+) {
+  _fetch('add_column', 'POST', {
+    table_name: tableName,
+    column_name: columnName,
+  }).then(onSuccess, onError);
+};
+
+// Delete the column definition AND filters all rows to remove the offending JSON property
+DatablockStorage.deleteColumn = function (
+  tableName,
+  columnName,
+  onSuccess,
+  onError
+) {
+  _fetch('delete_column', 'DELETE', {
+    table_name: tableName,
+    column_name: columnName,
+  }).then(onSuccess, onError);
+};
+
+DatablockStorage.renameColumn = function (
+  tableName,
+  oldName,
+  newName,
+  onSuccess,
+  onError
+) {
+  _fetch('rename_column', 'PUT', {
+    table_name: tableName,
+    old_column_name: oldName,
+    new_column_name: newName,
+  }).then(onSuccess, onError);
+};
+
+DatablockStorage.coerceColumn = function (
+  tableName,
+  columnName,
+  columnType,
+  onSuccess,
+  onError
+) {
+  _fetch('coerce_column', 'PUT', {
+    table_name: tableName,
+    column_name: columnName,
+    column_type: columnType,
+  }).then(onSuccess, onError);
+};
+
+async function getColumn({tableName, columnName}) {
+  const response = await _fetch('get_column', 'GET', {
+    table_name: tableName,
+    column_name: columnName,
+  });
+  return await response.json();
+}
+
+DatablockStorage.getColumn = function (
+  tableName,
+  columnName,
+  onSuccess,
+  onError
+) {
+  return getColumn({tableName, columnName}).then(onSuccess, onError);
+};
+
+DatablockStorage.deleteKeyValue = function (key, onSuccess, onError) {
+  _fetch('delete_key_value', 'DELETE', {
+    key,
+  }).then(onSuccess, onError);
+};
+
+// Used to inject levelbuilder defined data tables into the current project (see applab.js)
+/**
+ * Populates a channel with table data for one or more tables
+ * @param {string} jsonData The json data that represents the tables in the format of:
+ *   {
+ *     "table_name": [{ "name": "Trevor", "age": 30 }, { "name": "Hadi", "age": 72}],
+ *     "table_name2": [{ "city": "Seattle", "state": "WA" }, { "city": "Chicago", "state": "IL"}]
+ *   }
+ * @returns {Promise} which resolves when all table data has been written
+ */
+DatablockStorage.populateTable = function (jsonData) {
+  return _fetch('populate_tables', 'PUT', {
+    tables_json:
+      typeof jsonData === 'string' ? jsonData : JSON.stringify(jsonData),
+  });
+};
+
+DatablockStorage.populateKeyValue = function (jsonData, onSuccess, onError) {
+  _fetch('populate_key_values', 'PUT', {
+    key_values_json: JSON.stringify(jsonData),
+  }).then(onSuccess, onError);
+};
+
+// fetch the library manifest used to populate the "Data Library" browser
+// see: datablock_storage_library_manifest.rb
+DatablockStorage.getLibraryManifest = function () {
+  return _fetch('get_library_manifest', 'GET').then(response =>
+    response.json()
+  );
+};
+
+async function getColumnsForTable({tableName, isSharedTable = false}) {
+  const response = await _fetch('get_columns_for_table', 'GET', {
+    table_name: tableName,
+    is_shared_table: isSharedTable,
+  });
+  const json = await response.json();
+  return json;
+}
+
+// returns an array of strings for each of the columns in the table
+// Note this diverges a little from the F*rebase version, which takes a tableType param
+// which we do not need since we implement this on the backend.
+DatablockStorage.getColumnsForTable = function (tableName) {
+  return getColumnsForTable({tableName});
+};
+
+// @return {Promise<boolean>} whether the project has any data in it
+DatablockStorage.projectHasData = function () {
+  return _fetch('project_has_data', 'GET', {}).then(response =>
+    response.json()
+  );
+};
+
+// deletes all datablock storage data for this project,
+// used only one place, applab.js config.afterClearPuzzle()
+DatablockStorage.clearAllData = function (onSuccess, onError) {
+  _fetch('clear_all_data', 'DELETE', {}).then(onSuccess, onError);
+};
+
+// This is a new method for DatablockStorage which replaces the above APIs
+DatablockStorage.addSharedTable = function (tableName, onSuccess, onError) {
+  _fetch('add_shared_table', 'POST', {
+    table_name: tableName,
+  }).then(onSuccess, onError);
+};
+
+/* TESTING RELATED FUNCTIONS */
+
+// Deletes the entire database for the project, including data and config
+DatablockStorage.resetForTesting = function () {
+  return _fetch('clear_all_data', 'DELETE', {});
+};
+
+DatablockStorage.resetRecordListener = function () {};
+
+export default DatablockStorage;

--- a/apps/src/storage/firebaseCounters.js
+++ b/apps/src/storage/firebaseCounters.js
@@ -1,3 +1,5 @@
+// TODO: post-firebase-cleanup, remove this file #56994
+
 import Firebase from 'firebase';
 import {
   loadConfig,

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -1,3 +1,5 @@
+// TODO: post-firebase-cleanup, remove this file #56994
+
 import {getProjectDatabase, getPathRef} from './firebaseUtils';
 import _ from 'lodash';
 

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -1107,7 +1107,7 @@ FirebaseStorage.subscribeToListOfProjectTables = function (
     let tableName =
       typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key;
     tableName = unescapeFirebaseKey(tableName); // TODO: unfirebase
-    onTableAdded(tableName);
+    onTableAdded(tableName, tableType.PROJECT);
   });
   tableRef.on('child_removed', snapshot => {
     let tableName =
@@ -1128,7 +1128,7 @@ FirebaseStorage.subscribeToListOfProjectTables = function (
     let tableName =
       typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key;
     tableName = unescapeFirebaseKey(tableName);
-    onTableAdded(tableName);
+    onTableAdded(tableName, tableType.SHARED);
   });
   currentTableRef.on('child_removed', snapshot => {
     let tableName =

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -1,3 +1,5 @@
+// TODO: post-firebase-cleanup, remove this file #56994
+
 import {
   ColumnType,
   castValue,
@@ -18,6 +20,7 @@ import {
   isInitialized,
   validateFirebaseKey,
   getPathRef,
+  unescapeFirebaseKey,
 } from './firebaseUtils';
 import {
   enforceTableCount,
@@ -33,9 +36,20 @@ import {
   getColumnsRef,
   getColumnNamesFromRecords,
   getColumnNamesSnapshot,
+  onColumnsChange,
 } from './firebaseMetadata';
 import {tableType} from './redux/data';
 import {WarningType} from './constants';
+import _ from 'lodash';
+
+// TODO: unfirebase: ideally we would not have a back-reference to redux here, however
+// coupling firebaseStorage to redux made the datablock storage version much cleaner,
+// and since this code is being removed once we're done migrating, it was preferable
+// to make firebaseStorage.js ugly rather than the datablockStorage.js API ugly.
+//
+// We only use getStore to sniff if the table is a shared table or not, whereas in
+// datablock storage, we check this on the backend and hide the abstraction.
+import {getStore} from '../redux';
 
 /**
  * Namespace for Firebase storage.
@@ -63,7 +77,7 @@ FirebaseStorage.getColumnsForTable = function (tableName, tableType) {
 /**
  * @return {Promise<boolean>} whether the project channel exists
  */
-FirebaseStorage.channelExists = function () {
+FirebaseStorage.projectHasData = function () {
   return getProjectDatabase()
     .once('value')
     .then(snapshot => snapshot.val() !== null);
@@ -540,6 +554,14 @@ FirebaseStorage.resetForTesting = function () {
   resetConfigForTesting();
 };
 
+// Current tables are live updated, the data is NOT copied into
+// the student project, instead a new type of firebase node is created
+// like /v3/channels/{channelId}/current_tables/Daily Weather
+// as opposed to a normal table that would be like
+// /v3/channels/{channelId}/storage/tables/Daily Weather
+//
+// Current tables can be found in https://console.firebase.google.com/project/cdo-v3-shared/database/cdo-v3-shared/data/~2Fv3~2Fchannels~2Fshared~2Fmetadata~2Fmanifest~2Ftables
+// where the table has `current: true` set in the manifest object
 FirebaseStorage.addCurrentTableToProject = function (
   tableName,
   onSuccess,
@@ -557,6 +579,7 @@ FirebaseStorage.addCurrentTableToProject = function (
     .then(onSuccess, onError);
 };
 
+// TODO: unfirebase, this method is not found in DatablockStorage
 FirebaseStorage.copyStaticTable = function (tableName, onSuccess, onError) {
   return enforceUniqueTableNames(tableName)
     .then(incrementRateLimitCounters)
@@ -655,6 +678,8 @@ FirebaseStorage.createTable = function (tableName, onSuccess, onError) {
  * @param {function ()} onSuccess
  * @param {function (string)} onError
  */
+// TODO: unfirebase, note that this diverges from DatablockStorage.deleteTable
+// which doesn't take a `type` parameter, since that's handled on the backend
 FirebaseStorage.deleteTable = function (tableName, type, onSuccess, onError) {
   if (type === tableType.SHARED) {
     getPathRef(getProjectDatabase(), `current_tables/${tableName}`)
@@ -1067,6 +1092,161 @@ FirebaseStorage.importCsv = function (
     .then(recordsData => validateRecordsData(recordsData))
     .then(recordsData => overwriteTableData(tableName, recordsData))
     .then(onSuccess, onError);
+};
+
+// Initialize redux's list of tables from firebase, and keep it up to date as
+// new tables are added and removed.
+// TODO: unfirebase, this is ONLY implemented in FirebaseStorage, not DatablockStorage
+FirebaseStorage.subscribeToListOfProjectTables = function (
+  onTableAdded,
+  onTableRemoved
+) {
+  // Subscribe to the list of regular tables in the current project
+  const tableRef = getPathRef(getProjectDatabase(), 'counters/tables');
+  tableRef.on('child_added', snapshot => {
+    let tableName =
+      typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key;
+    tableName = unescapeFirebaseKey(tableName); // TODO: unfirebase
+    onTableAdded(tableName);
+  });
+  tableRef.on('child_removed', snapshot => {
+    let tableName =
+      typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key;
+    tableName = unescapeFirebaseKey(tableName); // TODO: unfirebase
+    onTableRemoved(tableName);
+  });
+
+  // Subscribe to the list of shared tables, aka "current tables"
+  // these are like "Spotify Viral 50", but we'll also put deduped
+  // stock tables here
+
+  // /v3/channels/<channel_id>/current_tables tracks which
+  // current tables the project has imported. Here we initialize the
+  // redux list of current tables and keep it in sync
+  let currentTableRef = getPathRef(getProjectDatabase(), 'current_tables');
+  currentTableRef.on('child_added', snapshot => {
+    let tableName =
+      typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key;
+    tableName = unescapeFirebaseKey(tableName);
+    onTableAdded(tableName);
+  });
+  currentTableRef.on('child_removed', snapshot => {
+    let tableName =
+      typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key;
+    tableName = unescapeFirebaseKey(tableName);
+    onTableRemoved(tableName);
+  });
+};
+
+FirebaseStorage.getKeyValuePairs = function (onKeyValuePairsChanged) {
+  const projectStorageRef = getPathRef(getProjectDatabase(), 'storage');
+
+  getPathRef(projectStorageRef, 'keys').on('value', snapshot => {
+    if (snapshot) {
+      let keyValueData = snapshot.val();
+      // "if all of the keys are integers, and more than half of the keys between 0 and
+      // the maximum key in the object have non-empty values, then Firebase will render
+      // it as an array."
+      // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
+      // Coerce it to an object here, if needed, so we can unescape the keys
+      if (Array.isArray(keyValueData)) {
+        keyValueData = Object.assign({}, keyValueData);
+      }
+      keyValueData = _.mapKeys(keyValueData, (_, key) =>
+        unescapeFirebaseKey(key)
+      );
+      onKeyValuePairsChanged(keyValueData);
+    }
+  });
+};
+
+FirebaseStorage.loadTable = function (
+  tableName,
+  onColumnsChanged,
+  onRecordsChanged
+) {
+  // This is an ugly coupling, we use getStore() from redux to check if this is a shared table or not
+  // this code is not required in the DatablockStorage version, because the backend does the switching
+  // and hides it from the frontend.
+  let newTableType = getStore().getState().data.tableListMap[tableName];
+
+  const db =
+    newTableType === tableType.PROJECT
+      ? getProjectDatabase()
+      : getSharedDatabase();
+
+  // subscribe to records
+  getPathRef(db, `storage/tables/${tableName}/records`).on(
+    'value',
+    snapshot => {
+      onRecordsChanged(snapshot.val());
+    }
+  );
+
+  // subscribe to columns
+  onColumnsChange(db, tableName, columnNames => {
+    onColumnsChanged(columnNames);
+  });
+};
+
+FirebaseStorage.previewSharedTable = function (
+  sharedTableName,
+  onColumnsChanged,
+  onRecordsChanged
+) {
+  const db = getSharedDatabase();
+
+  // load records, note only once
+  getPathRef(db, `storage/tables/${sharedTableName}/records`).once(
+    'value',
+    snapshot => {
+      onRecordsChanged(snapshot.val());
+    }
+  );
+
+  // subscribe to columns
+  onColumnsChange(db, sharedTableName, columnNames => {
+    onColumnsChanged(columnNames);
+  });
+};
+
+// Unsubscribe Firebase from a table
+// TODO: unfirebase, this is ONLY implemented in FirebaseStorage, not DatablockStorage
+FirebaseStorage.unsubscribeFromTable = function (tableName) {
+  const projectStorageRef = getPathRef(getProjectDatabase(), 'storage');
+  const sharedStorageRef = getPathRef(getSharedDatabase(), 'storage');
+
+  // Unlisten from previous data view. This should not interfere with events listened to
+  // by onRecordEvent, which listens for added/updated/deleted events, whereas we are
+  // only unlistening from 'value' events here.
+  getPathRef(projectStorageRef, `tables/${tableName}/records`).off('value');
+  getPathRef(sharedStorageRef, `tables/${tableName}/records`).off('value');
+  getColumnsRef(getProjectDatabase(), tableName).off();
+};
+
+// TODO: unfirebase, this is ONLY implemented in FirebaseStorage, not DatablockStorage
+FirebaseStorage.unsubscribeFromKeyValuePairs = function () {
+  const projectStorageRef = getPathRef(getProjectDatabase(), 'storage');
+  getPathRef(projectStorageRef, 'keys').off('value');
+};
+
+// This method was added so it could be optimized in the DatablockStorage version
+FirebaseStorage.getColumn = function (
+  tableName,
+  columnName,
+  onSuccess,
+  onError
+) {
+  this.readRecords(
+    tableName,
+    {},
+    records => {
+      let columnValues = [];
+      records.forEach(row => columnValues.push(row[columnName]));
+      onSuccess(columnValues);
+    },
+    onError
+  );
 };
 
 export default FirebaseStorage;

--- a/apps/src/storage/redux/data.js
+++ b/apps/src/storage/redux/data.js
@@ -6,6 +6,7 @@
 import {Record} from 'immutable';
 import {DataView} from '../constants';
 
+const UPDATE_TABLE_LIST = 'data/UPDATE_TABLE_LIST';
 const ADD_TABLE_NAME = 'data/ADD_TABLE_NAME';
 const CHANGE_VIEW = 'data/CHANGE_VIEW';
 const DELETE_TABLE_NAME = 'data/DELETE_TABLE_NAME';
@@ -45,6 +46,8 @@ const initialState = new DataState();
 
 export default function (state = initialState, action) {
   switch (action.type) {
+    case UPDATE_TABLE_LIST:
+      return state.set('tableListMap', action.tableListMap);
     case ADD_TABLE_NAME:
       return state.set(
         'tableListMap',
@@ -119,6 +122,11 @@ export default function (state = initialState, action) {
       return state;
   }
 }
+
+export const updateTableList = tableListMap => ({
+  type: UPDATE_TABLE_LIST,
+  tableListMap,
+});
 
 /**
  * Action which adds a table name to the table list map, if it doesn't exist already.

--- a/apps/src/storage/storage.js
+++ b/apps/src/storage/storage.js
@@ -1,0 +1,46 @@
+import DatablockStorage, {initDatablockStorage} from './datablockStorage';
+import FirebaseStorage, {initFirebaseStorage} from './firebaseStorage';
+
+export const DATABLOCK_STORAGE = 'DatablockStorage';
+export const FIREBASE_STORAGE = 'FirebaseStorage';
+
+export let type;
+export let isInitialized = false;
+
+export function isDatablockStorage() {
+  return getStorageType() === DATABLOCK_STORAGE;
+}
+
+// TODO: post-firebase-cleanup, remove this function: #56994
+export function isFirebaseStorage() {
+  return getStorageType() === FIREBASE_STORAGE;
+}
+
+export function getStorageType() {
+  return type;
+}
+
+export function storageBackend() {
+  // TODO: post-firebase-cleanup, remove this conditional: #56994
+  if (type === DATABLOCK_STORAGE) {
+    return DatablockStorage;
+  } else if (type === FIREBASE_STORAGE) {
+    return FirebaseStorage;
+  } else {
+    throw new Error(`Unknown storage type: ${type}`);
+  }
+}
+
+export function initStorage(storageType, config) {
+  type = storageType;
+  // TODO: post-firebase-cleanup, remove this conditional: #56994
+  if (storageType === DATABLOCK_STORAGE) {
+    isInitialized = true;
+    return initDatablockStorage(config);
+  } else if (storageType === FIREBASE_STORAGE) {
+    isInitialized = true;
+    return initFirebaseStorage(config);
+  } else {
+    throw new Error(`Unknown storage type: ${storageType}`);
+  }
+}

--- a/apps/test/integration/levelSolutions/applab1/ec_data_blocks.js
+++ b/apps/test/integration/levelSolutions/applab1/ec_data_blocks.js
@@ -38,6 +38,38 @@ export default {
     },
 
     {
+      description: 'Data getColumn',
+      editCode: true,
+      xml: `
+        createRecord("mytable", {name:'Alice'}, function(record) {
+          createRecord("mytable", {name: 'Bob'}, function (record) {
+            var names = getColumn('mytable', 'name');
+            console.log("getColumn returned: " + names.join(', '));
+          });
+        });`,
+
+      runBeforeClick(assert) {
+        // add a completion on timeout since this is a freeplay level
+        tickWrapper.runOnAppTick(Applab, 200, () => {
+          Applab.onPuzzleComplete();
+        });
+      },
+      customValidator(assert) {
+        // No errors in output console
+        const debugOutput = document.getElementById('debug-output');
+        assert.equal(
+          debugOutput.textContent,
+          '"getColumn returned: Alice, Bob"'
+        );
+        return true;
+      },
+      expected: {
+        result: true,
+        testResult: TestResults.FREE_PLAY,
+      },
+    },
+
+    {
       description: 'Data createRecord again to confirm mock is reset',
       editCode: true,
       xml: `

--- a/apps/test/integration/levelTests.js
+++ b/apps/test/integration/levelTests.js
@@ -22,7 +22,10 @@ import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import progress from '@cdo/apps/code-studio/progressRedux';
 import currentUser from '@cdo/apps/templates/currentUserRedux';
 import arrowDisplay from '@cdo/apps/templates/arrowDisplayRedux';
-import FirebaseStorage from '@cdo/apps/storage/firebaseStorage';
+import {
+  isInitialized as isStorageInitialized,
+  storageBackend,
+} from '@cdo/apps/storage/storage';
 import LegacyDialog from '@cdo/apps/code-studio/LegacyDialog';
 import loadSource from './util/loadSource';
 import projectRedux from '@cdo/apps/code-studio/projectRedux';
@@ -211,12 +214,9 @@ describe('Level tests', function () {
       window.Studio.interpreter = null;
     }
 
-    // Firebase is only used by Applab tests, but we don't have a reliable way
-    // to test for the app type here because window.Applab is always defined
-    // because loadApplab is always required (the same is true for other app
-    // types). Therefore, rely on FirebaseStorage to defensively reset itself.
-
-    FirebaseStorage.resetForTesting();
+    if (isStorageInitialized) {
+      storageBackend().resetForTesting();
+    }
 
     LegacyDialog.prototype.hide.restore();
     LegacyDialog.prototype.show.restore();

--- a/apps/test/unit/storage/FirebaseStorageTest.js
+++ b/apps/test/unit/storage/FirebaseStorageTest.js
@@ -1,3 +1,5 @@
+// TODO: post-firebase-cleanup, remove this file #56994
+
 import {expect} from '../../util/reconfiguredChai';
 import {initFirebaseStorage} from '@cdo/apps/storage/firebaseStorage';
 import {WarningType} from '@cdo/apps/storage/constants';

--- a/apps/webpackKarma.config.js
+++ b/apps/webpackKarma.config.js
@@ -35,6 +35,7 @@ const karmaConfig = {
             localeDoNotImportTest('@cdo/weblab/locale'),
           ]),
           ...{
+            // TODO: post-firebase-cleanup, remove this: #56994
             firebase: path.resolve(__dirname, 'test/util/MockFirebase.js'),
             // Use mock-firmata to unit test playground-io maker components
             firmata: 'mock-firmata/mock-firmata',

--- a/bin/cron/applab_datasets/covid19
+++ b/bin/cron/applab_datasets/covid19
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+# TODO: unfirebase, also update datablock storage: #56993
+# TODO: post-firebase-cleanup, remove the firebase version: #56994
+
 # This script fetches covid19 data and uploads to the shared firebase channel.
 require_relative '../../../deployment'
 require 'cdo/only_one'
@@ -7,6 +10,8 @@ require 'net/http'
 require 'csv'
 require 'date'
 require 'datapackage'
+
+# TODO: post-firebase-cleanup, remove the firebase reference: #56994
 require_relative '../../../dashboard/legacy/middleware/helpers/firebase_helper'
 
 US_DATA_URL = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv"
@@ -103,6 +108,7 @@ def get_world_covid19_data
 end
 
 def main
+  # TODO: post-firebase-cleanup, remove the firebase reference: #56994
   fb = FirebaseHelper.new('shared')
   records, columns = get_us_covid19_data
   fb.upload_live_table('COVID-19 Cases per US State', records, columns)

--- a/bin/cron/applab_datasets/daily_weather
+++ b/bin/cron/applab_datasets/daily_weather
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
+
+# TODO: unfirebase, also update datablock storage: #56993
+# TODO: post-firebase-cleanup, remove the firebase version: #56994
+
 require_relative '../only_one'
 abort 'Script already running' unless only_one_running?(__FILE__)
 
@@ -8,7 +12,8 @@ require 'net/http'
 require 'json'
 require 'ostruct'
 require 'date'
-require_relative '../../../dashboard/legacy/middleware/helpers/firebase_helper'
+# TODO: post-firebase-cleanup, remove the firebase reference: #56994
+require_relative '../../../dashboard/legacy/middleware/helpers/firebase_helper' # TODO: unfirebase, remaining firebase reference
 require 'honeybadger/ruby'
 
 WeatherForecastOffice = Struct.new(:city, :state, :zip_code)
@@ -207,6 +212,7 @@ def get_weather_data
 end
 
 def main
+  # TODO: post-firebase-cleanup, remove the firebase reference: #56994
   fb = FirebaseHelper.new('shared')
   records, columns = get_weather_data
   if records.empty?

--- a/bin/cron/applab_datasets/spotify
+++ b/bin/cron/applab_datasets/spotify
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
+
+# TODO: unfirebase, also update datablock storage: #56993
+# TODO: post-firebase-cleanup, remove the firebase version: #56994
+
 require_relative '../only_one'
 abort 'Script already running' unless only_one_running?(__FILE__)
 
@@ -11,6 +15,7 @@ abort 'Script already running' unless only_one_running?(__FILE__)
 
 require_relative '../../../deployment'
 require 'ostruct'
+# TODO: post-firebase-cleanup, remove the firebase reference: #56994
 require_relative '../../../dashboard/legacy/middleware/helpers/firebase_helper'
 require 'cdo/profanity_filter'
 require 'rest-client'
@@ -130,6 +135,7 @@ end
 
 def main
   get_token
+  # TODO: post-firebase-cleanup, remove the firebase reference: #56994
   fb = FirebaseHelper.new('shared')
 
   if $token.nil? || $token.empty?

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -1,0 +1,347 @@
+# DatablockStorage is the backend for the 'Data' tab of Applab, the 'Data' blocks
+# and the data browser. DatablockStorage stores student-controlled data generated
+# by and with the data blocks like `createRecord`, `updateRecord`, `setKeyValue`, etc.
+#
+# These backend methods are accessed exclusively by a thin wrapper on the JS side:
+# datablockStorage.js. Each method in this controller has a corresponding method there.
+#
+# Methods in this controller are available as (see `:datablock_storage` in routes.rb):
+# /datablock_storage/:channel_id/:method_name
+#
+# Student data is stored in MySQL in corresponding ActiveRecord models:
+# - datablock_storage_table.rb: stores a list of tables and their columns, after this file
+#   this model contains the most code.
+# - datablock_storage_record.rb: stores the records in each table
+# - datablock_storage_kvp.rb: stores key-value pairs
+#
+# Metadata for the code.org defined datasets are stored in:
+# - datablock_storage_library_manifest.rb
+#
+# Methods are broken into sections, for example the Key-Value-Pair API, Table API,
+# Table Column API, Table Record API, Library Manifest API & Project API
+#
+# More details can be found in the PR that initially created Datablock Storage:
+# https://github.com/code-dot-org/code-dot-org/pull/56279
+
+class DatablockStorageController < ApplicationController
+  before_action :validate_channel_id
+  before_action :authenticate_user!
+  skip_before_action :verify_authenticity_token
+
+  StudentFacingError = DatablockStorageTable::StudentFacingError
+
+  # A StudentFacingError can be thrown by any of the Datablock Storage models
+  # and indicates that the error should show up in the Applab "Debug Console".
+  #
+  # Here we catch any of these errors, and return it in the expected JSON format to
+  # datablockStorage.js, who in turn calls its onError() callback with appropriate data.
+  rescue_from StudentFacingError do |exception|
+    render json: {msg: exception.message, type: exception.type}, status: :bad_request
+  end
+
+  # We only permit requests to /datablock_storage/:channel_id for projects with
+  # the appropriate project_type (aka game.app).
+  SUPPORTED_PROJECT_TYPES = [
+    Game::APPLAB,
+    Game::GAMELAB,
+  ]
+
+  ##########################################################
+  #   Debug View                                           #
+  ##########################################################
+  def index
+    @key_value_pairs = DatablockStorageKvp.where(project_id: @project_id)
+    @records = DatablockStorageRecord.where(project_id: @project_id)
+    @tables = DatablockStorageTable.where(project_id: @project_id)
+    @library_manifest = DatablockStorageLibraryManifest.instance.library_manifest
+    @storage_backend = ProjectUseDatablockStorage.use_data_block_storage_for?(params[:channel_id]) ? "Datablock Storage" : "Firebase"
+  end
+
+  ##########################################################
+  #   Key-Value-Pair API                                   #
+  ##########################################################
+
+  def set_key_value
+    raise StudentFacingError, "The value is too large. The maximum allowable size is #{DatablockStorageKvp::MAX_VALUE_LENGTH} bytes" if params[:value].length > DatablockStorageKvp::MAX_VALUE_LENGTH
+    value = JSON.parse params[:value]
+    DatablockStorageKvp.set_kvp @project_id, params[:key], value
+    render json: {key: params[:key], value: value}
+  end
+
+  def get_key_value
+    kvp = DatablockStorageKvp.find_by(project_id: @project_id, key: params[:key])
+    render json: kvp ? JSON.parse(kvp.value).to_json : nil
+  end
+
+  def delete_key_value
+    key = params[:key]
+    DatablockStorageKvp.where(project_id: @project_id, key: key).delete_all
+
+    render json: true
+  end
+
+  def get_key_values
+    kvps = DatablockStorageKvp.get_kvps(@project_id)
+    render json: kvps
+  end
+
+  def populate_key_values
+    key_values_json = JSON.parse params[:key_values_json]
+    raise "key_values_json must be a hash" unless key_values_json.is_a? Hash
+
+    DatablockStorageKvp.set_kvps(@project_id, key_values_json, upsert: false)
+
+    render json: true
+  rescue JSON::ParserError => exception
+    raise StudentFacingError, "SyntaxError #{exception.message}\n while parsing initial key/value data: #{params[:key_values_json]}"
+  end
+
+  ##########################################################
+  #   Table API                                            #
+  ##########################################################
+
+  def create_table
+    table_or_create
+
+    render json: true
+  end
+
+  # Imports a table from the Data Library into the student's project
+  def add_shared_table
+    DatablockStorageTable.add_shared_table @project_id, params[:table_name]
+
+    render json: true
+  rescue ActiveRecord::RecordNotUnique
+    raise StudentFacingError.new(:DUPLICATE_TABLE_NAME), "There is already a table with name #{params[:table_name].inspect}"
+  end
+
+  def import_csv
+    table = table_or_create
+
+    # import_csv should overwrite existing data:
+    table.records.delete_all
+
+    table.import_csv params[:table_data_csv]
+    table.save!
+
+    render json: true
+  end
+
+  def export_csv
+    table_name = params[:table_name]
+    response.headers['Content-Disposition'] = "attachment; filename=\"#{table_name}.csv\""
+    response.headers['Content-Type'] = 'text/csv'
+
+    table = find_table
+    render plain: table.export_csv
+  end
+
+  def clear_table
+    table = find_table
+    table.records.delete_all
+    table.save!
+
+    render json: true
+  end
+
+  def delete_table
+    find_table.destroy
+
+    render json: true
+  end
+
+  def get_table_names
+    table_names = shared_table? ?
+      DatablockStorageTable.get_shared_table_names :
+      DatablockStorageTable.get_table_names(@project_id)
+
+    render json: table_names
+  end
+
+  # populate_tables is used by levelbuilder to inject curriculum defined
+  # initial table data into a project.
+  def populate_tables
+    tables_json = JSON.parse params[:tables_json]
+    DatablockStorageTable.populate_tables @project_id, tables_json
+    render json: true
+  rescue JSON::ParserError => exception
+    raise StudentFacingError, "SyntaxError #{exception.message}\n while parsing initial table data: #{params[:tables_json]}"
+  end
+
+  ##########################################################
+  #   Table Column API                                     #
+  ##########################################################
+
+  def add_column
+    table = find_table
+    table.add_column params[:column_name]
+    table.save!
+
+    render json: true
+  end
+
+  def rename_column
+    table = find_table
+    table.rename_column params[:old_column_name], params[:new_column_name]
+    table.save!
+
+    render json: true
+  end
+
+  # Typecast a column
+  def coerce_column
+    table = find_table
+    table.coerce_column params[:column_name], params[:column_type]
+    table.save!
+
+    render json: true
+  end
+
+  def delete_column
+    table = find_table
+    table.delete_column params[:column_name]
+    table.save!
+
+    render json: true
+  end
+
+  def get_column
+    table = find_table
+    column = table.get_column params[:column_name]
+    render json: column
+  rescue StudentFacingError
+    render json: nil # javascript expects null returned to indicate a table doesn't exists error
+  end
+
+  def get_columns_for_table
+    table = find_table_or_shared_table
+    render json: table.get_columns
+  end
+
+  ##########################################################
+  #   Table Record API                                     #
+  ##########################################################
+
+  def create_record
+    raise StudentFacingError, "The record is too large. The maximum allowable size is #{DatablockStorageRecord::MAX_RECORD_LENGTH} bytes" if params[:record_json].length > DatablockStorageRecord::MAX_RECORD_LENGTH
+    record_json = JSON.parse params[:record_json]
+    raise "record must be a hash" unless record_json.is_a? Hash
+
+    table = table_or_create
+    table.create_records [record_json]
+    table.save!
+
+    render json: record_json
+  end
+
+  def read_records
+    table = find_table_or_shared_table
+
+    render json: table.read_records.map(&:record_json)
+  end
+
+  def update_record
+    raise StudentFacingError, "The record is too large. The maximum allowable size is #{DatablockStorageRecord::MAX_RECORD_LENGTH} bytes" if params[:record_json].length > DatablockStorageRecord::MAX_RECORD_LENGTH
+
+    table = find_table
+    record_json = table.update_record params[:record_id], JSON.parse(params[:record_json])
+    table.save!
+
+    render json: record_json
+  end
+
+  def delete_record
+    table = find_table
+    begin
+      table.delete_record params[:record_id]
+    rescue ActiveRecord::RecordNotFound
+      raise StudentFacingError, "You tried to delete a record with id \"#{params[:record_id]}\" from table \"#{table.table_name}\" but no recording matching that ID could be found."
+    end
+    table.save!
+    render json: nil
+  end
+
+  ##########################################################
+  #   Library Manifest API (shared table metadata)         #
+  ##########################################################
+
+  def get_library_manifest
+    render json: DatablockStorageLibraryManifest.instance.library_manifest
+  end
+
+  def set_library_manifest
+    library_manifest = JSON.parse params[:library_manifest]
+    DatablockStorageLibraryManifest.instance.update!(library_manifest: library_manifest)
+    render json: true
+  end
+
+  ##########################################################
+  #   Project API                                          #
+  ##########################################################
+
+  # Returns true if there is any data for the project
+  def project_has_data
+    is_there_data = DatablockStorageTable.exists?(project_id: @project_id) || DatablockStorageKvp.exists?(project_id: @project_id)
+    render json: is_there_data
+  end
+
+  # Deletes all datablock storage data for the project
+  def clear_all_data
+    DatablockStorageTable.where(project_id: @project_id).delete_all
+    DatablockStorageKvp.where(project_id: @project_id).delete_all
+    DatablockStorageRecord.where(project_id: @project_id).delete_all
+    render json: true
+  end
+
+  ##########################################################
+  #   Project Use Datablock Storage API                    #
+  ##########################################################
+
+  # TODO: post-firebase-cleanup, remove this code: #56994
+  def use_datablock_storage
+    ProjectUseDatablockStorage.set_data_block_storage_for!(params[:channel_id], true)
+    render json: true
+  end
+
+  # TODO: post-firebase-cleanup, remove this code: #56994
+  def use_firebase_storage
+    ProjectUseDatablockStorage.set_data_block_storage_for!(params[:channel_id], false)
+    render json: true
+  end
+
+  ##########################################################
+  #   Private                                              #
+  ##########################################################
+
+  private def shared_table?
+    ActiveRecord::Type::Boolean.new.cast(params[:is_shared_table])
+  end
+
+  private def find_table_or_shared_table
+    shared_table? ?
+      DatablockStorageTable.find_shared_table(params[:table_name]) :
+      find_table
+  end
+
+  private def find_table
+    DatablockStorageTable.find([@project_id, params[:table_name]])
+  rescue ActiveRecord::RecordNotFound
+    raise StudentFacingError, "You tried to use a table called \"#{params[:table_name]}\" but that table doesn't exist in this app"
+  end
+
+  private def where_table
+    DatablockStorageTable.where(project_id: @project_id, table_name: params[:table_name])
+  end
+
+  private def table_or_create
+    where_table.first_or_create
+  end
+
+  private def validate_channel_id
+    project = Project.find_by_channel_id(params[:channel_id])
+    unless SUPPORTED_PROJECT_TYPES.include? project.project_type
+      raise "DatablockStorage is only available for applab and gamelab projects"
+    end
+    @project_id = project.id
+  end
+end

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -1,3 +1,6 @@
+# TODO: unfirebase, migrate this to datablock storage, ok to be migrated but not enabled: #56998
+# TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
+
 require 'json'
 require 'uri'
 

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -161,6 +161,8 @@ class LevelsController < ApplicationController
     @in_script = @level.script_levels.any? || any_parent_in_script
     @standalone = ProjectsController::STANDALONE_PROJECTS.values.map {|h| h[:name]}.include?(@level.name)
     if @level.is_a? Applab
+      # TODO: unfirebase, migrate this to datablock storage, ok to be migrated but not enabled: #56998
+      # TODO: post-firebase-cleanup, remove this code: #56994
       fb = FirebaseHelper.new('shared')
       @dataset_library_manifest = fb.get_library_manifest
     end

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -532,10 +532,11 @@ class ProjectsController < ApplicationController
 
   def export_config
     return if redirect_under_13_without_tos_teacher(@level)
+    # TODO: post-firebase-cleanup, remove both branches of this conditional: #56994
     if params[:script_call]
-      render js: "#{params[:script_call]}(#{firebase_options.to_json});"
+      render js: "#{params[:script_call]}(#{datablock_storage_options.to_json});"
     else
-      render json: firebase_options
+      render json: datablock_storage_options
     end
   end
 

--- a/dashboard/app/models/datablock_storage_kvp.rb
+++ b/dashboard/app/models/datablock_storage_kvp.rb
@@ -1,0 +1,59 @@
+# == Schema Information
+#
+# Table name: datablock_storage_kvps
+#
+#  project_id :integer          not null, primary key
+#  key        :string(700)      not null, primary key
+#  value      :json
+#
+# Indexes
+#
+#  index_datablock_storage_kvps_on_project_id  (project_id)
+#
+class DatablockStorageKvp < ApplicationRecord
+  # Stores student-owned KVP data for App Lab's data features, see datablock_storage_controller.rb
+  # Each key-value-pair is per-project, and is stored as a row in the table,
+  # which has a key column and a value column.
+
+  self.primary_keys = :project_id, :key
+
+  StudentFacingError = DatablockStorageTable::StudentFacingError
+
+  # TODO: #56999, implement enforcement of MAX_VALUE_LENGTH, we already have
+  # a test for it, but we're skipping it until this is implemented.
+  MAX_VALUE_LENGTH = 4096
+
+  # TODO: #57000, implement encforement of MAX_NUM_KVPS. We didn't find enfocrement
+  # of this in Firebase in our initial exploration, so we may need to partly pick
+  # a value here and start enforcing it, previous exploration:
+  # https://github.com/code-dot-org/code-dot-org/issues/55554#issuecomment-1876143286
+  MAX_NUM_KVPS = 20000 # does firebase already have a  limit? this matches max num table rows
+
+  def self.get_kvps(project_id)
+    where(project_id: project_id).
+      select(:key, :value).
+      to_h {|kvp| [kvp.key, JSON.parse(kvp.value)]}
+  end
+
+  def self.set_kvps(project_id, key_value_hashmap, upsert: true)
+    kvps = key_value_hashmap.map do |key, value|
+      {project_id: project_id, key: key, value: value.to_json}
+    end
+
+    if upsert
+      # This should generate a single MySQL insert statement using `ON DUPLICATE KEY UPDATE`
+      DatablockStorageKvp.upsert_all(kvps)
+    else
+      DatablockStorageKvp.insert_all(kvps)
+    end
+  end
+
+  def self.set_kvp(project_id, key, value)
+    if value.nil?
+      # Setting a key to null deletes it
+      DatablockStorageKvp.where(project_id: project_id, key: key).delete_all
+    else
+      DatablockStorageKvp.set_kvps(project_id, {key => value}, upsert: true)
+    end
+  end
+end

--- a/dashboard/app/models/datablock_storage_library_manifest.rb
+++ b/dashboard/app/models/datablock_storage_library_manifest.rb
@@ -1,0 +1,80 @@
+# == Schema Information
+#
+# Table name: datablock_storage_library_manifest
+#
+#  id               :bigint           not null, primary key
+#  library_manifest :json
+#  singleton_guard  :integer          not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  index_datablock_storage_library_manifest_on_singleton_guard  (singleton_guard) UNIQUE
+
+class DatablockStorageLibraryManifest < ApplicationRecord
+  # A one-row table storing a singleton JSON `library_manifest`` that
+  # describes all Data Library datasets and categories, example data:
+  #
+  # library_manifest = {
+  #   categories: [
+  #     {
+  #       datasets: [
+  #         '100 Birds of the World',
+  #         'Cats',
+  #         'Dogs',
+  #       ],
+  #       name: 'Animals',
+  #       published: true,
+  #     },
+  #   ],
+  #   tables: [
+  #     {
+  #       description:
+  #         'Data and images about 100 different species of birds around the world',
+  #       docUrl: 'https://studio.code.org/data_docs/100-birds/',
+  #       name: '100 Birds of the World',
+  #       published: true,
+  #     },
+  #   ],
+  # };
+  #
+  # See: `DatasetController` (Ruby) and `DatablockStorage.getLibraryManifest` (JS)
+
+  self.table_name = 'datablock_storage_library_manifest'
+
+  # DatablockStorageLibraryManifest is a singleton, only one-row allowed in the table
+  # with the unique `singleton_guard` value of 0
+  validates_inclusion_of :singleton_guard, in: [0]
+  validate :validate_library_manifest
+
+  after_initialize :set_default_library_manifest, if: :new_record?
+
+  # DatablockStorageLibraryManifest.instance returns the singleton row
+  def self.instance
+    first_or_create!(singleton_guard: 0)
+  end
+
+  validate :library_manifest
+
+  private
+
+  def validate_library_manifest
+    unless library_manifest.is_a?(Hash)
+      errors.add(:library_manifest, "must be a JSON object")
+      return
+    end
+
+    unless library_manifest.key?('categories') && library_manifest['categories'].is_a?(Array)
+      errors.add(:library_manifest, "must have a 'categories' array")
+    end
+
+    unless library_manifest.key?('tables') && library_manifest['tables'].is_a?(Array)
+      errors.add(:library_manifest, "must have a 'tables' array")
+    end
+  end
+
+  def set_default_library_manifest
+    self.library_manifest ||= {'categories' => [], 'tables' => []}
+  end
+end

--- a/dashboard/app/models/datablock_storage_record.rb
+++ b/dashboard/app/models/datablock_storage_record.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: datablock_storage_records
+#
+#  project_id  :integer          not null, primary key
+#  table_name  :string(700)      not null, primary key
+#  record_id   :integer          not null, primary key
+#  record_json :json
+#
+# Indexes
+#
+#  index_datablock_storage_records_on_project_id                 (project_id)
+#  index_datablock_storage_records_on_project_id_and_table_name  (project_id,table_name)
+#
+class DatablockStorageRecord < ApplicationRecord
+  # Stores student-owned records for App Lab's data features, see datablock_storage_controller.rb
+  # Most code that manipulates records lives in datablock_storage_table.rb
+  # Data is stored as a mysql-row-per-student-record
+
+  # Composite primary key:
+  self.primary_keys = :project_id, :table_name, :record_id
+
+  # TODO: #57001, implement enforcement of MAX_RECORD_LENGTH, we already have
+  # a test for this, but we're skipping it until this is implemented. This
+  # should ensure the string form of .json is less than 4096 bytes.
+  MAX_RECORD_LENGTH = 4096
+end

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -1,0 +1,319 @@
+# == Schema Information
+#
+# Table name: datablock_storage_tables
+#
+#  project_id      :integer          not null, primary key
+#  table_name      :string(700)      not null, primary key
+#  columns         :json
+#  is_shared_table :string(700)
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_datablock_storage_tables_on_project_id  (project_id)
+#
+class DatablockStorageTable < ApplicationRecord
+  # Stores student-owned tables for App Lab's data features, see datablock_storage_controller.rb
+  # Row data for each table is stored in datablock_storage_record.rb, but most code lives here
+  #
+  # Student data tables are stored as a single row in this model, and a row-per-record in
+  # DatablockStorageRecord.
+  #
+  # Student data is stored in a single JSON column in DatablockStorageRecord.record_json,
+  # which is a map of column-names to the value for that row/column.
+  # DatablockStorageTable.columns is the superset of all possible keys in the various
+  # DatablockStorageRecord.json records that comprise the table.
+  #
+  # Methods that read records, or write records, should be placed in the
+  # appropriate sections (below).
+
+  # Composite primary key:
+  self.primary_keys = :project_id, :table_name
+
+  # Data reading methods should use read_records instead of directly accessing records
+  has_many :records,
+    -> {order(record_id: :asc)},
+    autosave: true,
+    class_name: 'DatablockStorageRecord',
+    foreign_key: [:project_id, :table_name],
+    dependent: :delete_all
+
+  after_initialize -> {self.columns ||= ['id']}, if: :new_record?
+
+  # These are errors that should show up in the Applab Debug Console
+  # see description in datablock_storage_controller.rb.
+  class StudentFacingError < StandardError
+    attr_reader :type
+
+    def initialize(type=nil)
+      super
+      @type = type
+    end
+  end
+
+  # Shared tables are those defined by code.org and imported from the
+  # Data Library. They are referenced by name in is_shared_table. However,
+  # like all tables, they are required to have a project_id. We use 0 as
+  # the special project_id to indicate it's a shared table.
+  SHARED_TABLE_PROJECT_ID = 0
+
+  # TODO: #57003, implement enforcement of MAX_TABLE_COUNT, we already have
+  # a test for it but we're skipping it until this is implemented.
+  MAX_TABLE_COUNT = 10
+
+  # TODO: #57002, enforce MAX_TABLE_ROW_COUNT, we already have a test for it
+  # but we're skipping it until this is implemented.
+  MAX_TABLE_ROW_COUNT = 20000
+
+  def self.get_table_names(project_id)
+    DatablockStorageTable.where(project_id: project_id).pluck(:table_name)
+  end
+
+  def self.get_shared_table_names
+    get_table_names(SHARED_TABLE_PROJECT_ID)
+  end
+
+  def self.find_shared_table(table_name)
+    DatablockStorageTable.find_by(project_id: SHARED_TABLE_PROJECT_ID, table_name: table_name)
+  end
+
+  def self.add_shared_table(project_id, table_name)
+    unless DatablockStorageTable.exists?(project_id: SHARED_TABLE_PROJECT_ID, table_name: table_name)
+      raise "Shared table '#{table_name}' does not exist"
+    end
+    DatablockStorageTable.create!(project_id: project_id, table_name: table_name, is_shared_table: table_name)
+  end
+
+  def self.populate_tables(project_id, tables_json)
+    tables_json.each do |table_name, records|
+      table = DatablockStorageTable.create!(project_id: project_id, table_name: table_name)
+      table.create_records records
+      table.save!
+    rescue ActiveRecord::RecordNotUnique
+      # Its ok if the table already exists, but we won't re-populate it
+      logger.warn "Table already exists: not populating project_id=#{project_id}, table_name=#{table_name}"
+    end
+  end
+
+  def read_records
+    is_shared_table ? shared_table.records : records
+  end
+
+  ##########################################################
+  #   Table methods that read record data:                 #
+  ##########################################################
+  #
+  # Methods that access records should do so using `read_records` (vs using table.records)
+  # as tables with `is_shared_table` set do not have individual copies of their records,
+  # but instead "point to" the records of a table imported from the Data Library.
+  #
+  # See comments on our Copy-On-Write strategy below for more details.
+
+  def export_csv
+    column_names = get_columns
+
+    CSV.generate do |csv|
+      csv << column_names
+      read_records.map(&:record_json).each do |record_json|
+        csv << column_names.map {|x| record_json[x]}
+      end
+    end
+  end
+
+  def get_columns
+    is_shared_table ? shared_table.columns : columns
+  end
+
+  def get_column(column_name)
+    if get_columns.include? column_name
+      read_records.map do |record|
+        record.record_json[column_name]
+      end
+    else
+      [] # javascript expects a list with every element undefined to indicate column doesn't exists error
+    end
+  end
+
+  ##########################################################
+  #   Table methods that write record data:                #
+  ##########################################################
+  #
+  # DatablockStorageTable uses a Copy-On-Write strategy for 'shared' tables,
+  # that is: tables imported using the Data Library. Rather than copying the
+  # records immediately into a local table, we create a table row with
+  # is_shared_table set to the name of the shared table. When any write event
+  # occurs for the table, we immediately copy all the records into the local
+  # table, before applying the write. This avoids unnecessary duplication of
+  # data (80% of student data was unchanged imports of data library tables).
+  #
+  # To ensure consistent copy-on-write behavior, all "write methods" (those
+  # that modify record data) should start with a call to:
+  def if_shared_table_copy_on_write
+    copy_shared_table if is_shared_table
+  end
+
+  def create_records(record_jsons)
+    if_shared_table_copy_on_write
+
+    DatablockStorageRecord.transaction do
+      # Because we're using a composite primary key for records: (project_id, table_name, record_id)
+      # and we want an incrementing record_id unique to that (project_id, table_name), we lock
+      # the first record in a DatablockStorageTable when we begin to insert new records,
+      # and release it once we close the transaction.
+      DatablockStorageRecord.where(project_id: project_id, table_name: table_name).lock.minimum(:record_id)
+
+      max_record_id = DatablockStorageRecord.where(project_id: project_id, table_name: table_name).maximum(:record_id)
+      next_record_id = (max_record_id || 0) + 1
+
+      cols_in_records = Set.new
+      record_jsons.each do |record_json|
+        record_json.each do |_key, json_value|
+          raise StudentFacingError.new(:INVALID_RECORD), 'Invalid record: nested objects and arrays are not permitted' if json_value.is_a?(Hash) || json_value.is_a?(Array)
+        end
+
+        # We write the record_id into the JSON as well as storing it in its own column
+        # only create_record and update_record should be at risk of modifying this
+        record_json['id'] = next_record_id
+
+        DatablockStorageRecord.create(project_id: project_id, table_name: table_name, record_id: next_record_id, record_json: record_json)
+
+        cols_in_records.merge(record_json.keys)
+        next_record_id += 1
+      end
+
+      # Preserve the old column's order while adding any new columns
+      self.columns += (cols_in_records - columns).to_a
+      save!
+    end
+  end
+
+  def update_record(record_id, record_json)
+    if_shared_table_copy_on_write
+
+    record = records.find_by(record_id: record_id)
+    return unless record
+
+    record_json['id'] = record_id.to_i
+    record.record_json = record_json
+    record.save!
+
+    # update the table columns with any new JSON fields
+    self.columns += (record_json.keys.to_set - columns).to_a
+
+    return record_json
+  end
+
+  def delete_record(record_id)
+    if_shared_table_copy_on_write
+
+    records.find_by!(record_id: record_id).delete
+  end
+
+  def import_csv(table_data_csv)
+    if_shared_table_copy_on_write
+
+    records = CSV.parse(table_data_csv, headers: true).map(&:to_h)
+
+    # Auto-cast CSV strings on import, e.g. "5.0" => 5.0
+    same_as_undefined = ['', 'undefined']
+    records.map! do |record|
+      # This is equivalent to setting the value to be 'undefined' in JS: it deletes the key
+      record.reject! {|_key, value| same_as_undefined.include? value}
+      record.transform_values! do |string_value|
+        # Attempt to parse as JSON, fall back to original string on error
+        json_value = JSON.parse(string_value)
+        raise TypeError, 'Invalid entry type: object' if json_value.is_a?(Hash) || json_value.is_a?(Array)
+        json_value
+      rescue JSON::ParserError, TypeError
+        string_value
+      end
+    end
+
+    create_records(records)
+  end
+
+  def add_column(column_name)
+    if_shared_table_copy_on_write
+
+    unless columns.include? column_name
+      self.columns << column_name
+    end
+  end
+
+  def delete_column(column_name)
+    if_shared_table_copy_on_write
+
+    records.each do |record|
+      record.record_json.delete(column_name)
+    end
+
+    self.columns.delete column_name
+  end
+
+  def rename_column(old_column_name, new_column_name)
+    if_shared_table_copy_on_write
+
+    # First rename the column in all the JSON records
+    records.each do |record|
+      record.record_json[new_column_name] = record.record_json.delete(old_column_name)
+    end
+
+    # Second rename the column in the table definition
+    self.columns = columns.map {|column| column == old_column_name ? new_column_name : column}
+  end
+
+  # Convert all values in a column to a new type
+  def coerce_column(column_name, column_type)
+    if_shared_table_copy_on_write
+
+    unless ['string', 'number', 'boolean'].include? column_type
+      raise "column_type must be one of: string, number, boolean"
+    end
+
+    records.each do |record|
+      # column type is one of: string, number, boolean, date
+      if record.record_json.key?(column_name)
+        record.record_json[column_name] = coerce_type(record.record_json[column_name], column_type)
+      end
+    end
+  end
+
+  ##########################################################
+  #   Private                                              #
+  ##########################################################
+
+  private def shared_table
+    DatablockStorageTable.find_by(project_id: SHARED_TABLE_PROJECT_ID, table_name: is_shared_table)
+  end
+
+  # This is where we do the actual copy-on-write
+  private def copy_shared_table
+    to_copy = shared_table
+    self.columns = to_copy.columns
+    records.insert_all to_copy.records.map(&:as_json)
+    self.is_shared_table = nil
+    save!
+  end
+
+  private def coerce_type(value, column_type)
+    case column_type
+    when 'string'
+      if value.nil?
+        'null'
+      else
+        value.to_s
+      end
+    when 'number'
+      Float(value) rescue raise StudentFacingError.new(:CANNOT_CONVERT_COLUMN_TYPE), "Couldn't convert #{value.inspect} to number"
+    when 'boolean'
+      if [true, 'true'].include? value
+        true
+      elsif [false, 'false'].include? value
+        false
+      else
+        raise StudentFacingError.new(:CANNOT_CONVERT_COLUMN_TYPE), "Couldn't convert #{value.inspect} to boolean"
+      end
+    end
+  end
+end

--- a/dashboard/app/models/game.rb
+++ b/dashboard/app/models/game.rb
@@ -266,10 +266,6 @@ class Game < ApplicationRecord
     !([NETSIM].include? app)
   end
 
-  def use_firebase?
-    [APPLAB, GAMELAB].include? app
-  end
-
   def use_azure_speech_service?
     [APPLAB, GAMELAB, SPRITELAB].include? app
   end

--- a/dashboard/app/models/project_use_datablock_storage.rb
+++ b/dashboard/app/models/project_use_datablock_storage.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: project_use_datablock_storages
+#
+#  id                    :bigint           not null, primary key
+#  project_id            :integer          not null
+#  use_datablock_storage :boolean          default(FALSE), not null
+#
+# Indexes
+#
+#  index_project_use_datablock_storages_on_project_id  (project_id)
+#
+class ProjectUseDatablockStorage < ApplicationRecord
+  DEFAULT_USE_DATABLOCK_STORAGE = false
+  # Should a given Project use datablock storage?
+  # This allows us to progressively migrate between Firebase
+  # and Datablock storage.
+  #
+  # TODO: post-firebase-cleanup, #56994 remove this table once 100% of projects are use_datablock_storage=true.
+
+  def self.use_data_block_storage_for?(channel_id)
+    project = Project.find_by_channel_id(channel_id)
+    find_by(project_id: project.id)&.use_datablock_storage || DEFAULT_USE_DATABLOCK_STORAGE
+  rescue ActiveRecord::RecordNotFound
+    DEFAULT_USE_DATABLOCK_STORAGE
+  end
+
+  def self.set_data_block_storage_for!(channel_id, use_datablock_storage)
+    project = Project.find_by_channel_id(channel_id)
+    find_or_create_by(project_id: project.id).update!(use_datablock_storage: ActiveRecord::Type::Boolean.new.cast(use_datablock_storage))
+  end
+end

--- a/dashboard/app/views/datablock_storage/index.html.haml
+++ b/dashboard/app/views/datablock_storage/index.html.haml
@@ -1,0 +1,204 @@
+-# TODO: post-firebase-cleanup, consider removing this entire debug interface (or not 🤷‍♀️): #56994
+
+%strong{:class => "code", :id => "message"} This #{@project.project_type} project uses #{@storage_backend} as its backing store.
+
+-# TODO: post-firebase-cleanup, remove this conditional, #56994
+%h3 switch storage backend
+= form_tag "use_datablock_storage", :method => :put, :remote => false do
+  = submit_tag "use_datablock_storage"
+= form_tag "use_firebase_storage", :method => :put, :remote => false do
+  = submit_tag "use_firebase_storage"
+
+%h2 Tables
+%table
+  %tr
+    %td table_name
+    %td columns
+    %td is_shared_table
+  - @tables.each do |table|
+    %tr
+      %td= table.table_name
+      %td= table.columns
+      %td= table.is_shared_table
+
+%h2 Records
+
+%table
+  %tr
+    %td table_name
+    %td record_id
+    %td record_json
+  - @records.each do |record|
+    %tr
+      %td= record.table_name
+      %td= record.record_id
+      %td= record.record_json
+
+%h2 Key Value Pairs
+
+%table
+  %tr
+    %td key
+    %td value
+  - @key_value_pairs.each do |kvp|
+    %tr
+      %td= kvp.key
+      %td= kvp.value
+
+%h2 KeyValuePair
+
+%h3 set_key_value
+= form_tag "set_key_value", :method => :post, :remote => false do
+  = text_field_tag "key", "", placeholder: "key"
+  = text_field_tag "value", "", placeholder: "\"value\""
+  = submit_tag "set_key_value"
+
+%h3 get_key_value
+= form_tag "get_key_value", :method => :get, :remote => false do
+  = text_field_tag "key", "", placeholder: "key"
+  = submit_tag "get_key_value"
+
+%h2 Record
+
+%h3 create_record
+= form_tag "create_record", :method => :post, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = text_field_tag "record_json", "", placeholder: "record_json"
+  = submit_tag "create_record"
+
+%h3 read_records
+= form_tag "read_records", :method => :get, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = submit_tag "read_records"
+
+%h3 update_record
+= form_tag "update_record", :method => :put, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = text_field_tag "record_id", "", placeholder: "record_id"
+  = text_field_tag "record_json", "", placeholder: "record_json"
+  = submit_tag "update_record"
+
+
+%h3 delete_record
+= form_tag "delete_record", :method => :delete, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = text_field_tag "record_id", "", placeholder: "record_id"
+  = submit_tag "delete_record"
+
+%hr
+
+%h2 Dataset Browser Data Loading Methods
+
+%h3 get_table_names
+= form_tag "get_table_names", :method => :get, :remote => false do
+  = submit_tag "get_table_names"
+
+%h3 get_key_values
+= form_tag "get_key_values", :method => :get, :remote => false do
+  = submit_tag "get_key_values"
+
+%hr
+
+%h2 Dataset Browser Actions Methods
+
+%h3 create_table
+= form_tag "create_table", :method => :post, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = submit_tag "create_table"
+
+%h3 delete_table
+= form_tag "delete_table", :method => :delete, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = submit_tag "delete_table"
+
+%h3 clear_table
+= form_tag "clear_table", :method => :delete, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = submit_tag "clear_table"
+
+%h3 import_csv
+= form_tag "import_csv", :method => :post, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = text_area_tag "table_data_csv", "", placeholder: "table_data_csv"
+  = submit_tag "import_csv"
+
+%h3 export_csv
+= form_tag "export_csv", :method => :get, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = submit_tag "export_csv"
+
+%h3 get_column
+= form_tag "get_column", :method => :get, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = text_field_tag "column_name", "", placeholder: "column_name"
+  = submit_tag "get_column"
+
+%h3 add_column
+= form_tag "add_column", :method => :post, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = text_field_tag "column_name", "", placeholder: "column_name"
+  = submit_tag "add_column"
+
+%h3 delete_column
+= form_tag "delete_column", :method => :delete, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = text_field_tag "column_name", "", placeholder: "column_name"
+  = submit_tag "delete_column"
+
+%h3 rename_column
+= form_tag "rename_column", :method => :put, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = text_field_tag "old_column_name", "", placeholder: "old_column_name"
+  = text_field_tag "new_column_name", "", placeholder: "new_column_name"
+  = submit_tag "rename_column"
+
+%h3 coerce_column
+= form_tag "coerce_column", :method => :put, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = text_field_tag "column_name", "", placeholder: "column_name"
+  = text_field_tag "column_type", "", placeholder: "column_type"
+  = submit_tag "coerce_column"
+
+%h3 delete_key_value
+= form_tag "delete_key_value", :method => :delete, :remote => false do
+  = text_field_tag "key", "", placeholder: "key"
+  = submit_tag "delete_key_value"
+
+%h2 Other
+
+%h3 populate_tables
+= form_tag "populate_tables", :method => :put, :remote => false do
+  = text_area_tag "tables_json", '{"baz": [{"name": "Sam", "age": 5}, {"name": "Syd", "age": 7}]}', placeholder: "tables_json"
+  = submit_tag "populate_tables"
+
+%h3 populate_key_values
+= form_tag "populate_key_values", :method => :put, :remote => false do
+  = text_area_tag "key_values_json", '{"baz": true, "bing": "Hiya", "tim": 5}', placeholder: "key_values_json"
+  = submit_tag "populate_key_values"
+
+%h3 get_columns_for_table
+= form_tag "get_columns_for_table", :method => :get, :remote => false do
+  = text_field_tag "table_name", "", placeholder: "table_name"
+  = submit_tag "get_columns_for_table"
+
+%h3 clear_all_data
+= form_tag "clear_all_data", :method => :delete, :remote => false do
+  = submit_tag "clear_all_data"
+
+%h3 add_shared_table
+= form_tag "add_shared_table", :method => :post, :remote => false do
+  = text_field_tag "table_name", "100 Birds of the World", placeholder: "table_name"
+  = submit_tag "add_shared_table"
+
+%h2 Library Manifest
+
+%div= @library_manifest
+
+%h3 get_library_manifest
+= form_tag "get_library_manifest", :method => :get, :remote => false do
+  = submit_tag "get_library_manifest"
+
+%h3 set_library_manifest
+= form_tag "set_library_manifest", :method => :put, :remote => false do
+  = text_area_tag "library_manifest", '{"categories":[{"datasets":["100 Birds of the World"],"name":"Animals","published":true}],"tables":[{"current":false,"description":"Data and images about 100 different species of birds around the world","docUrl":"https://studio.code.org/data_docs/100-birds/","name":"100 Birds of the World","published":true}]}'
+  = submit_tag "set_library_manifest"

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1120,5 +1120,55 @@ Dashboard::Application.routes.draw do
       'policy_compliance#child_account_consent'
     post '/policy_compliance/child_account_consent/', to:
       'policy_compliance#child_account_consent_request'
+
+    # DatablockStorageController powers the data features of applab,
+    # and the key/value pair store feature of gamelab
+    resources :datablock_storage, path: '/datablock_storage/:channel_id/', only: [:index] do
+      collection do
+        # Datablock Storage: Key-Value-Pair API
+        post :set_key_value
+        get :get_key_value
+        delete :delete_key_value
+        get :get_key_values
+        put :populate_key_values
+
+        # Datablock Storage: Table API
+        post :create_table
+        post :add_shared_table
+        post :import_csv
+        get :export_csv
+        delete :clear_table
+        delete :delete_table
+        get :get_table_names
+        put :populate_tables
+
+        # Datablock Storage: Table Column API
+        post :add_column
+        put :rename_column
+        put :coerce_column
+        delete :delete_column
+        get :get_column
+        get :get_columns_for_table
+
+        # Datablock Storage: Table Record API
+        post :create_record
+        get :read_records
+        put :update_record
+        delete :delete_record
+
+        # Datablock Storage: Library Manifest API (=shared table metadata)
+        get :get_library_manifest
+        put :set_library_manifest
+
+        # Datablock Storage: Project API
+        get :project_has_data
+        delete :clear_all_data
+
+        # TODO: post-firebase-cleanup, remove
+        # Project Use Datablock Storage API
+        put :use_datablock_storage
+        put :use_firebase_storage
+      end
+    end
   end
 end

--- a/dashboard/legacy/middleware/helpers/firebase_helper.rb
+++ b/dashboard/legacy/middleware/helpers/firebase_helper.rb
@@ -1,3 +1,17 @@
+# TODO: post-firebase-cleanup, remove this file: #56994
+#
+# This file is used by:
+# - bin/cron/applab_datasets/covid19
+# - bin/cron/applab_datasets/daily_weather
+# - bin/cron/applab_datasets/spotify
+# - dashboard/app/controllers/datasets_controller.rb
+# - dashboard/app/controllers/levels_controller.rb
+# - dashboard/legacy/middleware/tables_api.rb
+# - dashboard/legacy/test/middleware/helpers/test_firebase_helper.rb
+# - dashboard/test/controllers/datasets_controller_test.rb
+# - dashboard/test/helpers/delete_accounts_helper_test.rb
+# - lib/cdo/delete_accounts_helper.rb
+
 require 'csv'
 require 'firebase'
 require 'time'

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -50,6 +50,9 @@ class Projects
     }
     row[:id] = @table.insert(row)
 
+    # TODO: post-firebase-cleanup, remove this once we switch 100% to datablock storage: #56994
+    set_use_datablock_storage row[:id], project_type
+
     storage_encrypt_channel_id(row[:storage_id], row[:id])
   end
 
@@ -447,6 +450,26 @@ class Projects
   end
 
   private
+
+  # TODO: post-firebase-cleanup, remove this once we switch 100% to datablock storage
+  def set_use_datablock_storage(project_id, project_type)
+    # TODO: unfirebase, include 'gamelab' in this list, see #56995
+    if ['applab'].include? project_type
+      # While we transition, a fraction of new projects will be set at creation
+      # to use datablock storage. As we gain confidence, we can increase this
+      # DCDO flag to 1.0. At that point, we're ready to migrate all the old projects.
+      #
+      # Once 100% of the old projects are migrated, we're ready to remove code
+      # marked with: TODO: post-firebase-cleanup
+      use_datablock_table = DASHBOARD_DB[:project_use_datablock_storages]
+      existing_record = use_datablock_table.where(project_id: project_id).first
+      unless existing_record
+        fraction = DCDO.get('fraction_of_new_projects_use_datablock_storage', 0.0)
+        should_use_datablock = rand < fraction
+        use_datablock_table.insert(project_id: project_id, use_datablock_storage: should_use_datablock)
+      end
+    end
+  end
 
   #
   # Discovering a channel's project type is a real mess.  We don't usually

--- a/dashboard/legacy/middleware/tables_api.rb
+++ b/dashboard/legacy/middleware/tables_api.rb
@@ -1,3 +1,5 @@
+# TODO: post-firebase-cleanup, consider removing this file, see https://github.com/code-dot-org/code-dot-org/issues/56996#issuecomment-1977935612, post-firebase-cleanup issue is: #56994
+
 require 'sinatra/base'
 require 'cdo/sinatra'
 require 'cdo/rack/request'
@@ -22,6 +24,7 @@ class TablesApi < Sinatra::Base
   # Exports a csv file from a table where the first row is the column names
   # and additional rows are the column values.
   #
+  # TODO: post-firebase-cleanup, remove this method at the least, probably remove whole file: #56994
   get %r{/v3/export-firebase-tables/([^/]+)/([^/]+)$} do |channel_id, table_name|
     dont_cache
     content_type :csv

--- a/dashboard/legacy/test/middleware/helpers/test_firebase_helper.rb
+++ b/dashboard/legacy/test/middleware/helpers/test_firebase_helper.rb
@@ -1,3 +1,5 @@
+# TODO: post-firebase-cleanup, remove this file: #56994
+
 require_relative '../middleware_test_helper'
 require_relative '../../../middleware/helpers/firebase_helper'
 

--- a/dashboard/legacy/test/middleware/test_tables.rb
+++ b/dashboard/legacy/test/middleware/test_tables.rb
@@ -69,6 +69,7 @@ class TablesTest < Minitest::Test
     assert last_response.successful?
   end
 
+  # TODO: unfirebase, this should moved to datablock_storage_controler, see: #56996
   def export_firebase(table_name = @table_name)
     get "/v3/export-firebase-tables/#{@channel_id}/#{table_name}"
   end

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -1,0 +1,751 @@
+require "test_helper"
+
+class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
+  setup_all do
+    @student = create :student
+
+    project = create :project, owner: @student
+    project.project_type = 'applab'
+    project.save!
+    @channel_id = project.channel_id
+  end
+
+  setup do
+    sign_in @student
+  end
+
+  def _url(action)
+    return "/datablock_storage/#{@channel_id}/#{action}"
+  end
+
+  def create_bob_record
+    post _url(:create_record), params: {
+      table_name: 'mytable',
+      record_json: {"name" => 'bob', "age" => 8}.to_json,
+    }
+    assert_response :success
+  end
+
+  def read_records(table_name = 'mytable')
+    get _url(:read_records), params: {
+      table_name: table_name,
+    }
+    assert_response :success
+    JSON.parse(@response.body).sort_by {|record| record[:id]}
+  end
+
+  def set_and_get_key_value(key, value)
+    post _url(:set_key_value), params: {
+      key: key,
+      value: value.to_json,
+    }
+    assert_response :success
+    get _url(:get_key_value), params: {
+      key: key
+    }
+    assert_response :success
+    val = JSON.parse(@response.body)
+    assert_equal value, val
+  end
+
+  test "sets and gets string value" do
+    set_and_get_key_value('key', 'val')
+  end
+
+  test "sets a number value" do
+    set_and_get_key_value('key', 7)
+  end
+
+  test "sets and gets an undefined value" do
+    set_and_get_key_value('key', nil)
+  end
+
+  test "sets and gets an emoji key and value" do
+    set_and_get_key_value('👁️👄👁️', 'value is: 🎉')
+  end
+
+  test "set_key_value should enforce MAX_VALUE_LENGTH" do
+    too_many_bees = 'b' * (DatablockStorageKvp::MAX_VALUE_LENGTH + 1) # 1 more 'b' char than max
+    post _url(:set_key_value), params: {
+      key: 'key',
+      value: too_many_bees.to_json,
+    }
+    assert_response :bad_request
+
+    skip "FIXME: controller bug, test will fail, because enforcing DatablockStorageTable::MAX_VALUE_LENGTH_EXCEEDED is not yet implemented, see #57002"
+    # Is MAX_VALUE_LENGTH_EXCEEDED the right error? check the JS
+    assert_equal 'MAX_VALUE_LENGTH_EXCEEDED', JSON.parse(@response.body)['type']
+  end
+
+  test "creates a record" do
+    post _url(:create_record), params: {
+      table_name: 'mytable',
+      record_json: {"name" => 'bob', "age" => 8}.to_json,
+    }
+    assert_response :success
+    get _url(:read_records), params: {
+      table_name: 'mytable',
+    }
+    assert_response :success
+    val = JSON.parse(@response.body)
+    assert_equal [{"name" => 'bob', "age" => 8, "id" => 1}], val
+  end
+
+  test "create_record creates a table if none exists" do
+    get _url(:get_table_names)
+    assert_response :success
+    assert_equal [], JSON.parse(@response.body)
+
+    create_bob_record
+
+    get _url(:get_table_names)
+    assert_response :success
+    assert_equal ['mytable'], JSON.parse(@response.body)
+  end
+
+  test "create_record wont create objects or arrays" do
+    create_bob_record
+
+    post _url(:create_record), params: {
+      table_name: 'mytable',
+      record_json: '{"name": "badbob", "badval": {"key":"value"}}',
+    }
+    assert_response :bad_request
+    assert_equal [{"name" => 'bob', "age" => 8, "id" => 1}], read_records
+
+    post _url(:create_record), params: {
+      table_name: 'mytable',
+      record_json: '{"name": "badbob", "badval": [1,2,3]}',
+    }
+    assert_response :bad_request
+    assert_equal [{"name" => 'bob', "age" => 8, "id" => 1}], read_records
+  end
+
+  test "create_record can't create more than MAX_TABLE_COUNT tables" do
+    # Lower the max table count to 3 so it's easy to test
+    original_max_table_count = DatablockStorageTable::MAX_TABLE_COUNT
+    DatablockStorageTable.const_set(:MAX_TABLE_COUNT, 3)
+
+    post _url(:create_record), params: {table_name: 'table1', record_json: {'name' => 'bob'}.to_json}
+    assert_response :success
+
+    post _url(:create_record), params: {table_name: 'table2', record_json: {'name' => 'bob'}.to_json}
+    assert_response :success
+
+    post _url(:create_record), params: {table_name: 'table3', record_json: {'name' => 'bob'}.to_json}
+    assert_response :success
+
+    post _url(:create_record), params: {table_name: 'table4', record_json: {'name' => 'bob'}.to_json}
+    skip "FIXME: controller bug, test will fail, because enforcing DatablockStorageTable::MAX_TABLE_COUNT is not yet implemented so we get :success when :bad_request is desired, see #57003"
+    assert_response :bad_request
+    assert_equal 'MAX_TABLES_EXCEEDED', JSON.parse(@response.body)['type']
+  ensure
+    DatablockStorageTable.const_set(:MAX_TABLE_COUNT, original_max_table_count)
+  end
+
+  test "create_record can't create more than MAX_TABLE_ROW_COUNT rows" do
+    # Lower the max table count to 3 so its easy to test
+    original_max_table_row_count = DatablockStorageTable::MAX_TABLE_ROW_COUNT
+    DatablockStorageTable.const_set(:MAX_TABLE_ROW_COUNT, 3)
+
+    # Create 3 records so we're right at the limit...
+    create_bob_record
+    create_bob_record
+    create_bob_record
+
+    post _url(:create_record), params: {table_name: 'mytable', record_json: {'name' => 'bob'}.to_json}
+
+    skip "FIXME: controller bug, test will fail, because enforcing DatablockStorageTable::MAX_TABLE_ROW_COUNT is not yet implemented so we get :success when :bad_request is desired, see #57002"
+    assert_response :bad_request
+    # Is MAX_ROWS_EXCEEDED the right error? check the JS
+    assert_equal 'MAX_ROWS_EXCEEDED', JSON.parse(@response.body)['type']
+  ensure
+    DatablockStorageTable.const_set(:MAX_TABLE_ROW_COUNT, original_max_table_row_count)
+  end
+
+  test "create_record can't create records over MAX_RECORD_LENGTH" do
+    not_too_many_bees = 'b' * (DatablockStorageRecord::MAX_RECORD_LENGTH - 20) # 20 less 'b' chars than max
+    post _url(:create_record), params: {table_name: 'mytable', record_json: {'name' => not_too_many_bees}.to_json}
+    assert_response :success
+
+    too_many_bees = 'b' * (DatablockStorageRecord::MAX_RECORD_LENGTH + 1) # 1 more 'b' char than max
+    post _url(:create_record), params: {table_name: 'mytable', record_json: {'name' => too_many_bees}.to_json}
+    assert_response :bad_request
+
+    skip "FIXME: controller bug, test will fail, because enforcing DatablockStorageRecord::MAX_RECORD_LENGTH is not yet implemented at the DatablockStorage level, see #57001"
+    # Is MAX_RECORD_LENGTH_EXCEEDED the right error? check the JS
+    assert_equal 'MAX_RECORD_LENGTH_EXCEEDED', JSON.parse(@response.body)['type']
+  end
+
+  test "create_table" do
+    get _url(:get_table_names)
+    assert_response :success
+    assert_equal [], JSON.parse(@response.body)
+
+    post _url(:create_table), params: {table_name: 'mytable'}
+    assert_response :success
+
+    get _url(:get_table_names)
+    assert_response :success
+    assert_equal ['mytable'], JSON.parse(@response.body)
+
+    get _url(:get_columns_for_table), params: {table_name: 'mytable'}
+    assert_response :success
+    assert_equal ['id'], JSON.parse(@response.body)
+  end
+
+  test "create_table with an emoji name" do
+    post _url(:create_table), params: {table_name: '👁️👄👁️'}
+    assert_response :success
+
+    get _url(:get_table_names)
+    assert_response :success
+    assert_equal ['👁️👄👁️'], JSON.parse(@response.body)
+  end
+
+  test "get_key_values" do
+    post _url(:set_key_value), params: {
+      key: 'name',
+      value: 'bob'.to_json,
+    }
+    assert_response :success
+    post _url(:set_key_value), params: {
+      key: 'age',
+      value: 8.to_json,
+    }
+    assert_response :success
+
+    get _url(:get_key_values)
+    assert_response :success
+    assert_equal ({"name" => 'bob', "age" => 8}), JSON.parse(@response.body)
+  end
+
+  test "delete_table" do
+    post _url(:create_table), params: {table_name: 'mytable'}
+    assert_response :success
+
+    create_bob_record
+
+    delete _url(:delete_table), params: {table_name: 'mytable'}
+    assert_response :success
+
+    get _url(:get_table_names)
+    assert_response :success
+    assert_equal [], JSON.parse(@response.body)
+
+    assert_response :success
+    get _url(:read_records), params: {table_name: 'mytable'}
+    assert_response :bad_request
+  end
+
+  test "clear_table" do
+    create_bob_record
+
+    delete _url(:clear_table), params: {table_name: 'mytable'}
+    assert_response :success
+
+    # Rows should be gone
+    get _url(:read_records), params: {table_name: 'mytable'}
+    assert_response :success
+    assert_equal [], JSON.parse(@response.body)
+
+    # Columns should still be there
+    get _url(:get_columns_for_table), params: {table_name: 'mytable'}
+    assert_response :success
+    assert_equal ['id', 'name', 'age'], JSON.parse(@response.body)
+  end
+
+  test "add_column" do
+    post _url(:create_table), params: {table_name: 'mytable'}
+
+    post _url(:add_column), params: {table_name: 'mytable', column_name: 'newcol'}
+    assert_response :success
+
+    get _url(:get_columns_for_table), params: {table_name: 'mytable'}
+    assert_response :success
+    assert_equal ['id', 'newcol'], JSON.parse(@response.body)
+  end
+
+  test "delete_column" do
+    create_bob_record
+
+    delete _url(:delete_column), params: {table_name: 'mytable', column_name: 'age'}
+    assert_response :success
+
+    get _url(:get_columns_for_table), params: {table_name: 'mytable'}
+    assert_equal ['id', 'name'], JSON.parse(@response.body)
+
+    # Make sure the 'age' key has been removed from JSON values too
+    get _url(:read_records), params: {table_name: 'mytable'}
+    assert_equal [{"name" => 'bob', "id" => 1}], JSON.parse(@response.body)
+  end
+
+  test "rename_column" do
+    create_bob_record
+
+    put _url(:rename_column), params: {
+      table_name: 'mytable',
+      old_column_name: 'name',
+      new_column_name: 'first_name'
+    }
+    assert_response :success
+
+    get _url(:get_columns_for_table), params: {table_name: 'mytable'}
+    assert_equal ['id', 'first_name', 'age'], JSON.parse(@response.body)
+
+    get _url(:read_records), params: {table_name: 'mytable'}
+    assert_equal [{"first_name" => 'bob', "age" => 8, "id" => 1}], JSON.parse(@response.body)
+  end
+
+  test "get_column" do
+    create_bob_record
+    get _url(:get_column), params: {table_name: 'mytable', column_name: 'name'}
+    assert_response :success
+    val = JSON.parse(@response.body)
+    assert_equal ['bob'], val
+  end
+
+  def create_record_where_foo_is(value)
+    post _url(:create_record), params: {
+      table_name: 'mytable',
+      record_json: {"foo" => value}.to_json,
+    }
+    assert_response :success
+  end
+
+  def create_record_without_foo
+    post _url(:create_record), params: {
+      table_name: 'mytable',
+      record_json: {}.to_json,
+    }
+    assert_response :success
+  end
+
+  test "coerce_column converts anything to string" do
+    create_record_where_foo_is(1)
+    create_record_where_foo_is('one')
+    create_record_where_foo_is('1')
+    create_record_where_foo_is(nil)
+    create_record_without_foo
+    create_record_where_foo_is(false)
+
+    put _url(:coerce_column), params: {table_name: 'mytable', column_name: 'foo', column_type: 'string'}
+    assert_response :success
+
+    assert_equal [
+      {"foo" => "1", "id" => 1},
+      {"foo" => "one", "id" => 2},
+      {"foo" => "1", "id" => 3},
+      {"foo" => "null", "id" => 4},
+      {"id" => 5},
+      {"foo" => "false", "id" => 6},
+    ], read_records
+  end
+
+  test "coerce_column converts valid booleans" do
+    create_record_where_foo_is(true)
+    create_record_where_foo_is('true')
+    create_record_where_foo_is(false)
+    create_record_where_foo_is('false')
+
+    put _url(:coerce_column), params: {table_name: 'mytable', column_name: 'foo', column_type: 'boolean'}
+    assert_response :success
+
+    assert_equal [
+      {"foo" => true, "id" => 1},
+      {"foo" => true, "id" => 2},
+      {"foo" => false, "id" => 3},
+      {"foo" => false, "id" => 4},
+    ], read_records
+  end
+
+  test "coerce_column converts valid numbers" do
+    create_record_where_foo_is(1)
+    create_record_where_foo_is('2')
+    create_record_where_foo_is('1e3')
+    create_record_where_foo_is('0.4')
+
+    put _url(:coerce_column), params: {table_name: 'mytable', column_name: 'foo', column_type: 'number'}
+    assert_response :success
+
+    assert_equal [
+      {"foo" => 1, "id" => 1},
+      {"foo" => 2, "id" => 2},
+      {"foo" => 1000, "id" => 3},
+      {"foo" => 0.4, "id" => 4},
+    ], read_records
+  end
+
+  test "coerce_column warns on invalid booleans" do
+    create_record_where_foo_is(true)
+    create_record_where_foo_is('bar')
+
+    put _url(:coerce_column), params: {table_name: 'mytable', column_name: 'foo', column_type: 'boolean'}
+
+    assert_response :bad_request
+    assert_equal 'CANNOT_CONVERT_COLUMN_TYPE', JSON.parse(@response.body)['type']
+
+    assert_equal [
+      {"foo" => true, "id" => 1},
+      {"foo" => 'bar', "id" => 2},
+    ], read_records
+  end
+
+  test "coerce_column warns on invalid numbers" do
+    create_record_where_foo_is(1)
+    create_record_where_foo_is('2xyz')
+
+    put _url(:coerce_column), params: {table_name: 'mytable', column_name: 'foo', column_type: 'number'}
+
+    assert_response :bad_request
+    assert_equal 'CANNOT_CONVERT_COLUMN_TYPE', JSON.parse(@response.body)['type']
+
+    assert_equal [
+      {"foo" => 1, "id" => 1},
+      {"foo" => '2xyz', "id" => 2},
+    ], read_records
+  end
+
+  POPULATE_TABLE_DATA_JSON_STRING = <<~JSON
+    {
+      "cities": [
+        {"city": "Seattle", "state": "WA"},
+        {"city": "Chicago", "state": "IL"}
+      ]
+    }
+  JSON
+
+  POPULATE_TABLE_DATA_RECORDS = [
+    {"city" => "Seattle", "state" => "WA", "id" => 1},
+    {"city" => "Chicago", "state" => "IL", "id" => 2},
+  ]
+
+  test "populate_tables" do
+    put _url(:populate_tables), params: {tables_json: POPULATE_TABLE_DATA_JSON_STRING}
+    assert_response :success
+
+    assert_equal POPULATE_TABLE_DATA_RECORDS, read_records('cities')
+  end
+
+  test "populate_table does not overwrite existing data" do
+    NYC_RECORD = {"city" => "New York", "state" => "NY", "id" => 1}
+
+    post _url(:create_record), params: {
+      table_name: 'cities',
+      record_json: NYC_RECORD.to_json,
+    }
+
+    put _url(:populate_tables), params: {tables_json: POPULATE_TABLE_DATA_JSON_STRING}
+    assert_response :success
+
+    assert_equal [NYC_RECORD], read_records('cities')
+  end
+
+  test "populate_table prints a friendly error message when given bad table json" do
+    BAD_JSON = '{'
+    put _url(:populate_tables), params: {tables_json: BAD_JSON}
+    assert_response :bad_request
+
+    error = JSON.parse(@response.body)
+
+    assert_match(/SyntaxError/, error['msg'])
+    assert_match(/while parsing initial table data: {/, error['msg'])
+  end
+
+  test "populate_key_values" do
+    put _url(:populate_key_values), params: {key_values_json: '{"click_count": 5}'}
+    assert_response :success
+
+    get _url(:get_key_values)
+    assert_response :success
+    assert_equal ({"click_count" => 5}), JSON.parse(@response.body)
+  end
+
+  test "populate_key_values does not overwrite existing data" do
+    post _url(:set_key_value), params: {key: 'click_count', value: 1.to_json}
+    assert_response :success
+
+    put _url(:populate_key_values), params: {key_values_json: '{"click_count": 5}'}
+    assert_response :success
+
+    get _url(:get_key_values)
+    assert_response :success
+
+    assert_equal ({"click_count" => 1}), JSON.parse(@response.body)
+  end
+
+  test "populate_key_values prints a friendly error message when given bad key value json" do
+    put _url(:populate_key_values), params: {key_values_json: '{'}
+
+    assert_response :bad_request
+
+    error = JSON.parse(@response.body)
+
+    assert_match(/SyntaxError/, error['msg'])
+    assert_match(/while parsing initial key\/value data: {/, error['msg'])
+  end
+
+  def create_shared_table
+    expected_records = [
+      {"id" => 1, "name" => "alice", "age" => 7},
+      {"id" => 2, "name" => "bob", "age" => 8},
+      {"id" => 3, "name" => "charlie", "age" => 9},
+    ]
+
+    mysharedtable = DatablockStorageTable.create!(
+      project_id: DatablockStorageTable::SHARED_TABLE_PROJECT_ID,
+      table_name: 'mysharedtable'
+    )
+    mysharedtable.create_records expected_records
+    mysharedtable.save!
+
+    return expected_records, mysharedtable
+  end
+
+  test "shared_table works with read_records" do
+    expected_records, _mysharedtable = create_shared_table
+
+    post _url(:add_shared_table), params: {table_name: 'mysharedtable'}
+    assert_response :success
+
+    assert_equal expected_records, read_records('mysharedtable')
+  end
+
+  test "shared_table copies on write when we create_record" do
+    shared_records, mysharedtable = create_shared_table
+    new_record = {"id" => 4, "name" => "anya", "age" => 10}
+
+    post _url(:add_shared_table), params: {table_name: 'mysharedtable'}
+    assert_response :success
+
+    post _url(:create_record), params: {
+      table_name: 'mysharedtable',
+      record_json: new_record.to_json,
+    }
+
+    # We shouldn't modify the original copy of the shared table
+    assert_equal shared_records.length, mysharedtable.records.count
+
+    assert_equal shared_records + [new_record], read_records('mysharedtable')
+  end
+
+  test "shared_table copies on write when we delete_record" do
+    shared_records, mysharedtable = create_shared_table
+
+    post _url(:add_shared_table), params: {table_name: 'mysharedtable'}
+    assert_response :success
+
+    delete _url(:delete_record), params: {
+      table_name: 'mysharedtable',
+      record_id: 1,
+    }
+    assert_response :success
+
+    # We shouldn't modify the original copy of the shared table
+    assert_equal shared_records.length, mysharedtable.records.count
+
+    assert_equal shared_records.drop(1), read_records('mysharedtable')
+  end
+
+  test "shared_table works with get_column" do
+    _expected_records, _mysharedtable = create_shared_table
+
+    post _url(:add_shared_table), params: {table_name: 'mysharedtable'}
+    assert_response :success
+
+    get _url(:get_column), params: {table_name: 'mysharedtable', column_name: 'name'}
+    assert_response :success
+    val = JSON.parse(@response.body)
+    assert_equal ['alice', 'bob', 'charlie'], val
+  end
+
+  test "add_shared_table cannot overwrite an existing table" do
+    _shared_records, _mysharedtable = create_shared_table
+
+    post _url(:create_record), params: {
+      table_name: 'mysharedtable',
+      record_json: {"name" => 'bob', "age" => 8}.to_json,
+    }
+    assert_response :success
+
+    post _url(:add_shared_table), params: {table_name: 'mysharedtable'}
+    assert_response :bad_request
+
+    error = JSON.parse(@response.body)
+    assert_equal 'DUPLICATE_TABLE_NAME', error['type']
+
+    assert_equal [{"id" => 1, "name" => 'bob', "age" => 8}], read_records('mysharedtable')
+  end
+
+  test "deletes a record" do
+    post _url(:create_record), params: {
+      table_name: 'mytable',
+      record_json: {'name' => 'bob', 'age' => 8}.to_json,
+    }
+    assert_response :success
+    # assert_equal 1, JSON.parse(@response.body).id
+    assert_equal 1, @response.parsed_body['id']
+    delete _url(:delete_record), params: {
+      table_name: 'mytable',
+      record_id: 1,
+    }
+    assert_response :success
+    get _url(:read_records), params: {
+      table_name: 'mytable',
+    }
+    assert_response :success
+    val = JSON.parse(@response.body)
+    assert_equal [], val
+  end
+
+  test "updates a record" do
+    post _url(:create_record), params: {
+      table_name: 'mytable',
+      record_json: {'name' => 'bob', 'age' => 8}.to_json,
+    }
+    assert_response :success
+
+    assert_equal 1, @response.parsed_body['id']
+    put _url(:update_record), params: {
+      table_name: 'mytable',
+      record_id: 1,
+      record_json: {'name' => 'sally', 'age' => 10}.to_json
+    }
+    assert_response :success
+    get _url(:read_records), params: {
+      table_name: 'mytable',
+    }
+    assert_response :success
+    val = JSON.parse(@response.body)
+    assert_equal [{'name' => 'sally', 'age' => 10, 'id' => 1}], val
+  end
+
+  test "import_csv" do
+    CSV_DATA = <<~CSV
+      id,name,age,male
+      4,alice,7,false
+      5,bob,8,true
+      6,charlie,9,true
+    CSV
+
+    EXPECTED_RECORDS = [
+      {"id" => 1, "name" => "alice", "age" => 7, "male" => false},
+      {"id" => 2, "name" => "bob", "age" => 8, "male" => true},
+      {"id" => 3, "name" => "charlie", "age" => 9, "male" => true},
+    ]
+
+    post _url(:import_csv), params: {
+      table_name: 'mytable',
+      table_data_csv: CSV_DATA,
+    }
+    assert_response :success
+
+    assert_equal EXPECTED_RECORDS, read_records
+  end
+
+  test "import_csv overwrites existing data" do
+    post _url(:create_record), params: {
+      table_name: 'mytable',
+      record_json: {"name" => 'tim', "age" => 2}.to_json,
+    }
+    assert_response :success
+
+    CSV_DATA = <<~CSV
+      id,name
+      1,alice
+      2,bob
+      3,charlie
+    CSV
+
+    EXPECTED_RECORDS = [
+      {"id" => 1, "name" => "alice"},
+      {"id" => 2, "name" => "bob"},
+      {"id" => 3, "name" => "charlie"},
+    ]
+
+    post _url(:import_csv), params: {
+      table_name: 'mytable',
+      table_data_csv: CSV_DATA,
+    }
+    assert_response :success
+
+    # Tim, age 2 record should be gone:
+    assert_equal EXPECTED_RECORDS, read_records
+  end
+
+  test "export csv" do
+    CSV_DATA = <<~CSV
+      id,name,age,male
+      1,alice,7,false
+      2,bob,8,true
+      3,charlie,9,true
+    CSV
+
+    post _url(:import_csv), params: {
+      table_name: 'mytable',
+      table_data_csv: CSV_DATA,
+    }
+    assert_response :success
+
+    get _url(:export_csv), params: {
+      table_name: 'mytable',
+    }
+    assert_response :success
+
+    assert_equal CSV_DATA, @response.body
+  end
+
+  test "project_has_data" do
+    get _url(:project_has_data)
+    assert_response :success
+    assert_equal false, JSON.parse(@response.body)
+
+    create_bob_record
+
+    get _url(:project_has_data)
+    assert_response :success
+    assert_equal true, JSON.parse(@response.body)
+
+    delete _url(:delete_table), params: {
+      table_name: 'mytable',
+    }
+
+    get _url(:project_has_data)
+    assert_response :success
+    assert_equal false, JSON.parse(@response.body)
+
+    post _url(:set_key_value), params: {
+      key: 'name',
+      value: 'bob'.to_json,
+    }
+
+    get _url(:project_has_data)
+    assert_response :success
+    assert_equal true, JSON.parse(@response.body)
+
+    delete _url(:delete_key_value), params: {
+      key: 'name',
+    }
+    assert_response :success
+
+    get _url(:project_has_data)
+    assert_response :success
+    assert_equal false, JSON.parse(@response.body)
+  end
+
+  test "clear_all_data" do
+    create_bob_record
+    set_and_get_key_value('somekey', 5)
+
+    delete _url(:clear_all_data)
+    assert_response :success
+
+    get _url(:get_table_names)
+    assert_response :success
+    assert_equal [], JSON.parse(@response.body)
+
+    get _url(:get_key_values)
+    assert_response :success
+    assert_equal({}, JSON.parse(@response.body))
+  end
+end

--- a/dashboard/test/controllers/datasets_controller_test.rb
+++ b/dashboard/test/controllers/datasets_controller_test.rb
@@ -31,6 +31,8 @@ class DatasetsControllerTest < ActionController::TestCase
   test 'update_manifest: can update manifest' do
     test_response = mock
     test_response.expects(:code).returns(200)
+    # TODO: unfirebase, write a version of this for Datablock Storage: #57004
+    # TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
     FirebaseHelper.any_instance.stubs(:set_library_manifest).returns(test_response)
     post :update_manifest, params: {manifest: @test_manifest.to_json}
     assert_response :success
@@ -39,6 +41,8 @@ class DatasetsControllerTest < ActionController::TestCase
   test 'update_manifest: passes through the error code' do
     test_response = mock
     test_response.expects(:code).returns(401)
+    # TODO: unfirebase, write a version of this for Datablock Storage: #57004
+    # TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
     FirebaseHelper.any_instance.stubs(:set_library_manifest).returns(test_response)
     post :update_manifest, params: {manifest: @test_manifest.to_json}
     assert_response :unauthorized

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1010,11 +1010,12 @@ FactoryBot.define do
     end
   end
 
-  # WARNING: Using this factory in new tests may cause other tests, including
-  # ProjectsController tests, to fail.
   factory :project_storage do
   end
 
+  # WARNING: using this factory in new tests may cause other tests, including
+  # ProjectsController tests, to fail with: `Mysql2::Error::TimeoutError`
+  # See: https://codedotorg.atlassian.net/browse/TEACH-230
   factory :project do
     transient do
       owner {create :user}

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -50,6 +50,8 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     end
 
     # Skip real Firebase operations
+    # TODO: unfirebase, write a version of this for Datablock Storage: #57004
+    # TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
     FirebaseHelper.stubs(:delete_channel)
     FirebaseHelper.stubs(:delete_channels)
 
@@ -1921,6 +1923,9 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
         student_channels = [storage_encrypt_channel_id(storage_id, project_id_a),
                             storage_encrypt_channel_id(storage_id, project_id_b)]
+
+        # TODO: unfirebase, write a version of this for Datablock Storage: #57004
+        # TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
         FirebaseHelper.
           expects(:delete_channels).
           with(student_channels)

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -71,6 +71,8 @@ class DeleteAccountsHelper
     end
 
     # Clear Firebase contents for user's channels
+    # TODO: unfirebase, write a version of this for Datablock Storage: #57004
+    # TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
     @log.puts "Deleting Firebase contents for #{channel_count} channels"
     FirebaseHelper.delete_channels encrypted_channel_ids
 


### PR DESCRIPTION
This PR reverts #57471 , which reverted the original datablock storage PR #56279 after it broke the `getColumn` block.

Fix `getColumn()`, which was producing debug console errors like "You tried to get a column called _ from a table called _ but that column doesn't exist.":
1. [71bde1b](https://github.com/code-dot-org/code-dot-org/pull/57480/commits/71bde1b3bd9ac6aadaa1f142a7119b9d9abd397a): `applabCommands.getColumn()`: now calls `Applab.storage.getColumn()` rather than `Applab.storage.readRecords()` like it did before datablockStorage.js:
    <img width="515" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/0f84b50a-3906-4fc2-a468-0b13674691b8">
2. [d834f5b](https://github.com/code-dot-org/code-dot-org/pull/57480/commits/d834f5b4005589076eab7feb39b126d995b7510e): ec_datablocks.js: Adds an apps integration test for the getColumn block, esp since this block is what our curriculum actually uses.

Fix "Daily Weather" and "Spotify" current tables shows up with no records in the data browser:
1. [116e480](https://github.com/code-dot-org/code-dot-org/pull/57480/commits/116e4806ed4883881fdd3a8d56960415ba8201db): pass tableType="shared" from firebaseStorage.js back to addTableName() when registering "current tables" with redux

For more details on datablock storage, see: #56279.