### PR TITLE
Updates User Configuration and Turns off Statsig auto js error logging

### DIFF
--- a/apps/src/lib/util/StatsigReporter.js
+++ b/apps/src/lib/util/StatsigReporter.js
@@ -44,7 +44,8 @@ class StatsigReporter {
     this.initialize(api_key, user, options);
   }
 
-  // Initialize with a null user object- current user redux will update on sign in
+  // This user object will potentially update via a setUserProperties call
+  // (below) from current user redux
   async initialize(api_key, user, options) {
     if (this.shouldPutRecord(ALWAYS_SEND)) {
       await Statsig.initialize(api_key, user, options);

--- a/apps/src/lib/util/StatsigReporter.js
+++ b/apps/src/lib/util/StatsigReporter.js
@@ -31,9 +31,10 @@ class StatsigReporter {
     this.initialize(api_key, options);
   }
 
+  // Initialize with a null user object- current user redux will update on sign in
   async initialize(api_key, options) {
     if (this.shouldPutRecord(ALWAYS_SEND)) {
-      await Statsig.initialize(api_key, options);
+      await Statsig.initialize(api_key, {}, options);
     }
   }
 

--- a/apps/src/lib/util/StatsigReporter.js
+++ b/apps/src/lib/util/StatsigReporter.js
@@ -26,6 +26,7 @@ class StatsigReporter {
     const options = {
       environment: {tier: getEnvironment()},
       localMode: this.local_mode,
+      disableErrorLogging: true,
     };
     this.initialize(api_key, options);
   }

--- a/apps/src/lib/util/StatsigReporter.js
+++ b/apps/src/lib/util/StatsigReporter.js
@@ -13,10 +13,12 @@ const NO_EVENT_NAME = 'NO_VALID_EVENT_NAME_LOG_ERROR';
 class StatsigReporter {
   constructor() {
     let user = {};
-    user_id_element = document.querySelector('script[data-user-id]');
-    user_id = user_id_element ? user_id_element.dataset.userId : null;
-    user_type_element = document.querySelector('script[data-user-type');
-    user_type = user_type_element ? user_type_element.dataset.userType : null;
+    const user_id_element = document.querySelector('script[data-user-id]');
+    const user_id = user_id_element ? user_id_element.dataset.userId : null;
+    const user_type_element = document.querySelector('script[data-user-type');
+    const user_type = user_type_element
+      ? user_type_element.dataset.userType
+      : null;
     if (user_id) {
       user = {
         userID: this.formatUserId(user_id),

--- a/apps/src/lib/util/StatsigReporter.js
+++ b/apps/src/lib/util/StatsigReporter.js
@@ -12,6 +12,17 @@ const NO_EVENT_NAME = 'NO_VALID_EVENT_NAME_LOG_ERROR';
 
 class StatsigReporter {
   constructor() {
+    let user = {};
+    user_id_element = document.querySelector('script[data-user-id]');
+    user_id = user_id_element ? user_id_element.dataset.userId : null;
+    user_type_element = document.querySelector('script[data-user-type');
+    user_type = user_type_element ? user_type_element.dataset.userType : null;
+    if (user_id) {
+      user = {
+        userID: this.formatUserId(user_id),
+        custom: {type: user_type},
+      };
+    }
     const api_element = document.querySelector(
       'script[data-statsig-api-client-key]'
     );
@@ -28,13 +39,13 @@ class StatsigReporter {
       localMode: this.local_mode,
       disableErrorLogging: true,
     };
-    this.initialize(api_key, options);
+    this.initialize(api_key, user, options);
   }
 
   // Initialize with a null user object- current user redux will update on sign in
-  async initialize(api_key, options) {
+  async initialize(api_key, user, options) {
     if (this.shouldPutRecord(ALWAYS_SEND)) {
-      await Statsig.initialize(api_key, {}, options);
+      await Statsig.initialize(api_key, user, options);
     }
   }
 

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -190,8 +190,7 @@ export default function currentUser(state = initialState, action) {
     // and because dual reporting is aspirationally temporary (March 2024)
     statsigReporter.setUserProperties(
       id,
-      user_type,
-      experiments.getEnabledExperiments()
+      user_type
     );
     return {
       ...state,

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -188,10 +188,7 @@ export default function currentUser(state = initialState, action) {
     );
     // Calling Statsig separately to emphasize different user integrations
     // and because dual reporting is aspirationally temporary (March 2024)
-    statsigReporter.setUserProperties(
-      id,
-      user_type
-    );
+    statsigReporter.setUserProperties(id, user_type);
     return {
       ...state,
       userId: id,

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -6,6 +6,7 @@
     = render partial: 'i18n/crowdin_in_context_tool'
     = render inline: File.read(Rails.root.join('..', 'shared', 'haml', 'onetrust_cookie_scripts.haml')), type: :haml, locals: {dashboard: true, domain: 'code.org'}
     - appname = Rails.env.production? ? t(:appname) : "#{t(:appname)} [#{Rails.env}]"
+    - managed_test_server = "#{CDO.running_web_application? && CDO.test_system?}"
     - title = @page_title ? "#{@page_title} - #{appname}" : appname
     %title= title
     = ::NewRelic::Agent.browser_timing_header rescue ''
@@ -29,7 +30,10 @@
     -# auth key needed for statsig analytics
     %script{data: {'statsig-api-client-key': CDO.safe_statsig_api_client_key}}
     -# for statsig to recognized managed test server
-    %script{data: {'managed-test-server': "#{CDO.running_web_application? && CDO.test_system?}"}}
+    %script{data: {'managed-test-server': managed_test_server}}
+    -# user id and type for analytics logging
+    %script{data: {'user-id': current_user&.id}}
+    %script{data: {'user-type': current_user&.user_type}}
     -# webpack-runtime.js must appear exactly once on any page containing webpack entries
     %script{src: webpack_asset_path('js/webpack-runtime.js')}
     -# essential.js is ordered above application.js to filter new relic errors

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -31,7 +31,7 @@
     %script{data: {'statsig-api-client-key': CDO.safe_statsig_api_client_key}}
     -# for statsig to recognized managed test server
     %script{data: {'managed-test-server': managed_test_server}}
-    -# user id and type for analytics logging
+    -# user id and type for analytics logging- may not work for cached pages
     %script{data: {'user-id': current_user&.id}}
     %script{data: {'user-type': current_user&.user_type}}
     -# webpack-runtime.js must appear exactly once on any page containing webpack entries


### PR DESCRIPTION
When Statsig is initialized, it defaults to logging all js errors. This means that now our integration is working and we're logging lots of errors! The options were being logged to the user object. This pointed to a bigger issue with the way we were planning to keep track of user data. On Amplitude, we send it through Current User Redux and that persists across a user's session. For Statsig, they strongly recommend sending the user in during the initialize() call and 'do not maintain or update user objects'. That led to this new solution:

1. Load the user id and user type into the dom to be queried by the same query selector element
2. If an id exists, populate a user object with the id and type, and send through to initialize
3. If no id exists, send an empty user object 

This way, the options parameter will always be the third parameter so flags like disableErrorLogging will work properly. A bonus: this now more closely matches our Statsig ruby implementation, where the user is sent in on initialize.

Additionally, I am updating the managed_test_server param to its own variable before sending it through, which I believe will enable our test server to send events.


<img width="867" alt="Screenshot 2024-03-22 at 4 08 58 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/a2956acc-59b1-47f9-b1dd-190fccf68c7a">

These errors do not count toward our billable events (see images from slack conversation with Statsig directly below).
<img width="399" alt="Screenshot 2024-03-22 at 12 29 23 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/81bc3454-cf5e-4e11-8949-118cdbc27594">
![Screenshot 2024-03-22 at 12 35 51 PM](https://github.com/code-dot-org/code-dot-org/assets/37230822/f3908bef-9132-4c9d-8c4c-41cb8b215b54)

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1660

## Testing story

I was able to show that initializing with user data makes it so every page refresh has a user_id, not just when we have a login (and the single send from current user redux). See image below. 

I was also able to verify that pegasus reporting still works as anticipated (I updated the amplitude event for 'page viewed' to send to statsig and it correctly sent with an empty user object). See second image below!

<img width="1191" alt="Screenshot 2024-03-22 at 7 40 35 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/891bb441-66ee-42b1-834b-c8a1b5f23f63">
<img width="1279" alt="Screenshot 2024-03-22 at 7 50 15 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/e98a6717-86ca-4d15-8611-13611ede7e99">


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
