### PR TITLE
Fixes issues with malformed evidence strings.

### DIFF
--- a/apps/src/EditorAnnotator.js
+++ b/apps/src/EditorAnnotator.js
@@ -747,7 +747,7 @@ export default class EditorAnnotator {
    * @returns {bool} Returns true when the editor is line based.
    */
   static isLineBased() {
-    return EditorAnnotator.annotator().isLineBased();
+    return EditorAnnotator.annotator()?.isLineBased() || false;
   }
 
   /**
@@ -756,7 +756,7 @@ export default class EditorAnnotator {
    * It may or not be still line-based.
    */
   static hasBlocks() {
-    return EditorAnnotator.annotator().hasBlocks();
+    return EditorAnnotator.annotator()?.hasBlocks() || false;
   }
 
   /**
@@ -766,7 +766,7 @@ export default class EditorAnnotator {
    * @returns {bool} Returns true when the editor is block based.
    */
   static isBlockBased() {
-    return EditorAnnotator.annotator().isBlockBased();
+    return EditorAnnotator.annotator()?.isBlockBased() || false;
   }
 
   static anonymizeCode_(code) {
@@ -1095,7 +1095,7 @@ export default class EditorAnnotator {
     icon = null,
     tipStyle = {}
   ) {
-    EditorAnnotator.annotator().annotateLine(
+    EditorAnnotator.annotator()?.annotateLine(
       lineNumber,
       message,
       logLevel,
@@ -1109,7 +1109,7 @@ export default class EditorAnnotator {
    * Removes annotations of a particular type.
    */
   static clearAnnotations(logLevel = 'INFO') {
-    EditorAnnotator.annotator().clearAnnotations(logLevel);
+    EditorAnnotator.annotator()?.clearAnnotations(logLevel);
   }
 }
 

--- a/apps/src/templates/rubrics/AiAssessmentBox.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentBox.jsx
@@ -73,26 +73,50 @@ export default function AiAssessmentBox({
             <StrongText>{i18n.aiAssessmentEvidence()}</StrongText>
           </BodyFourText>
           <ul>
-            {aiEvidence.map(
-              (info, i) =>
-                info &&
-                info.firstLine && (
-                  <li key={i}>
-                    {/* Lines [firstLine]-[lastLine]: [message] */}
-                    {info.firstLine === info.lastLine &&
-                      i18n.aiAssessmentEvidenceLine({
-                        lineNumber: info.firstLine,
-                        feedbackForLine: info.message,
-                      })}
-                    {info.firstLine !== info.lastLine &&
-                      i18n.aiAssessmentEvidenceLines({
-                        firstLineNumber: info.firstLine,
-                        lastLineNumber: info.lastLine,
-                        feedbackForLines: info.message,
-                      })}
-                  </li>
+            {
+              /* When the message is the same as the whole observations, this
+               * was evidence that did not have a dedicated message. In this
+               * case, this is where we fall back to just showing a list of
+               * observations instead of the evidence. This won't have line
+               * numbers and is certainly worse but better than nothing. */
+              (
+                aiEvidence
+                  .filter(info => info && info.observations === info.message)
+                  .map(info => info.observations)[0] || ''
+              )
+                .split('. ')
+                .map(
+                  (line, i) =>
+                    line.trim() && (
+                      <li key={i}>
+                        {/* Just the observation as a whole */}
+                        {line.endsWith('.') ? line : line + '.'}
+                      </li>
+                    )
                 )
-            )}
+            }
+            {aiEvidence
+              .filter(info => info && info.observations !== info.message)
+              .map(
+                (info, i) =>
+                  info &&
+                  info.firstLine && (
+                    <li key={i}>
+                      {/* Lines [firstLine]-[lastLine]: [message] */}
+                      {info.firstLine === info.lastLine &&
+                        i18n.aiAssessmentEvidenceLine({
+                          lineNumber: info.firstLine,
+                          feedbackForLine: info.message,
+                        })}
+                      {info.firstLine !== info.lastLine &&
+                        i18n.aiAssessmentEvidenceLines({
+                          firstLineNumber: info.firstLine,
+                          lastLineNumber: info.lastLine,
+                          feedbackForLines: info.message,
+                        })}
+                    </li>
+                  )
+              )}
           </ul>
         </div>
       )}

--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -471,7 +471,7 @@ export default function LearningGoals({
   const aiEvidence = useMemo(() => {
     // Annotate the lines based on the AI observation
     clearAnnotations();
-    if (!!aiEvalInfo && aiEvalInfo.evidence) {
+    if (!!aiEvalInfo?.evidence) {
       return annotateLines(aiEvalInfo.evidence, aiEvalInfo.observations);
     }
     return [];

--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -92,10 +92,20 @@ export function clearAnnotations() {
  * In this case, we might find this code on lines 8 through 10. So, we would
  * annotate line 8 and highlight lines 8 through 10.
  *
+ * Another case requiring a fallback is when the evidence feedback does not
+ * contain a message. Something like: `Lines 5-6: `if (something) {...}`.
+ * In this case, we can highlight the line, but we want to annotate the line
+ * with the full observations. This is why we also pass those along.
+ *
+ * Also seen above is the way the AI might truncate code. In that case, we
+ * fallback to finding the first partial code match using the code before the
+ * ellipsis (...).
+ *
  * This will return a list of annotation blocks containing the line numbers
  * and the description.
  *
  * @param {string} evidence - A text block described above.
+ * @param {string} observations - The text block for the overall observations, if needed.
  * @returns {Array} The ordered list of annotations.
  */
 export function annotateLines(evidence, observations) {

--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -494,11 +494,6 @@ export default function LearningGoals({
     // Annotate the lines based on the AI observation
     clearAnnotations();
     if (currentIndex !== learningGoals.length) {
-      const aiEvalInfo = getAiInfo(learningGoals[currentIndex].id);
-      if (!!aiEvalInfo && aiEvalInfo.evidence) {
-        setAiEvidence(annotateLines(aiEvalInfo.evidence));
-      }
-
       if (!isStudent) {
         const eventName = EVENTS.TA_RUBRIC_LEARNING_GOAL_SELECTED;
         analyticsReporter.sendEvent(eventName, {

--- a/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
+++ b/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
@@ -20,6 +20,33 @@ describe('AiAssessmentBox', () => {
       firstLine: 1,
       lastLine: 10,
       message: 'This is evidence.',
+      observations:
+        'This is the original observations. This is another line. This is a third line.',
+    },
+    {
+      firstLine: 42,
+      lastLine: 45,
+      message: 'This is some other evidence.',
+      observations:
+        'This is the original observations. This is another line. This is a third line.',
+    },
+  ];
+  const mockEvidenceWithObservations = [
+    {
+      firstLine: 1,
+      lastLine: 10,
+      message:
+        'This is the original observations. This is another line. This is a third line.',
+      observations:
+        'This is the original observations. This is another line. This is a third line.',
+    },
+    {
+      firstLine: 42,
+      lastLine: 45,
+      message:
+        'This is the original observations. This is another line. This is a third line.',
+      observations:
+        'This is the original observations. This is another line. This is a third line.',
     },
   ];
   const props = {
@@ -136,7 +163,7 @@ describe('AiAssessmentBox', () => {
         <AiAssessmentBox {...props} />
       </AiAssessmentFeedbackContext.Provider>
     );
-    expect(wrapper.find('ul li')).to.have.lengthOf(1);
+    expect(wrapper.find('ul li')).to.have.lengthOf(2);
     expect(wrapper.html().includes(props.aiEvidence[0].message)).to.be.true;
     expect(
       wrapper
@@ -145,5 +172,30 @@ describe('AiAssessmentBox', () => {
           `Lines ${props.aiEvidence[0].firstLine}-${props.aiEvidence[0].lastLine}`
         )
     ).to.be.true;
+  });
+
+  it('falls back to rendering evidence as observations if there is no message', () => {
+    const updatedProps = {...props, aiEvidence: mockEvidenceWithObservations};
+    const wrapper = mount(
+      <AiAssessmentFeedbackContext.Provider value={[-1, () => {}]}>
+        <AiAssessmentBox {...updatedProps} />
+      </AiAssessmentFeedbackContext.Provider>
+    );
+    // One item per sentence in 'observations'
+    expect(wrapper.find('ul li')).to.have.lengthOf(3);
+    // It should not render the entire message this time, but rather each sentence
+    expect(wrapper.html().includes(props.aiEvidence[0].message)).to.be.false;
+    expect(
+      wrapper.html().includes(props.aiEvidence[0].observations.split('.')[0])
+    ).to.be.true;
+    // And it should not render line numbers in this case since it does not know
+    // where any particular observation actually is.
+    expect(
+      wrapper
+        .html()
+        .includes(
+          `Lines ${props.aiEvidence[0].firstLine}-${props.aiEvidence[0].lastLine}`
+        )
+    ).to.be.false;
   });
 });

--- a/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
@@ -243,8 +243,8 @@ describe('LearningGoals - Enzyme', () => {
     clearHighlightedLinesStub;
   const studentLevelInfo = {name: 'Grace Hopper', timeSpent: 706};
 
-  // Stub out our references to the singleton and editor
-  beforeEach(() => {
+  function stubAnnotator() {
+    // Stub out our references to the singleton and editor
     let annotatorInstanceStub = sinon.stub();
     annotatorInstanceStub.getCode = sinon.stub().returns(code);
     annotatorStub = sinon
@@ -257,16 +257,24 @@ describe('LearningGoals - Enzyme', () => {
       EditorAnnotator,
       'clearHighlightedLines'
     );
-  });
-  afterEach(() => {
+  }
+
+  function restoreAnnotator() {
     annotatorStub.restore();
     annotateLineStub.restore();
     clearAnnotationsStub.restore();
     highlightLineStub.restore();
     clearHighlightedLinesStub.restore();
-  });
+  }
 
   describe('annotateLines', () => {
+    beforeEach(() => {
+      stubAnnotator();
+    });
+    afterEach(() => {
+      restoreAnnotator();
+    });
+
     it('should do nothing if the AI observation does not reference any lines', () => {
       // The AI tends to misreport the line number, so we shouldn't rely on it
       annotateLines('This is just a basic observation.', observations);
@@ -429,6 +437,13 @@ describe('LearningGoals - Enzyme', () => {
   });
 
   describe('clearAnnotations', () => {
+    beforeEach(() => {
+      stubAnnotator();
+    });
+    afterEach(() => {
+      restoreAnnotator();
+    });
+
     it('should clear annotations and clear highlighted lines', () => {
       clearAnnotations();
       sinon.assert.called(clearAnnotationsStub);

--- a/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
@@ -19,6 +19,9 @@ import i18n from '@cdo/locale';
 
 import {expect} from '../../../util/reconfiguredChai';
 
+// These are test observations that would be given by the AI.
+const observations = 'This is an observation. This is another observation.';
+
 const learningGoals = [
   {
     id: 2,
@@ -59,7 +62,8 @@ const aiEvaluations = [
     understanding: 2,
     aiConfidencePassFail: 2,
     aiConfidenceExactMatch: 1,
-    observations:
+    observations: observations,
+    evidence:
       'Line 3-5: The sprite is defined here. `var sprite = createSprite(100, 120)`',
   },
 ];
@@ -72,6 +76,12 @@ const code = `// code
     var z = x + y;
     */
     draw();
+
+    if (something) {
+      doSomething();
+    }
+
+    exit();
   `;
 
 const studentLevelInfo = {
@@ -83,6 +93,35 @@ const studentLevelInfo = {
 };
 
 describe('LearningGoals - React Testing Library', () => {
+  let annotatorStub,
+    annotateLineStub,
+    highlightLineStub,
+    clearAnnotationsStub,
+    clearHighlightedLinesStub;
+
+  // Stub out our references to the singleton and editor
+  beforeEach(() => {
+    let annotatorInstanceStub = sinon.stub();
+    annotatorInstanceStub.getCode = sinon.stub().returns(code);
+    annotatorStub = sinon
+      .stub(EditorAnnotator, 'annotator')
+      .returns(annotatorInstanceStub);
+    annotateLineStub = sinon.stub(EditorAnnotator, 'annotateLine');
+    clearAnnotationsStub = sinon.stub(EditorAnnotator, 'clearAnnotations');
+    highlightLineStub = sinon.stub(EditorAnnotator, 'highlightLine');
+    clearHighlightedLinesStub = sinon.stub(
+      EditorAnnotator,
+      'clearHighlightedLines'
+    );
+  });
+  afterEach(() => {
+    annotatorStub.restore();
+    annotateLineStub.restore();
+    clearAnnotationsStub.restore();
+    highlightLineStub.restore();
+    clearHighlightedLinesStub.restore();
+  });
+
   it('renders EvidenceLevels without canProvideFeedback', () => {
     render(<LearningGoals learningGoals={learningGoals} teacherHasEnabledAi />);
 
@@ -230,41 +269,77 @@ describe('LearningGoals - Enzyme', () => {
   describe('annotateLines', () => {
     it('should do nothing if the AI observation does not reference any lines', () => {
       // The AI tends to misreport the line number, so we shouldn't rely on it
-      annotateLines('This is just a basic observation.');
+      annotateLines('This is just a basic observation.', observations);
       expect(annotateLineStub.notCalled).to.be.true;
     });
 
     it('should annotate a single line of code referenced by the AI', () => {
       // The AI tends to misreport the line number, so we shouldn't rely on it
-      annotateLines('Line 1: This is a line of code `var x = 5;`');
+      annotateLines(
+        'Line 1: This is a line of code `var x = 5;`',
+        observations
+      );
       sinon.assert.calledWith(annotateLineStub, 2, 'This is a line of code');
     });
 
+    it('should annotate a truncated line of code referenced by the AI', () => {
+      // The AI tends to misreport the line number, so we shouldn't rely on it
+      annotateLines(
+        'Line 1: This is a line of code `if (something) { ... }`',
+        observations
+      );
+      sinon.assert.calledWith(annotateLineStub, 10, 'This is a line of code');
+    });
+
     it('should annotate the first line of code referenced by the AI', () => {
-      annotateLines('Line 1: This is a line of code `var x = 5; var y = 6;`');
+      annotateLines(
+        'Line 1: This is a line of code `var x = 5; var y = 6;`',
+        observations
+      );
       sinon.assert.calledWith(annotateLineStub, 2, 'This is a line of code');
     });
 
     it('should highlight a single line of code referenced by the AI', () => {
       // The AI tends to misreport the line number, so we shouldn't rely on it
-      annotateLines('Line 1: This is a line of code `var x = 5; var y = 6;`');
+      annotateLines(
+        'Line 1: This is a line of code `var x = 5; var y = 6;`',
+        observations
+      );
       sinon.assert.calledWith(highlightLineStub, 2);
     });
 
+    it('should highlight a truncated line of code referenced by the AI', () => {
+      // The AI tends to misreport the line number, so we shouldn't rely on it
+      annotateLines(
+        'Line 1: This is a line of code `if (something) { ... }`',
+        observations
+      );
+      sinon.assert.calledWith(highlightLineStub, 10);
+    });
+
     it('should highlight all lines of code referenced by the AI', () => {
-      annotateLines('Line 1: This is a line of code `var x = 5; var y = 6;`');
+      annotateLines(
+        'Line 1: This is a line of code `var x = 5; var y = 6;`',
+        observations
+      );
       sinon.assert.calledWith(highlightLineStub, 2);
       sinon.assert.calledWith(highlightLineStub, 3);
     });
 
     it('should just highlight the lines the AI thinks if the referenced code does not exist', () => {
-      annotateLines('Line 45: This is a line of code `var z = 0`');
+      annotateLines(
+        'Line 45: This is a line of code `var z = 0`',
+        observations
+      );
       sinon.assert.calledWith(annotateLineStub, 45, 'This is a line of code');
       sinon.assert.calledWith(highlightLineStub, 45);
     });
 
     it('should just highlight all of the lines the AI thinks if the referenced code does not exist', () => {
-      annotateLines('Line 42-44: This is a line of code `var z = 0`');
+      annotateLines(
+        'Line 42-44: This is a line of code `var z = 0`',
+        observations
+      );
       sinon.assert.calledWith(annotateLineStub, 42, 'This is a line of code');
       sinon.assert.calledWith(highlightLineStub, 42);
       sinon.assert.calledWith(highlightLineStub, 43);
@@ -272,12 +347,12 @@ describe('LearningGoals - Enzyme', () => {
     });
 
     it('should annotate the last line of code when referenced by the AI', () => {
-      annotateLines('Line 55: This is a line of code `draw();`');
+      annotateLines('Line 55: This is a line of code `draw();`', observations);
       sinon.assert.calledWith(annotateLineStub, 8, 'This is a line of code');
     });
 
     it('should pass along the correct info type for the annotation', () => {
-      annotateLines('Line 55: This is a line of code `draw();`');
+      annotateLines('Line 55: This is a line of code `draw();`', observations);
       sinon.assert.calledWith(
         annotateLineStub,
         sinon.match.any,
@@ -287,7 +362,7 @@ describe('LearningGoals - Enzyme', () => {
     });
 
     it('should pass along a hex color', () => {
-      annotateLines('Line 55: This is a line of code `draw();`');
+      annotateLines('Line 55: This is a line of code `draw();`', observations);
       sinon.assert.calledWith(
         annotateLineStub,
         sinon.match.any,
@@ -298,7 +373,7 @@ describe('LearningGoals - Enzyme', () => {
     });
 
     it('should pass along the appropriate image as an icon', () => {
-      annotateLines('Line 55: This is a line of code `draw();`');
+      annotateLines('Line 55: This is a line of code `draw();`', observations);
 
       sinon.assert.calledWith(
         annotateLineStub,
@@ -311,7 +386,7 @@ describe('LearningGoals - Enzyme', () => {
     });
 
     it('should pass along the appropriate image as an icon for the tooltip', () => {
-      annotateLines('Line 55: This is a line of code `draw();`');
+      annotateLines('Line 55: This is a line of code `draw();`', observations);
 
       sinon.assert.calledWith(
         annotateLineStub,
@@ -325,18 +400,31 @@ describe('LearningGoals - Enzyme', () => {
     });
 
     it('should highlight the last line of code when referenced by the AI', () => {
-      annotateLines('Line 55: This is a line of code `draw();`');
+      annotateLines('Line 55: This is a line of code `draw();`', observations);
       sinon.assert.calledWith(highlightLineStub, 8);
     });
 
     it('should highlight the line with a hex color', () => {
-      annotateLines('Line 55: This is a line of code `draw();`');
+      annotateLines('Line 55: This is a line of code `draw();`', observations);
       sinon.assert.calledWith(highlightLineStub, 8, sinon.match('#'));
     });
 
-    it('should ignore code snippets that are empty', () => {
-      annotateLines('Line 42: This is totally a thing ` `');
-      sinon.assert.notCalled(highlightLineStub);
+    it('should use the provided line numbers if the code snippet is empty', () => {
+      annotateLines('Line 42: This is totally a thing ` `', observations);
+      sinon.assert.calledWith(annotateLineStub, 42, 'This is totally a thing');
+    });
+
+    it('should use the provided line numbers if the code snippet is missing', () => {
+      annotateLines(
+        'Line 42: This is totally a thing Lines 45-56: This is also a thing `some code`',
+        observations
+      );
+      sinon.assert.calledWith(annotateLineStub, 42, 'This is totally a thing');
+    });
+
+    it('should annotate with the observations if the evidence has no message.', () => {
+      annotateLines('Line 42: `draw()`', observations);
+      sinon.assert.calledWith(annotateLineStub, 8, observations);
     });
   });
 
@@ -388,6 +476,27 @@ describe('LearningGoals - Enzyme', () => {
       2
     );
     expect(wrapper.find('AiAssessment').props().isAiAssessed).to.equal(true);
+  });
+
+  it('renders AiAssessment with the annotated list of evidence', () => {
+    const aiEvidence = annotateLines(
+      aiEvaluations[0].evidence,
+      aiEvaluations[0].observations
+    );
+
+    const wrapper = shallow(
+      <LearningGoals
+        learningGoals={learningGoals}
+        teacherHasEnabledAi={true}
+        aiUnderstanding={3}
+        studentLevelInfo={studentLevelInfo}
+        aiEvaluations={aiEvaluations}
+      />
+    );
+
+    expect(wrapper.find('AiAssessment').props().aiEvidence).to.deep.equal(
+      aiEvidence
+    );
   });
 
   it('does not renders AiAssessment when teacher has disabled ai', () => {


### PR DESCRIPTION
Since evidence is its own column, we can get away with not having some of the information and falling back to what is there. If the code isn't there, we still annotate with the message for those lines with the observations column instead. Here, we only use the line numbers to mark the highlights. The evidence listing is just a bulleted list of sentences provided in the observations column.

We also allow for partial matches of code. The AI sometimes truncates the code down (e.g. 'if (something) { ... }') and in those cases we want to gracefully fall back to highlighting the parts we match. It's not ideal.

Here is it showing the effect of truncated code regions. It would have been something like: `Lines 188-230: The student has... blah. `function movePlayer() { ... }` `function playerAtEdge() { ... }` etc:

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/bb88ad75-0d47-4219-96d6-206d917408d2)

Testing exposed the bug where the `LearningGoals` component does not render the AI information on the first load... only when the goal is switched will it do that. This is because the function to load the evaluations is not called outside of that carousel change method. I have updated it such that the aiEvaluations is a memo that is always up-to-date. It made testing a bit easier as well. (Note, this isn't true for any of our rubrics since those all start with the program guide learning goal, which is not AI assessed... so we never caught this in practice)

Updated:
* Adds ability to parse the partial code snippets when the AI 'helpfully' truncates the code it gives as a reference.
* Adds ability to fall back to the observations text when the evidence column does not contain messages alongside code references.
* Fixes issue where the `LearningGoals` component does not render the AI assessment for the first learning goal if it happens to be AI enabled.

## Links

- jira ticket: [AITT-541](https://codedotorg.atlassian.net/browse/AITT-541)

## Testing story

New tests to capture the changes to the annotator and the `annotateLines` method in `LearningGoals.jsx`.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
