### PR TITLE
Aggressively shrink callouts_seen part of cookies down.

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -337,13 +337,15 @@ class ApplicationController < ActionController::Base
 
   # Clean up a big cookie session
   def shrink_cookie
-    # Ensure the callouts_seen is an Array
-    session[:callouts_seen] ||= []
-    session[:callouts_seen] = session[:callouts_seen].to_a
+    if session.key? :callouts_seen
+      # Ensure the callouts_seen is an Array
+      session[:callouts_seen] ||= []
+      session[:callouts_seen] = session[:callouts_seen].to_a
 
-    # Just re-add the last callout to ensure that the list is maintained
-    # ClientState should be truncating the list
-    client_state.add_callout_seen(session[:callouts_seen][-1]) if session[:callouts_seen].any?
+      # Just re-add the last callout to ensure that the list is maintained
+      # ClientState should be truncating the list
+      client_state.add_callout_seen(session[:callouts_seen][-1]) if session[:callouts_seen].any?
+    end
   end
 
   # Check that the user is compliant with the Child Account Policy. If they

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -16,6 +16,9 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  # Try to correct cookie overflows
+  before_action :shrink_cookie
+
   before_action :assert_child_account_policy
 
   # this is needed to avoid devise breaking on email param
@@ -330,6 +333,17 @@ class ApplicationController < ActionController::Base
       session.delete(:sign_up_type)
       session.delete(:sign_up_tracking_expiration)
     end
+  end
+
+  # Clean up a big cookie session
+  def shrink_cookie
+    # Ensure the callouts_seen is an Array
+    session[:callouts_seen] ||= []
+    session[:callouts_seen] = session[:callouts_seen].to_a
+
+    # Just re-add the last callout to ensure that the list is maintained
+    # ClientState should be truncating the list
+    client_state.add_callout_seen(session[:callouts_seen][-1]) if session[:callouts_seen].any?
   end
 
   # Check that the user is compliant with the Child Account Policy. If they


### PR DESCRIPTION
Previously, I merged an update that maintains the `callouts_seen` list in our cookie to ensure it is capped out at 20 entries. Often the unbounded nature of this caused cookie overflows after around 45 or so.

However, this only triggers when a callout is added. That seemed sensible since that was the opportunity for that array to grow. We no longer see cookie overflows on level loads (most of the traffic) so that indeed seems to work.

With that, it seems like we will no longer see **new** errors. But, the cookie will still overflow in cases where the array is part of the session and some _other_ info is added to the session independently. For instance, a flash message on essentially any login page.

Specifically, this might happen on login via SSO giving no real opportunity to rectify it (outside of them clearing their cookies, which is not an obvious solution): https://app.honeybadger.io/projects/3240/faults/105680689

This perhaps over-dramatically adds a small measure to check and limit that session data on every dashboard request to clear up these historic sessions without user intervention. After they hit any route, their session will be 'healed' and hopefully this can be removed in time.

## Follow-up

I will create the revert for this PR, stage it as a draft PR, and own a task with a due date of 1 month to revert this change completely using that PR once we can see the occurrences of the CookieOverflow (due to the callouts_seen, at least) drop.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
