### PR TITLE
Update .button-wrapper row gap

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -217,7 +217,8 @@ hr {
 .button-wrapper {
   display: flex;
   flex-wrap: wrap;
-  gap: 1.5rem;
+  column-gap: 1.5rem;
+  row-gap: 0.5rem;
 
   &.centered {
     justify-content: center;


### PR DESCRIPTION
Updates the `row-gap` for the `.button-wrapper` class that decreases vertical space when buttons wrap. This will fix this everywhere `.button-wrapper` is used (which is a lot of places!).

**Jira ticket:** [ACQ-1646](https://codedotorg.atlassian.net/browse/ACQ-1646)

----

| Before | After |
| ----- | ----- |
| <img width="472" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/4a4ef43b-b21f-4669-8255-77271c7bd9f1"> | <img width="472" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/b5d29627-1414-4c0b-94bb-aed2482e0807"> |
