### PR TITLE
Remove Derniere Danse

### DIFF
--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -18,6 +18,7 @@ const DEPRECATED_SONGS = [
   'showdaspoderosas_anitta',
   'savagelove_jasonderulo',
   'astronautintheocean_maskedwolf',
+  'dernieredanse_indila',
 ];
 
 /**

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -665,7 +665,7 @@ module SharedConstants
   # Current song manifest file name for Dance Party. Note that different manifests
   # can be tested using query params (?manifest=...), but once this value is updated
   # the default manifest will change for all users.
-  DANCE_SONG_MANIFEST_FILENAME = 'songManifest2024_v1.json'
+  DANCE_SONG_MANIFEST_FILENAME = 'songManifest2024_v2.json'
 
   # We should always specify a version for the LLM so the results don't unexpectedly change.
   # reference: https://platform.openai.com/docs/models/gpt-3-5


### PR DESCRIPTION
Removes a song (Derniere Danse by Indila) from Dance Party that isn't properly licensed. Associated new song manifest (`songManifest2024_v2`) has been uploaded to S3.

## Testing story

- Tested manually in production via URL param that the song no longer appears in the song dropdown.
- Tested manually in development that changing the song manifest version in code produced the same result.
- I did not test that the right deprecation warning is shown if you have a project with this song.