### PR TITLE
Fix external link icon for RTL languages

### DIFF
--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -357,6 +357,7 @@ input[type="submit"] {
   an "a" tag when a link opens in a new tab or window */
 .has-external-link a::after,
 a.has-external-link::after {
+  display: inline-block;
   font: var(--fa-font-solid);
   content: "\f08e";
   font-size: 0.875em;
@@ -366,6 +367,11 @@ a.has-external-link::after {
 .has-external-link a.link-button::after,
 a.link-button.has-external-link::after {
   margin-inline: 4px 0;
+}
+
+html[dir="rtl"] .has-external-link a::after,
+html[dir="rtl"] a.has-external-link::after {
+  transform: scaleX(-1);
 }
 
 li > ul {


### PR DESCRIPTION
Applies RTL language specific styles to the `.has-external-link` class so it the icon is mirrored and shows in the right order.

**Jira ticket:** [ACQ-1659](https://codedotorg.atlassian.net/browse/ACQ-1659)

----

## Buttons
| Before | After | LTR |
| ----- | ----- | ----- |
| <img width="450" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/f9311bd0-9273-44b9-aff0-8af8d59b400a"> | <img width="450" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/e07939fb-2d80-4b47-8887-c16231bd1756"> | <img width="450" alt="LTR" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/d0d17e8f-73b5-4dba-aee8-cec7d8f7ef35"> |

## Text links
| Before | After | LTR |
| ----- | ----- | ----- |
| <img width="455" alt="Text_Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/9b9a1ec7-6ee7-4e64-bbcc-3db92e9f6ec3"> | <img width="455" alt="Text_After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/ddfe6d94-caa8-417b-b2de-f68ca22ffaa0"> | <img width="455" alt="Text_LTR" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/e78b3a58-80e6-4a37-818a-d8d6532ec48d"> |


