### PR TITLE
skip dropdown test on mobile

### DIFF
--- a/dashboard/test/ui/features/star_labs/dropdown.feature
+++ b/dashboard/test/ui/features/star_labs/dropdown.feature
@@ -3,6 +3,7 @@ Feature: Dropdowns work as expected
 Background:
   Given I am on "http://studio.code.org/s/playlab/lessons/1/levels/8?noautoplay=true"
 
+@no_mobile
 Scenario: Drag a dropdown and select a different option.
   When I wait for the page to fully load
   And I dismiss the login reminder


### PR DESCRIPTION
Since Friday, this test has been failing due to a stale element reference. It doesn't look like we've changed anything related to this feature recently. I've confirmed that dropdown in the test level works as expected on iPhone and iPad Safari. The proposal here is to skip this test on mobile for now to unblock the pipeline.

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
