### PR TITLE
feat(lms): do not render the student information popup if on the authenticate path

### DIFF
--- a/dashboard/app/views/layouts/_student_information_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_student_information_interstitial.html.haml
@@ -1,4 +1,4 @@
-.modal#student-information-modal{'data-backdrop' => 'static', 'data-keyboard' => 'false', display: 'none'}
+.modal#student-information-modal{'data-backdrop' => 'static', 'data-keyboard' => 'false', style: 'display: none'}
   .modal-dialog
     .modal-content.no-modal-icon
       %h1{style: 'margin: 25px 0 0 0;font-size: 28px'}= t('activerecord.attributes.user.finish_sign_up_header')
@@ -30,7 +30,11 @@
           = f.submit t('continue'), class: 'btn primary-button', disabled: true, id: 'submit-btn'
 :javascript
   $().ready(function() {
-    $("#student-information-modal").modal('show');
+    const pathName = window.location.pathname;
+
+    if (pathName !== "/lti/v1/authenticate") {
+      $("#student-information-modal").modal('show');
+    }
 
      function checkInputs() {
       const ageValue = $("#user_age").val();


### PR DESCRIPTION
Currently the student information popup will also show on the same page as the upgrade account popup which leads to a situation where both show up at the same time. Do not render the student information popup on the authenticate path.

## Links

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-800)

## Testing story

### Before

[popup before.webm](https://github.com/code-dot-org/code-dot-org/assets/538214/bb6ab6e5-732e-42bd-86f9-b89764509d7d)


### After

[popup after.webm](https://github.com/code-dot-org/code-dot-org/assets/538214/c469ee10-5a0e-41b5-9761-e505550ca6b6)


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
