### PR TITLE
Fix Rate Limit error on i18n sync-up

### DIFF
--- a/bin/i18n/utils/crowdin_client.rb
+++ b/bin/i18n/utils/crowdin_client.rb
@@ -169,26 +169,6 @@ module I18n
         request(:delete_storage, crowdin_storage_id) if crowdin_storage_id
       end
 
-      # Uploads the given i18n source files to Crowdin project
-      #
-      # @param source_files [Array<String>] the i18n source file paths
-      # @param :base_path [String] the i18n source base path
-      # @yield [Hash] the uploaded Crowdin source file data
-      # @return [Array<Hash>] the Crowdin source files data
-      def upload_source_files(source_files, base_path:)
-        mutex = Thread::Mutex.new
-        Parallel.map(source_files, in_threads: MAX_CONCURRENT_REQUESTS) do |source_file_path|
-          crowdin_file_path = File.join File::SEPARATOR, source_file_path.delete_prefix(base_path)
-          crowdin_dir_path = File.dirname(crowdin_file_path)
-
-          source_file_data = upload_source_file(source_file_path, crowdin_dir_path)
-
-          mutex.synchronize {yield source_file_data} if block_given?
-
-          source_file_data
-        end
-      end
-
       # Builds the given Crowdin source file translations
       # @see https://developer.crowdin.com/api/v2/#operation/api.projects.translations.builds.files.post
       #

--- a/bin/test/i18n/utils/test_crowdin_client.rb
+++ b/bin/test/i18n/utils/test_crowdin_client.rb
@@ -390,30 +390,6 @@ describe I18n::Utils::CrowdinClient do
     end
   end
 
-  describe '#upload_source_files' do
-    let(:upload_source_files) {described_instance.upload_source_files(source_files, base_path: base_path)}
-
-    let(:base_path) {'/expected_base_path'}
-    let(:crowdin_dir_path) {'/expected_crowdin_dir_path'}
-    let(:source_file_path) {File.join(base_path, crowdin_dir_path, 'expected_source_file_path')}
-    let(:source_files) {[source_file_path]}
-
-    it 'returns uploaded source file data' do
-      expected_source_file_data = 'uploaded_source_file_data'
-
-      described_instance.
-        expects(:upload_source_file).
-        with(source_file_path, crowdin_dir_path).
-        returns(expected_source_file_data)
-
-      source_files_data = upload_source_files do |uploaded_source_file_data|
-        _(uploaded_source_file_data).must_equal expected_source_file_data
-      end
-
-      _(source_files_data).must_equal [expected_source_file_data]
-    end
-  end
-
   describe '#download_translation' do
     let(:download_translation) do
       described_instance.download_translation(source_file_id, language_id, dest_path, etag: etag)

--- a/bin/test/i18n/utils/test_sync_up_base.rb
+++ b/bin/test/i18n/utils/test_sync_up_base.rb
@@ -153,12 +153,14 @@ describe I18n::Utils::SyncUpBase do
     let(:perform) {described_instance.send(:perform)}
 
     let(:crowdin_project) {'expected_crowdin_project'}
-    let(:base_path) {'expected_base_path'}
+    let(:base_path) {'/expected_base_path'}
+
+    let(:crowdin_dir_path) {'/expected_crowdin_dir_path'}
+    let(:source_file_path) {File.join(base_path, crowdin_dir_path, 'expected_source_file_path')}
+    let(:source_files) {[source_file_path]}
 
     let(:config) {stub(crowdin_project: crowdin_project, base_path: base_path)}
-
     let(:crowdin_client) {stub}
-    let(:source_files) {['expected_source_file_path']}
 
     before do
       described_class.stubs(:config).returns(config)
@@ -167,7 +169,10 @@ describe I18n::Utils::SyncUpBase do
     end
 
     it 'uploads source files' do
-      crowdin_client.expects(:upload_source_files).with(source_files, base_path: base_path).once
+      crowdin_client.
+        expects(:upload_source_file).
+        with(source_file_path, crowdin_dir_path).once
+
       perform
     end
   end


### PR DESCRIPTION
Limits the number of requests to 20 per second to avoid hitting Crowdin's rate limit
```
bundler: failed to load command: ./bin/i18n/sync-all.rb (./bin/i18n/sync-all.rb)
<head><title>429 Too Many Requests</title></head>
```