### PR TITLE
launch showing single evidence level when exact-match confidence is high

### DIFF
--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -12,7 +12,7 @@ class EvaluateRubricJob < ApplicationJob
   #
   # Basic validation of the new AI config is done by UI tests, or can be done locally
   # by running `EvaluateRubricJob.new.validate_ai_config` from the rails console.
-  S3_AI_RELEASE_PATH = 'teaching_assistant/releases/2024-03-15-ai-rubrics-json-evidence/'.freeze
+  S3_AI_RELEASE_PATH = 'teaching_assistant/releases/2024-03-25-confidence-exact/'.freeze
 
   STUB_AI_PROXY_PATH = '/api/test/ai_proxy'.freeze
 


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-559. PR https://github.com/code-dot-org/code-dot-org/pull/57125 adds all the functionality necessary to show a single AI score in the UI as opposed to multiple (see that PR for screenshots). This PR just updates the config to effectively launch this feature, by adding in the `confidence-exact.json` files:

```
Dave-MBP:~/src/aiproxy/releases (main)$ diff -qr 2024-03-15-ai-rubrics-json-evidence 2024-03-25-confidence-exact
Only in 2024-03-25-confidence-exact/csd3-2023-L11: confidence-exact.json
Only in 2024-03-25-confidence-exact/csd3-2023-L14: confidence-exact.json
Only in 2024-03-25-confidence-exact/csd3-2023-L18: confidence-exact.json
Only in 2024-03-25-confidence-exact/csd3-2023-L21: confidence-exact.json
Only in 2024-03-25-confidence-exact/csd3-2023-L24: confidence-exact.json
Only in 2024-03-25-confidence-exact/csd3-2023-L28: confidence-exact.json
```

## Testing story

* `EvaluateRubricJob.new.validate_ai_config` passes locally
* UI tests also run `validate_ai_config` in drone
* repeated manual verification steps, and confirmed that I still see what's shown in the screenshots in https://github.com/code-dot-org/code-dot-org/pull/57125