### PR TITLE
Update featured_project_controller and tests

### DIFF
--- a/dashboard/app/controllers/featured_projects_controller.rb
+++ b/dashboard/app/controllers/featured_projects_controller.rb
@@ -17,14 +17,7 @@ class FeaturedProjectsController < ApplicationController
     _, project_id = storage_decrypt_channel_id(params[:channel_id])
     return render_404 unless project_id
     @featured_project = FeaturedProject.find_or_create_by!(project_id: project_id)
-    puts "@featured_project in controller - feature #{@featured_project}"
-    puts "@featured_project.featured_at #{@featured_project.featured_at}"
-    puts "@featured_project.unfeatured_at #{@featured_project.unfeatured_at}"
     @featured_project.update! unfeatured_at: nil, featured_at: DateTime.now
-    puts "@featured_project in feature#{@featured_project}"
-    puts "@featured_project after UPDATE #{@featured_project}"
-    puts "@featured_project.featured_at #{@featured_project.featured_at}"
-    puts "@featured_project.unfeatured_at #{@featured_project.unfeatured_at}"
     # Set the featured project's abuse score to -50.
     buffer_abuse_score
     freeze_featured_project(project_id)

--- a/dashboard/app/controllers/featured_projects_controller.rb
+++ b/dashboard/app/controllers/featured_projects_controller.rb
@@ -79,8 +79,6 @@ class FeaturedProjectsController < ApplicationController
 
   def freeze_featured_project(project_id)
     project = Project.find_by(id: project_id)
-    # This early return is added to circumvent unit tests that involve creating projects.
-    return if project.nil?
     project_value = JSON.parse(project.value)
     project_value["frozen"] = true
     project_value["updatedAt"] = DateTime.now.to_s
@@ -89,8 +87,6 @@ class FeaturedProjectsController < ApplicationController
 
   def unfreeze_featured_project(project_id)
     project = Project.find_by(id: project_id)
-    # This early return is added to circumvent unit tests that involve creating projects.
-    return if project.nil?
     project_value = JSON.parse(project.value)
     project_value["frozen"] = false
     # Unhide in case this project was frozen manually by the project owner.

--- a/dashboard/app/controllers/featured_projects_controller.rb
+++ b/dashboard/app/controllers/featured_projects_controller.rb
@@ -17,7 +17,14 @@ class FeaturedProjectsController < ApplicationController
     _, project_id = storage_decrypt_channel_id(params[:channel_id])
     return render_404 unless project_id
     @featured_project = FeaturedProject.find_or_create_by!(project_id: project_id)
+    puts "@featured_project in controller - feature #{@featured_project}"
+    puts "@featured_project.featured_at #{@featured_project.featured_at}"
+    puts "@featured_project.unfeatured_at #{@featured_project.unfeatured_at}"
     @featured_project.update! unfeatured_at: nil, featured_at: DateTime.now
+    puts "@featured_project in feature#{@featured_project}"
+    puts "@featured_project after UPDATE #{@featured_project}"
+    puts "@featured_project.featured_at #{@featured_project.featured_at}"
+    puts "@featured_project.unfeatured_at #{@featured_project.unfeatured_at}"
     # Set the featured project's abuse score to -50.
     buffer_abuse_score
     freeze_featured_project(project_id)

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -83,6 +83,7 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
     @controller.expects(:storage_decrypt_channel_id).with("567").returns([345, 888])
     refute @archived_featured_project.active?
     put :feature, params: {channel_id: "567"}
+    @archived_featured_project.reload
     assert @archived_featured_project.active? # FAIL
   end
 
@@ -91,6 +92,7 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
     @controller.expects(:storage_decrypt_channel_id).with("678").returns([987, 777])
     assert @active_featured_project.active?
     put :unfeature, params: {channel_id: "678"}
+    @active_featured_project.reload
     refute @active_featured_project.active? # FAIL
   end
 end

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -80,17 +80,9 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
 
   test 'featuring a currently unfeatured project should update the correct featured project' do
     sign_in @project_validator
-    puts "featuring a currently unfeatured project"
     @controller.expects(:storage_decrypt_channel_id).with("567").returns([345, 888])
-    puts "@archived_featured_project #{@archived_featured_project}"
-    puts "@archived_featured_project.featured_at #{@archived_featured_project.featured_at}"
-    puts "@archived_featured_project.unfeatured_at #{@archived_featured_project.unfeatured_at}"
     refute @archived_featured_project.active?
     put :feature, params: {channel_id: "567"}
-    puts "@archived_featured_project after call to :feature - back IN TEST #{@archived_featured_project}"
-    puts "@archived_featured_project.featured_at #{@archived_featured_project.featured_at}"
-    puts "@archived_featured_project.unfeatured_at #{@archived_featured_project.unfeatured_at}"
-
     assert @archived_featured_project.active? # FAIL
   end
 

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -84,7 +84,7 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
     refute @archived_featured_project.active?
     put :feature, params: {channel_id: "567"}
     @archived_featured_project.reload
-    assert @archived_featured_project.active? # FAIL
+    assert @archived_featured_project.active?
   end
 
   test 'unfeaturing a featured project should unfeature the project' do
@@ -93,6 +93,6 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
     assert @active_featured_project.active?
     put :unfeature, params: {channel_id: "678"}
     @active_featured_project.reload
-    refute @active_featured_project.active? # FAIL
+    refute @active_featured_project.active?
   end
 end

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -1,8 +1,14 @@
 require 'test_helper'
 
 class FeaturedProjectsControllerTest < ActionController::TestCase
-  setup do
+  # Setting this to true causes some weird db locking issue, possibly due to
+  # some writes to the projects table coming from a different connection via
+  # sequel.
+  self.use_transactional_test_case = false
+
+  setup_all do
     @project_validator = create :project_validator
+    @project = create :project, id: 456, value: {frozen: false, hidden: false, updatedAt: DateTime.now}.to_json
     # @featured_project has a project_id of 456
     @featured_project = create :featured_project
     @teacher = create :teacher
@@ -10,15 +16,14 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
 
   test 'project validators can bookmark a project as a featured project' do
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 654])
+    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
     put :bookmark, params: {channel_id: "789"}
     assert_response :success
   end
 
   test 'project validators can feature projects' do
-    skip 'Investigate flaky test'
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 654])
+    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
     put :feature, params: {channel_id: "789"}
     assert_response :success
   end
@@ -63,9 +68,9 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
 
   test 'bookmarking a never featured project creates a new featured project' do
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 654])
+    @controller.expects(:storage_decrypt_channel_id).with("678").returns([234, 654])
     assert_creates(FeaturedProject) do
-      put :bookmark, params: {channel_id: "789"}
+      put :bookmark, params: {channel_id: "678"}
     end
     assert FeaturedProject.last.project_id == 654
     assert FeaturedProject.last.unfeatured_at.nil?
@@ -73,7 +78,6 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
   end
 
   test 'featuring a currently unfeatured project should update the correct featured project' do
-    skip 'Investigate flaky test'
     sign_in @project_validator
     @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
     @featured_project.update! unfeatured_at: DateTime.now

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -1,11 +1,6 @@
 require 'test_helper'
 
 class FeaturedProjectsControllerTest < ActionController::TestCase
-  # Setting this to true causes some weird db locking issue, possibly due to
-  # some writes to the projects table coming from a different connection via
-  # sequel.
-  self.use_transactional_test_case = false
-
   setup_all do
     @project_validator = create :project_validator
     @project = create :project, id: 456, value: {frozen: false, hidden: false, updatedAt: DateTime.now}.to_json

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -3,42 +3,41 @@ require 'test_helper'
 class FeaturedProjectsControllerTest < ActionController::TestCase
   setup_all do
     @project_validator = create :project_validator
-    @project_new = create :project, id: 456, value: {frozen: false, hidden: false, updatedAt: DateTime.now}.to_json
-    @project_active = create :project, id: 777, value: {frozen: true, hidden: true, updatedAt: DateTime.now}.to_json
-    @project_archived = create :project, id: 888, value: {frozen: false, hidden: false, updatedAt: DateTime.now}.to_json
-    # @new_featured_project has a project_id of 456
-    @new_featured_project = create :new_featured_project
-    # @active_featured_project has a project_id of 777
-    @active_featured_project = create :active_featured_project
-    # @archived_featured_project has a project_id of 888
-    @archived_featured_project = create :archived_featured_project
     @teacher = create :teacher
+
+    @project_new = create :project, value: {frozen: false, hidden: false, updatedAt: DateTime.now}.to_json
+    @project_active = create :project, value: {frozen: true, hidden: true, updatedAt: DateTime.now}.to_json
+    @project_archived = create :project, value: {frozen: false, hidden: false, updatedAt: DateTime.now}.to_json
+
+    @new_featured_project = create :featured_project, project_id: @project_new.id
+    @active_featured_project = create :active_featured_project, project_id: @project_active.id
+    @archived_featured_project = create :archived_featured_project, project_id: @project_archived.id
   end
 
   test 'project validators can bookmark a project as a featured project' do
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
+    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, @project_new.id])
     put :bookmark, params: {channel_id: "789"}
     assert_response :success
   end
 
   test 'project validators can feature projects' do
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
+    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, @project_new.id])
     put :feature, params: {channel_id: "789"}
     assert_response :success
   end
 
   test 'project validators can unfeature projects' do
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
+    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, @project_new.id])
     put :unfeature, params: {channel_id: "789"}
     assert_response :success
   end
 
   test 'project validators can delete a featured project' do
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
+    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, @project_new.id])
     delete :destroy, params: {channel_id: "789"}
     assert_response :success
   end
@@ -80,7 +79,7 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
 
   test 'featuring a currently unfeatured project should update the correct featured project' do
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("567").returns([345, 888])
+    @controller.expects(:storage_decrypt_channel_id).with("567").returns([345, @project_archived.id])
     refute @archived_featured_project.active?
     put :feature, params: {channel_id: "567"}
     @archived_featured_project.reload
@@ -89,7 +88,7 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
 
   test 'unfeaturing a featured project should unfeature the project' do
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("678").returns([987, 777])
+    @controller.expects(:storage_decrypt_channel_id).with("678").returns([987, @project_active.id])
     assert @active_featured_project.active?
     put :unfeature, params: {channel_id: "678"}
     @active_featured_project.reload

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -3,9 +3,15 @@ require 'test_helper'
 class FeaturedProjectsControllerTest < ActionController::TestCase
   setup_all do
     @project_validator = create :project_validator
-    @project = create :project, id: 456, value: {frozen: false, hidden: false, updatedAt: DateTime.now}.to_json
-    # @featured_project has a project_id of 456
-    @featured_project = create :featured_project
+    @project_new = create :project, id: 456, value: {frozen: false, hidden: false, updatedAt: DateTime.now}.to_json
+    @project_active = create :project, id: 777, value: {frozen: true, hidden: true, updatedAt: DateTime.now}.to_json
+    @project_archived = create :project, id: 888, value: {frozen: false, hidden: false, updatedAt: DateTime.now}.to_json
+    # @new_featured_project has a project_id of 456
+    @new_featured_project = create :new_featured_project
+    # @active_featured_project has a project_id of 777
+    @active_featured_project = create :active_featured_project
+    # @archived_featured_project has a project_id of 888
+    @archived_featured_project = create :archived_featured_project
     @teacher = create :teacher
   end
 
@@ -74,20 +80,25 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
 
   test 'featuring a currently unfeatured project should update the correct featured project' do
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
-    @featured_project.update! unfeatured_at: DateTime.now
-    refute @featured_project.reload.active?
-    put :feature, params: {channel_id: "789"}
-    assert @featured_project.reload.active?
+    puts "featuring a currently unfeatured project"
+    @controller.expects(:storage_decrypt_channel_id).with("567").returns([345, 888])
+    puts "@archived_featured_project #{@archived_featured_project}"
+    puts "@archived_featured_project.featured_at #{@archived_featured_project.featured_at}"
+    puts "@archived_featured_project.unfeatured_at #{@archived_featured_project.unfeatured_at}"
+    refute @archived_featured_project.active?
+    put :feature, params: {channel_id: "567"}
+    puts "@archived_featured_project after call to :feature - back IN TEST #{@archived_featured_project}"
+    puts "@archived_featured_project.featured_at #{@archived_featured_project.featured_at}"
+    puts "@archived_featured_project.unfeatured_at #{@archived_featured_project.unfeatured_at}"
+
+    assert @archived_featured_project.active? # FAIL
   end
 
   test 'unfeaturing a featured project should unfeature the project' do
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
-    @featured_project.update! featured_at: DateTime.now
-    @featured_project.update! unfeatured_at: nil
-    assert @featured_project.reload.active?
-    put :unfeature, params: {channel_id: "789"}
-    refute @featured_project.reload.active?
+    @controller.expects(:storage_decrypt_channel_id).with("678").returns([987, 777])
+    assert @active_featured_project.active?
+    put :unfeature, params: {channel_id: "678"}
+    refute @active_featured_project.active? # FAIL
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1037,7 +1037,7 @@ FactoryBot.define do
     factory :new_featured_project do
       project_id {456}
     end
-  
+
     factory :active_featured_project do
       project_id {777}
       after(:create) do |active_featured_project|

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1026,7 +1026,6 @@ FactoryBot.define do
     after(:build) do |project, evaluator|
       project_storage = create :project_storage, user_id: evaluator.owner.id
       project.storage_id = project_storage.id
-      project.value = evaluator.value if evaluator.value
     end
   end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1019,8 +1019,6 @@ FactoryBot.define do
   factory :project do
     transient do
       owner {create :user}
-      id {nil}
-      value {nil}
     end
 
     updated_ip {'127.0.0.1'}
@@ -1028,32 +1026,18 @@ FactoryBot.define do
     after(:build) do |project, evaluator|
       project_storage = create :project_storage, user_id: evaluator.owner.id
       project.storage_id = project_storage.id
-      project.id = evaluator.id if evaluator.id
       project.value = evaluator.value if evaluator.value
     end
   end
 
   factory :featured_project do
-    factory :new_featured_project do
-      project_id {456}
-    end
-
     factory :active_featured_project do
-      project_id {777}
-      after(:create) do |active_featured_project|
-        active_featured_project.featured_at = DateTime.now
-        active_featured_project.unfeatured_at = nil
-        active_featured_project.save
-      end
+      featured_at {DateTime.now}
     end
 
     factory :archived_featured_project do
-      project_id {888}
-      after(:create) do |archived_featured_project|
-        archived_featured_project.featured_at = DateTime.now
-        archived_featured_project.unfeatured_at = DateTime.now
-        archived_featured_project.save
-      end
+      featured_at {DateTime.now}
+      unfeatured_at {DateTime.now}
     end
   end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1019,6 +1019,8 @@ FactoryBot.define do
   factory :project do
     transient do
       owner {create :user}
+      id {nil}
+      value {nil}
     end
 
     updated_ip {'127.0.0.1'}
@@ -1026,6 +1028,8 @@ FactoryBot.define do
     after(:build) do |project, evaluator|
       project_storage = create :project_storage, user_id: evaluator.owner.id
       project.storage_id = project_storage.id
+      project.id = evaluator.id if evaluator.id
+      project.value = evaluator.value if evaluator.value
     end
   end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1057,8 +1057,6 @@ FactoryBot.define do
     end
   end
 
-
-
   factory :user_ml_model do
     user
     model_id {SecureRandom.alphanumeric(12)}

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1034,8 +1034,30 @@ FactoryBot.define do
   end
 
   factory :featured_project do
-    project_id {456}
+    factory :new_featured_project do
+      project_id {456}
+    end
+  
+    factory :active_featured_project do
+      project_id {777}
+      after(:create) do |active_featured_project|
+        active_featured_project.featured_at = DateTime.now
+        active_featured_project.unfeatured_at = nil
+        active_featured_project.save
+      end
+    end
+
+    factory :archived_featured_project do
+      project_id {888}
+      after(:create) do |archived_featured_project|
+        archived_featured_project.featured_at = DateTime.now
+        archived_featured_project.unfeatured_at = DateTime.now
+        archived_featured_project.save
+      end
+    end
   end
+
+
 
   factory :user_ml_model do
     user


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the functions that freeze and unfreeze featured projects in the `featured_projects_controller`. It removes the early return if `project_id` is not defined which was added to avoid unit test errors having to do with created projects added in https://github.com/code-dot-org/code-dot-org/pull/57495.

Thanks to @bencodeorg for his help with this PR!

I closed [this past PR](https://github.com/code-dot-org/code-dot-org/pull/57476) due to these unit test errors in test files un-related to my changes. See [failed Drone build](https://drone.cdn-code.org/code-dot-org/code-dot-org/3171/1/5)

![Screenshot 2024-03-26 at 9 19 30 AM](https://github.com/code-dot-org/code-dot-org/assets/107423305/cf9b4ae2-38b5-4d29-889a-9a06e55a6c92)


![Screenshot 2024-03-26 at 9 19 51 AM](https://github.com/code-dot-org/code-dot-org/assets/107423305/de4f2e76-5d0e-49fd-8a1c-62537fa90b60)

Dashboard unit tests that include created projects have historically caused issues in testing. See [Slack thread](https://codedotorg.slack.com/archives/C046G4TRLEN/p1697038404300649) with another example of similar issue reported by @bencodeorg .

After consulting with Ben, I modified the tests in `featured_projects_controller_test.rb` to use `setup_all` instead of `setup`. This resolved the mysql timeout errors! I tried setting `self.use_transactional_test_case` to `false`, but this did not seem to make a difference so removed dc267143ecfc75b3e0657b64290065c17cd14bc5.

I updated the `featured_project` factory by adding 2 additional types of `featured_project`: `active_featured_project` and `archived_featured_project` to help with testing.

WIth these changes, I've re-enabled two skipped tests that were flaky in the past -  'project validators can feature projects' and 'featuring a currently unfeatured project should update the correct featured project'. Hopefully, these tests will be more robust.

There is a comment in `code_review_controller_test` that may be related to the mysql timeout errors I was seeing prior to using `setup_all`.
```
  # Setting this to true causes some weird db locking issue, possibly due to
  # some writes to the projects table coming from a different connection via
  # sequel.
  self.use_transactional_test_case = false
```
Although I didn't need to set this value to `false`, it does seem like the `projects` table has some complexities which have  caused testing issues to occur.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
