### PR TITLE
Run drone builds on all branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -114,6 +114,7 @@ trigger:
     exclude:
       - "production"
       - "test"
+      - "levelbuilder"
   event:
     - pull_request
 
@@ -283,6 +284,7 @@ trigger:
     exclude:
       - "production"
       - "test"
+      - "levelbuilder"
   event:
     - push
 ---

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,8 +18,8 @@ steps:
     image: curlimages/curl
     commands:
       # If running on EC2, get hostname from ec2 metadata
-      - "IMDS_TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
-      - "hostname=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/public-hostname)"
+      - "IMDS_TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\")"
+      - "hostname=$(curl -s -H \"X-aws-ec2-metadata-token: $IMDS_TOKEN\" http://169.254.169.254/latest/meta-data/public-hostname)"
       - echo "Running on $hostname"
 
   # We cache a clone of staging in the `cache-staging-clone` pipeline
@@ -137,8 +137,8 @@ steps:
     image: curlimages/curl
     commands:
       # If running on EC2, get hostname from ec2 metadata
-      - "IMDS_TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
-      - "hostname=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/public-hostname)"
+      - "IMDS_TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\")"
+      - "hostname=$(curl -s -H \"X-aws-ec2-metadata-token: $IMDS_TOKEN\" http://169.254.169.254/latest/meta-data/public-hostname)"
       - echo "Running on $hostname"
 
   # We cache a clone of staging in the `cache-staging-clone` pipeline
@@ -282,13 +282,12 @@ steps:
 trigger:
   branch:
     exclude:
-      - "production"
-      - "test"
-      - "levelbuilder"
+      - "staging"
+      - "staging-next"
   event:
     - push
 ---
 kind: signature
-hmac: 9ad071371bd2d0832675d3779737d185419485b62f5e584f3bca21244595f7fe
+hmac: 1e9a6df9ffff498a280d67bec72a99ce05f207afafc46e68b9b28b49bc5e5324
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 # Drone CI pipeline running at: https://drone.cdn-code.org/code-dot-org/code-dot-org/
-# 
+#
 # Docs here: https://docs.google.com/document/d/1Qls20xfNN6T_DErOMwVQOFJsxAEAdMWFHzBDIbxyUQQ/edit#heading=h.9bln2fv2lgqd
 #
 # NOTE: after making changes to this file, you'll need to sign them using
@@ -18,8 +18,8 @@ steps:
     image: curlimages/curl
     commands:
       # If running on EC2, get hostname from ec2 metadata
-      - "IMDS_TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\")"
-      - "hostname=$(curl -s -H \"X-aws-ec2-metadata-token: $IMDS_TOKEN\" http://169.254.169.254/latest/meta-data/public-hostname)"
+      - 'IMDS_TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")'
+      - 'hostname=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/public-hostname)'
       - echo "Running on $hostname"
 
   # We cache a clone of staging in the `cache-staging-clone` pipeline
@@ -111,8 +111,9 @@ volumes:
 
 trigger:
   branch:
-    - "staging"
-    - "staging-next"
+    exclude:
+      - "production"
+      - "test"
   event:
     - pull_request
 
@@ -135,8 +136,8 @@ steps:
     image: curlimages/curl
     commands:
       # If running on EC2, get hostname from ec2 metadata
-      - "IMDS_TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\")"
-      - "hostname=$(curl -s -H \"X-aws-ec2-metadata-token: $IMDS_TOKEN\" http://169.254.169.254/latest/meta-data/public-hostname)"
+      - 'IMDS_TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")'
+      - 'hostname=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/public-hostname)'
       - echo "Running on $hostname"
 
   # We cache a clone of staging in the `cache-staging-clone` pipeline
@@ -250,7 +251,6 @@ trigger:
     - pull_request
 
 ---
-
 # On push, cache a clone of staging to drone's S3 bucket.
 # The staging cache reduces git bandwidth in PR pipelines.
 kind: pipeline
@@ -261,12 +261,11 @@ clone:
   disable: true
 
 steps:
-
   - name: clone
     image: bitnami/git
     commands:
       - git lfs install
-      - git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL . 
+      - git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL .
 
   - name: cache-staging-clone
     image: plugins/s3-cache
@@ -281,12 +280,11 @@ steps:
 
 trigger:
   branch:
-    - "staging"
-    - "staging-next"
+    exclude:
+      - "production"
+      - "test"
   event:
     - push
 ---
 kind: signature
 hmac: a16fa2865512ffb9127b4d8a311fa8fdc078145723a8aa2767bea7cce97c1ed5
-
-...

--- a/.drone.yml
+++ b/.drone.yml
@@ -266,7 +266,7 @@ steps:
     image: bitnami/git
     commands:
       - git lfs install
-      - git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL .
+      - git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL . 
 
   - name: cache-staging-clone
     image: plugins/s3-cache
@@ -281,13 +281,12 @@ steps:
 
 trigger:
   branch:
-    exclude:
-      - "staging"
-      - "staging-next"
+    - "staging"
+    - "staging-next"
   event:
     - push
 ---
 kind: signature
-hmac: 1e9a6df9ffff498a280d67bec72a99ce05f207afafc46e68b9b28b49bc5e5324
+hmac: e51f14b739c978b477222c272341dc9552ad743ee7658a48cf75ee5d5b976d7f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,8 +18,8 @@ steps:
     image: curlimages/curl
     commands:
       # If running on EC2, get hostname from ec2 metadata
-      - 'IMDS_TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")'
-      - 'hostname=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/public-hostname)'
+      - "IMDS_TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+      - "hostname=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/public-hostname)"
       - echo "Running on $hostname"
 
   # We cache a clone of staging in the `cache-staging-clone` pipeline
@@ -137,8 +137,8 @@ steps:
     image: curlimages/curl
     commands:
       # If running on EC2, get hostname from ec2 metadata
-      - 'IMDS_TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")'
-      - 'hostname=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/public-hostname)'
+      - "IMDS_TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+      - "hostname=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/public-hostname)"
       - echo "Running on $hostname"
 
   # We cache a clone of staging in the `cache-staging-clone` pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -242,8 +242,9 @@ volumes:
 
 trigger:
   branch:
-    - "staging"
-    - "staging-next"
+    exclude:
+      - "production"
+      - "test"
   event:
     - pull_request
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -245,6 +245,7 @@ trigger:
     exclude:
       - "production"
       - "test"
+      - "levelbuilder"
   event:
     - pull_request
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -289,4 +289,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: a16fa2865512ffb9127b4d8a311fa8fdc078145723a8aa2767bea7cce97c1ed5
+hmac: 9ad071371bd2d0832675d3779737d185419485b62f5e584f3bca21244595f7fe
+
+...


### PR DESCRIPTION
From a recent slack conversation:

Currently, we run drone builds only on branches that are merging directly to `staging` or `staging-next` branches. This was originally to prevent waste of resources. However, this does not prevent much since most branches go directly to staging directly and there are cases where running drone on other branches would be helpful. E.g. a feature branch that merges smaller branches into a main feature branch before merging the feature in one PR. In this feature branch case, it would be helpful to run drone builds on all PRs to prevent bugs or large debugging before merging the larger PR.

This changes:
* Drone only runs on PRs merging into `staging` or `staging-next` -> Drone runs on all PRs not merging into `production` or `test` 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
