### PR TITLE
Update foundational doc PDF for advocacy.code.org - 2024

### DIFF
--- a/pegasus/sites.v3/advocacy.code.org/public/making_cs_foundational_2024.pdf.fetch
+++ b/pegasus/sites.v3/advocacy.code.org/public/making_cs_foundational_2024.pdf.fetch
@@ -1,0 +1,1 @@
+https://cdo-fetch.s3.amazonaws.com/Making_CS_Foundational_2024.pdf

--- a/pegasus/sites.v3/advocacy.code.org/public/policy-resources.md
+++ b/pegasus/sites.v3/advocacy.code.org/public/policy-resources.md
@@ -8,7 +8,7 @@ style_min: true
 
 ## Code.org State Policy Agenda
 
-- [10 policies to make computer science education foundational](/2023_making_cs_foundational.pdf)
+- [10 policies to make computer science education foundational](/making_cs_foundational_2024.pdf)
 - [State tracker of our 10 policies](https://docs.google.com/spreadsheets/d/1YtTVcpQXoZz0IchihwGOihaCNeqCz2HyLwaXYpyb2SQ/pubhtml)
 
 ## Model Legislation

--- a/pegasus/src/advocacy_site.rb
+++ b/pegasus/src/advocacy_site.rb
@@ -53,7 +53,7 @@ class AdvocacySite
           [
             {
               text_actual: "Our state policy agenda",
-              url: "/2023_making_cs_foundational.pdf",
+              url: "/making_cs_foundational_2024.pdf",
               new_tab: true
             },
             {


### PR DESCRIPTION
Updates the Making CS Foundational PDF for use on advocacy.code.org. I uploaded this to AWS and used a `.fetch` file to link it. Tested both links locally.

**Jira ticket:** [ACQ-1663](https://codedotorg.atlassian.net/browse/ACQ-1663)