### PR TITLE
Update warning banner styles on code.org

### DIFF
--- a/pegasus/sites.v3/code.org/views/unsupported_browser.haml
+++ b/pegasus/sites.v3/code.org/views/unsupported_browser.haml
@@ -1,4 +1,3 @@
 #warning-banner{style: 'display: none;'}
   %i.fa.fa-warning.warning-sign
-  &nbsp;
   = I18n.t("compatibility_unsupported_browser_markdown", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743', markdown: true).html_safe

--- a/shared/css/warning-banner.scss
+++ b/shared/css/warning-banner.scss
@@ -7,13 +7,11 @@
   overflow: hidden;
   width: 100%;
   box-sizing: border-box;
-  padding: 10px 20px;
-  font-size: 13px;
-  line-height: 16px;
-  background-color: $purple;
-  color: white;
+  padding: 1rem;
+  background-color: $light_secondary_700;
   display: flex;
   align-items: center;
+  gap: 0.75rem;
 
   #dismiss-icon {
     margin-left: auto;
@@ -30,6 +28,12 @@
   }
   a:hover {
     background: transparent;
+  }
+
+  p {
+    color: $light_white;
+    margin-bottom: 0;
+    font-size: 0.875rem;
   }
 
   #message {


### PR DESCRIPTION
Updates the styles on the `unsupported_browser.haml` view on https://code.org.

**Jira ticket:** [ACQ-1556](https://codedotorg.atlassian.net/browse/ACQ-1556)

----

## Before
<img width="1315" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/81f92fd0-eb79-4ada-a328-170d8ea54430">

## After
<img width="1315" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/db7b6b2b-a896-404e-9eea-06318cb4ec63">

## Responsive
https://github.com/code-dot-org/code-dot-org/assets/9256643/afe672fa-74d9-4f7f-b194-070145195ca0

## RTL
<img width="1315" alt="RTL" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/4ac4b9d6-3e43-44f3-839d-0e2218267b2f">

