### PR TITLE
Allow hiding error overlay in development

### DIFF
--- a/apps/envConstants.js
+++ b/apps/envConstants.js
@@ -39,6 +39,8 @@ module.exports = {
   CIRCLE_TEST_REPORTS: process.env.CIRCLE_TEST_REPORTS,
   // If set, run webpack dev server (with hot reloading)
   HOT: !!process.env.HOT,
+  // If set, hides error overlay in browser in development
+  HIDE_ERROR_OVERLAY: !!process.env.HIDE_ERROR_OVERLAY,
   // Include static assets when serving storybook locally
   STORYBOOK_STATIC_ASSETS: process.env.STORYBOOK_STATIC_ASSETS,
 };

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -662,7 +662,9 @@ function createWebpackConfig({
       ...(envConstants.HOT
         ? [
             new webpack.HotModuleReplacementPlugin({}),
-            new ReactRefreshWebpackPlugin(),
+            new ReactRefreshWebpackPlugin({
+              overlay: !envConstants.HIDE_ERROR_OVERLAY,
+            }),
             // Prints a URL for accessing the Dashboard via webpack-dev-server
             {
               apply: compiler => {


### PR DESCRIPTION
Allows you to hide the error overlay introduced in https://github.com/code-dot-org/code-dot-org/pull/56882.

Usage is `HIDE_ERROR_OVERLAY=1 yarn start`.

## Testing story

Tested manually that with the command listed above, I get no error overlay when errors are thrown. Without the flag, still get overlay.