### PR TITLE
Remove "Partner with us" from the hamburger menu

### DIFF
--- a/lib/cdo/hamburger.rb
+++ b/lib/cdo/hamburger.rb
@@ -121,7 +121,6 @@ class Hamburger
       {title: "educate_middle", url: CDO.code_org_url("/educate/curriculum/middle-school")},
       {title: "educate_high", url: CDO.code_org_url("/educate/curriculum/high-school")},
       {title: "educate_hoc", url: "https://hourofcode.com"},
-      {title: "educate_partner", url: CDO.code_org_url("/educate/partner")},
       {title: "educate_beyond", url: CDO.code_org_url("/educate/curriculum/3rd-party")},
       {title: "educate_inspire", url: CDO.code_org_url("/educate/resources/inspire")},
       {title: "educate_community", url: CDO.code_org_url("/educate/community")},


### PR DESCRIPTION
Removes the "Partner with us" link from the hamburger menu on code.org and studio.code.org.

 **Jira ticket:** [ACQ-1652](https://codedotorg.atlassian.net/browse/ACQ-1652)

----

## Signed out
| Before | After | 
| ----- | ------ |
| <img width="339" alt="Before_signed_out" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/546682c3-90eb-4539-8a59-636671ec9ee1"> | <img width="339" alt="After_signed_out" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/59b1f0ad-dccb-4b37-bd93-2c75f61ba20c"> |

## Signed in
| Before | After | 
| ----- | ------ |
| <img width="339" alt="Before_signed_in" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/6617b001-e05e-4f46-b295-c7949ed2fe95"> | <img width="339" alt="After_signed_in" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/334ca1bc-af1d-432a-9884-b62af19bbfef"> |

