### PR TITLE
Lab2: use level paths instead of full URLs

### DIFF
--- a/apps/src/code-studio/browserNavigation.js
+++ b/apps/src/code-studio/browserNavigation.js
@@ -49,10 +49,10 @@ export function setupNavigationHandler(lessonData) {
 // onto the browser session history stack, and updating the window title.
 export function updateBrowserForLevelNavigation(
   progressStoreState,
-  levelUrl,
+  levelPath,
   levelId
 ) {
-  window.history.pushState({}, '', levelUrl + window.location.search);
+  window.history.pushState({}, '', levelPath + window.location.search);
   setWindowTitle(progressStoreState, levelId);
 }
 

--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -295,7 +295,7 @@ export function navigateToLevelId(levelId: string): ProgressThunkAction {
       return;
     }
 
-    updateBrowserForLevelNavigation(state, newLevel.url, levelId);
+    updateBrowserForLevelNavigation(state, newLevel.path, levelId);
     dispatch(setCurrentLevelId(levelId));
   };
 }

--- a/apps/src/types/progressTypes.ts
+++ b/apps/src/types/progressTypes.ts
@@ -58,6 +58,7 @@ export interface Level {
   position: number;
   title: number;
   url: string;
+  path: string;
   status?: string;
   usesLab2: boolean;
 }

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -329,6 +329,7 @@ class ScriptLevel < ApplicationRecord
         is_concept_level: level.concept_level?,
         title: level_display_text,
         url: build_script_level_url(self),
+        path: build_script_level_path(self),
         freePlay: level.try(:free_play) == "true",
         bonus: bonus,
         display_as_unplugged: level.display_as_unplugged?,


### PR DESCRIPTION
After enabling [Webpack hot module replacement](https://github.com/code-dot-org/code-dot-org/pull/56882), we noticed an issue with Lab2 progressions; Lab2 progressions don't perform a full page reload between levels, but do update the browser stack so that back/forward buttons still act as intended. The issue here is that we were previously updating the stack using level's fully qualified URL which is constructed on the rails side, with a hardcoded port of 3000. Because HMR requires us to run on port 9000, pushing a URL with port 3000 onto the stack was causing a crash. The solution here is to just pass through and use the relative level path instead of full URL, which is a more ideal solution anyway.

https://github.com/code-dot-org/code-dot-org/assets/85528507/638bf04a-6af5-4d24-8199-26194f773723

## Links

https://codedotorg.slack.com/archives/C05DMS18MEX/p1711039238242839

## Testing story

Tested with the Music Lab intro script + a few allthethings lab2 progressions.