### PR TITLE
Update Devise Gem to 4.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,7 +158,7 @@ gem 'gemoji'
 
 # Authentication and permissions.
 gem 'cancancan', '~> 3.5.0'
-gem 'devise', '~> 4.7.0'
+gem 'devise', '~> 4.9.0'
 gem 'devise_invitable', '~> 2.0.2'
 
 # Ref: https://github.com/daynew/omniauth-clever/pull/1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,7 +341,7 @@ GEM
     delayed_job_active_record (4.1.7)
       activerecord (>= 3.0, < 8.0)
       delayed_job (>= 3.0, < 5)
-    devise (4.7.3)
+    devise (4.9.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -926,8 +926,8 @@ GEM
     validates_email_format_of (1.6.3)
       i18n
     vcr (3.0.3)
-    warden (1.2.7)
-      rack (>= 1.0)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -1003,7 +1003,7 @@ DEPENDENCIES
   database_cleaner-active_record (~> 2.1.0)
   datapackage
   delayed_job_active_record (~> 4.1)
-  devise (~> 4.7.0)
+  devise (~> 4.9.0)
   devise_invitable (~> 2.0.2)
   dotiw
   execjs


### PR DESCRIPTION
Only two minor versions ahead of our current version, but that still represents about three years worth of updates. Notably, version 4.8 adds official support for Rails 6.1

None of the breaking changes seem dangerous to us.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [Changelog](https://github.com/heartcombo/devise/blob/main/CHANGELOG.md#493---2023-10-11)
- [adhoc](https://adhoc-devise-4-9-3.cdn-code.org)

## Testing story

Tested locally and on an adhoc that I can register a new user, log in as that user, log out as that user, and log in again.

Relying on unit tests to catch any obscure edge cases.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
