### PR TITLE
Deflake ai rubrics project save

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -22,6 +22,7 @@ Feature: Evaluate student code against rubrics using AI
     When I ensure droplet is in text mode
     And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
     And I click selector "#runButton"
+    And I wait until element ".project_updated_at" contains text "Saved"
     And I wait until element "#submitButton" is visible
     And I click selector "#submitButton"
     And I wait until element "#confirm-button" is visible
@@ -70,7 +71,7 @@ Feature: Evaluate student code against rubrics using AI
     When I ensure droplet is in text mode
     And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
     And I click selector "#runButton"
-    And I wait until element "#resetButton" is visible
+    And I wait until element ".project_updated_at" contains text "Saved"
 
     # Teacher views student progress and floating action button
     When I sign in as "Teacher_Aiden"
@@ -119,7 +120,7 @@ Feature: Evaluate student code against rubrics using AI
     When I ensure droplet is in text mode
     And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
     And I click selector "#runButton"
-    And I wait until element "#resetButton" is visible
+    And I wait until element ".project_updated_at" contains text "Saved"
 
     # Teacher views student progress and floating action button
     When I sign in as "Teacher_Aiden"

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -1,4 +1,3 @@
-@skip
 # AI evaluation is stubbed out in UI tests via the /api/test/ai_proxy/assessment route.
 @no_firefox
 Feature: Evaluate student code against rubrics using AI

--- a/dashboard/test/ui/features/teacher_tools/rubrics/student_completes_rubric_level.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/student_completes_rubric_level.feature
@@ -10,6 +10,7 @@ Feature: Student can complete rubric-enabled level
     When I ensure droplet is in text mode
     And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
     And I click selector "#runButton"
+    And I wait until element ".project_updated_at" contains text "Saved"
     And I wait until element "#submitButton" is visible
     And I click selector "#submitButton"
     And I wait until element "#confirm-button" is visible
@@ -32,6 +33,7 @@ Feature: Student can complete rubric-enabled level
     When I ensure droplet is in text mode
     And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
     And I click selector "#runButton"
+    And I wait until element ".project_updated_at" contains text "Saved"
     And I wait until element "#submitButton" is visible
     And I click selector "#submitButton"
     And I wait until element "#confirm-button" is visible
@@ -54,6 +56,7 @@ Feature: Student can complete rubric-enabled level
     When I ensure droplet is in text mode
     And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
     And I click selector "#runButton"
+    And I wait until element ".project_updated_at" contains text "Saved"
     And I wait until element "#submitButton" is visible
     And I click selector "#submitButton"
     And I wait until element "#confirm-button" is visible

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -10,6 +10,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I click selector ".uitest-taRubricTab" once I see it
   Then I wait to see "#runButton"
   And I press "runButton"
+  And I wait until element ".project_updated_at" contains text "Saved"
   And I wait to see "#submitButton"
   And I press "submitButton"
   And I wait to see "#confirm-button"


### PR DESCRIPTION
the ai_evaluate_student_code.feature UI tests have been flaky in a way that have not typically repro'ed locally. However, today I managed to get a local repro and saw this error in my dashboard server output:
```
EvaluateRubricJob Error: /Users/dsb/src/cdo/dashboard/app/jobs/evaluate_rubric_job.rb:302:in `read_user_code': main.json not found for channel id BtjWWLJn54RED7gR8FnzWQ (RuntimeError)
	from /Users/dsb/src/cdo/dashboard/app/jobs/evaluate_rubric_job.rb:244:in `perform'
```

In the [saucelabs video](https://app.saucelabs.com/tests/b7e7987392334e9ba4b1f4b4edfb3a7c), you can see that as the student navigates away from the page, the project is still saving:
![Screenshot 2024-03-26 at 1 42 12 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/f1bdc5fb-ecbb-4881-9f33-7abf1877e5e2)

Based on these observations, I'm adding some calls to an existing test step to wait for the project save to complete before leaving the page.

The resulting output looks a lot like the flaky failures we have seen in the past:
![Screenshot 2024-03-26 at 1 38 08 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/729a18ea-90ef-43f6-8d98-3d73ea44707f)

Based on this, I am re-enabling the test to see if the flakiness has been fixed on the test machine.

## Testing story

UI test is passing locally. I'd like to merge ahead of drone in order to use this afternoon to debug on the test machine.

## Follow-up work

If this does not fix the issue, I'll debug it on the test machine after today's DTP completes.