### PR TITLE
Revert "Update Redis gem to 4.8.1"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'google_drive'
 gem 'jumphash'
 gem 'os'
 gem 'parallel'
-gem 'redis', '~> 4.8.1'
+gem 'redis', '~> 3.3.3'
 # Using commit ref on fork until maintainer publishes a new version.
 gem 'redis-slave-read', require: false, github: 'code-dot-org/redis-slave-read', ref: 'cfe1bd0f5cf65eee5b52560139cab133f22cb880'
 gem 'xxhash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,8 +382,8 @@ GEM
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
     fakefs (2.5.0)
-    fakeredis (0.9.2)
-      redis (~> 4.8)
+    fakeredis (0.6.0)
+      redis (~> 3.2)
     faraday (1.10.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -742,7 +742,7 @@ GEM
     recaptcha (4.6.3)
       json
     redcarpet (3.5.1)
-    redis (4.8.1)
+    redis (3.3.3)
     regexp_parser (2.8.1)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -1090,7 +1090,7 @@ DEPENDENCIES
   rambling-trie (>= 2.1.1)
   recaptcha
   redcarpet (~> 3.5.1)
-  redis (~> 4.8.1)
+  redis (~> 3.3.3)
   redis-slave-read!
   require_all
   rerun


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#57204

Seems like this caused a production build failure. See thread at https://codedotorg.slack.com/archives/C0T0PNTM3/p1711487652183599 for more