### PR TITLE
disable flaky ai rubrics ui test again

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -1,3 +1,4 @@
+@skip
 # AI evaluation is stubbed out in UI tests via the /api/test/ai_proxy/assessment route.
 @no_firefox
 Feature: Evaluate student code against rubrics using AI


### PR DESCRIPTION
partially undoes https://github.com/code-dot-org/code-dot-org/pull/57552 due to ongoing flakiness.

planning to merge ahead of drone to unblock the pipeline.