### PR TITLE
Display only sections being actively synced in the sync confirmation

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1602,6 +1602,7 @@
   "low": "low",
   "ltiSectionSyncButtonDisabledAltText": "Roster sync is disabled. To re-enable, go to your account settings.",
   "ltiSectionSyncDialogDescription": "New to Code.org? A [section]({aboutSectionsUrl}) is used to manage your classroom and assign curricula. We've identified the following sections & students associated with your course.\n\nYou can re-sync your sections & students at any time! Learn more [about syncing here]({aboutSyncingUrl}).",
+  "ltiSectionSyncDialogDescriptionNoChange": "You're all set! Your sections & students are already up to date.\n\nYou can re-sync your sections at any time. Learn more [about syncing here]({aboutSyncingUrl})",
   "ltiSectionSyncDialogError": "We encountered an error when trying to sync with your LMS.",
   "ltiSectionSyncDialogErrorNoIntegration": "LTI Integration not found",
   "ltiSectionSyncDialogErrorNoSectionFound": "We couldn't find the given section.",

--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.story.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.story.tsx
@@ -37,7 +37,7 @@ SuccessfulSync.args = {
         size: 32,
       },
     },
-    updated: {
+    changed: {
       2: {
         name: 'CSD - Period 2',
         size: 27,

--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
@@ -94,10 +94,13 @@ export default function LtiSectionSyncDialog({
       'https://support.code.org/hc/en-us/articles/115000488132-Creating-a-Classroom-Section';
     const aboutSyncingUrl = LmsLinks.ROSTER_SYNC_INSTRUCTIONS_URL;
     const dialogTitle = i18n.ltiSectionSyncDialogTitle();
-    const dialogDescription = i18n.ltiSectionSyncDialogDescription({
-      aboutSectionsUrl,
-      aboutSyncingUrl,
-    });
+    const dialogDescription =
+      syncResult.changed && Object.keys(syncResult.changed).length > 0
+        ? i18n.ltiSectionSyncDialogDescription({
+            aboutSectionsUrl,
+            aboutSyncingUrl,
+          })
+        : i18n.ltiSectionSyncDialogDescriptionNoChange({aboutSyncingUrl});
     let sectionListItems;
     if (syncResult && syncResult.changed) {
       sectionListItems = Object.entries(syncResult.changed).map(

--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
@@ -99,8 +99,8 @@ export default function LtiSectionSyncDialog({
       aboutSyncingUrl,
     });
     let sectionListItems;
-    if (syncResult && syncResult.all) {
-      sectionListItems = Object.entries(syncResult.all).map(
+    if (syncResult && syncResult.changed) {
+      sectionListItems = Object.entries(syncResult.changed).map(
         ([section_id, section]) => {
           const studentCount = i18n.ltiSectionSyncDialogStudentCount({
             numberOfStudents: section.size,
@@ -187,7 +187,7 @@ const LtiSectionShape = PropTypes.shape({
 });
 export const LtiSectionSyncResultShape = PropTypes.shape({
   all: PropTypes.objectOf(LtiSectionShape),
-  updated: PropTypes.objectOf(LtiSectionShape),
+  changed: PropTypes.objectOf(LtiSectionShape),
   error: PropTypes.string,
 });
 

--- a/apps/src/lib/ui/lti/sync/types.ts
+++ b/apps/src/lib/ui/lti/sync/types.ts
@@ -7,7 +7,7 @@ export type LtiSectionMap = {[sectionId: string]: LtiSection};
 
 export interface LtiSectionSyncResult {
   all?: LtiSectionMap;
-  updated?: LtiSectionMap;
+  changed?: LtiSectionMap;
   error?: string;
 }
 

--- a/apps/test/unit/lib/ui/lti/sync/LtiSectionSyncDialogTest.tsx
+++ b/apps/test/unit/lib/ui/lti/sync/LtiSectionSyncDialogTest.tsx
@@ -30,7 +30,7 @@ const MOCK_UPDATED_SECTION_MAP: LtiSectionMap = {
 
 const MOCK_SYNC_RESULT: LtiSectionSyncResult = {
   all: MOCK_ALL_SECTION_MAP,
-  updated: MOCK_UPDATED_SECTION_MAP,
+  changed: MOCK_UPDATED_SECTION_MAP,
 };
 
 describe('LTI Section Sync Dialog', () => {
@@ -54,8 +54,7 @@ describe('LTI Section Sync Dialog', () => {
       const items = getAllByRole('listitem', {exact: false});
       const sectionListItems = items.map(item => item.textContent);
 
-      expect(sectionListItems[0]).to.match(/Section 1(.*)100 students/);
-      expect(sectionListItems[1]).to.match(/Section 2 (.*) 10 students/);
+      expect(sectionListItems[0]).to.match(/Section 2(.*)15 students/);
 
       // no 'disable roster sync'
       expect(

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -190,8 +190,11 @@ module Services
         had_changes ||= (user.new_record? || user.changed?)
         user.save!
         if account_type == ::User::TYPE_TEACHER
-          add_instructor_result = section.add_instructor(user)
-          had_changes ||= add_instructor_result
+          # Skip adding the instructor and reporting changes if the user is already an instructor
+          unless section.instructors.include?(user)
+            add_instructor_result = section.add_instructor(user)
+            had_changes ||= add_instructor_result
+          end
           current_teachers.add(user.id)
         else
           add_student_result = section.add_student(user)

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -217,16 +217,22 @@ module Services
         end
       end
 
-      had_changes
+      section_size = nrps_members.count {|member| member[:roles].include?(Policies::Lti::CONTEXT_LEARNER_ROLE)}
+      {
+        had_changes: had_changes,
+        size: section_size,
+        name: lti_section.section.name,
+      }
     end
 
     # Syncs a course and all its sections from an NRPS response.
     def self.sync_course_roster(lti_integration:, lti_course:, nrps_sections:, current_user:)
       had_changes = false
+      course_sync_result = {
+        all: {},
+        changed: {}
+      }
       lti_sections = LtiSection.where(lti_course_id: lti_course.id)
-
-      # Only sync the section if there are no sections or the section's owner is equal to the current user
-      return false unless lti_sections.empty? || lti_sections.first.section.user_id == current_user.id
 
       # Prune sections that have been deleted in the LMS
       lti_sections.each do |lti_section|
@@ -243,7 +249,7 @@ module Services
 
         lti_user_type = lti_user_type(current_user, lti_integration, nrps_section)
 
-        # Skip if the current user is not an instructor
+        # Skip if the current user is not an instructor within this section
         next unless lti_user_type == ::User::TYPE_TEACHER
 
         if lti_section.nil?
@@ -262,10 +268,14 @@ module Services
           lti_section.section.update(name: section_name)
           had_changes = true
         end
-        sync_section_roster_result = sync_section_roster(lti_integration, lti_section, nrps_sections[lms_section_id][:members])
-        had_changes ||= sync_section_roster_result
+        current_section_result = sync_section_roster(lti_integration, lti_section, nrps_sections[lms_section_id][:members])
+        had_changes ||= current_section_result[:had_changes]
+        course_sync_result[:all][lms_section_id] = current_section_result
+        if current_section_result[:had_changes]
+          course_sync_result[:changed][lms_section_id] = current_section_result
+        end
       end
-      had_changes
+      course_sync_result
     end
   end
 end

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -244,6 +244,28 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
        ]
      }
     }
+
+    @sync_course_result_with_changes = {
+      all: {
+        '1' => {name: 'Section 1', size: 3},
+        '2' => {name: 'Section 2', size: 3},
+        '3' => {name: 'Section 3', size: 3},
+      },
+      changed: {
+        '1' => {name: 'Section 1', size: 3},
+        '2' => {name: 'Section 2', size: 3},
+        '3' => {name: 'Section 3', size: 3},
+      },
+    }
+
+    @sync_course_result_no_changes = {
+      all: {
+        '1' => {name: 'Section 1', size: 3},
+        '2' => {name: 'Section 2', size: 3},
+        '3' => {name: 'Section 3', size: 3},
+      },
+      changed: {},
+    }
   end
 
   setup do
@@ -575,7 +597,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     lti_course = create :lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid, resource_link_id: SecureRandom.uuid, nrps_url: 'https://example.com/nrps'
     LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id)
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
-    Services::Lti.expects(:sync_course_roster).returns(had_changes)
+    Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_with_changes)
 
     get '/lti/v1/sync_course', params: {lti_integration_id: lti_integration.id, deployment_id: 'foo', context_id: lti_course.context_id, rlid: lti_course.resource_link_id, nrps_url: lti_course.nrps_url}
     assert_response :ok
@@ -598,7 +620,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
     LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course_nrps_url, lti_course_resource_link_id)
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
-    Services::Lti.expects(:sync_course_roster).returns(true)
+    Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_no_changes)
 
     sign_in user
 
@@ -626,14 +648,13 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'sync - should not sync given no changes' do
-    had_changes = false
     user = create :teacher, :with_lti_auth
     sign_in user
     lti_integration = create :lti_integration
     lti_course = create :lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid, resource_link_id: SecureRandom.uuid, nrps_url: 'https://example.com/nrps'
     LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id)
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
-    Services::Lti.expects(:sync_course_roster).returns(had_changes)
+    Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_no_changes)
 
     get '/lti/v1/sync_course', params: {lti_integration_id: lti_integration.id, deployment_id: 'foo', context_id: lti_course.context_id, rlid: lti_course.resource_link_id, nrps_url: lti_course.nrps_url}
     assert_response :redirect
@@ -647,7 +668,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     lti_section = create :lti_section, lti_course: lti_course
     LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, lti_course.resource_link_id)
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
-    Services::Lti.expects(:sync_course_roster).returns(true)
+    Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_with_changes)
 
     get '/lti/v1/sync_course', params: {section_code: lti_section.section.code}
     assert_response :ok

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -590,7 +590,6 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'sync - should sync and show the confirmation page' do
-    had_changes = true
     user = create :teacher, :with_lti_auth
     sign_in user
     lti_integration = create :lti_integration

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -224,6 +224,11 @@ class Services::LtiTest < ActiveSupport::TestCase
         }
       ]
     }.deep_symbolize_keys
+
+    @empty_sync_result = {
+      all: {},
+      changed: {},
+    }
   end
 
   test 'initialize_lti_user should create User::TYPE_TEACHER when id_token contains teacher/admin roles' do
@@ -554,9 +559,9 @@ class Services::LtiTest < ActiveSupport::TestCase
     lti_course = create :lti_course, lti_integration: lti_integration
     Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
     parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response, @id_token[:iss])
-    had_changes = Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
+    result = Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
 
-    assert_equal false, had_changes
+    assert_equal @empty_sync_result, result
   end
 
   test 'lti_user_roles should return the LTI roles for a given user' do


### PR DESCRIPTION
Recently, the LTI roster sync logic was changed to include only sections where the current user is listed as a teacher. Even if the user owns the course in the LMS, if they aren't listed as a teacher for a given section, that section will not be synced. However, the sync confirmation modal wasn't updated to match this new functionality, so it was still displaying student counts for all sections in the course.

This PR:
- Changes `Services::Lti.sync_course_roster`, which used to just return a boolean for whether or not changes occurred, to returning the whole roster result object that used to only be returned from the `sync_course` route in the controller. Instead of creating this object directly from the NRPS response JSON, the object is now constructed during the actual sync process, and accurately reflects which courses were actually updated. The object used to have both an :all and a :changed property, but the :changed property wasn't being assigned any values. The sync result object is then returned, the same as before, from the `sync_course` route.
- Now that the object returned by the route accurately reflects which sections were actually synced, the `LtiSectionSyncDialog` has been updated to list summaries for only the sections present in the `changed` object, instead of all the sections in the `all` object.
- Added handling in the `LtiSectionSyncDialog` for a response that includes no changes. This is specifically for the sync button in the Teacher Dashboard. If you click the button, the dialog still pops up to provide feedback that the operation was successful despite being a no-op, with updated messaging. See screenshot below for details. Open to suggestions on the new wording.

Example Canvas course where the teacher is listed for Section B, but not Section A:
<img width="915" alt="Screenshot 2024-03-26 at 9 36 29 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/db46634a-c63d-4da8-87aa-2a6acbbd8eeb">

After syncing, the dialog now only lists section B:
<img width="777" alt="Screenshot 2024-03-26 at 9 37 10 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/c1ff2008-284c-4ebe-adca-a70c425fbd8f">

After clicking the sync button on a section that is already up-to-date:
<img width="767" alt="Screenshot 2024-03-26 at 10 41 48 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/7a6af218-60ab-44a4-8367-938cdbe02518">


## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-799)

## Testing story

LTI Controller tests have been updated with new mock return values for the stubbed sync_course_roster service method, which now returns an object instead of a boolean.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
