### PR TITLE
Fix Violations of and Reenable `Style/GlobalStdStream`

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -2,7 +2,7 @@
 
 current_dir = File.dirname(__FILE__)
 log_level                :info
-log_location             $stdout
+log_location             STDOUT
 node_name                @node_name = ENV['CDO_CHEF_NODE_NAME'] || 'cdo-ci'
                          @org_name = ENV['CDO_CHEF_ORG_NAME'] || 'code-dot-org'
 client_key               @client_key = ENV['CDO_CHEF_CLIENT_KEY'] || "#{ENV['HOME']}/.chef/#{@node_name}.pem"

--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -2,7 +2,7 @@
 
 current_dir = File.dirname(__FILE__)
 log_level                :info
-log_location             STDOUT
+log_location             $stdout
 node_name                @node_name = ENV['CDO_CHEF_NODE_NAME'] || 'cdo-ci'
                          @org_name = ENV['CDO_CHEF_ORG_NAME'] || 'code-dot-org'
 client_key               @client_key = ENV['CDO_CHEF_CLIENT_KEY'] || "#{ENV['HOME']}/.chef/#{@node_name}.pem"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -253,11 +253,6 @@ Style/FormatStringToken:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-# Offense count: 45
-# This cop supports safe auto-correction (--auto-correct).
-Style/GlobalStdStream:
-  Enabled: false
-
 # Offense count: 325
 # Configuration parameters: AllowedVariables.
 Style/GlobalVars:

--- a/bin/dotd
+++ b/bin/dotd
@@ -358,7 +358,7 @@ def puts_quit_message
   EOS
 end
 
-# Flushes STDIN, returning the results of gets.
+# Flushes $stdin, returning the results of gets.
 # @return [String] The result of gets.
 def flush_and_gets
   $stdin.iflush

--- a/bin/oneoff/backfill_data/backfill_pilot_section_course_id
+++ b/bin/oneoff/backfill_data/backfill_pilot_section_course_id
@@ -2,7 +2,7 @@
 
 require_relative '../../../dashboard/config/environment'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 ActiveRecord::Base.record_timestamps = false
 
 options = {actually_update: false}

--- a/bin/oneoff/backfill_data/backfill_section_instructors
+++ b/bin/oneoff/backfill_data/backfill_section_instructors
@@ -5,7 +5,7 @@ require_relative '../../../dashboard/config/environment'
 # This script backfills the section_instructors table to ensure that older
 # sections have their owner represented in this table.
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 ActiveRecord::Base.record_timestamps = false
 
 options = {actually_update: false, start_with: 1}

--- a/bin/oneoff/data_fix/csedweek_event_to_hoc_signup_2013
+++ b/bin/oneoff/data_fix/csedweek_event_to_hoc_signup_2013
@@ -12,7 +12,7 @@ require File.expand_path('../../../../pegasus/src/env', __FILE__)
 require 'cdo/db'
 require src_dir 'forms'
 
-STDOUT.sync = true
+$stdout.sync = true
 
 rows = PEGASUS_DB[:forms].where(kind: 'CSEdWeekEvent2013').order(:id)
 puts "#{__FILE__}: #{rows.sql}"

--- a/bin/oneoff/data_fix/fix_bad_school_info_in_users
+++ b/bin/oneoff/data_fix/fix_bad_school_info_in_users
@@ -22,7 +22,7 @@ require_relative '../../../dashboard/config/environment'
 require 'optparse'
 require 'tmpdir'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 ActiveRecord::Base.record_timestamps = false
 
 options = {actually_update: false, interstitial_days: nil, deleted_filter: nil}

--- a/bin/oneoff/data_fix/fix_invalid_users
+++ b/bin/oneoff/data_fix/fix_invalid_users
@@ -27,7 +27,7 @@ require_relative '../../../dashboard/config/environment'
 # Please note that we _did_ see some impact to database performance while running
 # this script, even on the upgraded HoC db instance.
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 ActiveRecord::Base.record_timestamps = false
 
 options = {actually_update: false}

--- a/bin/oneoff/data_fix/update_last_seen_school_info_interstitial
+++ b/bin/oneoff/data_fix/update_last_seen_school_info_interstitial
@@ -7,7 +7,7 @@
 require_relative '../../../dashboard/config/environment'
 require 'optparse'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 ActiveRecord::Base.record_timestamps = false
 
 options = {interstitial_days: nil, csv_file: '/tmp/fix_bad_school_info_in_users.201710112304.csv'}

--- a/bin/oneoff/nces_data/export_school_districts
+++ b/bin/oneoff/nces_data/export_school_districts
@@ -3,7 +3,7 @@
 require_relative '../../../dashboard/config/environment'
 require 'optparse'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 
 options = {test: false}
 OptionParser.new do |opts|

--- a/bin/oneoff/nces_data/export_schools
+++ b/bin/oneoff/nces_data/export_schools
@@ -3,7 +3,7 @@
 require_relative '../../../dashboard/config/environment'
 require 'optparse'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 
 options = {test: false}
 OptionParser.new do |opts|

--- a/bin/oneoff/nces_data/import_school_districts
+++ b/bin/oneoff/nces_data/import_school_districts
@@ -2,6 +2,6 @@
 
 require_relative '../../../dashboard/config/environment'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 
 SchoolDistrict.seed_from_s3

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2014_2015_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2014_2015_ccd
@@ -2,7 +2,7 @@
 
 require_relative '../../../dashboard/config/environment'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 
 SURVEY_YEAR = '2014-2015'.freeze
 

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2015_2016_pss
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2015_2016_pss
@@ -2,7 +2,7 @@
 
 require_relative '../../../dashboard/config/environment'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 
 SURVEY_YEAR = '2015-2016'.freeze
 

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2017_2018_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2017_2018_ccd
@@ -2,7 +2,7 @@
 
 require_relative '../../../dashboard/config/environment'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 
 SURVEY_YEAR = '2017-2018'.freeze
 

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2018_2019_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2018_2019_ccd
@@ -2,7 +2,7 @@
 
 require_relative '../../../dashboard/config/environment'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 
 SURVEY_YEAR = '2018-2019'.freeze
 

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2019_2020_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2019_2020_ccd
@@ -2,7 +2,7 @@
 
 require_relative '../../../dashboard/config/environment'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 
 SURVEY_YEAR = '2019-2020'.freeze
 

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2019_2020_pss
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2019_2020_pss
@@ -2,7 +2,7 @@
 
 require_relative '../../../dashboard/config/environment'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 
 SURVEY_YEAR = '2019-2020'.freeze
 

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2020_2021_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2020_2021_ccd
@@ -2,7 +2,7 @@
 
 require_relative '../../../dashboard/config/environment'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 
 SURVEY_YEAR = '2020-2021'.freeze
 

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_ccd
@@ -2,7 +2,7 @@
 
 require_relative '../../../dashboard/config/environment'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 
 SURVEY_YEAR = '2021-2022'.freeze
 SURVEY_YEAR_HEADER = '2021-22'.freeze

--- a/bin/oneoff/nces_data/import_schools
+++ b/bin/oneoff/nces_data/import_schools
@@ -2,6 +2,6 @@
 
 require_relative '../../../dashboard/config/environment'
 
-CDO.log = Logger.new(STDOUT)
+CDO.log = Logger.new($stdout)
 
 School.seed_from_s3

--- a/bin/test/animation_assets/test_manifest_builder.rb
+++ b/bin/test/animation_assets/test_manifest_builder.rb
@@ -5,7 +5,7 @@ describe ManifestBuilder do
   let(:aws_credentials) {Aws::Credentials.new('test_aws_key', 'test_aws_secret')}
 
   before do
-    STDOUT.stubs(:print)
+    $stdout.stubs(:print)
     Aws::CredentialProviderChain.any_instance.stubs(:static_credentials).returns(aws_credentials)
   end
 

--- a/bin/test/test_helper.rb
+++ b/bin/test/test_helper.rb
@@ -46,9 +46,9 @@ module MiniTest
   class Spec
     before do
       if ENV['CIRCLECI']
-        STDOUT.stubs(:print)
-        STDOUT.stubs(:puts)
-        STDOUT.stubs(:warn)
+        $stdout.stubs(:print)
+        $stdout.stubs(:puts)
+        $stdout.stubs(:warn)
       end
     end
   end

--- a/bin/update-contact-email
+++ b/bin/update-contact-email
@@ -22,7 +22,7 @@ def update_email(old_email, new_email)
   end
   puts "Update #{old_email} with #{new_email}? (y/N)"
 
-  unless STDIN.readline.strip.casecmp?('y')
+  unless $stdin.readline.strip.casecmp?('y')
     puts 'Canceled.'
     exit
   end

--- a/cookbooks/cdo-users/templates/default/chef_knife.rb.erb
+++ b/cookbooks/cdo-users/templates/default/chef_knife.rb.erb
@@ -2,7 +2,7 @@
 
 current_dir = File.dirname(__FILE__)
 log_level                :info
-log_location             STDOUT
+log_location             $stdout
 node_name                @node_name = ENV['CDO_CHEF_NODE_NAME'] || '<%= @chef_user_name %>'
                          @org_name = ENV['CDO_CHEF_ORG_NAME'] || 'code-dot-org'
 client_key               @client_key = ENV['CDO_CHEF_CLIENT_KEY'] || "#{ENV['HOME']}/.chef/#{@node_name}.pem"

--- a/dashboard/lib/account_purger.rb
+++ b/dashboard/lib/account_purger.rb
@@ -21,7 +21,7 @@ class AccountPurger
   attr_reader :dry_run
   alias :dry_run? :dry_run
 
-  def initialize(dry_run: false, log: STDERR, bypass_safety_constraints: false)
+  def initialize(dry_run: false, log: $stderr, bypass_safety_constraints: false)
     @dry_run = dry_run
     raise ArgumentError, 'dry_run must be boolean' unless [true, false].include? @dry_run
 

--- a/dashboard/scripts/archive/chicago_stats
+++ b/dashboard/scripts/archive/chicago_stats
@@ -2,7 +2,7 @@
 
 require_relative '../../config/environment'
 
-STDIN.each do |row|
+$stdin.each do |row|
   email = row.split(',').first
   if email && email =~ /@/
     if user = User.find_by_email_or_hashed_email(email)

--- a/dashboard/test/lib/account_purger_test.rb
+++ b/dashboard/test/lib/account_purger_test.rb
@@ -29,8 +29,8 @@ class AccountPurgerTest < ActiveSupport::TestCase
   end
 
   test 'raises ArgumentError unless log is a stream-like' do
-    AccountPurger.new log: STDOUT
-    AccountPurger.new log: STDERR
+    AccountPurger.new log: $stdout
+    AccountPurger.new log: $stderr
     AccountPurger.new log: StringIO.new
     assert_raises ArgumentError do
       AccountPurger.new log: ''

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -301,7 +301,7 @@ module Cdo
 
     def log
       require 'logger'
-      @@log ||= Logger.new(STDOUT).tap do |l|
+      @@log ||= Logger.new($stdout).tap do |l|
         l.level = Logger::INFO
         l.formatter = proc do |severity, _, _, msg|
           "#{severity == 'INFO' ? '' : "#{severity}: "}#{msg}\n"

--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -37,7 +37,7 @@ module AWS
 
     # @param [Cdo::CloudFormation::StackTemplate] stack
     # @param [Logger] log
-    def initialize(stack:, log: Logger.new(STDOUT), **options)
+    def initialize(stack:, log: Logger.new($stdout), **options)
       @stack = stack
       @log = log
       @options = options

--- a/lib/cdo/aws/s3_packaging.rb
+++ b/lib/cdo/aws/s3_packaging.rb
@@ -23,7 +23,7 @@ class S3Packaging
     @package_name = package_name
     @source_location = source_location
     @target_location = target_location
-    @logger = Logger.new(STDOUT)
+    @logger = Logger.new($stdout)
     regenerate_commit_hash
   end
 

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -28,7 +28,7 @@ class DeleteAccountsHelper
   #   usual checks on account type, row limits, etc.  For use only when an
   #   engineer needs to purge an account manually after investigating whatever
   #   prevented it from being automatically purged.
-  def initialize(log: STDERR, bypass_safety_constraints: false)
+  def initialize(log: $stderr, bypass_safety_constraints: false)
     @pegasus_db = PEGASUS_DB
 
     @log = log

--- a/lib/cdo/google/sheet.rb
+++ b/lib/cdo/google/sheet.rb
@@ -2,7 +2,7 @@ require 'cdo/google/drive'
 
 # Squash an unhelpful warning that's causing a Honeybadger error when we use
 # this module in a cronjob, because the cronjob helper sends an HB error if
-# any unexpected output to STDERR occurs.
+# any unexpected output to $stderr occurs.
 # see https://github.com/nahi/httpclient/issues/252#issuecomment-302427338
 # If we end up using Google::Sheets very broadly, it might be better for this
 # monkeypatch to live in our bin/cronjob helper instead.

--- a/lib/cdo/honeybadger.rb
+++ b/lib/cdo/honeybadger.rb
@@ -84,7 +84,7 @@ module Honeybadger
   def self.parse_exception_dump(error)
     return if error.to_s.empty?
 
-    # Unhandled Ruby exceptions are dumped to STDERR in the following format:
+    # Unhandled Ruby exceptions are dumped to $stderr in the following format:
     #   file:number:in `method': message
     #     from file:number:in `method'
     #     from ...

--- a/lib/cdo/rake_utils.rb
+++ b/lib/cdo/rake_utils.rb
@@ -312,8 +312,8 @@ module RakeUtils
   # - execute the block
   # - revert streams to original pipes and return output
   def self.capture(&block)
-    old_stdout = STDOUT.clone
-    old_stderr = STDERR.clone
+    old_stdout = $stdout.clone
+    old_stderr = $stderr.clone
     pipe_r, pipe_w = IO.pipe
     pipe_r.sync = true
     output = StringIO.new('', 'w')
@@ -324,12 +324,12 @@ module RakeUtils
     rescue EOFError
       # Do nothing.
     end
-    STDOUT.reopen(pipe_w)
-    STDERR.reopen(pipe_w)
+    $stdout.reopen(pipe_w)
+    $stderr.reopen(pipe_w)
     yield
   ensure
-    STDOUT.reopen(old_stdout)
-    STDERR.reopen(old_stderr)
+    $stdout.reopen(old_stdout)
+    $stderr.reopen(old_stderr)
     pipe_w.close
     reader.join
     pipe_r.close

--- a/lib/cdo/rake_utils.rb
+++ b/lib/cdo/rake_utils.rb
@@ -60,13 +60,13 @@ module RakeUtils
     status
   end
 
-  # Alternate version of RakeUtils.rake which always streams STDOUT to the shell
+  # Alternate version of RakeUtils.rake which always streams $stdout to the shell
   # during execution.
   def self.rake_stream_output(*args, &block)
     system_stream_output "RAILS_ENV=#{rack_env}", "RACK_ENV=#{rack_env}", 'bundle', 'exec', 'rake', *args, &block
   end
 
-  # Alternate version of RakeUtils.system which always streams STDOUT to the
+  # Alternate version of RakeUtils.system which always streams $stdout to the
   # shell during execution.
   def self.system_stream_output(*args, &block)
     command = command_(*args)
@@ -306,7 +306,7 @@ module RakeUtils
   end
 
   # Captures all stdout and stderr within a block, including subprocesses:
-  # - redirect STDOUT and STDERR streams to a pipe
+  # - redirect $stdout and $stderr streams to a pipe
   # - have a background thread read from the pipe
   # - store data in a StringIO
   # - execute the block

--- a/pegasus/Rakefile
+++ b/pegasus/Rakefile
@@ -39,7 +39,7 @@ end
 there_can_be_only_one("#{File.basename(__FILE__)}.pid") unless ENV['PEGASUS_RAKE_RECURSIVE'].to_s.casecmp?('true')
 
 unless ENV['PEGASUS_RAKE_LOGGER'].to_s.casecmp?('true')
-  $log = Logger.new STDOUT
+  $log = Logger.new $stdout
   $log.level = Logger::INFO
 end
 

--- a/pegasus/src/env.rb
+++ b/pegasus/src/env.rb
@@ -34,7 +34,7 @@ module Pegasus
   end
 
   def self.create_logger
-    logger = Logger.new STDOUT if rack_env?(:development)
+    logger = Logger.new $stdout if rack_env?(:development)
     logger ||= Logger.new pegasus_dir('log', "#{rack_env}.log")
 
     logger.level = Logger::INFO if rack_env?(:production)

--- a/shared/test/test_log.rb
+++ b/shared/test/test_log.rb
@@ -17,7 +17,7 @@ class LogTest < Minitest::Test
   end
 
   def test_override_log
-    CDO.log = Logger.new(STDOUT).tap do |l|
+    CDO.log = Logger.new($stdout).tap do |l|
       l.formatter = proc do |_, _, _, msg|
         "TEST LOG: #{msg}"
       end


### PR DESCRIPTION
Quoting from [the official Ruby style guide](https://rubystyle.guide/#global-stdout):

> Use `$stdout/$stderr/$stdin` instead of `STDOUT/STDERR/STDIN`. `STDOUT/STDERR/STDIN` are constants, and while you can actually reassign (possibly to redirect some stream) constants in Ruby, you’ll get an interpreter warning if you do so.

Most changes made automatically with `bundle exec rubocop --autocorrect-all --only Style/GlobalStdStream`. I then manually updated a few references in comments and unlinted files, just for consistency.

## Links

- https://rubystyle.guide/#global-stdout
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/GlobalStdStream
- https://docs.rubocop.org/rubocop/cops_style.html#styleglobalstdstream

## Testing story

Relying on existing unit tests to verify that this does not result in any change to functionality.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
