### PR TITLE
re-enable all ai rubrics ui tests except class eval button

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -1,4 +1,3 @@
-@skip
 # AI evaluation is stubbed out in UI tests via the /api/test/ai_proxy/assessment route.
 @no_firefox
 Feature: Evaluate student code against rubrics using AI
@@ -106,6 +105,7 @@ Feature: Evaluate student code against rubrics using AI
     And I wait until element ".uitest-ai-assessment" is visible
     Then element ".uitest-ai-assessment" contains text "Aiden has achieved Extensive or Convincing Evidence"
 
+  @skip
   Scenario: Student code is evaluated by AI when teacher requests evaluation for entire class
     Given I create a teacher-associated student named "Aiden"
     And I get debug info for the current user


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/57552 attempted to deflake and re-enabled ai rubrics ui tests, but they had to be disabled again in https://github.com/code-dot-org/code-dot-org/pull/57560 because of ongoing flakiness across browsers. closer inspection of the [cucumber logs](https://cucumber-logs.s3.amazonaws.com/test/test/Safari_teacher_tools_rubrics_ai_evaluate_student_code_output.html?versionId=XZnKMRQMwXh69A8C29ewt8dum0Q1Xy9e) reveals that now only one scenario is failing: 
![Screenshot 2024-03-26 at 4 01 14 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/e24b106a-ce5a-4d47-9b2b-309df32262a5)
![Screenshot 2024-03-26 at 3 56 18 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/001bb8d5-e131-40d7-8d97-6a07453471cb)

This PR re-enables all the other scenarios, which appear to be passing now.

## Follow-up work

It looks like the remaining UI test issue could be due to:
* [AITT-539](https://codedotorg.atlassian.net/browse/AITT-539) Run for all says it completed really quickly but then is still running

The following evidence from the [saucelabs video](https://app.saucelabs.com/tests/0e87dd065e034c7e961fad6c6a9cba45#156) supports this:
![Screenshot 2024-03-26 at 3 57 30 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/20107b2b-5044-4cf9-825c-a70ab348f174)
![Screenshot 2024-03-26 at 3 57 51 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/51163898-72e7-4881-81b0-04fe6de26833)

I also looked at the problem projects in S3 and confirmed their main.json files were present, verified that their EvaluateRubricJob requests succeeded and created successful RubricAiEvaluation entries in the database.

Based on the above, I'll plan to tackle [AITT-539](https://codedotorg.atlassian.net/browse/AITT-539) next, then see if fixing that issue is enough to get this UI test passing again.
