### PR TITLE
Revert "[Progress] Improve teacher dashboard load time by returning only used fields"

### DIFF
--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -687,6 +687,7 @@ function newSectionData(participantType) {
     courseVersionId: null,
     unitId: null,
     hidden: false,
+    isAssigned: undefined,
     restrictSection: false,
   };
 }
@@ -1344,6 +1345,7 @@ export const sectionFromServerSection = serverSection => ({
   unitId: serverSection.unit_id,
   courseId: serverSection.course_id,
   hidden: serverSection.hidden,
+  isAssigned: serverSection.isAssigned,
   restrictSection: serverSection.restrict_section,
   postMilestoneDisabled: serverSection.post_milestone_disabled,
   codeReviewExpiresAt: serverSection.code_review_expires_at

--- a/apps/test/unit/templates/studioHomepages/fakeSectionUtils.js
+++ b/apps/test/unit/templates/studioHomepages/fakeSectionUtils.js
@@ -24,6 +24,7 @@ export const sections = [
     courseOfferingId: null,
     courseVersionId: null,
     unitId: null,
+    isAssigned: true,
     participant_type: 'student',
   },
   {
@@ -43,6 +44,7 @@ export const sections = [
     courseOfferingId: null,
     courseVersionId: null,
     unitId: null,
+    isAssigned: false,
     participant_type: 'student',
   },
 ];

--- a/apps/test/unit/templates/teacherDashboard/AddSectionDialogTest.jsx
+++ b/apps/test/unit/templates/teacherDashboard/AddSectionDialogTest.jsx
@@ -42,6 +42,7 @@ describe('AddSectionDialog', () => {
         courseVersionId: null,
         unitId: null,
         hidden: false,
+        isAssigned: undefined,
         restrictSection: false,
       },
       beginImportRosterFlow,

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -358,6 +358,7 @@ describe('teacherSectionsRedux', () => {
         courseVersionId: null,
         unitId: null,
         hidden: false,
+        isAssigned: undefined,
         restrictSection: false,
       });
     });
@@ -389,6 +390,7 @@ describe('teacherSectionsRedux', () => {
         courseVersionId: courseVersionId,
         unitId: unitId,
         hidden: false,
+        isAssigned: undefined,
         restrictSection: false,
       });
     });
@@ -416,6 +418,7 @@ describe('teacherSectionsRedux', () => {
         courseVersionId: null,
         unitId: null,
         hidden: false,
+        isAssigned: undefined,
         restrictSection: false,
       });
     });
@@ -444,6 +447,7 @@ describe('teacherSectionsRedux', () => {
         createdAt: createdAt,
         studentCount: 1,
         hidden: false,
+        isAssigned: undefined,
         restrictSection: false,
         postMilestoneDisabled: false,
         codeReviewExpiresAt: null,
@@ -775,6 +779,7 @@ describe('teacherSectionsRedux', () => {
           courseId: undefined,
           createdAt: createdAt,
           hidden: false,
+          isAssigned: undefined,
           restrictSection: false,
           postMilestoneDisabled: false,
           codeReviewExpiresAt: null,

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -2,15 +2,15 @@ class TeacherDashboardController < ApplicationController
   load_and_authorize_resource :section
 
   def show
-    @section_summary = @section.selected_section_summarize
-    @sections = current_user.sections_instructed.map(&:concise_summarize)
+    @section_summary = @section.summarize
+    @sections = current_user.sections_instructed.map(&:summarize)
     @locale_code = request.locale
     view_options(full_width: true, no_padding_container: true)
   end
 
   def parent_letter
-    @section_summary = @section.selected_section_summarize
-    @sections = current_user.sections_instructed.map(&:concise_summarize)
+    @section_summary = @section.summarize
+    @sections = current_user.sections_instructed.map(&:summarize)
     render layout: false
   end
 end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#57504, suspected to cause eyes diffs due to change in default unit displayed on unit selector for progress page.