### PR TITLE
Add DCDO flag for AI TA launch

### DIFF
--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -45,6 +45,8 @@ class DCDOBase < DynamicConfigBase
       # Whether the scholarship dropdown is locked on the application dashboard.
       'scholarship-dropdown-locked': DCDO.get('scholarship-dropdown-locked', true),
       hoc_mode: DCDO.get('hoc_mode', false),
+      # Whether to show the marketing banners for the AI Teacher Assistant launch. Can be removed later.
+      'ai-teaching-assistant-launch': DCDO.get('ai-teaching-assistant-launch', false),
     }
   end
 end


### PR DESCRIPTION
Adds the DCDO flag `ai-teaching-assistant-launch` to be used on banners for the AI TA launch in early April.

**Jira ticket:** [ACQ-1671](https://codedotorg.atlassian.net/browse/ACQ-1671)