### PR TITLE
Improve Examples for Publishing Secrets

### DIFF
--- a/config/secrets.yml.template
+++ b/config/secrets.yml.template
@@ -1,18 +1,20 @@
 # Sample secrets.yml file.
-# Top-level key is secret name, second-level key is environment name.
-# (`base` is an alias for staging, test, levelbuilder, and production.)
-# The value is the secret string.
-# (Complex objects will be converted to JSON.)
 ---
-foo:
-  base: bar # staging, test, levelbuilder and production
-  production: baz
-qux:
-  development:
-    qux: quux
-  staging:
-    qux: quuz
-  test:
-    qux: quuz
-  production:
-    qux: quuz
+# Publish AWS Secrets Manager Secrets named `[environment type]/cdo/acme_api_key` that can be used to populate `CDO.acme_api_key`
+acme_api_key:
+  development: 123ABC      # Development API key
+  adhoc: 123ABC            # Development API key
+  staging: 123ABC          # Development API key
+  test: ZYX987             # Test API key
+  levelbuilder: ZYX987     # Test API key
+  production: a1b2c3d4e5f6 # Production API key
+
+# Publish AWS Secrets Manager Secrets named `[environment type]/cdo/wile_e_coyote_credentials` that can be used to
+# populate `CDO.wile_e_coyote_credentials` with a value whose data type is complex.
+wile_e_coyote_credentials:
+  development: {"username": "dev@code.org", "password": "Q3rt^"}        # Development credentials
+  adhoc: {"username": "dev@code.org", "password": "Qw3rt^"}             # Development credentials
+  staging: {"username": "dev@code.org", "password": "Qw3rt^"}           # Development credentials
+  test: {"username": "dev+test@code.org", "password": "Dv0ra@"}         # Test credentials
+  levelbuilder: {"username": "dev+test@code.org", "password": "Dv0ra@"} # Test credentials
+  production: {"username": "site@code.org", "password": "6f5e4d3c2b1a"} # Production credentials


### PR DESCRIPTION
We've had two recent cases where engineers published Secrets that were inadvertently populated with JSON/complex values. The engineer intended to publish AWS Secrets Manager Secret `production/cdo/foo` with value `bar` and instead populated it with the value `{"foo": "bar"}` due to confusion about how to format the `config/secrets.yml` file.

Update the example with a better illustration of how to publish Secrets with values that are either simple or complex .

## Testing story

`bin/update_secrets` using a `secrets.yml` populated with the examples from `secrets.yml.template`

![image](https://github.com/code-dot-org/code-dot-org/assets/2157034/fed80ca9-452e-4b03-b354-480deb648a91)


![image](https://github.com/code-dot-org/code-dot-org/assets/2157034/5b8ef1ad-c51c-4612-9f30-f95f1f72db6c)


## Deployment strategy

## Follow-up work

Delete all the example Secrets that were published during the manual test of this new template.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
