### PR TITLE
Handle empty song list in Dance

### DIFF
--- a/apps/src/dance/danceRedux.ts
+++ b/apps/src/dance/danceRedux.ts
@@ -84,10 +84,15 @@ export const initSongs = createAsyncThunk(
 
     // a song should be included if we do NOT have a filtered song set
     // OR if we do have a set and our song's id is in them.
-    const songManifest = unfilteredSongManifest.filter(
+    let songManifest = unfilteredSongManifest.filter(
       (song: {id: string}) =>
         !filteredSongSet.size || filteredSongSet.has(song.id)
     );
+    // Handle dev scenario where there's no overlap between
+    // levelbuilder-configured songs and the list of dev-only songs
+    if (!songManifest.length) {
+      songManifest = unfilteredSongManifest;
+    }
     const songData = parseSongOptions(songManifest) as SongData;
 
     if (


### PR DESCRIPTION
We noticed that the song selector appears empty on levels where a levelbuilder has configured a slimmed set of songs, and a developer is using dev only songs (synthesize, etc) -- there's no intersection between these two lists. Trying to run dance party with no song selected in development causes a crash.

Default to show all songs in selector if there is no overlap between what's specified in levelbuilder and what is available in the song manifest.

## Links

- Slack: https://codedotorg.slack.com/archives/C05DMS18MEX/p1711546547296989

## Testing story

Tested manually that the song dropdown was empty on [this level ](http://localhost-studio.code.org:3000/s/dance-ai-2023/lessons/1/levels/10) without this change, and was populated with it.

Also tested that the levelbuilder-configured list continued to show up on this level when production songs were made accessible.