### PR TITLE
P20-793: Fix "uninitialized constant SharedConstants::USER_TYPES"

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -71,6 +71,7 @@
 
 require 'digest/md5'
 require 'cdo/aws/metrics'
+require 'cdo/shared_constants'
 require_relative '../../legacy/middleware/helpers/user_helpers'
 require 'school_info_interstitial_helper'
 require 'sign_up_tracking'


### PR DESCRIPTION
## Error
```
/home/ubuntu/test/dashboard/app/models/user.rb:196:in `<class:User>': uninitialized constant SharedConstants::USER_TYPES
Did you mean?  UserHelpers (NameError)
        from /home/ubuntu/test/dashboard/app/models/user.rb:84:in `<top (required)>'
```

## Links
- JIRA ticket: [P20-793](https://codedotorg.atlassian.net/browse/P20-793)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/57517