### PR TITLE
[Sprite Lab] validation quick fixes

### DIFF
--- a/apps/src/p5lab/spritelab/commands/validationCommands.js
+++ b/apps/src/p5lab/spritelab/commands/validationCommands.js
@@ -125,17 +125,17 @@ export const commands = {
   setBonusSuccessMessage(message) {
     this.bonusSuccessMessage = message;
   },
-  setEarlyTime(frames) {
-    this.validationFrames.early = frames;
-  },
   setWaitTime(frames) {
     this.validationFrames.fail = frames;
+    return true;
   },
   setFailTime(frames) {
     this.validationFrames.fail = frames;
+    return true;
   },
   setDelayTime(frames) {
     this.validationFrames.delay = frames;
+    return true;
   },
   getFailTime() {
     return this.validationFrames.fail;


### PR DESCRIPTION
A couple quick fixes for validation commands. `setEarlyTime` is unused. For the other used functions, returning `true` allows them to be included in criterion logic which makes it possible to leverage JavaScript's `&&` chaining logic to dynamically update the fail and delay time. Note that wait time and fail time are equivalent, but both appear in levels so neither can be removed without also changing level files.