### PR TITLE
Teacher Dashboard: when a user clicks off the More Details dialog, it closes

### DIFF
--- a/apps/src/templates/AccessibleDialog.jsx
+++ b/apps/src/templates/AccessibleDialog.jsx
@@ -11,6 +11,7 @@ function AccessibleDialog({
   children,
   className,
   initialFocus = true,
+  closeOnClickBackdrop = false,
 }) {
   // If these styles are provided by the given stylesheet, use them
   const modalStyle = styles?.modal || defaultStyle.modal;
@@ -20,7 +21,13 @@ function AccessibleDialog({
     <div>
       <div className={backdropStyle} />
       <CloseOnEscape handleClose={onClose}>
-        <FocusTrap focusTrapOptions={{initialFocus: initialFocus}}>
+        <FocusTrap
+          focusTrapOptions={{
+            initialFocus: initialFocus,
+            onDeactivate: onClose,
+            clickOutsideDeactivates: closeOnClickBackdrop,
+          }}
+        >
           <div
             aria-modal
             className={classnames(modalStyle, className)}
@@ -40,6 +47,7 @@ AccessibleDialog.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   initialFocus: PropTypes.bool,
+  closeOnClickBackdrop: PropTypes.bool,
 };
 
 export default AccessibleDialog;

--- a/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
+++ b/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
@@ -28,7 +28,7 @@ export default function MoreDetailsDialog({hasValidation, onClose}) {
   );
 
   return (
-    <AccessibleDialog onClose={onClose}>
+    <AccessibleDialog onClose={onClose} closeOnClickBackdrop={true}>
       <Heading3>{i18n.progressTrackingIconKey()}</Heading3>
       <button type="button" onClick={onClose} className={styles.xCloseButton}>
         <i id="x-close" className="fa-solid fa-xmark" />


### PR DESCRIPTION
Modifies `AccessibleDialog` so that it can be exited by clicking outside. 

The video below shows the feature.  Note that it still closes using the `esc` key on the keyboard and `X` button in the component.


https://github.com/code-dot-org/code-dot-org/assets/24883357/0c7d406e-cba5-477b-9145-88cb55c8a8cf

I also show a different use of the AcessibleDialog to show that this change does not impact the AccessibleDialog uses elsewhere.


## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-941)
Note that I needed to do some digging to find more about the options for a `FocusTrap` -[ you can read about them here](https://github.com/focus-trap/focus-trap#createoptions).  Initially, I tried just adding an `onClick` to the `backgroundModal` but the `FocusTrap` was preventing the recognition of the `click`.   [I found this blog post also helpful.](https://www.dhiwise.com/post/mastering-accessibility-with-focus-trap-react)

## Testing story

I did not add any more tests here.  There is a possibility that if we want to use this "click off to close" feature more widely, that we might want to add a UI test to the `AccessibleDialog`.  I have also heard that `AccessibleDialogs` are going to be upgraded soon anyway... 

Finally, note that I did add this feature in a way that I believe still makes it accessible.  Using tabs, a user can still:

- Close the dialog with the X button
- Be returned to where the last left off
- Close the dialog using the `esc` key

Note on the accessibility front, the scrolling is not accessible and users cannot tab through the icons.  I tried adding a `tabIndex` to each of the items, but got the following error.  Given Molly and Brian's feedback [here](https://codedotorg.slack.com/archives/C045UAX4WKH/p1711569931828699), I didn't try to fix it any further - I am open to other ideas though!

```
/Users/kaitlynobryan/GitHub/code-dot-org/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
  21:34  error  `tabIndex` should only be declared on interactive elements  jsx-a11y/no-noninteractive-tabindex

✖ 1 problem (1 error, 0 warnings)
```

