### PR TITLE
Lab2: Allow lab2 levels to navigate to non-lab2 levels

### DIFF
--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -22,14 +22,20 @@ import {
 import {
   processServerStudentProgress,
   getLevelResult,
+  processedLevel,
 } from '@cdo/apps/templates/progress/progressHelpers';
 import {mergeActivityResult} from './activityUtils';
 import {SET_VIEW_TYPE} from './viewAsRedux';
 import {setVerified} from '@cdo/apps/code-studio/verifiedInstructorRedux';
 import {authorizeLockable} from './lessonLockRedux';
-import {updateBrowserForLevelNavigation} from './browserNavigation';
+import {
+  canChangeLevelInPage,
+  updateBrowserForLevelNavigation,
+} from './browserNavigation';
 import {TestResults} from '@cdo/apps/constants';
 import {nextLevelId} from './progressReduxSelectors';
+import {getBubbleUrl} from '../templates/progress/BubbleFactory';
+import {navigateToHref} from '../utils';
 
 export interface ProgressState {
   currentLevelId: string | null;
@@ -283,20 +289,27 @@ export const queryUserProgress =
 export function navigateToLevelId(levelId: string): ProgressThunkAction {
   return (dispatch, getState) => {
     const state = getState().progress;
-    if (!state.currentLessonId) {
+    if (!state.currentLessonId || !state.currentLevelId) {
       return;
     }
-    const newLevel = getLevelById(
-      state.lessons,
-      state.currentLessonId,
-      levelId
+    const newLevel = processedLevel(
+      getLevelById(state.lessons, state.currentLessonId, levelId)
     );
     if (!newLevel) {
       return;
     }
 
-    updateBrowserForLevelNavigation(state, newLevel.path, levelId);
-    dispatch(setCurrentLevelId(levelId));
+    const currentLevel = processedLevel(
+      getLevelById(state.lessons, state.currentLessonId, state.currentLevelId)
+    );
+
+    if (canChangeLevelInPage(currentLevel, newLevel)) {
+      updateBrowserForLevelNavigation(state, newLevel.path, levelId);
+      dispatch(setCurrentLevelId(levelId));
+    } else {
+      const url = getBubbleUrl(newLevel.path, undefined, undefined, true);
+      navigateToHref(url);
+    }
   };
 }
 

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -294,6 +294,7 @@ export const processedLevel = level => {
         : PUZZLE_PAGE_NONE,
     sublevels:
       level.sublevels && level.sublevels.map(level => processedLevel(level)),
+    path: level.path,
   };
 };
 

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -60,6 +60,7 @@ const lessonData = [
         app: 'maze',
         uses_lab2: false,
         is_validated: true,
+        path: '/s/course3/lessons/1/levels/1',
       },
       {
         ids: ['323'],
@@ -77,6 +78,7 @@ const lessonData = [
         app: 'maze',
         uses_lab2: false,
         is_validated: true,
+        path: '/s/course3/lessons/1/levels/2',
       },
       {
         ids: ['322'],
@@ -95,6 +97,7 @@ const lessonData = [
         app: 'maze',
         uses_lab2: false,
         is_validated: false,
+        path: '/s/course3/lessons/1/levels/3',
       },
     ],
     lesson_plan_html_url:
@@ -132,6 +135,7 @@ const lessonData = [
         app: 'maze',
         uses_lab2: false,
         is_validated: true,
+        path: '/s/course3/lessons/2/levels/1',
       },
       {
         ids: ['339'],
@@ -148,6 +152,7 @@ const lessonData = [
         app: 'maze',
         uses_lab2: false,
         is_validated: false,
+        path: '/s/course3/lessons/2/levels/2',
       },
       {
         ids: ['341'],
@@ -164,6 +169,7 @@ const lessonData = [
         app: 'maze',
         uses_lab2: false,
         is_validated: false,
+        path: '/s/course3/lessons/2/levels/3',
       },
     ],
     lesson_plan_html_url:
@@ -201,6 +207,7 @@ const lockableLessonData = [
         display_as_unplugged: true,
         sublevels: [],
         uses_lab2: false,
+        path: '/s/course3/lessons/1/levels/1',
       },
     ],
   },
@@ -611,6 +618,7 @@ describe('progressReduxTest', () => {
             usesLab2: false,
             isValidated: true,
             canHaveFeedback: undefined,
+            path: '/s/course3/lessons/1/levels/1',
           },
           {
             id: '323',
@@ -636,6 +644,7 @@ describe('progressReduxTest', () => {
             usesLab2: false,
             isValidated: true,
             canHaveFeedback: undefined,
+            path: '/s/course3/lessons/1/levels/2',
           },
           {
             id: '322',
@@ -661,6 +670,7 @@ describe('progressReduxTest', () => {
             usesLab2: false,
             isValidated: false,
             canHaveFeedback: undefined,
+            path: '/s/course3/lessons/1/levels/3',
           },
         ],
         [
@@ -688,6 +698,7 @@ describe('progressReduxTest', () => {
             usesLab2: false,
             isValidated: true,
             canHaveFeedback: undefined,
+            path: '/s/course3/lessons/2/levels/1',
           },
           {
             id: '339',
@@ -713,6 +724,7 @@ describe('progressReduxTest', () => {
             usesLab2: false,
             isValidated: false,
             canHaveFeedback: undefined,
+            path: '/s/course3/lessons/2/levels/2',
           },
           {
             id: '341',
@@ -738,6 +750,7 @@ describe('progressReduxTest', () => {
             usesLab2: false,
             isValidated: false,
             canHaveFeedback: undefined,
+            path: '/s/course3/lessons/2/levels/3',
           },
         ],
       ];


### PR DESCRIPTION
This mostly worked already; the main change we need here is that the `navigateToNextLevel` redux action assumes that we are navigating to a lab2 level and therefore tries to update the browser stack. Instead, we just need to check if the current and next level are lab2, and either update the browser stack, or do a full page load accordingly.

https://github.com/code-dot-org/code-dot-org/assets/85528507/92b8dfb6-e1c3-4607-83f1-5e1fc7cb9b28

## Links

Motivated by wanting to use the Panels level in non-lab2 progressions: https://codedotorg.slack.com/archives/CFGAVL2CA/p1711569834707299

## Testing story

Tested locally on allthethings with a progression containing both lab2 and non-lab2 levels.