### PR TITLE
Music: fix parsing key from library

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -40,7 +40,7 @@ export default class MusicLibrary {
     }
 
     if (libraryJson.key) {
-      this.key = Key[libraryJson.key.toUpperCase() as keyof typeof Key];
+      this.key = libraryJson.key;
     }
   }
 
@@ -222,7 +222,7 @@ export type LibraryJson = {
   imageSrc: string;
   path: string;
   bpm?: number;
-  key?: string;
+  key?: number;
   defaultSound?: string;
   folders: SoundFolder[];
   instruments: SoundFolder[];


### PR DESCRIPTION
Previously we were assuming the key was a string (e.g. "F#") since we were reading it from the URL, but keys in the library JSON are numbers from 0-11.

## Testing story

Tested locally with a library that has key & bpm info: http://localhost-studio.code.org:3000/projectbeats?library=test&player=tonejs