### PR TITLE
Support: `HOT=0 yarn start` to disable HMR 

### DIFF
--- a/apps/envConstants.js
+++ b/apps/envConstants.js
@@ -38,7 +38,7 @@ module.exports = {
   DRONE: process.env.DRONE,
   CIRCLE_TEST_REPORTS: process.env.CIRCLE_TEST_REPORTS,
   // If set, run webpack dev server (with hot reloading)
-  HOT: false,
+  HOT: !(process.env.HOT === '0'),
   // Include static assets when serving storybook locally
   STORYBOOK_STATIC_ASSETS: process.env.STORYBOOK_STATIC_ASSETS,
 };

--- a/apps/envConstants.js
+++ b/apps/envConstants.js
@@ -38,7 +38,7 @@ module.exports = {
   DRONE: process.env.DRONE,
   CIRCLE_TEST_REPORTS: process.env.CIRCLE_TEST_REPORTS,
   // If set, run webpack dev server (with hot reloading)
-  HOT: !!process.env.HOT,
+  HOT: false,
   // Include static assets when serving storybook locally
   STORYBOOK_STATIC_ASSETS: process.env.STORYBOOK_STATIC_ASSETS,
 };

--- a/apps/envConstants.js
+++ b/apps/envConstants.js
@@ -38,7 +38,7 @@ module.exports = {
   DRONE: process.env.DRONE,
   CIRCLE_TEST_REPORTS: process.env.CIRCLE_TEST_REPORTS,
   // If set, run webpack dev server (with hot reloading)
-  HOT: !(process.env.HOT === '0'),
+  HOT: process.env.HOT === '1',
   // Include static assets when serving storybook locally
   STORYBOOK_STATIC_ASSETS: process.env.STORYBOOK_STATIC_ASSETS,
 };

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -691,25 +691,27 @@ function createWebpackConfig({
           ]
         : []),
     ],
-    devServer: {
-      allowedHosts: ['localhost-studio.code.org', 'localhost.code.org'],
-      client: {overlay: false},
-      port: WEBPACK_DEV_SERVER_PORT,
-      proxy: [
-        {
-          context: ['**'],
-          target: 'http://localhost-studio.code.org:3000',
-          changeOrigin: false,
-          logLevel: 'debug',
-        },
-      ],
-      host: '0.0.0.0',
-      hot: false,
-      liveReload: false,
-      devMiddleware: {
-        writeToDisk: true,
-      },
-    },
+    devServer: envConstants.DEV
+      ? {
+          allowedHosts: ['localhost-studio.code.org', 'localhost.code.org'],
+          client: {overlay: false},
+          port: WEBPACK_DEV_SERVER_PORT,
+          proxy: [
+            {
+              context: ['**'],
+              target: 'http://localhost-studio.code.org:3000',
+              changeOrigin: false,
+              logLevel: 'debug',
+            },
+          ],
+          host: '0.0.0.0',
+          hot: envConstants.HOT,
+          liveReload: envConstants.HOT,
+          devMiddleware: {
+            writeToDisk: true,
+          },
+        }
+      : undefined,
   };
 
   //////////////////////////////////////////////

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -691,26 +691,25 @@ function createWebpackConfig({
           ]
         : []),
     ],
-    devServer: envConstants.HOT
-      ? {
-          allowedHosts: ['localhost-studio.code.org', 'localhost.code.org'],
-          client: {overlay: false},
-          port: WEBPACK_DEV_SERVER_PORT,
-          proxy: [
-            {
-              context: ['**'],
-              target: 'http://localhost-studio.code.org:3000',
-              changeOrigin: false,
-              logLevel: 'debug',
-            },
-          ],
-          host: '0.0.0.0',
-          hot: true,
-          devMiddleware: {
-            writeToDisk: true,
-          },
-        }
-      : undefined,
+    devServer: {
+      allowedHosts: ['localhost-studio.code.org', 'localhost.code.org'],
+      client: {overlay: false},
+      port: WEBPACK_DEV_SERVER_PORT,
+      proxy: [
+        {
+          context: ['**'],
+          target: 'http://localhost-studio.code.org:3000',
+          changeOrigin: false,
+          logLevel: 'debug',
+        },
+      ],
+      host: '0.0.0.0',
+      hot: false,
+      liveReload: false,
+      devMiddleware: {
+        writeToDisk: true,
+      },
+    },
   };
 
   //////////////////////////////////////////////


### PR DESCRIPTION
An explicit HOT=0 env variable will disable hot module reloading.

- `webpack-dev-server` is still enabled, and used to serve files via proxy AND writeToDisk: to update apps/build
- but the compiled JS will not contain hot reload hooks, so it shouldn't attempt to access port 9000
