### PR TITLE
[Minecraft] dynamically add procedure call blocks to flyout

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -31,6 +31,7 @@ import {Block, BlockSvg, Field, Theme, WorkspaceSvg} from 'blockly';
 import {BlockColor, JsonBlockConfig, WorkspaceSerialization} from '../types';
 import experiments from '@cdo/apps/util/experiments';
 import {getBaseName} from '../utils';
+import {ToolboxItemInfo} from 'blockly/core/utils/toolbox';
 
 /**
  * Loads blocks to a workspace.
@@ -58,6 +59,48 @@ export function loadBlocksToWorkspace(
   Blockly.serialization.workspaces.load(mainSource, workspace);
   positionBlocksOnWorkspace(workspace);
   Blockly.hasLoadedBlocks = true;
+
+  // Dynamically add procedure call blocks to an uncategorized toolbox
+  // if specified in the level config (e.g. Minecraft Agent levels).
+  // Levels will include: "top_level_procedure_autopopulate": "true"
+  if (Blockly.topLevelProcedureAutopopulate) {
+    addProcedureCallBlocksToFlyout(workspace, mainSource);
+  }
+}
+
+function addProcedureCallBlocksToFlyout(
+  workspace: WorkspaceSvg,
+  mainSource: WorkspaceSerialization
+) {
+  // options.languageTree is the translated toolbox info
+  if (workspace.getFlyout() && workspace.options?.languageTree) {
+    const callBlocks = [] as ToolboxItemInfo[];
+    const defBlocks = mainSource.blocks.blocks.filter(
+      block => block.type === 'procedures_defnoreturn'
+    );
+    defBlocks.forEach(def => {
+      // Procedure definitions should have a valid name
+      if (typeof def.fields?.NAME === 'string') {
+        // Create the block XML for a procedure call block.
+        const block = document.createElement('block');
+        block.setAttribute('type', 'procedures_callnoreturn');
+        const mutation = document.createElement('mutation');
+        mutation.setAttribute('name', def.fields.NAME);
+        block.appendChild(mutation);
+
+        callBlocks.push({
+          kind: 'BLOCK',
+          blockxml: block,
+          type: 'procedures_callnoreturn',
+        });
+      }
+    });
+    if (callBlocks.length) {
+      // Add the new callblocks to the toolbox and refresh it.
+      workspace.options.languageTree.contents.push(...callBlocks);
+      workspace.getFlyout()?.show(workspace.options.languageTree);
+    }
+  }
 }
 
 /**

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -729,6 +729,9 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       options
     ) as ExtendedWorkspaceSvg;
 
+    blocklyWrapper.topLevelProcedureAutopopulate =
+      !!options.topLevelProcedureAutopopulate;
+
     if (options.noFunctionBlockFrame) {
       workspace.noFunctionBlockFrame = options.noFunctionBlockFrame;
     }

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -67,6 +67,7 @@ type GoogleBlocklyType = typeof GoogleBlockly;
 
 // Type for the Blockly instance created and modified by googleBlocklyWrapper.
 export interface BlocklyWrapperType extends GoogleBlocklyType {
+  topLevelProcedureAutopopulate: boolean;
   getNewCursor: (type: string) => Cursor;
   LineCursor: typeof GoogleBlockly.BasicCursor;
   version: BlocklyVersion;
@@ -217,6 +218,7 @@ export interface ExtendedBlocklyOptions extends BlocklyOptions {
   levelBlockIds: string[];
   isBlockEditMode: boolean;
   editBlocks: string | undefined;
+  topLevelProcedureAutopopulate: boolean | undefined;
   noFunctionBlockFrame: boolean;
   useModalFunctionEditor: boolean;
   useBlocklyDynamicCategories: boolean;


### PR DESCRIPTION
Nine Minecraft levels have a `"top_level_procedure_autopopulate": "true"` property which is handled in CDO Blockly by automatically adding call blocks for each definition block that has been loaded into the workspace. These levels are all clones of the "Free Play" level found at the end of the Hero progression:

<img width="700" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/eababd5d-1b4b-4be6-a151-16befef4c338">

This setting allows us to omit these call blocks from the toolbox XML and dynamically create them.

## How it works in CDO Blockly
If `inject` is called with this option, it is added to the `Blockly` instance. If present, when blocks are loaded with `domToBlockSpace`, we trigger an update to the flyout: 

https://github.com/code-dot-org/blockly/blob/f012d8262f21bae3e54fb11dd8bc29cf0d29f3cd/core/utils/xml.js#L350-L352

This in turn calls `flyout_.show()` using the current language tree (translated toolbox items): 

https://github.com/code-dot-org/blockly/blob/f012d8262f21bae3e54fb11dd8bc29cf0d29f3cd/core/ui/block_space/block_space_editor.js#L668-L673

## Google Blockly

The code linked above led me to investigate similar potential paths for Google Blockly. It is easy to add a `topLevelProcedureAutopopulate` to the Google Blockly wrapper, and the option was already being passed into the `inject` call by StudioApp. 

If it's there, we need to update the flyout after we finish loading blocks to the workspace. CDO Blockly's `udpateFlyout` is custom, but we can still refresh the contents in Google Blockly by calling `show()` directly. The `languageTree` array still exists in Google Blockly. For type info and references, see below:
* https://github.com/google/blockly/blob/0e22a7982ee99f9efd258c68826806189729d096/core/options.ts#L47
* https://github.com/google/blockly/blob/d9ea9b7f44b021186654a153c14c80ce0057e048/core/inject.ts#L235-L248

The `languageTree` is made up of toolbox items, typically of type `BlockInfo`: https://github.com/google/blockly/blob/d9ea9b7f44b021186654a153c14c80ce0057e048/core/utils/toolbox.ts#L18-L36

## Proposal
We already have a well-established point in time right after blocks have been loaded. At this point, if the wrapper property is there, we can create new toolbox items based on the main workspace serialization source. Note that this setting is only meant to be used in levels without categories and without the modal function editor. For each toolbox item, I created a block element with a mutation that matches what would typically be found in the toolbox XML for a block like it.

This results in the blocks being created in the toolbox as expected:

<img width="1512" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/946b25a1-e144-492c-87ce-1ed377318b29">



## Links

Minecraft bug tracking doc: https://docs.google.com/document/d/1EZ3LKUj091Yf2EXRIuU4Sw9oVzY8KcvU_sschVk8DA0/edit

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I tested that the call blocks work as expected and show up in the user's language. In an edge case scenario where a user has changed languages after saving progress, the toolbox will still match the names of the actual functions on the workspace.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
