### PR TITLE
Add strings for AI TA landing page

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10498,6 +10498,69 @@
     aria_label: "Explore the Coding with AI lessons"
     button_label: "Explore lessons"
 
+  ai_ta_page:
+    heading: "AI Teaching Assistant"
+    desc: "Introducing our AI Teaching Assistant: Designed for CS educators, it offers instant, insightful project assessments, enabling teachers to concentrate on inspiring and connecting with their students."
+    button: "Apply to join the pilot"
+    announcement_banner: "We are now enrolling CSD Unit 3 teachers for our pilot! [Apply now](%{apply_url})"
+    assessment_power:
+      heading: "Smart assessment power"
+      desc: "Unlock the power of AI to evaluate student projects with precision, speed, and confidence."
+      list_01: "**Automated Assessment:** Instantly assess student work against Code.org's rubrics."
+      list_02: "**Feedback Insights:** Provide targeted, constructive feedback to foster student growth."
+      list_03: "**Efficiency Boost:** Reduce administrative workload, freeing up more time for teaching."
+    focus:
+      heading: "Focus more on what matters"
+      desc: "The AI Teaching Assistant transforms CS education, easing the workload for new and experienced teachers alike. By streamlining assessments, it boosts educator confidence, enabling a focus on enriching student interactions and tailored learning experiences."
+    pilot_apps:
+      heading: "Accepting pilot applications through June 2024"
+      desc: "We are enrolling **CSD Unit 3 teachers** to into our AI Teaching Assistant pilot. You'll get the chance to help experience and test this exciting new tool!"
+      cta: "Not a CSD teacher? [Sign up for our AI updates](%{sign_up_url})!"
+    resources:
+      heading: "Additional AI resources for educators"
+      curriculum:
+        title: "AI curriculum"
+        desc: "Explore our broad range of artificial intelligence (AI) curriculum offerings that explore the impacts, applications, and ethics of AI. Available for different grade levels and diverse needs."
+        button: "Explore AI curriculum"
+      pl:
+        title: "Professional learning"
+        desc: "Get a hands-on introduction to the artificial intelligence and machine learning curriculum. Train a machine learning model using AI Lab, and engage with machine learning apps."
+        button: "See professional learning"
+      videos:
+        title: "AI videos"
+        desc: "Videos that introduce you to how artificial intelligence works and why it matters. Then delve into issues like algorithmic bias and the ethics of AI decision-making."
+        button: "Watch AI videos"
+    form:
+      heading: "Stay informed on AI at Code.org"
+      desc: "Keep up with Code.org's innovative AI tools and updates. Subscribe to our newsletter for the latest insights and developments."
+    faq:
+      heading: "Frequently asked questions"
+      support:
+        question: "What can the AI Teaching Assistant currently support?"
+        answer_01: "The AI Teaching Assistant's first feature is AI-supported rubrics in the Interactive Games and Animations unit of Code.
+        org's Computer Science Discoveries (CSD) curriculum. This feature:"
+        answer_02: "In the future, the AI Teaching Assistant's feature set will expand to assist teachers with additional tasks."
+        list_01: "Allows teachers to assess their students' coding projects within the Code.org platform"
+        list_02: "Saves teachers time by providing an initial assessment of student work"
+        list_03: "Helps build confidence for teachers who are new to teaching Computer Science"
+      units:
+        question: "What Units is the AI Teaching Assistant available for?"
+        answer: "The AI Teaching Assistant is launching in CSD's Interactive Games and Animations Unit. The team is hard at work building AI-supported features for additional curriculum."
+      available:
+        question: "When will the AI Teaching Assistant be available to all Interactive Games and Animation users?"
+        answer: "The AI Teaching Assistant will launch to all CSD teachers in August 2024, in time for the 2024-2025 school year."
+      access:
+        question: "How do I access the AI Teaching Assistant?"
+        answer: "The AI Teaching Assistant is available for teachers accepted into the pilot in mini and end-of-unit projects in the Interactive Games and Animations unit. In those lessons, the AI Teaching Assistant will appear in the bottom left-hand corner of your screen."
+      keep_up:
+        question: "Where should I go to keep up with Code.org's investment in AI-supported tools?"
+        answer: "Code.org is investing in using AI to enhance teaching and learning.  Check out [https://code.org/ai](https://code.org/ai) to learn more about our AI curriculum, professional learning, and tools."
+      demo:
+        question: "Can I see a demo of how AI TA works?"
+        answer: ""
+    partners:
+      heading: "Developed in partnership with"
+
   video_library_page_main_title: "Educational short videos"
   video_library_page_hero_description: "Code.org's growing library of educational videos is available for re-use by educators worldwide, online or in classrooms. Our goal is to amplify our efforts beyond our own curriculum's reach."
   video_library_page_title_ai_works: "How AI Works"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10553,10 +10553,10 @@
         answer: "The AI Teaching Assistant is available for teachers accepted into the pilot in mini and end-of-unit projects in the Interactive Games and Animations unit. In those lessons, the AI Teaching Assistant will appear in the bottom left-hand corner of your screen."
       keep_up:
         question: "Where should I go to keep up with Code.org's investment in AI-supported tools?"
-        answer: "Code.org is investing in using AI to enhance teaching and learning.  Check out [https://code.org/ai](https://code.org/ai) to learn more about our AI curriculum, professional learning, and tools."
+        answer: "Code.org is investing in using AI to enhance teaching and learning.  Check out [code.org/ai](https://code.org/ai) to learn more about our AI curriculum, professional learning, and tools."
       demo:
         question: "Can I see a demo of how AI TA works?"
-        answer: "Join our curriculum manager, Angelina as she introduces the AI Teaching Assistant."
+        answer: "Join our curriculum manager, Angelina, as she introduces the AI Teaching Assistant."
     partners:
       heading: "Developed in partnership with"
 

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10514,7 +10514,7 @@
       desc: "The AI Teaching Assistant transforms CS education, easing the workload for new and experienced teachers alike. By streamlining assessments, it boosts educator confidence, enabling a focus on enriching student interactions and tailored learning experiences."
     pilot_apps:
       heading: "Accepting pilot applications through June 2024"
-      desc: "We are enrolling **CSD Unit 3 teachers** to into our AI Teaching Assistant pilot. You'll get the chance to help experience and test this exciting new tool!"
+      desc: "We are enrolling **CSD Unit 3 teachers** into our AI Teaching Assistant pilot. You'll get the chance to help experience and test this exciting new tool!"
       cta: "Not a CSD teacher? [Sign up for our AI updates](%{sign_up_url})!"
     resources:
       heading: "Additional AI resources for educators"
@@ -10537,12 +10537,11 @@
       heading: "Frequently asked questions"
       support:
         question: "What can the AI Teaching Assistant currently support?"
-        answer_01: "The AI Teaching Assistant's first feature is AI-supported rubrics in the Interactive Games and Animations unit of Code.
-        org's Computer Science Discoveries (CSD) curriculum. This feature:"
-        answer_02: "In the future, the AI Teaching Assistant's feature set will expand to assist teachers with additional tasks."
+        answer_01: "The AI Teaching Assistant's first feature is AI-supported rubrics in the Interactive Games and Animations unit of Code.org's Computer Science Discoveries (CSD) curriculum. This feature:"
         list_01: "Allows teachers to assess their students' coding projects within the Code.org platform"
         list_02: "Saves teachers time by providing an initial assessment of student work"
         list_03: "Helps build confidence for teachers who are new to teaching Computer Science"
+        answer_02: "In the future, the AI Teaching Assistant's feature set will expand to assist teachers with additional tasks."
       units:
         question: "What Units is the AI Teaching Assistant available for?"
         answer: "The AI Teaching Assistant is launching in CSD's Interactive Games and Animations Unit. The team is hard at work building AI-supported features for additional curriculum."
@@ -10557,7 +10556,7 @@
         answer: "Code.org is investing in using AI to enhance teaching and learning.  Check out [https://code.org/ai](https://code.org/ai) to learn more about our AI curriculum, professional learning, and tools."
       demo:
         question: "Can I see a demo of how AI TA works?"
-        answer: ""
+        answer: "Join our curriculum manager, Angelina as she introduces the AI Teaching Assistant."
     partners:
       heading: "Developed in partnership with"
 


### PR DESCRIPTION
Adds strings for use on the new https://code.org/ai/teaching-assistant page. 

**Jira ticket:** [ACQ-1692](https://codedotorg.atlassian.net/browse/ACQ-1692)
**Figma mock:** [AI TA Landing Page V1](https://www.figma.com/file/5Pcxl4tcFgTeKDHZJUAQ5p/AI-TA-Launch?type=design&node-id=2373%3A2856&mode=design&t=ZBi6eBccRsHhqttE-1)