### PR TITLE
Removed Not Started Icon

### DIFF
--- a/apps/src/templates/sectionProgressV2/AssignmentCompletionStatesBox.jsx
+++ b/apps/src/templates/sectionProgressV2/AssignmentCompletionStatesBox.jsx
@@ -16,16 +16,6 @@ export default function AssignmentCompletionStatesBox({hasValidatedLevels}) {
       <div className={styles.icons}>
         <div className={styles.legendColumn}>
           <LegendItem
-            itemType={ITEM_TYPE.NOT_STARTED}
-            labelText={i18n.notStarted()}
-          />
-          <LegendItem
-            itemType={ITEM_TYPE.NO_ONLINE_WORK}
-            labelText={i18n.noOnlineWork()}
-          />
-        </div>
-        <div className={styles.legendColumn}>
-          <LegendItem
             itemType={ITEM_TYPE.IN_PROGRESS}
             labelText={i18n.inProgress()}
           />
@@ -34,14 +24,18 @@ export default function AssignmentCompletionStatesBox({hasValidatedLevels}) {
             labelText={i18n.submitted()}
           />
         </div>
-        {hasValidatedLevels && (
-          <div className={styles.legendColumn}>
+        <div className={styles.legendColumn}>
+          {hasValidatedLevels && (
             <LegendItem
               itemType={ITEM_TYPE.VALIDATED}
               labelText={i18n.validated()}
             />
-          </div>
-        )}
+          )}
+          <LegendItem
+            itemType={ITEM_TYPE.NO_ONLINE_WORK}
+            labelText={i18n.noOnlineWork()}
+          />
+        </div>
       </div>
     );
   };

--- a/apps/src/templates/sectionProgressV2/ItemType.jsx
+++ b/apps/src/templates/sectionProgressV2/ItemType.jsx
@@ -3,10 +3,9 @@ import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 
 export const ITEM_TYPE = Object.freeze({
-  NOT_STARTED: 1,
-  VIEWED: 2,
-  NEEDS_FEEDBACK: 3,
-  FEEDBACK_GIVEN: 4,
+  VIEWED: 1,
+  NEEDS_FEEDBACK: 2,
+  FEEDBACK_GIVEN: 3,
   ASSESSMENT_LEVEL: ['star', color.neutral_dark60],
   CHOICE_LEVEL: ['split', color.neutral_dark60],
   KEEP_WORKING: ['rotate-left', color.neutral_dark],

--- a/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
+++ b/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
@@ -37,16 +37,6 @@ export default function MoreDetailsDialog({hasValidation, onClose}) {
       <div role="region" className={styles.dialog}>
         <Heading6>{i18n.assignmentCompletionStates()}</Heading6>
         {renderItem(
-          ITEM_TYPE.NOT_STARTED,
-          i18n.notStarted(),
-          i18n.progressLegendDetailsNotStarted()
-        )}
-        {renderItem(
-          ITEM_TYPE.NO_ONLINE_WORK,
-          i18n.noOnlineWork(),
-          i18n.progressLegendDetailsNoOnlineWork()
-        )}
-        {renderItem(
           ITEM_TYPE.IN_PROGRESS,
           i18n.inProgress(),
           i18n.progressLegendDetailsInProgress()
@@ -72,6 +62,11 @@ export default function MoreDetailsDialog({hasValidation, onClose}) {
             i18n.validated(),
             i18n.progressLegendDetailsValidated()
           )}
+        {renderItem(
+          ITEM_TYPE.NO_ONLINE_WORK,
+          i18n.noOnlineWork(),
+          i18n.progressLegendDetailsNoOnlineWork()
+        )}
         <Heading6>{i18n.teacherActions()}</Heading6>
         {renderItem(
           ITEM_TYPE.NEEDS_FEEDBACK,

--- a/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
@@ -2,7 +2,6 @@ import classNames from 'classnames';
 import React from 'react';
 
 import FontAwesome from '../FontAwesome';
-import ProgressBox from '../sectionProgress/ProgressBox';
 
 import {ITEM_TYPE, ITEM_TYPE_SHAPE} from './ItemType';
 
@@ -25,30 +24,6 @@ export default function ProgressIcon({itemType}) {
     />
   );
 
-  const notStartedBox = () => (
-    <ProgressBox
-      started={false}
-      incomplete={20}
-      imperfect={0}
-      perfect={0}
-      lessonIsAllAssessment={false}
-    />
-  );
-
-  /*   Note that we decided not to have a viewedBox icon in this iteration
-  of the icon key.  However, this may be part of a future iteration
-  of the IconKey. If so, this is the approach we took to rendering it
-  const viewedBox = () => (
-    <ProgressBox
-      started={false}
-      incomplete={20}
-      imperfect={0}
-      perfect={0}
-      lessonIsAllAssessment={false}
-      viewed={true}
-    />
-  ); */
-
   return (
     <div data-testid="progress-icon">
       {itemType?.length && (
@@ -60,7 +35,6 @@ export default function ProgressIcon({itemType}) {
           aria-label={PROGRESS_ICON_TITLE_PREFIX + itemType[0]}
         />
       )}
-      {itemType === ITEM_TYPE.NOT_STARTED && notStartedBox()}
       {itemType === ITEM_TYPE.NEEDS_FEEDBACK && needsFeedbackTriangle()}
       {itemType === ITEM_TYPE.FEEDBACK_GIVEN && feedbackGivenTriangle()}
     </div>

--- a/apps/test/unit/templates/sectionProgressV2/AssignmentCompletionStatesBoxTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/AssignmentCompletionStatesBoxTest.jsx
@@ -9,7 +9,6 @@ describe('AssignmentCompletionStatesBox Component', () => {
   it('renders all but the "Validated" icon when user is viewing the Assignment Completion States without a validated level open', () => {
     render(<AssignmentCompletionStatesBox hasValidatedLevels={false} />);
     expect(screen.getByText('Assignment Completion States')).to.exist;
-    expect(screen.getByText('Not started')).to.exist;
     expect(screen.getByText('In progress')).to.exist;
     expect(screen.getByText('No online work')).to.exist;
     expect(screen.getByText('Submitted')).to.exist;
@@ -19,7 +18,6 @@ describe('AssignmentCompletionStatesBox Component', () => {
   it('renders all icons when a user is viewing a validated level', () => {
     render(<AssignmentCompletionStatesBox hasValidatedLevels={true} />);
     expect(screen.getByText('Assignment Completion States')).to.exist;
-    expect(screen.getByText('Not started')).to.exist;
     expect(screen.getByText('In progress')).to.exist;
     expect(screen.getByText('No online work')).to.exist;
     expect(screen.getByText('Submitted')).to.exist;

--- a/apps/test/unit/templates/sectionProgressV2/ProgressIconTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressIconTest.jsx
@@ -19,12 +19,6 @@ describe('ProgressIconComponent', () => {
     expect(iconElement).to.be.visible;
   });
 
-  it('renders the not started box when itemType is NOT_STARTED', () => {
-    render(<ProgressIcon itemType={ITEM_TYPE.NOT_STARTED} />);
-    const progressBox = screen.getByTestId('progress-box');
-    expect(progressBox).to.be.visible;
-  });
-
   it('renders the feedback given triangle when itemType is FEEDBACK_GIVEN', () => {
     render(<ProgressIcon itemType={ITEM_TYPE.FEEDBACK_GIVEN} />);
     const feedbackGivenTriangle = screen.getByTestId('feedback-given-triangle');


### PR DESCRIPTION
Removed the "Not Started" icon and reordered the icons as per Bryan's feedback.

<img width="873" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/71722fab-ac93-4325-aace-e3fc58f91f48">

NOTE: We do have a `NOT_STARTED` type in the `ItemType` [file](https://github.com/code-dot-org/code-dot-org/blob/32c87af11266a304008bb50b3adcaa6f83ab09dd/apps/src/templates/sectionProgressV2/ItemType.jsx#L6) as well as inside the `ProgressIcon.jsx` file.  I am reluctant to remove anything from those files now just in case this gets added back in later.  Open to thoughts though...



## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-969)

## Testing story

Updated existing tests.

