### PR TITLE
Fix `test_secrets_config` Test

### DIFF
--- a/config/secrets.yml.template
+++ b/config/secrets.yml.template
@@ -1,4 +1,4 @@
-# Sample secrets.yml file.
+# Sample secrets.yml file; consumed by test_secrets_config.rb
 ---
 # Publish AWS Secrets Manager Secrets named `[environment type]/cdo/acme_api_key` that can be used to populate `CDO.acme_api_key`
 acme_api_key:

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -382,7 +382,16 @@ namespace :test do
 
     desc 'Runs lib tests if lib might have changed from staging.'
     timed_task_with_logging :lib do
-      run_tests_if_changed('lib', ['Gemfile', 'Gemfile.lock', 'deployment.rb', 'lib/**/*']) do
+      run_tests_if_changed(
+        'lib',
+        [
+          'Gemfile',
+          'Gemfile.lock',
+          'deployment.rb',
+          'lib/**/*',
+          'config/**/*'
+        ]
+      ) do
         TestRunUtils.run_lib_tests
       end
     end

--- a/lib/test/cdo/test_secrets_config.rb
+++ b/lib/test/cdo/test_secrets_config.rb
@@ -20,7 +20,10 @@ class SecretsConfigTest < Minitest::Test
   def test_load
     secrets_file = CDO.dir('config/secrets.yml.template')
     secrets = Cdo::SecretsConfig.load(secrets_file)
-    assert_equal 'bar', secrets['staging/cdo/foo']
+    assert_equal '123ABC', secrets['staging/cdo/acme_api_key']
+    complex_secret = secrets['development/cdo/wile_e_coyote_credentials']
+    assert_equal 'dev@code.org', complex_secret["username"]
+    assert_equal 'Q3rt^', complex_secret["password"]
   end
 
   def load_configuration(yml_erb)


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/57586, which significantly improved the quality of the examples in that file. Unfortunately and unexpectedly, it turns out that file is also consumed by a test:

https://github.com/code-dot-org/code-dot-org/blob/660f150dc904cd2f77a024cde556a106140e37ab/lib/test/cdo/test_secrets_config.rb#L20-L24

Even more unfortunately, our "test only changed files" logic does not recognize that changes to the config files should result in `lib/` tests getting rerun. In addition to updating the test to reflect the updates to that file, this PR also updates our "test changed" logic so that we run lib tests when config files are changed.

## Testing story

First I pushed a commit that updated the test config, so we can verify that Drone now catches this test failure. Then I pushed a commit which updates the test so we can verify that the test now passes.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
