### PR TITLE
Remove null ref from datablock_storage debug view

### DIFF
--- a/dashboard/app/views/datablock_storage/index.html.haml
+++ b/dashboard/app/views/datablock_storage/index.html.haml
@@ -1,6 +1,6 @@
 -# TODO: post-firebase-cleanup, consider removing this entire debug interface (or not 🤷‍♀️): #56994
 
-%strong{:class => "code", :id => "message"} This #{@project.project_type} project uses #{@storage_backend} as its backing store.
+%strong{:class => "code", :id => "message"} This project uses #{@storage_backend} as its backing store.
 
 -# TODO: post-firebase-cleanup, remove this conditional, #56994
 %h3 switch storage backend


### PR DESCRIPTION
Fix a bug where our (non-customer facing) debug view for datablock_storage projects fails to load due to 500 internal server error. 

## Links

Fixes #57628

Related PR: #57480

## Testing story

Loaded debug view locally