### PR TITLE
P20-722: Validate NRPS Full response on course sync

### DIFF
--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
@@ -46,11 +46,15 @@ export default function LtiSectionSyncDialog({
     );
   };
 
-  const errorView = (error: string | undefined) => {
+  const errorView = (syncResult: LtiSectionSyncResult) => {
+    const errorMessages = getRosterSyncErrorMessage(syncResult).split('\n');
+
     return (
       <div>
         <h2 style={styles.dialogHeader}>{i18n.errorOccurredTitle()}</h2>
-        {error && <SafeMarkdown markdown={getRosterSyncErrorMessage(error)} />}
+        {errorMessages.map((errorMessage: string, index: React.Key) => (
+          <SafeMarkdown key={index} markdown={errorMessage} />
+        ))}
       </div>
     );
   };
@@ -146,7 +150,7 @@ export default function LtiSectionSyncDialog({
       case SubView.SPINNER:
         return spinnerView();
       case SubView.ERROR:
-        return errorView(syncResult.error);
+        return errorView(syncResult);
       case SubView.DISABLE_ROSTER_SYNC:
         return disableRosterSyncView();
       default:

--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialogHelpers.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialogHelpers.tsx
@@ -1,7 +1,8 @@
 import i18n from '@cdo/locale';
+import {LtiSectionSyncResult} from '@cdo/apps/lib/ui/lti/sync/types';
 
-export const getRosterSyncErrorMessage = (error: string) => {
-  switch (error) {
+export const getRosterSyncErrorMessage = (syncResult: LtiSectionSyncResult) => {
+  switch (syncResult.error) {
     case 'wrong_context':
       return i18n.ltiSectionSyncDialogErrorWrongContext({url: '/'});
     case 'no_integration':
@@ -9,6 +10,8 @@ export const getRosterSyncErrorMessage = (error: string) => {
     case 'no_section':
       return i18n.ltiSectionSyncDialogErrorNoSectionFound();
     default:
-      return i18n.ltiSectionSyncDialogError();
+      return syncResult.message
+        ? syncResult.message
+        : i18n.ltiSectionSyncDialogError();
   }
 };

--- a/apps/src/lib/ui/lti/sync/types.ts
+++ b/apps/src/lib/ui/lti/sync/types.ts
@@ -9,6 +9,7 @@ export interface LtiSectionSyncResult {
   all?: LtiSectionMap;
   changed?: LtiSectionMap;
   error?: string;
+  message?: string;
 }
 
 export interface LtiSectionSyncDialogProps {

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -200,12 +200,13 @@ class LtiV1Controller < ApplicationController
     JSON::JWT.decode(id_token, jwk_set)
   end
 
-  def render_sync_course_error(message, status, error = nil)
-    @lti_section_sync_result = {error: error}
+  def render_sync_course_error(reason, status, error = nil, message: nil)
+    @lti_section_sync_result = {error: error, message: message}
     Honeybadger.notify(
       'LTI roster sync error',
       context: {
-        reason: message,
+        reason: reason,
+        details: message,
       }
     )
     return respond_to do |format|
@@ -277,6 +278,22 @@ class LtiV1Controller < ApplicationController
       nrps_url = params[:nrps_url]
     end
 
+    lti_advantage_client = LtiAdvantageClient.new(lti_integration.client_id, lti_integration.issuer)
+    nrps_response = lti_advantage_client.get_context_membership(nrps_url, resource_link_id)
+    if Policies::Lti.issuer_accepts_resource_link?(lti_integration.issuer)
+      nrps_response_errors = Services::Lti::NRPSResponseValidator.call(nrps_response)
+
+      if nrps_response_errors.present?
+        return render_sync_course_error(
+          'Invalid LTI key configuration',
+          :unprocessable_entity,
+          'invalid_configs',
+          message: nrps_response_errors.join("\n")
+        )
+      end
+    end
+    nrps_sections = Services::Lti.parse_nrps_response(nrps_response, lti_integration.issuer)
+
     result = nil
     had_changes = false
     ActiveRecord::Base.transaction do
@@ -287,10 +304,6 @@ class LtiV1Controller < ApplicationController
         nrps_url: nrps_url,
         resource_link_id: resource_link_id
       )
-
-      lti_advantage_client = LtiAdvantageClient.new(lti_integration.client_id, lti_integration.issuer)
-      nrps_response = lti_advantage_client.get_context_membership(nrps_url, resource_link_id)
-      nrps_sections = Services::Lti.parse_nrps_response(nrps_response, lti_integration.issuer)
 
       result = Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: nrps_sections, current_user: current_user)
       had_changes ||= !result[:changed].empty?

--- a/dashboard/config/initializers/inflections.rb
+++ b/dashboard/config/initializers/inflections.rb
@@ -18,4 +18,5 @@
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "DSL" # Domain-Specific Language
   inflect.acronym "JSON" # JavaScript Object Notation
+  inflect.acronym 'NRPS' # Names and Role Provisioning Services
 end

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1422,7 +1422,7 @@ en:
       missing_params: "Missing required param(s): School/District name, Client ID, LMS, Email"
       unsupported_lms_type: "Unsupported LMS platform type"
       wrong_resource_type: "Only LtiResourceLink is supported right now"
-      missing_key_config: 'Your LTI key configuration is missing the required "%{field}" field'
+      missing_tool_config: 'Your LTI Tool configuration is missing the required "%{field}" field'
     iframe_button: "Open in New Tab"
     iframe_message: "Code.org cannot be run in an embedded window. Please open it in a new tab."
     iframe_title: "Opening Code.org in New Tab"

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1422,6 +1422,7 @@ en:
       missing_params: "Missing required param(s): School/District name, Client ID, LMS, Email"
       unsupported_lms_type: "Unsupported LMS platform type"
       wrong_resource_type: "Only LtiResourceLink is supported right now"
+      missing_key_config: 'Your LTI key configuration is missing the required "%{field}" field'
     iframe_button: "Open in New Tab"
     iframe_message: "Code.org cannot be run in an embedded window. Please open it in a new tab."
     iframe_title: "Opening Code.org in New Tab"

--- a/dashboard/lib/services/base.rb
+++ b/dashboard/lib/services/base.rb
@@ -1,0 +1,11 @@
+module Services
+  class Base
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      raise NotImplementedError
+    end
+  end
+end

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -140,7 +140,6 @@ module Services
           # Custom variables substitutions must be configured in the LMS.
           custom_variables = message[Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym]
 
-          # Handles the possibility of the LMS not having sectionId variable substitution configured.
           member_section_ids = custom_variables[:section_ids]&.split(',') || [nil]
           # :section_names from Canvas is a stringified JSON array
           member_section_names = JSON.parse(custom_variables[:section_names])

--- a/dashboard/lib/services/lti/nrps_response_validator.rb
+++ b/dashboard/lib/services/lti/nrps_response_validator.rb
@@ -1,0 +1,52 @@
+module Services
+  module Lti
+    class NRPSResponseValidator < Services::Base
+      REQUIRED_CUSTOM_FIELDS = %i[section_ids section_names].freeze
+
+      # @param nrps_response [Hash] The NRPS response to be validated
+      # @example nrps_response
+      #   {
+      #     members: [
+      #       {
+      #         message: [
+      #           {
+      #             'https://purl.imsglobal.org/spec/lti/claim/custom': {
+      #               section_ids: '1,2,3',
+      #               section_names: '["Section 1", "Section 2", "Section 3"]'
+      #             }
+      #           }
+      #         ]
+      #       }
+      #     }
+      #   }
+      def initialize(nrps_response)
+        @nrps_response = nrps_response
+      end
+
+      # @return [Array<String>] Error messages. If the NRPS response is valid, the array is empty.
+      def call
+        errors = []
+
+        REQUIRED_CUSTOM_FIELDS.each do |custom_field|
+          next unless custom_field_missing?(custom_field)
+          errors << ::I18n.t('lti.error.missing_key_config', field: custom_field)
+        end
+
+        errors
+      end
+
+      private
+
+      attr_reader :nrps_response
+
+      def custom_field_missing?(field)
+        Array.wrap(nrps_response[:members]).any? do |member|
+          Array.wrap(member[:message]).any? do |message|
+            custom_fields = message[Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym]
+            custom_fields.is_a?(Hash) && !custom_fields.key?(field)
+          end
+        end
+      end
+    end
+  end
+end

--- a/dashboard/lib/services/lti/nrps_response_validator.rb
+++ b/dashboard/lib/services/lti/nrps_response_validator.rb
@@ -29,7 +29,7 @@ module Services
 
         REQUIRED_CUSTOM_FIELDS.each do |custom_field|
           next unless custom_field_missing?(custom_field)
-          errors << ::I18n.t('lti.error.missing_key_config', field: custom_field)
+          errors << ::I18n.t('lti.error.missing_tool_config', field: "custom_fields[#{custom_field}]")
         end
 
         errors

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -646,6 +646,83 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_sections_data, JSON.parse(response.body)
   end
 
+  test 'sync_course as json - does not sync and returns NRPS response errors when Canvas LTI key is missing required fields' do
+    expected_nrps_response_error_1 = 'error1'
+    expected_nrps_response_error_2 = 'error2'
+
+    lti_course_context_id = SecureRandom.uuid
+    lti_course_resource_link_id = SecureRandom.uuid
+    lti_course_nrps_url = 'https://example.com/nrps'
+
+    user = create :teacher, :with_lti_auth
+    lti_integration = create :lti_integration
+
+    LtiAdvantageClient.
+      any_instance.
+      expects(:get_context_membership).
+      with(lti_course_nrps_url, lti_course_resource_link_id).
+      returns(@parsed_nrps_sections)
+    Policies::Lti.expects(:issuer_accepts_resource_link?).
+      with(lti_integration.issuer).
+      returns(true)
+    Services::Lti::NRPSResponseValidator.
+      expects(:call).
+      with(@parsed_nrps_sections).
+      returns([expected_nrps_response_error_1, expected_nrps_response_error_2])
+
+    Services::Lti.expects(:parse_nrps_response).never
+    Services::Lti.expects(:sync_course_roster).never
+
+    sign_in user
+
+    assert_no_difference 'LtiCourse.count' do
+      get '/lti/v1/sync_course', params: {
+        lti_integration_id: lti_integration.id,
+        deployment_id: 'foo',
+        context_id: lti_course_context_id,
+        rlid: lti_course_resource_link_id,
+        nrps_url: lti_course_nrps_url
+      }, as: :json
+    end
+
+    expected_response = {
+      'error' => 'invalid_configs',
+      'message' => "#{expected_nrps_response_error_1}\n#{expected_nrps_response_error_2}"
+    }
+
+    assert_response :unprocessable_entity
+    assert_equal expected_response, JSON.parse(response.body)
+  end
+
+  test 'sync_course as json - does not validate response of the non rlid NRPS request' do
+    lti_course_context_id = SecureRandom.uuid
+    lti_course_resource_link_id = SecureRandom.uuid
+    lti_course_nrps_url = 'https://example.com/nrps'
+
+    user = create :teacher, :with_lti_auth
+    lti_integration = create :lti_integration
+
+    LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course_nrps_url, lti_course_resource_link_id)
+    Policies::Lti.expects(:issuer_accepts_resource_link?).with(lti_integration.issuer).returns(false)
+    Services::Lti::NRPSResponseValidator.expects(:call).never
+    Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
+    Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_with_changes)
+
+    sign_in user
+
+    assert_no_difference 'LtiCourse.count' do
+      get '/lti/v1/sync_course', params: {
+        lti_integration_id: lti_integration.id,
+        deployment_id: 'foo',
+        context_id: lti_course_context_id,
+        rlid: lti_course_resource_link_id,
+        nrps_url: lti_course_nrps_url
+      }, as: :json
+    end
+
+    assert_response :ok
+  end
+
   test 'sync - should not sync given no changes' do
     user = create :teacher, :with_lti_auth
     sign_in user

--- a/dashboard/test/lib/services/lti/nrps_response_validator_test.rb
+++ b/dashboard/test/lib/services/lti/nrps_response_validator_test.rb
@@ -21,14 +21,14 @@ class Services::Lti::NRPSResponseValidatorTest < ActiveSupport::TestCase
   test 'returns errors when required "section_ids" field is missing' do
     @nrps_response.dig(:members, 0, :message, 0, Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym).delete(:section_ids)
 
-    assert_equal ['Your LTI key configuration is missing the required "section_ids" field'],
+    assert_equal ['Your LTI Tool configuration is missing the required "custom_fields[section_ids]" field'],
                  Services::Lti::NRPSResponseValidator.call(@nrps_response)
   end
 
   test 'returns errors when required "section_names" field is missing' do
     @nrps_response.dig(:members, 0, :message, 0, Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym).delete(:section_names)
 
-    assert_equal ['Your LTI key configuration is missing the required "section_names" field'],
+    assert_equal ['Your LTI Tool configuration is missing the required "custom_fields[section_names]" field'],
                  Services::Lti::NRPSResponseValidator.call(@nrps_response)
   end
 end

--- a/dashboard/test/lib/services/lti/nrps_response_validator_test.rb
+++ b/dashboard/test/lib/services/lti/nrps_response_validator_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class Services::Lti::NRPSResponseValidatorTest < ActiveSupport::TestCase
+  setup do
+    @nrps_response = {
+      members: [
+        message: [
+          Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym => {
+            section_ids: [1],
+            section_names: ['expected_section'],
+          }
+        ]
+      ]
+    }
+  end
+
+  test 'does not return any errors when all required fields are present' do
+    assert_empty Services::Lti::NRPSResponseValidator.call(@nrps_response)
+  end
+
+  test 'returns errors when required "section_ids" field is missing' do
+    @nrps_response.dig(:members, 0, :message, 0, Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym).delete(:section_ids)
+
+    assert_equal ['Your LTI key configuration is missing the required "section_ids" field'],
+                 Services::Lti::NRPSResponseValidator.call(@nrps_response)
+  end
+
+  test 'returns errors when required "section_names" field is missing' do
+    @nrps_response.dig(:members, 0, :message, 0, Policies::Lti::LTI_CUSTOM_CLAIMS.to_sym).delete(:section_names)
+
+    assert_equal ['Your LTI key configuration is missing the required "section_names" field'],
+                 Services::Lti::NRPSResponseValidator.call(@nrps_response)
+  end
+end


### PR DESCRIPTION
## Summary
Validates the NRPS Full response and displays errors if missing custom keys `section_id` and `section_names` within LTI key configurations are detected during course sync.

## Screenshot
<img width="1010" alt="Screenshot 2024-03-28 at 22 26 35" src="https://github.com/code-dot-org/code-dot-org/assets/11708250/34481ab6-39f9-4f90-95c9-ac59f300469c">

## Overview
![lti-sync-errors](https://github.com/code-dot-org/code-dot-org/assets/11708250/759eb5e2-3f59-4fe7-ac42-5efefc9c3435)

## Links
- JIRA task: [P20-722](https://codedotorg.atlassian.net/browse/P20-722)
