### PR TITLE
Fix UI status for pending requests to evaluate entire class

### DIFF
--- a/apps/src/templates/rubrics/RubricSettings.jsx
+++ b/apps/src/templates/rubrics/RubricSettings.jsx
@@ -110,7 +110,6 @@ export default function RubricSettings({
   // load initial ai evaluation status
   useEffect(() => {
     if (!!rubricId && !!sectionId) {
-      console.log('initial fetchAiEvaluationStatusAll');
       fetchAiEvaluationStatusAll(rubricId, sectionId).then(response => {
         if (!response.ok) {
           setStatusAll(STATUS_ALL.ERROR);
@@ -180,7 +179,6 @@ export default function RubricSettings({
     if (polling && !!rubricId && !!sectionId) {
       const intervalId = setInterval(() => {
         refreshAiEvaluations();
-        console.log('updated fetchAiEvaluationStatusAll');
         fetchAiEvaluationStatusAll(rubricId, sectionId).then(response => {
           if (!response.ok) {
             setStatusAll(STATUS_ALL.ERROR);

--- a/apps/src/templates/rubrics/RubricSettings.jsx
+++ b/apps/src/templates/rubrics/RubricSettings.jsx
@@ -130,6 +130,7 @@ export default function RubricSettings({
     setDisplayDetails(!displayDetails);
   };
 
+  // load initial ai evaluation status
   useEffect(() => {
     if (!!rubricId && !!sectionId) {
       fetchAiEvaluationStatusAll(rubricId, sectionId).then(response => {
@@ -196,6 +197,7 @@ export default function RubricSettings({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rubricId, sectionId]);
 
+  // after ai eval is requested, poll for status changes
   useEffect(() => {
     if (polling && !!rubricId && !!sectionId) {
       const intervalId = setInterval(() => {

--- a/apps/src/templates/rubrics/RubricSettings.jsx
+++ b/apps/src/templates/rubrics/RubricSettings.jsx
@@ -110,6 +110,7 @@ export default function RubricSettings({
   // load initial ai evaluation status
   useEffect(() => {
     if (!!rubricId && !!sectionId) {
+      console.log('initial fetchAiEvaluationStatusAll');
       fetchAiEvaluationStatusAll(rubricId, sectionId).then(response => {
         if (!response.ok) {
           setStatusAll(STATUS_ALL.ERROR);
@@ -179,6 +180,7 @@ export default function RubricSettings({
     if (polling && !!rubricId && !!sectionId) {
       const intervalId = setInterval(() => {
         refreshAiEvaluations();
+        console.log('updated fetchAiEvaluationStatusAll');
         fetchAiEvaluationStatusAll(rubricId, sectionId).then(response => {
           if (!response.ok) {
             setStatusAll(STATUS_ALL.ERROR);

--- a/apps/src/templates/rubrics/RubricSettings.jsx
+++ b/apps/src/templates/rubrics/RubricSettings.jsx
@@ -208,13 +208,13 @@ export default function RubricSettings({
               // we can't fetch the csrf token from the DOM because CSRF protection
               // is disabled on script level pages.
               setCsrfToken(data.csrfToken);
-              setUnevaluatedCount(data.attemptedUnevaluatedCount);
+              setEvaluatedCount(data.lastAttemptEvaluatedCount);
               if (data.attemptedCount === 0) {
                 setStatusAll(STATUS_ALL.NOT_ATTEMPTED);
-              } else if (data.attemptedUnevaluatedCount === 0) {
-                setStatusAll(STATUS_ALL.SUCCESS);
+              } else if (data.pendingCount > 0) {
+                setStatusAll(STATUS_ALL.EVALUATION_PENDING);
               } else {
-                setStatusAll(STATUS_ALL.READY);
+                setStatusAll(STATUS_ALL.SUCCESS);
               }
             });
           }

--- a/apps/src/templates/rubrics/RubricSettings.jsx
+++ b/apps/src/templates/rubrics/RubricSettings.jsx
@@ -17,29 +17,6 @@ import {UNDERSTANDING_LEVEL_STRINGS_V2, TAB_NAMES} from './rubricHelpers';
 import {CSVLink} from 'react-csv';
 import _ from 'lodash';
 
-const STATUS = {
-  // we are waiting for initial status from the server
-  INITIAL_LOAD: 'initial_load',
-  // the student has not attempted this level
-  NOT_ATTEMPTED: 'not_attempted',
-  // after initial load, the student has submitted work, but it has already been evaluated
-  ALREADY_EVALUATED: 'already_evaluated',
-  // the student has work which is ready to evaluate
-  READY: 'ready',
-  // evaluation queued and ready to run
-  EVALUATION_PENDING: 'evaluation_pending',
-  // evaluation currently in progress
-  EVALUATION_RUNNING: 'evaluation_running',
-  // evaluation successfully completed
-  SUCCESS: 'success',
-  // general evaluation error
-  ERROR: 'error',
-  // personal identifying info present in code
-  PII_ERROR: 'pii_error',
-  // profanity present in code
-  PROFANITY_ERROR: 'profanity_error',
-};
-
 const STATUS_ALL = {
   // we are waiting for initial status from the server
   INITIAL_LOAD: 'initial_load',
@@ -112,9 +89,9 @@ export default function RubricSettings({
         return i18n.aiEvaluationStatus_pending();
       case STATUS_ALL.ERROR:
         return i18n.aiEvaluationStatus_error();
-      case STATUS.ALREADY_EVALUATED:
+      case STATUS_ALL.ALREADY_EVALUATED:
         return i18n.aiEvaluationStatusAll_already_evaluated();
-      case STATUS.NOT_ATTEMPTED:
+      case STATUS_ALL.NOT_ATTEMPTED:
         return i18n.aiEvaluationStatusAll_not_attempted();
     }
   };

--- a/apps/test/unit/templates/rubrics/RubricSettingsTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricSettingsTest.jsx
@@ -87,6 +87,13 @@ describe('RubricSettings', () => {
     csrfToken: 'abcdef',
   };
 
+  const onePending = {
+    attemptedCount: 1,
+    attemptedUnevaluatedCount: 1,
+    pendingCount: 1,
+    csrfToken: 'abcdef',
+  };
+
   const noEvals = [
     {
       user_name: 'Stilgar',
@@ -192,6 +199,44 @@ describe('RubricSettings', () => {
     // Perform fetches and re-render
     await wait();
     wrapper.update();
+
+    expect(wrapper.find('Button').first().props().disabled).to.be.true;
+  });
+
+  it('shows pending status when eval is pending', async () => {
+    // show ready state on initial load
+
+    stubFetchEvalStatusForAll(ready);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <RubricSettings
+          visible
+          refreshAiEvaluations={refreshAiEvaluationsSpy}
+          rubric={defaultRubric}
+          sectionId={1}
+        />
+      </Provider>
+    );
+
+    // Perform fetches and re-render
+    await wait();
+    wrapper.update();
+
+    let status = wrapper.find('BodyTwoText.uitest-eval-status-all-text');
+    expect(status.text()).to.include(
+      i18n.aiEvaluationStatusAll_ready({unevaluatedCount: 1})
+    );
+    expect(wrapper.find('Button').first().props().disabled).to.be.false;
+
+    // show pending state after clicking run
+
+    stubFetchEvalStatusForAll(onePending);
+
+    wrapper.find('button.uitest-run-ai-assessment-all').simulate('click');
+
+    status = wrapper.find('BodyTwoText.uitest-eval-status-all-text');
+    expect(status.text()).to.include(i18n.aiEvaluationStatus_pending());
 
     expect(wrapper.find('Button').first().props().disabled).to.be.true;
   });

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -248,6 +248,7 @@ class RubricsController < ApplicationController
     attempted_count = 0
     attempted_unevaluated_count = 0
     last_attempt_evaluated_count = 0
+    pending_count = 0
 
     user_ids = Section.find_by(id: section_id).followers.pluck(:student_user_id)
     user_ids.each do |user_id|
@@ -261,20 +262,20 @@ class RubricsController < ApplicationController
         user_id: user_id
       ).order(updated_at: :desc).first
 
-      last_eval_time = nil # any evaluation- pending, success, or failure
-      if rubric_ai_evaluation&.status
-        last_eval_time = rubric_ai_evaluation.created_at
-      end
+      status = rubric_ai_evaluation&.status
+      is_pending = status == RUBRIC_AI_EVALUATION_STATUS[:QUEUED] || status == RUBRIC_AI_EVALUATION_STATUS[:RUNNING]
 
-      attempted_unevaluated_count += 1 if !!attempted && (!last_eval_time || (!!last_eval_time && last_eval_time < attempted))
+      attempted_unevaluated_count += 1 if attempted && !last_attempt_evaluated
       attempted_count += 1 if !!attempted
       last_attempt_evaluated_count += 1 if last_attempt_evaluated
+      pending_count += 1 if is_pending
     end
     render json: {
       notAttemptedCount: user_ids.length - attempted_count,
       attemptedCount: attempted_count,
       attemptedUnevaluatedCount: attempted_unevaluated_count,
       lastAttemptEvaluatedCount: last_attempt_evaluated_count,
+      pendingCount: pending_count,
       csrfToken: form_authenticity_token
     }
   end

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -1,5 +1,6 @@
 class RubricsController < ApplicationController
   include Rails.application.routes.url_helpers
+  include SharedConstants
 
   before_action :require_levelbuilder_mode_or_test_env, except: [:submit_evaluations, :get_ai_evaluations, :get_teacher_evaluations, :get_teacher_evaluations_for_all, :ai_evaluation_status_for_user, :ai_evaluation_status_for_all, :run_ai_evaluations_for_user, :run_ai_evaluations_for_all]
   load_resource only: [:get_teacher_evaluations, :get_teacher_evaluations_for_all, :ai_evaluation_status_for_user, :ai_evaluation_status_for_all, :run_ai_evaluations_for_user, :run_ai_evaluations_for_all]
@@ -315,7 +316,7 @@ class RubricsController < ApplicationController
 
   def ai_evaluated_at
     RubricAiEvaluation.
-      where(rubric_id: @rubric.id, user_id: @user.id, status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]).
+      where(rubric_id: @rubric.id, user_id: @user.id, status: RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]).
       order(updated_at: :desc).
       first&.
       created_at

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -255,6 +255,7 @@ class RubricsController < ApplicationController
       next unless @user&.student_of?(current_user)
       attempted = attempted_at
       evaluated = ai_evaluated_at # only finished, successful evaluations
+      last_attempt_evaluated = attempted && evaluated && evaluated >= attempted
       rubric_ai_evaluation = RubricAiEvaluation.where(
         rubric_id: @rubric.id,
         user_id: user_id
@@ -267,7 +268,7 @@ class RubricsController < ApplicationController
 
       attempted_unevaluated_count += 1 if !!attempted && (!last_eval_time || (!!last_eval_time && last_eval_time < attempted))
       attempted_count += 1 if !!attempted
-      last_attempt_evaluated_count += 1 if !!attempted && !!evaluated && evaluated >= attempted
+      last_attempt_evaluated_count += 1 if last_attempt_evaluated
     end
     render json: {
       notAttemptedCount: user_ids.length - attempted_count,

--- a/dashboard/app/controllers/test_ai_proxy_controller.rb
+++ b/dashboard/app/controllers/test_ai_proxy_controller.rb
@@ -20,9 +20,6 @@ class TestAiProxyController < ApplicationController
         'Label' => 'Convincing Evidence'
       }
     end
-    # wait long enough that we have a good chance of catching a bug if the UI,
-    # which polls every 5 seconds, does not properly wait for a response.
-    sleep 10
     render json: {data: response_data}
   end
 end

--- a/dashboard/app/controllers/test_ai_proxy_controller.rb
+++ b/dashboard/app/controllers/test_ai_proxy_controller.rb
@@ -20,6 +20,9 @@ class TestAiProxyController < ApplicationController
         'Label' => 'Convincing Evidence'
       }
     end
+    # wait long enough that we have a good chance of catching a bug if the UI,
+    # which polls every 5 seconds, does not properly wait for a response.
+    sleep 10
     render json: {data: response_data}
   end
 end

--- a/dashboard/app/models/rubric_ai_evaluation.rb
+++ b/dashboard/app/models/rubric_ai_evaluation.rb
@@ -25,7 +25,7 @@ class RubricAiEvaluation < ApplicationRecord
   belongs_to :requester, class_name: 'User'
   belongs_to :rubric
 
-  has_many :learning_goal_ai_evaluations, inverse_of: :rubric_ai_evaluation
+  has_many :learning_goal_ai_evaluations, inverse_of: :rubric_ai_evaluation, dependent: :destroy
 
   validates :status, inclusion: {in: SharedConstants::RUBRIC_AI_EVALUATION_STATUS.values}
 

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -10,17 +10,19 @@ class RubricsControllerTest < ActionController::TestCase
     @level = create(:level)
     @script_level = create :script_level, script: @lesson.script, lesson: @lesson, levels: [@level]
 
+    # set up a section containing 6 students: 1 @student and 5 other_students.
+
     @teacher = create :teacher
     @student = create :student
     @follower = create :follower, student_user: @student, user: @teacher
     @rubric = create :rubric, lesson: @lesson, level: @level
 
-    @followers = []
-    @students = []
+    other_followers = []
+    other_students = []
 
     5.times do
-      @students << create(:student)
-      @followers << create(:follower, section: @follower.section, student_user: @students[-1], user: @teacher)
+      other_students << create(:student)
+      other_followers << create(:follower, section: @follower.section, student_user: other_students[-1], user: @teacher)
     end
 
     @fake_ip = '127.0.0.1'

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -407,6 +407,7 @@ class RubricsControllerTest < ActionController::TestCase
     assert_equal 0, json_response['attemptedCount']
     assert_equal 0, json_response['attemptedUnevaluatedCount']
     assert_equal 0, json_response['lastAttemptEvaluatedCount']
+    assert_equal 0, json_response['pendingCount']
     assert json_response['csrfToken']
   end
 
@@ -426,6 +427,7 @@ class RubricsControllerTest < ActionController::TestCase
     assert_equal 1, json_response['attemptedCount']
     assert_equal 1, json_response['attemptedUnevaluatedCount']
     assert_equal 0, json_response['lastAttemptEvaluatedCount']
+    assert_equal 0, json_response['pendingCount']
     assert json_response['csrfToken']
   end
 
@@ -488,6 +490,7 @@ class RubricsControllerTest < ActionController::TestCase
     assert_equal 6, json_response['attemptedCount']
     assert_equal 1, json_response['attemptedUnevaluatedCount']
     assert_equal 5, json_response['lastAttemptEvaluatedCount']
+    assert_equal 0, json_response['pendingCount']
     assert json_response['csrfToken']
   end
 

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class RubricsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
+  include SharedConstants
 
   setup do
     @levelbuilder = create :levelbuilder
@@ -212,7 +213,7 @@ class RubricsControllerTest < ActionController::TestCase
       rubric: @rubric,
       user: student,
       requester: @teacher,
-      status: 1
+      status: RUBRIC_AI_EVALUATION_STATUS[:RUNNING]
     )
     ai_evaluation1 = create(
       :learning_goal_ai_evaluation,
@@ -234,7 +235,7 @@ class RubricsControllerTest < ActionController::TestCase
         rubric: @rubric,
         user: classmate,
         requester: @teacher,
-        status: 1
+        status: RUBRIC_AI_EVALUATION_STATUS[:RUNNING]
       )
       create(
         :learning_goal_ai_evaluation,
@@ -276,7 +277,7 @@ class RubricsControllerTest < ActionController::TestCase
       rubric: learning_goal.rubric,
       user: student,
       requester: @teacher,
-      status: 1
+      status: RUBRIC_AI_EVALUATION_STATUS[:RUNNING]
     )
     create(
       :learning_goal_ai_evaluation,
@@ -305,7 +306,7 @@ class RubricsControllerTest < ActionController::TestCase
       rubric: learning_goal.rubric,
       user: student,
       requester: @teacher,
-      status: 1
+      status: RUBRIC_AI_EVALUATION_STATUS[:RUNNING]
     )
     create(
       :learning_goal_ai_evaluation,
@@ -319,7 +320,7 @@ class RubricsControllerTest < ActionController::TestCase
         rubric: learning_goal.rubric,
         user: student,
         requester: @teacher,
-        status: 1
+        status: RUBRIC_AI_EVALUATION_STATUS[:RUNNING]
       )
       create(
         :learning_goal_ai_evaluation,
@@ -444,7 +445,7 @@ class RubricsControllerTest < ActionController::TestCase
         rubric: @rubric,
         user: @student,
         requester: @teacher,
-        status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:QUEUED]
+        status: RUBRIC_AI_EVALUATION_STATUS[:QUEUED]
       )
     end
 
@@ -476,7 +477,7 @@ class RubricsControllerTest < ActionController::TestCase
         rubric: @rubric,
         user: @student,
         requester: @teacher,
-        status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:RUNNING]
+        status: RUBRIC_AI_EVALUATION_STATUS[:RUNNING]
       )
     end
 
@@ -528,7 +529,7 @@ class RubricsControllerTest < ActionController::TestCase
           rubric: @rubric,
           user: s,
           requester: @teacher,
-          status: 2 # successful
+          status: RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]
         )
         create(
           :learning_goal_ai_evaluation,
@@ -642,7 +643,7 @@ class RubricsControllerTest < ActionController::TestCase
           rubric: @rubric,
           user: s,
           requester: @teacher,
-          status: 2 # successful
+          status: RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]
         )
         create(
           :learning_goal_ai_evaluation,
@@ -686,7 +687,7 @@ class RubricsControllerTest < ActionController::TestCase
           rubric: @rubric,
           user: s,
           requester: @teacher,
-          status: 2 # successful
+          status: RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]
         )
         create(
           :learning_goal_ai_evaluation,
@@ -933,7 +934,7 @@ class RubricsControllerTest < ActionController::TestCase
         rubric: @rubric,
         user: @student,
         requester: @teacher,
-        status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]
+        status: RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]
       )
       create(
         :learning_goal_ai_evaluation,
@@ -950,7 +951,7 @@ class RubricsControllerTest < ActionController::TestCase
         rubric: @rubric,
         user: @student,
         requester: @teacher,
-        status: SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]
+        status: RUBRIC_AI_EVALUATION_STATUS[:SUCCESS]
       )
       create(
         :learning_goal_ai_evaluation,
@@ -991,7 +992,7 @@ class RubricsControllerTest < ActionController::TestCase
         rubric: @rubric,
         user: @student,
         requester: @teacher,
-        status: 1
+        status: RUBRIC_AI_EVALUATION_STATUS[:RUNNING]
       )
       create(
         :learning_goal_ai_evaluation,

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -105,7 +105,6 @@ Feature: Evaluate student code against rubrics using AI
     And I wait until element ".uitest-ai-assessment" is visible
     Then element ".uitest-ai-assessment" contains text "Aiden has achieved Extensive or Convincing Evidence"
 
-  @skip
   Scenario: Student code is evaluated by AI when teacher requests evaluation for entire class
     Given I create a teacher-associated student named "Aiden"
     And I get debug info for the current user


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-539. There were problems with how we calculated attempted_unevaluated_count, and also pending_count needed to be added in order to know when to show the pending state. The main changes in this PR are in these commits:
* 09f8aa6ae92d71cb26e3c0a8adbf1566763a97b9 fix attempted_unevaluated_count and add pending_count (on server)
* f719442ac42ff05d08f9b667d07d4ba92f169c4a fix logic for pending evals in status-all response handler (on client)
* re-enable UI test

the other commits are cleanup of various kinds.

## Testing story
* re-enabled UI test
* also ran the UI test locally with this line commented out, to make timing more closely resemble DTT: https://github.com/code-dot-org/code-dot-org/blob/e55a85df86803935cdb83a90969bdf8f085bf938/dashboard/config/environments/development.rb#L81-L85
* updated + added unit tests in js and ruby