### PR TITLE
Aitt evidence goto line

### DIFF
--- a/apps/src/EditorAnnotator.js
+++ b/apps/src/EditorAnnotator.js
@@ -193,6 +193,13 @@ export class Annotator {
    * @param {string} logLevel The type of annotation to clear ('ERROR', 'INFO', etc)
    */
   clearAnnotations(logLevel = 'INFO') {}
+
+  /**
+   * Makes the given line visible on the screen, if in a line-based editor.
+   *
+   * @param {number} lineNumber The line to scroll to where 1 is the first line.
+   */
+  scrollToLine(lineNumber) {}
 }
 
 /**
@@ -663,6 +670,16 @@ export class DropletAnnotator extends Annotator {
     this.knownAnnotations_ = [];
     this.annotationList_().filterOutRuntimeAnnotations(logLevel);
   }
+
+  /**
+   * Makes the given line visible on the screen, if in a line-based editor.
+   *
+   * @param {number} lineNumber The line to scroll to where 1 is the first line.
+   */
+  scrollToLine(lineNumber) {
+    const aceEditor = this.droplet().aceEditor;
+    aceEditor.scrollToLine(lineNumber, true, true);
+  }
 }
 
 /**
@@ -1110,6 +1127,15 @@ export default class EditorAnnotator {
    */
   static clearAnnotations(logLevel = 'INFO') {
     EditorAnnotator.annotator()?.clearAnnotations(logLevel);
+  }
+
+  /**
+   * Makes the given line visible on the screen, if in a line-based editor.
+   *
+   * @param {number} lineNumber The line to scroll to where 1 is the first line.
+   */
+  static scrollToLine(lineNumber) {
+    EditorAnnotator.annotator()?.scrollToLine(lineNumber);
   }
 }
 

--- a/apps/src/templates/rubrics/AiAssessmentBox.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentBox.jsx
@@ -55,9 +55,8 @@ export default function AiAssessmentBox({
      * observations instead of the evidence. This won't have line
      * numbers and is certainly worse but better than nothing. */
     if (evidence.firstLine === undefined) {
-      return (<p key={i}>{text}</p>);
-    }
-    else if (evidence.firstLine === evidence.lastLine) {
+      return <p key={i}>{text}</p>;
+    } else if (evidence.firstLine === evidence.lastLine) {
       // Line [lineNumber]: [message]
       text = i18n.aiAssessmentEvidenceLine({
         lineNumber: '<><first-line><>',
@@ -73,11 +72,12 @@ export default function AiAssessmentBox({
     }
 
     return (
-      <p key={i + 100}>
-        {text.split('<>').map(subtext => {
+      <p key={i}>
+        {text.split('<>').map((subtext, k) => {
           if (subtext === '<first-line>') {
             return (
               <a
+                key={`${i}-${k}`}
                 href="#"
                 onClick={e => {
                   e.preventDefault();
@@ -90,6 +90,7 @@ export default function AiAssessmentBox({
           } else if (subtext === '<last-line>') {
             return (
               <a
+                key={`${i}-${k}`}
                 href="#"
                 onClick={e => {
                   e.preventDefault();
@@ -100,7 +101,7 @@ export default function AiAssessmentBox({
               </a>
             );
           } else {
-            return <span>{subtext}</span>;
+            return <span key={`${i}-${k}`}>{subtext}</span>;
           }
         })}
       </p>
@@ -135,11 +136,9 @@ export default function AiAssessmentBox({
             <StrongText>{i18n.aiAssessmentEvidence()}</StrongText>
           </BodyFourText>
           <ul>
-            {aiEvidence.map(
-              (info, i) =>
-                info &&
-                info.firstLine && <li key={i}>{renderEvidenceItem(info, i)}</li>
-            )}
+            {aiEvidence.map((info, i) => (
+              <li key={i}>{renderEvidenceItem(info, i)}</li>
+            ))}
           </ul>
         </div>
       )}

--- a/apps/src/templates/rubrics/AiAssessmentBox.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentBox.jsx
@@ -46,6 +46,12 @@ export default function AiAssessmentBox({
       : i18n.aiAssessmentDoesNotMeet();
   };
 
+  // When a line number is clicked in the evidence listing
+  const lineNumberClickHandler = (lineNumber, e) => {
+    e.preventDefault();
+    EditorAnnotator.scrollToLine(lineNumber);
+  };
+
   const renderEvidenceItem = (evidence, i) => {
     let text = evidence.message;
 
@@ -79,10 +85,7 @@ export default function AiAssessmentBox({
               <a
                 key={`${i}-${k}`}
                 href="#"
-                onClick={e => {
-                  e.preventDefault();
-                  EditorAnnotator.scrollToLine(evidence.firstLine);
-                }}
+                onClick={lineNumberClickHandler.bind(this, evidence.firstLine)}
               >
                 {evidence.firstLine}
               </a>
@@ -92,10 +95,7 @@ export default function AiAssessmentBox({
               <a
                 key={`${i}-${k}`}
                 href="#"
-                onClick={e => {
-                  e.preventDefault();
-                  EditorAnnotator.scrollToLine(evidence.lastLine);
-                }}
+                onClick={lineNumberClickHandler.bind(this, evidence.lastLine)}
               >
                 {evidence.lastLine}
               </a>

--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -191,10 +191,9 @@ export function annotateLines(evidence, observations) {
           EditorAnnotator.highlightLine(i, ai_rubric_cyan);
         }
 
-        if (message !== observations) {
+        if (message === observations) {
           shouldIncludeObservationsColumn = true;
-        }
-        else {
+        } else {
           ret.push({
             firstLine: position.firstLine,
             lastLine: position.lastLine,
@@ -222,10 +221,9 @@ export function annotateLines(evidence, observations) {
       // If we are forcing these lines to have the bulk annotation of
       // the observations column, we do not append it to the list. This way,
       // it does not get listed out.
-      if (message !== observations) {
+      if (message === observations) {
         shouldIncludeObservationsColumn = true;
-      }
-      else {
+      } else {
         ret.push({
           firstLine: lineNumber,
           lastLine: lastLineNumber,
@@ -239,7 +237,7 @@ export function annotateLines(evidence, observations) {
   // sources of evidence. We want to list out the observations column in our
   // rendered list. So, here we parse out the observations column.
   if (shouldIncludeObservationsColumn) {
-    observations.split('. ').forEach( (observation) => {
+    observations.split('. ').forEach(observation => {
       ret.push({
         message: observation,
       });

--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -106,6 +106,21 @@ export function clearAnnotations() {
  * returned here will be listed. However, other content may be highlighted
  * that does not end up in that list.
  *
+ * This table suggests the fallbacks we have in place for responding to the
+ * provided 'evidence' column. Ideally, the evidence column can be parsed into
+ * items with a line number, code snippet, and a message (this first row of
+ * this table.) Then, it may be missing any one of those items and has to be
+ * gracefully handled. We should still strive to fix upstream the prompts such
+ * that they provide the ideal form.
+ *
+ * line number? | has code? | message? | annotated by | line number via
+ * ---------------------------------------------------------------------
+ * yes          | yes       | yes      | evidence     | code snippet
+ * yes          | no        | yes      | evidence     | AI line number
+ * yes          | yes       | no       | observations | code snippet
+ * yes          | no        | no       | observations | AI line number
+ * no           | --        | --       | none         | none
+ *
  * @param {string} evidence - A text block described above.
  * @param {string} observations - The text block for the overall observations, if needed.
  * @returns {Array} The ordered list of annotations.

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -619,6 +619,10 @@ p.aiAssessmentScoreText {
 
 p.aiAssessmentEvidenceBlock {
   margin: 0;
+
+  + ul li p {
+    margin: 0;
+  }
 }
 
 .aiConfidenceBox {

--- a/apps/test/unit/EditorAnnotatorTest.js
+++ b/apps/test/unit/EditorAnnotatorTest.js
@@ -459,4 +459,17 @@ describe('EditorAnnotator', () => {
       sinon.assert.calledOnce(undimBlocksStub);
     });
   });
+
+  describe('scrollToLine', () => {
+    let scrollToLineStub;
+
+    beforeEach(() => {
+      scrollToLineStub = dropletStub.aceEditor.scrollToLine = sinon.stub();
+    });
+
+    it('should wrap and call the necessary method in Ace', () => {
+      EditorAnnotator.scrollToLine(42);
+      sinon.assert.calledOnceWithExactly(scrollToLineStub, 42, true, true);
+    });
+  });
 });

--- a/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
+++ b/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
@@ -20,33 +20,22 @@ describe('AiAssessmentBox', () => {
       firstLine: 1,
       lastLine: 10,
       message: 'This is evidence.',
-      observations:
-        'This is the original observations. This is another line. This is a third line.',
     },
     {
       firstLine: 42,
       lastLine: 45,
       message: 'This is some other evidence.',
-      observations:
-        'This is the original observations. This is another line. This is a third line.',
     },
   ];
-  const mockEvidenceWithObservations = [
+  const mockEvidenceWithoutLines = [
     {
-      firstLine: 1,
-      lastLine: 10,
-      message:
-        'This is the original observations. This is another line. This is a third line.',
-      observations:
-        'This is the original observations. This is another line. This is a third line.',
+      message: 'This is the original observations.',
     },
     {
-      firstLine: 42,
-      lastLine: 45,
-      message:
-        'This is the original observations. This is another line. This is a third line.',
-      observations:
-        'This is the original observations. This is another line. This is a third line.',
+      message: 'This is another line.',
+    },
+    {
+      message: 'This is a third line.',
     },
   ];
   const props = {
@@ -165,37 +154,25 @@ describe('AiAssessmentBox', () => {
     );
     expect(wrapper.find('ul li')).to.have.lengthOf(2);
     expect(wrapper.html().includes(props.aiEvidence[0].message)).to.be.true;
-    expect(
-      wrapper
-        .html()
-        .includes(
-          `Lines ${props.aiEvidence[0].firstLine}-${props.aiEvidence[0].lastLine}`
-        )
-    ).to.be.true;
+
+    // Expect that lines are present
+    expect(wrapper.html().includes(`Lines`)).to.be.true;
+
+    // And we expect two links for each line for a total of 4 links
+    expect(wrapper.find('ul li p a')).to.have.lengthOf(4);
   });
 
-  it('falls back to rendering evidence as observations if there is no message', () => {
-    const updatedProps = {...props, aiEvidence: mockEvidenceWithObservations};
+  it('falls back to rendering evidence as observations if there is no line numbers', () => {
+    const updatedProps = {...props, aiEvidence: mockEvidenceWithoutLines};
     const wrapper = mount(
       <AiAssessmentFeedbackContext.Provider value={[-1, () => {}]}>
         <AiAssessmentBox {...updatedProps} />
       </AiAssessmentFeedbackContext.Provider>
     );
-    // One item per sentence in 'observations'
+    // Still one list item per evidence provided.
     expect(wrapper.find('ul li')).to.have.lengthOf(3);
-    // It should not render the entire message this time, but rather each sentence
-    expect(wrapper.html().includes(props.aiEvidence[0].message)).to.be.false;
-    expect(
-      wrapper.html().includes(props.aiEvidence[0].observations.split('.')[0])
-    ).to.be.true;
     // And it should not render line numbers in this case since it does not know
     // where any particular observation actually is.
-    expect(
-      wrapper
-        .html()
-        .includes(
-          `Lines ${props.aiEvidence[0].firstLine}-${props.aiEvidence[0].lastLine}`
-        )
-    ).to.be.false;
+    expect(wrapper.html().includes(`Lines`)).to.be.false;
   });
 });

--- a/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
+++ b/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
@@ -1,8 +1,10 @@
 import {mount} from 'enzyme';
+import React from 'react';
 import sinon from 'sinon';
-import AiAssessmentFeedbackContext from '@cdo/apps/templates/rubrics/AiAssessmentFeedbackContext';
-import AiAssessmentBox from '@cdo/apps/templates/rubrics/AiAssessmentBox';
+
 import EditorAnnotator from '@cdo/apps/EditorAnnotator';
+import AiAssessmentBox from '@cdo/apps/templates/rubrics/AiAssessmentBox';
+import AiAssessmentFeedbackContext from '@cdo/apps/templates/rubrics/AiAssessmentFeedbackContext';
 import {RubricUnderstandingLevels} from '@cdo/apps/util/sharedConstants';
 import i18n from '@cdo/locale';
 

--- a/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
@@ -434,6 +434,20 @@ describe('LearningGoals - Enzyme', () => {
       annotateLines('Line 42: `draw()`', observations);
       sinon.assert.calledWith(annotateLineStub, 8, observations);
     });
+
+    it('should return the set of sentences reflected in observations if the evidence has no message.', () => {
+      const annotations = annotateLines('Line 42: `draw()`', observations);
+
+      // One for each sentence
+      expect(annotations.length).to.be.equal(2);
+
+      // The lines are undefined for the written annotation since we don't know
+      // if it is relevant.
+      expect(annotations[0].firstLine).to.be.undefined;
+
+      // And they are in the order provided by the given observations string.
+      expect(annotations[0].message).to.be.equal(observations.split('.')[0]);
+    });
   });
 
   describe('clearAnnotations', () => {


### PR DESCRIPTION
This adds the ability to 'jump' to the lines provided by AI or Static Analysis assessment of code in the TA rubric view.

It does this by embedding links in the written out listing of evidence in the rubric view. Specifically, it does this by crafting the localized string and then substituting out placeholder strings with `<a>` tags. React makes this somewhat a 'blah' process, so that's a little bit about why the implementation looks a tad strange.

Ideally, the evidence column gives useful information and we can highlight the lines and give a specific reason. The line numbers go to those indicated lines (first and last of the region):

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/499afcf4-5d28-429d-8097-f35e65954c16)

When the evidence column is malformed and the observations column is used instead, there are no links and the bulleted list shows the sentences in the observations column:

<details>
<summary>Here is the problematic result... it has no reason annotated for the code.</summary>
<pre>
evidence: "Lines 52-54: `function background1() {...}`, Lines 56-58: `function background2() {...}`, Lines 35-39: `if (score < 20){...} else {...}`"
observations: "The student has created two backgrounds that are displayed during runtime. The background that is displayed is determined by the score."
</pre>
</details>

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/9bc2bdd4-e0dd-4f8a-9dae-8c8a838232a5)

In this case, it still highlights the lines because it can partially find them. It then annotates with the full observations text, since it cannot disambiguate which specific observation matches with the given code as a whole.

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/bd29c946-621d-49d6-8002-b206d30d66de)

## Links

- jira ticket: [AITT-560](https://codedotorg.atlassian.net/browse/AITT-560)

## Testing story

Some responsibility was shifted back to the `LearningGoals` `annotateLines` method for breaking down the observations text so that explains how a test or two moved over there.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
