### PR TITLE
Fix URL redirects from cached levels not working (Via Liam)

### DIFF
--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,7 @@ require 'cdo/firehose'
 class Api::V1::UsersController < Api::V1::JSONApiController
   before_action :load_user
   skip_before_action :verify_authenticity_token
-  skip_before_action :load_user, only: [:current, :netsim_signed_in, :post_sort_by_family_name, :post_show_progress_table_v2, :get_current_permissions, :post_disable_lti_roster_sync, :update_ai_tutor_access]
+  skip_before_action :load_user, only: [:current, :netsim_signed_in, :post_sort_by_family_name, :cached_page_auth_redirect, :post_show_progress_table_v2, :get_current_permissions, :post_disable_lti_roster_sync, :update_ai_tutor_access]
   skip_before_action :clear_sign_up_session_vars, only: [:current]
 
   private def to_bool(val)
@@ -76,6 +76,24 @@ class Api::V1::UsersController < Api::V1::JSONApiController
       email: current_user&.email,
       zip: current_user&.school_info&.school&.zip || current_user&.school_info&.zip,
     }
+  end
+
+  # This is used as a way to redirect correctly to either the sign in page or the
+  # URL specified in the user_return_to parameter. This is necessary because
+  # cached pages do not have a valid user auth token and therefore will attempt to
+  # redirect to the sign in page instead of the correct page if the user is signed in.
+  # See https://codedotorg.atlassian.net/browse/TEACH-758 for more details.
+  # NOTE: the `user_return_to` path must not include a redirect back to this path
+  # or there will be an infinite redirect loop. e.g. strip out `login_required` URL
+  # parameters before calling this method.
+  # GET /api/v1/users/cached_page_auth_redirect
+  def cached_page_auth_redirect
+    if user_signed_in?
+      redirect_to params[:user_return_to] || home_url
+    else
+      session[:user_return_to] ||= params[:user_return_to]
+      authenticate_user!
+    end
   end
 
   # GET /api/v1/users/<user_id>/using_text_mode

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -105,8 +105,19 @@ class ScriptLevelsController < ApplicationController
 
     @script_level = ScriptLevelsController.get_script_level(@script, params)
     raise ActiveRecord::RecordNotFound unless @script_level
-    # If we have a signed out user for any of these cases we will want to redirect them to sign in
-    authenticate_user! if !can?(:read, @script) || @script.login_required? || (!params.nil? && params[:login_required] == "true")
+    if @script.login_required? || (!params.nil? && params[:login_required] == "true")
+      if cachable_request?(request)
+        # if login_required on a cached level, redirect to cached_page_auth_redirect
+        # See https://codedotorg.atlassian.net/browse/TEACH-758 for more details.
+        path_without_params = request.fullpath.split('?').first || request.fullpath
+        return redirect_to "/api/v1/users/cached_page_auth_redirect?user_return_to=" + path_without_params
+      else
+        authenticate_user!
+      end
+    end
+    authenticate_user! unless can?(:read, @script)
+
+    #    authenticate_user! if !can?(:read, @script) || @script.login_required? || (!params.nil? && params[:login_required] == "true" && !cachable_request?(request))
     return render 'levels/no_access' unless can?(:read, @script_level)
 
     if current_user&.script_level_hidden?(@script_level)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -915,6 +915,8 @@ Dashboard::Application.routes.draw do
         get 'users/:user_id/school_donor_name', to: 'users#get_school_donor_name'
         get 'users/:user_id/tos_version', to: 'users#get_tos_version'
 
+        get 'users/cached_page_auth_redirect', to: 'users#cached_page_auth_redirect'
+
         patch 'user_school_infos/:id/update_last_confirmation_date', to: 'user_school_infos#update_last_confirmation_date'
 
         patch 'user_school_infos', to: 'user_school_infos#update'

--- a/dashboard/test/ui/features/platform/login_redirect.feature
+++ b/dashboard/test/ui/features/platform/login_redirect.feature
@@ -1,0 +1,16 @@
+Feature: Navigating to a level page with login required
+
+Scenario: Student navigates to provided cached level link with a login_required parameter
+  Given I create a student named "Carah Student"
+  And I sign out
+  Given I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1?login_required=true"
+  Then I wait until I am on "http://studio.code.org/users/sign_in"
+  And I wait to see "#signin"
+  And I fill in username and password for "Carah Student"
+  And I click "#signin-button" to load a new page
+  Then I wait until I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1"
+
+Scenario: Student already logged in navigates to provided cached level link with a login_required parameter
+  Given I create a student who has never signed in named "François Student" and go home
+  And I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1?login_required=true"
+  Then I wait until I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1"

--- a/dashboard/test/ui/features/platform/login_redirect.feature
+++ b/dashboard/test/ui/features/platform/login_redirect.feature
@@ -1,16 +1,23 @@
 Feature: Navigating to a level page with login required
 
+# The 'starwars' level is specifically chosen because it is a level that is
+# seeded in the test environment (see list in dashboard/lib/tasks/seed.rake)
+# and is a cached unit. (see lib/cdo/http_cache.rb for that fixed listing)
+#
+# These tests are meant to track regressions on redirect-after-login.
+# See https://codedotorg.atlassian.net/browse/TEACH-758 for more details.
+
 Scenario: Student navigates to provided cached level link with a login_required parameter
   Given I create a student named "Carah Student"
   And I sign out
-  Given I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1?login_required=true"
+  Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/1?login_required=true"
   Then I wait until I am on "http://studio.code.org/users/sign_in"
   And I wait to see "#signin"
   And I fill in username and password for "Carah Student"
   And I click "#signin-button" to load a new page
-  Then I wait until I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1"
+  Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/1"
 
 Scenario: Student already logged in navigates to provided cached level link with a login_required parameter
   Given I create a student who has never signed in named "François Student" and go home
-  And I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1?login_required=true"
-  Then I wait until I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1"
+  And I am on "http://studio.code.org/s/starwars/lessons/1/levels/1?login_required=true"
+  Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/1"

--- a/dashboard/test/ui/features/platform/signing_in.feature
+++ b/dashboard/test/ui/features/platform/signing_in.feature
@@ -4,9 +4,9 @@ Feature: Signing in and signing out
 
 Scenario: Student sign in from code.org
   Given I create a student named "Bob"
+  And I set the cookie named "_loc_notice" to "1"
   And I sign out
   Given I am on "http://code.org/"
-  And I reload the page
   Then I wait to see "#header_user_signin"
   Then I click "#header_user_signin"
   And I wait to see "#signin"
@@ -16,6 +16,7 @@ Scenario: Student sign in from code.org
   Then I wait to see "#header_user_menu"
   And I wait until element ".display_name" is visible
   And element ".display_name" contains text "Bob"
+  And I delete the cookie named "_loc_notice"
 
 Scenario: Student sign in from studio.code.org
   Given I create a student named "Alice"
@@ -69,3 +70,18 @@ Scenario: Join existing section from sign in page goes to section join page
   And I click ".section-sign-in button" to load a new page
   Then I wait to see ".main"
   And element ".main" contains text "Register to join section"
+
+Scenario: Student navigates to provided cached level link with a login_required parameter
+  Given I create a student named "Carah Student"
+  And I sign out
+  Given I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1?login_required=true"
+  Then I wait until I am on "http://studio.code.org/users/sign_in"
+  And I wait to see "#signin"
+  And I fill in username and password for "Carah Student"
+  And I click "#signin-button" to load a new page
+  Then I wait until I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1"
+
+Scenario: Student already logged in navigates to provided cached level link with a login_required parameter
+  Given I create a student who has never signed in named "François Student" and go home
+  And I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1?login_required=true"
+  Then I wait until I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1"

--- a/dashboard/test/ui/features/platform/signing_in.feature
+++ b/dashboard/test/ui/features/platform/signing_in.feature
@@ -70,18 +70,3 @@ Scenario: Join existing section from sign in page goes to section join page
   And I click ".section-sign-in button" to load a new page
   Then I wait to see ".main"
   And element ".main" contains text "Register to join section"
-
-Scenario: Student navigates to provided cached level link with a login_required parameter
-  Given I create a student named "Carah Student"
-  And I sign out
-  Given I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1?login_required=true"
-  Then I wait until I am on "http://studio.code.org/users/sign_in"
-  And I wait to see "#signin"
-  And I fill in username and password for "Carah Student"
-  And I click "#signin-button" to load a new page
-  Then I wait until I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1"
-
-Scenario: Student already logged in navigates to provided cached level link with a login_required parameter
-  Given I create a student who has never signed in named "François Student" and go home
-  And I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1?login_required=true"
-  Then I wait until I am on "http://studio.code.org/s/poem-art-2021/lessons/1/levels/1"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -311,7 +311,13 @@ end
 
 Then /^I wait until I am on "([^"]*)"$/ do |url|
   url = replace_hostname(url)
-  wait_until {@browser.current_url == url}
+  begin
+    wait_until {@browser.current_url == url}
+  rescue Selenium::WebDriver::Error::TimeoutError => exception
+    puts "Timeout: I am not on #{url} like I want."
+    puts "         I am on #{@browser.current_url} instead."
+    raise exception
+  end
 end
 
 Then /^check that the URL contains "([^"]*)"$/i do |url|
@@ -1006,10 +1012,10 @@ Then /^element "([^"]*)" is a child of element "([^"]*)"$/ do |child_id, parent_
   expect(actual_parent_id).to eq(parent_id)
 end
 
-And(/^I set the language cookie$/) do
+def set_cookie(key, value)
   params = {
-    name: "_language",
-    value: 'en'
+    name: key,
+    value: value,
   }
 
   if ENV['DASHBOARD_TEST_DOMAIN'] && ENV['DASHBOARD_TEST_DOMAIN'] =~ /\.code.org/ &&
@@ -1020,18 +1026,16 @@ And(/^I set the language cookie$/) do
   @browser.manage.add_cookie params
 end
 
+And(/^I set the language cookie$/) do
+  set_cookie '_language', 'en'
+end
+
 And(/^I set the pagemode cookie to "([^"]*)"$/) do |cookie_value|
-  params = {
-    name: "pm",
-    value: cookie_value
-  }
+  set_cookie 'pm', cookie_value
+end
 
-  if ENV['DASHBOARD_TEST_DOMAIN'] && ENV['DASHBOARD_TEST_DOMAIN'] =~ /\.code.org/ &&
-      ENV['PEGASUS_TEST_DOMAIN'] && ENV['PEGASUS_TEST_DOMAIN'] =~ /\.code.org/
-    params[:domain] = '.code.org' # top level domain cookie
-  end
-
-  @browser.manage.add_cookie params
+And(/^I set the cookie named "([^"]*)" to "([^"]*)"$/) do |key, value|
+  set_cookie key, value
 end
 
 Given(/^I am enrolled in a plc course$/) do


### PR DESCRIPTION
**Problem**: This addresses the attached tickets which were reported from some teachers where the shared links to projects and such were not working as expected. What was happening is that certain levels cause an authentication check. This has them sign in, but the post-sign-in redirect did not respect the desired redirect for that level.

**Solution**: Thanks to Liam, we have a simple solution that 'remembers' the redirect via a session parameter. This is the conventional way of having the 'post signin' redirect happen, but it does not happen on `authenticate_user!` is some situations, apparently. Here, it carefully redirects to a route that will sign in the user with this session parameter being used.

Sneaking in a refactor to a test step and a fix for a potentially flaky test that was causing me grief.

## Links

- jira ticket: [TEACH-758](https://codedotorg.atlassian.net/browse/TEACH-758)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
