### PR TITLE
re-add Game Lab documentation for randomNumber

### DIFF
--- a/dashboard/config/programming_expressions/gamelab/randomnumber.json
+++ b/dashboard/config/programming_expressions/gamelab/randomnumber.json
@@ -1,0 +1,8 @@
+{
+  "key": "randomNumber",
+  "name": "randomNumber",
+  "category": "Math",
+  "category_key": "math",
+  "content": "Please see: [`randomNumber(min, max)`(#ffb74d)](/docs/gamelab/randomNumber_min_max/)",
+  "short_description": "see randomNumber(min, max)"
+}


### PR DESCRIPTION
A deleted programming expression page is causing drone runs and the staging build to fail: https://codedotorg.slack.com/archives/C0T0PNTM3/p1711725765489529

```
Error parsing script file config/scripts_json/csd3-2023.script_json: No programming expression with key randomNumber found
```

The deletion, performed on levelbuilder was intentional. According to @dancodedotorg, it was requested both by users and internally to help with i18n redundancies. Unfortunately, according to @davidsbailey, there is a problem with edits to lesson plans made on levelbuilder. Sometimes our system for getting content from levelbuilder to staging is not resilient in the case of things being deleted.

Dave proposed a revert to the levelbuilder change. Rather than performing a partial git revert, this just re-adds the block using the levelbuilder UI.
![image (191)](https://github.com/code-dot-org/code-dot-org/assets/43474485/e17d45f5-f375-4eda-88a6-e10567538a65)

