### PR TITLE
[ProgressV2] Add a couple amplitude metrics

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -93,6 +93,7 @@ const EVENTS = {
   PROGRESS_V2_EXPAND_ICON_KEY: 'Section New Progress Icon Key Expand',
   PROGRESS_V2_COLLAPSE_ICON_KEY: 'Section New Progress Icon Key Collapse',
   PROGRESS_V2_VIEW_MORE_DETAILS: 'Section New Progress More Details',
+  PROGRESS_V2_VIEW_LESSON_DETAILS: 'Section New Progress Lesson Details',
 
   // Levels
   FEEDBACK_SUBMITTED: 'Level Feedback Submitted',

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -93,7 +93,7 @@ const EVENTS = {
   PROGRESS_V2_EXPAND_ICON_KEY: 'Section New Progress Icon Key Expand',
   PROGRESS_V2_COLLAPSE_ICON_KEY: 'Section New Progress Icon Key Collapse',
   PROGRESS_V2_VIEW_MORE_DETAILS: 'Section New Progress More Details',
-  PROGRESS_V2_VIEW_LESSON_DETAILS: 'Section New Progress Lesson Details',
+  PROGRESS_V2_VIEW_LEVEL_DETAILS: 'Section New Progress Level Details',
 
   // Levels
   FEEDBACK_SUBMITTED: 'Level Feedback Submitted',

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -68,6 +68,8 @@ class SectionProgress extends Component {
     analyticsReporter.sendEvent(EVENTS.PROGRESS_VIEWED, {
       sectionId: this.props.sectionId,
       unitId: this.props.scriptId,
+      windowWidth: window.screen.width,
+      windowHeight: window.screen.height,
     });
   }
 
@@ -90,6 +92,8 @@ class SectionProgress extends Component {
       analyticsReporter.sendEvent(EVENTS.PROGRESS_VIEWED, {
         sectionId: this.props.sectionId,
         unitId: this.props.scriptId,
+        windowWidth: window.screen.width,
+        windowHeight: window.screen.height,
       });
     }
   }

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -68,8 +68,8 @@ class SectionProgress extends Component {
     analyticsReporter.sendEvent(EVENTS.PROGRESS_VIEWED, {
       sectionId: this.props.sectionId,
       unitId: this.props.scriptId,
-      windowWidth: window.screen.width,
-      windowHeight: window.screen.height,
+      windowWidth: window.innerWidth,
+      windowHeight: window.innerHeight,
     });
   }
 
@@ -92,8 +92,8 @@ class SectionProgress extends Component {
       analyticsReporter.sendEvent(EVENTS.PROGRESS_VIEWED, {
         sectionId: this.props.sectionId,
         unitId: this.props.scriptId,
-        windowWidth: window.screen.width,
-        windowHeight: window.screen.height,
+        windowWidth: window.innerWidth,
+        windowHeight: window.innerHeight,
       });
     }
   }

--- a/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
@@ -5,6 +5,8 @@ import queryString from 'query-string';
 import React from 'react';
 import {connect} from 'react-redux';
 
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 import {commentLeft, studentNeedsFeedback} from '../progress/progressHelpers';
@@ -15,6 +17,13 @@ import ProgressIcon from './ProgressIcon';
 
 import legendStyles from './progress-table-legend.module.scss';
 import styles from './progress-table-v2.module.scss';
+
+const levelClickedAmplitude = (sectionId, isAssessment) => () => {
+  analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW, {
+    sectionId: sectionId,
+    isAssessment: isAssessment,
+  });
+};
 
 export const navigateToLevelOverviewUrl = (levelUrl, studentId, sectionId) => {
   if (!levelUrl) {
@@ -95,6 +104,7 @@ function LevelDataCell({
       openInNewTab
       external
       className={classNames(styles.gridBox, styles.gridBoxLevel, feedbackStyle)}
+      onClick={levelClickedAmplitude(sectionId, level.isAssessment)}
     >
       {itemType && <ProgressIcon itemType={itemType} />}
     </Link>

--- a/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
@@ -20,7 +20,7 @@ import styles from './progress-table-v2.module.scss';
 
 const levelClickedAmplitude = (sectionId, isAssessment) => () => {
   console.log('levelClickedAmplitude', sectionId, isAssessment);
-  analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW, {
+  analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW_LEVEL_DETAILS, {
     sectionId: sectionId,
     isAssessment: isAssessment,
   });

--- a/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
@@ -19,6 +19,7 @@ import legendStyles from './progress-table-legend.module.scss';
 import styles from './progress-table-v2.module.scss';
 
 const levelClickedAmplitude = (sectionId, isAssessment) => () => {
+  console.log('levelClickedAmplitude', sectionId, isAssessment);
   analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW, {
     sectionId: sectionId,
     isAssessment: isAssessment,
@@ -104,7 +105,7 @@ function LevelDataCell({
       openInNewTab
       external
       className={classNames(styles.gridBox, styles.gridBoxLevel, feedbackStyle)}
-      onClick={levelClickedAmplitude(sectionId, level.isAssessment)}
+      onClick={levelClickedAmplitude(sectionId, level.kind === 'assessment')}
     >
       {itemType && <ProgressIcon itemType={itemType} />}
     </Link>

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -51,6 +51,8 @@ function SectionProgressV2({
     analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW, {
       sectionId: sectionId,
       unitId: scriptId,
+      windowWidth: window.screen.width,
+      windowHeight: window.screen.height,
     });
   }, [scriptId, sectionId]);
 

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -51,8 +51,8 @@ function SectionProgressV2({
     analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW, {
       sectionId: sectionId,
       unitId: scriptId,
-      windowWidth: window.screen.width,
-      windowHeight: window.screen.height,
+      windowWidth: window.innerWidth,
+      windowHeight: window.innerHeight,
     });
   }, [scriptId, sectionId]);
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
* Adds an amplitude metric when a user opens level details through the progress page
* Adds fields for screen height and width to progress viewed amplitude metrics

## Links
https://codedotorg.atlassian.net/browse/TEACH-977
https://codedotorg.atlassian.net/browse/TEACH-976
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested manually locally
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
