### PR TITLE
Add top skinny banner to code.org/csd for AI TA launch

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/csd/index.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csd/index.haml
@@ -8,7 +8,7 @@ theme: responsive_full_width
 
 -# TODO - Remove the DCDO logic after the AI Teaching Assistant launch
 - if !!DCDO.get('ai-teaching-assistant-launch', false)
-  = view :top_skinny_banner, banner_id: "banner-csd", banner_url: nil, banner_icon: "fa fa-megaphone", banner_text: hoc_s("ai_ta_page.announcement_banner_csd_page", markdown: :inline, locals: {apply_url: "https://forms.gle/84GHPpoRRG9QGmAM8"}), external_link: true, light_theme: true
+  = view :top_skinny_banner, banner_id: "banner-csd", banner_url: nil, banner_icon: "fa fa-megaphone", banner_text: hoc_s("ai_ta_page.announcement_banner_csd_page", markdown: :inline, locals: {learn_url: "/ai/teaching-assistant"}), external_link: false, light_theme: true
 
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap

--- a/pegasus/sites.v3/code.org/public/educate/csd/index.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csd/index.haml
@@ -8,7 +8,7 @@ theme: responsive_full_width
 
 -# TODO - Remove the DCDO logic after the AI Teaching Assistant launch
 - if !!DCDO.get('ai-teaching-assistant-launch', false)
-  = view :top_skinny_banner, banner_id: "banner-csd", banner_url: nil, banner_icon: "fa fa-megaphone", banner_text: hoc_s("ai_ta_page.announcement_banner", markdown: :inline, locals: {apply_url: "https://forms.gle/84GHPpoRRG9QGmAM8"}), external_link: true, light_theme: true
+  = view :top_skinny_banner, banner_id: "banner-csd", banner_url: nil, banner_icon: "fa fa-megaphone", banner_text: hoc_s("ai_ta_page.announcement_banner_csd_page", markdown: :inline, locals: {apply_url: "https://forms.gle/84GHPpoRRG9QGmAM8"}), external_link: true, light_theme: true
 
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap

--- a/pegasus/sites.v3/code.org/public/educate/csd/index.haml
+++ b/pegasus/sites.v3/code.org/public/educate/csd/index.haml
@@ -6,7 +6,9 @@ theme: responsive_full_width
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/csd-styles.css", rel: "stylesheet"}
 
-= view :top_skinny_banner, banner_id: "banner-csd", banner_url: CDO.studio_url("/s/csd-web-dev-beta-2024"), banner_icon: "fa fa-sparkles", banner_text: hoc_s(:call_to_action_pilot_web_dev_unit), external_link: false, light_theme: true
+-# TODO - Remove the DCDO logic after the AI Teaching Assistant launch
+- if !!DCDO.get('ai-teaching-assistant-launch', false)
+  = view :top_skinny_banner, banner_id: "banner-csd", banner_url: nil, banner_icon: "fa fa-megaphone", banner_text: hoc_s("ai_ta_page.announcement_banner", markdown: :inline, locals: {apply_url: "https://forms.gle/84GHPpoRRG9QGmAM8"}), external_link: true, light_theme: true
 
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10510,7 +10510,7 @@
     desc: "Introducing our AI Teaching Assistant: Designed for CS educators, it offers instant, insightful project assessments, enabling teachers to concentrate on inspiring and connecting with their students."
     button: "Apply to join the pilot"
     announcement_banner: "We are now enrolling CSD Unit 3 teachers for our pilot! [Apply now](%{apply_url})"
-    announcement_banner_csd_page: "We're recruiting CSD teachers for our AI Teaching Assistant pilot! [Apply now](%{apply_url})"
+    announcement_banner_csd_page: "We're recruiting CSD teachers for our AI Teaching Assistant pilot! [Learn more](%{learn_url})"
     assessment_power:
       heading: "Smart assessment power"
       desc: "Unlock the power of AI to evaluate student projects with precision, speed, and confidence."

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10510,6 +10510,7 @@
     desc: "Introducing our AI Teaching Assistant: Designed for CS educators, it offers instant, insightful project assessments, enabling teachers to concentrate on inspiring and connecting with their students."
     button: "Apply to join the pilot"
     announcement_banner: "We are now enrolling CSD Unit 3 teachers for our pilot! [Apply now](%{apply_url})"
+    announcement_banner_csd_page: "We're recruiting CSD teachers for our AI Teaching Assistant pilot! [Apply now](%{apply_url})"
     assessment_power:
       heading: "Smart assessment power"
       desc: "Unlock the power of AI to evaluate student projects with precision, speed, and confidence."


### PR DESCRIPTION
Adds a top skinny banner to https://code.org/csd for the AI Teaching Assistant lauch.
- Uses the DCDO flag `ai-teaching-assistant-launch` to hide the banner until the embargo is lifted
  - Tested locally and it works 👍 

**Jira ticket:** [ACQ-1683](https://codedotorg.atlassian.net/browse/ACQ-1683)

----

## With DCDO flag set to `true`

<img width="1376" alt="Screenshot 2024-03-29 at 11 03 22 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/724bbb4b-fa34-4658-9d78-a41493ceace4">
