### PR TITLE
RTL Migration for two tests in UnitEditorTests for levelbuilder UnitEditor page.

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -727,7 +727,7 @@ class UnitEditor extends React.Component {
                   </div>
                 )}
               {!this.props.hasCourse && (
-                <div>
+                <div data-testid="course-version-publishing-editor">
                   <CourseVersionPublishingEditor
                     pilotExperiment={this.state.pilotExperiment}
                     versionYear={this.state.versionYear}

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -125,7 +125,9 @@ describe('UnitEditor', () => {
       renderDefault({hasCourse: false});
       screen.queryByTestId('course-version-publishing-editor');
     });
+  });
 
+  describe('Script Editor - Legacy (Enzyme)', () => {
     it('shows hide this unit in course if hasCourse and course is not in development', () => {
       const wrapper = createWrapper({
         hasCourse: true,

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -19,7 +19,7 @@ import createResourcesReducer, {
 import sinon from 'sinon';
 import * as utils from '@cdo/apps/utils';
 import $ from 'jquery';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import {
   PublishedState,
   InstructionType,
@@ -111,13 +111,14 @@ describe('UnitEditor', () => {
       <Provider store={store}>
         <UnitEditor {...combinedProps} />
       </Provider>
-    )
+    );
   }
 
   describe('Script Editor', () => {
-    it('does not show publishing editor if hasCourse is true', () => {  
+    it('does not show publishing editor if hasCourse is true', () => {
       renderDefault({hasCourse: true});
-      expect(screen.queryByTestId('course-version-publishing-editor')).to.not.exist;
+      expect(screen.queryByTestId('course-version-publishing-editor')).to.not
+        .exist;
     });
 
     it('shows publishing editor if hasCourse is false', () => {

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -19,6 +19,7 @@ import createResourcesReducer, {
 import sinon from 'sinon';
 import * as utils from '@cdo/apps/utils';
 import $ from 'jquery';
+import {render, screen, fireEvent} from '@testing-library/react';
 import {
   PublishedState,
   InstructionType,
@@ -104,15 +105,24 @@ describe('UnitEditor', () => {
     );
   };
 
+  function renderDefault(overrideProps = {}) {
+    const combinedProps = {...defaultProps, ...overrideProps};
+    render(
+      <Provider store={store}>
+        <UnitEditor {...combinedProps} />
+      </Provider>
+    )
+  }
+
   describe('Script Editor', () => {
-    it('does not show publishing editor if hasCourse is true', () => {
-      const wrapper = createWrapper({hasCourse: true});
-      assert.equal(wrapper.find('CourseVersionPublishingEditor').length, 0);
+    it('does not show publishing editor if hasCourse is true', () => {  
+      renderDefault({hasCourse: true});
+      expect(screen.queryByTestId('course-version-publishing-editor')).to.not.exist;
     });
 
     it('shows publishing editor if hasCourse is false', () => {
-      const wrapper = createWrapper({hasCourse: false});
-      assert.equal(wrapper.find('CourseVersionPublishingEditor').length, 1);
+      renderDefault({hasCourse: false});
+      screen.queryByTestId('course-version-publishing-editor');
     });
 
     it('shows hide this unit in course if hasCourse and course is not in development', () => {


### PR DESCRIPTION
Migrating couple of enzyme tests to RTL for the UnitEditor component used in editing script page in levelbuilder. 

## Links

None

## Testing story

Existing test coverage

## Deployment strategy

Regular DTP

## Follow-up work

No tracking task, will continue to chip away other tests in this file.

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
