### PR TITLE
Remove responsive Icon Key

### DIFF
--- a/apps/src/templates/sectionProgressV2/AssignmentCompletionStatesBox.jsx
+++ b/apps/src/templates/sectionProgressV2/AssignmentCompletionStatesBox.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 
 import {StrongText} from '@cdo/apps/componentLibrary/typography';
@@ -9,8 +8,7 @@ import LegendItem from './LegendItem';
 
 import styles from './progress-table-legend.module.scss';
 
-export default function AssignmentCompletionStatesBox({hasValidatedLevels}) {
-  // TO-DO (TEACH-800): Fix spacing on validated levels once width on page is set
+export default function AssignmentCompletionStatesBox() {
   const legendIcons = () => {
     return (
       <div className={styles.icons}>
@@ -25,12 +23,10 @@ export default function AssignmentCompletionStatesBox({hasValidatedLevels}) {
           />
         </div>
         <div className={styles.legendColumn}>
-          {hasValidatedLevels && (
-            <LegendItem
-              itemType={ITEM_TYPE.VALIDATED}
-              labelText={i18n.validated()}
-            />
-          )}
+          <LegendItem
+            itemType={ITEM_TYPE.VALIDATED}
+            labelText={i18n.validated()}
+          />
           <LegendItem
             itemType={ITEM_TYPE.NO_ONLINE_WORK}
             labelText={i18n.noOnlineWork()}
@@ -49,7 +45,3 @@ export default function AssignmentCompletionStatesBox({hasValidatedLevels}) {
     </div>
   );
 }
-
-AssignmentCompletionStatesBox.propTypes = {
-  hasValidatedLevels: PropTypes.bool,
-};

--- a/apps/src/templates/sectionProgressV2/IconKey.jsx
+++ b/apps/src/templates/sectionProgressV2/IconKey.jsx
@@ -17,11 +17,7 @@ import TeacherActionsBox from './TeacherActionsBox';
 
 import styles from './progress-table-legend.module.scss';
 
-export default function IconKey({
-  isViewingValidatedLevel,
-  expandedLessonIds,
-  sectionId,
-}) {
+export default function IconKey({sectionId}) {
   const [isOpen, setIsOpen] = useState(
     tryGetLocalStorage('iconKeyIsOpen', 'true') !== 'false'
   );
@@ -36,17 +32,13 @@ export default function IconKey({
     });
   };
 
-  const isViewingLevelProgress = expandedLessonIds.length > 0;
-
   const caret = isOpenA => (isOpenA ? 'caret-down' : 'caret-right');
 
   const sectionContent = () => (
     <>
-      <AssignmentCompletionStatesBox
-        hasValidatedLevels={isViewingValidatedLevel}
-      />
-      <TeacherActionsBox isViewingLevelProgress={isViewingLevelProgress} />
-      {isViewingLevelProgress && <LevelTypesBox />}
+      <AssignmentCompletionStatesBox />
+      <TeacherActionsBox />
+      <LevelTypesBox />
     </>
   );
 
@@ -93,17 +85,12 @@ export default function IconKey({
       </div>
       {isOpen && sectionContent()}
       {isIconDetailsOpen && (
-        <MoreDetailsDialog
-          onClose={() => setIconDetailsOpen(false)}
-          hasValidation={isViewingValidatedLevel}
-        />
+        <MoreDetailsDialog onClose={() => setIconDetailsOpen(false)} />
       )}
     </div>
   );
 }
 
 IconKey.propTypes = {
-  isViewingValidatedLevel: PropTypes.bool,
-  expandedLessonIds: PropTypes.array,
   sectionId: PropTypes.number,
 };

--- a/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
+++ b/apps/src/templates/sectionProgressV2/MoreDetailsDialog.jsx
@@ -16,7 +16,7 @@ import ProgressIcon from './ProgressIcon';
 
 import styles from './progress-table-legend.module.scss';
 
-export default function MoreDetailsDialog({hasValidation, onClose}) {
+export default function MoreDetailsDialog({onClose}) {
   const renderItem = (itemType, itemTitle, itemDetails) => (
     <div className={styles.item}>
       <ProgressIcon itemType={itemType} />
@@ -56,12 +56,11 @@ export default function MoreDetailsDialog({hasValidation, onClose}) {
             />
           </div>
         </div>
-        {hasValidation &&
-          renderItem(
-            ITEM_TYPE.VALIDATED,
-            i18n.validated(),
-            i18n.progressLegendDetailsValidated()
-          )}
+        {renderItem(
+          ITEM_TYPE.VALIDATED,
+          i18n.validated(),
+          i18n.progressLegendDetailsValidated()
+        )}
         {renderItem(
           ITEM_TYPE.NO_ONLINE_WORK,
           i18n.noOnlineWork(),
@@ -100,6 +99,5 @@ export default function MoreDetailsDialog({hasValidation, onClose}) {
 }
 
 MoreDetailsDialog.propTypes = {
-  hasValidation: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
 };

--- a/apps/src/templates/sectionProgressV2/TeacherActionsBox.jsx
+++ b/apps/src/templates/sectionProgressV2/TeacherActionsBox.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 
 import {StrongText} from '@cdo/apps/componentLibrary/typography';
@@ -9,37 +8,27 @@ import LegendItem from './LegendItem';
 
 import styles from './progress-table-legend.module.scss';
 
-export default function TeacherActionsBox({isViewingLevelProgress}) {
-  const legendIcons = () =>
-    isViewingLevelProgress ? (
-      <div className={styles.icons}>
-        <div className={styles.legendColumn}>
-          <LegendItem
-            itemType={ITEM_TYPE.NEEDS_FEEDBACK}
-            labelText={i18n.needsFeedback()}
-          />
-          <LegendItem
-            itemType={ITEM_TYPE.FEEDBACK_GIVEN}
-            labelText={i18n.feedbackGiven()}
-          />
-        </div>
-        <div className={styles.legendColumn}>
-          <LegendItem
-            itemType={ITEM_TYPE.KEEP_WORKING}
-            labelText={i18n.markedAsKeepWorking()}
-          />
-        </div>
+export default function TeacherActionsBox() {
+  const legendIcons = () => (
+    <div className={styles.icons}>
+      <div className={styles.legendColumn}>
+        <LegendItem
+          itemType={ITEM_TYPE.NEEDS_FEEDBACK}
+          labelText={i18n.needsFeedback()}
+        />
+        <LegendItem
+          itemType={ITEM_TYPE.FEEDBACK_GIVEN}
+          labelText={i18n.feedbackGiven()}
+        />
       </div>
-    ) : (
-      <div className={styles.icons}>
-        <div className={styles.legendColumn}>
-          <LegendItem
-            itemType={ITEM_TYPE.NEEDS_FEEDBACK}
-            labelText={i18n.needsFeedback()}
-          />
-        </div>
+      <div className={styles.legendColumn}>
+        <LegendItem
+          itemType={ITEM_TYPE.KEEP_WORKING}
+          labelText={i18n.markedAsKeepWorking()}
+        />
       </div>
-    );
+    </div>
+  );
 
   return (
     <div className={styles.legend}>
@@ -50,7 +39,3 @@ export default function TeacherActionsBox({isViewingLevelProgress}) {
     </div>
   );
 }
-
-TeacherActionsBox.propTypes = {
-  isViewingLevelProgress: PropTypes.bool,
-};

--- a/apps/test/unit/templates/sectionProgressV2/AssignmentCompletionStatesBoxTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/AssignmentCompletionStatesBoxTest.jsx
@@ -6,17 +6,8 @@ import AssignmentCompletionStatesBox from '@cdo/apps/templates/sectionProgressV2
 import {expect} from '../../../util/reconfiguredChai';
 
 describe('AssignmentCompletionStatesBox Component', () => {
-  it('renders all but the "Validated" icon when user is viewing the Assignment Completion States without a validated level open', () => {
-    render(<AssignmentCompletionStatesBox hasValidatedLevels={false} />);
-    expect(screen.getByText('Assignment Completion States')).to.exist;
-    expect(screen.getByText('In progress')).to.exist;
-    expect(screen.getByText('No online work')).to.exist;
-    expect(screen.getByText('Submitted')).to.exist;
-    expect(screen.queryByText('Validated')).to.be.null;
-  });
-
-  it('renders all icons when a user is viewing a validated level', () => {
-    render(<AssignmentCompletionStatesBox hasValidatedLevels={true} />);
+  it('renders all options', () => {
+    render(<AssignmentCompletionStatesBox />);
     expect(screen.getByText('Assignment Completion States')).to.exist;
     expect(screen.getByText('In progress')).to.exist;
     expect(screen.getByText('No online work')).to.exist;

--- a/apps/test/unit/templates/sectionProgressV2/IconKeyTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/IconKeyTest.jsx
@@ -10,18 +10,18 @@ import {expect} from '../../../util/reconfiguredChai';
 describe('IconKey Component', () => {
   it('renders the open state initially', () => {
     sinon.stub(utils, 'tryGetLocalStorage').returns('true');
-    render(<IconKey isViewingValidatedLevel={false} expandedLessonIds={[]} />);
+    render(<IconKey />);
     expect(screen.getByLabelText('Icon Key')).be.visible;
     expect(screen.queryByText('More Details')).be.visible;
     screen.getByText('Assignment Completion States');
     screen.getByText('Teacher Actions');
-    expect(screen.queryByText('Level Types')).to.be.null;
+    screen.getByText('Level Types');
     utils.tryGetLocalStorage.restore();
   });
 
   it('renders the closed state when localStorage indicates the key is closed', () => {
     sinon.stub(utils, 'tryGetLocalStorage').returns('false');
-    render(<IconKey isViewingValidatedLevel={false} expandedLessonIds={[]} />);
+    render(<IconKey />);
     expect(screen.queryByText('Assignment Completion States')).to.be.null;
     expect(screen.queryByText('Teacher Actions')).to.be.null;
     expect(screen.queryByText('Level Types')).to.be.null;
@@ -30,7 +30,7 @@ describe('IconKey Component', () => {
 
   it('expands collapses on click', () => {
     sinon.stub(utils, 'tryGetLocalStorage').returns('true');
-    render(<IconKey isViewingValidatedLevel={false} expandedLessonIds={[]} />);
+    render(<IconKey />);
     const containerDiv = screen.getByTestId('expandable-container');
     fireEvent.click(containerDiv);
     expect(screen.queryByText('Assignment Completion States')).to.be.null;
@@ -39,28 +39,17 @@ describe('IconKey Component', () => {
     utils.tryGetLocalStorage.restore();
   });
 
-  it('displays LevelTypesBox when viewing level progress', () => {
+  it('displays all icon options when open', () => {
     sinon.stub(utils, 'tryGetLocalStorage').returns('true');
-    render(
-      <IconKey isViewingValidatedLevel={false} expandedLessonIds={[123]} />
-    );
+    render(<IconKey />);
     screen.getByText('Assignment Completion States');
     screen.getByText('Teacher Actions');
     screen.getByText('Level Types');
     utils.tryGetLocalStorage.restore();
   });
 
-  it('displays Validated level type when viewing level with validated property', () => {
-    sinon.stub(utils, 'tryGetLocalStorage').returns('true');
-    render(
-      <IconKey isViewingValidatedLevel={true} expandedLessonIds={[123]} />
-    );
-    screen.getByText('Validated');
-    utils.tryGetLocalStorage.restore();
-  });
-
   it('shows pop-up when more details are clicked', () => {
-    render(<IconKey isViewingValidatedLevel={false} expandedLessonIds={[]} />);
+    render(<IconKey />);
     const moreDetailsLink = screen.queryByText('More Details');
     expect(moreDetailsLink).be.visible;
     expect(screen.queryByText('Progress Tracking Icon Key')).to.be.null;

--- a/apps/test/unit/templates/sectionProgressV2/MoreDetailsDialogTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/MoreDetailsDialogTest.jsx
@@ -8,7 +8,7 @@ import {expect} from '../../../util/reconfiguredChai';
 
 describe('MoreDetailsDialog', () => {
   it('renders the dialog with required elements', () => {
-    render(<MoreDetailsDialog hasValidation={true} onClose={() => {}} />);
+    render(<MoreDetailsDialog onClose={() => {}} />);
 
     expect(screen.getByText('Progress Tracking Icon Key')).be.visible;
     expect(screen.getByRole('button')).be.visible;
@@ -19,21 +19,11 @@ describe('MoreDetailsDialog', () => {
 
   it('calls onClose when the close button is clicked', () => {
     const onCloseMock = sinon.spy();
-    render(<MoreDetailsDialog hasValidation={false} onClose={onCloseMock} />);
+    render(<MoreDetailsDialog onClose={onCloseMock} />);
 
     const closeButton = screen.getByRole('button');
     fireEvent.click(closeButton);
 
     expect(onCloseMock).to.have.been.calledOnce;
-  });
-
-  it('conditionally renders the validated item based on hasValidation prop', () => {
-    const {rerender} = render(
-      <MoreDetailsDialog hasValidation={false} onClose={() => {}} />
-    );
-    expect(screen.queryByText('Validated')).not.be.visible;
-
-    rerender(<MoreDetailsDialog hasValidation={true} onClose={() => {}} />);
-    expect(screen.queryByText('Validated')).be.visible;
   });
 });

--- a/apps/test/unit/templates/sectionProgressV2/TeacherActionsBoxTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/TeacherActionsBoxTest.jsx
@@ -6,16 +6,8 @@ import TeacherActionsBox from '@cdo/apps/templates/sectionProgressV2/TeacherActi
 import {expect} from '../../../util/reconfiguredChai';
 
 describe('TeacherActionsBox Component', () => {
-  it('renders the box with only "Needs feedback" when user does not have a lesson open', () => {
-    render(<TeacherActionsBox isViewingLevelProgress={false} />);
-    expect(screen.getByText('Teacher Actions')).to.exist;
-    expect(screen.getByText('Needs feedback')).to.exist;
-    expect(screen.queryByText('Feedback given')).to.be.null;
-    expect(screen.queryByText("Marked as 'keep working'")).to.be.null;
-  });
-
-  it('renders the box with all available options when user has a lesson open', () => {
-    render(<TeacherActionsBox isViewingLevelProgress={true} />);
+  it('renders all options', () => {
+    render(<TeacherActionsBox />);
     expect(screen.getByText('Teacher Actions')).to.exist;
     expect(screen.getByText('Needs feedback')).to.exist;
     expect(screen.getByText('Feedback given')).to.exist;


### PR DESCRIPTION
Shows all options in the Icon Key and Dialog regardless of what is open on the screen.

Below is what will always show on the screen for the key and dialog. 
<img width="852" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/d8371192-c435-4898-a89a-003d5e7cf0b4">

<img width="589" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/fe3cd39b-ce5a-439d-93e6-cefcf5743501">

And, here's a video which shows nothing changes on the screen.

https://github.com/code-dot-org/code-dot-org/assets/24883357/2e33be4a-0df1-4db3-8089-0f24d9146935




## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-970)

## Testing story

Modified existing tests
