### PR TITLE
Music: ensure music levels update when level properties change

### DIFF
--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -198,7 +198,7 @@ export const setUpWithoutLevel = createAsyncThunk(
         {
           initialSources: sources,
           channel,
-          levelProperties: {appName: payload.appName},
+          levelProperties: {id: 0, appName: payload.appName},
         },
         thunkAPI.signal.aborted,
         thunkAPI.dispatch

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -116,6 +116,7 @@ export interface Level {
  */
 export interface LevelProperties {
   // Not a complete list; add properties as needed.
+  id: number;
   isProjectLevel?: boolean;
   hideShareAndRemix?: boolean;
   usesProjects?: boolean;

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -804,6 +804,7 @@ class Level < ApplicationRecord
   def summarize_for_lab2_properties(script)
     video = specified_autoplay_video&.summarize(false)&.camelize_keys
     properties_camelized = properties.camelize_keys
+    properties_camelized[:id] = id
     properties_camelized[:levelData] = video if video
     properties_camelized[:type] = type
     properties_camelized[:appName] = game&.app

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -83,7 +83,7 @@ class LevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => [], "usesProjects" => false}, body)
+    assert_equal({"id" => level.id, "levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => [], "usesProjects" => false}, body)
   end
 
   test "should get filtered levels with just page param" do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -112,7 +112,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => [], "usesProjects" => false}, body)
+    assert_equal({"id" => level.id, "levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => [], "usesProjects" => false}, body)
   end
 
   test 'should show script level for csp1-2020 lockable lesson with lesson plan' do


### PR DESCRIPTION
We had an issue where certain levels in the Music Lab Elementary onboarding progression where showing a blanked out blockly workspace. This was because if two levels had identical level data and initial sources, we would never call the `onLevelLoad` hook in `MusicView` to initialize the blockly workspace. Since the Blockly workspace always gets disposed when we change levels, this would result in an empty workspace when loading the new level.

The fix here is to compare the entire level properties object when determining whether to call the `onLevelLoad` hook, so that if any property changes, we'll load all our components for the level as expected. Furthermore, I added an `id` field to the level properties object with the current level's ID, to guarantee that each level's properties are unique. That way if labs want to be sure if a level has changed, even if the other properties are identical, they can check the ID to know for sure.

Some additional context here - we do already have a current level ID stored in progress redux that some labs, including Music Lab, listen to for changes. There's a slight nuance here though, because that current level ID in progress redux technically updates before all the other lab2 fields have updated. This is because the change in the current level ID in progress redux is what triggers Lab2's ProgressContainer to start fetching data for the new level. So by adding the ID to the level properties, we always have a way to listen for level changes in a way that guarantees that all the level information has been loaded, rather than listening to the level ID in progress redux which will change before Lab2 has loaded level information. That being said, there are still cases where we may want to listen for the level ID in progress redux; specifically if we want to take any actions as soon as the level has changed, but before Lab2 has loaded the data for the next level. For example in Music Lab, we want to stop playback as soon as we start transitioning away from the level, so that music is not playing while we're loading the next level.

## Links

https://codedotorg.slack.com/archives/C043WM7TCH3/p1711726843187269

## Testing story

Tested this on the music lab intro progression, elementary intro progression, standalone levels, and project beats.