### PR TITLE
New school and school district data ingestion from NCES for 2022-2023

### DIFF
--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -421,6 +421,29 @@ class School < ApplicationRecord
           }
         end
       end
+
+      CDO.log.info "Seeding 2022-2023 public school data."
+      AWS::S3.seed_from_file('cdo-nces', "2022-2023/ccd/schools_public.csv") do |filename|
+        merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: false, ignore_attributes: ['last_known_school_year_open']) do |row|
+          row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+          {
+            id:                           row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,
+            name:                         row['School Name'].upcase,
+            address_line1:                row['Location Address 1 [Public School] 2022-23'].to_s.upcase.truncate(50).presence,
+            address_line2:                row['Location Address 2 [Public School] 2022-23'].to_s.upcase.truncate(30).presence,
+            address_line3:                row['Location Address 3 [Public School] 2022-23'].to_s.upcase.presence,
+            city:                         row['Location City [Public School] 2022-23'].to_s.upcase.presence,
+            state:                        row['Location State Abbr [Public School] 2022-23'].to_s.strip.upcase.presence,
+            zip:                          row['Location ZIP [Public School] 2022-23'],
+            latitude:                     row['Latitude [Public School] 2022-23'].to_f,
+            longitude:                    row['Longitude [Public School] 2022-23'].to_f,
+            school_type:                  CHARTER_SCHOOL_MAP[row['Charter School [Public School] 2022-23'].to_s] || 'public',
+            school_district_id:           row['Agency ID - NCES Assigned [Public School] Latest available year'].to_i,
+            school_category:              SCHOOL_CATEGORY_MAP[row['School Type [Public School] 2022-23']].presence,
+            last_known_school_year_open:  OPEN_SCHOOL_STATUSES.include?(row['Updated Status [Public School] 2022-23']) ? '2022-2023' : nil
+          }
+        end
+      end
     end
   end
 

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -422,6 +422,7 @@ class School < ApplicationRecord
         end
       end
 
+      # Some of this data has #- appended to the front, so we strip that off with .to_s.slice(2) (it's always a single digit)
       CDO.log.info "Seeding 2022-2023 public school data."
       AWS::S3.seed_from_file('cdo-nces', "2022-2023/ccd/schools_public.csv") do |filename|
         merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: false, ignore_attributes: ['last_known_school_year_open']) do |row|


### PR DESCRIPTION
Updates seeding to ingest 2022-2023 school and school district NCES data. The 2022-2023 data has already been uploaded in CSV format to our [Google Drive](https://drive.google.com/drive/u/1/folders/14CxZes5y5SsuviqnOg45WeWg027Xfcit) and to our [S3 bucket](https://s3.console.aws.amazon.com/s3/buckets/cdo-nces?region=us-east-1&bucketType=general&prefix=2022-2023/ccd/&showversions=false).

These changes follow [last year's changes](https://github.com/code-dot-org/code-dot-org/pull/51416) and are virtually identical other than the years being updated.

### `seed:school_districts` output
![test_run_local](https://github.com/code-dot-org/code-dot-org/assets/56283563/e84d3dad-d7d0-49e2-98ad-98cd5a94d824)

### `seed:schools` output
![school_real_local](https://github.com/code-dot-org/code-dot-org/assets/56283563/e1a1c87d-4fd1-453c-8e82-b170d404c3a3)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1617)
Last year's PR for this equivalent change: [here](https://github.com/code-dot-org/code-dot-org/pull/51416)

## Testing story
First I updated my local db to match that of production in the `school_districts` and `schools` tables. Then, I did a dry run of both seeding tasks and checked that the output made sense and roughly paralleled last year's numbers of added/updated/unchanged schools. Lastly, I ran them for real locally, saw the same numbers in the output, and checked that the number of entries in `school_districts` and `schools` went up by the number of new school districts and schools.

## Deployment strategy
Since seeding occurs during the DTP, we should see these changes in the DTP after this is merged.

## Follow-up work
Following @vijayamanohararaj 's strategy from last year, there will be a followup PR with a one-off script to use this ingested data (as well as the `locale_public.csv` file) to populate the `school_stats_by_year` table.
