### PR TITLE
P20-828: Lazy load i18n files on the Dashboard test env

### DIFF
--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -13,6 +13,9 @@ Dashboard::Application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = true
 
+  # Configure i18n
+  config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
+
   # Configure static asset server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {'Cache-Control' => "public, max-age=3600, s-maxage=1800"}

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -30,7 +30,7 @@ Dashboard::Application.configure do
     # Version of your assets, change this if you want to expire all your assets.
     config.assets.version = '1.0'
 
-    # Speeds up the env loading by avoid loading all i18n files up front.
+    # Avoid loading all i18n files up front, which can significantly slow down initialization.
     # Instead, it only loads i18n files that belong to the current locale.
     config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
   end

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -13,9 +13,6 @@ Dashboard::Application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = true
 
-  # Configure i18n
-  config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
-
   # Configure static asset server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {'Cache-Control' => "public, max-age=3600, s-maxage=1800"}
@@ -32,6 +29,10 @@ Dashboard::Application.configure do
 
     # Version of your assets, change this if you want to expire all your assets.
     config.assets.version = '1.0'
+
+    # Speeds up the env loading by avoid loading all i18n files up front.
+    # Instead, it only loads i18n files that belong to the current locale.
+    config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
   end
 
   config.assets.quiet = true

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -189,7 +189,7 @@ module Cdo
         locales[k.to_sym] = v.to_sym if v.is_a?(String)
       end.freeze
 
-      # The original method has been modified to works on i18n files named with a prefix and the locale,
+      # The original method has been modified to work on i18n files named with a prefix and the locale,
       # like "common.en.yml" or "common.en-US.json" and not only on files named with the locale, like "en-US.json".
       # https://github.com/ruby-i18n/i18n/blob/v1.12.0/lib/i18n/backend/lazy_loadable.rb#L55-L63
       class ::I18n::Backend::LocaleExtractor
@@ -256,7 +256,7 @@ module Cdo
         unexpected_locales = translations.each_key.reject {|locale| valid_locales.include?(locale.to_sym)}
         return if unexpected_locales.empty?
 
-        warn "INVALID I18N: Incorrect filename of #{file}".yellow
+        warn "INVALID I18N: File #{file.inspect} contains translations for unexpected locale".yellow
         warn "       valid: #{valid_locales.inspect}".blue
         warn "    expected: #{expected_locale.inspect}".green
         warn "  unexpected: #{unexpected_locales.inspect}".red

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -179,7 +179,7 @@ module Cdo
     # - Modified the `LocaleExtractor` class to support filenames that include both a prefix and the locale (e.g., "courses.en-US.yml").
     # - Modified the `filenames_for_current_locale` method to load files for the current locale and its fallbacks, (e.g, "en" for "en-US" and vice versa)
     # - Modified the `eager_load!` method to ignore eager loading when lazy loading is enabled.
-    # - Prevented the `assert_file_named_correctly!` method from raising an irrelevant error regarding file locale mismatches.
+    # - Modified the `assert_file_named_correctly!` method to check if a filename corresponds to the locale it loaded.
     # - Implemented a mechanism to avoid reloading already loaded translation files.
     # https://github.com/ruby-i18n/i18n/blob/v1.12.0/lib/i18n/backend/lazy_loadable.rb
     class LazyLoadableBackend < ::I18n::Backend::LazyLoadable
@@ -243,7 +243,7 @@ module Cdo
         end
       end
 
-      # Checks if a filename is named in correspondence to the translations it loaded.
+      # Checks if a filename corresponds to the locale it has loaded.
       # The locale extracted from the path must be either the single locale loaded in
       # the translations or one of the expected variations of the locale, taking into
       # account both long locale codes and fallbacks.

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -205,7 +205,11 @@ module Cdo
       end
 
       def reload!
-        @loaded_files = nil if lazy_load?
+        if lazy_load?
+          @loaded_files = nil
+          @valid_locales = nil
+        end
+
         super
       end
 
@@ -247,6 +251,10 @@ module Cdo
       # The locale extracted from the path must be either the single locale loaded in
       # the translations or one of the expected variations of the locale, taking into
       # account both long locale codes and fallbacks.
+      #
+      # The original implementation was changed from raising an error to log the details to the console,
+      # because the error isn't all that critical to catch and
+      # the new loading logic includes more weird edge cases.
       # https://github.com/ruby-i18n/i18n/blob/v1.12.0/lib/i18n/backend/lazy_loadable.rb#L173-L181
       def assert_file_named_correctly!(file, translations)
         expected_locale = ::I18n::Backend::LocaleExtractor.locale_from_path(file)

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -258,9 +258,9 @@ module Cdo
       # the translations or one of the expected variations of the locale, taking into
       # account both long locale codes and fallbacks.
       #
-      # The original implementation was changed from raising an error to log the details to the console,
-      # because the error isn't all that critical to catch and
-      # the new loading logic includes more weird edge cases.
+      # The original implementation was changed from raising an error to logging
+      # the details to the console, because the error isn't all that critical
+      # to catch and the new loading logic includes more weird edge cases.
       # https://github.com/ruby-i18n/i18n/blob/v1.12.0/lib/i18n/backend/lazy_loadable.rb#L173-L181
       def assert_file_named_correctly!(file, translations)
         expected_locale = ::I18n::Backend::LocaleExtractor.locale_from_path(file)

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -227,10 +227,16 @@ module Cdo
       # Get the set of valid locales for a given base locale code. For example,
       # for a base of `:pt`, we expect valid locales `:pt`, `:"pt-BR"`, `:"en-US"`, and `en`
       def valid_locales_for(base_locale)
-        valid_locales = Set.new(::I18n.fallbacks[base_locale])
-        valid_locales << base_locale
-        valid_locales << LOCALES_MAPPING[base_locale] # en: :'en-US'
-        valid_locales.compact_blank
+        @valid_locales ||= {}
+
+        unless @valid_locales[base_locale]
+          @valid_locales[base_locale] = Set.new(::I18n.fallbacks[base_locale])
+          @valid_locales[base_locale] << base_locale
+          @valid_locales[base_locale] << LOCALES_MAPPING[base_locale] # en: :'en-US'
+          @valid_locales[base_locale] = @valid_locales[base_locale].compact_blank
+        end
+
+        @valid_locales[base_locale]
       end
 
       # The original method has been modified to also load files for the current locale's fallbacks,


### PR DESCRIPTION
The dashboard test env loads 6 times faster by lazily loading i18n files:
| Before  | After |
| ------- | ----- |
| ![without-lazy-loading](https://github.com/code-dot-org/code-dot-org/assets/11708250/99c8a65b-78ba-4e8d-a639-71d9a5ac643a) | ![with-lazy-loading](https://github.com/code-dot-org/code-dot-org/assets/11708250/6c694615-11e4-4948-9888-4706a498ae88) |

## Links

- [P20-806](https://codedotorg.atlassian.net/browse/P20-806)
- [P20-828](https://codedotorg.atlassian.net/browse/P20-828)