### PR TITLE
on the test server, write ruby errors to cloudwatch and honeybadger

### DIFF
--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -75,5 +75,16 @@ Dashboard::Application.configure do
   # Set to :debug to see everything in the log.
   config.log_level = :info
 
+  if CDO.running_web_application?
+    # Use default logging formatter so that PID and timestamp are not suppressed.
+    config.log_formatter = Logger::Formatter.new
+
+    # Log condensed lines to syslog for centralized logging.
+    config.lograge.enabled = true
+    config.lograge.formatter = Lograge::Formatters::Cee.new
+    require 'syslog/logger'
+    config.logger = Syslog::Logger.new 'dashboard', Syslog::LOG_LOCAL0
+  end
+
   config.experiment_cache_time_seconds = 0
 end

--- a/dashboard/config/honeybadger.yml
+++ b/dashboard/config/honeybadger.yml
@@ -8,3 +8,8 @@ breadcrumbs:
 request:
   filter_keys:
     - "warden.user.user.key"
+
+# report data to honeybadger on the test server. this will not happen in unit tests
+# or ci because we unset the api key in those situations (see test.yml.erb).
+test:
+  report_data: true


### PR DESCRIPTION
today it is difficult to debug server errors on the test machine. this is especially bad when working with Active Job, because there is no easy way to surface these errors in the UI. Logs are currently written to dashboard/log/test.log, in rails format, which does not include a timestamp:
```
Started GET "/print_certificates/eyJuYW1lIjoiUHVzaHRp" for 71.212.102.136 at 2024-03-29 19:10:58 +0000
Processing by PrintCertificatesController#show as HTML
  Parameters: {"encoded_params"=>"eyJuYW1lIjoiUHVzaHRp"}
Completed 500 Internal Server Error in 2ms (Allocations: 911)
  
JSON::ParserError (859: unexpected token at '{"name":"Pushti'):
  
app/controllers/print_certificates_controller.rb:15:in `show'
app/controllers/application_controller.rb:186:in `block in with_locale'
app/controllers/application_controller.rb:185:in `with_locale'
** [Honeybadger] Initializing Honeybadger Error Tracker for Ruby. Ship it! version=4.12.1 framework=rails level=1 pid=1864053
** [Honeybadger] Initializing Honeybadger Error Tracker for Ruby. Ship it! version=4.12.1 framework=rails level=1 pid=1864053
** [Honeybadger] Development mode is enabled. Data will not be reported until you deploy your app. level=2 pid=1864053
** [Honeybadger] Reporting error id=5829e667-c308-47e3-a912-79bc0357b015 level=1 pid=1767892
** [Honeybadger] Success ⚡ Development mode is enabled; this error will be reported if it occurs after you deploy your app. id=5829e667-c308-47e3-a912-79bc0357b015 level=1 pid=1767892
** [Honeybadger] Initializing Honeybadger Error Tracker for Ruby. Ship it! version=4.12.1 framework=rails level=1 pid=1864348
** [Honeybadger] Development mode is enabled. Data will not be reported until you deploy your app. level=2 pid=1864348
```

This config change makes the logs show up in cloudwatch and also includes a timestamp in /var/log/syslog: 
```
Mar 29 20:33:28 test dashboard[1942529]: @cee: {"method":"GET","path":"/print_certificates/eyJuYW1lIjoiUHVzaHRp","format":"html","controller":"PrintCertificatesController","action":"show","status":500,"error":"JSON::ParserError: 859: unexpected token at '{\"name\":\"Pushti'","duration":6.85,"view":0.0}
Mar 29 20:33:28 test dashboard[1942529]: @cee: {"method":"GET","path":"/print_certificates/eyJuYW1lIjoiUHVzaHRp","format":"html","controller":null,"action":null,"status":500,"error":"JSON::ParserError: 859: unexpected token at '{\"name\":\"Pushti'","duration":0.01}
Mar 29 20:33:28 test dashboard[1942282]: Rendered ActiveModel::Serializer::CollectionSerializer with Array (29.58ms)
Mar 29 20:33:28 test dashboard[1942282]: @cee: {"method":"GET","path":"/api/v1/test_logs/test/test/since/1711741146","format":"json","controller":"Api::V1::TestLogsController","action":"get_logs_since","status":200,"duration":1604.8,"view":33.48}
Mar 29 20:33:29 test dashboard[1942529]: ** [Honeybadger] Reporting error id=beb69396-87b5-40c8-a8e8-389518878dd9 level=1 pid=1942529
Mar 29 20:33:29 test dashboard[1942529]: ** [Honeybadger] Success ⚡ Development mode is enabled; this error will be reported if it occurs after you deploy your app. id=beb69396-87b5-40c8-a8e8-389518878dd9 level=1 pid=1942529
```

f5c0597dd6bc1927b416f347dbe4a0f9ca82003b also makes the error details show up in honey badger.

## Testing story

patched onto the test machine, and verified that new ruby errors appear in:
* /var/log/syslog
* `test-syslog` group in cloudwatch
* honey badger: https://app.honeybadger.io/projects/3240/faults/106022369