### PR TITLE
Add support for localizing Panels levels

### DIFF
--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -182,6 +182,15 @@ module I18n
                 end
               end
 
+              # Panels
+              if level.is_a? Panels
+                panels = level.panels
+                i18n_strings['panels'] = Hash.new unless panels.empty?
+                panels.each do |panel|
+                  i18n_strings['panels'][panel['key']] = panel['text']
+                end
+              end
+
               level_xml = Nokogiri::XML(level.to_xml, &:noblanks)
               blocks = level_xml.xpath('//blocks').first
               if blocks
@@ -393,6 +402,7 @@ module I18n
               short_instructions
               teacher_markdown
               validations
+              panels
             )
 
             redactable = i18n_strings.select do |key, _|

--- a/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
@@ -629,6 +629,40 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
     assert_equal expected_result, sync_in_instance.send(:get_i18n_strings, level)
   end
 
+  def test_i18n_strings_collection_for_level_panels
+    sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
+
+    level = FactoryBot.build(:panels)
+
+    level.panels = [
+      {
+        'text' => 'text-1',
+        'imageUrl' => 'imageUrl-1',
+        'key' => 'panel-1',
+        'layout' => 'text-bottom-left'
+      },
+      {
+        'text' => 'text-2',
+        'imageUrl' => 'imageUrl-2',
+        'key' => 'panel-2',
+        'nextUrl' => 'nextUrl-2'
+      },
+    ]
+
+    expected_result = {
+      'panels' => {
+        'panel-1' => 'text-1',
+        'panel-2' => 'text-2'
+      }
+    }
+
+    assert_equal expected_result, sync_in_instance.send(:get_i18n_strings, level)
+
+    level.panels = []
+    expected_result = {}
+    assert_equal expected_result, sync_in_instance.send(:get_i18n_strings, level)
+  end
+
   def test_yml_file_writting
     sync_in_instance = I18n::Resources::Dashboard::CourseContent::SyncIn.new
 
@@ -664,6 +698,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
       'teacher_markdown'   => 'expected_teacher_markdown',
       'authored_hints'     => 'expected_authored_hints',
       'validations'        => 'expected_validations',
+      'panels'             => 'expected_panels',
       'contained levels'   => [
         {
           'unexpected_key'     => 'unexpected_value',
@@ -684,6 +719,7 @@ class I18n::Resources::Dashboard::CourseContent::SyncInTest < Minitest::Test
       'teacher_markdown'   => 'expected_teacher_markdown',
       'authored_hints'     => 'expected_authored_hints',
       'validations'        => 'expected_validations',
+      'panels'             => 'expected_panels',
       'contained levels'   => [
         {
           'short_instructions' => 'expected_short_instructions',

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -744,6 +744,23 @@ class Level < ApplicationRecord
     end
   end
 
+  def localized_panels
+    if should_localize?
+      panels_clone = panels.map(&:clone)
+      panels_clone.each do |panel|
+        panel['text'] = I18n.t(
+          panel["key"],
+          scope: [:data, :panels, name],
+          default: panel["text"],
+          smart: true
+        )
+      end
+      panels_clone
+    else
+      panels
+    end
+  end
+
   # There's a bit of trickery here. We consider a level to be
   # hint_prompt_enabled for the sake of the level editing experience if any of
   # the scripts associated with the level are hint_prompt_enabled.
@@ -811,6 +828,7 @@ class Level < ApplicationRecord
     properties_camelized[:usesProjects] = try(:is_project_level) || channel_backed?
     # Localized properties
     properties_camelized["validations"] = localized_validations if properties_camelized["validations"]
+    properties_camelized["panels"] = localized_panels if properties_camelized["panels"]
     properties_camelized
   end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -855,6 +855,11 @@ FactoryBot.define do
     level_num {'custom'}
   end
 
+  factory :panels, parent: :level, class: Panels do
+    game {Game.panels}
+    level_num {'custom'}
+  end
+
   factory :block do
     transient do
       sequence(:index)


### PR DESCRIPTION
Add panels text to the localization pipeline. This is pretty similar to https://github.com/code-dot-org/code-dot-org/pull/57302.

## Links

https://codedotorg.atlassian.net/browse/LABS-547

## Testing story

Tested by running i18n sync locally.

**Sync In** file example:
<img width="1030" alt="Screenshot 2024-03-27 at 4 28 20 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/b986fd80-ab15-433d-a2ad-3006609d750b">

**Sync Down & Out** output example:
<img width="1112" alt="Screenshot 2024-03-29 at 5 34 02 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/c14a4406-17ad-40d5-a174-a4499c5e7518">

Localized content in the music intro progression:
<img width="1512" alt="Screenshot 2024-03-29 at 5 32 58 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/6aec423c-6d11-4d4f-8cd3-2031ef084e01">
