### PR TITLE
Raise `StudentFacingError` when importing an invalid CSV file

### DIFF
--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -231,6 +231,8 @@ class DatablockStorageTable < ApplicationRecord
     end
 
     create_records(records)
+  rescue CSV::MalformedCSVError => exception
+    raise StudentFacingError.new(:INVALID_CSV), "Could not import CSV as it was not in the format we expected: #{exception.message}"
   end
 
   def add_column(column_name)


### PR DESCRIPTION
This does NOT cause an error to show up for the student (which would be nice, but silent failure matches Firebase's behavior, which is our target bug for bug), but it also does not cause a 500 error that shows up in Honey Badger.

Fixes: #57676 