### PR TITLE
Retry table_or_create on failure

### DIFF
--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -335,6 +335,9 @@ class DatablockStorageController < ApplicationController
 
   private def table_or_create
     where_table.first_or_create
+  rescue ActiveRecord::RecordNotUnique
+    # first_or_create() is not atomic, retry in case a create was done in parallel
+    where_table.first_or_create
   end
 
   private def validate_channel_id


### PR DESCRIPTION
Fixes race condition caused by first_or_create() not being atomic, found using honeybadger. If two first_or_create() run in parallel, they might both try to create, but the second create will fail due to duplicate primary key. The fix is to retry on the first failure.

Fixes #57681 
