### PR TITLE
Fix width of lesson cells

### DIFF
--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -57,8 +57,8 @@ $level-cell-width: 52;
 
   &Lesson {
     text-align: center;
-    min-width: 47px;
-    max-width: 47px;  
+    min-width: 52px;
+    max-width: 52px;  
     height: 47px;
     line-height: 47px !important;
   }


### PR DESCRIPTION
Width of lesson cells is now 52 instead of 48

![image](https://github.com/code-dot-org/code-dot-org/assets/25193259/a8723d60-d057-4dab-b7e7-5d24ea99d2e9)


## Links
[TEACH-984](https://codedotorg.atlassian.net/browse/TEACH-984)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
