### PR TITLE
feat(lms): disable adding or removing co-teachers if the section is managed by lms

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -559,6 +559,7 @@
   "coteacherAddButton": "Add co-teacher",
   "coteacherCount": "{count}/5 co-teachers added",
   "coteacherEmailAddress": "Email address",
+  "coteacherLtiAddInfo": "To add or remove co-teachers, please update your roster on the LMS and re-sync the section.",
   "coteacherRemoveDialogHeader": "Remove {email} as a co-teacher?",
   "coteacherRemoveDialogDescription": "This teacher will lose their ability to manage or view student work for this section.",
   "coteacherNoCoteachers": "You haven't added any co-teachers yet",

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -307,6 +307,10 @@ export default function SectionsSetUpContainer({
   };
 
   const renderCoteacherSection = () => {
+    const isCoTeacherManagementDisabled =
+      sections[0].primaryInstructor?.ltiRosterSyncEnabled === true &&
+      sections[0].loginType === 'ltiV1';
+
     return renderExpandableSection(
       'uitest-expandable-coteacher',
       () => (
@@ -328,7 +332,7 @@ export default function SectionsSetUpContainer({
           sectionMetricInformation={getCoteacherMetricInfoFromSection(
             sections[0]
           )}
-          loginType={sections[0].loginType}
+          disabled={isCoTeacherManagementDisabled}
         />
       ),
       isCoteacherOpen,

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -328,6 +328,7 @@ export default function SectionsSetUpContainer({
           sectionMetricInformation={getCoteacherMetricInfoFromSection(
             sections[0]
           )}
+          loginType={sections[0].loginType}
         />
       ),
       isCoteacherOpen,

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
@@ -93,7 +93,7 @@ export default function AddCoteacher({
   addError,
   setAddError,
   sectionMetricInformation,
-  loginType,
+  disabled,
 }) {
   const [inputValue, setInputValue] = useState('');
 
@@ -196,7 +196,7 @@ export default function AddCoteacher({
   const isMaxCoteachers = numCoteachers >= 5;
 
   const getErrorOrCount = () => {
-    if (loginType === 'ltiV1') {
+    if (disabled) {
       return null;
     }
 
@@ -225,7 +225,7 @@ export default function AddCoteacher({
         <input
           className={classNames(styles.input, !!addError && styles.inputError)}
           type="text"
-          disabled={isMaxCoteachers || loginType === 'ltiV1'}
+          disabled={isMaxCoteachers || !!disabled}
           value={inputValue}
           onChange={handleInputChange}
           onKeyDown={handleSubmitAddEmail}
@@ -237,7 +237,7 @@ export default function AddCoteacher({
           type="submit"
           text={i18n.coteacherAddButton()}
           onClick={handleAddEmail}
-          disabled={isMaxCoteachers || loginType === 'ltiV1'}
+          disabled={isMaxCoteachers || !!disabled}
         />
       </div>
       {getErrorOrCount()}
@@ -254,5 +254,5 @@ AddCoteacher.propTypes = {
   addSavedCoteacher: PropTypes.func.isRequired,
   setAddError: PropTypes.func.isRequired,
   sectionMetricInformation: PropTypes.object,
-  loginType: PropTypes.string,
+  disabled: PropTypes.bool,
 };

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/AddCoteacher.jsx
@@ -93,6 +93,7 @@ export default function AddCoteacher({
   addError,
   setAddError,
   sectionMetricInformation,
+  loginType,
 }) {
   const [inputValue, setInputValue] = useState('');
 
@@ -195,6 +196,10 @@ export default function AddCoteacher({
   const isMaxCoteachers = numCoteachers >= 5;
 
   const getErrorOrCount = () => {
+    if (loginType === 'ltiV1') {
+      return null;
+    }
+
     if (addError) {
       return (
         <Figcaption
@@ -220,7 +225,7 @@ export default function AddCoteacher({
         <input
           className={classNames(styles.input, !!addError && styles.inputError)}
           type="text"
-          disabled={isMaxCoteachers}
+          disabled={isMaxCoteachers || loginType === 'ltiV1'}
           value={inputValue}
           onChange={handleInputChange}
           onKeyDown={handleSubmitAddEmail}
@@ -232,7 +237,7 @@ export default function AddCoteacher({
           type="submit"
           text={i18n.coteacherAddButton()}
           onClick={handleAddEmail}
-          disabled={isMaxCoteachers}
+          disabled={isMaxCoteachers || loginType === 'ltiV1'}
         />
       </div>
       {getErrorOrCount()}
@@ -249,4 +254,5 @@ AddCoteacher.propTypes = {
   addSavedCoteacher: PropTypes.func.isRequired,
   setAddError: PropTypes.func.isRequired,
   sectionMetricInformation: PropTypes.object,
+  loginType: PropTypes.string,
 };

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherSettings.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherSettings.jsx
@@ -43,6 +43,7 @@ export default function CoteacherSettings({
   setCoteachersToAdd,
   coteachersToAdd,
   sectionMetricInformation,
+  loginType,
 }) {
   const [addError, setAddError] = useState('');
   const [coteacherToRemove, setCoteacherToRemove] = useState(null);
@@ -77,7 +78,9 @@ export default function CoteacherSettings({
 
   return (
     <div className={styles.expandedSection}>
-      {i18n.coteacherAddInfo()}
+      {loginType === 'ltiV1'
+        ? i18n.coteacherLtiAddInfo()
+        : i18n.coteacherAddInfo()}
       <PrimaryTeacher
         primaryTeacher={primaryTeacher}
         numCoteachers={coteachers.length}
@@ -95,10 +98,12 @@ export default function CoteacherSettings({
           addError={addError}
           setAddError={setAddError}
           sectionMetricInformation={sectionMetricInformation}
+          loginType={loginType}
         />
         <CoteacherTable
           coteachers={coteachers}
           setCoteacherToRemove={setCoteacherToRemove}
+          loginType={loginType}
         />
         <RemoveCoteacherDialog
           coteacherToRemove={coteacherToRemove}
@@ -119,4 +124,5 @@ CoteacherSettings.propTypes = {
   setCoteachersToAdd: PropTypes.func.isRequired,
   coteachersToAdd: PropTypes.arrayOf(PropTypes.string),
   sectionMetricInformation: PropTypes.object,
+  loginType: PropTypes.string,
 };

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherSettings.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherSettings.jsx
@@ -43,7 +43,7 @@ export default function CoteacherSettings({
   setCoteachersToAdd,
   coteachersToAdd,
   sectionMetricInformation,
-  loginType,
+  disabled,
 }) {
   const [addError, setAddError] = useState('');
   const [coteacherToRemove, setCoteacherToRemove] = useState(null);
@@ -78,9 +78,7 @@ export default function CoteacherSettings({
 
   return (
     <div className={styles.expandedSection}>
-      {loginType === 'ltiV1'
-        ? i18n.coteacherLtiAddInfo()
-        : i18n.coteacherAddInfo()}
+      {disabled ? i18n.coteacherLtiAddInfo() : i18n.coteacherAddInfo()}
       <PrimaryTeacher
         primaryTeacher={primaryTeacher}
         numCoteachers={coteachers.length}
@@ -98,12 +96,12 @@ export default function CoteacherSettings({
           addError={addError}
           setAddError={setAddError}
           sectionMetricInformation={sectionMetricInformation}
-          loginType={loginType}
+          disabled={disabled}
         />
         <CoteacherTable
           coteachers={coteachers}
           setCoteacherToRemove={setCoteacherToRemove}
-          loginType={loginType}
+          disabled={disabled}
         />
         <RemoveCoteacherDialog
           coteacherToRemove={coteacherToRemove}
@@ -124,5 +122,5 @@ CoteacherSettings.propTypes = {
   setCoteachersToAdd: PropTypes.func.isRequired,
   coteachersToAdd: PropTypes.arrayOf(PropTypes.string),
   sectionMetricInformation: PropTypes.object,
-  loginType: PropTypes.string,
+  disabled: PropTypes.bool,
 };

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherTable.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherTable.jsx
@@ -78,7 +78,7 @@ const getStatusPill = status => {
 export default function CoteacherTable({
   coteachers,
   setCoteacherToRemove,
-  loginType,
+  disabled,
 }) {
   const tableRow = (index, coteacher) => {
     return (
@@ -98,7 +98,7 @@ export default function CoteacherTable({
         <td className={styles.tableStatusCell}>
           {getStatusPill(coteacher.status)}
         </td>
-        {loginType !== 'ltiV1' && (
+        {!disabled && (
           <td>
             <button
               type="button"
@@ -131,5 +131,5 @@ export default function CoteacherTable({
 CoteacherTable.propTypes = {
   coteachers: PropTypes.arrayOf(PropTypes.object).isRequired,
   setCoteacherToRemove: PropTypes.func.isRequired,
-  loginType: PropTypes.string,
+  disabled: PropTypes.bool,
 };

--- a/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherTable.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherTable.jsx
@@ -75,7 +75,11 @@ const getStatusPill = status => {
   }
 };
 
-export default function CoteacherTable({coteachers, setCoteacherToRemove}) {
+export default function CoteacherTable({
+  coteachers,
+  setCoteacherToRemove,
+  loginType,
+}) {
   const tableRow = (index, coteacher) => {
     return (
       <tr key={index} className={styles.tableRow}>
@@ -94,15 +98,19 @@ export default function CoteacherTable({coteachers, setCoteacherToRemove}) {
         <td className={styles.tableStatusCell}>
           {getStatusPill(coteacher.status)}
         </td>
-        <td>
-          <button
-            type="button"
-            onClick={() => setCoteacherToRemove(coteacher)}
-            className={styles.tableRemoveButton}
-          >
-            <i className={classNames('fa-solid fa-trash', styles.trashIcon)} />
-          </button>
-        </td>
+        {loginType !== 'ltiV1' && (
+          <td>
+            <button
+              type="button"
+              onClick={() => setCoteacherToRemove(coteacher)}
+              className={styles.tableRemoveButton}
+            >
+              <i
+                className={classNames('fa-solid fa-trash', styles.trashIcon)}
+              />
+            </button>
+          </td>
+        )}
       </tr>
     );
   };
@@ -123,4 +131,5 @@ export default function CoteacherTable({coteachers, setCoteacherToRemove}) {
 CoteacherTable.propTypes = {
   coteachers: PropTypes.arrayOf(PropTypes.object).isRequired,
   setCoteacherToRemove: PropTypes.func.isRequired,
+  loginType: PropTypes.string,
 };

--- a/apps/test/unit/templates/sectionsRefresh/coteacherSettings/AddCoteacherTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/coteacherSettings/AddCoteacherTest.jsx
@@ -72,10 +72,8 @@ describe('AddCoteacher', () => {
     expect(wrapper.find('Button').first().props().disabled).to.be.true;
   });
 
-  it('disables email input and add button when loginType is LTIv1', () => {
-    const wrapper = shallow(
-      <AddCoteacher {...DEFAULT_PROPS} loginType={'ltiV1'} />
-    );
+  it('disables email input and add button when disabled', () => {
+    const wrapper = shallow(<AddCoteacher {...DEFAULT_PROPS} disabled />);
 
     expect(wrapper.find('input').first().props().disabled).to.be.true;
     expect(wrapper.find('Button').first().props().disabled).to.be.true;

--- a/apps/test/unit/templates/sectionsRefresh/coteacherSettings/AddCoteacherTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/coteacherSettings/AddCoteacherTest.jsx
@@ -72,6 +72,16 @@ describe('AddCoteacher', () => {
     expect(wrapper.find('Button').first().props().disabled).to.be.true;
   });
 
+  it('disables email input and add button when loginType is LTIv1', () => {
+    const wrapper = shallow(
+      <AddCoteacher {...DEFAULT_PROPS} loginType={'ltiV1'} />
+    );
+
+    expect(wrapper.find('input').first().props().disabled).to.be.true;
+    expect(wrapper.find('Button').first().props().disabled).to.be.true;
+    expect(wrapper.find('Figcaption')).to.have.lengthOf(0);
+  });
+
   it('adds coteacher when valid email is added', done => {
     fetchSpy.returns(Promise.resolve({ok: true}));
     const setCoteachersToAddSpy = sinon.spy();

--- a/apps/test/unit/templates/sectionsRefresh/coteacherSettings/CoteacherSettingsTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/coteacherSettings/CoteacherSettingsTest.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import sinon from 'sinon';
 
 import CoteacherSettings from '@cdo/apps/templates/sectionsRefresh/coteacherSettings/CoteacherSettings';
+import i18n from '@cdo/locale';
 
 import {expect} from '../../../../util/reconfiguredChai';
 
@@ -97,6 +98,23 @@ describe('CoteacherSettings', () => {
     expect(cells.at(6).text()).to.include('Allosaurus');
     expect(cells.at(6).text()).to.include('allosaurus@code.org');
     expect(cells.at(7).text()).to.include('ACCEPTED');
+  });
+  it('renders LTI instructions for co-teacher and disables remove button', () => {
+    const wrapper = shallow(
+      <CoteacherSettings
+        sectionInstructors={testSectionInstructors}
+        setCoteachersToAdd={() => {}}
+        coteachersToAdd={[]}
+        primaryTeacher={testPrimaryTeacher}
+        loginType={'ltiV1'}
+      />
+    );
+    const addCoteacher = wrapper.find('div').first().childAt(0);
+    expect(addCoteacher.text()).to.equal(i18n.coteacherLtiAddInfo());
+
+    const cells = wrapper.find('CoteacherTable').dive().find('td');
+    const button = cells.find('button');
+    expect(button).to.have.lengthOf(0);
   });
   it('clicking remove opens dialog', () => {
     const wrapper = shallow(

--- a/apps/test/unit/templates/sectionsRefresh/coteacherSettings/CoteacherSettingsTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/coteacherSettings/CoteacherSettingsTest.jsx
@@ -99,14 +99,14 @@ describe('CoteacherSettings', () => {
     expect(cells.at(6).text()).to.include('allosaurus@code.org');
     expect(cells.at(7).text()).to.include('ACCEPTED');
   });
-  it('renders LTI instructions for co-teacher and disables remove button', () => {
+  it('renders LTI instructions for co-teacher and disables remove button if disabled', () => {
     const wrapper = shallow(
       <CoteacherSettings
         sectionInstructors={testSectionInstructors}
         setCoteachersToAdd={() => {}}
         coteachersToAdd={[]}
         primaryTeacher={testPrimaryTeacher}
-        loginType={'ltiV1'}
+        disabled
       />
     );
     const addCoteacher = wrapper.find('div').first().childAt(0);

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -28,6 +28,7 @@ class SectionsController < ApplicationController
     @section['primaryInstructor'] = {
       email: existing_section.teacher.email,
       name: existing_section.teacher.name,
+      lti_roster_sync_enabled: existing_section.teacher&.properties&.[]("lti_roster_sync_enabled")
     }
 
     @section = @section.to_json.camelize


### PR DESCRIPTION
When the roster is managed externally by an LMS, adding or removing co-teachers will result in a desynchronized state which will lead to some confusion when a roster sync occurs. Instead, inform the teacher to make updates on the LMS directly.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-801)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

### Scenario 1: Go to co-teacher dashboard for LMS managed roster

![Screenshot from 2024-04-01 12-03-52](https://github.com/code-dot-org/code-dot-org/assets/538214/89f90c7a-1799-4cae-92fd-f9996da020e3)

Expected:
1. No co-teachers can be added
2. No co-teachers can be removed
3. i18n text for co-teacher replaced with LMS specific i18n text

### Scenario 2: Go to co-teacher dashboard for native roster (not LMS)

Expected:
1. Co-teachers can be added
2. Co-teachers can be removed
3. i18n text displays normal text

### Scenario 3: LTI Roster Sync Disabled (but is a LMS managed section)

![Screenshot from 2024-04-02 14-19-45](https://github.com/code-dot-org/code-dot-org/assets/538214/ea2f627e-8f7d-4183-b7e4-f1f4f3eaa87c)


Expected:
1. Co-teachers can be added
2. Co-teachers can be removed
3. i18n text displays normal text

## Deployment strategy

## Follow-up work

N/A

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

N/A


<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

N/A


<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

N/A


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
