### PR TITLE
Add Schoology section to LTI onboarding docs

### DIFF
--- a/docs/Screenshot 2024-04-01 at 1.00.04 PM.png
+++ b/docs/Screenshot 2024-04-01 at 1.00.04 PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b57fa8c0937eafe474b00e5068c42e7e4aeffd22ae9ab2f782b90c45c148fb99
+size 59296

--- a/docs/Screenshot 2024-04-01 at 1.00.04 PM.png
+++ b/docs/Screenshot 2024-04-01 at 1.00.04 PM.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b57fa8c0937eafe474b00e5068c42e7e4aeffd22ae9ab2f782b90c45c148fb99
-size 59296

--- a/docs/Screenshot 2024-04-01 at 1.00.36 PM-1.png
+++ b/docs/Screenshot 2024-04-01 at 1.00.36 PM-1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8bb7b3121cf4e5f310a5f5dbab4bf5d01982c595960a25dd4b0850ea030c7551
-size 111477

--- a/docs/Screenshot 2024-04-01 at 1.00.36 PM-1.png
+++ b/docs/Screenshot 2024-04-01 at 1.00.36 PM-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bb7b3121cf4e5f310a5f5dbab4bf5d01982c595960a25dd4b0850ea030c7551
+size 111477

--- a/docs/Screenshot 2024-04-01 at 1.00.36 PM.png
+++ b/docs/Screenshot 2024-04-01 at 1.00.36 PM.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:394346149a877cf8b0f0feb1526735433efba01ce5e2f639f875a601c0264227
-size 104801

--- a/docs/Screenshot 2024-04-01 at 1.00.36 PM.png
+++ b/docs/Screenshot 2024-04-01 at 1.00.36 PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:394346149a877cf8b0f0feb1526735433efba01ce5e2f639f875a601c0264227
+size 104801

--- a/docs/Screenshot 2024-04-01 at 1.03.09 PM.png
+++ b/docs/Screenshot 2024-04-01 at 1.03.09 PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93753b85c830d502c8d9154328d010edc0e970e74e319276df5a57e94308d8a7
+size 30823

--- a/docs/Screenshot 2024-04-01 at 1.03.09 PM.png
+++ b/docs/Screenshot 2024-04-01 at 1.03.09 PM.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93753b85c830d502c8d9154328d010edc0e970e74e319276df5a57e94308d8a7
-size 30823

--- a/docs/Screenshot 2024-04-01 at 11.51.53 AM.png
+++ b/docs/Screenshot 2024-04-01 at 11.51.53 AM.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:46da174030509982a3ddcda6d97dc4118b473421b7037025a28f0d75ffd1ef22
-size 209241

--- a/docs/Screenshot 2024-04-01 at 11.51.53 AM.png
+++ b/docs/Screenshot 2024-04-01 at 11.51.53 AM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46da174030509982a3ddcda6d97dc4118b473421b7037025a28f0d75ffd1ef22
+size 209241

--- a/docs/Screenshot 2024-04-01 at 11.52.13 AM.png
+++ b/docs/Screenshot 2024-04-01 at 11.52.13 AM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b9c3a3266ba90ddbb8bc7ca4aac46d7fcae158d9fe4740b0e06a83b9295e6e7
+size 142719

--- a/docs/Screenshot 2024-04-01 at 11.52.13 AM.png
+++ b/docs/Screenshot 2024-04-01 at 11.52.13 AM.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b9c3a3266ba90ddbb8bc7ca4aac46d7fcae158d9fe4740b0e06a83b9295e6e7
-size 142719

--- a/docs/Screenshot 2024-04-01 at 11.52.35 AM.png
+++ b/docs/Screenshot 2024-04-01 at 11.52.35 AM.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4112cfccb6ae114f0d90efef8493253c982a0d0f93d89e3c05bdcd0f59d6a0e
-size 270111

--- a/docs/Screenshot 2024-04-01 at 11.52.35 AM.png
+++ b/docs/Screenshot 2024-04-01 at 11.52.35 AM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4112cfccb6ae114f0d90efef8493253c982a0d0f93d89e3c05bdcd0f59d6a0e
+size 270111

--- a/docs/Screenshot 2024-04-01 at 11.52.46 AM.png
+++ b/docs/Screenshot 2024-04-01 at 11.52.46 AM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95e37eb72bd58ac27a2e4ab3ef88cf52091df54a5a6c588ce842189c7b3eae53
+size 185394

--- a/docs/Screenshot 2024-04-01 at 11.52.46 AM.png
+++ b/docs/Screenshot 2024-04-01 at 11.52.46 AM.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:95e37eb72bd58ac27a2e4ab3ef88cf52091df54a5a6c588ce842189c7b3eae53
-size 185394

--- a/docs/Screenshot 2024-04-01 at 12.59.34 PM.png
+++ b/docs/Screenshot 2024-04-01 at 12.59.34 PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e303a45cd99f11132fce0d50f8813440db26b6993ead3f55eaa11c7217ca5b65
+size 139178

--- a/docs/Screenshot 2024-04-01 at 12.59.34 PM.png
+++ b/docs/Screenshot 2024-04-01 at 12.59.34 PM.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e303a45cd99f11132fce0d50f8813440db26b6993ead3f55eaa11c7217ca5b65
-size 139178

--- a/docs/lti-integration.md
+++ b/docs/lti-integration.md
@@ -200,10 +200,10 @@ be manually installed.
   - Category: `Technology`
   - Recommended For: `Instructors` and `Students`
   - Available For: `Only people in my school`
-![image](<Screenshot 2024-04-01 at 11.51.53 AM.png>)
+![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/395e733f-72ea-41f7-af11-613130e89bfa)
+
 
 3. You can leave the App logo Feature graphic empty
-![image](<Screenshot 2024-04-01 at 11.52.13 AM.png>)
 
 4. Type of App: `LTI 1.3 App`
 5. Select where the tool can be installed, `Can Be Installed For`:
@@ -219,7 +219,7 @@ be manually installed.
 6. Configuration Type: `Manual`
 7. Privacy: `Send Name and Email/Username of user who luanches the tool`
 8. Check `Names and Roles Services`, leave `Assignment and Grade Services` unchecked
-![alt text](<Screenshot 2024-04-01 at 11.52.35 AM.png>)
+![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/73ab74e1-4c70-4ba6-8c41-5e5d46bc543f)
 
 9. JWKS URL: `https://studio.code.org/oauth/jwks
 10. Domain/URL: `https://studio.code.org/lti/v1/sync_course
@@ -227,7 +227,7 @@ be manually installed.
   - `display_name=$User.username`
 12. OIDC Login Init Url: `https://studio.code.org/lti/v1/login`
 13. Redirect URLs: `https://studio.code.org/lti/v1/authenticate`
-![alt text](<Screenshot 2024-04-01 at 11.52.46 AM.png>)
+![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/96f09b29-3c90-46cd-a60d-2f206abf8ca4)
 
 14. Click toggle to accept Schoology Terms of Use
 15. Click `Save Changes`
@@ -236,19 +236,25 @@ After you install the App to the district, you also need to install it to the
 areas where it should appear (Courses, Groups, etc). Click the ‘Install’ button
 next to your app on the District App list to complete that additional installation
 process.
-![image](<Screenshot 2024-04-01 at 1.00.36 PM-1.png>)
+![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/f78e0051-922e-4eff-b96f-8bf99c1d4768)
+
 
 This will open a modal, where you'll need to accept and continue. When prompted
 for where you want to install it, click `Add to Organization`.
-![image](<Screenshot 2024-04-01 at 1.03.09 PM.png>)
+<p align="center">
+<img width="368" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/03e2dd29-1f23-4408-867a-2c8fde1e74d2">
+</p>
 
 This will take you to the Organization Apps page, where you will click on the
 `Install/Remove` button for the Code.org tool.
-![image](<Screenshot 2024-04-01 at 1.00.04 PM.png>)
+![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/8ac87431-6a21-4b6c-af94-0cd9696260a4)
+
 
 A modal will open, where you'll be prompted to select who and where this app
 will be available for.
-![image](<Screenshot 2024-04-01 at 12.59.34 PM.png>)
+<p align="center">
+<img width="496" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/08b2fc57-6e39-42d1-aa2b-29f5e4ef5665">
+</p>
 
 Once you make your selection, click `Submit`.
 

--- a/docs/lti-integration.md
+++ b/docs/lti-integration.md
@@ -145,8 +145,6 @@ After configuring & saving your LTI Key, you will be redirected to your table of
 
 ![image](https://github.com/code-dot-org/code-dot-org/assets/1631660/1c0c9ad3-0b97-42b0-b70c-6f0738db4636)
 
-Now you can navigate to
-
 ## Installing Code.org in Schoology
 
 These instructions are based on the [Schoology docs](https://developers.schoology.com/app-platform/lti-apps/#how-to-add-your-app-to-schoology)
@@ -184,8 +182,8 @@ be manually installed.
 8. Check `Names and Roles Services`, leave `Assignment and Grade Services` unchecked
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/73ab74e1-4c70-4ba6-8c41-5e5d46bc543f)
 
-9. JWKS URL: `https://studio.code.org/oauth/jwks
-10. Domain/URL: `https://studio.code.org/lti/v1/sync_course
+9. JWKS URL: `https://studio.code.org/oauth/jwks`
+10. Domain/URL: `https://studio.code.org/lti/v1/sync_course`
 11. Custom Parameters:
   - `display_name=$User.username`
 12. OIDC Login Init Url: `https://studio.code.org/lti/v1/login`

--- a/docs/lti-integration.md
+++ b/docs/lti-integration.md
@@ -201,7 +201,7 @@ be manually installed.
   - Recommended For: `Instructors` and `Students`
   - Available For: `Only people in my school`
 
-![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/395e733f-72ea-41f7-af11-613130e89bfa)
+![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/02898ddb-1155-4aa0-a39a-7c518e4e2a38)
 
 3. You can leave the App logo Feature graphic empty
 4. Type of App: `LTI 1.3 App`

--- a/docs/lti-integration.md
+++ b/docs/lti-integration.md
@@ -1,19 +1,28 @@
 # LTI 1.3 Integration
 
-Code.org is developing an LTI 1.3 compliant integration for Canvas. This integration is undergoing beta testing with a small group of Canvas users and is expected to release broadly in 2024.
+Code.org is developing an LTI 1.3 compliant integration for Canvas and Schoology.
+This integration is undergoing beta testing with a small group of Canvas users
+and is expected to release broadly in 2024.
 
 The following documentation details the steps required to install Code.org as an
-LTI Tool in Canvas. Completing the following steps will generate a `Client ID`
-and a `Deployment ID`. 
+LTI Tool in Canvas and Schoology. Completing the following steps will generate a
+`Client ID`.
 
-Please supply these two IDs to Code.org via
-[this form][lti-integration-form] to register your LMS & complete your installation.
+Please supply the Client ID to Code.org via
+[this form][lti-integration-form] to register your LMS & complete your 
+installation.
 
-[lti-integration-form]: https://forms.gle/hLqdbgQ1VhZdKR7N8
+[lti-integration-form]: https://studio.code.org/lti/v1/integrations
+
+## Table of Contents
+
+* [Canvas Install Instructions](#installing-codeorg-in-canvas)
+* [Schoology Install Instructions](#installing-codeorg-in-schoology)
 
 ## Installing Code.org in Canvas
 
-Visual guides for Steps 1 - 3 can be [found here][install-canvas], and for Step 4 [here][configure-canvas]
+Visual guides for Steps 1 - 3 can be [found here][install-canvas], and for Step
+4 [here][configure-canvas]
 
 ### Step 1: Create your LTI Key
 
@@ -27,7 +36,9 @@ Visual guides for Steps 1 - 3 can be [found here][install-canvas], and for Step 
 
 ### Step 2: Configure your LTI Key
 
-There are two options for configuring your LTI key. The easiest is to paste in a JSON configuration snippet (Option 1). Optionally, you can elect to manually enter these settings (Option 2).
+There are two options for configuring your LTI key. The easiest is to paste in
+a JSON configuration snippet (Option 1). Optionally, you can elect to manually
+enter these settings (Option 2).
 
 #### Option 1 (Easiest): Enter JSON Details
 
@@ -130,8 +141,8 @@ select any placements that utilize an `LtiDeepLinkRequest`.
 After configuring & saving your LTI Key, you will be redirected to your table of Developer Keys. 
 
 1. Navigate to the Code.org Key you just created
-2. Copy the 18-digit numerical code in the Details column, e.g.: `000000000123456789` - this is your Client ID
-3. Paste this Client ID into the [Code.org Registration Form][lti-integration-form], and keep it handy for the next step
+1. Copy the 18-digit numerical code in the Details column, e.g.: `000000000123456789` - this is your Client ID
+1. Paste this Client ID into the [Code.org Registration Form][lti-integration-form], and keep it handy for the next step
 
 ![image](https://github.com/code-dot-org/code-dot-org/assets/1631660/1c0c9ad3-0b97-42b0-b70c-6f0738db4636)
 
@@ -141,13 +152,13 @@ Now that you have the LTI Key, you need to configure the Code.org LTI App to
 generate a `Deployment ID`. You can follow the steps below or [refer to the visual instructions here][configure-canvas]
 
 1. Visit the `Admin` panel and click `Settings`
-2. Click the `Apps` tab
-3. Click `View App Configurations`
-4. Click the `Add App` button
-5. Select `By Client ID` in the Configuration Type drop-down menu
-6. Paste your `Client ID` copied from Step 3
-7. Click `Submit`
-8. Click the `Install` button to confirm your installation
+1. Click the `Apps` tab
+1. Click `View App Configurations`
+1. Click the `Add App` button
+1. Select `By Client ID` in the Configuration Type drop-down menu
+1. Paste your `Client ID` copied from Step 3
+1. Click `Submit`
+1. Click the `Install` button to confirm your installation
 
 <p align="center">
 <img width="430" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/1631660/29eb6290-98e5-4891-be9a-ca241d7026dd">
@@ -157,9 +168,9 @@ generate a `Deployment ID`. You can follow the steps below or [refer to the visu
 After installing the application, you can now generate a `Deployment ID`
 
 1. View your app on the External Apps page
-2. Click the `Settings` (gear) icon
-3. Click `Deployment ID`
-4. Copy the `Deployment ID` string and submit it into the [Code.org Registration Form][lti-integration-form]
+1. Click the `Settings` (gear) icon
+1. Click `Deployment ID`
+1. Copy the `Deployment ID` string and submit it into the [Code.org Registration Form][lti-integration-form]
 
 ![image](https://github.com/code-dot-org/code-dot-org/assets/1631660/bcf40fa9-be26-42cd-865d-7e34e600c4c5)
 
@@ -173,6 +184,75 @@ After installing the application, you can now generate a `Deployment ID`
 ### Step 5: Submit the Code.org Registration Form
 
 Now that you've created and entered both your `Client ID` (Step 3) & `Deployment ID` (Step 4) into the [Code.org Registration Form][lti-integration-form], submit the form and wait for a confirmation email from our team! You can expect this confirmation mail within 1 - 2 business days.
+
+## Installing Code.org in Schoology
+
+These instructions are based on the [Schoology docs](https://developers.schoology.com/app-platform/lti-apps/#how-to-add-your-app-to-schoology)
+for adding a new App to Schoology.
+
+Currently, Code.org's LTI Tool is not listed in Schoology's App Store, and must
+be manually installed.
+
+1. Navigate to https://app.schoology.com/apps/publisher
+2. Fill in required fields
+  - App Name: `Code.org`
+  - App Description: `Code.org LTI Tool`
+  - Category: `Technology`
+  - Recommended For: `Instructors` and `Students`
+  - Available For: `Only people in my school`
+![image](<Screenshot 2024-04-01 at 11.51.53 AM.png>)
+
+3. You can leave the App logo Feature graphic empty
+![image](<Screenshot 2024-04-01 at 11.52.13 AM.png>)
+
+4. Type of App: `LTI 1.3 App`
+5. Select where the tool can be installed, `Can Be Installed For`:
+  - Users
+    - App Center Dropdown
+    - User Profile Left Navigation Menu
+  - Courses
+    - Left Navigation
+    - Rich Text Editor
+    - External Tool
+  - Groups
+  - Resources
+6. Configuration Type: `Manual`
+7. Privacy: `Send Name and Email/Username of user who luanches the tool`
+8. Check `Names and Roles Services`, leave `Assignment and Grade Services` unchecked
+![alt text](<Screenshot 2024-04-01 at 11.52.35 AM.png>)
+
+9. JWKS URL: `https://studio.code.org/oauth/jwks
+10. Domain/URL: `https://studio.code.org/lti/v1/sync_course
+11. Custom Parameters:
+  - `display_name=$User.username`
+12. OIDC Login Init Url: `https://studio.code.org/lti/v1/login`
+13. Redirect URLs: `https://studio.code.org/lti/v1/authenticate`
+![alt text](<Screenshot 2024-04-01 at 11.52.46 AM.png>)
+
+14. Click toggle to accept Schoology Terms of Use
+15. Click `Save Changes`
+
+After you install the App to the district, you also need to install it to the
+areas where it should appear (Courses, Groups, etc). Click the ‘Install’ button
+next to your app on the District App list to complete that additional installation
+process.
+![image](<Screenshot 2024-04-01 at 1.00.36 PM-1.png>)
+
+This will open a modal, where you'll need to accept and continue. When prompted
+for where you want to install it, click `Add to Organization`.
+![image](<Screenshot 2024-04-01 at 1.03.09 PM.png>)
+
+This will take you to the Organization Apps page, where you will click on the
+`Install/Remove` button for the Code.org tool.
+![image](<Screenshot 2024-04-01 at 1.00.04 PM.png>)
+
+A modal will open, where you'll be prompted to select who and where this app
+will be available for.
+![image](<Screenshot 2024-04-01 at 12.59.34 PM.png>)
+
+Once you make your selection, click `Submit`.
+
+Code.org's LTI app is now ready to use in your Schoology account!
 
 ## Using Code.org as an LTI Tool
 
@@ -191,3 +271,4 @@ these instructions, or refer to the steps above for Code.org specific details.
 
 [install-canvas]: https://community.canvaslms.com/t5/Admin-Guide/How-do-I-configure-an-LTI-key-for-an-account/ta-p/140
 [configure-canvas]: https://community.canvaslms.com/t5/Admin-Guide/How-do-I-configure-an-external-app-for-an-account-using-a-client/ta-p/202
+

--- a/docs/lti-integration.md
+++ b/docs/lti-integration.md
@@ -239,6 +239,9 @@ the Code.org LTI app, and select `API Info`.
 1. Copy the Client ID displayed in the pop up modal
 1. Paste this Client ID into the [Code.org Registration Portal][lti-integration-portal]
 
+![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/a74180c2-84a1-46ad-bb22-f945a75c1642)
+
+
 ## Using Code.org as an LTI Tool
 
 To install Code.org in your Canvas course, first ensure the LTI Key is enabled from the admin panel. Next, select `Code.org` from the `External Tool` dialogue when adding an Item to your App Modules. **Code.org must be configured to open in a new tab, and will not work in an iFrame.**

--- a/docs/lti-integration.md
+++ b/docs/lti-integration.md
@@ -9,10 +9,10 @@ LTI Tool in Canvas and Schoology. Completing the following steps will generate a
 `Client ID`.
 
 Please supply the Client ID to Code.org via
-[this form][lti-integration-form] to register your LMS & complete your 
+[this portal][lti-integration-portal] to register your LMS & complete your 
 installation.
 
-[lti-integration-form]: https://studio.code.org/lti/v1/integrations
+[lti-integration-portal]: https://studio.code.org/lti/v1/integrations
 
 ## Table of Contents
 
@@ -21,8 +21,7 @@ installation.
 
 ## Installing Code.org in Canvas
 
-Visual guides for Steps 1 - 3 can be [found here][install-canvas], and for Step
-4 [here][configure-canvas]
+Visual guides for Steps 1 - 3 can be [found here][install-canvas]
 
 ### Step 1: Create your LTI Key
 
@@ -142,48 +141,11 @@ After configuring & saving your LTI Key, you will be redirected to your table of
 
 1. Navigate to the Code.org Key you just created
 1. Copy the 18-digit numerical code in the Details column, e.g.: `000000000123456789` - this is your Client ID
-1. Paste this Client ID into the [Code.org Registration Form][lti-integration-form], and keep it handy for the next step
+1. Paste this Client ID into the [Code.org Registration Portal][lti-integration-portal]
 
 ![image](https://github.com/code-dot-org/code-dot-org/assets/1631660/1c0c9ad3-0b97-42b0-b70c-6f0738db4636)
 
-### Step 4: Generate your Deployment ID
-
-Now that you have the LTI Key, you need to configure the Code.org LTI App to
-generate a `Deployment ID`. You can follow the steps below or [refer to the visual instructions here][configure-canvas]
-
-1. Visit the `Admin` panel and click `Settings`
-1. Click the `Apps` tab
-1. Click `View App Configurations`
-1. Click the `Add App` button
-1. Select `By Client ID` in the Configuration Type drop-down menu
-1. Paste your `Client ID` copied from Step 3
-1. Click `Submit`
-1. Click the `Install` button to confirm your installation
-
-<p align="center">
-<img width="430" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/1631660/29eb6290-98e5-4891-be9a-ca241d7026dd">
-</p>   
-
-
-After installing the application, you can now generate a `Deployment ID`
-
-1. View your app on the External Apps page
-1. Click the `Settings` (gear) icon
-1. Click `Deployment ID`
-1. Copy the `Deployment ID` string and submit it into the [Code.org Registration Form][lti-integration-form]
-
-![image](https://github.com/code-dot-org/code-dot-org/assets/1631660/bcf40fa9-be26-42cd-865d-7e34e600c4c5)
-
-
-<p align="center">
-<img width="430" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/1631660/8ce5ff5d-cbf0-4942-8329-bca57ac85360">
-</p>   
-
-
-
-### Step 5: Submit the Code.org Registration Form
-
-Now that you've created and entered both your `Client ID` (Step 3) & `Deployment ID` (Step 4) into the [Code.org Registration Form][lti-integration-form], submit the form and wait for a confirmation email from our team! You can expect this confirmation mail within 1 - 2 business days.
+Now you can navigate to
 
 ## Installing Code.org in Schoology
 
@@ -192,6 +154,8 @@ for adding a new App to Schoology.
 
 Currently, Code.org's LTI Tool is not listed in Schoology's App Store, and must
 be manually installed.
+
+### Step 1: Create your LTI Key
 
 1. Navigate to https://app.schoology.com/apps/publisher
 2. Fill in required fields
@@ -232,15 +196,17 @@ be manually installed.
 14. Click toggle to accept Schoology Terms of Use
 15. Click `Save Changes`
 
+### Step 2: Configure the App
+
 After you install the App to the district, you also need to install it to the
-areas where it should appear (Courses, Groups, etc). Click the ‘Install’ button
+areas where it should appear (Courses, Groups, etc). Click the `Install` button
 next to your app on the District App list to complete that additional installation
 process.
 
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/f78e0051-922e-4eff-b96f-8bf99c1d4768)
 
 
-This will open a modal, where you'll need to accept and continue. When prompted
+1. This will open a modal, where you'll need to accept and continue. When prompted
 for where you want to install it, click `Add to Organization`.
 
 
@@ -248,13 +214,13 @@ for where you want to install it, click `Add to Organization`.
 <img width="368" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/03e2dd29-1f23-4408-867a-2c8fde1e74d2">
 </p>
 
-This will take you to the Organization Apps page, where you will click on the
+2. This will take you to the Organization Apps page, where you will click on the
 `Install/Remove` button for the Code.org tool.
 
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/8ac87431-6a21-4b6c-af94-0cd9696260a4)
 
 
-A modal will open, where you'll be prompted to select who and where this app
+3. A modal will open, where you'll be prompted to select who and where this app
 will be available for.
 
 
@@ -262,9 +228,16 @@ will be available for.
 <img width="496" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/08b2fc57-6e39-42d1-aa2b-29f5e4ef5665">
 </p>
 
-Once you make your selection, click `Submit`.
+4. Once you make your selection, click `Submit`.
 
-Code.org's LTI app is now ready to use in your Schoology account!
+### Step 3: Copy your Client ID
+
+Next we will retrive the Client ID
+
+1. From the My Developer Apps section, click on the options dropdown for
+the Code.org LTI app, and select `API Info`.
+1. Copy the Client ID displayed in the pop up modal
+1. Paste this Client ID into the [Code.org Registration Portal][lti-integration-portal]
 
 ## Using Code.org as an LTI Tool
 
@@ -282,5 +255,4 @@ these instructions, or refer to the steps above for Code.org specific details.
 - [Configure the LTI app][configure-canvas] to generate the Deployment ID
 
 [install-canvas]: https://community.canvaslms.com/t5/Admin-Guide/How-do-I-configure-an-LTI-key-for-an-account/ta-p/140
-[configure-canvas]: https://community.canvaslms.com/t5/Admin-Guide/How-do-I-configure-an-external-app-for-an-account-using-a-client/ta-p/202
 

--- a/docs/lti-integration.md
+++ b/docs/lti-integration.md
@@ -218,8 +218,9 @@ for where you want to install it, click `Add to Organization`.
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/8ac87431-6a21-4b6c-af94-0cd9696260a4)
 
 
-4. A modal will open, where you'll be prompted to select who and where this app
-will be available for.
+4. A modal will open, where you'll be prompted to select where and for whom this
+app will be available.
+
 
 
 <p align="center">

--- a/docs/lti-integration.md
+++ b/docs/lti-integration.md
@@ -200,11 +200,10 @@ be manually installed.
   - Category: `Technology`
   - Recommended For: `Instructors` and `Students`
   - Available For: `Only people in my school`
+
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/395e733f-72ea-41f7-af11-613130e89bfa)
 
-
 3. You can leave the App logo Feature graphic empty
-
 4. Type of App: `LTI 1.3 App`
 5. Select where the tool can be installed, `Can Be Installed For`:
   - Users
@@ -227,6 +226,7 @@ be manually installed.
   - `display_name=$User.username`
 12. OIDC Login Init Url: `https://studio.code.org/lti/v1/login`
 13. Redirect URLs: `https://studio.code.org/lti/v1/authenticate`
+
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/96f09b29-3c90-46cd-a60d-2f206abf8ca4)
 
 14. Click toggle to accept Schoology Terms of Use
@@ -236,22 +236,28 @@ After you install the App to the district, you also need to install it to the
 areas where it should appear (Courses, Groups, etc). Click the ‘Install’ button
 next to your app on the District App list to complete that additional installation
 process.
+
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/f78e0051-922e-4eff-b96f-8bf99c1d4768)
 
 
 This will open a modal, where you'll need to accept and continue. When prompted
 for where you want to install it, click `Add to Organization`.
+
+
 <p align="center">
 <img width="368" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/03e2dd29-1f23-4408-867a-2c8fde1e74d2">
 </p>
 
 This will take you to the Organization Apps page, where you will click on the
 `Install/Remove` button for the Code.org tool.
+
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/8ac87431-6a21-4b6c-af94-0cd9696260a4)
 
 
 A modal will open, where you'll be prompted to select who and where this app
 will be available for.
+
+
 <p align="center">
 <img width="496" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/08b2fc57-6e39-42d1-aa2b-29f5e4ef5665">
 </p>

--- a/docs/lti-integration.md
+++ b/docs/lti-integration.md
@@ -188,8 +188,7 @@ be manually installed.
   - `display_name=$User.username`
 12. OIDC Login Init Url: `https://studio.code.org/lti/v1/login`
 13. Redirect URLs: `https://studio.code.org/lti/v1/authenticate`
-
-![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/96f09b29-3c90-46cd-a60d-2f206abf8ca4)
+![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/c1be38ac-a136-4e47-9bfb-b41f3ece713f)
 
 14. Click toggle to accept Schoology Terms of Use
 15. Click `Save Changes`

--- a/docs/lti-integration.md
+++ b/docs/lti-integration.md
@@ -167,7 +167,8 @@ be manually installed.
 
 3. You can leave the App logo Feature graphic empty
 4. Type of App: `LTI 1.3 App`
-5. Select where the tool can be installed, `Can Be Installed For`:
+5. Uncheck the box for `Launch app in Schoology`
+6. Select where the tool can be installed, `Can Be Installed For`:
     - Users
       - App Center Dropdown
       - User Profile Left Navigation Menu
@@ -177,33 +178,33 @@ be manually installed.
       - External Tool
     - Groups
     - Resources
-6. Configuration Type: `Manual`
-7. Privacy: `Send Name and Email/Username of user who launches the tool`
-8. Check `Names and Roles Services`, leave `Assignment and Grade Services` unchecked
+7. Configuration Type: `Manual`
+8. Privacy: `Send Name and Email/Username of user who launches the tool`
+9. Check `Names and Roles Services`, leave `Assignment and Grade Services` unchecked
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/73ab74e1-4c70-4ba6-8c41-5e5d46bc543f)
 
-9. JWKS URL: `https://studio.code.org/oauth/jwks`
-10. Domain/URL: `https://studio.code.org/lti/v1/sync_course`
-11. Custom Parameters:
+10. JWKS URL: `https://studio.code.org/oauth/jwks`
+11. Domain/URL: `https://studio.code.org/lti/v1/sync_course`
+12. Custom Parameters:
     - `display_name=$User.username`
-12. OIDC Login Init Url: `https://studio.code.org/lti/v1/login`
-13. Redirect URLs: `https://studio.code.org/lti/v1/authenticate`
-![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/c1be38ac-a136-4e47-9bfb-b41f3ece713f)
+13. OIDC Login Init Url: `https://studio.code.org/lti/v1/login`
+14. Redirect URLs: `https://studio.code.org/lti/v1/authenticate`
 
-14. Click toggle to accept Schoology Terms of Use
-15. Click `Save Changes`
+![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/2bcfef58-57b2-4306-9558-4e7acd189bfa)
 
-### Step 2: Configure the App
+16. Click toggle to accept Schoology Terms of Use
+17. Click `Submit`
 
-After you install the App to the district, you also need to install it to the
-areas where it should appear (Courses, Groups, etc). Click the `Install` button
-next to your app on the District App list to complete that additional installation
-process.
+### Step 2: Install the App
 
-![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/f78e0051-922e-4eff-b96f-8bf99c1d4768)
+After you create the App, you'll be directed to the page to install the App in
+your district.
 
+1. Click on the `Install LTI 1.3 App` button
 
-1. This will open a modal, where you'll need to accept and continue. When prompted
+![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/2001fc33-0f5f-4f73-ab38-0ebdb6c2db0e)
+
+2. This will open a modal, where you'll need to accept and continue. When prompted
 for where you want to install it, click `Add to Organization`.
 
 
@@ -211,13 +212,13 @@ for where you want to install it, click `Add to Organization`.
 <img width="368" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/03e2dd29-1f23-4408-867a-2c8fde1e74d2">
 </p>
 
-2. This will take you to the Organization Apps page, where you will click on the
+3. This will take you to the Organization Apps page, where you will click on the
 `Install/Remove` button for the Code.org tool.
 
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/8ac87431-6a21-4b6c-af94-0cd9696260a4)
 
 
-3. A modal will open, where you'll be prompted to select who and where this app
+4. A modal will open, where you'll be prompted to select who and where this app
 will be available for.
 
 
@@ -225,7 +226,13 @@ will be available for.
 <img width="496" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/08b2fc57-6e39-42d1-aa2b-29f5e4ef5665">
 </p>
 
-4. Once you make your selection, click `Submit`.
+5. Once you make your selection, click `Submit`.
+6. From the Organization Apps page, click the `App Center` link at the top left
+of the page, which will take you back to the My Developer Apps section, and we
+will move on to Step 3.
+
+![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/4b774828-3b65-4151-ba3a-9eb2c512c1a0)
+
 
 ### Step 3: Copy your Client ID
 

--- a/docs/lti-integration.md
+++ b/docs/lti-integration.md
@@ -178,7 +178,7 @@ be manually installed.
     - Groups
     - Resources
 6. Configuration Type: `Manual`
-7. Privacy: `Send Name and Email/Username of user who luanches the tool`
+7. Privacy: `Send Name and Email/Username of user who launches the tool`
 8. Check `Names and Roles Services`, leave `Assignment and Grade Services` unchecked
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/73ab74e1-4c70-4ba6-8c41-5e5d46bc543f)
 
@@ -241,9 +241,9 @@ the Code.org LTI app, and select `API Info`.
 
 ## Using Code.org as an LTI Tool
 
-To install Code.org in your Canvas course, first ensure the LTI Key is enabled from the admin panel. Next, select `Code.org` from the `External Tool` dialogue when adding an Item to your App Modules. **Code.org must be configured to open in a new tab, and will not work in an iFrame.**
+- To install Code.org in your Canvas course, first ensure the LTI Key is enabled from the admin panel. Next, select `Code.org` from the `External Tool` dialogue when adding an Item to your App Modules. **Code.org must be configured to open in a new tab, and will not work in an iFrame.**
 
-The Code.org LTI integration does not yet support Deep Linking. Some of the placments for LTI Tools in Canvas will trigger a Deep Link request that is not curently supported by Code.org.
+- The Code.org LTI integration does not yet support Deep Linking. Some of the placments for LTI Tools- will trigger a Deep Link request that is not curently supported by Code.org.
 
 
 ## References
@@ -252,7 +252,6 @@ Canvas provides installation and configuration instructions for LTI Tools. Use
 these instructions, or refer to the steps above for Code.org specific details.
 
 - [Create a new LTI Key][install-canvas] which configures Code.org as an LTI Tool
-- [Configure the LTI app][configure-canvas] to generate the Deployment ID
 
 [install-canvas]: https://community.canvaslms.com/t5/Admin-Guide/How-do-I-configure-an-LTI-key-for-an-account/ta-p/140
 

--- a/docs/lti-integration.md
+++ b/docs/lti-integration.md
@@ -157,26 +157,26 @@ be manually installed.
 
 1. Navigate to https://app.schoology.com/apps/publisher
 2. Fill in required fields
-  - App Name: `Code.org`
-  - App Description: `Code.org LTI Tool`
-  - Category: `Technology`
-  - Recommended For: `Instructors` and `Students`
-  - Available For: `Only people in my school`
+    - App Name: `Code.org`
+    - App Description: `Code.org LTI Tool`
+    - Category: `Technology`
+    - Recommended For: `Instructors` and `Students`
+    - Available For: `Only people in my school`
 
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/02898ddb-1155-4aa0-a39a-7c518e4e2a38)
 
 3. You can leave the App logo Feature graphic empty
 4. Type of App: `LTI 1.3 App`
 5. Select where the tool can be installed, `Can Be Installed For`:
-  - Users
-    - App Center Dropdown
-    - User Profile Left Navigation Menu
-  - Courses
-    - Left Navigation
-    - Rich Text Editor
-    - External Tool
-  - Groups
-  - Resources
+    - Users
+      - App Center Dropdown
+      - User Profile Left Navigation Menu
+    - Courses
+      - Left Navigation
+      - Rich Text Editor
+      - External Tool
+    - Groups
+    - Resources
 6. Configuration Type: `Manual`
 7. Privacy: `Send Name and Email/Username of user who luanches the tool`
 8. Check `Names and Roles Services`, leave `Assignment and Grade Services` unchecked
@@ -185,7 +185,7 @@ be manually installed.
 9. JWKS URL: `https://studio.code.org/oauth/jwks`
 10. Domain/URL: `https://studio.code.org/lti/v1/sync_course`
 11. Custom Parameters:
-  - `display_name=$User.username`
+    - `display_name=$User.username`
 12. OIDC Login Init Url: `https://studio.code.org/lti/v1/login`
 13. Redirect URLs: `https://studio.code.org/lti/v1/authenticate`
 ![image](https://github.com/code-dot-org/code-dot-org/assets/8847422/c1be38ac-a136-4e47-9bfb-b41f3ece713f)


### PR DESCRIPTION
This PR adds Schoology onboarding/LTI tool installation instructions. It also removes deprecated references to Deployment ID for Canvas, as well as points to the LTI Installation portal rather than the Google doc.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[Jira](https://codedotorg.atlassian.net/browse/P20-708)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
