### PR TITLE
Rework AI Chat types (part 1)

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -18,7 +18,7 @@ import {
   AiCustomizations,
   ModelCardInfo,
   Visibility,
-  LevelAiChatSettings,
+  LevelAichatSettings,
 } from '../types';
 import {RootState} from '@cdo/apps/types/redux';
 
@@ -212,14 +212,14 @@ const aichatSlice = createSlice({
     setStartingAiCustomizations: (
       state,
       action: PayloadAction<{
-        levelAiChatSettings?: LevelAiChatSettings;
+        levelAichatSettings?: LevelAichatSettings;
         studentAiCustomizations: AiCustomizations;
       }>
     ) => {
-      const {levelAiChatSettings, studentAiCustomizations} = action.payload;
+      const {levelAichatSettings, studentAiCustomizations} = action.payload;
 
       let reconciledAiCustomizations: AiCustomizations = {
-        ...(levelAiChatSettings?.initialCustomizations ||
+        ...(levelAichatSettings?.initialCustomizations ||
           EMPTY_AI_CUSTOMIZATIONS),
       };
 
@@ -227,7 +227,7 @@ const aichatSlice = createSlice({
         const customization = customizationUntyped as keyof AiCustomizations;
 
         if (
-          (levelAiChatSettings?.visibilities || DEFAULT_VISIBILITIES)[
+          (levelAichatSettings?.visibilities || DEFAULT_VISIBILITIES)[
             customization
           ] === Visibility.EDITABLE &&
           studentAiCustomizations[customization]
@@ -242,7 +242,7 @@ const aichatSlice = createSlice({
       state.previouslySavedAiCustomizations = reconciledAiCustomizations;
       state.currentAiCustomizations = reconciledAiCustomizations;
       state.fieldVisibilities =
-        levelAiChatSettings?.visibilities || DEFAULT_VISIBILITIES;
+        levelAichatSettings?.visibilities || DEFAULT_VISIBILITIES;
     },
     setPreviouslySavedAiCustomizations: (
       state,

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -33,13 +33,13 @@ export interface AichatLevelProperties extends LevelProperties {
   // ---
 
   /**
-   * Initial AI customizations set by the level.
+   * Initial AI chat customizations set by the level.
    * For each field, levelbuilders may define the initial default value,
    * and visibility (hidden, readonly, or editable).
    * Visibility is not editable by the student; students can only change
    * the value if it is set to editable.
    */
-  aiChatSettings?: LevelAiChatSettings;
+  aichatSettings?: LevelAichatSettings;
   initialAiCustomizations?: LevelAiCustomizations;
 }
 
@@ -72,7 +72,7 @@ export enum Visibility {
  * Level-defined AI customizations for student chat bots set by levelbuilders on the level's properties.
  * Levelbuilders can define initial default values for each field, as well as their visibilities.
  */
-export interface LevelAiChatSettings {
+export interface LevelAichatSettings {
   initialCustomizations: AiCustomizations;
   visibilities: {[key in keyof AiCustomizations]: Visibility};
   /** If the presentation panel is hidden from the student. */

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -39,6 +39,7 @@ export interface AichatLevelProperties extends LevelProperties {
    * Visibility is not editable by the student; students can only change
    * the value if it is set to editable.
    */
+  aiChatSettings?: LevelAiChatSettings;
   initialAiCustomizations?: LevelAiCustomizations;
 }
 
@@ -65,6 +66,13 @@ export enum Visibility {
   HIDDEN = 'hidden',
   READONLY = 'readonly',
   EDITABLE = 'editable',
+}
+
+export interface LevelAiChatSettings {
+  initialCustomizations: AiCustomizations;
+  visibilities: {[key in keyof AiCustomizations]: Visibility};
+  /** If the presentation panel is hidden from the student. */
+  hidePresentationPanel?: boolean;
 }
 
 /**

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -68,6 +68,10 @@ export enum Visibility {
   EDITABLE = 'editable',
 }
 
+/**
+ * Level-defined AI customizations for student chat bots set by levelbuilders on the level's properties.
+ * Levelbuilders can define initial default values for each field, as well as their visibilities.
+ */
 export interface LevelAiChatSettings {
   initialCustomizations: AiCustomizations;
   visibilities: {[key in keyof AiCustomizations]: Visibility};

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -26,10 +26,10 @@ const AichatView: React.FunctionComponent = () => {
     dispatch(sendSuccessReport('aichat'));
   }, [dispatch]);
 
-  const levelAiChatSettings = useAppSelector(
+  const levelAichatSettings = useAppSelector(
     state =>
       (state.lab.levelProperties as AichatLevelProperties | undefined)
-        ?.aiChatSettings
+        ?.aichatSettings
   );
 
   const initialSources = useAppSelector(
@@ -40,11 +40,11 @@ const AichatView: React.FunctionComponent = () => {
     const studentAiCustomizations = JSON.parse(initialSources);
     dispatch(
       setStartingAiCustomizations({
-        levelAiChatSettings,
+        levelAichatSettings,
         studentAiCustomizations,
       })
     );
-  }, [dispatch, initialSources, levelAiChatSettings]);
+  }, [dispatch, initialSources, levelAichatSettings]);
 
   const {botName} = useAppSelector(
     state => state.aichat.currentAiCustomizations
@@ -77,7 +77,7 @@ const AichatView: React.FunctionComponent = () => {
 
   return (
     <>
-      {!levelAiChatSettings?.hidePresentationPanel && (
+      {!levelAichatSettings?.hidePresentationPanel && (
         <div className={moduleStyles.viewModeButtons}>
           <SegmentedButtons {...viewModeButtonsProps} />
         </div>

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -17,7 +17,6 @@ import SegmentedButtons, {
 } from '@cdo/apps/componentLibrary/segmentedButtons/SegmentedButtons';
 import moduleStyles from './aichatView.module.scss';
 import {AichatLevelProperties, ViewMode} from '@cdo/apps/aichat/types';
-import {EMPTY_AI_CUSTOMIZATIONS} from '@cdo/apps/aichat/views/modelCustomization/constants';
 
 const AichatView: React.FunctionComponent = () => {
   const [viewMode, setViewMode] = useState<string>(ViewMode.EDIT);
@@ -27,12 +26,11 @@ const AichatView: React.FunctionComponent = () => {
     dispatch(sendSuccessReport('aichat'));
   }, [dispatch]);
 
-  const levelAiCustomizationsWithVisibility = useAppSelector(
+  const levelAiChatSettings = useAppSelector(
     state =>
       (state.lab.levelProperties as AichatLevelProperties | undefined)
-        ?.initialAiCustomizations || EMPTY_AI_CUSTOMIZATIONS
+        ?.aiChatSettings
   );
-  const {hidePresentationPanel} = levelAiCustomizationsWithVisibility;
 
   const initialSources = useAppSelector(
     state => (state.lab.initialSources?.source as string) || '{}'
@@ -42,11 +40,11 @@ const AichatView: React.FunctionComponent = () => {
     const studentAiCustomizations = JSON.parse(initialSources);
     dispatch(
       setStartingAiCustomizations({
-        levelAiCustomizationsWithVisibility,
+        levelAiChatSettings,
         studentAiCustomizations,
       })
     );
-  }, [dispatch, initialSources, levelAiCustomizationsWithVisibility]);
+  }, [dispatch, initialSources, levelAiChatSettings]);
 
   const {botName} = useAppSelector(
     state => state.aichat.currentAiCustomizations
@@ -79,7 +77,7 @@ const AichatView: React.FunctionComponent = () => {
 
   return (
     <>
-      {!hidePresentationPanel && (
+      {!levelAiChatSettings?.hidePresentationPanel && (
         <div className={moduleStyles.viewModeButtons}>
           <SegmentedButtons {...viewModeButtonsProps} />
         </div>

--- a/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
+++ b/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
@@ -1,27 +1,19 @@
 import React from 'react';
 
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {AichatLevelProperties} from '../types';
 import Tabs, {Tab} from './tabs/Tabs';
 import PromptCustomization from './modelCustomization/PromptCustomization';
 import RetrievalCustomization from './modelCustomization/RetrievalCustomization';
 import PublishNotes from './modelCustomization/PublishNotes';
 import styles from './model-customization-workspace.module.scss';
-import {EMPTY_AI_CUSTOMIZATIONS} from './modelCustomization/constants';
 import {isVisible} from './modelCustomization/utils';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 const ModelCustomizationWorkspace: React.FunctionComponent = () => {
-  const {retrievalContexts, modelCardInfo, botName, temperature, systemPrompt} =
-    useAppSelector(
-      state =>
-        (state.lab.levelProperties as AichatLevelProperties | undefined)
-          ?.initialAiCustomizations || EMPTY_AI_CUSTOMIZATIONS
-    );
+  const {botName, temperature, systemPrompt, retrievalContexts, modelCardInfo} =
+    useAppSelector(state => state.aichat.fieldVisibilities);
 
   const showPromptCustomization =
-    isVisible(botName.visibility) ||
-    isVisible(temperature.visibility) ||
-    isVisible(systemPrompt.visibility);
+    isVisible(botName) || isVisible(temperature) || isVisible(systemPrompt);
 
   return (
     <div className={styles.modelCustomizationWorkspace}>
@@ -32,11 +24,11 @@ const ModelCustomizationWorkspace: React.FunctionComponent = () => {
               title: 'Setup',
               content: <PromptCustomization />,
             },
-            isVisible(retrievalContexts.visibility) && {
+            isVisible(retrievalContexts) && {
               title: 'Retrieval',
               content: <RetrievalCustomization />,
             },
-            isVisible(modelCardInfo.visibility) && {
+            isVisible(modelCardInfo) && {
               title: 'Publish',
               content: <PublishNotes />,
             },

--- a/apps/src/aichat/views/modelCustomization/PromptCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/PromptCustomization.tsx
@@ -8,30 +8,23 @@ import {
 } from '../../redux/aichatRedux';
 import styles from '../model-customization-workspace.module.scss';
 import {
-  EMPTY_AI_CUSTOMIZATIONS,
   MAX_TEMPERATURE,
   MIN_TEMPERATURE,
   SET_TEMPERATURE_STEP,
 } from './constants';
 import {isVisible, isDisabled} from './utils';
-import {AichatLevelProperties} from '@cdo/apps/aichat/types';
 
 const PromptCustomization: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
-
   const {botName, temperature, systemPrompt} = useAppSelector(
-    state =>
-      (state.lab.levelProperties as AichatLevelProperties | undefined)
-        ?.initialAiCustomizations || EMPTY_AI_CUSTOMIZATIONS
+    state => state.aichat.fieldVisibilities
   );
   const aiCustomizations = useAppSelector(
     state => state.aichat.currentAiCustomizations
   );
 
   const allFieldsDisabled =
-    isDisabled(botName.visibility) &&
-    isDisabled(temperature.visibility) &&
-    isDisabled(systemPrompt.visibility);
+    isDisabled(botName) && isDisabled(temperature) && isDisabled(systemPrompt);
 
   const onUpdate = useCallback(
     () => dispatch(updateAiCustomization()),
@@ -41,7 +34,7 @@ const PromptCustomization: React.FunctionComponent = () => {
   return (
     <div className={styles.verticalFlexContainer}>
       <div>
-        {isVisible(botName.visibility) && (
+        {isVisible(botName) && (
           <div className={styles.inputContainer}>
             <label htmlFor="chatbot-name">
               <StrongText>Chatbot name</StrongText>
@@ -49,7 +42,7 @@ const PromptCustomization: React.FunctionComponent = () => {
             <input
               id="chatbot-name"
               value={aiCustomizations.botName}
-              disabled={isDisabled(botName.visibility)}
+              disabled={isDisabled(botName)}
               onChange={event =>
                 dispatch(
                   setAiCustomizationProperty({
@@ -61,7 +54,7 @@ const PromptCustomization: React.FunctionComponent = () => {
             />
           </div>
         )}
-        {isVisible(temperature.visibility) && (
+        {isVisible(temperature) && (
           <div className={styles.inputContainer}>
             <div className={styles.horizontalFlexContainer}>
               <label htmlFor="temperature">
@@ -75,7 +68,7 @@ const PromptCustomization: React.FunctionComponent = () => {
               max={MAX_TEMPERATURE}
               step={SET_TEMPERATURE_STEP}
               value={aiCustomizations.temperature}
-              disabled={isDisabled(temperature.visibility)}
+              disabled={isDisabled(temperature)}
               onChange={event =>
                 dispatch(
                   setAiCustomizationProperty({
@@ -87,7 +80,7 @@ const PromptCustomization: React.FunctionComponent = () => {
             />
           </div>
         )}
-        {isVisible(systemPrompt.visibility) && (
+        {isVisible(systemPrompt) && (
           <div className={styles.inputContainer}>
             <label htmlFor="system-prompt">
               <StrongText>System prompt</StrongText>
@@ -95,7 +88,7 @@ const PromptCustomization: React.FunctionComponent = () => {
             <textarea
               id="system-prompt"
               value={aiCustomizations.systemPrompt}
-              disabled={isDisabled(systemPrompt.visibility)}
+              disabled={isDisabled(systemPrompt)}
               onChange={event =>
                 dispatch(
                   setAiCustomizationProperty({

--- a/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
+++ b/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
@@ -2,26 +2,20 @@ import React, {useCallback} from 'react';
 
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
-import {
-  EMPTY_AI_CUSTOMIZATIONS,
-  MODEL_CARD_FIELDS_AND_LABELS,
-} from './constants';
+import {MODEL_CARD_FIELDS_AND_LABELS} from './constants';
 import {isVisible, isDisabled} from './utils';
 import {
   setModelCardProperty,
   updateAiCustomization,
 } from '@cdo/apps/aichat/redux/aichatRedux';
 import styles from '../model-customization-workspace.module.scss';
-import {AichatLevelProperties} from '@cdo/apps/aichat/types';
 
 const PublishNotes: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
 
-  const {visibility} = useAppSelector(
-    state =>
-      (state.lab.levelProperties as AichatLevelProperties | undefined)
-        ?.initialAiCustomizations || EMPTY_AI_CUSTOMIZATIONS
-  ).modelCardInfo;
+  const visibility = useAppSelector(
+    state => state.aichat.fieldVisibilities.modelCardInfo
+  );
   const {modelCardInfo} = useAppSelector(
     state => state.aichat.currentAiCustomizations
   );

--- a/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
@@ -10,19 +10,14 @@ import {
   setAiCustomizationProperty,
   updateAiCustomization,
 } from '@cdo/apps/aichat/redux/aichatRedux';
-import {AichatLevelProperties} from '@cdo/apps/aichat/types';
-import {EMPTY_AI_CUSTOMIZATIONS} from '@cdo/apps/aichat/views/modelCustomization/constants';
 
 const RetrievalCustomization: React.FunctionComponent = () => {
   const [newRetrievalContext, setNewRetrievalContext] = useState('');
 
   const dispatch = useAppDispatch();
-
-  const {visibility} = useAppSelector(
-    state =>
-      (state.lab.levelProperties as AichatLevelProperties | undefined)
-        ?.initialAiCustomizations || EMPTY_AI_CUSTOMIZATIONS
-  ).retrievalContexts;
+  const visibility = useAppSelector(
+    state => state.aichat.fieldVisibilities.retrievalContexts
+  );
   const {retrievalContexts} = useAppSelector(
     state => state.aichat.currentAiCustomizations
   );

--- a/apps/src/aichat/views/modelCustomization/constants.ts
+++ b/apps/src/aichat/views/modelCustomization/constants.ts
@@ -1,6 +1,5 @@
 import {
   AiCustomizations,
-  LevelAiChatSettings,
   LevelAiCustomizations,
   ModelCardInfo,
   Visibility,
@@ -55,9 +54,4 @@ export const DEFAULT_VISIBILITIES: {
   systemPrompt: Visibility.EDITABLE,
   retrievalContexts: Visibility.EDITABLE,
   modelCardInfo: Visibility.EDITABLE,
-};
-
-export const EMPTY_LEVEL_AI_CHAT_SETTINGS: LevelAiChatSettings = {
-  initialCustomizations: EMPTY_AI_CUSTOMIZATIONS,
-  visibilities: DEFAULT_VISIBILITIES,
 };

--- a/apps/src/aichat/views/modelCustomization/constants.ts
+++ b/apps/src/aichat/views/modelCustomization/constants.ts
@@ -1,5 +1,6 @@
 import {
   AiCustomizations,
+  LevelAiChatSettings,
   LevelAiCustomizations,
   ModelCardInfo,
   Visibility,
@@ -26,7 +27,7 @@ export const EMPTY_MODEL_CARD_INFO: ModelCardInfo = {
   exampleTopics: [],
 };
 
-export const EMPTY_AI_CUSTOMIZATIONS: LevelAiCustomizations = {
+export const EMPTY_AI_LEVEL_CUSTOMIZATIONS: LevelAiCustomizations = {
   botName: {value: '', visibility: Visibility.EDITABLE},
   temperature: {value: 0.5, visibility: Visibility.EDITABLE},
   systemPrompt: {value: '', visibility: Visibility.EDITABLE},
@@ -38,10 +39,25 @@ export const EMPTY_AI_CUSTOMIZATIONS: LevelAiCustomizations = {
   hidePresentationPanel: false,
 };
 
-export const EMPTY_AI_CUSTOMIZATIONS_STUDENT: AiCustomizations = {
+export const EMPTY_AI_CUSTOMIZATIONS: AiCustomizations = {
   botName: '',
   temperature: 0.5,
   systemPrompt: '',
   retrievalContexts: [],
   modelCardInfo: EMPTY_MODEL_CARD_INFO,
+};
+
+export const DEFAULT_VISIBILITIES: {
+  [key in keyof AiCustomizations]: Visibility;
+} = {
+  botName: Visibility.EDITABLE,
+  temperature: Visibility.EDITABLE,
+  systemPrompt: Visibility.EDITABLE,
+  retrievalContexts: Visibility.EDITABLE,
+  modelCardInfo: Visibility.EDITABLE,
+};
+
+export const EMPTY_LEVEL_AI_CHAT_SETTINGS: LevelAiChatSettings = {
+  initialCustomizations: EMPTY_AI_CUSTOMIZATIONS,
+  visibilities: DEFAULT_VISIBILITIES,
 };

--- a/apps/src/lab2/levelEditors/aiCustomizations/EditAiCustomizations.tsx
+++ b/apps/src/lab2/levelEditors/aiCustomizations/EditAiCustomizations.tsx
@@ -16,7 +16,7 @@ import {
   MIN_TEMPERATURE,
   SET_TEMPERATURE_STEP,
   EMPTY_MODEL_CARD_INFO,
-  EMPTY_AI_CUSTOMIZATIONS,
+  EMPTY_AI_LEVEL_CUSTOMIZATIONS,
 } from '@cdo/apps/aichat/views/modelCustomization/constants';
 import MultiItemInput from './MultiItemInput';
 import FieldSection from './FieldSection';
@@ -51,7 +51,7 @@ const EditAiCustomizations: React.FunctionComponent<{
 }> = ({initialCustomizations}) => {
   const [aiCustomizations, setAiCustomizations] =
     useState<LevelAiCustomizations>(
-      initialCustomizations || EMPTY_AI_CUSTOMIZATIONS
+      initialCustomizations || EMPTY_AI_LEVEL_CUSTOMIZATIONS
     );
 
   const setPropertyVisibility = useCallback(


### PR DESCRIPTION
First part of reworking some of the AI Chat types to make them a bit easier to work with. Notably, this turns the `LevelAiCustomizations` type into a `LevelAiSettings` type that lists initial level customizations and visibilities separately, for easier comparison and lookup. 

This first part only updates the user-facing code (effectively anything in apps/src/aichat). The second part will complete the updates in the levelbuilder edit code (apps/lab2/levelEditors). Just splitting these apart for easier reviewing/readability, but I'll plan on merging them together to avoid breaking functionality.

## Links

https://codedotorg.atlassian.net/browse/LABS-645

## Testing story

Tested with allthethings AI Chat levels. Tested basic functionality and project saving/loading.