### PR TITLE
Fix bug where site crashes on clever login

### DIFF
--- a/apps/src/code-studio/responsiveRedux.js
+++ b/apps/src/code-studio/responsiveRedux.js
@@ -17,7 +17,14 @@ const Breakpoints = [
 ];
 
 export function getResponsiveBreakpoint(width) {
-  return Breakpoints.find(({breakpoint}) => width > breakpoint).responsiveSize;
+  const responsiveSize = Breakpoints.find(({breakpoint}) => width > breakpoint);
+  if (responsiveSize === undefined) {
+    console.error(
+      `No responsive size found for width ${width}, defaulting to xs`
+    );
+    return ResponsiveSize.xs;
+  }
+  return responsiveSize.responsiveSize;
 }
 
 const initialState = {

--- a/apps/test/unit/code-studio/responsiveReduxTest.js
+++ b/apps/test/unit/code-studio/responsiveReduxTest.js
@@ -1,0 +1,27 @@
+import {expect} from '../../util/reconfiguredChai';
+import sinon from 'sinon';
+
+import {
+  getResponsiveBreakpoint,
+  ResponsiveSize,
+} from '@cdo/apps/code-studio/responsiveRedux';
+
+describe('responsiveRedux', () => {
+  it('getResponsiveBreakpoint returns lg', () => {
+    expect(getResponsiveBreakpoint(1000)).to.equal(ResponsiveSize.lg);
+  });
+  it('getResponsiveBreakpoint returns md', () => {
+    expect(getResponsiveBreakpoint(800)).to.equal(ResponsiveSize.md);
+  });
+  it('getResponsiveBreakpoint returns sm', () => {
+    expect(getResponsiveBreakpoint(700)).to.equal(ResponsiveSize.sm);
+  });
+  it('getResponsiveBreakpoint returns xs', () => {
+    expect(getResponsiveBreakpoint(500)).to.equal(ResponsiveSize.xs);
+  });
+  it('getResponsiveBreakpoint returns xs if 0', () => {
+    sinon.stub(console, 'error');
+    expect(getResponsiveBreakpoint(0)).to.equal(ResponsiveSize.xs);
+    expect(console.error).to.have.been.calledOnce;
+  });
+});


### PR DESCRIPTION
On clever login, there was a race condition where `window.innerWidth` was returning 0, causing a null pointer exception in `responsiveRedux`. 

This PR returns `xs` ResponsiveSize if we cannot determine the window width

## Links
[Slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1712002341313539)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
