### PR TITLE
added experiment flag for new dashboard view

### DIFF
--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -46,11 +46,12 @@ function SectionProgressSelector({
   // If progress table is disabled, only show the v1 table.
   // If closed beta is disabled or the user is not in the closed beta, only show the v1 table.
   const isInClosedBeta =
-    experiments.isEnabled(experiments.SECTION_PROGRESS_V2) ||
-    (DCDO.get('progress-table-v2-closed-beta-enabled', false) &&
-      progressTableV2ClosedBeta);
+    DCDO.get('progress-table-v2-closed-beta-enabled', false) &&
+    progressTableV2ClosedBeta;
   const allowSelection =
-    DCDO.get('progress-table-v2-enabled', false) || isInClosedBeta;
+    experiments.isEnabled(experiments.SECTION_PROGRESS_V2) ||
+    DCDO.get('progress-table-v2-enabled', false) ||
+    isInClosedBeta;
   if (!allowSelection) {
     return <SectionProgress />;
   }

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -8,6 +8,7 @@ import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {setShowProgressTableV2} from '@cdo/apps/templates/currentUserRedux';
+import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
 
 import SectionProgress from '../sectionProgress/SectionProgress';
@@ -45,8 +46,9 @@ function SectionProgressSelector({
   // If progress table is disabled, only show the v1 table.
   // If closed beta is disabled or the user is not in the closed beta, only show the v1 table.
   const isInClosedBeta =
-    DCDO.get('progress-table-v2-closed-beta-enabled', false) &&
-    progressTableV2ClosedBeta;
+    experiments.isEnabled(experiments.SECTION_PROGRESS_V2) ||
+    (DCDO.get('progress-table-v2-closed-beta-enabled', false) &&
+      progressTableV2ClosedBeta);
   const allowSelection =
     DCDO.get('progress-table-v2-enabled', false) || isInClosedBeta;
   if (!allowSelection) {

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -56,6 +56,8 @@ experiments.GOOGLE_BLOCKLY = 'google_blockly';
 experiments.SPRITE_LAB_DOCS = 'sl_docs';
 // Adds a keyboard navigation toggle to the workspace header in Google Blockly labs
 experiments.KEYBOARD_NAVIGATION = 'blockly_keyboard';
+// Adds the ability to toggle between v1 and v2 of the section progress page of the teacher dashboard
+experiments.SECTION_PROGRESS_V2 = 'section_progress_v2';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
This flag was added to help us write UI tests for the new progress dashboard.  Ideally, we would use the DCDO flag UI on `test` to run these tests, but that is broken at the moment so this flag was added to help us get around that situation.

To test this I:

- set the `DCDO` flag for the `progress-table-v2-enabled` to `false`.
- Confirmed that I was unable to see the new dashboard locally
- Enabled the experiment by adding `?enableExperiments=section_progress_v2` to the end of the URL
- Verified I could see the new dashboard

Note: I tried logging into a different account thinking that it should then help me test that a different user would also NOT see the new dashboard.  However, that was not the case - even with a brand new account, I could still see the new dashboard.  After researching `localStorage` a bit more, it seems like this is expected.  It does make it a bit harder to test locally AND it is my first time setting this up, so please let me know if I missed anything.  

