### PR TITLE
Fix staging build break: remove leftover renamed file that should have been deleted.

### DIFF
--- a/dashboard/config/scripts/csa_u6l2_l5__modular.bubble_choice
+++ b/dashboard/config/scripts/csa_u6l2_l5__modular.bubble_choice
@@ -1,9 +1,0 @@
-name 'CSA U6L2-L5_-modular'
-display_name 'Practice: Checking String objects for certain criteria'
-description 'Practice using the `substring()` method to check if `String` objects meet a criteria.'
-
-sublevels
-level 'CSA U6L2-L5a_-modular'
-level 'CSA U6L2-L5b_-modular'
-level 'CSA U6L2-L5c_-modular'
-level 'CSA U6L2-L5d_-modular'


### PR DESCRIPTION
This file was renamed on Levelbuilder, but when the PR merged with staging, it became an add instead. This cleans up the old file that should have been deleted.