### PR TITLE
Create ActionBlocksWrapper component

### DIFF
--- a/apps/src/templates/studioHomepages/ActionBlocksWrapper.jsx
+++ b/apps/src/templates/studioHomepages/ActionBlocksWrapper.jsx
@@ -69,6 +69,8 @@ export default function ActionBlocksWrapper({actionBlocks}) {
       className={
         // This automatically adjusts the column count CSS
         // based on the number of blocks in an array.
+        // If there are 3 or more, it'll use a 3-column layout.
+        // For example: 6 blocks would result in a 3x2 grid.
         actionBlocks?.length >= 3
           ? styles.wrapperThreeCol
           : styles.wrapperTwoCol

--- a/apps/src/templates/studioHomepages/ActionBlocksWrapper.jsx
+++ b/apps/src/templates/studioHomepages/ActionBlocksWrapper.jsx
@@ -26,7 +26,7 @@ const OneColumnActionBlock = ({
         {heading && (
           <Heading2 visualAppearance="heading-md">{heading}</Heading2>
         )}
-        {imageUrl && <img src={imageUrl} alt="" className={styles.image} />}
+        {imageUrl && <img src={imageUrl} alt="" />}
         {description && <BodyThreeText>{description}</BodyThreeText>}
       </div>
       <div className={styles.buttonWrapper}>

--- a/apps/src/templates/studioHomepages/ActionBlocksWrapper.jsx
+++ b/apps/src/templates/studioHomepages/ActionBlocksWrapper.jsx
@@ -1,0 +1,93 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {LinkButton} from '@cdo/apps/componentLibrary/button';
+import {
+  Heading2,
+  OverlineTwoText,
+  BodyThreeText,
+} from '@cdo/apps/componentLibrary/typography';
+import styles from './actionBlocksWrapper.module.scss';
+
+const OneColumnActionBlock = ({
+  overline,
+  imageUrl,
+  heading,
+  description,
+  buttons,
+}) => {
+  return (
+    <div className={styles.oneColumnActionBlock}>
+      <div className={styles.contentWrapper}>
+        {overline && (
+          <OverlineTwoText className={styles.overline}>
+            {overline}
+          </OverlineTwoText>
+        )}
+        {heading && (
+          <Heading2 visualAppearance="heading-md">{heading}</Heading2>
+        )}
+        {imageUrl && <img src={imageUrl} alt="" className={styles.image} />}
+        {description && <BodyThreeText>{description}</BodyThreeText>}
+      </div>
+      <div className={styles.buttonWrapper}>
+        {buttons &&
+          buttons.map((button, index) => (
+            <LinkButton
+              key={index}
+              color={button.color}
+              href={button.url}
+              size="m"
+              text={button.text}
+              type={button.type}
+            />
+          ))}
+      </div>
+    </div>
+  );
+};
+
+OneColumnActionBlock.propTypes = {
+  overline: PropTypes.string,
+  imageUrl: PropTypes.string,
+  heading: PropTypes.string,
+  description: PropTypes.string,
+  buttons: PropTypes.arrayOf(
+    PropTypes.shape({
+      color: PropTypes.string,
+      url: PropTypes.string,
+      size: PropTypes.string,
+      text: PropTypes.string,
+      target: PropTypes.string,
+      type: PropTypes.string,
+    })
+  ),
+};
+
+export default function ActionBlocksWrapper({actionBlocks}) {
+  return (
+    <div
+      className={
+        // This automatically adjusts the column count CSS
+        // based on the number of blocks in an array.
+        actionBlocks?.length >= 3
+          ? styles.wrapperThreeCol
+          : styles.wrapperTwoCol
+      }
+    >
+      {actionBlocks.map((actionBlock, index) => (
+        <OneColumnActionBlock
+          key={index}
+          overline={actionBlock.overline}
+          heading={actionBlock.heading}
+          imageUrl={actionBlock.imageUrl}
+          description={actionBlock.description}
+          buttons={actionBlock.buttons}
+        />
+      ))}
+    </div>
+  );
+}
+
+ActionBlocksWrapper.propTypes = {
+  actionBlocks: PropTypes.arrayOf(PropTypes.object),
+};

--- a/apps/src/templates/studioHomepages/ActionBlocksWrapper.story.jsx
+++ b/apps/src/templates/studioHomepages/ActionBlocksWrapper.story.jsx
@@ -42,3 +42,8 @@ export const ThreeColumns = () => {
   const actionBlocks = generateActionBlocks(3);
   return <ActionBlocksWrapper actionBlocks={actionBlocks} />;
 };
+
+export const SixTiles = () => {
+  const actionBlocks = generateActionBlocks(6);
+  return <ActionBlocksWrapper actionBlocks={actionBlocks} />;
+};

--- a/apps/src/templates/studioHomepages/ActionBlocksWrapper.story.jsx
+++ b/apps/src/templates/studioHomepages/ActionBlocksWrapper.story.jsx
@@ -13,7 +13,8 @@ const generateActionBlocks = count => {
       imageUrl:
         'https://code.org/images/dance-hoc/dance-party-activity-ai-edition.png',
       heading: `Heading ${i + 1}`,
-      description: `Description ${i + 1}`,
+      description:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent eget risus vitae massa semper aliquam quis mattis quam. Morbi vitae tortor tempus, placerat leo et, suscipit.',
       buttons: [
         {
           color: 'purple',

--- a/apps/src/templates/studioHomepages/ActionBlocksWrapper.story.jsx
+++ b/apps/src/templates/studioHomepages/ActionBlocksWrapper.story.jsx
@@ -5,9 +5,9 @@ export default {
   component: ActionBlocksWrapper,
 };
 
-const generateActionBlocks = count => {
+const generateActionBlocks = tileCount => {
   const actionBlocks = [];
-  for (let i = 0; i < count; i++) {
+  for (let i = 0; i < tileCount; i++) {
     actionBlocks.push({
       overline: `Overline ${i + 1}`,
       imageUrl:

--- a/apps/src/templates/studioHomepages/ActionBlocksWrapper.story.jsx
+++ b/apps/src/templates/studioHomepages/ActionBlocksWrapper.story.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import ActionBlocksWrapper from './ActionBlocksWrapper';
+
+export default {
+  component: ActionBlocksWrapper,
+};
+
+const generateActionBlocks = count => {
+  const actionBlocks = [];
+  for (let i = 0; i < count; i++) {
+    actionBlocks.push({
+      overline: `Overline ${i + 1}`,
+      imageUrl:
+        'https://code.org/images/dance-hoc/dance-party-activity-ai-edition.png',
+      heading: `Heading ${i + 1}`,
+      description: `Description ${i + 1}`,
+      buttons: [
+        {
+          color: 'purple',
+          url: '#',
+          text: 'Primary button',
+        },
+        {
+          color: 'black',
+          url: '#',
+          text: 'Secondary button',
+          type: 'secondary',
+        },
+      ],
+    });
+  }
+  return actionBlocks;
+};
+
+export const TwoColumns = () => {
+  const actionBlocks = generateActionBlocks(2);
+  return <ActionBlocksWrapper actionBlocks={actionBlocks} />;
+};
+
+export const ThreeColumns = () => {
+  const actionBlocks = generateActionBlocks(3);
+  return <ActionBlocksWrapper actionBlocks={actionBlocks} />;
+};

--- a/apps/src/templates/studioHomepages/actionBlocksWrapper.module.scss
+++ b/apps/src/templates/studioHomepages/actionBlocksWrapper.module.scss
@@ -1,0 +1,52 @@
+@import 'color';
+
+// Breakpoints
+$width-sm: 640px;
+$width-lg: 1020px;
+
+// Set up default grid
+@mixin default-grid($columns: 2) {
+  display: grid;
+  gap: 1.25rem;
+
+  @media screen and (min-width: $width-sm) {
+    grid-template-columns: repeat($columns, 1fr);
+  }
+}
+
+// Begin styles
+.wrapperTwoCol {
+  @include default-grid;
+}
+
+.wrapperThreeCol {
+  @include default-grid(2);
+
+  @media screen and (min-width: $width-lg) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.oneColumnActionBlock {
+  background: $light_gray_50;
+  border: 1px solid $light_gray_200;
+  border-radius: 4px;
+  padding: 1.25rem;
+  text-align: initial;
+  display: flex;
+  flex-direction: column;
+
+  .overline {
+    color: $light_primary_500;
+  }
+
+  img {
+    margin-bottom: 1rem;
+  }
+
+  .buttonWrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+}

--- a/apps/src/templates/studioHomepages/actionBlocksWrapper.module.scss
+++ b/apps/src/templates/studioHomepages/actionBlocksWrapper.module.scss
@@ -35,6 +35,7 @@ $width-lg: 1020px;
   text-align: initial;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
 
   .overline {
     color: $light_primary_500;


### PR DESCRIPTION
Creates an `ActionBlocksWrapper` component that uses a `OneColumnActionBlock` component to create two and three column action block sections for use on pages on studio.code.org. This is the React implementation of the `.action-block__wrapper` classes on code.org ([ref](https://docs.google.com/document/d/1wev8I2BQVViNXPuhLEXMpIAYSoAJb0kVoSRKaI3zEAk/edit#heading=h.ncdwn07vxw41)).
- Columns are dynamically set between two and three columns with CSS based on if there are three or more tile objects
- Fully responsive
- Works with LTR and RTL languages 

**Jira ticket:** [ACQ-1704](https://codedotorg.atlassian.net/browse/ACQ-1704)

----

## Storybook

<img width="1045" alt="Screenshot 2024-04-02 at 8 14 50 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/01891af2-9da4-4645-b986-0dfc4ca6ae46">

<img width="1045" alt="Screenshot 2024-04-02 at 8 15 01 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/6c1b46d5-06c7-4d6d-aa6c-7ac9ef07ce59">

## RTL

<img width="1045" alt="RTL" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/65ac1c25-dc77-4898-9be2-0a72f1a830c6">

## Responsive

https://github.com/code-dot-org/code-dot-org/assets/9256643/d1710c29-9635-4d4f-b4a7-99d585dce401


