### PR TITLE
change color of in progress circle on progress dashboard.

### DIFF
--- a/apps/src/templates/sectionProgressV2/ItemType.jsx
+++ b/apps/src/templates/sectionProgressV2/ItemType.jsx
@@ -10,7 +10,7 @@ export const ITEM_TYPE = Object.freeze({
   CHOICE_LEVEL: ['split', color.neutral_dark60],
   KEEP_WORKING: ['rotate-left', color.neutral_dark],
   NO_ONLINE_WORK: ['dash', color.neutral_dark],
-  IN_PROGRESS: ['circle-o', color.neutral_dark],
+  IN_PROGRESS: ['circle-o', color.product_affirmative_default],
   SUBMITTED: ['circle', color.product_affirmative_default],
   VALIDATED: ['circle-check', color.product_affirmative_default],
 });


### PR DESCRIPTION
Changed color of the open circle to be green.  Screenshots below show everywhere this was applied.

<img width="513" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/d2b9e9f4-31d6-40ea-995c-862062be2d99">

<img width="572" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/bede38c9-4c90-4767-8b0c-b810fad99af5">

<img width="345" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/54cd3c44-c621-48c2-9086-dbe888bfc825">


## Links

[Ticket](https://codedotorg.atlassian.net/browse/TEACH-1003)

