### PR TITLE
[Google Blockly] Generate code for block array

### DIFF
--- a/apps/src/blockly/addons/cdoGenerator.ts
+++ b/apps/src/blockly/addons/cdoGenerator.ts
@@ -22,7 +22,7 @@ export default function initializeGenerator(
   // This function was a custom addition in CDO Blockly, so we need to add it here
   // so that our code generation logic still works with Google Blockly
   blocklyWrapper.Generator.blockSpaceToCode = function (name) {
-    let blocksToGenerate = blocklyWrapper.mainBlockSpace.getTopBlocks(
+    const blocksToGenerate = blocklyWrapper.mainBlockSpace.getTopBlocks(
       true /* ordered */
     );
     return blocklyWrapper.Generator.blocksToCode(name, blocksToGenerate);

--- a/apps/src/blockly/addons/cdoGenerator.ts
+++ b/apps/src/blockly/addons/cdoGenerator.ts
@@ -21,20 +21,25 @@ export default function initializeGenerator(
 
   // This function was a custom addition in CDO Blockly, so we need to add it here
   // so that our code generation logic still works with Google Blockly
-  blocklyWrapper.Generator.blockSpaceToCode = function (name, opt_typeFilter) {
-    const generator = blocklyWrapper.getGenerator();
-    generator.init(blocklyWrapper.mainBlockSpace);
+  blocklyWrapper.Generator.blockSpaceToCode = function (name) {
     let blocksToGenerate = blocklyWrapper.mainBlockSpace.getTopBlocks(
       true /* ordered */
     );
-    if (opt_typeFilter) {
-      if (typeof opt_typeFilter === 'string') {
-        opt_typeFilter = [opt_typeFilter];
-      }
-      blocksToGenerate = blocksToGenerate.filter(block =>
-        (opt_typeFilter as string[]).includes(block.type)
+    return blocklyWrapper.Generator.blocksToCode(name, blocksToGenerate);
+  };
+
+  // Used to generate code for an array of top blocks.
+  blocklyWrapper.Generator.blocksToCode = function (
+    name: string,
+    blocksToGenerate: Block[]
+  ) {
+    if (name !== 'JavaScript') {
+      console.warn(
+        `Can only generate code in JavaScript. ${name} is unsupported.`
       );
     }
+    const generator = blocklyWrapper.getGenerator();
+    generator.init(blocklyWrapper.getMainWorkspace());
     const code: string[] = [];
     blocksToGenerate.forEach(block => {
       code.push(blocklyWrapper.JavaScript.blockToCode(block));

--- a/apps/src/blockly/addons/cdoGenerator.ts
+++ b/apps/src/blockly/addons/cdoGenerator.ts
@@ -21,10 +21,18 @@ export default function initializeGenerator(
 
   // This function was a custom addition in CDO Blockly, so we need to add it here
   // so that our code generation logic still works with Google Blockly
-  blocklyWrapper.Generator.blockSpaceToCode = function (name) {
-    const blocksToGenerate = blocklyWrapper.mainBlockSpace.getTopBlocks(
+  blocklyWrapper.Generator.blockSpaceToCode = function (name, opt_typeFilter) {
+    let blocksToGenerate = blocklyWrapper.mainBlockSpace.getTopBlocks(
       true /* ordered */
     );
+    if (opt_typeFilter) {
+      if (typeof opt_typeFilter === 'string') {
+        opt_typeFilter = [opt_typeFilter];
+      }
+      blocksToGenerate = blocksToGenerate.filter(block =>
+        (opt_typeFilter as string[]).includes(block.type)
+      );
+    }
     return blocklyWrapper.Generator.blocksToCode(name, blocksToGenerate);
   };
 

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -238,7 +238,10 @@ export interface ExtendedWorkspace extends Workspace {
 type CodeGeneratorType = typeof CodeGenerator;
 export interface ExtendedGenerator extends CodeGeneratorType {
   xmlToBlocks: (name: string, xml: Node) => Block[];
-  blockSpaceToCode: (name: string) => string;
+  blockSpaceToCode: (
+    name: string,
+    opt_typeFilter?: string | string[]
+  ) => string;
   blocksToCode: (name: string, blocksToGenerate: Block[]) => string;
   prefixLines: (text: string, prefix: string) => string;
 }

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -238,10 +238,8 @@ export interface ExtendedWorkspace extends Workspace {
 type CodeGeneratorType = typeof CodeGenerator;
 export interface ExtendedGenerator extends CodeGeneratorType {
   xmlToBlocks: (name: string, xml: Node) => Block[];
-  blockSpaceToCode: (
-    name: string,
-    opt_typeFilter?: string | string[]
-  ) => string;
+  blockSpaceToCode: (name: string) => string;
+  blocksToCode: (name: string, blocksToGenerate: Block[]) => string;
   prefixLines: (text: string, prefix: string) => string;
 }
 


### PR DESCRIPTION
Some CDO Blockly labs (Maze, Artist, Play Lab) need to be able to generate code for an arbitrary list of blocks via `blocksToCode`. This could have a range of purposes beyond just running the student's code, such as running the solution blocks in Artist or initialization blocks in Artist or Play Lab.
Note: `blocksToCode` _used to be_ part of the Minecraft code, but because we only ever needed to generate code from the main workspace, we were able to safely replace it with our custom `Blockly.getWorkspaceCode()`. https://github.com/code-dot-org/code-dot-org/pull/55993/commits/3c8902bd93dd86fc183976d7abf178ed19987f91

Because `blocksToCode` is used in other labs that we intend to migrate, and it won't always just be looking at workspace blocks, it makes to actually just support it. Like the CDO Blockly version, the new Google Blockly generator function will iterate through the list using `blockToCode`. 
CDO Blockly code: https://github.com/code-dot-org/blockly/blob/f012d8262f21bae3e54fb11dd8bc29cf0d29f3cd/core/code_generation/generator.js#L60-L99

This change makes it possible to run the student code in the first level of our Maze HOC progression:

**Before:**
<img width="1512" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/85fc3833-e839-4b67-8a0e-8761a7c2ea82">

**After:**
<img width="1124" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/4f5f0ec6-c176-466e-87ba-dfda840d1a03">

While working on this, I also made some changes to `blockSpaceToCode`. This function works almost the exact same way except the block array is always the workspace's top blocks. I refactored `blockSpaceToCode` to call the new `blocksToCode` using that list. I was also curious about its optional `opt_typeFilter` parameter. This was added to CDO Blockly for the deprecated Eval lab (a Play Lab descendent). Since we are not going to migrate Eval, it save to remove the parameter now.


## Links

Jira: https://codedotorg.atlassian.net/browse/CT-465

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
