### PR TITLE
Removes outline for active learning goal rubric left/right button.

### DIFF
--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -866,35 +866,33 @@ em.aiFeedbackReceived {
   min-width: 100%;
 }
 
-.learningGoalButton {
-  background: none;
-  border: none;
-  align-self: center;
-  flex: 0 0 auto;
-}
-
 .learningGoalRing {
   flex: 0 0 auto;
 }
 
 button.learningGoalButton {
+  align-self: center;
+  background: none;
+  border: none;
   box-shadow: none;
-  border: 1px solid transparent;
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 0.5rem;
 
   &:active,
   &:hover {
     box-shadow: none;
+    // The important is needed here to override the common button:active style
+    border: none !important;
   }
 }
 
-.learningGoalButtonLeft {
-  margin: 0 0.625rem 0 0;
-  padding: 0 0.5rem 0 0;
+button.learningGoalButtonLeft {
+  margin-left: 0.5rem;
 }
 
-.learningGoalButtonRight {
-  margin: 0 0 0 0.625rem;
-  padding: 0 0 0 0.5rem;
+button.learningGoalButtonRight {
+  margin-right: 0.5rem;
 }
 
 .learningGoalsHeader {
@@ -905,7 +903,7 @@ button.learningGoalButton {
   align-self: stretch;
   line-height: 154%;
   position: relative;
-  margin: 1rem 1rem 0 1rem;
+  margin: 1rem 0 0 0;
   padding: 0 0 0.75rem 0;
   border-bottom: 1px $light_gray_100 solid;
   overflow: hidden;


### PR DESCRIPTION
This just removes the ring around the arrow as it is clicked. Since this would affect the focus ring when it is tab-navigated, there is a little bit of work to make sure that focus ring looks reasonable as well.

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/d1dd7856-e954-46e0-ba18-bbe5bbf8c249)

## Links

- jira ticket: [AITT-538](https://codedotorg.atlassian.net/browse/AITT-538)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
