### PR TITLE
Grant Contributors access to AI rubric

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -563,6 +563,7 @@ roles.each do |name, config| %>
               - arn:aws:s3:::cdo-v3-assets
               - arn:aws:s3:::cdo-v3-animations
               - arn:aws:s3:::cdo-v3-files
+              - arn:aws:s3:::cdo-ai
             Condition:
               StringLike: {
                 "s3:prefix": [
@@ -570,7 +571,8 @@ roles.each do |name, config| %>
                     "sources_development/*",
                     "assets_development/*",
                     "animations_development/*",
-                    "files_development/*"
+                    "files_development/*",
+                    "teaching_assistant/*"
                 ]
               }
           - Sid: AllowNeededS3ActionsInCertainBucketFolders
@@ -599,6 +601,7 @@ roles.each do |name, config| %>
               - arn:aws:s3:::cdo-v3-assets/assets_development/*
               - arn:aws:s3:::cdo-v3-animations/animations_development/*
               - arn:aws:s3:::cdo-v3-files/files_development/*
+              - arn:aws:s3:::cdo-ai/teaching_assistant/*
           - Sid: AllowListingToLibraryBuckets
             Effect: Allow
             Action:


### PR DESCRIPTION
Temporarily grant Contributors access to AI Rubric Objects in S3 to unblock seeding of curriculum content during `rake build`.  See discussion: https://codedotorg.slack.com/archives/C0T0PNTM3/p1712080345221629

## Testing story



```
$ export AWS_PROFILE=codeorg-admin
$ bundle exec rake stack:iam:validate RAILS_ENV=production ADMIN=true

Finished stack:iam:environment (less than a minute)
Pending update for stack `IAM`:
Modify ContributorS3Policy [AWS::IAM::ManagedPolicy] Properties (PolicyDocument)
Finished stack:iam:validate (less than a minute)
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
