### PR TITLE
Don't try to run broken update for 'COVID-19 Cases per Country'

### DIFF
--- a/bin/cron/applab_datasets/covid19
+++ b/bin/cron/applab_datasets/covid19
@@ -61,60 +61,11 @@ def get_us_covid19_data
   return records, columns
 end
 
-def get_world_covid19_data
-  package = JSON.parse(Net::HTTP.get_response(URI('https://datahub.io/core/covid-19/datapackage.json')).body)
-  resource = package['resources'].find {|r| r['name'] == "countries-aggregated_csv"}
-  return unless resource
-  response = Net::HTTP.get_response(URI(resource['path']))
-  return unless response.code == '200'
-  lines = CSV.parse(response.body, headers: true)
-  weekly_data = {}
-
-  # Group records by week
-  lines.each do |line|
-    parsed_date = Date.strptime(line.field("Date"), "%Y-%m-%d")
-    next unless parsed_date.wday == 0 # Downsample to one data point per week
-    formatted_date = parsed_date.strftime('%a %-m/%-d') # ex Wed 1/7
-    record = {}
-    record['Date'] = formatted_date
-    record['Country'] = line.field("Country")
-    record['Total Confirmed Cases'] = line.field("Confirmed").to_i
-    record['Total Recovered'] = line.field("Recovered").to_i
-    record['Total Deaths'] = line.field("Deaths").to_i
-    weekly_data[formatted_date] ||= []
-    weekly_data[formatted_date].push record
-  end
-
-  # Truncate to MAX_WEEKS most recent weeks
-  weeks = if weekly_data.length > MAX_WEEKS
-            weekly_data.keys.slice(weekly_data.length - MAX_WEEKS, MAX_WEEKS)
-          else
-            weekly_data.keys
-          end
-
-  # Add id to each record
-  columns = ['id', 'Date', 'Country', 'Total Confirmed Cases', 'Total Recovered', 'Total Deaths']
-  records = {}
-  id = 1
-  weeks.each do |week|
-    week_records = weekly_data[week]
-    week_records.each do |record|
-      record['id'] = id
-      records[id] = record.to_json
-      id += 1
-    end
-  end
-  return records, columns
-end
-
 def main
   # TODO: post-firebase-cleanup, remove the firebase reference: #56994
   fb = FirebaseHelper.new('shared')
   records, columns = get_us_covid19_data
   fb.upload_live_table('COVID-19 Cases per US State', records, columns)
-
-  records, columns = get_world_covid19_data
-  fb.upload_live_table('COVID-19 Cases per Country', records, columns)
 end
 
 main if only_one_running?(__FILE__)

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -11,7 +11,7 @@ class DatasetsController < ApplicationController
   authorize_resource class: false
 
   LIVE_DATASETS = ['Daily Weather', 'Top 200 USA', 'Top 200 Worldwide', 'Viral 50 USA', 'Viral 50 Worldwide',
-                   'Top 50 USA', 'Top 50 Worldwide', 'COVID-19 Cases per US State', 'COVID-19 Cases per Country']
+                   'Top 50 USA', 'Top 50 Worldwide', 'COVID-19 Cases per US State']
 
   # GET /datasets
   def index


### PR DESCRIPTION
The upstream URL`bin/cron/applab_datasets/covid19` was fetching for 'COVID-19 Cases per Country' had its format change. We're not sure if this is a recent, or a long-standing one. In either case, the data set is no longer being updated upstream (upstream source of the dataset https://datahub.io/core/covid-19/datapackage.json), last update on datahub.io is from 2022.

Because the new data set format is actually broken, AND the data is not being updated anyway, in consultation with Curriculum we decided to drop this live dataset.

1) @kakiha11 is removing the dataset from the manifest on levelbuilder
2) This PR removes the failing attempt to update the table from the covid19 cron job that runs on prod

Fixes #57710 
Fixes #57675 

Co-authored-by: Cassi Brenci <cnbrenci@users.noreply.github.com>