### PR TITLE
P20-829: Prepare Units only when needed on the Dashboard test run

### DIFF
--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -7,7 +7,7 @@ class LevelsControllerTest < ActionController::TestCase
   STUB_ENCRYPTION_KEY = SecureRandom.base64(Encryption::KEY_LENGTH / 8)
 
   setup_all do
-    setup_units
+    seed_deprecated_unit_fixtures
   end
 
   setup do

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -6,6 +6,10 @@ class LevelsControllerTest < ActionController::TestCase
 
   STUB_ENCRYPTION_KEY = SecureRandom.base64(Encryption::KEY_LENGTH / 8)
 
+  setup_all do
+    setup_units
+  end
+
   setup do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     Policies::LevelFiles.stubs(:write_to_file?).returns(false) # don't write to level files

--- a/dashboard/test/integration/caching_test.rb
+++ b/dashboard/test/integration/caching_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class CachingTest < ActionDispatch::IntegrationTest
   setup_all do
-    setup_units
+    seed_deprecated_unit_fixtures
   end
 
   def setup

--- a/dashboard/test/integration/caching_test.rb
+++ b/dashboard/test/integration/caching_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class CachingTest < ActionDispatch::IntegrationTest
+  setup_all do
+    setup_units
+  end
+
   def setup
     setup_script_cache
   end

--- a/dashboard/test/integration/session_cookie_test.rb
+++ b/dashboard/test/integration/session_cookie_test.rb
@@ -3,7 +3,7 @@ require 'cdo/script_config'
 
 class SessionCookieTest < ActionDispatch::IntegrationTest
   setup_all do
-    setup_units
+    seed_deprecated_unit_fixtures
   end
 
   test 'session cookie name contains environment' do

--- a/dashboard/test/integration/session_cookie_test.rb
+++ b/dashboard/test/integration/session_cookie_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 require 'cdo/script_config'
 
 class SessionCookieTest < ActionDispatch::IntegrationTest
+  setup_all do
+    setup_units
+  end
+
   test 'session cookie name contains environment' do
     get '/reset_session'
 

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -8,6 +8,8 @@ class ScriptLevelTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
+    # setup_units
+
     @script_level = create(:script_level)
     @script_level2 = create(:script_level)
     @lesson = create(:lesson)

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -8,7 +8,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    setup_units
+    seed_deprecated_unit_fixtures
 
     @script_level = create(:script_level)
     @script_level2 = create(:script_level)

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -8,7 +8,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    # setup_units
+    setup_units
 
     @script_level = create(:script_level)
     @script_level2 = create(:script_level)

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -7,7 +7,7 @@ class UnitTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    # setup_units
+    setup_units
 
     Rails.application.config.stubs(:levelbuilder_mode).returns false
     @game = create(:game)

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -7,6 +7,8 @@ class UnitTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
+    # setup_units
+
     Rails.application.config.stubs(:levelbuilder_mode).returns false
     @game = create(:game)
     # Level names match those in 'test.script'

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -7,7 +7,7 @@ class UnitTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    setup_units
+    seed_deprecated_unit_fixtures
 
     Rails.application.config.stubs(:levelbuilder_mode).returns false
     @game = create(:game)

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -133,7 +133,7 @@ class ActiveSupport::TestCase
   include ActiveSupport::Testing::TransactionalTestCase
   include CaptureQueries
 
-  def setup_units
+  def seed_deprecated_unit_fixtures
     # Some of the functionality we're testing here relies on Scripts with
     # certain hardcoded names. In the old fixture-based model, this data was
     # all provided; in the new factory-based model, we need to do a little

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -133,7 +133,7 @@ class ActiveSupport::TestCase
   include ActiveSupport::Testing::TransactionalTestCase
   include CaptureQueries
 
-  setup_all do
+  def setup_units
     # Some of the functionality we're testing here relies on Scripts with
     # certain hardcoded names. In the old fixture-based model, this data was
     # all provided; in the new factory-based model, we need to do a little


### PR DESCRIPTION
| Before  | After |
| ------- | ----- |
| ![before](https://github.com/code-dot-org/code-dot-org/assets/11708250/b1d3fd0d-090e-444d-9cd5-91f16cebb7b8) | ![after](https://github.com/code-dot-org/code-dot-org/assets/11708250/7da717fd-f98a-4373-ae02-afc0df40bf6a) |

## Links
- JIRA ticket [P20-829](https://codedotorg.atlassian.net/browse/P20-829)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/57661