### PR TITLE
Music: fix bug loading initial level data

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -163,7 +163,10 @@ class UnconnectedMusicView extends React.Component {
     });
 
     if (this.props.levelProperties?.appName === 'music') {
-      this.onLevelLoad(this.props.levelProperties, this.props.initialSources);
+      this.onLevelLoad(
+        this.props.levelProperties?.levelData,
+        this.props.initialSources
+      );
     }
     this.player.setUpdateLoadProgress(this.props.updateLoadProgress);
   }


### PR DESCRIPTION
Accidental regression from https://github.com/code-dot-org/code-dot-org/pull/57657. We need to pass `levelData`, not the whole `levelProperties` object (i've been too spoiled by typescript usually catching this stuff 😅)

## Links

https://codedotorg.slack.com/archives/C043WM7TCH3/p1712099642674699?thread_ts=1711726843.187269&cid=C043WM7TCH3

## Testing story

Tested with music lab elementary progression and intro progression.