### PR TITLE
Panels: two more layouts

### DIFF
--- a/apps/src/lab2/levelEditors/panels/EditPanels.tsx
+++ b/apps/src/lab2/levelEditors/panels/EditPanels.tsx
@@ -209,10 +209,12 @@ const EditPanel: React.FunctionComponent<EditPanelProps> = ({
               layout: e.target.value as PanelLayout,
             })
           }
-          selectedValue={panel.layout}
+          selectedValue={panel.layout || 'text-top-right'}
           items={[
+            {value: 'text-top-left', text: 'Top Left'},
             {value: 'text-top-right', text: 'Top Right'},
             {value: 'text-bottom-left', text: 'Bottom Left'},
+            {value: 'text-bottom-right', text: 'Bottom Right'},
           ]}
         />
       </div>

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -90,8 +90,12 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
 
   const showSmallText = height < 300;
   const textLayoutClass =
-    panel.layout === 'text-bottom-left'
+    panel.layout === 'text-top-left'
+      ? styles.markdownTextTopLeft
+      : panel.layout === 'text-bottom-left'
       ? styles.markdownTextBottomLeft
+      : panel.layout === 'text-bottom-right'
+      ? styles.markdownTextBottomRight
       : styles.markdownTextTopRight;
 
   return (

--- a/apps/src/panels/panels.module.scss
+++ b/apps/src/panels/panels.module.scss
@@ -64,6 +64,11 @@
         }
       }
 
+      &TopLeft {
+        top: 40px;
+        left: -20px;
+      }
+
       &TopRight {
         top: 40px;
         right: -20px;
@@ -72,6 +77,12 @@
       &BottomLeft {
         bottom: 40px;
         left: -20px;
+      }
+
+
+      &BottomRight {
+        bottom: 40px;
+        right: -20px;
       }
     }
   }

--- a/apps/src/panels/types.ts
+++ b/apps/src/panels/types.ts
@@ -10,7 +10,11 @@ export interface PanelsLevelProperties extends LevelProperties {
   panels: Panel[];
 }
 
-export type PanelLayout = 'text-bottom-left' | 'text-top-right';
+export type PanelLayout =
+  | 'text-top-left'
+  | 'text-top-right'
+  | 'text-bottom-left'
+  | 'text-bottom-right';
 
 export interface Panel {
   imageUrl: string;


### PR DESCRIPTION
This simple change adds two more layouts to the Panels level type.  "Top left" and "bottom right" are now available, augmenting the existing "top right" and "bottom left".  

<img width="790" alt="Screenshot 2024-04-03 at 6 14 13 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/dddecc3f-26a3-458a-b583-18a64c8bce01">
