### PR TITLE
[Google Blockly] support gray undeletable blocks

### DIFF
--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -59,6 +59,7 @@ export const BlockColors = {
   // The colors below do not have a corresponding style and are incompatible with themes.
   COMMENT: [0, 0, 0.6],
   UNKNOWN: [0, 0, 0.8],
+  DISABLED: [0, 0, 0.5],
 };
 
 export const Renderers = {

--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.ts
@@ -67,6 +67,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedure_def_validator_helper',
       'procedure_defnoreturn_get_caller_block_mixin',
       'procedure_def_set_no_return_helper',
+      'procedure_def_no_gray_out',
       'behaviors_block_frame',
       'procedure_def_mini_toolbox',
       'modal_procedures_no_destroy',

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.ts
@@ -64,6 +64,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedures_block_frame',
       'procedure_def_mini_toolbox',
       'modal_procedures_no_destroy',
+      'procedure_def_no_gray_out',
     ],
     mutator: 'procedure_def_mutator',
   },
@@ -280,6 +281,13 @@ GoogleBlockly.Extensions.registerMixin(
   procedureCallerOnChangeMixin
 );
 
+// Labs like Maze and Artist turn undeletable blocks gray. This is not
+// done for special blocks like "when run" or procedure definitions.
+GoogleBlockly.Extensions.registerMixin('procedure_def_no_gray_out', {
+  shouldBeGrayedOut: function () {
+    return false;
+  },
+});
 /**
  * Constructs the blocks required by the flyout for the procedure category.
  * Modeled after core Blockly procedures flyout category, but excludes unwanted blocks.

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -505,7 +505,11 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
 
   // Labs like Maze and Artist turn undeletable blocks gray.
   extendedBlockSvg.shouldBeGrayedOut = function () {
-    return blocklyWrapper.grayOutUndeletableBlocks && !this.isDeletable();
+    return (
+      blocklyWrapper.grayOutUndeletableBlocks &&
+      !this.workspace.isReadOnly() &&
+      !this.isDeletable()
+    );
   };
 
   const originalSetDeletable = blocklyWrapper.Block.prototype.setDeletable;
@@ -559,6 +563,10 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
 
   extendedWorkspaceSvg.getAllUsedBlocks = function () {
     return this.getAllBlocks().filter(block => block.isEnabled());
+  };
+
+  extendedWorkspaceSvg.isReadOnly = function () {
+    return blocklyWrapper.readOnly || this.options.readOnly;
   };
 
   // Used in levels when starting over or resetting Version History
@@ -763,6 +771,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       !!options.grayOutUndeletableBlocks;
     blocklyWrapper.topLevelProcedureAutopopulate =
       !!options.topLevelProcedureAutopopulate;
+    blocklyWrapper.readOnly = !!opt_options.readOnly;
 
     if (options.noFunctionBlockFrame) {
       workspace.noFunctionBlockFrame = options.noFunctionBlockFrame;

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -74,6 +74,7 @@ type GoogleBlocklyType = typeof GoogleBlockly;
 
 // Type for the Blockly instance created and modified by googleBlocklyWrapper.
 export interface BlocklyWrapperType extends GoogleBlocklyType {
+  grayOutUndeletableBlocks: boolean;
   topLevelProcedureAutopopulate: boolean;
   getNewCursor: (type: string) => Cursor;
   LineCursor: typeof GoogleBlockly.BasicCursor;
@@ -171,6 +172,7 @@ export type GoogleBlocklyInstance = typeof GoogleBlockly;
 export interface ExtendedBlockSvg extends BlockSvg {
   isVisible: () => boolean;
   isUserVisible: () => boolean;
+  shouldBeGrayedOut: () => boolean;
   // imageSourceId, shortString, longString and thumbnailSize are used for sprite pointer blocks
   imageSourceId?: string;
   shortString?: string;
@@ -229,6 +231,7 @@ export interface ExtendedBlocklyOptions extends BlocklyOptions {
   noFunctionBlockFrame: boolean;
   useModalFunctionEditor: boolean;
   useBlocklyDynamicCategories: boolean;
+  grayOutUndeletableBlocks: boolean | undefined;
 }
 
 export interface ExtendedWorkspace extends Workspace {

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -74,6 +74,7 @@ type GoogleBlocklyType = typeof GoogleBlockly;
 
 // Type for the Blockly instance created and modified by googleBlocklyWrapper.
 export interface BlocklyWrapperType extends GoogleBlocklyType {
+  readOnly: boolean;
   grayOutUndeletableBlocks: boolean;
   topLevelProcedureAutopopulate: boolean;
   getNewCursor: (type: string) => Cursor;
@@ -211,6 +212,7 @@ export interface ExtendedWorkspaceSvg extends WorkspaceSvg {
   getContainer: () => ParentNode | null;
   setEnableToolbox: () => void;
   traceOn: () => void;
+  isReadOnly: () => boolean;
 }
 
 export interface EditorWorkspaceSvg extends ExtendedWorkspaceSvg {


### PR DESCRIPTION
Certain labs, like Maze and Artist change the color of deletable blocks to gray. This can be seen in places like levels 14 and 20 of the original Hour of Code progression:

### CDO Blockly (Baseline)
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/17619dca-4249-4cc4-93f5-17a7c725935c)

As of staging, we don't treat these blocks differently than other undeletable blocks:

### Google Blockly (Before/staging)
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/33f0193a-db0f-4e92-861f-31410fbf4995)

This branch establishes parity for this feature with CDO Blockly:

### Google Blockly (After/feature branch)
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/56a165e0-8cf7-4be4-a459-659edd0033be)

Whether we do this or not is determined by an `inject` option `grayOutUndeletableBlocks` which is already present in those lab files. We'll now add this option to the wrapper. If it's true, and the block is undeletable, we set a different block color. This can be handled by a new override for `setDeletable` which called during deserialization, or when toggling the deletable state (via levelbuilder context menu or console commands). Comments have been left with links to the comparable CDO Blockly logic, where applicable.

As you can see in the screenshots above, the `when run` block is not gray even though it is always undeletable. This is due to a `shouldBeGrayedOut()` override in the block definition here: 
https://github.com/code-dot-org/code-dot-org/blob/mike/undeletable-gray-blocks/apps/src/blocksCommon.js#L260-L262
We also want to exempt procedure definition blocks from being "grayed out" so I've created a new mixin for that.



## Links

Jira: https://codedotorg.atlassian.net/browse/CT-468
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I tested that we do not show gray blocks in a read only workspace by comparing a project to the signed out view:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/8accf414-1b8a-4494-aa67-831f44e57af0)
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/0b42c655-8cdb-4544-9bb5-611b89cd9899)


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
