### PR TITLE
[AI Tutor] CT-440: Migration for ai_tutor_iteraction_feedbacks table

### DIFF
--- a/dashboard/app/models/ai_tutor_interaction.rb
+++ b/dashboard/app/models/ai_tutor_interaction.rb
@@ -10,9 +10,9 @@
 #  type               :string(255)
 #  project_id         :string(255)
 #  project_version_id :string(255)
-#  prompt             :text(16777215)
+#  prompt             :text(65535)
 #  status             :string(255)
-#  ai_response        :text(16777215)
+#  ai_response        :text(65535)
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/dashboard/app/models/ai_tutor_interaction.rb
+++ b/dashboard/app/models/ai_tutor_interaction.rb
@@ -10,9 +10,9 @@
 #  type               :string(255)
 #  project_id         :string(255)
 #  project_version_id :string(255)
-#  prompt             :text(65535)
+#  prompt             :text(16777215)
 #  status             :string(255)
-#  ai_response        :text(65535)
+#  ai_response        :text(16777215)
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/dashboard/app/models/lti/feedback.rb
+++ b/dashboard/app/models/lti/feedback.rb
@@ -3,7 +3,7 @@
 # Table name: lti_feedbacks
 #
 #  id           :bigint           not null, primary key
-#  user_id      :bigint           not null
+#  user_id      :integer          not null
 #  satisfied    :boolean          not null
 #  locale       :string(255)
 #  early_access :boolean

--- a/dashboard/app/models/lti/feedback.rb
+++ b/dashboard/app/models/lti/feedback.rb
@@ -3,7 +3,7 @@
 # Table name: lti_feedbacks
 #
 #  id           :bigint           not null, primary key
-#  user_id      :integer          not null
+#  user_id      :bigint           not null
 #  satisfied    :boolean          not null
 #  locale       :string(255)
 #  early_access :boolean

--- a/dashboard/db/migrate/20240403074309_create_ai_tutor_interaction_feedbacks.rb
+++ b/dashboard/db/migrate/20240403074309_create_ai_tutor_interaction_feedbacks.rb
@@ -1,0 +1,14 @@
+class CreateAiTutorInteractionFeedbacks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :ai_tutor_interaction_feedbacks do |t|
+      t.bigint :ai_tutor_interaction_id, null: false, foreign_key: true
+      t.bigint :user_id, null: false, foreign_key: true
+      t.boolean :thumbs_up
+      t.boolean :thumbs_down
+      
+      t.timestamps
+    end
+
+    add_index :ai_tutor_interaction_feedbacks, [:ai_tutor_interaction_id, :user_id], unique: true, name: 'index_ai_tutor_feedback_on_interaction_and_user'
+  end
+end

--- a/dashboard/db/migrate/20240403074309_create_ai_tutor_interaction_feedbacks.rb
+++ b/dashboard/db/migrate/20240403074309_create_ai_tutor_interaction_feedbacks.rb
@@ -5,7 +5,7 @@ class CreateAiTutorInteractionFeedbacks < ActiveRecord::Migration[6.1]
       t.bigint :user_id, null: false
       t.boolean :thumbs_up
       t.boolean :thumbs_down
-      
+
       t.timestamps
     end
 

--- a/dashboard/db/migrate/20240403074309_create_ai_tutor_interaction_feedbacks.rb
+++ b/dashboard/db/migrate/20240403074309_create_ai_tutor_interaction_feedbacks.rb
@@ -1,14 +1,16 @@
 class CreateAiTutorInteractionFeedbacks < ActiveRecord::Migration[6.1]
   def change
     create_table :ai_tutor_interaction_feedbacks do |t|
-      t.bigint :ai_tutor_interaction_id, null: false, foreign_key: true
-      t.bigint :user_id, null: false, foreign_key: true
+      t.bigint :ai_tutor_interaction_id, null: false
+      t.bigint :user_id, null: false
       t.boolean :thumbs_up
       t.boolean :thumbs_down
       
       t.timestamps
     end
 
+    add_foreign_key :ai_tutor_interaction_feedbacks, :ai_tutor_interactions
+    add_foreign_key :ai_tutor_interaction_feedbacks, :users
     add_index :ai_tutor_interaction_feedbacks, [:ai_tutor_interaction_id, :user_id], unique: true, name: 'index_ai_tutor_feedback_on_interaction_and_user'
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_21_184256) do
+ActiveRecord::Schema.define(version: 2024_04_03_074309) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -39,6 +39,16 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
+  create_table "ai_tutor_interaction_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "ai_tutor_interaction_id", null: false
+    t.bigint "user_id", null: false
+    t.boolean "thumbs_up"
+    t.boolean "thumbs_down"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["ai_tutor_interaction_id", "user_id"], name: "index_ai_tutor_feedback_on_interaction_and_user", unique: true
+  end
+
   create_table "ai_tutor_interactions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id"
@@ -47,9 +57,9 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.string "type"
     t.string "project_id"
     t.string "project_version_id"
-    t.text "prompt", size: :medium
+    t.text "prompt"
     t.string "status"
-    t.text "ai_response", size: :medium
+    t.text "ai_response"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["level_id"], name: "index_ai_tutor_interactions_on_level_id"
@@ -442,7 +452,7 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["project_id"], name: "index_datablock_storage_kvps_on_project_id"
   end
 
-  create_table "datablock_storage_library_manifest", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "datablock_storage_library_manifest", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.json "library_manifest"
     t.integer "singleton_guard", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -469,7 +479,7 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["project_id"], name: "index_datablock_storage_tables_on_project_id"
   end
 
-  create_table "delayed_jobs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "delayed_jobs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -645,7 +655,7 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["user_id"], name: "index_hint_view_requests_on_user_id"
   end
 
-  create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "learning_goal_ai_evaluation_id", null: false
     t.bigint "teacher_id", null: false
     t.boolean "ai_feedback_approval", null: false
@@ -659,7 +669,7 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["learning_goal_ai_evaluation_id"], name: "index_feedback_on_learning_goal_ai_evaluation"
   end
 
-  create_table "learning_goal_ai_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_ai_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "rubric_ai_evaluation_id", null: false
     t.bigint "learning_goal_id", null: false
     t.integer "understanding"
@@ -839,7 +849,7 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "lti_courses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_courses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "lti_integration_id", null: false
     t.bigint "lti_deployment_id", null: false
     t.string "context_id"
@@ -865,7 +875,7 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["lti_integration_id"], name: "index_lti_deployments_on_lti_integration_id"
   end
 
-  create_table "lti_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "satisfied", null: false
     t.string "locale"
@@ -892,7 +902,7 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["platform_id"], name: "index_lti_integrations_on_platform_id"
   end
 
-  create_table "lti_sections", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_sections", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "lti_course_id", null: false
     t.integer "section_id", null: false
     t.string "lms_section_id"
@@ -1035,7 +1045,7 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["user_id"], name: "index_pd_applications_on_user_id"
   end
 
-  create_table "pd_applications_status_logs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications_status_logs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "pd_application_id", null: false
     t.string "status", null: false
     t.datetime "timestamp", null: false
@@ -1522,7 +1532,7 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["user_id", "plc_course_id"], name: "index_plc_user_course_enrollments_on_user_id_and_plc_course_id", unique: true
   end
 
-  create_table "potential_teachers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "potential_teachers", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
     t.integer "script_id"
@@ -1613,7 +1623,7 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
   end
 
-  create_table "project_use_datablock_storages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "project_use_datablock_storages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "project_id", null: false
     t.boolean "use_datablock_storage", default: false, null: false
     t.index ["project_id"], name: "index_project_use_datablock_storages_on_project_id"
@@ -1718,7 +1728,7 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["name", "url"], name: "index_resources_on_name_and_url", type: :fulltext
   end
 
-  create_table "rubric_ai_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "rubric_ai_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "requester_id", null: false
     t.bigint "rubric_id", null: false
@@ -1920,7 +1930,7 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["stage_id"], name: "index_section_hidden_stages_on_stage_id"
   end
 
-  create_table "section_instructors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "section_instructors", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "instructor_id", null: false
     t.integer "section_id", null: false
     t.integer "invited_by_id"
@@ -2373,12 +2383,8 @@ ActiveRecord::Schema.define(version: 2024_03_21_184256) do
     t.index ["word", "definition"], name: "index_vocabularies_on_word_and_definition", type: :fulltext
   end
 
-  add_foreign_key "census_submission_form_maps", "census_submissions"
-  add_foreign_key "census_summaries", "schools"
-  add_foreign_key "hint_view_requests", "users"
   add_foreign_key "learning_goal_ai_evaluations", "learning_goals"
   add_foreign_key "learning_goal_ai_evaluations", "rubric_ai_evaluations"
-  add_foreign_key "level_concept_difficulties", "levels"
   add_foreign_key "lti_courses", "lti_deployments"
   add_foreign_key "lti_courses", "lti_integrations"
   add_foreign_key "lti_deployments", "lti_integrations"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -57,9 +57,9 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.string "type"
     t.string "project_id"
     t.string "project_version_id"
-    t.text "prompt"
+    t.text "prompt", size: :medium
     t.string "status"
-    t.text "ai_response"
+    t.text "ai_response", size: :medium
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["level_id"], name: "index_ai_tutor_interactions_on_level_id"
@@ -452,7 +452,7 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.index ["project_id"], name: "index_datablock_storage_kvps_on_project_id"
   end
 
-  create_table "datablock_storage_library_manifest", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "datablock_storage_library_manifest", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.json "library_manifest"
     t.integer "singleton_guard", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -479,7 +479,7 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.index ["project_id"], name: "index_datablock_storage_tables_on_project_id"
   end
 
-  create_table "delayed_jobs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "delayed_jobs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -655,7 +655,7 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.index ["user_id"], name: "index_hint_view_requests_on_user_id"
   end
 
-  create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "learning_goal_ai_evaluation_id", null: false
     t.bigint "teacher_id", null: false
     t.boolean "ai_feedback_approval", null: false
@@ -669,7 +669,7 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.index ["learning_goal_ai_evaluation_id"], name: "index_feedback_on_learning_goal_ai_evaluation"
   end
 
-  create_table "learning_goal_ai_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_ai_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "rubric_ai_evaluation_id", null: false
     t.bigint "learning_goal_id", null: false
     t.integer "understanding"
@@ -849,7 +849,7 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "lti_courses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "lti_courses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lti_integration_id", null: false
     t.bigint "lti_deployment_id", null: false
     t.string "context_id"
@@ -875,7 +875,7 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.index ["lti_integration_id"], name: "index_lti_deployments_on_lti_integration_id"
   end
 
-  create_table "lti_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "lti_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "satisfied", null: false
     t.string "locale"
@@ -902,7 +902,7 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.index ["platform_id"], name: "index_lti_integrations_on_platform_id"
   end
 
-  create_table "lti_sections", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "lti_sections", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lti_course_id", null: false
     t.integer "section_id", null: false
     t.string "lms_section_id"
@@ -1045,7 +1045,7 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.index ["user_id"], name: "index_pd_applications_on_user_id"
   end
 
-  create_table "pd_applications_status_logs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications_status_logs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "pd_application_id", null: false
     t.string "status", null: false
     t.datetime "timestamp", null: false
@@ -1532,7 +1532,7 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.index ["user_id", "plc_course_id"], name: "index_plc_user_course_enrollments_on_user_id_and_plc_course_id", unique: true
   end
 
-  create_table "potential_teachers", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "potential_teachers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
     t.integer "script_id"
@@ -1623,7 +1623,7 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
   end
 
-  create_table "project_use_datablock_storages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "project_use_datablock_storages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "project_id", null: false
     t.boolean "use_datablock_storage", default: false, null: false
     t.index ["project_id"], name: "index_project_use_datablock_storages_on_project_id"
@@ -1728,7 +1728,7 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.index ["name", "url"], name: "index_resources_on_name_and_url", type: :fulltext
   end
 
-  create_table "rubric_ai_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "rubric_ai_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "requester_id", null: false
     t.bigint "rubric_id", null: false
@@ -1930,7 +1930,7 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.index ["stage_id"], name: "index_section_hidden_stages_on_stage_id"
   end
 
-  create_table "section_instructors", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "section_instructors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "instructor_id", null: false
     t.integer "section_id", null: false
     t.integer "invited_by_id"
@@ -2383,8 +2383,12 @@ ActiveRecord::Schema.define(version: 2024_04_03_074309) do
     t.index ["word", "definition"], name: "index_vocabularies_on_word_and_definition", type: :fulltext
   end
 
+  add_foreign_key "census_submission_form_maps", "census_submissions"
+  add_foreign_key "census_summaries", "schools"
+  add_foreign_key "hint_view_requests", "users"
   add_foreign_key "learning_goal_ai_evaluations", "learning_goals"
   add_foreign_key "learning_goal_ai_evaluations", "rubric_ai_evaluations"
+  add_foreign_key "level_concept_difficulties", "levels"
   add_foreign_key "lti_courses", "lti_deployments"
   add_foreign_key "lti_courses", "lti_integrations"
   add_foreign_key "lti_deployments", "lti_integrations"


### PR DESCRIPTION
The following PR creates the migration for a new `ai_tutor_iteraction_feedbacks` table. 

Long term, I expect the UI for this may be more like the Teacher Tools' AI TA feedback (see below), and we would need to add 1) column(s) to store boolean values associated with checkboxes for detailed feedback included in the UI and/or 2) a column to store the text of free-form feedback.

<img width="605" alt="Screenshot 2024-04-03 at 12 22 05 AM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/8cda29b7-0837-4b4c-943b-a362a0b14534">

Since I don't know what these checkboxes/more detailed feedback paths might look like yet, I left them out of this version. This table should be pretty easy to alter after the fact, especially while I'm just testing with a few rows. 

## Links

Thread in #ai-tutor about how this should look: https://codedotorg.slack.com/archives/C06KYAJDB24/p1711573169852269

Thread in #ai-tutor with old Figma files from Edu bot: https://codedotorg.slack.com/archives/C06KYAJDB24/p1712000586140329?thread_ts=1711990444.119789&cid=C06KYAJDB24

Jira ticket: https://codedotorg.atlassian.net/browse/CT-440

## Testing story

Ran the migration locally using `rails db:migrate` and inspected.

<img width="669" alt="Screenshot 2024-04-03 at 8 45 27 AM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/d9654d54-4cc6-43e2-ae07-f58770970f49">

## Follow-up work

Potentially: 
- Decide which checkbox-based feedback buttons we want, if any, and write alter to add columns
- Add an "other_context" column as a catch-all for text-based feedback at the interaction level
- Add this to the cron job that deletes student responses after 30 days: https://codedotorg.atlassian.net/browse/CT-472

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
