### PR TITLE
Nicklathe/debug statsig

### DIFF
--- a/dashboard/config/initializers/statsig.rb
+++ b/dashboard/config/initializers/statsig.rb
@@ -1,6 +1,6 @@
 require "cdo/statsig"
-# Statsig is initialized here for the development environment. In managed
-# environments, it is initialized in lib/cdo/app_server_hooks
-if CDO.rack_env?(:development)
-  Cdo::StatsigInitializer.init
-end
+# Statsig is initialized here for all environments. In managed
+# environments, it is also initialized in lib/cdo/app_server_hooks. This
+# guarantees Statsig has been initialized everywhere, and is available in all
+# worker threads.
+Cdo::StatsigInitializer.init

--- a/lib/cdo/statsig.rb
+++ b/lib/cdo/statsig.rb
@@ -4,14 +4,14 @@ module Cdo
   module StatsigInitializer
     def self.init
       # Determine if this is the managed Test web application server
-      # managed_test_environment = CDO.running_web_application? && CDO.test_system?
+      managed_test_environment = CDO.running_web_application? && CDO.test_system?
       # Enable local_mode for all environments except Production and our managed Test
       # web application server. This is done to keep parity between those two
       # environments. Anything else that runs on the Test server, as well as
       # code that executes in the continous integration builds, will run in local_mode.
       # This limits the number of metrics we emit, thereby lowering our credit usage.
-      # local_mode = CDO.rack_env?(:production) || managed_test_environment ? false : true
-      options = StatsigOptions.new({'tier' => CDO.rack_env}, network_timeout: 5, local_mode: false)
+      local_mode = CDO.rack_env?(:production) || managed_test_environment ? false : true
+      options = StatsigOptions.new({'tier' => CDO.rack_env}, network_timeout: 5, local_mode: local_mode)
       # Initialize Statsig
       Statsig.initialize(CDO.statsig_server_secret_key, options)
     end

--- a/lib/cdo/statsig.rb
+++ b/lib/cdo/statsig.rb
@@ -4,14 +4,14 @@ module Cdo
   module StatsigInitializer
     def self.init
       # Determine if this is the managed Test web application server
-      managed_test_environment = CDO.running_web_application? && CDO.test_system?
+      # managed_test_environment = CDO.running_web_application? && CDO.test_system?
       # Enable local_mode for all environments except Production and our managed Test
       # web application server. This is done to keep parity between those two
       # environments. Anything else that runs on the Test server, as well as
       # code that executes in the continous integration builds, will run in local_mode.
       # This limits the number of metrics we emit, thereby lowering our credit usage.
-      local_mode = CDO.rack_env?(:production) || managed_test_environment ? false : true
-      options = StatsigOptions.new({'tier' => CDO.rack_env}, network_timeout: 5, local_mode: local_mode)
+      # local_mode = CDO.rack_env?(:production) || managed_test_environment ? false : true
+      options = StatsigOptions.new({'tier' => CDO.rack_env}, network_timeout: 5, local_mode: false)
       # Initialize Statsig
       Statsig.initialize(CDO.statsig_server_secret_key, options)
     end


### PR DESCRIPTION
This fixes the bug where Statsig was not being initialized in Production. This was due to misunderstanding the (slightly unclear) [Statsig initialization instructions](https://docs.statsig.com/server/rubySDK#initializing-statsig-in-a-rails-application). In addtion to initializing in Puma, it's also necessary to initialize in the Rails initializer. This is true for all environments, not just development.

Statsig is idempotent in it's initialization, and is safe to re-init even if it's already running.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
