### PR TITLE
P20-829: Fix `ScriptLevelsControllerTest`

### DIFF
--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -10,6 +10,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
+    seed_deprecated_unit_fixtures
+
     @student = create :student
     @young_student = create :young_student
     @teacher = create :teacher


### PR DESCRIPTION
## Error
```
ERROR["test_end_of_HoC_for_logged_in_user_works", "ScriptLevelsControllerTest", 394.0016790710001]
 test_end_of_HoC_for_logged_in_user_works#ScriptLevelsControllerTest (394.00s)
Minitest::UnexpectedError:         RuntimeError: No active levels found for scriptlevel 47986
            app/controllers/script_levels_controller.rb:481:in `select_level'
```

## Links
- JIRA ticket [P20-829](https://codedotorg.atlassian.net/browse/P20-829)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/57743