### PR TITLE
LinkButton component style updates

### DIFF
--- a/apps/src/componentLibrary/button/CHANGELOG.md
+++ b/apps/src/componentLibrary/button/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.1](https://github.com/code-dot-org/code-dot-org/pull/56925)
+## [0.2.1](https://github.com/code-dot-org/code-dot-org/pull/57764)
 * updated link button styles to prevent overrides by application.scss
-* added a border to all buttons so they are the same height
+* added a transparent border to all buttons, so they are the same height
 * added a subtle hover transition animation
 
 ## [0.2.0](https://github.com/code-dot-org/code-dot-org/pull/56925)

--- a/apps/src/componentLibrary/button/CHANGELOG.md
+++ b/apps/src/componentLibrary/button/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1](https://github.com/code-dot-org/code-dot-org/pull/56925)
+* updated link button styles to prevent overrides by application.scss
+* added a border to all buttons so they are the same height
+* added a subtle hover transition animation
+
 ## [0.2.0](https://github.com/code-dot-org/code-dot-org/pull/56925)
 * implemented component
 * added tests

--- a/apps/src/componentLibrary/button/_baseButton/_baseButton.module.scss
+++ b/apps/src/componentLibrary/button/_baseButton/_baseButton.module.scss
@@ -2,7 +2,8 @@
 @import "@cdo/apps/componentLibrary/common/styles/mixins";
 
 // Button common styles
-.button {
+.button,
+a.button {
   display: inline-flex;
   justify-content: center;
   text-align: center;
@@ -56,7 +57,8 @@
 }
 
 // Button Colors
-.button-primary {
+.button-primary,
+a.button-primary {
   &.button-purple {
     background-color: $light_secondary_500;
     color: $light_white;
@@ -100,7 +102,8 @@
   }
 }
 
-.button-secondary {
+.button-secondary,
+a.button-secondary {
   &.button-purple {
     border: 1px solid $light_secondary_500;
     color: $light_secondary_500;
@@ -168,7 +171,8 @@
   }
 }
 
-.button-tertiary {
+.button-tertiary,
+a.button-tertiary {
   &.button-purple {
     color: $light_secondary_500;
 
@@ -228,7 +232,8 @@
 }
 
 // Button Sizes
-.button-l {
+.button-l,
+a.button-l {
   padding: 0.625rem 1rem;
   gap: 0.5rem;
 
@@ -248,7 +253,8 @@
   }
 }
 
-.button-m {
+.button-m,
+a.button-m {
   padding: 0.5rem 1rem;
   gap: 0.5rem;
 
@@ -268,7 +274,8 @@
   }
 }
 
-.button-s {
+.button-s,
+a.button-s {
   padding: 0.3125rem 1rem;
   gap: 0.5rem;
 
@@ -288,7 +295,8 @@
   }
 }
 
-.button-xs {
+.button-xs,
+a.button-xs {
   padding: 0.125rem 0.5rem;
   gap: 0.25rem;
 

--- a/apps/src/componentLibrary/button/_baseButton/_baseButton.module.scss
+++ b/apps/src/componentLibrary/button/_baseButton/_baseButton.module.scss
@@ -13,7 +13,7 @@ a.button {
 
   margin: 0;
   padding: 0;
-  border: 1px solid;
+  border: 1px solid transparent;
   background-color: transparent;
   color: unset;
   text-decoration: none !important;
@@ -48,7 +48,7 @@ a.button {
 
   &:active {
     // !important is used here to override the ./apps/style/common.scss line 655 styles
-    border: none !important;
+    border: 1px solid transparent !important;
   }
 
   &:disabled, &[aria-disabled="true"] {

--- a/apps/src/componentLibrary/button/_baseButton/_baseButton.module.scss
+++ b/apps/src/componentLibrary/button/_baseButton/_baseButton.module.scss
@@ -13,11 +13,12 @@ a.button {
 
   margin: 0;
   padding: 0;
-  border: none;
+  border: 1px solid;
   background-color: transparent;
   color: unset;
-  text-decoration: none;
+  text-decoration: none !important;
   cursor: pointer;
+  transition: all 0.2s ease-in-out;
 
   &:focus-visible, &:focus {
     text-decoration: none;
@@ -52,7 +53,7 @@ a.button {
 
   &:disabled, &[aria-disabled="true"] {
     cursor: not-allowed;
-    border: none;
+    border-color: $light_gray_200;
   }
 }
 


### PR DESCRIPTION
Adds link tag (`a.button`) selectors to button style groups on `_baseButton.module.scss` to override link styles on `application.scss`: https://github.com/code-dot-org/code-dot-org/blob/21c14b9c5c9c2edc65111afb229ab773fab58670/dashboard/app/assets/stylesheets/application.scss#L491-L518

**Also includes the following enhancements:** 
  - Adds a border to all buttons (primary and disabled) so they're the same height as the secondary buttons
  - Adds a subtle hover transition animation

💬 [Slack convo](https://codedotorg.slack.com/archives/C0532LCK125/p1712162369463069) - see more context on how styles are being overridden. 

----

## Border
| Before | After |
| ---- | ---- |
| <img width="262" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/ed65fe25-a8d4-49e7-bbc1-16d75392a887"> | <img width="262" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/250a8698-80ff-4a9c-8838-fa570b0e1e7d"> |

## Hover transition

https://github.com/code-dot-org/code-dot-org/assets/9256643/31584260-001d-495f-b510-ea048a44d20a

