### PR TITLE
P20-829: Fix `ScriptsControllerTest` and `ScriptLevelsHelperTest`

### DIFF
--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 class ScriptsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
+  setup_all do
+    seed_deprecated_unit_fixtures
+  end
+
   setup do
     @coursez_2017 = create :script, name: 'coursez-2017', family_name: 'coursez', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
     @coursez_2018 = create :script, name: 'coursez-2018', family_name: 'coursez', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -5,6 +5,10 @@ class ScriptLevelsHelperTest < ActionView::TestCase
   include ApplicationHelper
   include LevelsHelper
 
+  setup_all do
+    seed_deprecated_unit_fixtures
+  end
+
   setup do
     @teacher = create(:teacher)
     @student = create(:student)


### PR DESCRIPTION
## Errors
```
ERROR["test_show_of_hourofcode_redirects_to_hoc", "ScriptsControllerTest", 28.481689999985974]
 test_show_of_hourofcode_redirects_to_hoc#ScriptsControllerTest (28.48s)
Minitest::UnexpectedError:         NoMethodError: undefined method `id' for nil:NilClass
```

```
ERROR["test_show_lesson_name_in_header_for_multi-lesson_script", "ScriptLevelsHelperTest", 4.859929999976885]
 test_show_lesson_name_in_header_for_multi-lesson_script#ScriptLevelsHelperTest (4.86s)
Minitest::UnexpectedError:         NoMethodError: undefined method `id' for nil:NilClass
```

## Links
- JIRA ticket [P20-829](https://codedotorg.atlassian.net/browse/P20-829)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/57743