### PR TITLE
Add ariaLabel prop to LinkButton on ActionBlocksWrapper component

### DIFF
--- a/apps/src/templates/studioHomepages/ActionBlocksWrapper.jsx
+++ b/apps/src/templates/studioHomepages/ActionBlocksWrapper.jsx
@@ -39,6 +39,7 @@ const OneColumnActionBlock = ({
               size="m"
               text={button.text}
               type={button.type}
+              ariaLabel={button.ariaLabel}
             />
           ))}
       </div>
@@ -59,6 +60,7 @@ OneColumnActionBlock.propTypes = {
       text: PropTypes.string,
       target: PropTypes.string,
       type: PropTypes.string,
+      ariaLabel: PropTypes.string,
     })
   ),
 };

--- a/apps/src/templates/studioHomepages/ActionBlocksWrapper.story.jsx
+++ b/apps/src/templates/studioHomepages/ActionBlocksWrapper.story.jsx
@@ -20,6 +20,7 @@ const generateActionBlocks = tileCount => {
           color: 'purple',
           url: '#',
           text: 'Primary button',
+          ariaLabel: 'Aria label goes here',
         },
         {
           color: 'black',


### PR DESCRIPTION
Adds the `ariaLabel` prop to the `ActionBlocksWrapper` component. 

**Jira ticket:** [ACQ-1710](https://codedotorg.atlassian.net/browse/ACQ-1710)

----

## Storybook example
<img width="500" alt="Screenshot 2024-04-03 at 10 38 05 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/2d5773a6-34d7-4950-9fb1-ff4f48c77fa6">
