### PR TITLE
P20-829: Fix `DBQueryTest`

### DIFF
--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 # Prevent regressions in the number of database queries on high-traffic routes.
 class DBQueryTest < ActionDispatch::IntegrationTest
+  setup_all do
+    seed_deprecated_unit_fixtures
+  end
+
   def setup
     setup_script_cache
   end


### PR DESCRIPTION
## Error
```
ERROR["test_script_level_show", "DBQueryTest", 13.879512000014074]
 test_script_level_show#DBQueryTest (13.88s)
Minitest::UnexpectedError:         ActiveRecord::NotNullViolation: Mysql2::Error: Field 'level_id' doesn't have a default value
            config/initializers/mysql_check_index_used.rb:33:in `block (3 levels) in execute'
            config/initializers/mysql_check_index_used.rb:32:in `block (2 levels) in execute'
            config/initializers/mysql_check_index_used.rb:31:in `block in execute'
            config/initializers/mysql_check_index_used.rb:30:in `execute'
            test/integration/db_query_test.rb:17:in `block in <class:DBQueryTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

## Links
- JIRA ticket [P20-829](https://codedotorg.atlassian.net/browse/P20-829)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/57743