### PR TITLE
P20-829: Undo optimization of deprecated unit fixtures seeding

### DIFF
--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -174,6 +174,10 @@ class ActiveSupport::TestCase
     end
   end
 
+  setup_all do
+    seed_deprecated_unit_fixtures
+  end
+
   def assert_creates(*args)
     assert_difference(args.collect(&:to_s).collect {|class_name| "#{class_name}.count"}) do
       yield


### PR DESCRIPTION
Only relevant on Apr 3, to be merged if test build doesn't pass (apply this as an alternative to reverting https://github.com/code-dot-org/code-dot-org/pull/57743). Can delete after apr 3 if not already applied.

## Links
- JIRA ticket [P20-829](https://codedotorg.atlassian.net/browse/P20-829)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/57743