### PR TITLE
Backfill level reference_links and map_reference properties for 2024 scripts

### DIFF
--- a/bin/oneoff/backfill_data/backfill_level_references.rb
+++ b/bin/oneoff/backfill_data/backfill_level_references.rb
@@ -4,7 +4,7 @@
 # Context
 # Reference guides for curriculum was migrated to a framework that supports versioning
 # But, the corresponding change needed to update version for linked reference guides when
-# cloning scripts is currently missing. That is tracked by task TEACH-
+# cloning scripts is currently missing. That is tracked by task https://codedotorg.atlassian.net/browse/TEACH-1008
 
 # This script is a backfill to fix the reference guide version for scripts that are already
 # cloned for 2024.

--- a/bin/oneoff/backfill_data/backfill_level_references.rb
+++ b/bin/oneoff/backfill_data/backfill_level_references.rb
@@ -26,11 +26,8 @@ def update_reference_guide_format(unit_group_name, course_version_id, reference_
 
   reference_guide = ReferenceGuide.find_by(key: reference_guide_key, course_version_id: course_version_id)
   if reference_guide.nil?
-    ref_guide_missing_err = "Unable to find reference guide with key #{reference_guide_key}"
-    puts ref_guide_missing_err
-
-    raise ref_guide_missing_err unless DRY_RUN
-    return nil
+    puts "Unable to find reference guide with key #{reference_guide_key}, should be udpated manually"
+    return reference_guide_link
   end
 
   "/courses/#{unit_group_name}/guides/#{reference_guide_key}"

--- a/bin/oneoff/backfill_data/backfill_level_references.rb
+++ b/bin/oneoff/backfill_data/backfill_level_references.rb
@@ -15,6 +15,10 @@ require_relative '../../../dashboard/config/environment'
 DRY_RUN = !((ARGV.find {|arg| arg.casecmp('-dryrun')}).nil?)
 
 def update_reference_guide_format(unit_group_name, course_version_id, reference_guide_link)
+  if !reference_guide_link.starts_with?("/docs/") && !reference_guide_link.starts_with?("/courses/")
+    return reference_guide_link
+  end
+
   reference_guide_key = reference_guide_link.split("/").reject(&:blank?).map(&:strip).last
   reference_guide = ReferenceGuide.find_by(key: reference_guide_key, course_version_id: course_version_id)
 

--- a/bin/oneoff/backfill_data/backfill_level_references.rb
+++ b/bin/oneoff/backfill_data/backfill_level_references.rb
@@ -18,7 +18,7 @@ def update_reference_guide_format(unit_group_name, course_version_id, reference_
   # Reference guide formats
   # in the old unversioned framework - /docs/concepts/patterns/random-list-access/
   # in the versioned framework - /courses/csd-2024/guides/animation-tab
-  if !reference_guide_link.starts_with?("/docs/") && !reference_guide_link.starts_with?("/courses/")
+  if !reference_guide_link.starts_with?("/docs/concepts") && !reference_guide_link.starts_with?("/courses/")
     return reference_guide_link
   end
 

--- a/bin/oneoff/backfill_data/backfill_level_references.rb
+++ b/bin/oneoff/backfill_data/backfill_level_references.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+
+# https://codedotorg.atlassian.net/browse/TEACH-935
+# Context
+# Reference guides for curriculum was migrated to a framework that supports versioning
+# But, the corresponding change needed to update version for linked reference guides when
+# cloning scripts is currently missing. That is tracked by task TEACH-
+
+# This script is a backfill to fix the reference guide version for scripts that are already
+# cloned for 2024.
+
+require_relative '../../../dashboard/config/environment'
+
+# Override for the dry run variable using an commandline argument
+DRY_RUN = !((ARGV.find {|arg| arg.casecmp('-dryrun')}).nil?)
+
+def update_reference_guide_format(unit_group_name, course_version_id, reference_guide_link)
+  reference_guide_key = reference_guide_link.split("/").reject(&:blank?).map(&:strip).last
+  reference_guide = ReferenceGuide.find_by(key: reference_guide_key, course_version_id: course_version_id)
+
+  if reference_guide.nil?
+    ref_guide_missing_err = "Unable to find reference guide with key #{reference_guide_key}"
+    puts ref_guide_missing_err
+
+    raise ref_guide_missing_err unless DRY_RUN
+    return nil
+  end
+
+  "/courses/#{unit_group_name}/guides/#{reference_guide_key}"
+end
+
+def backfill_level_reference_guides
+  raise unless Rails.application.config.levelbuilder_mode
+
+  backfill_unit_groups = ["csa-2024", "csd-2024", "csp-2024"]
+
+  backfill_unit_groups.each do |unit_gp|
+    unit_group = UnitGroup.find_by(name: unit_gp)
+    course_ver_id = unit_group.course_version.id
+
+    puts "Backfilling reference guides in Unit group [#{unit_gp}], course Version ID [#{course_ver_id}]"
+    unit_group.default_units.each do |scpt|
+      puts "Processing Unit [#{scpt.name}], ID: [#{scpt.id}]"
+      next if scpt.levels.nil?
+
+      scpt.levels.each do |level|
+        puts "Processing Level [#{level.name}], ID: [#{level.id}], current reference links [#{level.reference_links}] map reference [#{level.map_reference}]"
+        level_updates = false
+
+        unless level.reference_links.nil?
+          # create new array and have each existing ref go through above method
+          # update reference_link with new array
+          new_references = level.reference_links.map {|rl| update_reference_guide_format(unit_gp, course_ver_id, rl)}
+          level.reference_links = new_references
+          level_updates = true
+        end
+
+        unless level.map_reference.nil?
+          # directly update map_reference property, which is a string
+          level.map_reference = update_reference_guide_format(unit_gp, course_ver_id, level.map_reference)
+          level_updates = true
+        end
+
+        next unless level_updates
+
+        puts "New reference links [#{level.reference_links}] map reference [#{level.map_reference}]"
+        unless DRY_RUN
+          level.save!
+        end
+      end
+    end
+  end
+end
+
+backfill_level_reference_guides

--- a/bin/oneoff/backfill_data/backfill_level_references.rb
+++ b/bin/oneoff/backfill_data/backfill_level_references.rb
@@ -15,13 +15,16 @@ require_relative '../../../dashboard/config/environment'
 DRY_RUN = !((ARGV.find {|arg| arg.casecmp('-dryrun')}).nil?)
 
 def update_reference_guide_format(unit_group_name, course_version_id, reference_guide_link)
+  # Reference guide formats
+  # in the old unversioned framework - /docs/concepts/patterns/random-list-access/
+  # in the versioned framework - /courses/csd-2024/guides/animation-tab
   if !reference_guide_link.starts_with?("/docs/") && !reference_guide_link.starts_with?("/courses/")
     return reference_guide_link
   end
 
   reference_guide_key = reference_guide_link.split("/").reject(&:blank?).map(&:strip).last
-  reference_guide = ReferenceGuide.find_by(key: reference_guide_key, course_version_id: course_version_id)
 
+  reference_guide = ReferenceGuide.find_by(key: reference_guide_key, course_version_id: course_version_id)
   if reference_guide.nil?
     ref_guide_missing_err = "Unable to find reference guide with key #{reference_guide_key}"
     puts ref_guide_missing_err
@@ -52,15 +55,12 @@ def backfill_level_reference_guides
         level_updates = false
 
         unless level.reference_links.nil?
-          # create new array and have each existing ref go through above method
-          # update reference_link with new array
           new_references = level.reference_links.map {|rl| update_reference_guide_format(unit_gp, course_ver_id, rl)}
           level.reference_links = new_references
           level_updates = true
         end
 
         unless level.map_reference.nil?
-          # directly update map_reference property, which is a string
           level.map_reference = update_reference_guide_format(unit_gp, course_ver_id, level.map_reference)
           level_updates = true
         end


### PR DESCRIPTION
Context: The set of reference guides in the curriculum are versioned. But, the cloning processing today is missing a step to update the reference guides that are linked in new/cloned levels to use the appropriate version. 

This PR is a script that would retroactively fix the reference guides for levels in 2024 version of CSD, CSA and CSP.

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-935

## Testing story

Validated the change locally by running in "-dryrun" mode. Trimmed sample output below

```
Processing Unit [csd3-2024], ID: [22969]
Processing Level [CSD U3 L1 - Design Templates_2024], ID: [47984], current reference links [] map reference []
Processing Level [intro-pulse-survey_csd3_2024], ID: [48073], current reference links [] map reference []
Processing Level [CSD U3 Plotting Shapes Shape Lab_2024], ID: [47171], current reference links [] map reference []
Processing Level [CSD U3L3 rect_2024], ID: [47358], current reference links [] map reference []
Processing Level [CSD U3 rect_2024], ID: [47343], current reference links [] map reference []
Processing Level [CSD U3 Drawing Squares to Corners_2024], ID: [47092], current reference links [] map reference [/courses/csd-2022/guides/drawing-shapes]
New reference links [] map reference [/courses/csd-2024/guides/drawing-shapes]
Processing Level [CSD U3 fill_2024], ID: [47300], current reference links [] map reference [/courses/csd-2022/guides/drawing-shapes]
New reference links [] map reference [/courses/csd-2024/guides/drawing-shapes]
Processing Level [CSD U3 sequence_2024], ID: [47345], current reference links [] map reference [/courses/csd-2022/guides/drawing-shapes]
New reference links [] map reference [/courses/csd-2024/guides/drawing-shapes]
Processing Level [CSD U3 ellipse_2024], ID: [47299], current reference links [] map reference [/courses/csd-2022/guides/drawing-shapes]
New reference links [] map reference [/courses/csd-2024/guides/drawing-shapes]
Processing Level [CSD U3 drawing practice choice_2024], ID: [47981], current reference links [] map reference []
Processing Level [CSD U3 debug_2024], ID: [47292], current reference links [] map reference [/courses/csd-2022/guides/drawing-shapes]
New reference links [] map reference [/courses/csd-2024/guides/drawing-shapes]
Processing Level [CSD U3 drawing challenges_2024], ID: [47980], current reference links [] map reference []
Processing Level [CSD U3L4 - Predict_2024], ID: [47360], current reference links [["/courses/csd-2022/guides/shapes-and-parameters"]] map reference [/courses/csd-2022/guides/drawing-shapes]
New reference links [["/courses/csd-2024/guides/shapes-and-parameters"]] map reference [/courses/csd-2024/guides/drawing-shapes]
......
```

## Deployment strategy

1. Deploy script to levelbuilder machine as part of regular deployment
2. Run the script in dryrun mode to identify any errors/issues
3. After resolution of issues and we have a clean dryrun, execute the script to make the actual updates

## Follow-up work

https://codedotorg.atlassian.net/browse/TEACH-1008

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
