### PR TITLE
Hide deprecated projects from personal project table

### DIFF
--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -188,3 +188,5 @@ export const TOOLBOX_EDIT_MODE = 'toolbox_blocks';
 export const NOTIFICATION_ALERT_TYPE = 'notification';
 
 export const START_BLOCKS = 'start_blocks';
+
+export const DEPRECATED_LABS = ['calc', 'eval'];

--- a/apps/src/templates/projects/PersonalProjectsTable.jsx
+++ b/apps/src/templates/projects/PersonalProjectsTable.jsx
@@ -17,6 +17,8 @@ import DeleteProjectDialog from '@cdo/apps/templates/projects/deleteDialog/Delet
 import FrozenProjectInfoDialog from '@cdo/apps/templates/projects/frozenProjectInfoDialog/FrozenProjectInfoDialog';
 import {isSignedIn} from '@cdo/apps/templates/currentUserRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import {filter} from 'lodash';
+import {DEPRECATED_LABS} from '@cdo/apps/constants';
 
 const PROJECT_DEFAULT_IMAGE = '/blockly/media/projects/project_default.png';
 
@@ -186,6 +188,11 @@ class PersonalProjectsTable extends React.Component {
   render() {
     const personalProjectsList = this.props.personalProjectsList || [];
 
+    // Filter out projects of deprecated labs, like Calc and Eval.
+    const supportedPersonalProjectsList = personalProjectsList.filter(
+      project => !DEPRECATED_LABS.includes(project.type)
+    );
+
     // Define a sorting transform that can be applied to each column
     const sortable = wrappedSortable(
       this.getSortingColumns,
@@ -199,9 +206,9 @@ class PersonalProjectsTable extends React.Component {
       columns,
       sortingColumns,
       sort: orderBy,
-    })(personalProjectsList);
+    })(supportedPersonalProjectsList);
 
-    const noProjects = personalProjectsList.length === 0;
+    const noProjects = supportedPersonalProjectsList.length === 0;
 
     return (
       <div>

--- a/apps/src/templates/projects/PersonalProjectsTable.jsx
+++ b/apps/src/templates/projects/PersonalProjectsTable.jsx
@@ -17,7 +17,6 @@ import DeleteProjectDialog from '@cdo/apps/templates/projects/deleteDialog/Delet
 import FrozenProjectInfoDialog from '@cdo/apps/templates/projects/frozenProjectInfoDialog/FrozenProjectInfoDialog';
 import {isSignedIn} from '@cdo/apps/templates/currentUserRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
-import {filter} from 'lodash';
 import {DEPRECATED_LABS} from '@cdo/apps/constants';
 
 const PROJECT_DEFAULT_IMAGE = '/blockly/media/projects/project_default.png';


### PR DESCRIPTION
Calc and Eval were deprecated in January 2023, but projects of these types still show up in the personal projects table. 

This makes it harder for us to actually end support for (ie. break) these labs. Having the freedom to do so could expedite the process of migrating other labs to mainline Blockly, specifically Play Lab ("Studio") and Star Wars.

Slack threads:
* https://codedotorg.slack.com/archives/C05DK21DAHK/p1712166286197639
* https://codedotorg.slack.com/archives/C03DBDN67B7/p1712170539321259

We can filter the projects list by type to remove them from the personal projects list.

Before:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/cba305f1-0eab-447a-a8b9-27a809d86cba)

After:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/bf97ad00-2737-4dd5-b250-2061d4b31f01)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
