### PR TITLE
[Google Blockly] Image and Label fields for K1 blocks

### DIFF
--- a/apps/src/blockly/addons/cdoFieldImage.ts
+++ b/apps/src/blockly/addons/cdoFieldImage.ts
@@ -1,4 +1,5 @@
-import GoogleBlockly from 'blockly/core';
+import GoogleBlockly, {Field, FieldImage, FieldImageConfig} from 'blockly/core';
+import {FIELD_IMAGE_DEFAULT_SIZE} from '../constants';
 
 export default class CdoFieldImage extends GoogleBlockly.FieldImage {
   // Y_PADDING is private in the parent class, so we need to redefine it here.
@@ -6,6 +7,21 @@ export default class CdoFieldImage extends GoogleBlockly.FieldImage {
   newWidth: number | null = null;
   newHeight: number | null = null;
   allowImageChange = true;
+
+  // width and height are required in the parent class, but were optional
+  // in the CDO Blockly implementation. We override the constructor in order
+  // to provide default values for the image width and height.
+  constructor(
+    src: string | typeof Field.SKIP_SETUP,
+    width: string | number = FIELD_IMAGE_DEFAULT_SIZE,
+    height: string | number = FIELD_IMAGE_DEFAULT_SIZE,
+    alt?: string,
+    onClick?: (p1: FieldImage) => void,
+    flipRtl?: boolean,
+    config?: FieldImageConfig
+  ) {
+    super(src, width, height, alt, onClick, flipRtl, config);
+  }
 
   updateDimensions(width: number, height: number) {
     this.newWidth = width;

--- a/apps/src/blockly/addons/cdoFieldLabel.ts
+++ b/apps/src/blockly/addons/cdoFieldLabel.ts
@@ -1,0 +1,22 @@
+import GoogleBlockly, {Field, FieldLabelConfig} from 'blockly/core';
+
+// The second parameter of CDO Blockly implementation of this class is
+// a config object, which we are not currently using. In Google Blockly,
+// the second parameter is an optional string for a class name. If the
+// config option was used, errors would occur.
+// The config option is specified for certain blocks in Jigsaw, Maze,
+// Artist, and Play Lab. We can potentially add additional handling of
+// this argument to this class in the future should we need it.
+export default class CdoFieldLabel extends GoogleBlockly.FieldLabel {
+  constructor(
+    value?: string | typeof Field.SKIP_SETUP,
+    styleConfig?: string | object,
+    config?: FieldLabelConfig
+  ) {
+    let textClass = undefined;
+    if (typeof styleConfig === 'string') {
+      textClass = styleConfig;
+    }
+    super(value, textClass, config);
+  }
+}

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -86,6 +86,7 @@ export const DEFAULT_SOUND = 'sound://category_digital/ping.mp3';
 export const NO_OPTIONS_MESSAGE = 'uninitialized';
 export const EMPTY_OPTION = '???';
 export const WORKSPACE_PADDING = 16;
+export const FIELD_IMAGE_DEFAULT_SIZE = 40;
 
 export function stringIsXml(str: string) {
   try {

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -16,6 +16,7 @@ import CdoFieldAnimationDropdown from './addons/cdoFieldAnimationDropdown';
 import CdoFieldBehaviorPicker from './addons/cdoFieldBehaviorPicker';
 import CdoFieldButton from './addons/cdoFieldButton';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
+import CdoFieldLabel from './addons/cdoFieldLabel';
 import CdoFieldToggle from './addons/cdoFieldToggle';
 import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
 import CdoFieldFlyout from './addons/cdoFieldFlyout';
@@ -266,7 +267,6 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('FieldColour');
   blocklyWrapper.wrapReadOnlyProperty('FieldColourDropdown');
   blocklyWrapper.wrapReadOnlyProperty('FieldIcon');
-  blocklyWrapper.wrapReadOnlyProperty('FieldLabel');
   blocklyWrapper.wrapReadOnlyProperty('FieldParameter');
   blocklyWrapper.wrapReadOnlyProperty('FieldRectangularDropdown');
   blocklyWrapper.wrapReadOnlyProperty('fieldRegistry');
@@ -330,6 +330,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     // CdoFieldBitmap extends from a JavaScript class without typing.
     // We know it's a field, so it's safe to cast as unknown.
     ['field_bitmap', 'FieldBitmap', CdoFieldBitmap as unknown as FieldProto],
+    ['field_label', 'FieldLabel', CdoFieldLabel],
   ];
   blocklyWrapper.overrideFields(fieldOverrides);
 

--- a/apps/test/unit/blockly/googleBlocklyWrapperTest.js
+++ b/apps/test/unit/blockly/googleBlocklyWrapperTest.js
@@ -44,7 +44,6 @@ describe('Google Blockly Wrapper', () => {
       'FieldColour',
       'FieldColourDropdown',
       'FieldIcon',
-      'FieldLabel',
       'FieldParameter',
       'FieldRectangularDropdown',
       'fish_locale',


### PR DESCRIPTION
This week I managed to get all of the Maze HoC levels into a usable state. Next, I went looking for the first Maze level in CSF (at `/s/coursea-2023/lessons/8/levels/1`). 

The maze levels in our pre-reader courses use "K1 Blocks" which work the same way but use images and shortened labels in place of the more verbose text commands. Shown below on production with CDO Blockly:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/31c4d920-31b1-41fe-bca6-0241feeae987)


I found that there were two somewhat similar problems with these blocks' fields that were causing errors with Google Blockly.

## Image Fields
First, we were evidently trying to create the image fields without specify a width and height. These size properties are required and expected to be numbers by Google Blockly: https://github.com/google/blockly/blob/9e05d69d2accba5dca97b39281b322a2ec0961d3/core/field_image.ts#L76-L77
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/eeb13e4e-f764-40f5-b062-4381367faccd)

So far, the images I've checked look to be rendered at 40px x 40px, which aligns with the width and height constants defined in the CDO Blockly `FieldImage`: https://github.com/code-dot-org/blockly/blob/f012d8262f21bae3e54fb11dd8bc29cf0d29f3cd/core/ui/fields/field_image.js#L62-L63
Since we already have our own extended `CdoFieldImage`, I realized we could could override the constructor to provide default values for the `width` and `height` that Google Blockly requires.


## Label Fields
Second, the constructor signatures differ greatly between our fork's Field Image class and the one in Mainline Google Blockly.

- CDO: https://github.com/code-dot-org/blockly/blob/f012d8262f21bae3e54fb11dd8bc29cf0d29f3cd/core/ui/fields/field_label.js#L38
- Google: https://github.com/google/blockly/blob/9e05d69d2accba5dca97b39281b322a2ec0961d3/core/field_label.ts#L48-L52
This was causing an error because Google Blockly was trying to split a config object as if it was a class name.

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/d7852af1-b9e4-4e85-a3bb-92a056f1cd7e)

For our migrated labs, we have been specifying a `value`, but not the optional `textClass` or `config` arguments. Several of our non-migrated labs have fields created with `value` and `config`. _It's important to note that the structure and purpose of the `config` parameters are different in each class._ Usually the config for our blocks is a set of style rules like `{fixedSize: {width: 12, height: 18}}`. If we ignore this value, the field renders just fine. FWIW, we probably don't actually even want a "fixed size" when we're aiming to support a high contrast theme with a larger text size.
I created a new `CdoFieldLabel` class which effectively ignores these config options for now, while also allowing for a class name to be used - in case that's something we'd ever want.

## After
The level loads without errors and can be completed as expected.
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/cddf0a94-8e07-4113-911f-097fb23146b2)



## Links

Jira: https://codedotorg.atlassian.net/browse/CT-474
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
