### PR TITLE
Enabling ES lint rule for folders aichat, ailab and aitutor

### DIFF
--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -186,9 +186,6 @@ module.exports = {
       files: [
         'src/*',
         'src/acemode/*',
-        'src/aichat/**',
-        'src/ailab/*',
-        'src/aiTutor/**',
         'src/applab/**',
         'src/assetManagement/*',
         'src/blockly/**',

--- a/apps/src/aiTutor/accessControlsApi.ts
+++ b/apps/src/aiTutor/accessControlsApi.ts
@@ -1,6 +1,7 @@
-import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
-import MetricsReporter from '@cdo/apps/lib/metrics/MetricsReporter';
 import {MetricEvent} from '@cdo/apps/lib/metrics/events';
+import MetricsReporter from '@cdo/apps/lib/metrics/MetricsReporter';
+import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
+
 import {StudentServerData} from './types';
 
 const formatServerData = (student: StudentServerData) => ({

--- a/apps/src/aiTutor/interactionsApi.ts
+++ b/apps/src/aiTutor/interactionsApi.ts
@@ -1,7 +1,8 @@
-import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
-import {AITutorInteraction} from './types';
-import MetricsReporter from '@cdo/apps/lib/metrics/MetricsReporter';
 import {MetricEvent} from '@cdo/apps/lib/metrics/events';
+import MetricsReporter from '@cdo/apps/lib/metrics/MetricsReporter';
+import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
+
+import {AITutorInteraction} from './types';
 
 // TODO: Pagination options can be added here
 interface FetchAITutorInteractionsOptions {

--- a/apps/src/aiTutor/redux/aiTutorRedux.ts
+++ b/apps/src/aiTutor/redux/aiTutorRedux.ts
@@ -1,10 +1,12 @@
-import {getChatCompletionMessage} from '@cdo/apps/aichat/chatApi';
 import {createSlice, PayloadAction, createAsyncThunk} from '@reduxjs/toolkit';
+
+import {getChatCompletionMessage} from '@cdo/apps/aichat/chatApi';
 import {
   compilationSystemPrompt,
   generalChatSystemPrompt,
   validationSystemPrompt,
 } from '@cdo/apps/aiTutor/constants';
+
 import {savePromptAndResponse} from '../interactionsApi';
 import {
   TutorType,

--- a/apps/src/aichat/chatApi.ts
+++ b/apps/src/aichat/chatApi.ts
@@ -5,9 +5,11 @@ import {
   PII,
 } from '@cdo/apps/aiTutor/types';
 import HttpClient from '@cdo/apps/util/HttpClient';
-import {CHAT_COMPLETION_URL} from './constants';
-import Lab2Registry from '../lab2/Lab2Registry';
+
 import {TutorType} from '../aiTutor/types';
+import Lab2Registry from '../lab2/Lab2Registry';
+
+import {CHAT_COMPLETION_URL} from './constants';
 
 /**
  * This function sends a POST request to the chat completion backend controller.

--- a/apps/src/aichat/locale-do-not-import.js
+++ b/apps/src/aichat/locale-do-not-import.js
@@ -7,8 +7,8 @@
  * which is important for making locale setup work seamlessly in tests.
  */
 
-import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 
 let locale = safeLoadLocale('aichat_locale');
 locale = localeWithI18nStringTracker(locale, 'aichat');

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -1,15 +1,12 @@
-import moment from 'moment';
 import {createSlice, PayloadAction, createAsyncThunk} from '@reduxjs/toolkit';
+import moment from 'moment';
+
 import {LabState} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-const registerReducers = require('@cdo/apps/redux').registerReducers;
+import {RootState} from '@cdo/apps/types/redux';
 
-import {
-  DEFAULT_VISIBILITIES,
-  EMPTY_AI_CUSTOMIZATIONS,
-} from '../views/modelCustomization/constants';
-import {initialChatMessages} from '../constants';
 import {getChatCompletionMessage} from '../chatApi';
+import {initialChatMessages} from '../constants';
 import {
   ChatCompletionMessage,
   AichatLevelProperties,
@@ -20,7 +17,12 @@ import {
   Visibility,
   LevelAichatSettings,
 } from '../types';
-import {RootState} from '@cdo/apps/types/redux';
+import {
+  DEFAULT_VISIBILITIES,
+  EMPTY_AI_CUSTOMIZATIONS,
+} from '../views/modelCustomization/constants';
+
+const registerReducers = require('@cdo/apps/redux').registerReducers;
 
 const haveDifferentValues = (
   value1: AiCustomizations[keyof AiCustomizations],

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -1,23 +1,27 @@
 /** @file Top-level view for AI Chat Lab */
 
 import React, {useCallback, useEffect, useState} from 'react';
-import Instructions from '@cdo/apps/lab2/views/components/Instructions';
-import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
-import {sendSuccessReport} from '@cdo/apps/code-studio/progressRedux';
-import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-const commonI18n = require('@cdo/locale');
-const aichatI18n = require('@cdo/aichat/locale');
 
-import {setStartingAiCustomizations} from '../redux/aichatRedux';
-import ChatWorkspace from './ChatWorkspace';
-import ModelCustomizationWorkspace from './ModelCustomizationWorkspace';
-import PresentationView from './presentation/PresentationView';
-import CopyButton from './CopyButton';
+import {AichatLevelProperties, ViewMode} from '@cdo/apps/aichat/types';
+import {sendSuccessReport} from '@cdo/apps/code-studio/progressRedux';
 import SegmentedButtons, {
   SegmentedButtonsProps,
 } from '@cdo/apps/componentLibrary/segmentedButtons/SegmentedButtons';
+import Instructions from '@cdo/apps/lab2/views/components/Instructions';
+import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import {setStartingAiCustomizations} from '../redux/aichatRedux';
+
+import ChatWorkspace from './ChatWorkspace';
+import CopyButton from './CopyButton';
+import ModelCustomizationWorkspace from './ModelCustomizationWorkspace';
+import PresentationView from './presentation/PresentationView';
+
 import moduleStyles from './aichatView.module.scss';
-import {AichatLevelProperties, ViewMode} from '@cdo/apps/aichat/types';
+
+const aichatI18n = require('@cdo/aichat/locale');
+const commonI18n = require('@cdo/locale');
 
 const AichatView: React.FunctionComponent = () => {
   const [viewMode, setViewMode] = useState<string>(ViewMode.EDIT);

--- a/apps/src/aichat/views/ChatMessage.tsx
+++ b/apps/src/aichat/views/ChatMessage.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
-import moduleStyles from './chatMessage.module.scss';
 import classNames from 'classnames';
+import React from 'react';
+import {useSelector} from 'react-redux';
+
+import Typography from '@cdo/apps/componentLibrary/typography/Typography';
+import {LabState} from '@cdo/apps/lab2/lab2Redux';
+
 import aichatI18n from '../locale';
 import {
   AichatLevelProperties,
@@ -8,9 +12,8 @@ import {
   Role,
   Status,
 } from '../types';
-import Typography from '@cdo/apps/componentLibrary/typography/Typography';
-import {useSelector} from 'react-redux';
-import {LabState} from '@cdo/apps/lab2/lab2Redux';
+
+import moduleStyles from './chatMessage.module.scss';
 
 interface ChatMessageProps {
   message: ChatCompletionMessage;

--- a/apps/src/aichat/views/ChatWarningModal.tsx
+++ b/apps/src/aichat/views/ChatWarningModal.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 
 import aichatI18n from '@cdo/apps/aichat/locale';
-import moduleStyles from './chatWarningModal.module.scss';
 import {
   BodyTwoText,
   Heading3,
   StrongText,
 } from '@cdo/apps/componentLibrary/typography';
-import Button from '@cdo/apps/templates/Button';
 import AccessibleDialog from '@cdo/apps/templates/AccessibleDialog';
+import Button from '@cdo/apps/templates/Button';
+
+import moduleStyles from './chatWarningModal.module.scss';
 
 export interface ChatWarningModalProps {
   onClose: () => void;

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -1,16 +1,19 @@
 import React, {useCallback, useEffect} from 'react';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {useSelector} from 'react-redux';
-import ChatWarningModal from '@cdo/apps/aichat/views/ChatWarningModal';
-import ChatMessage from './ChatMessage';
-import UserChatMessageEditor from './UserChatMessageEditor';
-import moduleStyles from './chatWorkspace.module.scss';
+
 import {
   AichatState,
   clearChatMessages,
   setShowWarningModal,
 } from '@cdo/apps/aichat/redux/aichatRedux';
+import ChatWarningModal from '@cdo/apps/aichat/views/ChatWarningModal';
 import {ProgressState} from '@cdo/apps/code-studio/progressRedux';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+
+import ChatMessage from './ChatMessage';
+import UserChatMessageEditor from './UserChatMessageEditor';
+
+import moduleStyles from './chatWorkspace.module.scss';
 
 /**
  * Renders the AI Chat Lab main chat workspace component.

--- a/apps/src/aichat/views/CopyButton.tsx
+++ b/apps/src/aichat/views/CopyButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {useSelector} from 'react-redux';
 
+import {AichatState} from '@cdo/apps/aichat/redux/aichatRedux';
 import Button from '@cdo/apps/templates/Button';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
-import {AichatState} from '@cdo/apps/aichat/redux/aichatRedux';
 
 const CopyButton: React.FunctionComponent = () => {
   const storedMessages = useSelector(

--- a/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
+++ b/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 
-import Tabs, {Tab} from './tabs/Tabs';
-import PromptCustomization from './modelCustomization/PromptCustomization';
-import RetrievalCustomization from './modelCustomization/RetrievalCustomization';
-import PublishNotes from './modelCustomization/PublishNotes';
-import styles from './model-customization-workspace.module.scss';
-import {isVisible} from './modelCustomization/utils';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import PromptCustomization from './modelCustomization/PromptCustomization';
+import PublishNotes from './modelCustomization/PublishNotes';
+import RetrievalCustomization from './modelCustomization/RetrievalCustomization';
+import {isVisible} from './modelCustomization/utils';
+import Tabs, {Tab} from './tabs/Tabs';
+
+import styles from './model-customization-workspace.module.scss';
 
 const ModelCustomizationWorkspace: React.FunctionComponent = () => {
   const {botName, temperature, systemPrompt, retrievalContexts, modelCardInfo} =

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -1,10 +1,13 @@
 import React, {useState, useCallback} from 'react';
+import {useSelector} from 'react-redux';
+
 import Button from '@cdo/apps/componentLibrary/button/Button';
-import moduleStyles from './userChatMessageEditor.module.scss';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+
 import aichatI18n from '../locale';
 import {AichatState, submitChatMessage} from '../redux/aichatRedux';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
-import {useSelector} from 'react-redux';
+
+import moduleStyles from './userChatMessageEditor.module.scss';
 
 /**
  * Renders the AI Chat Lab user chat message editor component.

--- a/apps/src/aichat/views/modelCustomization/CompareModelsDialog.tsx
+++ b/apps/src/aichat/views/modelCustomization/CompareModelsDialog.tsx
@@ -1,10 +1,11 @@
 import React, {useState} from 'react';
 
-import AccessibleDialog from '@cdo/apps/templates/AccessibleDialog';
-import {Heading3} from '@cdo/apps/componentLibrary/typography';
 import Button from '@cdo/apps/componentLibrary/button/Button';
+import {Heading3} from '@cdo/apps/componentLibrary/typography';
+import AccessibleDialog from '@cdo/apps/templates/AccessibleDialog';
 
 import ModelDescriptionPanel from './ModelDescriptionPanel';
+
 import styles from './compare-models-dialog.module.scss';
 
 const CompareModelsDialog: React.FunctionComponent<{onClose: () => void}> = ({

--- a/apps/src/aichat/views/modelCustomization/ModelDescriptionPanel.tsx
+++ b/apps/src/aichat/views/modelCustomization/ModelDescriptionPanel.tsx
@@ -1,8 +1,8 @@
 import React, {useEffect, useState, useRef} from 'react';
 
+import Button from '@cdo/apps/componentLibrary/button/Button';
 import SimpleDropdown from '@cdo/apps/componentLibrary/dropdown/simpleDropdown';
 import {BodyThreeText, StrongText} from '@cdo/apps/componentLibrary/typography';
-import Button from '@cdo/apps/componentLibrary/button/Button';
 
 import styles from './compare-models-dialog.module.scss';
 

--- a/apps/src/aichat/views/modelCustomization/PromptCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/PromptCustomization.tsx
@@ -1,5 +1,5 @@
-import React, {useCallback, useState} from 'react';
 import classNames from 'classnames';
+import React, {useCallback, useState} from 'react';
 
 import Button from '@cdo/apps/componentLibrary/button/Button';
 import SimpleDropdown from '@cdo/apps/componentLibrary/dropdown/simpleDropdown/SimpleDropdown';
@@ -11,13 +11,13 @@ import {
   updateAiCustomization,
 } from '../../redux/aichatRedux';
 
+import CompareModelsDialog from './CompareModelsDialog';
 import {
   MAX_TEMPERATURE,
   MIN_TEMPERATURE,
   SET_TEMPERATURE_STEP,
 } from './constants';
 import {isVisible, isDisabled} from './utils';
-import CompareModelsDialog from './CompareModelsDialog';
 
 import styles from '../model-customization-workspace.module.scss';
 

--- a/apps/src/aichat/views/modelCustomization/PromptCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/PromptCustomization.tsx
@@ -1,15 +1,16 @@
 import React, {useCallback, useState} from 'react';
 import classNames from 'classnames';
 
-import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
 import Button from '@cdo/apps/componentLibrary/button/Button';
 import SimpleDropdown from '@cdo/apps/componentLibrary/dropdown/simpleDropdown/SimpleDropdown';
+import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+
 import {
   setAiCustomizationProperty,
   updateAiCustomization,
 } from '../../redux/aichatRedux';
-import styles from '../model-customization-workspace.module.scss';
+
 import {
   MAX_TEMPERATURE,
   MIN_TEMPERATURE,
@@ -17,6 +18,8 @@ import {
 } from './constants';
 import {isVisible, isDisabled} from './utils';
 import CompareModelsDialog from './CompareModelsDialog';
+
+import styles from '../model-customization-workspace.module.scss';
 
 const PromptCustomization: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();

--- a/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
+++ b/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
@@ -1,14 +1,16 @@
 import React, {useCallback} from 'react';
 
-import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
-import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
-import Button from '@cdo/apps/componentLibrary/button/Button';
-import {MODEL_CARD_FIELDS_AND_LABELS} from './constants';
-import {isVisible, isDisabled} from './utils';
 import {
   setModelCardProperty,
   updateAiCustomization,
 } from '@cdo/apps/aichat/redux/aichatRedux';
+import Button from '@cdo/apps/componentLibrary/button/Button';
+import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
+import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
+
+import {MODEL_CARD_FIELDS_AND_LABELS} from './constants';
+import {isVisible, isDisabled} from './utils';
+
 import styles from '../model-customization-workspace.module.scss';
 
 const PublishNotes: React.FunctionComponent = () => {

--- a/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
@@ -1,16 +1,18 @@
 import React, {useState, useCallback} from 'react';
 
-import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
-import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
-import Button from '@cdo/apps/componentLibrary/button/Button';
-import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
-import modelCustomizationStyles from '../model-customization-workspace.module.scss';
-import styles from './retrieval-customization.module.scss';
-import {isDisabled} from './utils';
 import {
   setAiCustomizationProperty,
   updateAiCustomization,
 } from '@cdo/apps/aichat/redux/aichatRedux';
+import Button from '@cdo/apps/componentLibrary/button/Button';
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
+import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
+import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
+
+import {isDisabled} from './utils';
+
+import styles from './retrieval-customization.module.scss';
+import modelCustomizationStyles from '../model-customization-workspace.module.scss';
 
 const RetrievalCustomization: React.FunctionComponent = () => {
   const [newRetrievalContext, setNewRetrievalContext] = useState('');

--- a/apps/src/aichat/views/presentation/ModelCardRow.tsx
+++ b/apps/src/aichat/views/presentation/ModelCardRow.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import moduleStyles from './model-card-row.module.scss';
-import CollapsibleSection from '@cdo/apps/templates/CollapsibleSection';
+
 import {BodyThreeText} from '@cdo/apps/componentLibrary/typography';
+import CollapsibleSection from '@cdo/apps/templates/CollapsibleSection';
+
+import moduleStyles from './model-card-row.module.scss';
 
 interface ModelCardRowProps {
   keyName: string;

--- a/apps/src/aichat/views/presentation/PresentationView.tsx
+++ b/apps/src/aichat/views/presentation/PresentationView.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import ModelCardRow from './ModelCardRow';
+
 import {MODEL_CARD_FIELDS_AND_LABELS} from '@cdo/apps/aichat/views/modelCustomization/constants';
-import styles from '@cdo/apps/aichat/views/model-customization-workspace.module.scss';
 import {Heading4} from '@cdo/apps/componentLibrary/typography';
+
+import ModelCardRow from './ModelCardRow';
+
 import moduleStyles from './presentation-view.module.scss';
+import styles from '@cdo/apps/aichat/views/model-customization-workspace.module.scss';
 
 const PresentationView: React.FunctionComponent = () => {
   return (

--- a/apps/src/aichat/views/tabs/Tabs.tsx
+++ b/apps/src/aichat/views/tabs/Tabs.tsx
@@ -1,8 +1,9 @@
-import React, {useState} from 'react';
 import classNames from 'classnames';
+import React, {useState} from 'react';
+
+import TabPanel from './TabPanel';
 
 import styles from './tabs.module.scss';
-import TabPanel from './TabPanel';
 
 export type Tab = {
   title: string;

--- a/apps/src/ailab/Ailab.js
+++ b/apps/src/ailab/Ailab.js
@@ -1,20 +1,22 @@
+import {setAssetPath} from '@code-dot-org/ml-playground/dist/assetPath';
+import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import AilabView from './AilabView';
 import {Provider} from 'react-redux';
-import {getStore} from '../redux';
-import {setAssetPath} from '@code-dot-org/ml-playground/dist/assetPath';
+
 import {TestResults} from '@cdo/apps/constants';
-import ailabMsg from './locale';
-import mlPlaygroundMsg from './mlPlayground_locale';
-import $ from 'jquery';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 
+import {getStore} from '../redux';
 import {
   setDynamicInstructionsDefaults,
   setDynamicInstructionsKey,
   setDynamicInstructionsOverlayDismissCallback,
 } from '../redux/instructions';
+
+import AilabView from './AilabView';
+import ailabMsg from './locale';
+import mlPlaygroundMsg from './mlPlayground_locale';
 
 /**
  * This is used to set the viewport width in portrait mode, and will become

--- a/apps/src/ailab/AilabView.jsx
+++ b/apps/src/ailab/AilabView.jsx
@@ -2,11 +2,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import StudioAppWrapper from '../templates/StudioAppWrapper';
-import InstructionsWithWorkspace from '../templates/instructions/InstructionsWithWorkspace';
-import CodeWorkspaceContainer from '../templates/CodeWorkspaceContainer';
-import Overlay from '../templates/Overlay';
+
 import fontConstants from '@cdo/apps/fontConstants';
+
+import CodeWorkspaceContainer from '../templates/CodeWorkspaceContainer';
+import InstructionsWithWorkspace from '../templates/instructions/InstructionsWithWorkspace';
+import Overlay from '../templates/Overlay';
+import StudioAppWrapper from '../templates/StudioAppWrapper';
 
 /**
  * Top-level React wrapper for Ailab

--- a/apps/src/ailab/locale-do-not-import.js
+++ b/apps/src/ailab/locale-do-not-import.js
@@ -8,8 +8,8 @@
  */
 // locale for ailab
 
-import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 
 let locale = safeLoadLocale('ailab_locale');
 locale = localeWithI18nStringTracker(locale, 'ailab');

--- a/apps/src/ailab/locale.js
+++ b/apps/src/ailab/locale.js
@@ -1,7 +1,7 @@
 // locale for ailab
 
-import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 
 let locale = safeLoadLocale('ailab_locale');
 locale = localeWithI18nStringTracker(locale, 'ailab');

--- a/apps/src/ailab/mlPlayground_locale.js
+++ b/apps/src/ailab/mlPlayground_locale.js
@@ -1,7 +1,7 @@
 // locale for ml-playground
 
-import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 
 let locale = safeLoadLocale('mlPlayground_locale');
 locale = localeWithI18nStringTracker(locale, 'mlPlayground');


### PR DESCRIPTION
Enabling ES lint rule on a few more folders. All the changes were by running yarn lint --fix.

## Links

None

## Testing story

Leveraging existing test coverage

## Deployment strategy

Regular DTP

## Follow-up work

Not tracked

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
