### PR TITLE
[Python Lab] add support for matplotlib and small updates

### DIFF
--- a/apps/src/pythonlab/PythonEditor.tsx
+++ b/apps/src/pythonlab/PythonEditor.tsx
@@ -36,7 +36,7 @@ const PythonEditor: React.FunctionComponent = () => {
     const parsedData = data ? (data as PermissionResponse) : {permissions: []};
     // For now, restrict running python code to levelbuilders.
     if (parsedData.permissions.includes('levelbuilder')) {
-      dispatch(appendSystemMessage('Running code...'));
+      dispatch(appendSystemMessage('Running program...'));
       if (source) {
         const code = getFileByName(source.files, 'main.py')?.contents;
         if (code) {

--- a/apps/src/pythonlab/PythonEditor.tsx
+++ b/apps/src/pythonlab/PythonEditor.tsx
@@ -3,7 +3,7 @@ import {darkMode} from '@cdo/apps/lab2/views/components/editor/editorThemes';
 import {python} from '@codemirror/lang-python';
 import moduleStyles from './python-editor.module.scss';
 import {useDispatch} from 'react-redux';
-import {appendOutput, resetOutput, setSource} from './pythonlabRedux';
+import {appendSystemMessage, resetOutput, setSource} from './pythonlabRedux';
 import Button from '@cdo/apps/templates/Button';
 import {runPythonCode} from './pyodideRunner';
 import {useFetch} from '@cdo/apps/util/useFetch';
@@ -36,13 +36,13 @@ const PythonEditor: React.FunctionComponent = () => {
     const parsedData = data ? (data as PermissionResponse) : {permissions: []};
     // For now, restrict running python code to levelbuilders.
     if (parsedData.permissions.includes('levelbuilder')) {
-      dispatch(appendOutput('Running code...'));
+      dispatch(appendSystemMessage('Running code...'));
       if (source) {
         const code = getFileByName(source.files, 'main.py')?.contents;
         if (code) {
           runPythonCode(code);
         } else {
-          appendOutput('No main.py to run.');
+          dispatch(appendSystemMessage('No main.py to run.'));
         }
       }
     } else {
@@ -102,7 +102,22 @@ const PythonEditor: React.FunctionComponent = () => {
       <div>
         Output:
         {codeOutput.map((outputLine, index) => {
-          return <div key={index}>{outputLine}</div>;
+          if (outputLine.type === 'img') {
+            return (
+              <img
+                key={index}
+                src={`data:image/png;base64,${outputLine.contents}`}
+                alt="matplotlib_image"
+              />
+            );
+          } else if (
+            outputLine.type === 'system_out' ||
+            outputLine.type === 'system_in'
+          ) {
+            return <div key={index}>{outputLine.contents}</div>;
+          } else {
+            return <div key={index}>[PYTHON LAB] {outputLine.contents}</div>;
+          }
         })}
       </div>
     </div>

--- a/apps/src/pythonlab/patches/patches.ts
+++ b/apps/src/pythonlab/patches/patches.ts
@@ -1,6 +1,13 @@
 export const MATPLOTLIB_IMG_TAG = 'MATPLOTLIB_SHOW_IMG';
 
-export const PATCH_MATPLOTLIB = `
+// This allows us to use matplotlib in the webworker version of pyodide.
+// It patches show to save the image to a base64 string and print it along with
+// a tag indicating it is a matplotlib image. It's a bit fragile, as a user could
+// either overwrite the matplotlib backend and ignore the patch, or use the same tag
+// elsewhere for confusing results.
+// This patch is always prepended to the user's code.
+// Adapted from https://github.com/pyodide/matplotlib-pyodide/issues/6#issuecomment-1242747625
+const PATCH_MATPLOTLIB = `
 import base64
 import os
 
@@ -27,9 +34,18 @@ def ensure_matplotlib_patch():
 ensure_matplotlib_patch()
 `;
 
-export const FLUSH_STDOUT = `import sys
+// Ensure stdout is flushed at the end of the user's program
+// so all of their prints show up. This patch is always appended to the end of the user's code.
+const FLUSH_STDOUT = `import sys
 import os
 
 sys.stdout.flush()
 os.fsync(sys.stdout.fileno())
 `;
+
+// TODO: Should we always patch matplotlib? Or can we be smarter about when to patch it?
+// (patching it requires importing it, which can be slow).
+export const ALL_PATCHES = [
+  {contents: PATCH_MATPLOTLIB, shouldPrepend: true},
+  {contents: FLUSH_STDOUT, shouldPrepend: false},
+];

--- a/apps/src/pythonlab/patches/patches.ts
+++ b/apps/src/pythonlab/patches/patches.ts
@@ -1,3 +1,5 @@
+export const MATPLOTLIB_IMG_TAG = 'MATPLOTLIB_SHOW_IMG';
+
 export const PATCH_MATPLOTLIB = `
 import base64
 import os
@@ -12,13 +14,12 @@ def ensure_matplotlib_patch():
     _old_show = matplotlib.pyplot.show
 
     def show():
-        print('hello from show')
         buf = BytesIO()
         matplotlib.pyplot.savefig(buf, format='png')
         buf.seek(0)
         # encode to a base64 str
         img = base64.b64encode(buf.read()).decode('utf-8')
-        print('MATPLOTLIB_SHOW_IMG % s' % img)
+        print('${MATPLOTLIB_IMG_TAG} % s' % img)
         matplotlib.pyplot.clf()
 
     matplotlib.pyplot.show = show

--- a/apps/src/pythonlab/patches/patches.ts
+++ b/apps/src/pythonlab/patches/patches.ts
@@ -45,6 +45,7 @@ os.fsync(sys.stdout.fileno())
 
 // TODO: Should we always patch matplotlib? Or can we be smarter about when to patch it?
 // (patching it requires importing it, which can be slow).
+// Ticket: https://codedotorg.atlassian.net/browse/CT-475
 export const ALL_PATCHES = [
   {contents: PATCH_MATPLOTLIB, shouldPrepend: true},
   {contents: FLUSH_STDOUT, shouldPrepend: false},

--- a/apps/src/pythonlab/patches/patches.ts
+++ b/apps/src/pythonlab/patches/patches.ts
@@ -1,0 +1,34 @@
+export const PATCH_MATPLOTLIB = `
+import base64
+import os
+
+from io import BytesIO
+
+os.environ['MPLBACKEND'] = 'AGG'
+
+import matplotlib.pyplot
+
+def ensure_matplotlib_patch():
+    _old_show = matplotlib.pyplot.show
+
+    def show():
+        print('hello from show')
+        buf = BytesIO()
+        matplotlib.pyplot.savefig(buf, format='png')
+        buf.seek(0)
+        # encode to a base64 str
+        img = base64.b64encode(buf.read()).decode('utf-8')
+        print('MATPLOTLIB_SHOW_IMG % s' % img)
+        matplotlib.pyplot.clf()
+
+    matplotlib.pyplot.show = show
+
+ensure_matplotlib_patch()
+`;
+
+export const FLUSH_STDOUT = `import sys
+import os
+
+sys.stdout.flush()
+os.fsync(sys.stdout.fileno())
+`;

--- a/apps/src/pythonlab/patches/pythonScriptUtils.ts
+++ b/apps/src/pythonlab/patches/pythonScriptUtils.ts
@@ -1,4 +1,4 @@
-import {FLUSH_STDOUT, PATCH_MATPLOTLIB} from './patches';
+import {ALL_PATCHES} from './patches';
 
 // Helper function that adds code to import a local file for use in the user's script.
 export function importFileCode(fileName: string, fileContents: string) {
@@ -15,13 +15,8 @@ importlib.invalidate_caches()
 
 export function applyPatches(originalCode: string) {
   let finalCode = originalCode;
-  // TODO: Should we always patch matplotlib? Or can we be smarter about when to patch it?
-  // (patching it requires importing it, which can be slow).
-  const patches = [
-    {contents: PATCH_MATPLOTLIB, shouldPrepend: true},
-    {contents: FLUSH_STDOUT, shouldPrepend: false},
-  ];
-  for (const patch of patches) {
+
+  for (const patch of ALL_PATCHES) {
     finalCode = patch.shouldPrepend
       ? patch.contents + '\n' + finalCode
       : finalCode + '\n' + patch.contents;

--- a/apps/src/pythonlab/patches/pythonScriptUtils.ts
+++ b/apps/src/pythonlab/patches/pythonScriptUtils.ts
@@ -1,0 +1,29 @@
+import {FLUSH_STDOUT, PATCH_MATPLOTLIB} from './patches';
+
+// Helper function that adds code to import a local file for use in the user's script.
+export function importFileCode(fileName: string, fileContents: string) {
+  return `
+import importlib
+from pathlib import Path
+Path("${fileName}").write_text("""\
+${fileContents}
+"""
+)
+importlib.invalidate_caches()
+`;
+}
+
+export function applyPatches(originalCode: string) {
+  let finalCode = originalCode;
+  const patches = [
+    {contents: PATCH_MATPLOTLIB, shouldPrepend: true},
+    {contents: FLUSH_STDOUT, shouldPrepend: false},
+  ];
+  for (const patch of patches) {
+    finalCode = patch.shouldPrepend
+      ? patch.contents + finalCode
+      : finalCode + patch.contents;
+  }
+  console.log({finalCode});
+  return finalCode;
+}

--- a/apps/src/pythonlab/patches/pythonScriptUtils.ts
+++ b/apps/src/pythonlab/patches/pythonScriptUtils.ts
@@ -15,6 +15,8 @@ importlib.invalidate_caches()
 
 export function applyPatches(originalCode: string) {
   let finalCode = originalCode;
+  // TODO: Should we always patch matplotlib? Or can we be smarter about when to patch it?
+  // (patching it requires importing it, which can be slow).
   const patches = [
     {contents: PATCH_MATPLOTLIB, shouldPrepend: true},
     {contents: FLUSH_STDOUT, shouldPrepend: false},
@@ -24,6 +26,5 @@ export function applyPatches(originalCode: string) {
       ? patch.contents + '\n' + finalCode
       : finalCode + '\n' + patch.contents;
   }
-  console.log({finalCode});
   return finalCode;
 }

--- a/apps/src/pythonlab/patches/pythonScriptUtils.ts
+++ b/apps/src/pythonlab/patches/pythonScriptUtils.ts
@@ -21,8 +21,8 @@ export function applyPatches(originalCode: string) {
   ];
   for (const patch of patches) {
     finalCode = patch.shouldPrepend
-      ? patch.contents + finalCode
-      : finalCode + patch.contents;
+      ? patch.contents + '\n' + finalCode
+      : finalCode + '\n' + patch.contents;
   }
   console.log({finalCode});
   return finalCode;

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -4,7 +4,11 @@ async function loadPyodideAndPackages() {
   self.pyodide = await loadPyodide({
     indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.24.1/full',
   });
-  await self.pyodide.loadPackage(['numpy']);
+  //await self.pyodide.loadPackage(['numpy', 'matplotlib']);
+  await self.pyodide.loadPackage('micropip');
+  const micropip = self.pyodide.pyimport('micropip');
+  await micropip.install('numpy');
+  await micropip.install('matplotlib');
   self.pyodide.setStdout({
     batched: msg => {
       self.postMessage({type: 'sysout', message: msg, id: 'none'});

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -4,11 +4,8 @@ async function loadPyodideAndPackages() {
   self.pyodide = await loadPyodide({
     indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.24.1/full',
   });
-  //await self.pyodide.loadPackage(['numpy', 'matplotlib']);
-  await self.pyodide.loadPackage('micropip');
-  const micropip = self.pyodide.pyimport('micropip');
-  await micropip.install('numpy');
-  await micropip.install('matplotlib');
+  // pre-load numpy as it will frequently be used, and matplotlib as we patch it.
+  await self.pyodide.loadPackage(['numpy', 'matplotlib']);
   self.pyodide.setStdout({
     batched: msg => {
       self.postMessage({type: 'sysout', message: msg, id: 'none'});
@@ -23,6 +20,9 @@ async function initializePyodide() {
   }
   await pyodideReadyPromise;
 }
+
+// Get pyodide ready as soon as possible.
+initializePyodide();
 
 self.onmessage = async event => {
   // make sure loading is done

--- a/apps/src/pythonlab/pyodideWorkerManager.js
+++ b/apps/src/pythonlab/pyodideWorkerManager.js
@@ -1,6 +1,7 @@
 import {getStore} from '@cdo/apps/redux';
-import {appendOutput} from './pythonlabRedux';
 import {applyPatches, importFileCode} from './patches/pythonScriptUtils';
+import {MATPLOTLIB_IMG_TAG} from './patches/patches';
+import {appendOutputImage, appendSystemOutMessage} from './pythonlabRedux';
 
 // A default file to import into the user's script.
 const otherFileContents = "def hello():\n  print('hello')\n";
@@ -17,7 +18,13 @@ pyodideWorker.onmessage = event => {
   console.log('in onmessage');
   console.log({event});
   if (type === 'sysout') {
-    getStore().dispatch(appendOutput(data.message));
+    if (data.message.startsWith(MATPLOTLIB_IMG_TAG)) {
+      // This is a matplotlib image, so we need to append it to the output
+      const image = data.message.slice(MATPLOTLIB_IMG_TAG.length + 1);
+      getStore().dispatch(appendOutputImage(image));
+      return;
+    }
+    getStore().dispatch(appendSystemOutMessage(data.message));
     return;
   }
   const onSuccess = callbacks[id];

--- a/apps/src/pythonlab/pyodideWorkerManager.js
+++ b/apps/src/pythonlab/pyodideWorkerManager.js
@@ -1,7 +1,11 @@
 import {getStore} from '@cdo/apps/redux';
 import {applyPatches, importFileCode} from './patches/pythonScriptUtils';
 import {MATPLOTLIB_IMG_TAG} from './patches/patches';
-import {appendOutputImage, appendSystemOutMessage} from './pythonlabRedux';
+import {
+  appendOutputImage,
+  appendSystemMessage,
+  appendSystemOutMessage,
+} from './pythonlabRedux';
 
 // A default file to import into the user's script.
 const otherFileContents = "def hello():\n  print('hello')\n";
@@ -15,8 +19,6 @@ const callbacks = {};
 
 pyodideWorker.onmessage = event => {
   const {type, id, ...data} = event.data;
-  console.log('in onmessage');
-  console.log({event});
   if (type === 'sysout') {
     if (data.message.startsWith(MATPLOTLIB_IMG_TAG)) {
       // This is a matplotlib image, so we need to append it to the output
@@ -26,6 +28,10 @@ pyodideWorker.onmessage = event => {
     }
     getStore().dispatch(appendSystemOutMessage(data.message));
     return;
+  } else if (type === 'run_complete') {
+    getStore().dispatch(appendSystemMessage('Program completed.'));
+  } else if (type === 'error') {
+    getStore().dispatch(appendSystemMessage(`Error: ${data.error}`));
   }
   const onSuccess = callbacks[id];
   delete callbacks[id];

--- a/apps/src/pythonlab/pythonlabRedux.ts
+++ b/apps/src/pythonlab/pythonlabRedux.ts
@@ -4,7 +4,12 @@ const registerReducers = require('@cdo/apps/redux').registerReducers;
 
 export interface PythonlabState {
   source: MultiFileSource | undefined;
-  output: string[];
+  output: ConsoleLog[];
+}
+
+export interface ConsoleLog {
+  type: 'system_out' | 'system_in' | 'img' | 'system_msg';
+  contents: string;
 }
 
 export const initialState: PythonlabState = {
@@ -19,8 +24,17 @@ const pythonlabSlice = createSlice({
     setSource(state, action: PayloadAction<MultiFileSource>) {
       state.source = action.payload;
     },
-    appendOutput(state, action: PayloadAction<string>) {
-      state.output.push(action.payload);
+    appendSystemOutMessage(state, action: PayloadAction<string>) {
+      state.output.push({type: 'system_out', contents: action.payload});
+    },
+    appendSystemInMessage(state, action: PayloadAction<string>) {
+      state.output.push({type: 'system_in', contents: action.payload});
+    },
+    appendOutputImage(state, action: PayloadAction<string>) {
+      state.output.push({type: 'img', contents: action.payload});
+    },
+    appendSystemMessage(state, action: PayloadAction<string>) {
+      state.output.push({type: 'system_msg', contents: action.payload});
     },
     resetOutput(state) {
       state.output = [];
@@ -30,4 +44,11 @@ const pythonlabSlice = createSlice({
 
 registerReducers({pythonlab: pythonlabSlice.reducer});
 
-export const {setSource, appendOutput, resetOutput} = pythonlabSlice.actions;
+export const {
+  setSource,
+  appendSystemOutMessage,
+  appendSystemInMessage,
+  appendOutputImage,
+  appendSystemMessage,
+  resetOutput,
+} = pythonlabSlice.actions;


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Summary

The work in this PR came out of investigating if we could get matplotlib working in Python Lab. matplotlib is a supported pyodide package, but there are some issues with getting it working in a web worker (see [this issue](https://github.com/pyodide/matplotlib-pyodide/issues/6) for details). As a simple workaround we can patch the matplotlib `show` function to print a base64 string, then show said string in an image element. This may prove to be a little fragile; I filed a [follow up task](https://codedotorg.atlassian.net/browse/CT-475) to productionize this.

This work required a couple things that caused me to do a few refactors/improvements more generally to Python Lab. These are:
- update the console log storage in redux to have different log types, image, system out, system in (not used yet), and system message (things we send, such as start/end messages). 
- Clean up and update how we wrap the user's code with our custom patches. Previously this was all done in `pyodideWorkerManager`. Now I have moved the existing flush system out patch (which is appended to all student code) and the new matplotlib patch into a separate file, and created a utils file to handle wrapping the user's code.
- Always load pyodide on page load. Now that we are patching matplotlib, we would be importing numpy and matplotlib on first run if we continued to lazy load. matplotlib takes a few seconds to load, so starting that process early makes the first run faster. We can do this now because we only load the component if we are on a Python Lab level, as opposed to previously when it was loaded for all lab2 levels.

This is what it looks like to run a program that outputs two graphs
![Screenshot 2024-04-03 at 2 34 41 PM](https://github.com/code-dot-org/code-dot-org/assets/33666587/eac25fc2-daa0-42f1-8eaf-3b1be7c23aa7)


## Links
- jira tickets: [CT-448](https://codedotorg.atlassian.net/browse/CT-448), [CT-458](https://codedotorg.atlassian.net/browse/CT-458)


## Testing story
Tested locally. Python Lab is isolated code and not in use, so this is low risk.

## Follow-up work
- [CT-475](https://codedotorg.atlassian.net/browse/CT-475) is a placeholder for productionizing this work.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
