### PR TITLE
Ceara/aitt 543 565 more rubric amplitude

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -140,6 +140,7 @@ const EVENTS = {
   TA_RUBRIC_CSV_DOWNLOADED: 'TA Rubric CSV Downloaded',
   TA_RUBRIC_INDIVIDUAL_AI_EVAL: 'TA Rubric Individual AI Eval Requested',
   TA_RUBRIC_SECTION_AI_EVAL: 'TA Rubric Section AI Eval Requested',
+  TA_RUBRIC_AI_PAGE_VISITED: 'TA Rubrics AI Level Page Visited',
 
   // AI Tutor
   AI_TUTOR_PANEL_OPENED: 'AI Tutor Panel Opened',

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -142,6 +142,8 @@ const EVENTS = {
   TA_RUBRIC_SECTION_AI_EVAL: 'TA Rubric Section AI Eval Requested',
   TA_RUBRIC_AI_PAGE_VISITED: 'TA Rubric AI Level Page Visited',
   TA_RUBRIC_STUDENT_AI_SUBMITTED: 'TA Rubric Student AI Level Submitted',
+  TA_RUBRIC_AI_EVAL_FROM_SECTION:
+    'TA Rubric AI Eval started from section request',
 
   // AI Tutor
   AI_TUTOR_PANEL_OPENED: 'AI Tutor Panel Opened',

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -140,7 +140,8 @@ const EVENTS = {
   TA_RUBRIC_CSV_DOWNLOADED: 'TA Rubric CSV Downloaded',
   TA_RUBRIC_INDIVIDUAL_AI_EVAL: 'TA Rubric Individual AI Eval Requested',
   TA_RUBRIC_SECTION_AI_EVAL: 'TA Rubric Section AI Eval Requested',
-  TA_RUBRIC_AI_PAGE_VISITED: 'TA Rubrics AI Level Page Visited',
+  TA_RUBRIC_AI_PAGE_VISITED: 'TA Rubric AI Level Page Visited',
+  TA_RUBRIC_STUDENT_AI_SUBMITTED: 'TA Rubric Student AI Level Submitted',
 
   // AI Tutor
   AI_TUTOR_PANEL_OPENED: 'AI Tutor Panel Opened',

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -138,6 +138,8 @@ const EVENTS = {
   TA_RUBRIC_LEARNING_GOAL_SELECTED: 'TA Rubric Learning Goal Selected',
   TA_RUBRIC_DROPDOWN_STUDENT_SELECTED: 'TA Rubric Student Switched',
   TA_RUBRIC_CSV_DOWNLOADED: 'TA Rubric CSV Downloaded',
+  TA_RUBRIC_INDIVIDUAL_AI_EVAL: 'TA Rubric Individual AI Eval Requested',
+  TA_RUBRIC_SECTION_AI_EVAL: 'TA Rubric Section AI Eval Requested',
 
   // AI Tutor
   AI_TUTOR_PANEL_OPENED: 'AI Tutor Panel Opened',

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -16,6 +16,8 @@ import {setLevel, setScriptId} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
 import experiments from '@cdo/apps/util/experiments';
 import RubricFloatingActionButton from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
 import AITutorFloatingActionButton from '@cdo/apps/code-studio/components/aiTutor/aiTutorFloatingActionButton';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 $(document).ready(initPage);
 
@@ -102,6 +104,21 @@ function initPage() {
       'rubric-fab-mount-point'
     );
     if (rubricFabMountPoint) {
+      //rubric fab mount point is only true for teachers
+      if (
+        experiments.isEnabled('ai-rubrics') &&
+        !!rubric &&
+        rubric.learningGoals.some(lg => lg.aiEnabled)
+      ) {
+        analyticsReporter.sendEvent(
+          EVENTS.TA_RUBRIC_AI_PAGE_VISITED,
+          {
+            ...reportingData,
+            studentId: !!studentLevelInfo ? studentLevelInfo.user_id : '',
+          },
+          PLATFORMS.BOTH
+        );
+      }
       ReactDOM.render(
         <Provider store={getStore()}>
           <RubricFloatingActionButton

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -100,6 +100,8 @@ function initPage() {
     };
     getStore().dispatch(setTaRubric(rubric));
 
+    console.log(config);
+    console.log(rubric);
     const rubricFabMountPoint = document.getElementById(
       'rubric-fab-mount-point'
     );
@@ -108,7 +110,8 @@ function initPage() {
       if (
         experiments.isEnabled('ai-rubrics') &&
         !!rubric &&
-        rubric.learningGoals.some(lg => lg.aiEnabled)
+        rubric.learningGoals.some(lg => lg.aiEnabled) &&
+        config.level_name === rubric.level.name
       ) {
         analyticsReporter.sendEvent(
           EVENTS.TA_RUBRIC_AI_PAGE_VISITED,

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -100,8 +100,6 @@ function initPage() {
     };
     getStore().dispatch(setTaRubric(rubric));
 
-    console.log(config);
-    console.log(rubric);
     const rubricFabMountPoint = document.getElementById(
       'rubric-fab-mount-point'
     );

--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -470,6 +470,7 @@ export default function LearningGoals({
           ...(reportingData || {}),
           learningGoalKey: learningGoals[currentIndex].key,
           learningGoal: learningGoals[currentIndex].learningGoal,
+          studentId: !!studentLevelInfo ? studentLevelInfo.user_id : '',
         });
       }
     }

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -150,6 +150,7 @@ export default function RubricContainer({
             refreshAiEvaluations={fetchAiEvaluations}
             rubric={rubric}
             studentName={studentLevelInfo && studentLevelInfo.name}
+            reportingData={reportingData}
           />
 
           <RubricContent

--- a/apps/src/templates/rubrics/RubricSettings.jsx
+++ b/apps/src/templates/rubrics/RubricSettings.jsx
@@ -10,7 +10,7 @@ import {
   StrongText,
 } from '@cdo/apps/componentLibrary/typography';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {reportingDataShape, rubricShape} from './rubricShapes';
 import Button from '@cdo/apps/templates/Button';
 import SectionSelector from './SectionSelector';
@@ -232,11 +232,15 @@ export default function RubricSettings({
     const url = `/rubrics/${rubricId}/run_ai_evaluations_for_all`;
     const params = {section_id: sectionId};
     const eventName = EVENTS.TA_RUBRIC_SECTION_AI_EVAL;
-    analyticsReporter.sendEvent(eventName, {
-      ...(reportingData || {}),
-      rubricId: rubricId,
-      sectionId: sectionId,
-    });
+    analyticsReporter.sendEvent(
+      eventName,
+      {
+        ...(reportingData || {}),
+        rubricId: rubricId,
+        sectionId: sectionId,
+      },
+      PLATFORMS.BOTH
+    );
     fetch(url, {
       method: 'POST',
       headers: {

--- a/apps/src/templates/rubrics/RubricSettings.jsx
+++ b/apps/src/templates/rubrics/RubricSettings.jsx
@@ -231,6 +231,12 @@ export default function RubricSettings({
     setStatusAll(STATUS_ALL.EVALUATION_PENDING);
     const url = `/rubrics/${rubricId}/run_ai_evaluations_for_all`;
     const params = {section_id: sectionId};
+    const eventName = EVENTS.TA_RUBRIC_SECTION_AI_EVAL;
+    analyticsReporter.sendEvent(eventName, {
+      ...(reportingData || {}),
+      rubricId: rubricId,
+      sectionId: sectionId,
+    });
     fetch(url, {
       method: 'POST',
       headers: {

--- a/apps/src/templates/rubrics/RubricTabButtons.jsx
+++ b/apps/src/templates/rubrics/RubricTabButtons.jsx
@@ -4,7 +4,7 @@ import style from './rubrics.module.scss';
 import i18n from '@cdo/locale';
 import SegmentedButtons from '@cdo/apps/componentLibrary/segmentedButtons/SegmentedButtons';
 import RunAIAssessmentButton, {STATUS} from './RunAIAssessmentButton';
-import {rubricShape} from './rubricShapes';
+import {reportingDataShape, rubricShape} from './rubricShapes';
 import {InfoAlert} from './RubricContent';
 import {TAB_NAMES} from './rubricHelpers';
 
@@ -18,6 +18,7 @@ export default function RubricTabButtons({
   refreshAiEvaluations,
   rubric,
   studentName,
+  reportingData,
 }) {
   const [status, setStatus] = useState(STATUS.INITIAL_LOAD);
 
@@ -74,6 +75,7 @@ export default function RubricTabButtons({
               studentName={studentName}
               status={status}
               setStatus={setStatus}
+              reportingData={reportingData}
             />
           </div>
         )}
@@ -102,4 +104,5 @@ RubricTabButtons.propTypes = {
   refreshAiEvaluations: PropTypes.func,
   rubric: rubricShape.isRequired,
   studentName: PropTypes.string,
+  reportingData: reportingDataShape,
 };

--- a/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
+++ b/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
@@ -4,7 +4,7 @@ import i18n from '@cdo/locale';
 import {reportingDataShape, rubricShape} from './rubricShapes';
 import Button from '@cdo/apps/templates/Button';
 import {RubricAiEvaluationStatus} from '@cdo/apps/util/sharedConstants';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 
 export const STATUS = {
@@ -136,11 +136,15 @@ export default function RunAIAssessmentButton({
     const url = `/rubrics/${rubricId}/run_ai_evaluations_for_user`;
     const params = {user_id: studentUserId};
     const eventName = EVENTS.TA_RUBRIC_INDIVIDUAL_AI_EVAL;
-    analyticsReporter.sendEvent(eventName, {
-      ...(reportingData || {}),
-      rubricId: rubricId,
-      studentId: studentUserId,
-    });
+    analyticsReporter.sendEvent(
+      eventName,
+      {
+        ...(reportingData || {}),
+        rubricId: rubricId,
+        studentId: studentUserId,
+      },
+      PLATFORMS.BOTH
+    );
     fetch(url, {
       method: 'POST',
       headers: {

--- a/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
+++ b/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
@@ -1,9 +1,11 @@
 import React, {useEffect, useMemo, useState} from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
-import {rubricShape} from './rubricShapes';
+import {reportingDataShape, rubricShape} from './rubricShapes';
 import Button from '@cdo/apps/templates/Button';
 import {RubricAiEvaluationStatus} from '@cdo/apps/util/sharedConstants';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 
 export const STATUS = {
   // we are waiting for initial status from the server
@@ -42,6 +44,7 @@ export default function RunAIAssessmentButton({
   studentName,
   status,
   setStatus,
+  reportingData,
 }) {
   const rubricId = rubric.id;
   const [csrfToken, setCsrfToken] = useState('');
@@ -132,6 +135,12 @@ export default function RunAIAssessmentButton({
     setStatus(STATUS.EVALUATION_PENDING);
     const url = `/rubrics/${rubricId}/run_ai_evaluations_for_user`;
     const params = {user_id: studentUserId};
+    const eventName = EVENTS.TA_RUBRIC_INDIVIDUAL_AI_EVAL;
+    analyticsReporter.sendEvent(eventName, {
+      ...(reportingData || {}),
+      rubricId: rubricId,
+      studentId: studentUserId,
+    });
     fetch(url, {
       method: 'POST',
       headers: {
@@ -176,4 +185,5 @@ RunAIAssessmentButton.propTypes = {
   studentName: PropTypes.string,
   status: PropTypes.string,
   setStatus: PropTypes.func,
+  reportingData: reportingDataShape,
 };

--- a/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
@@ -202,7 +202,7 @@ describe('LearningGoals - Enzyme', () => {
     highlightLineStub,
     clearAnnotationsStub,
     clearHighlightedLinesStub;
-  const studentLevelInfo = {name: 'Grace Hopper', timeSpent: 706};
+  const studentLevelInfo = {name: 'Grace Hopper', timeSpent: 706, user_id: 1};
 
   // Stub out our references to the singleton and editor
   beforeEach(() => {
@@ -475,6 +475,7 @@ describe('LearningGoals - Enzyme', () => {
       <LearningGoals
         learningGoals={learningGoals}
         reportingData={{unitName: 'test-2023', levelName: 'test-level'}}
+        studentLevelInfo={studentLevelInfo}
       />
     );
     wrapper.find('button').at(1).simulate('click');
@@ -485,6 +486,7 @@ describe('LearningGoals - Enzyme', () => {
         levelName: 'test-level',
         learningGoalKey: 'efgh',
         learningGoal: 'Learning Goal 2',
+        studentId: 1,
       }
     );
     wrapper.find('button').first().simulate('click');
@@ -495,6 +497,7 @@ describe('LearningGoals - Enzyme', () => {
         levelName: 'test-level',
         learningGoalKey: 'abcd',
         learningGoal: 'Learning Goal 1',
+        studentId: 1,
       }
     );
     sendEventSpy.restore();

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -8,6 +8,8 @@ import sinon from 'sinon';
 
 import teacherPanel from '@cdo/apps/code-studio/teacherPanelRedux';
 import * as utils from '@cdo/apps/code-studio/utils';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {
   getStore,
   registerReducers,
@@ -410,6 +412,7 @@ describe('RubricContainer', () => {
     */
     clock = sinon.useFakeTimers();
 
+    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
     stubFetchEvalStatusForUser(readyJson);
     stubFetchEvalStatusForAll(readyJsonAll);
     stubFetchTeacherEvaluations(noEvals);
@@ -443,6 +446,15 @@ describe('RubricContainer', () => {
       .returns(Promise.resolve(new Response(JSON.stringify({}))));
     stubFetchEvalStatusForUser(pendingJson);
     wrapper.find('Button').at(0).simulate('click');
+
+    //expect amplitude event on click
+    expect(sendEventSpy).to.have.been.calledWith(
+      EVENTS.TA_RUBRIC_INDIVIDUAL_AI_EVAL,
+      {
+        rubricId: defaultRubric.id,
+        studentId: defaultStudentInfo.user_id,
+      }
+    );
 
     // Wait for fetches and re-render
     clock.tick(5000);
@@ -479,6 +491,7 @@ describe('RubricContainer', () => {
     expect(wrapper.find('RubricContent').props().aiEvaluations).to.eql(
       mockAiEvaluations
     );
+    sendEventSpy.restore();
   });
 
   it('shows general error message for status 1000', async () => {

--- a/apps/test/unit/templates/rubrics/RubricSettingsTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricSettingsTest.jsx
@@ -206,6 +206,7 @@ describe('RubricSettings', () => {
 
   it('runs AI assessment for all unevaluated projects when requested by teacher', async () => {
     stubFetchEvalStatusForAll(ready);
+    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
 
     clock = sinon.useFakeTimers();
 
@@ -229,6 +230,15 @@ describe('RubricSettings', () => {
 
     wrapper.find('Button').first().simulate('click');
 
+    //sends event on click
+    expect(sendEventSpy).to.have.been.calledWith(
+      EVENTS.TA_RUBRIC_SECTION_AI_EVAL,
+      {
+        rubricId: defaultRubric.id,
+        sectionId: 1,
+      }
+    );
+
     // Perform fetches and re-renders
     await wait();
     wrapper.update();
@@ -245,6 +255,7 @@ describe('RubricSettings', () => {
     expect(fetchStub).to.have.callCount(4);
     expect(wrapper.find('Button').first().props().disabled).to.be.true;
     expect(wrapper.text()).to.include(i18n.aiEvaluationStatus_success());
+    sendEventSpy.restore();
   });
 
   it('displays switch tab text and button when there are no evaluations', async () => {

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -2,6 +2,7 @@ require 'cdo/activity_constants'
 require 'cdo/share_filtering'
 require 'cdo/firehose'
 require 'cdo/web_purify'
+require 'metrics/events'
 
 class ActivitiesController < ApplicationController
   include LevelsHelper
@@ -124,6 +125,16 @@ class ActivitiesController < ApplicationController
       is_ai_experiment_enabled = current_user && Experiment.enabled?(user: current_user, script: @script_level&.script, experiment_name: 'ai-rubrics')
       is_level_ai_enabled = EvaluateRubricJob.ai_enabled?(@script_level)
       if is_ai_experiment_enabled && is_level_ai_enabled && params[:submitted] == 'true'
+        metadata = {
+          'userId' => current_user.id,
+          'levelId' => @level.id,
+          'levelName' => @level.name,
+        }
+        Metrics::Events.log_event(
+          user: current_user,
+          event_name: 'TA Rubric Student AI Level Submitted',
+          metadata: metadata,
+        )
         EvaluateRubricJob.perform_later(user_id: current_user.id, requester_id: current_user.id, script_level_id: @script_level.id)
       end
     end

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -126,8 +126,8 @@ class ActivitiesController < ApplicationController
       is_level_ai_enabled = EvaluateRubricJob.ai_enabled?(@script_level)
       if is_ai_experiment_enabled && is_level_ai_enabled && params[:submitted] == 'true'
         metadata = {
-          'userId' => current_user.id,
-          'levelId' => @level.id,
+          'studentId' => current_user.id,
+          'unitName' => @script_level.script.name,
           'levelName' => @level.name,
         }
         Metrics::Events.log_event(

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -192,6 +192,16 @@ class RubricsController < ApplicationController
       end
 
       next unless attempted && (!last_eval_time || last_eval_time < attempted)
+      metadata = {
+        'studentId' => @user.id,
+        'unitName' => script_level.script.name,
+        'levelName' => script_level.level.name,
+      }
+      Metrics::Events.log_event(
+        user: current_user,
+        event_name: 'TA Rubric AI Eval started from section request',
+        metadata: metadata,
+      )
       EvaluateRubricJob.perform_later(
         user_id: @user.id,
         requester_id: current_user.id,

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -196,6 +196,7 @@ class RubricsController < ApplicationController
         'studentId' => @user.id,
         'unitName' => script_level.script.name,
         'levelName' => script_level.level.name,
+        'sectionId' => section_id,
       }
       Metrics::Events.log_event(
         user: current_user,

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -75,6 +75,7 @@ class ActivitiesControllerTest < ActionController::TestCase
       user_id: @student.id,
       submitted: 'true'
     )
+    Metrics::Events.stubs(:log_event).never
     EvaluateRubricJob.expects(:perform_later).never
   end
 
@@ -1141,6 +1142,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
   test 'milestone with student in experiment triggers rubric eval job' do
     create :single_section_experiment, section: @section, name: 'ai-rubrics', script: @script
+    Metrics::Events.stubs(:log_event).once
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).with(user_id: @student.id, requester_id: @student.id, script_level_id: @script_level.id).once
     sign_in @student
@@ -1151,6 +1153,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
   test 'milestone with student in experiment on non ai level does not trigger rubric eval job' do
     create :single_section_experiment, section: @section, name: 'ai-rubrics'
+    Metrics::Events.stubs(:log_event).never
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(false)
     EvaluateRubricJob.expects(:perform_later).never
     sign_in @student
@@ -1161,6 +1164,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
   test 'milestone with teacher in experiment does not trigger rubric eval job' do
     create :single_section_experiment, section: @section, name: 'ai-rubrics'
+    Metrics::Events.stubs(:log_event).never
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).never
     sign_in @teacher
@@ -1177,6 +1181,7 @@ class ActivitiesControllerTest < ActionController::TestCase
   test 'milestone with student not in experiment does not trigger rubric eval job' do
     # some other section is added to the experiment
     create :single_section_experiment, name: 'ai-rubrics'
+    Metrics::Events.stubs(:log_event).never
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).never
     sign_in @student
@@ -1187,6 +1192,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
   test 'milestone on level without ai enabled does not trigger rubric eval job' do
     create :single_section_experiment, section: @section, name: 'ai-rubrics'
+    Metrics::Events.stubs(:log_event).never
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(false)
     EvaluateRubricJob.expects(:perform_later).never
     sign_in @student

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -495,6 +495,7 @@ class RubricsControllerTest < ActionController::TestCase
     sign_in @teacher
 
     Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(false)
+    Metrics::Events.stubs(:log_event).never
 
     get :run_ai_evaluations_for_all, params: {
       id: @rubric.id,
@@ -509,6 +510,7 @@ class RubricsControllerTest < ActionController::TestCase
 
     Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     EvaluateRubricJob.expects(:ai_enabled?).with(@script_level).returns(false)
+    Metrics::Events.stubs(:log_event).never
 
     get :run_ai_evaluations_for_all, params: {
       id: @rubric.id,
@@ -533,6 +535,7 @@ class RubricsControllerTest < ActionController::TestCase
     Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).never
+    Metrics::Events.stubs(:log_event).never
 
     get :run_ai_evaluations_for_all, params: {
       id: @rubric.id,
@@ -591,6 +594,7 @@ class RubricsControllerTest < ActionController::TestCase
     Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     EvaluateRubricJob.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).once
+    Metrics::Events.stubs(:log_event).once
 
     get :run_ai_evaluations_for_all, params: {
       id: @rubric.id,
@@ -656,6 +660,8 @@ class RubricsControllerTest < ActionController::TestCase
     assert json_response['csrfToken']
 
     EvaluateRubricJob.expects(:perform_later).times(5)
+    Metrics::Events.stubs(:log_event).times(5)
+
     get :run_ai_evaluations_for_all, params: {
       id: @rubric.id,
       sectionId: follower.section.id,


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

## Description

Adds amplitude/statsig logging to various events to track the time between student submitting/ teacher pressing evaluate and teachers looking at ai evaluations. Adds the following events:
```  
  TA_RUBRIC_INDIVIDUAL_AI_EVAL: 'TA Rubric Individual AI Eval Requested',
  TA_RUBRIC_SECTION_AI_EVAL: 'TA Rubric Section AI Eval Requested',
  TA_RUBRIC_AI_PAGE_VISITED: 'TA Rubric AI Level Page Visited',
  TA_RUBRIC_STUDENT_AI_SUBMITTED: 'TA Rubric Student AI Level Submitted',
```

## Links

https://codedotorg.atlassian.net/browse/AITT-565
https://codedotorg.atlassian.net/browse/AITT-543

## Testing story

Adds unit tests for the UI amplitude/ statsig logging, but I couldn't figure out how to add a test for the logging in the ruby tests/ couldn't find any other examples of testing the statsig logging in ruby.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
