### PR TITLE
Update logging to include Stretch Curriculum

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -230,9 +230,11 @@ const EVENTS = {
   EXPORT_APP: 'User Exports App From Share Advanced Options',
 
   // Curriculumm Recommender
-  RECOMMENDED_SIMILAR_CURRICULUM_SHOWN: 'Recommended Similar Curriculum Shown',
+  RECOMMENDED_CATALOG_CURRICULUM_SHOWN: 'Recommended Catalog Curriculum Shown',
   RECOMMENDED_SIMILAR_CURRICULUM_CLICKED:
     'Recommended Similar Curriculum Clicked',
+  RECOMMENDED_STRETCH_CURRICULUM_CLICKED:
+    'Recommended Stretch Curriculum Clicked',
 };
 
 const EVENT_GROUP_NAMES = {

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -33,6 +33,10 @@ const CurriculumCatalog = ({
   const [showAssignSuccessMessage, setShowAssignSuccessMessage] =
     useState(false);
   const [expandedCardKey, setExpandedCardKey] = useState(null);
+  const [recommendedSimilarCurriculum, setRecommendedSimilarCurriculum] =
+    useState(null);
+  const [recommendedStretchCurriculum, setRecommendedStretchCurriculum] =
+    useState(null);
 
   useEffect(() => {
     const expandedCardFound = filteredCurricula.some(
@@ -41,6 +45,8 @@ const CurriculumCatalog = ({
 
     if (!expandedCardFound) {
       setExpandedCardKey(null);
+      setRecommendedSimilarCurriculum(null);
+      setRecommendedStretchCurriculum(null);
     }
   }, [expandedCardKey, filteredCurricula]);
 
@@ -65,16 +71,42 @@ const CurriculumCatalog = ({
     setAssignSuccessMessage('');
   };
 
-  const handleExpandedCardChange = key => {
-    if (expandedCardKey !== key) {
+  const handleQuickViewClicked = key => {
+    if (expandedCardKey === key) {
+      // If Quick View is clicked again to close the card (or the 'X' on the expanded card is clicked)
+      setExpandedCardKey(null);
+      setRecommendedSimilarCurriculum(null);
+      setRecommendedStretchCurriculum(null);
+    } else {
       analyticsReporter.sendEvent(
         EVENTS.CURRICULUM_CATALOG_QUICK_VIEW_CLICKED_EVENT,
         {
           curriculum_offering: key,
         }
       );
+      handleSetExpandedCardKey(key);
     }
-    setExpandedCardKey(expandedCardKey === key ? null : key);
+  };
+
+  const handleSetExpandedCardKey = key => {
+    const newRecommendedSimilarCurriculum =
+      getRecommendedSimilarCurriculum(key);
+    const newRecommendedStretchCurriculum = getRecommendedStretchCurriculum(
+      key,
+      newRecommendedSimilarCurriculum.key
+    );
+
+    analyticsReporter.sendEvent(EVENTS.RECOMMENDED_CATALOG_CURRICULUM_SHOWN, {
+      current_curriculum_offering: key,
+      recommended_similar_curriculum_offering:
+        newRecommendedSimilarCurriculum.key,
+      recommended_stretch_curriculum_offering:
+        newRecommendedStretchCurriculum.key,
+    });
+
+    setRecommendedSimilarCurriculum(newRecommendedSimilarCurriculum);
+    setRecommendedStretchCurriculum(newRecommendedStretchCurriculum);
+    setExpandedCardKey(key);
   };
 
   // Get the top recommended similar curriculum based on the curriculum with the given
@@ -192,18 +224,14 @@ const CurriculumCatalog = ({
                     self_paced_pl_course_offering_path
                   }
                   isExpanded={expandedCardKey === key}
-                  setExpandedCardKey={setExpandedCardKey}
-                  onQuickViewClick={() => handleExpandedCardChange(key)}
+                  handleSetExpandedCardKey={handleSetExpandedCardKey}
+                  onQuickViewClick={() => handleQuickViewClicked(key)}
                   isInUS={isInUS}
                   availableResources={available_resources}
                   isSignedOut={isSignedOut}
                   isTeacher={isTeacher}
-                  getRecommendedSimilarCurriculum={
-                    getRecommendedSimilarCurriculum
-                  }
-                  getRecommendedStretchCurriculum={
-                    getRecommendedStretchCurriculum
-                  }
+                  recommendedSimilarCurriculum={recommendedSimilarCurriculum}
+                  recommendedStretchCurriculum={recommendedStretchCurriculum}
                   {...props}
                 />
               )

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -104,11 +104,6 @@ const CurriculumCatalog = ({
       JSON.stringify(similarRecommenderResults)
     );
 
-    analyticsReporter.sendEvent(EVENTS.RECOMMENDED_SIMILAR_CURRICULUM_SHOWN, {
-      current_curriculum_offering: curriculumKey,
-      recommended_curriculum_offering: recommendedCurriculum.key,
-    });
-
     return recommendedCurriculum;
   };
 

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -50,14 +50,14 @@ const CurriculumCatalogCard = ({
   publishedDate,
   selfPacedPlCourseOfferingPath,
   isExpanded,
-  setExpandedCardKey,
+  handleSetExpandedCardKey,
   onQuickViewClick,
   isInUS,
   availableResources,
   isSignedOut,
   isTeacher,
-  getRecommendedSimilarCurriculum,
-  getRecommendedStretchCurriculum,
+  recommendedSimilarCurriculum,
+  recommendedStretchCurriculum,
   ...props
 }) => (
   <CustomizableCurriculumCatalogCard
@@ -100,13 +100,13 @@ const CurriculumCatalogCard = ({
     selfPacedPlCourseOfferingPath={selfPacedPlCourseOfferingPath}
     isExpanded={isExpanded}
     onQuickViewClick={onQuickViewClick}
-    setExpandedCardKey={setExpandedCardKey}
+    handleSetExpandedCardKey={handleSetExpandedCardKey}
     isInUS={isInUS}
     availableResources={availableResources}
     isSignedOut={isSignedOut}
     isTeacher={isTeacher}
-    getRecommendedSimilarCurriculum={getRecommendedSimilarCurriculum}
-    getRecommendedStretchCurriculum={getRecommendedStretchCurriculum}
+    recommendedSimilarCurriculum={recommendedSimilarCurriculum}
+    recommendedStretchCurriculum={recommendedStretchCurriculum}
     {...props}
   />
 );
@@ -142,14 +142,14 @@ CurriculumCatalogCard.propTypes = {
   publishedDate: PropTypes.string,
   selfPacedPlCourseOfferingPath: PropTypes.string,
   isExpanded: PropTypes.bool,
-  setExpandedCardKey: PropTypes.func.isRequired,
+  handleSetExpandedCardKey: PropTypes.func.isRequired,
   onQuickViewClick: PropTypes.func,
   isInUS: PropTypes.bool,
   availableResources: PropTypes.object,
   isTeacher: PropTypes.bool.isRequired,
-  getRecommendedSimilarCurriculum: PropTypes.func.isRequired,
-  getRecommendedStretchCurriculum: PropTypes.func.isRequired,
   isSignedOut: PropTypes.bool.isRequired,
+  recommendedSimilarCurriculum: PropTypes.object,
+  recommendedStretchCurriculum: PropTypes.object,
 };
 
 const CustomizableCurriculumCatalogCard = ({
@@ -181,12 +181,12 @@ const CustomizableCurriculumCatalogCard = ({
   publishedDate,
   selfPacedPlCourseOfferingPath,
   isExpanded,
-  setExpandedCardKey,
+  handleSetExpandedCardKey,
   onQuickViewClick,
   isInUS,
   availableResources,
-  getRecommendedSimilarCurriculum,
-  getRecommendedStretchCurriculum,
+  recommendedSimilarCurriculum,
+  recommendedStretchCurriculum,
   ...props
 }) => {
   const [isAssignDialogOpen, setIsAssignDialogOpen] = useState(false);
@@ -351,15 +351,15 @@ const CustomizableCurriculumCatalogCard = ({
           assignButtonOnClick={handleClickAssign}
           assignButtonDescription={assignButtonDescription}
           onClose={onQuickViewClick}
-          setExpandedCardKey={setExpandedCardKey}
+          handleSetExpandedCardKey={handleSetExpandedCardKey}
           isInUS={isInUS}
           imageSrc={imageSrc}
           imageAltText={imageAltText}
           availableResources={availableResources}
           isSignedOut={isSignedOut}
           isTeacher={isTeacher}
-          getRecommendedSimilarCurriculum={getRecommendedSimilarCurriculum}
-          getRecommendedStretchCurriculum={getRecommendedStretchCurriculum}
+          recommendedSimilarCurriculum={recommendedSimilarCurriculum}
+          recommendedStretchCurriculum={recommendedStretchCurriculum}
         />
       )}
     </div>
@@ -401,12 +401,12 @@ CustomizableCurriculumCatalogCard.propTypes = {
   publishedDate: PropTypes.string,
   selfPacedPlCourseOfferingPath: PropTypes.string,
   isExpanded: PropTypes.bool,
-  setExpandedCardKey: PropTypes.func.isRequired,
+  handleSetExpandedCardKey: PropTypes.func.isRequired,
   onQuickViewClick: PropTypes.func,
   isInUS: PropTypes.bool,
   availableResources: PropTypes.object,
-  getRecommendedSimilarCurriculum: PropTypes.func.isRequired,
-  getRecommendedStretchCurriculum: PropTypes.func.isRequired,
+  recommendedSimilarCurriculum: PropTypes.object,
+  recommendedStretchCurriculum: PropTypes.object,
 };
 
 export default connect(

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
@@ -26,9 +26,9 @@ const defaultArgs = {
   isSignedOut: false,
   isTeacher: true,
   onQuickViewClick: () => {},
-  setExpandedCardKey: () => {},
-  getRecommendedSimilarCurriculum: () => {},
-  getRecommendedStretchCurriculum: () => {},
+  handleSetExpandedCardKey: () => {},
+  recommendedSimilarCurriculum: {},
+  recommendedStretchCurriculum: {},
 };
 
 export const AllOptionsCard = Template.bind({});

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -90,12 +90,26 @@ const ExpandedCurriculumCatalogCard = ({
     recommendedSimilarCurriculum.key
   );
 
+  analyticsReporter.sendEvent(EVENTS.RECOMMENDED_CATALOG_CURRICULUM_SHOWN, {
+    current_curriculum_offering: courseKey,
+    recommended_similar_curriculum_offering: recommendedSimilarCurriculum.key,
+    recommended_stretch_curriculum_offering: recommendedStretchCurriculum.key,
+  });
+
   const handleClickRecommendedSimilarCurriculum = () => {
     analyticsReporter.sendEvent(EVENTS.RECOMMENDED_SIMILAR_CURRICULUM_CLICKED, {
       current_curriculum_offering: courseKey,
-      recommended_curriculum_offering: recommendedSimilarCurriculum.key,
+      recommended_similar_curriculum_offering: recommendedSimilarCurriculum.key,
     });
     setExpandedCardKey(recommendedSimilarCurriculum.key);
+  };
+
+  const handleClickRecommendedStretchCurriculum = () => {
+    analyticsReporter.sendEvent(EVENTS.RECOMMENDED_STRETCH_CURRICULUM_CLICKED, {
+      current_curriculum_offering: courseKey,
+      recommended_stretch_curriculum_offering: recommendedStretchCurriculum.key,
+    });
+    setExpandedCardKey(recommendedStretchCurriculum.key);
   };
 
   useEffect(() => {
@@ -325,9 +339,7 @@ const ExpandedCurriculumCatalogCard = ({
                   styleAsText
                   className={style.relatedCurriculaLink}
                   text={recommendedStretchCurriculum.display_name}
-                  onClick={() =>
-                    setExpandedCardKey(recommendedStretchCurriculum.key)
-                  }
+                  onClick={handleClickRecommendedStretchCurriculum}
                 />
               </div>
             </div>

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -35,15 +35,15 @@ const ExpandedCurriculumCatalogCard = ({
   assignButtonOnClick,
   assignButtonDescription,
   onClose,
-  setExpandedCardKey,
+  handleSetExpandedCardKey,
   isInUS,
   imageSrc,
   imageAltText,
   availableResources,
   isSignedOut,
   isTeacher,
-  getRecommendedSimilarCurriculum,
-  getRecommendedStretchCurriculum,
+  recommendedSimilarCurriculum,
+  recommendedStretchCurriculum,
 }) => {
   const isTeacherOrSignedOut = isSignedOut || isTeacher;
   const expandedCardRef = useRef(null);
@@ -82,26 +82,12 @@ const ExpandedCurriculumCatalogCard = ({
     return ++availableResourceCounter < availableResourcesCount;
   };
 
-  const recommendedSimilarCurriculum =
-    getRecommendedSimilarCurriculum(courseKey);
-
-  const recommendedStretchCurriculum = getRecommendedStretchCurriculum(
-    courseKey,
-    recommendedSimilarCurriculum.key
-  );
-
-  analyticsReporter.sendEvent(EVENTS.RECOMMENDED_CATALOG_CURRICULUM_SHOWN, {
-    current_curriculum_offering: courseKey,
-    recommended_similar_curriculum_offering: recommendedSimilarCurriculum.key,
-    recommended_stretch_curriculum_offering: recommendedStretchCurriculum.key,
-  });
-
   const handleClickRecommendedSimilarCurriculum = () => {
     analyticsReporter.sendEvent(EVENTS.RECOMMENDED_SIMILAR_CURRICULUM_CLICKED, {
       current_curriculum_offering: courseKey,
       recommended_similar_curriculum_offering: recommendedSimilarCurriculum.key,
     });
-    setExpandedCardKey(recommendedSimilarCurriculum.key);
+    handleSetExpandedCardKey(recommendedSimilarCurriculum.key);
   };
 
   const handleClickRecommendedStretchCurriculum = () => {
@@ -109,7 +95,7 @@ const ExpandedCurriculumCatalogCard = ({
       current_curriculum_offering: courseKey,
       recommended_stretch_curriculum_offering: recommendedStretchCurriculum.key,
     });
-    setExpandedCardKey(recommendedStretchCurriculum.key);
+    handleSetExpandedCardKey(recommendedStretchCurriculum.key);
   };
 
   useEffect(() => {
@@ -365,14 +351,14 @@ ExpandedCurriculumCatalogCard.propTypes = {
   assignButtonOnClick: PropTypes.func,
   assignButtonDescription: PropTypes.string,
   onClose: PropTypes.func,
-  setExpandedCardKey: PropTypes.func.isRequired,
+  handleSetExpandedCardKey: PropTypes.func.isRequired,
   isInUS: PropTypes.bool,
   imageSrc: PropTypes.string,
   imageAltText: PropTypes.string,
   availableResources: PropTypes.object,
   isTeacher: PropTypes.bool.isRequired,
   isSignedOut: PropTypes.bool.isRequired,
-  getRecommendedSimilarCurriculum: PropTypes.func.isRequired,
-  getRecommendedStretchCurriculum: PropTypes.func.isRequired,
+  recommendedSimilarCurriculum: PropTypes.object,
+  recommendedStretchCurriculum: PropTypes.object,
 };
 export default ExpandedCurriculumCatalogCard;

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -65,10 +65,11 @@ describe('CurriculumCatalogCard', () => {
       scriptId: 1,
       isSignedOut: true,
       onQuickViewClick: () => {},
+      handleSetExpandedCardKey: () => {},
       isTeacher: true,
       setExpandedCardKey: () => {},
-      getRecommendedSimilarCurriculum: () => {},
-      getRecommendedStretchCurriculum: () => {},
+      recommendedSimilarCurriculum: {},
+      recommendedStretchCurriculum: {},
     };
   });
 

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogExpandedCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogExpandedCardTest.jsx
@@ -53,13 +53,9 @@ describe('CurriculumCatalogExpandedCard', () => {
         'https://images.code.org/58cc5271d85e017cf5030ea510ae2715-AI for Oceans.png',
       isSignedOut: false,
       isTeacher: true,
-      setExpandedCardKey: () => {},
-      getRecommendedSimilarCurriculum: () => {
-        return FULL_TEST_COURSES[0];
-      },
-      getRecommendedStretchCurriculum: () => {
-        return FULL_TEST_COURSES[1];
-      },
+      handleSetExpandedCardKey: () => {},
+      recommendedSimilarCurriculum: FULL_TEST_COURSES[0],
+      recommendedStretchCurriculum: FULL_TEST_COURSES[1],
     };
   });
 


### PR DESCRIPTION
This PR provides some cleanup to reduce the number of calls to the curriculum recommender and adds/updates logging of curriculum recommenders to include the Stretch Curriculum.

## Cleanup
I updated where the `getSimilarCurriculumRecommendation` and `getStretchCurriculumRecommendation` functions are being called (moved into `CurriculumCatalog.jsx`) so that all the logic with them is consolidated to one file, and it improves runtime by only calling the recommendation functions when an expanded card changes. Before, I realized that if an expanded card was open and the user applied a filter or updated the page in some way, it would re-run the functions as `ExpandedCurriculumCatalogCard` was re-rendered.

## Logging
Updates the Curriculum Catalog to log Stretch Curriculum content. I also updated how the recommended content is logged upon showing the expanded card. I felt like it made more sense to log a single 'Recommended Catalog Curriculum Shown' event (and include a property for the similar curriculum and a property for the stretch curriculum) rather than log two separate 'Recommended Similar Curriculum Shown' and 'Recommended Stretch Curriculum Shown' events that would trigger at the same time. The events on Amplitude have already been updated accordingly.

As for the click events, there is a separate one for the similar curriculum and for the stretch curriculum depending on which one the user clicks.

### 'Recommended Catalog Curriculum Shown'
This was triggered by clicking "Quick View" on the "AI for Oceans" card.

Logged properties:
- `current_curriculum_offering`: the current course offering id of the expanded card
- `recommended_similar_curriculum_offering`: the recommended similar curriculum course offering id
- `recommended_stretch_curriculum_offering`: the recommended stretch curriculum course offering id

![SHOWN](https://github.com/code-dot-org/code-dot-org/assets/56283563/ac1b7101-79c7-4828-9f59-b0c1425eb274)

### 'Recommended Similar Curriculum Clicked'
This was triggered by clicking the similar recommended curriculum, "Dance Party: AI Edition", in the "AI for Oceans" expanded card.

Logged properties:
- `current_curriculum_offering`: the current course offering id of the expanded card
- `recommended_similar_curriculum_offering`: the recommended similar curriculum course offering id

![CLICK SIMILAR](https://github.com/code-dot-org/code-dot-org/assets/56283563/8e74ec32-82d7-452c-a16f-ff59d6482552)

### 'Recommended Stretch Curriculum Clicked'
This was triggered by clicking the stretch recommended curriculum, "How AI Works", in the "Dance Party: AI Edition" expanded card.

Logged properties:
- `current_curriculum_offering`: the current course offering id of the expanded card
- `recommended_stretch_curriculum_offering`: the recommended stretch curriculum course offering id

![CLICK STRETCH](https://github.com/code-dot-org/code-dot-org/assets/56283563/12119842-3963-4feb-b179-ded415b01dfb)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-663)
Spec: [here](https://docs.google.com/document/d/1Ya0FaDTugMVLxAV_2OxdYgP4kkch-BGeq4prH4wzd7I/edit)

## Testing story
Local testing.
