### PR TITLE
P20-892: Revert changes

### DIFF
--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -6,10 +6,6 @@ class LevelsControllerTest < ActionController::TestCase
 
   STUB_ENCRYPTION_KEY = SecureRandom.base64(Encryption::KEY_LENGTH / 8)
 
-  setup_all do
-    setup_units
-  end
-
   setup do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     Policies::LevelFiles.stubs(:write_to_file?).returns(false) # don't write to level files

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -7,7 +7,7 @@ class LevelsControllerTest < ActionController::TestCase
   STUB_ENCRYPTION_KEY = SecureRandom.base64(Encryption::KEY_LENGTH / 8)
 
   setup_all do
-    seed_deprecated_unit_fixtures
+    setup_units
   end
 
   setup do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -10,8 +10,6 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    seed_deprecated_unit_fixtures
-
     @student = create :student
     @young_student = create :young_student
     @teacher = create :teacher

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -3,10 +3,6 @@ require 'test_helper'
 class ScriptsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
-  setup_all do
-    seed_deprecated_unit_fixtures
-  end
-
   setup do
     @coursez_2017 = create :script, name: 'coursez-2017', family_name: 'coursez', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
     @coursez_2018 = create :script, name: 'coursez-2018', family_name: 'coursez', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -5,10 +5,6 @@ class ScriptLevelsHelperTest < ActionView::TestCase
   include ApplicationHelper
   include LevelsHelper
 
-  setup_all do
-    seed_deprecated_unit_fixtures
-  end
-
   setup do
     @teacher = create(:teacher)
     @student = create(:student)

--- a/dashboard/test/integration/caching_test.rb
+++ b/dashboard/test/integration/caching_test.rb
@@ -1,10 +1,6 @@
 require 'test_helper'
 
 class CachingTest < ActionDispatch::IntegrationTest
-  setup_all do
-    setup_units
-  end
-
   def setup
     setup_script_cache
   end

--- a/dashboard/test/integration/caching_test.rb
+++ b/dashboard/test/integration/caching_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class CachingTest < ActionDispatch::IntegrationTest
   setup_all do
-    seed_deprecated_unit_fixtures
+    setup_units
   end
 
   def setup

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -2,10 +2,6 @@ require 'test_helper'
 
 # Prevent regressions in the number of database queries on high-traffic routes.
 class DBQueryTest < ActionDispatch::IntegrationTest
-  setup_all do
-    seed_deprecated_unit_fixtures
-  end
-
   def setup
     setup_script_cache
   end

--- a/dashboard/test/integration/session_cookie_test.rb
+++ b/dashboard/test/integration/session_cookie_test.rb
@@ -2,10 +2,6 @@ require 'test_helper'
 require 'cdo/script_config'
 
 class SessionCookieTest < ActionDispatch::IntegrationTest
-  setup_all do
-    setup_units
-  end
-
   test 'session cookie name contains environment' do
     get '/reset_session'
 

--- a/dashboard/test/integration/session_cookie_test.rb
+++ b/dashboard/test/integration/session_cookie_test.rb
@@ -3,7 +3,7 @@ require 'cdo/script_config'
 
 class SessionCookieTest < ActionDispatch::IntegrationTest
   setup_all do
-    seed_deprecated_unit_fixtures
+    setup_units
   end
 
   test 'session cookie name contains environment' do

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -8,7 +8,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    seed_deprecated_unit_fixtures
+    setup_units
 
     @script_level = create(:script_level)
     @script_level2 = create(:script_level)

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -8,7 +8,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    setup_units
+    # setup_units
 
     @script_level = create(:script_level)
     @script_level2 = create(:script_level)

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -8,8 +8,6 @@ class ScriptLevelTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    # setup_units
-
     @script_level = create(:script_level)
     @script_level2 = create(:script_level)
     @lesson = create(:lesson)

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -7,7 +7,7 @@ class UnitTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    setup_units
+    # setup_units
 
     Rails.application.config.stubs(:levelbuilder_mode).returns false
     @game = create(:game)

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -7,8 +7,6 @@ class UnitTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    # setup_units
-
     Rails.application.config.stubs(:levelbuilder_mode).returns false
     @game = create(:game)
     # Level names match those in 'test.script'

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -7,7 +7,7 @@ class UnitTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    seed_deprecated_unit_fixtures
+    setup_units
 
     Rails.application.config.stubs(:levelbuilder_mode).returns false
     @game = create(:game)

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -133,7 +133,7 @@ class ActiveSupport::TestCase
   include ActiveSupport::Testing::TransactionalTestCase
   include CaptureQueries
 
-  def setup_units
+  setup_all do
     # Some of the functionality we're testing here relies on Scripts with
     # certain hardcoded names. In the old fixture-based model, this data was
     # all provided; in the new factory-based model, we need to do a little

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -174,10 +174,6 @@ class ActiveSupport::TestCase
     end
   end
 
-  setup_all do
-    seed_deprecated_unit_fixtures
-  end
-
   def assert_creates(*args)
     assert_difference(args.collect(&:to_s).collect {|class_name| "#{class_name}.count"}) do
       yield

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -133,7 +133,7 @@ class ActiveSupport::TestCase
   include ActiveSupport::Testing::TransactionalTestCase
   include CaptureQueries
 
-  def seed_deprecated_unit_fixtures
+  def setup_units
     # Some of the functionality we're testing here relies on Scripts with
     # certain hardcoded names. In the old fixture-based model, this data was
     # all provided; in the new factory-based model, we need to do a little


### PR DESCRIPTION
Reverted due to the error on the DTT testing server:
```
====[0m[1000D[KERROR["test_cache_find_level_uses_cache_with_ID_lookup", "UnitTest", 43.43938366882503]
 test_cache_find_level_uses_cache_with_ID_lookup#UnitTest (43.44s)
Minitest::UnexpectedError:         RuntimeError: Error finding level 548: Database disconnected
            app/models/unit.rb:520:in `cache_find_level'
            test/models/unit_test.rb:206:in `block in <class:UnitTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'

=========[0m[1000D[KERROR["test_cache_find_level_uses_cache_with_name_lookup", "UnitTest", 45.374213360249996]
 test_cache_find_level_uses_cache_with_name_lookup#UnitTest (45.37s)
Minitest::UnexpectedError:         RuntimeError: Error finding level Level_533: Database disconnected
            app/models/unit.rb:520:in `cache_find_level'
            test/models/unit_test.rb:214:in `block in <class:UnitTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

## Links
- JIRA ticket [P20-829](https://codedotorg.atlassian.net/browse/P20-829)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/57743