### PR TITLE
Adds back the rubric header padding on the left/right buttons.

### DIFF
--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -890,9 +890,11 @@ button.learningGoalButton {
 
 button.learningGoalButtonLeft {
   margin-left: 0.5rem;
+  margin-right: 0.625rem;
 }
 
 button.learningGoalButtonRight {
+  margin-left: 0.625rem;
   margin-right: 0.5rem;
 }
 


### PR DESCRIPTION
Just adds back the missing padding.

Original:

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/800a78f4-2221-4388-b2f5-a784e3cdc25c)

Broken (eyes diff):

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/661a97bc-886d-441c-9a0b-cb78d27f7351)

Now:

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/8001fb91-f3bb-4d53-937c-14df81dc31c0)

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
