### PR TITLE
Supported placements URL for LTI launch outside of context

### DIFF
--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialogHelpers.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialogHelpers.tsx
@@ -4,7 +4,9 @@ import {LtiSectionSyncResult} from '@cdo/apps/lib/ui/lti/sync/types';
 export const getRosterSyncErrorMessage = (syncResult: LtiSectionSyncResult) => {
   switch (syncResult.error) {
     case 'wrong_context':
-      return i18n.ltiSectionSyncDialogErrorWrongContext({url: '/'});
+      return i18n.ltiSectionSyncDialogErrorWrongContext({
+        url: 'https://support.code.org/hc/en-us/articles/23622036958093-Create-and-sync-rosters-with-Schoology',
+      });
     case 'no_integration':
       return i18n.ltiSectionSyncDialogErrorNoIntegration();
     case 'no_section':


### PR DESCRIPTION
Adds the URL for supported placements when launching the Code.org integration from the wrong context in an LMS.


## Links
- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/P20/boards/69?assignee=712020%3Af0e2716f-09f9-4686-8490-9f1f9a08bb06&selectedIssue=P20-856)
- slack conversation: [here](https://codedotorg.slack.com/archives/C061VNB3YE9/p1712249268373739)


