### PR TITLE
P20-788: Prevent user creation if the associated LTI User Identity creation fails

### DIFF
--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -35,7 +35,7 @@ module Services
       auth_option = user.authentication_options.find(&:lti?)
       issuer, client_id, subject = auth_option.authentication_id.split('|')
       lti_integration = Queries::Lti.get_lti_integration(issuer, client_id)
-      LtiUserIdentity.create(user: user, subject: subject, lti_integration: lti_integration)
+      LtiUserIdentity.create!(user: user, subject: subject, lti_integration: lti_integration)
     end
 
     def self.create_lti_integration(


### PR DESCRIPTION
## Summary
Prevents user creation if the associated LTI User Identity creation fails by raising an error in the `after_create` callback

## Links
- JIRA ticket [P20-788](https://codedotorg.atlassian.net/browse/P20-788)