### PR TITLE
Full width by default in `SimpleDropdown`

### DIFF
--- a/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0](https://github.com/code-dot-org/code-dot-org/pull/57105)
+* use `width: 100%` instead of `width: auto` as default when styling `select` element. 
+
 ## [0.3.0](https://github.com/code-dot-org/code-dot-org/pull/57105)
 * moved `SimpleDropdown` to dropdown folder
 

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/SimpleDropdown.tsx
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/SimpleDropdown.tsx
@@ -82,7 +82,6 @@ const SimpleDropdown: React.FunctionComponent<SimpleDropdownProps> = ({
           onChange={onChange}
           value={selectedValue}
           id={id}
-          className={moduleStyles.dropdown}
           disabled={disabled}
         >
           {itemGroups.length > 0

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
@@ -11,11 +11,11 @@
     display: block;
   }
 
-  .dropdown {
+  select {
     display: inline-flex;
     align-items: center;
     align-self: stretch;
-    width: auto;
+    width: 100%;
     background-color: unset;
     border-radius: 0.25rem;
     border: 1px solid;
@@ -51,7 +51,7 @@
     color: $light_black;
   }
 
-  .dropdown {
+  select {
     color: $light_black;
     border-color: $light_black;
   }
@@ -83,7 +83,7 @@
   }
 
   &:has(.dropdown:disabled) {
-    .dropdown {
+    select {
       color: $light_gray_200;
       border-color: $light_gray_200;
     }
@@ -99,7 +99,7 @@
     color: $light_white;
   }
 
-  .dropdown {
+  select {
     color: $light_white;
     border-color: $light_white;
   }
@@ -127,7 +127,7 @@
   }
 
   &:has(.dropdown:disabled) {
-    .dropdown {
+    select {
       color: $light_gray_900;
       border-color: $light_gray_900;
     }
@@ -149,7 +149,7 @@
     margin-bottom: 0.37rem;
   }
 
-  .dropdown {
+  select {
     @include button-one-text;
     height: 3rem;
     padding: 0.625rem 1rem;
@@ -172,7 +172,7 @@
     margin-bottom: 0.37rem;
   }
 
-  .dropdown {
+  select {
     @include button-two-text;
     height: 2.5rem;
     padding: 0.5rem 1rem;
@@ -195,7 +195,7 @@
     margin-bottom: 0.37rem;
   }
 
-  .dropdown {
+  select {
     @include button-three-text;
     height: 2rem;
     padding: 0.3125rem 1rem;
@@ -218,7 +218,7 @@
     margin-bottom: 0.37rem;
   }
 
-  .dropdown {
+  select {
     @include button-four-text;
     height: 1.5rem;
     padding: 0.125rem 0.5rem;


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/57775, based on discussion [here](https://github.com/code-dot-org/code-dot-org/pull/57775#issuecomment-2037636273) -- this defaults the `SimpleDropdown` component to take up the full width of its parent, and allows customization of this property (eg, setting `width: auto`) by passing in a classname to `SimpleDropdown`.

## Testing story

Tested a few things:
- I looked at gen AI lab usages of this component and saw the desired behavior (full width).
- I tested passing in an override width via the `className` prop (`width: auto`), and saw width revert to the width of the content.
- I looked at one use of this component outside of gen AI lab (in the teacher panel on the right side of the page when you're looking at a level as a teacher) and saw no visible change.
- I also looked at Storybook components, which looked good as well.