### PR TITLE
P20-829: Fix `Unit.clear_cache`

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1723,6 +1723,7 @@ class Unit < ApplicationRecord
     raise "only call this in a test!" unless Rails.env.test?
     @@unit_cache = nil
     @@unit_family_cache = nil
+    @@script_level_cache = nil
     @@level_cache = nil
     @@all_scripts = nil
     @@visible_units = nil

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -178,10 +178,6 @@ class ActiveSupport::TestCase
     assert_difference(args.collect(&:to_s).collect {|class_name| "#{class_name}.count"}, &block)
   end
 
-  setup_all do
-    seed_deprecated_unit_fixtures
-  end
-
   def assert_does_not_create(*args, &block)
     assert_no_difference(args.collect(&:to_s).collect {|class_name| "#{class_name}.count"}, &block)
   end


### PR DESCRIPTION
1. Fixed `Unit.clear_cache`: since `@@script_level_cache` wasn't being cleared, the data set during the first test remained unchanged in subsequent tests.
https://github.com/code-dot-org/code-dot-org/blob/751e8529137d7b72ab4dee2dbc3321b4fd229cef/dashboard/app/models/unit.rb#L452-L459
2. Re-introduced the `seed_deprecated_unit_fixtures` optimization that was reverted here: https://github.com/code-dot-org/code-dot-org/pull/57772

## Links
- JIRA ticket [P20-829](https://codedotorg.atlassian.net/browse/P20-829)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/57743