### PR TITLE
Implement existing effects in ToneJS

### DIFF
--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -220,7 +220,7 @@ export const setEffectAtCurrentLocationSimple2 = {
         type: 'field_dropdown',
         name: FIELD_EFFECTS_VALUE,
         options: [
-          ['normal', ''],
+          ['normal', 'normal'],
           ['medium', 'medium'],
           ['low', 'low'],
         ],

--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -1,8 +1,8 @@
+import {Effects} from './player/interfaces/Effects';
 import {Key} from './utils/Notes';
 
 export const baseAssetUrl = 'https://curriculum.code.org/media/musiclab/';
-export const baseAssetUrlRestricted =
-  'https://studio.code.org/restricted/musiclab/';
+export const baseAssetUrlRestricted = '/restricted/musiclab/';
 
 export interface Trigger {
   id: string;
@@ -77,3 +77,14 @@ export const DEFAULT_BEATS_PER_MEASURE = 4;
 export const DEFAULT_KEY = Key.C;
 export const MIN_BPM = 60;
 export const MAX_BPM = 200;
+
+export const BUS_EFFECT_COMBINATIONS: Effects[] = [
+  {filter: 'medium', delay: 'medium'},
+  {filter: 'low', delay: 'low'},
+  {filter: 'low', delay: 'medium'},
+  {filter: 'medium', delay: 'low'},
+  {filter: 'medium'},
+  {filter: 'low'},
+  {delay: 'medium'},
+  {delay: 'low'},
+];

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -471,6 +471,7 @@ export default class MusicPlayer {
 
     return {
       instrument,
+      effects: event.effects,
       events: generatedNotes.map(({note, tick}) => ({
         notes: [getPitchName(note)],
         playbackPosition: event.when + (tick - 1) / 16,
@@ -496,6 +497,7 @@ export default class MusicPlayer {
 
     return {
       instrument: kit,
+      effects: patternEvent.effects,
       events: patternEvent.value.events.map(event => {
         return {
           notes: [getPitchName(event.note)],

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -18,6 +18,7 @@ import {BarsBeatsSixteenths} from 'tone/build/esm/core/type/Units';
 import {Source, SourceOptions} from 'tone/build/esm/source/Source';
 import {BUS_EFFECT_COMBINATIONS, DEFAULT_BPM} from '../constants';
 import {Effects} from './interfaces/Effects';
+import {generateEffectsKeyString} from './utils';
 
 const EMPTY_EFFECTS_KEY = '';
 
@@ -228,7 +229,7 @@ class ToneJSPlayer implements AudioPlayer {
     }
 
     const effectKeyString = effects
-      ? this.generateKeyString(effects)
+      ? generateEffectsKeyString(effects)
       : EMPTY_EFFECTS_KEY;
 
     events.forEach(({notes, playbackPosition}) => {
@@ -338,26 +339,14 @@ class ToneJSPlayer implements AudioPlayer {
       }
 
       if (firstNode && lastNode) {
-        this.effectBusses[this.generateKeyString(effects)] = firstNode;
+        this.effectBusses[generateEffectsKeyString(effects)] = firstNode;
         lastNode.toDestination();
       }
     });
   }
 
-  // Generate a unique key string for a given set of effects.
-  private generateKeyString(effects: Effects) {
-    const keyStrings: string[] = [];
-    for (const key of Object.keys(effects)) {
-      const keyTyped = key as keyof Effects;
-      if (keyTyped !== 'volume' && effects[keyTyped] !== 'normal') {
-        keyStrings.push(`${key}_${effects[keyTyped]}`);
-      }
-    }
-    return keyStrings.join('_');
-  }
-
   private connectNodeToEffects(node: ToneAudioNode, effects: Effects) {
-    const key = this.generateKeyString(effects);
+    const key = generateEffectsKeyString(effects);
     if (this.effectBusses[key]) {
       node.connect(this.effectBusses[key]);
     } else {

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -169,7 +169,8 @@ class ToneJSPlayer implements AudioPlayer {
         notes,
         `+${Transport.toSeconds(
           this.playbackTimeToTransportTime(playbackPosition)
-        )}`
+        )}`,
+        1
       );
     });
   }

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -1,12 +1,25 @@
 import {SoundLoadCallbacks} from '../types';
 import SoundCache from './SoundCache';
-import {GrainPlayer, Player, Sampler, Transport, getContext, start} from 'tone';
+import {
+  Filter,
+  GrainPlayer,
+  PingPongDelay,
+  Player,
+  Sampler,
+  ToneAudioNode,
+  Transport,
+  getContext,
+  start,
+} from 'tone';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import {AudioPlayer, SampleEvent, SamplerSequence} from './types';
 import {BarsBeatsSixteenths} from 'tone/build/esm/core/type/Units';
 import {Source, SourceOptions} from 'tone/build/esm/source/Source';
-import {DEFAULT_BPM} from '../constants';
+import {BUS_EFFECT_COMBINATIONS, DEFAULT_BPM} from '../constants';
+import {Effects} from './interfaces/Effects';
+
+const EMPTY_EFFECTS_KEY = '';
 
 /**
  * An {@link AudioPlayer} implementation using the Tone.js library.
@@ -16,12 +29,13 @@ import {DEFAULT_BPM} from '../constants';
  * - Sample sequences
  */
 class ToneJSPlayer implements AudioPlayer {
-  private samplers: {[instrument: string]: Sampler};
+  private samplers: {[instrument: string]: {[effectsKey: string]: Sampler}};
   private activePlayers: Source<SourceOptions>[];
   private currentPreview: {
     url: string;
     player: Source<SourceOptions>;
   } | null;
+  private effectBusses: {[key: string]: ToneAudioNode};
 
   constructor(
     bpm = DEFAULT_BPM,
@@ -32,6 +46,8 @@ class ToneJSPlayer implements AudioPlayer {
     this.activePlayers = [];
     this.samplers = {};
     this.currentPreview = null;
+    this.effectBusses = {};
+    this.generateEffectBusses();
   }
 
   supportsSamplers(): boolean {
@@ -81,8 +97,18 @@ class ToneJSPlayer implements AudioPlayer {
       }
     });
 
-    const sampler = new Sampler(urls).toDestination();
-    this.samplers[instrumentName] = sampler;
+    // Create a separate sampler for each set of effects
+    const effectsSamplers: {[effectsKey: string]: Sampler} = {
+      // Default Sampler without effects
+      [EMPTY_EFFECTS_KEY]: new Sampler(urls).toDestination(),
+    };
+    for (const keyString of Object.keys(this.effectBusses)) {
+      const sampler = new Sampler(urls);
+      sampler.connect(this.effectBusses[keyString]);
+      effectsSamplers[keyString] = sampler;
+    }
+
+    this.samplers[instrumentName] = effectsSamplers;
   }
 
   isInstrumentLoaded(instrumentName: string): boolean {
@@ -139,7 +165,7 @@ class ToneJSPlayer implements AudioPlayer {
 
     await this.startContextIfNeeded();
     events.forEach(({notes, playbackPosition}) => {
-      this.samplers[instrument].triggerAttack(
+      this.samplers[instrument][EMPTY_EFFECTS_KEY].triggerAttack(
         notes,
         `+${Transport.toSeconds(
           this.playbackTimeToTransportTime(playbackPosition)
@@ -153,7 +179,7 @@ class ToneJSPlayer implements AudioPlayer {
       this.currentPreview.player.stop();
     }
 
-    Object.values(this.samplers).forEach(sampler => sampler.releaseAll());
+    this.stopAllSamplers();
   }
 
   setBpm(bpm: number) {
@@ -171,26 +197,46 @@ class ToneJSPlayer implements AudioPlayer {
     }
 
     const playbackRate = Transport.bpm.value / sample.originalBpm;
-    const player = this.createPlayer(buffer, playbackRate, sample.pitchShift)
-      .toDestination()
+    const player = this.createPlayer(buffer, playbackRate, sample.pitchShift);
+
+    if (sample.effects) {
+      this.connectNodeToEffects(player, sample.effects);
+      if (sample.effects.volume && sample.effects.volume !== 'normal') {
+        player.volume.value = sample.effects.volume === 'low' ? -9 : -4;
+      }
+    } else {
+      player.toDestination();
+    }
+
+    player
       .sync()
       .start(this.playbackTimeToTransportTime(sample.playbackPosition));
 
     this.activePlayers.push(player);
   }
 
-  scheduleSamplerSequence({instrument, events}: SamplerSequence) {
+  scheduleSamplerSequence({instrument, events, effects}: SamplerSequence) {
     if (this.samplers[instrument] === undefined) {
       this.metricsReporter.logError(`Instrument not loaded: ${instrument}`);
       return;
     }
 
+    let velocity = 1;
+    if (effects?.volume && effects?.volume !== 'normal') {
+      velocity = effects.volume === 'low' ? 0.4 : 0.75;
+    }
+
+    const effectKeyString = effects
+      ? this.generateKeyString(effects)
+      : EMPTY_EFFECTS_KEY;
+
     events.forEach(({notes, playbackPosition}) => {
-      this.samplers[instrument]
+      this.samplers[instrument][effectKeyString]
         .sync()
         .triggerAttack(
           notes,
-          this.playbackTimeToTransportTime(playbackPosition)
+          this.playbackTimeToTransportTime(playbackPosition),
+          velocity
         );
     });
   }
@@ -206,6 +252,7 @@ class ToneJSPlayer implements AudioPlayer {
   }
 
   stop() {
+    Transport.cancel();
     Transport.stop();
     this.stopAllPlayers();
   }
@@ -218,9 +265,7 @@ class ToneJSPlayer implements AudioPlayer {
   private stopAllPlayers() {
     this.activePlayers.forEach(player => player.dispose());
     this.activePlayers = [];
-    Object.values(this.samplers).forEach(sampler =>
-      sampler.releaseAll().unsync()
-    );
+    this.stopAllSamplers();
   }
 
   private async startContextIfNeeded() {
@@ -251,16 +296,71 @@ class ToneJSPlayer implements AudioPlayer {
     pitchShift: number
   ): Source<SourceOptions> {
     if (pitchShift === 0 && playbackRate === 1) {
-      return new Player(buffer).toDestination();
+      return new Player(buffer);
     } else {
       const player = new GrainPlayer({
         url: buffer,
         grainSize: playbackRate * 0.1,
-      }).toDestination();
+      });
 
       player.detune = pitchShift * 100;
       player.playbackRate = playbackRate;
       return player;
+    }
+  }
+
+  private stopAllSamplers() {
+    Object.values(this.samplers).forEach(samplerList =>
+      Object.values(samplerList).forEach(sampler => sampler.releaseAll())
+    );
+  }
+
+  private generateEffectBusses() {
+    BUS_EFFECT_COMBINATIONS.forEach(effects => {
+      const {filter, delay} = effects;
+      let firstNode, lastNode;
+      if (filter) {
+        const filterNode = new Filter(filter === 'low' ? 800 : 3000, 'lowpass');
+        firstNode = filterNode;
+        lastNode = filterNode;
+      }
+
+      if (delay) {
+        const delayNode = new PingPongDelay('8n', delay === 'low' ? 0.2 : 0.5);
+        delayNode.wet.value = delay === 'low' ? 0.1 : 0.25;
+        if (!firstNode) {
+          firstNode = delayNode;
+        } else {
+          firstNode.connect(delayNode);
+        }
+        lastNode = delayNode;
+      }
+
+      if (firstNode && lastNode) {
+        this.effectBusses[this.generateKeyString(effects)] = firstNode;
+        lastNode.toDestination();
+      }
+    });
+  }
+
+  // Generate a unique key string for a given set of effects.
+  private generateKeyString(effects: Effects) {
+    const keyStrings: string[] = [];
+    for (const key of Object.keys(effects)) {
+      const keyTyped = key as keyof Effects;
+      if (keyTyped !== 'volume' && effects[keyTyped] !== 'normal') {
+        keyStrings.push(`${key}_${effects[keyTyped]}`);
+      }
+    }
+    return keyStrings.join('_');
+  }
+
+  private connectNodeToEffects(node: ToneAudioNode, effects: Effects) {
+    const key = this.generateKeyString(effects);
+    if (this.effectBusses[key]) {
+      node.connect(this.effectBusses[key]);
+    } else {
+      node.toDestination();
     }
   }
 }

--- a/apps/src/music/player/soundEffects.js
+++ b/apps/src/music/player/soundEffects.js
@@ -3,6 +3,8 @@
 // possible combinations of more expensive sound effects, so that any
 // sound can attach to the right one.
 
+import {BUS_EFFECT_COMBINATIONS} from '../constants';
+
 export default class SoundEffects {
   constructor(audioContext, delayTimeSeconds) {
     this.audioContext = audioContext;
@@ -33,18 +35,7 @@ export default class SoundEffects {
   // expensive, we want to pre-generate the busses and then connect
   // sounds to the appropriate one.
   generateBusses() {
-    const busEffectsCombinations = [
-      {filter: 'medium', delay: 'medium'},
-      {filter: 'low', delay: 'low'},
-      {filter: 'low', delay: 'medium'},
-      {filter: 'medium', delay: 'low'},
-      {filter: 'medium'},
-      {filter: 'low'},
-      {delay: 'medium'},
-      {delay: 'low'},
-    ];
-
-    busEffectsCombinations.forEach(busEffects => {
+    BUS_EFFECT_COMBINATIONS.forEach(busEffects => {
       const {firstNode, lastNode} = this.generateBus(busEffects);
 
       // The bus connects to our main output.

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -99,4 +99,5 @@ export interface SamplerSequence {
   instrument: string;
   // Notes to play
   events: {notes: string[]; playbackPosition: number}[];
+  effects?: Effects;
 }

--- a/apps/src/music/player/utils.ts
+++ b/apps/src/music/player/utils.ts
@@ -1,0 +1,18 @@
+import {Effects} from './interfaces/Effects';
+
+export function generateEffectsKeyString(effects: Effects) {
+  const keyStrings: string[] = [];
+  if (effects.filter === 'medium') {
+    keyStrings.push('filter_medium');
+  }
+  if (effects.filter === 'low') {
+    keyStrings.push('filter_low');
+  }
+  if (effects.delay === 'medium') {
+    keyStrings.push('delay_medium');
+  }
+  if (effects.delay === 'low') {
+    keyStrings.push('delay_low');
+  }
+  return keyStrings.join('-');
+}


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Description

Adds support for our existing effects in ToneJS. Similar to the [existing effects approach](https://github.com/code-dot-org/code-dot-org/blob/f8ded42001df2909d70e43ecd6486fbd04db27a1/apps/src/music/player/soundEffects.js#L4), I created separate busses for each combination of effects to avoid having to add new effects nodes for every individual sound. This got a little more complicated with sampler instruments since those are created ahead of time; I opted to just create a separate sampler for each effects chain. I think this is fine for now, but we should keep an eye on this and generally the number of effects busses we have as those will increase exponentially as we add more effects.

General effects playback:

https://github.com/code-dot-org/code-dot-org/assets/85528507/626348b8-d690-4a07-a0ae-49ca65f85335

Effects scoped to individual functions:

https://github.com/code-dot-org/code-dot-org/assets/85528507/dc886b26-14c5-4de6-bf75-f8d5bc07eb13

## Links

https://codedotorg.atlassian.net/browse/LABS-528

## Testing story

Tested this on a standalone project with `player=tonejs`.
