### PR TITLE
Gen AI lab: update styling / content of model update messages

### DIFF
--- a/apps/src/aiTutor/types.ts
+++ b/apps/src/aiTutor/types.ts
@@ -64,6 +64,8 @@ export enum Role {
   ASSISTANT = 'assistant',
   USER = 'user',
   SYSTEM = 'system',
+  // only used in Aichat, but our types are currently tangled up :)
+  MODEL_UPDATE = 'update',
 }
 export type Status =
   (typeof AiTutorInteractionSaveStatus)[keyof typeof AiTutorInteractionSaveStatus];

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -7,6 +7,7 @@ const registerReducers = require('@cdo/apps/redux').registerReducers;
 import {
   DEFAULT_VISIBILITIES,
   EMPTY_AI_CUSTOMIZATIONS,
+  READABLE_AI_CUSTOMIZATIONS,
 } from '../views/modelCustomization/constants';
 import {initialChatMessages} from '../constants';
 import {getChatCompletionMessage} from '../chatApi';
@@ -108,7 +109,8 @@ export const updateAiCustomization = createAsyncThunk(
         addChatMessage({
           id: 0,
           role: Role.SYSTEM,
-          chatMessageText: property,
+          chatMessageText:
+            READABLE_AI_CUSTOMIZATIONS[property as keyof AiCustomizations],
           status: Status.OK,
           timestamp: getCurrentTime(),
         })

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -7,7 +7,7 @@ const registerReducers = require('@cdo/apps/redux').registerReducers;
 import {
   DEFAULT_VISIBILITIES,
   EMPTY_AI_CUSTOMIZATIONS,
-  READABLE_AI_CUSTOMIZATIONS,
+  AI_CUSTOMIZATIONS_LABELS,
 } from '../views/modelCustomization/constants';
 import {initialChatMessages} from '../constants';
 import {getChatCompletionMessage} from '../chatApi';
@@ -110,7 +110,7 @@ export const updateAiCustomization = createAsyncThunk(
           id: 0,
           role: Role.MODEL_UPDATE,
           chatMessageText:
-            READABLE_AI_CUSTOMIZATIONS[property as keyof AiCustomizations],
+            AI_CUSTOMIZATIONS_LABELS[property as keyof AiCustomizations],
           status: Status.OK,
           timestamp: getCurrentTime(),
         })
@@ -197,16 +197,12 @@ const aichatSlice = createSlice({
       state.chatMessages.push(newMessage);
     },
     removeChatMessage: (state, action: PayloadAction<number>) => {
-      const updatedMessages = [...state.chatMessages];
-      const messageToRemovePosition = updatedMessages.findIndex(
-        message => message.id === action.payload
+      const updatedMessages = state.chatMessages.filter(
+        message => message.id !== action.payload
       );
-      if (!messageToRemovePosition) {
-        return;
+      if (updatedMessages.length !== state.chatMessages.length) {
+        state.chatMessages = updatedMessages;
       }
-      updatedMessages.splice(messageToRemovePosition, 1);
-
-      state.chatMessages = updatedMessages;
     },
     clearChatMessages: state => {
       state.chatMessages = initialChatMessages;

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -53,6 +53,7 @@ const findChangedProperties = (
 };
 
 const getCurrentTimestamp = () => moment(Date.now()).format('YYYY-MM-DD HH:mm');
+const getCurrentTime = () => moment(Date.now()).format('LT');
 
 export interface AichatState {
   // All user and assistant chat messages - includes too personal and inappropriate user messages.
@@ -102,14 +103,17 @@ export const updateAiCustomization = createAsyncThunk(
       previouslySavedAiCustomizations,
       currentAiCustomizations
     );
-    thunkAPI.dispatch(
-      addChatMessage({
-        id: 0,
-        role: Role.ASSISTANT,
-        chatMessageText: `${changedProperties} were updated`,
-        status: Status.OK,
-      })
-    );
+    changedProperties.forEach(property => {
+      thunkAPI.dispatch(
+        addChatMessage({
+          id: 0,
+          role: Role.SYSTEM,
+          chatMessageText: property,
+          status: Status.OK,
+          timestamp: getCurrentTime(),
+        })
+      );
+    });
   }
 );
 
@@ -189,6 +193,20 @@ const aichatSlice = createSlice({
         id: newMessageId,
       };
       state.chatMessages.push(newMessage);
+    },
+    removeChatMessage: (state, action: PayloadAction<number>) => {
+      console.log('here');
+      const updatedMessages = [...state.chatMessages];
+      const messageToRemovePosition = updatedMessages.findIndex(
+        message => message.id === action.payload
+      );
+      if (!messageToRemovePosition) {
+        return;
+      }
+      console.log(updatedMessages);
+      updatedMessages.splice(messageToRemovePosition, 1);
+      console.log(updatedMessages);
+      state.chatMessages = updatedMessages;
     },
     clearChatMessages: state => {
       state.chatMessages = initialChatMessages;
@@ -298,6 +316,7 @@ const aichatSlice = createSlice({
 registerReducers({aichat: aichatSlice.reducer});
 export const {
   addChatMessage,
+  removeChatMessage,
   clearChatMessages,
   setIsWaitingForChatResponse,
   setShowWarningModal,

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -108,7 +108,7 @@ export const updateAiCustomization = createAsyncThunk(
       thunkAPI.dispatch(
         addChatMessage({
           id: 0,
-          role: Role.SYSTEM,
+          role: Role.MODEL_UPDATE,
           chatMessageText:
             READABLE_AI_CUSTOMIZATIONS[property as keyof AiCustomizations],
           status: Status.OK,
@@ -197,7 +197,6 @@ const aichatSlice = createSlice({
       state.chatMessages.push(newMessage);
     },
     removeChatMessage: (state, action: PayloadAction<number>) => {
-      console.log('here');
       const updatedMessages = [...state.chatMessages];
       const messageToRemovePosition = updatedMessages.findIndex(
         message => message.id === action.payload
@@ -205,9 +204,8 @@ const aichatSlice = createSlice({
       if (!messageToRemovePosition) {
         return;
       }
-      console.log(updatedMessages);
       updatedMessages.splice(messageToRemovePosition, 1);
-      console.log(updatedMessages);
+
       state.chatMessages = updatedMessages;
     },
     clearChatMessages: state => {

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -13,6 +13,7 @@ export enum Role {
   ASSISTANT = 'assistant',
   USER = 'user',
   SYSTEM = 'system',
+  MODEL_UPDATE = 'update',
 }
 
 export type Status =

--- a/apps/src/aichat/views/ChatMessage.tsx
+++ b/apps/src/aichat/views/ChatMessage.tsx
@@ -94,6 +94,32 @@ const displayAssistantMessage = (status: string, chatMessageText: string) => {
   }
 };
 
+const displaySystemMessage = (
+  message: ChatCompletionMessage,
+  onRemove: () => void
+) => {
+  const {chatMessageText, timestamp} = message;
+
+  return (
+    <>
+      <div>
+        <FontAwesomeV6Icon iconName="check" className={moduleStyles.check} />
+        <span className={moduleStyles.systemMessageTextContainer}>
+          <StrongText>{chatMessageText}</StrongText> has been updated
+        </span>
+        <StrongText>{timestamp}</StrongText>
+      </div>
+      <Button
+        onClick={onRemove}
+        isIconOnly
+        icon={{iconName: 'xmark'}}
+        size="s"
+        className={moduleStyles.removeStatusUpdate}
+      />
+    </>
+  );
+};
+
 const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({message}) => {
   const dispatch = useAppDispatch();
 
@@ -123,22 +149,9 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({message}) => {
 
       {isSystem(message.role) && (
         <div className={moduleStyles.systemMessageContainer}>
-          <div className={moduleStyles.systemMessageDetailsContainer}>
-            <FontAwesomeV6Icon
-              iconName="check"
-              className={moduleStyles.check}
-            />
-            <span>
-              <StrongText>{message.chatMessageText}</StrongText> has been
-              updated
-            </span>
-            <StrongText>{message.timestamp}</StrongText>
-          </div>
-          <Button
-            onClick={() => dispatch(removeChatMessage(message.id))}
-            isIconOnly
-            icon={{iconName: 'x'}}
-          />
+          {displaySystemMessage(message, () =>
+            dispatch(removeChatMessage(message.id))
+          )}
         </div>
       )}
     </div>

--- a/apps/src/aichat/views/ChatMessage.tsx
+++ b/apps/src/aichat/views/ChatMessage.tsx
@@ -28,7 +28,7 @@ const TOO_PERSONAL_MESSAGE = aichatI18n.tooPersonalUserMessage();
 
 const isAssistant = (role: string) => role === Role.ASSISTANT;
 const isUser = (role: string) => role === Role.USER;
-const isSystem = (role: string) => role === Role.SYSTEM;
+const isModelUpdate = (role: string) => role === Role.MODEL_UPDATE;
 
 const displayUserMessage = (status: string, chatMessageText: string) => {
   if (status === Status.OK || status === Status.UNKNOWN) {
@@ -94,7 +94,7 @@ const displayAssistantMessage = (status: string, chatMessageText: string) => {
   }
 };
 
-const displaySystemMessage = (
+const displayModelUpdateMessage = (
   message: ChatCompletionMessage,
   onRemove: () => void
 ) => {
@@ -104,7 +104,7 @@ const displaySystemMessage = (
     <>
       <div>
         <FontAwesomeV6Icon iconName="check" className={moduleStyles.check} />
-        <span className={moduleStyles.systemMessageTextContainer}>
+        <span className={moduleStyles.modelUpdateMessageTextContainer}>
           <StrongText>{chatMessageText}</StrongText> has been updated
         </span>
         <StrongText>{timestamp}</StrongText>
@@ -147,9 +147,9 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({message}) => {
         </div>
       )}
 
-      {isSystem(message.role) && (
-        <div className={moduleStyles.systemMessageContainer}>
-          {displaySystemMessage(message, () =>
+      {isModelUpdate(message.role) && (
+        <div className={moduleStyles.modelUpdateMessageContainer}>
+          {displayModelUpdateMessage(message, () =>
             dispatch(removeChatMessage(message.id))
           )}
         </div>

--- a/apps/src/aichat/views/ChatMessage.tsx
+++ b/apps/src/aichat/views/ChatMessage.tsx
@@ -1,16 +1,23 @@
 import React from 'react';
-import moduleStyles from './chatMessage.module.scss';
+import {useSelector} from 'react-redux';
 import classNames from 'classnames';
-import aichatI18n from '../locale';
+
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {LabState} from '@cdo/apps/lab2/lab2Redux';
+import Typography from '@cdo/apps/componentLibrary/typography/Typography';
+import {StrongText} from '@cdo/apps/componentLibrary/typography';
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon';
+import Button from '@cdo/apps/componentLibrary/button';
+
+import {removeChatMessage} from '../redux/aichatRedux';
 import {
   AichatLevelProperties,
   ChatCompletionMessage,
   Role,
   Status,
 } from '../types';
-import Typography from '@cdo/apps/componentLibrary/typography/Typography';
-import {useSelector} from 'react-redux';
-import {LabState} from '@cdo/apps/lab2/lab2Redux';
+import aichatI18n from '../locale';
+import moduleStyles from './chatMessage.module.scss';
 
 interface ChatMessageProps {
   message: ChatCompletionMessage;
@@ -19,13 +26,9 @@ interface ChatMessageProps {
 const INAPPROPRIATE_MESSAGE = aichatI18n.inappropriateUserMessage();
 const TOO_PERSONAL_MESSAGE = aichatI18n.tooPersonalUserMessage();
 
-const isAssistant = (role: string) => {
-  return role === Role.ASSISTANT;
-};
-
-const isUser = (role: string) => {
-  return role === Role.USER;
-};
+const isAssistant = (role: string) => role === Role.ASSISTANT;
+const isUser = (role: string) => role === Role.USER;
+const isSystem = (role: string) => role === Role.SYSTEM;
 
 const displayUserMessage = (status: string, chatMessageText: string) => {
   if (status === Status.OK || status === Status.UNKNOWN) {
@@ -92,12 +95,15 @@ const displayAssistantMessage = (status: string, chatMessageText: string) => {
 };
 
 const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({message}) => {
+  const dispatch = useAppDispatch();
+
   const botTitle =
     useSelector(
       (state: {lab: LabState}) =>
         (state.lab.levelProperties as AichatLevelProperties | undefined)
           ?.botTitle
     ) || 'EduBot';
+
   return (
     <div id={`ChatMessage id: ${message.id}`}>
       {isUser(message.role) && (
@@ -112,6 +118,27 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({message}) => {
             {botTitle} ({message.role})
           </Typography>
           {displayAssistantMessage(message.status, message.chatMessageText)}
+        </div>
+      )}
+
+      {isSystem(message.role) && (
+        <div className={moduleStyles.systemMessageContainer}>
+          <div className={moduleStyles.systemMessageDetailsContainer}>
+            <FontAwesomeV6Icon
+              iconName="check"
+              className={moduleStyles.check}
+            />
+            <span>
+              <StrongText>{message.chatMessageText}</StrongText> has been
+              updated
+            </span>
+            <StrongText>{message.timestamp}</StrongText>
+          </div>
+          <Button
+            onClick={() => dispatch(removeChatMessage(message.id))}
+            isIconOnly
+            icon={{iconName: 'x'}}
+          />
         </div>
       )}
     </div>

--- a/apps/src/aichat/views/chatMessage.module.scss
+++ b/apps/src/aichat/views/chatMessage.module.scss
@@ -1,21 +1,21 @@
 @import 'color.scss';
 
 .message {
-    padding: 10px 10px;
-    border-radius: 10px;
-    overflow: hidden;
+  padding: 10px 10px;
+  border-radius: 10px;
+  overflow: hidden;
 }
 
 .userMessageContainer {
-    margin: 0 0 15px 50px;
+  margin: 0 0 15px 50px;
 }
 
 .assistantMessageContainer {
-    margin: 0 50px 15px 0;
+  margin: 0 50px 15px 0;
 
-    h5 {
-        margin: 5px 0 5px 0;
-    }
+  h5 {
+    margin: 5px 0 5px 0;
+  }
 }
 
 .systemMessageContainer {
@@ -23,28 +23,42 @@
   justify-content: space-between;
   align-items: center;
   background-color: $light_affirmative_100;
+  border-radius: 4px;
+  padding: 5px 10px;
+  margin: 3px 0;
+
+  .removeStatusUpdate {
+    background-color: transparent;
+    color: $light_gray_700;
+
+    &:hover {
+      background-color: transparent;
+      color: $light_gray_700;
+    }
+  }
 }
 
-.systemMessageDetailsContainer {
-  gap: 5px;
+.systemMessageTextContainer {
+  margin: 0 10px;
 }
 
 .check {
   color: $light_affirmative_500;
+  font-size: 16px;
 }
 
 .userMessage {
-    background-color: $lightest_cyan;
+  background-color: $lightest_cyan;
 }
 
 .assistantMessage {
-    background-color: $lightest_gray;
+  background-color: $lightest_gray;
 }
 
 .inappropriateMessage {
-    background-color: $lightest_red;
+  background-color: $lightest_red;
 }
 
 .tooPersonalMessage {
-    background-color: $lightest_yellow;
+  background-color: $lightest_yellow;
 }

--- a/apps/src/aichat/views/chatMessage.module.scss
+++ b/apps/src/aichat/views/chatMessage.module.scss
@@ -18,7 +18,7 @@
   }
 }
 
-.systemMessageContainer {
+.modelUpdateMessageContainer {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -38,7 +38,7 @@
   }
 }
 
-.systemMessageTextContainer {
+.modelUpdateMessageTextContainer {
   margin: 0 10px;
 }
 

--- a/apps/src/aichat/views/chatMessage.module.scss
+++ b/apps/src/aichat/views/chatMessage.module.scss
@@ -18,6 +18,21 @@
     }
 }
 
+.systemMessageContainer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: $light_affirmative_100;
+}
+
+.systemMessageDetailsContainer {
+  gap: 5px;
+}
+
+.check {
+  color: $light_affirmative_500;
+}
+
 .userMessage {
     background-color: $lightest_cyan;
 }

--- a/apps/src/aichat/views/modelCustomization/compare-models-dialog.module.scss
+++ b/apps/src/aichat/views/modelCustomization/compare-models-dialog.module.scss
@@ -14,7 +14,7 @@
 }
 
 div.modelComparisonDialog {
-  height: calc(100vh - 100px);
+  height: calc(90vh - 100px);
   width: 800px;
   max-width: 800px;
   display: flex;

--- a/apps/src/aichat/views/modelCustomization/constants.ts
+++ b/apps/src/aichat/views/modelCustomization/constants.ts
@@ -53,3 +53,13 @@ export const DEFAULT_LEVEL_AICHAT_SETTINGS: LevelAichatSettings = {
   visibilities: DEFAULT_VISIBILITIES,
   hidePresentationPanel: false,
 };
+
+export const READABLE_AI_CUSTOMIZATIONS: {
+  [key in keyof AiCustomizations]: string;
+} = {
+  botName: 'Bot name',
+  temperature: 'Temperature',
+  systemPrompt: 'System prompt',
+  retrievalContexts: 'Retrieval',
+  modelCardInfo: 'Model description',
+};

--- a/apps/src/aichat/views/modelCustomization/constants.ts
+++ b/apps/src/aichat/views/modelCustomization/constants.ts
@@ -54,7 +54,7 @@ export const DEFAULT_LEVEL_AICHAT_SETTINGS: LevelAichatSettings = {
   hidePresentationPanel: false,
 };
 
-export const READABLE_AI_CUSTOMIZATIONS: {
+export const AI_CUSTOMIZATIONS_LABELS: {
   [key in keyof AiCustomizations]: string;
 } = {
   botName: 'Bot name',


### PR DESCRIPTION
This PR updates the styling and content of the messages put in the chat window when a user updates their model customizations, and adds a "delete" button to each message to remove them from the window if desired.

**New model update message UI**

<img width="739" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/292ebc9b-4045-480f-b91d-ab3bc4656fe1">

## Testing story

Tested manually as I changed different customizations.

## Follow-up work

[I started a thread in Slack](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1712267186733659) about the level of detail we want to include in the messages that are sent here (eg, do we want separate messages for updates to, say, temperature and system prompt)? It sounds like we want to include one message per update, not per tab, which is what is implemented here. There's a slight difference in Figma in the language for updates to the publish tab ("has been published" rather than "has been updated"), but [I'm seeking guidance on some specifics there](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1712271704257019) about how we want saves to work for that tab.