### PR TITLE
AI TA - Fix summary tab.

### DIFF
--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -286,7 +286,7 @@ export default function LearningGoals({
   };
 
   const aiEvalInfo = useMemo(() => {
-    if (!!aiEvaluations) {
+    if (!!aiEvaluations && currentLearningGoal < learningGoals.length) {
       const aiInfo = aiEvaluations.find(
         item => item.learning_goal_id === learningGoals[currentLearningGoal].id
       );

--- a/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
@@ -472,6 +472,20 @@ describe('LearningGoals - Enzyme', () => {
     );
   });
 
+  it('renders the summary page after AI evaluations are run', () => {
+    const wrapper = shallow(
+      <LearningGoals
+        learningGoals={learningGoals}
+        aiEvaluations={aiEvaluations}
+        teacherHasEnabledAi
+      />
+    );
+    wrapper.find('button').first().simulate('click');
+    expect(wrapper.find('Heading5 span').first().text()).to.equal(
+      i18n.rubricLearningGoalSummary()
+    );
+  });
+
   it('renders AiAssessment when teacher has AiEnabled and the learning goal can be tested by AI', () => {
     const wrapper = shallow(
       <LearningGoals


### PR DESCRIPTION
We were missing a test for rendering the summary after AI evaluation had been performed. The test only rendered the summary prior and that avoided the bug. The bug itself is just an indexing error where the summary page is using a 'learning goal index' that is one more than the number of learning goals. This was not guarded and so crashed the page.

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- jira ticket: [AITT-576](https://codedotorg.atlassian.net/browse/AITT-576)

## Testing story

Added a new test that was red to begin with. Green after the proposed change. This test should properly cover rendering the summary with AI evaluations.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
