### PR TITLE
Add FAQ with video demo to code.org/ai-ta

### DIFF
--- a/pegasus/sites.v3/code.org/views/ai_teaching_assistant/ai_ta_faq.haml
+++ b/pegasus/sites.v3/code.org/views/ai_teaching_assistant/ai_ta_faq.haml
@@ -24,6 +24,10 @@
       question: hoc_s("ai_ta_page.faq.keep_up.question"),
       answer: hoc_s("ai_ta_page.faq.keep_up.answer", markdown: :inline),
     },
+    {
+      question: hoc_s("ai_ta_page.faq.demo.question"),
+      answer: hoc_s("ai_ta_page.faq.demo.answer", markdown: :inline),
+    },
   ]
 
 - faq_items.each_with_index do |faq_item, index|
@@ -39,4 +43,6 @@
           %li= faq_item[:list_02]
           %li= faq_item[:list_03]
         = faq_item[:answer_02]
+      - if index === 5
+        = view :display_video_thumbnail, id: "ai_ta_demo", video_code: "Lj7uZx-BKhw", play_button: 'center', letterbox: 'false', download_path: "//videos.code.org/ai_teaching_assistant/ai_ta_demo_v1.mp4"
 


### PR DESCRIPTION
Adds an FAQ question to https://code.org/ai/teaching-assistant that shows a demo video.
- Also added the downloadable version to AWS

**Jira ticket:** [ACQ-1718](https://codedotorg.atlassian.net/browse/ACQ-1718)

----


https://github.com/code-dot-org/code-dot-org/assets/9256643/32853278-4209-4aac-8c43-5b619222c1ce

