### PR TITLE
Small style change for the setting content width

### DIFF
--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -1165,6 +1165,7 @@ button.infoAlertRight {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  width: 100%;
 }
 
 .settingsContainers {


### PR DESCRIPTION
Tiny style change for the width of content on the settings tab- set it to 100%

Before: 
<img width="763" alt="Screenshot 2024-04-05 at 11 59 23 AM" src="https://github.com/code-dot-org/code-dot-org/assets/7144482/cdede330-1005-4e3a-9512-2af93767f464">

After:
<img width="763" alt="Screenshot 2024-04-05 at 11 59 38 AM" src="https://github.com/code-dot-org/code-dot-org/assets/7144482/f338e8c3-593a-4643-8086-fc3fbf2945fb">


## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

## Links

https://codedotorg.atlassian.net/browse/AITT-568

## Testing story

Tested on local env, may need eyes test changes


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
