### PR TITLE
allow teacher to rerun ai eval when previous attempt resulted in error

### DIFF
--- a/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
+++ b/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
@@ -59,6 +59,7 @@ export default function RunAIAssessmentButton({
     return i18n.runAiAssessment();
   };
 
+  // fetch initial status
   useEffect(() => {
     if (!!rubricId && !!studentUserId) {
       fetchAiEvaluationStatus(rubricId, studentUserId).then(response => {
@@ -94,6 +95,7 @@ export default function RunAIAssessmentButton({
     }
   }, [rubricId, studentUserId, setStatus]);
 
+  // poll for status updates
   useEffect(() => {
     if (polling && !!rubricId && !!studentUserId) {
       const intervalId = setInterval(() => {
@@ -169,7 +171,7 @@ export default function RunAIAssessmentButton({
             color={Button.ButtonColor.neutralDark}
             onClick={handleRunAiAssessment}
             style={{margin: 0}}
-            disabled={status !== STATUS.READY}
+            disabled={status !== STATUS.READY && status !== STATUS.ERROR}
           >
             {polling && <i className="fa fa-spinner fa-spin" />}
           </Button>

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -532,7 +532,7 @@ describe('RubricContainer', () => {
     expect(userFetchStub).to.have.been.called;
     expect(allFetchStub).to.have.been.called;
     expect(wrapper.text()).to.include(i18n.aiEvaluationStatus_error());
-    expect(wrapper.find('Button').at(0).props().disabled).to.be.true;
+    expect(wrapper.find('Button').at(0).props().disabled).to.be.false;
   });
 
   it('shows PII error message for status 1001', async () => {

--- a/dashboard/app/controllers/test_ai_proxy_controller.rb
+++ b/dashboard/app/controllers/test_ai_proxy_controller.rb
@@ -21,5 +21,6 @@ class TestAiProxyController < ApplicationController
       }
     end
     render json: {data: response_data}
+    # render json: {data: {foo: 'bar'}}, status: :bad_request
   end
 end

--- a/dashboard/app/controllers/test_ai_proxy_controller.rb
+++ b/dashboard/app/controllers/test_ai_proxy_controller.rb
@@ -21,6 +21,5 @@ class TestAiProxyController < ApplicationController
       }
     end
     render json: {data: response_data}
-    # render json: {data: {foo: 'bar'}}, status: :bad_request
   end
 end


### PR DESCRIPTION
FInishes https://codedotorg.atlassian.net/browse/AITT-450

before, run button is disabled in error case:

![Screenshot 2024-04-05 at 11 45 06 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/170b3ef1-e482-4e29-90ec-82e64523f51a)

after, run button is enabled in error case, and rerunning succeeds:

https://github.com/code-dot-org/code-dot-org/assets/8001765/26def329-e0b5-4f4a-87c4-07c41b7b451e

## Testing story

* updated unit test
* manual verification to produce screenshots
