### PR TITLE
ToneJS: setup sampler instruments on demand

### DIFF
--- a/apps/src/music/blockly/FieldChord.ts
+++ b/apps/src/music/blockly/FieldChord.ts
@@ -6,6 +6,7 @@ import {ChordEventValue} from '../player/interfaces/ChordEvent';
 import MusicLibrary from '../player/MusicLibrary';
 import {getNoteName} from '../utils/Notes';
 import {generateGraphDataFromChord, ChordGraphNote} from '../utils/Chords';
+import {LoadFinishedCallback} from '../types';
 const experiments = require('@cdo/apps/util/experiments');
 const color = require('@cdo/apps/util/color');
 
@@ -20,6 +21,15 @@ interface FieldChordOptions {
   previewNote: (note: number, instrument: string, onStop?: () => void) => void;
   cancelPreviews: () => void;
   currentValue: ChordEventValue;
+  setupSampler: (
+    instrument: string,
+    onLoadFinished?: LoadFinishedCallback
+  ) => void;
+  isInstrumentLoading: (instrument: string) => boolean;
+  isInstrumentLoaded: (instrument: string) => boolean;
+  registerInstrumentLoadCallback: (
+    callback: (instrumentName: string) => void
+  ) => void;
 }
 
 /**
@@ -185,10 +195,8 @@ export default class FieldChord extends Field {
       React.createElement<ChordPanelProps>(ChordPanel, {
         library: this.options.getLibrary(),
         initValue: this.getValue(),
-        previewChord: this.options.previewChord,
-        previewNote: this.options.previewNote,
-        cancelPreviews: this.options.cancelPreviews,
         onChange: this.onValueChange,
+        ...this.options,
       }),
       this.newDiv
     );

--- a/apps/src/music/blockly/FieldPattern.js
+++ b/apps/src/music/blockly/FieldPattern.js
@@ -107,12 +107,10 @@ class FieldPattern extends GoogleBlockly.Field {
         library={this.options.getLibrary()}
         initValue={this.getValue()}
         bpm={this.options.getBPM()}
-        previewSound={this.options.previewSound}
-        previewPattern={this.options.previewPattern}
-        cancelPreviews={this.options.cancelPreviews}
         onChange={value => {
           this.setValue(value);
         }}
+        {...this.options}
       />,
       this.newDiv_
     );

--- a/apps/src/music/blockly/fields.js
+++ b/apps/src/music/blockly/fields.js
@@ -15,6 +15,22 @@ import {
   TRIGGER_FIELD,
 } from './constants';
 
+const instrumentCommonOptions = {
+  getLibrary: () => MusicLibrary.getInstance(),
+  cancelPreviews: () => {
+    Globals.getPlayer().cancelPreviews();
+  },
+  setupSampler: (instrument, onLoadFinished) =>
+    Globals.getPlayer().setupSampler(instrument, onLoadFinished),
+  isInstrumentLoading: instrument =>
+    Globals.getPlayer().isInstrumentLoading(instrument),
+  isInstrumentLoaded: instrument =>
+    Globals.getPlayer().isInstrumentLoaded(instrument),
+  registerInstrumentLoadCallback: callback => {
+    Globals.getPlayer().registerCallback('InstrumentLoaded', callback);
+  },
+};
+
 export const fieldSoundsDefinition = {
   type: FIELD_SOUNDS_TYPE,
   name: FIELD_SOUNDS_NAME,
@@ -30,33 +46,27 @@ export const fieldPatternDefinition = {
   type: FIELD_PATTERN_TYPE,
   name: FIELD_PATTERN_NAME,
   getBPM: () => Globals.getPlayer().getBPM(),
-  getLibrary: () => MusicLibrary.getInstance(),
   previewSound: (id, onStop) => {
     Globals.getPlayer().previewSound(id, onStop);
   },
   previewPattern: (patternValue, onStop) => {
     Globals.getPlayer().previewPattern(patternValue, onStop);
   },
-  cancelPreviews: () => {
-    Globals.getPlayer().cancelPreviews();
-  },
   currentValue: DEFAULT_PATTERN,
+  ...instrumentCommonOptions,
 };
 
 export const fieldChordDefinition = {
   type: FIELD_CHORD_TYPE,
   name: FIELD_CHORD_NAME,
-  getLibrary: () => MusicLibrary.getInstance(),
   previewChord: (chordValue, onStop) => {
     Globals.getPlayer().previewChord(chordValue, onStop);
   },
   previewNote: (note, instrument, onStop) => {
     Globals.getPlayer().previewNote(note, instrument, onStop);
   },
-  cancelPreviews: () => {
-    Globals.getPlayer().cancelPreviews();
-  },
   currentValue: DEFAULT_CHORD,
+  ...instrumentCommonOptions,
 };
 
 export const fieldRestDurationDefinition = {

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -14,7 +14,13 @@ import {Effects} from './interfaces/Effects';
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {LoadFinishedCallback, UpdateLoadProgressCallback} from '../types';
-import {AudioPlayer, SampleEvent, SamplerSequence} from './types';
+import {
+  AudioPlayer,
+  InstrumentData,
+  PlayerEvent,
+  SampleEvent,
+  SamplerSequence,
+} from './types';
 import SamplePlayerWrapper from './SamplePlayerWrapper';
 import {
   DEFAULT_PATTERN_LENGTH,
@@ -120,10 +126,28 @@ export default class MusicPlayer {
     events: PlaybackEvent[],
     onLoadFinished?: LoadFinishedCallback
   ) {
-    // If using samplers, chord and pattern sounds have already been loaded.
+    // If using samplers, collect all instrument samples.
+    const instruments: InstrumentData[] = [];
     if (this.audioPlayer.supportsSamplers()) {
+      const instrumentNames = new Set(
+        events
+          .filter(event => event.type !== 'sound')
+          .map(event =>
+            event.type === 'chord'
+              ? (event as ChordEvent).value.instrument
+              : (event as PatternEvent).value.kit
+          )
+      );
+      for (const instrumentName of instrumentNames) {
+        const sampleMap = this.generateSampleMap(instrumentName);
+        if (sampleMap) {
+          instruments.push({instrumentName, sampleMap});
+        }
+      }
+      // Filter out instrument/kit events
       events = events.filter(event => event.type === 'sound');
     }
+
     const sampleUrls = Array.from(
       new Set(
         events
@@ -133,7 +157,7 @@ export default class MusicPlayer {
       )
     );
 
-    return this.audioPlayer.loadSounds(sampleUrls, {
+    return this.audioPlayer.loadSounds(sampleUrls, instruments, {
       onLoadFinished,
       updateLoadProgress: this.updateLoadProgress,
     });
@@ -529,24 +553,16 @@ export default class MusicPlayer {
     return soundData.type === 'beat' ? 0 : this.key - (soundData.key || Key.C);
   }
 
-  // TODO: Temporary method to load all instruments at once.
-  // Instead we should load instruments as needed when they are first added to a project.
-  loadAllInstruments() {
-    if (!this.audioPlayer.supportsSamplers()) {
-      return;
-    }
+  isInstrumentLoading(instrument: string): boolean {
+    return this.audioPlayer.isInstrumentLoading(instrument);
+  }
 
-    const library = MusicLibrary.getInstance();
-    if (library === undefined) {
-      return;
-    }
+  isInstrumentLoaded(instrument: string): boolean {
+    return this.audioPlayer.isInstrumentLoaded(instrument);
+  }
 
-    for (const instrument of library.folders.filter(
-      folder => folder.type === 'instrument' || folder.type === 'kit'
-    )) {
-      console.log(`Creating sampler for ${instrument.id}`);
-      this.setupSampler(instrument.id);
-    }
+  registerCallback(event: PlayerEvent, callback: (payload?: string) => void) {
+    this.audioPlayer.registerCallback(event, callback);
   }
 
   async setupSampler(
@@ -560,6 +576,18 @@ export default class MusicPlayer {
       return;
     }
 
+    const sampleMap = this.generateSampleMap(instrument);
+    if (!sampleMap) {
+      return;
+    }
+
+    return this.audioPlayer.loadInstrument(instrument, sampleMap, {
+      updateLoadProgress: this.updateLoadProgress,
+      onLoadFinished,
+    });
+  }
+
+  private generateSampleMap(instrument: string) {
     const library = MusicLibrary.getInstance();
     if (library === undefined) {
       this.metricsReporter.logWarning('Library not set. Cannot load sampler.');
@@ -571,17 +599,12 @@ export default class MusicPlayer {
       return;
     }
 
-    const sampleMap = folder.sounds.reduce((map, sound, index) => {
+    return folder.sounds.reduce((map, sound, index) => {
       const soundData = library.getSoundForId(`${folder.id}/${sound.src}`);
       if (soundData) {
         map[sound.note || index] = library.generateSoundUrl(folder, soundData);
       }
       return map;
     }, {} as {[note: number]: string});
-
-    return this.audioPlayer.loadInstrument(folder.id, sampleMap, {
-      updateLoadProgress: this.updateLoadProgress,
-      onLoadFinished,
-    });
   }
 }

--- a/apps/src/music/player/SamplePlayerWrapper.ts
+++ b/apps/src/music/player/SamplePlayerWrapper.ts
@@ -1,7 +1,7 @@
 import {DEFAULT_BEATS_PER_MEASURE, DEFAULT_BPM} from '../constants';
 import {SoundLoadCallbacks} from '../types';
 import SamplePlayer from './SamplePlayer';
-import {AudioPlayer, SampleEvent} from './types';
+import {AudioPlayer, InstrumentData, SampleEvent} from './types';
 
 /**
  * An {@link AudioPlayer} implementation that wraps the {@link SamplePlayer}.
@@ -33,6 +33,7 @@ class SamplePlayerWrapper implements AudioPlayer {
 
   async loadSounds(
     sampleUrls: string[],
+    instruments: InstrumentData[],
     callbacks?: SoundLoadCallbacks
   ): Promise<void> {
     return this.samplePlayer.loadSounds(sampleUrls, callbacks);
@@ -42,8 +43,14 @@ class SamplePlayerWrapper implements AudioPlayer {
     console.warn('loadInstrument not supported');
   }
 
-  isInstrumentLoaded(): boolean {
+  isInstrumentLoading(): boolean {
+    // Assume instruments are always loaded since samples will be loaded directly
     return false;
+  }
+
+  isInstrumentLoaded(): boolean {
+    // Assume instruments are always loaded since samples will be loaded directly
+    return true;
   }
 
   async playSampleImmediately(
@@ -114,6 +121,10 @@ class SamplePlayerWrapper implements AudioPlayer {
 
   jumpToPosition() {
     console.warn('jumpToPosition not supported');
+  }
+
+  registerCallback(): void {
+    // No events are currently supported; ignore.
   }
 
   // Converts actual seconds used by the audio system into a playhead

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -17,15 +17,19 @@ export interface AudioPlayer {
   /** Load sounds into the cache */
   loadSounds(
     sampleUrls: string[],
+    instruments: InstrumentData[],
     callbacks?: SoundLoadCallbacks
   ): Promise<void>;
 
   /** Load instrument into the cache */
   loadInstrument(
     instrumentName: string,
-    sampleMap: {[note: number]: string},
+    sampleMap: SampleMap,
     callbacks?: SoundLoadCallbacks
   ): Promise<void>;
+
+  /** If the given instrument is currently loading */
+  isInstrumentLoading(instrumentName: string): boolean;
 
   /** If the given instrument has been loaded */
   isInstrumentLoaded(instrumentName: string): boolean;
@@ -73,6 +77,11 @@ export interface AudioPlayer {
 
   /** Jump to the given playback position */
   jumpToPosition(position: number): void;
+
+  registerCallback(
+    event: PlayerEvent,
+    callback: (payload?: string) => void
+  ): void;
 }
 
 /** A single sound played on the timeline */
@@ -101,3 +110,12 @@ export interface SamplerSequence {
   events: {notes: string[]; playbackPosition: number}[];
   effects?: Effects;
 }
+
+export type SampleMap = {[note: number]: string};
+
+export interface InstrumentData {
+  instrumentName: string;
+  sampleMap: SampleMap;
+}
+
+export type PlayerEvent = 'InstrumentLoaded'; // Add more as needed

--- a/apps/src/music/views/ChordPanel.tsx
+++ b/apps/src/music/views/ChordPanel.tsx
@@ -7,6 +7,8 @@ import {generateGraphDataFromChord, ChordGraphNote} from '../utils/Chords';
 import PreviewControls from './PreviewControls';
 import musicI18n from '../locale';
 import moduleStyles from './chordPanel.module.scss';
+import LoadingOverlay from './LoadingOverlay';
+import {LoadFinishedCallback} from '../types';
 
 const NUM_OCTAVES = 3;
 const START_OCTAVE = 4;
@@ -26,6 +28,15 @@ export interface ChordPanelProps {
   previewChord: (chord: ChordEventValue, onStop?: () => void) => void;
   previewNote: (note: number, instrument: string, onStop?: () => void) => void;
   cancelPreviews: () => void;
+  setupSampler: (
+    instrument: string,
+    onLoadFinished?: LoadFinishedCallback
+  ) => void;
+  isInstrumentLoading: (instrument: string) => boolean;
+  isInstrumentLoaded: (instrument: string) => boolean;
+  registerInstrumentLoadCallback: (
+    callback: (instrumentName: string) => void
+  ) => void;
 }
 
 const ChordPanel: React.FunctionComponent<ChordPanelProps> = ({
@@ -35,6 +46,10 @@ const ChordPanel: React.FunctionComponent<ChordPanelProps> = ({
   previewNote,
   cancelPreviews,
   library,
+  setupSampler,
+  isInstrumentLoading,
+  isInstrumentLoaded,
+  registerInstrumentLoadCallback,
 }) => {
   const [selectedNotes, setSelectedNotes] = useState<number[]>(initValue.notes);
   const [playStyle, setPlayStyle] = useState<PlayStyle>(initValue.playStyle);
@@ -42,6 +57,7 @@ const ChordPanel: React.FunctionComponent<ChordPanelProps> = ({
   const [isDisabled, setIsDisabled] = useState<boolean>(
     selectedNotes.length >= MAX_NOTES
   );
+  const [isLoading, setIsLoading] = useState(false);
 
   const instruments: [string, string][] = library.libraryJson.instruments.map(
     folder => [folder.name, folder.id]
@@ -60,6 +76,30 @@ const ChordPanel: React.FunctionComponent<ChordPanelProps> = ({
     },
     [selectedNotes, instrument, setSelectedNotes, previewNote]
   );
+
+  useEffect(() => {
+    if (!isInstrumentLoaded(instrument)) {
+      setIsLoading(true);
+      // If the instrument is already loading, register a callback and wait for it to finish.
+      if (isInstrumentLoading(instrument)) {
+        registerInstrumentLoadCallback(instrumentName => {
+          if (instrumentName === instrument) {
+            setIsLoading(false);
+          }
+        });
+      } else {
+        // Otherwise, initiate the load.
+        setupSampler(instrument, () => setIsLoading(false));
+      }
+    }
+  }, [
+    setupSampler,
+    isInstrumentLoading,
+    isInstrumentLoaded,
+    instrument,
+    setIsLoading,
+    registerInstrumentLoadCallback,
+  ]);
 
   useEffect(() => {
     onChange({
@@ -92,6 +132,7 @@ const ChordPanel: React.FunctionComponent<ChordPanelProps> = ({
           value={instrument}
           onChange={event => setInstrument(event.target.value)}
           className={moduleStyles.dropdown}
+          disabled={isLoading}
         >
           {instruments.map(([name, value]) => (
             <option key={value} value={value}>
@@ -116,7 +157,7 @@ const ChordPanel: React.FunctionComponent<ChordPanelProps> = ({
         startOctave={START_OCTAVE}
         selectedNotes={selectedNotes}
         onPressKey={onPressKey}
-        isDisabled={isDisabled}
+        isDisabled={isDisabled || isLoading}
       />
       <NoteGrid
         numOctaves={NUM_OCTAVES}
@@ -125,8 +166,9 @@ const ChordPanel: React.FunctionComponent<ChordPanelProps> = ({
         playStyle={playStyle}
         instrument={instrument}
       />
+      <LoadingOverlay show={isLoading} />
       <PreviewControls
-        enabled={selectedNotes.length > 0}
+        enabled={selectedNotes.length > 0 && !isLoading}
         playPreview={playPreview}
         onClickClear={onClear}
         cancelPreviews={cancelPreviews}

--- a/apps/src/music/views/LoadingOverlay.tsx
+++ b/apps/src/music/views/LoadingOverlay.tsx
@@ -1,0 +1,21 @@
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
+import React from 'react';
+import moduleStyles from './loading-overlay.module.scss';
+import classNames from 'classnames';
+
+const LoadingOverlay: React.FunctionComponent<{show: boolean}> = ({show}) => (
+  <div
+    className={classNames(
+      moduleStyles.loadingContainer,
+      show && moduleStyles.loadingContainerShow
+    )}
+  >
+    <FontAwesomeV6Icon
+      iconName="spinner"
+      animationType="spin"
+      className={moduleStyles.loadingSpinner}
+    />
+  </div>
+);
+
+export default LoadingOverlay;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -334,9 +334,6 @@ class UnconnectedMusicView extends React.Component {
       this.library.getKey()
     );
 
-    // Temporarily loading all instruments for ToneJS player.
-    this.player.loadAllInstruments();
-
     this.props.setLibraryName(libraryName);
 
     this.props.setIsLoading(false);

--- a/apps/src/music/views/chordPanel.module.scss
+++ b/apps/src/music/views/chordPanel.module.scss
@@ -1,4 +1,4 @@
-@import "color.scss";
+@import 'color.scss';
 
 .chordPanelContainer {
   background-color: $neutral_dark;
@@ -41,7 +41,7 @@
 
       &.blackKey {
         border-width: 2px 2px;
-        z-index: 10;
+        z-index: 1;
         width: 10px;
         height: 23px;
         background-color: black;

--- a/apps/src/music/views/loading-overlay.module.scss
+++ b/apps/src/music/views/loading-overlay.module.scss
@@ -1,0 +1,26 @@
+@import 'color.scss';
+
+.loadingContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background-color: rgba($neutral_dark, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 10;
+  transition: opacity 0.2s ease;
+
+  &Show {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.loadingSpinner {
+  font-size: 35px;
+}


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Description

This adds the ability to load/set up sampler instruments for the ToneJS player on demand (instead of all at once, like we do currently). There are a couple of nuances to this to make sure the user experience remains consistent, and this does add some extra loading time whenever a user opens up a new instrument for the first time, because we need to cache all the samples for the instrument at once. Some details:
- whenever an instrument block is added to the project (or we open a project with an instrument block) we will auto-load that instrument as part of the precaching process. We compile all the samples needed for the instruments and batch load them with the other samples to have a consistent loading bar.
- if an instrument block is dragged out but not connected to the when run block, we'll start loading the instrument as soon as the field is opened up.
- The loads do take a bit of time, but once we are using ToneJS, we could definitely strip down the number of samples. I experimented with reducing the number of piano samples from 36 to 10 (one sample every major third) and the playback still sounded quite good with a much faster load time. See video below for an example.

Note: I'm also realizing the name 'instrument' is very overloaded here, sometimes meaning specifically instruments in the "play chord" block or sometimes referring to all non-'pack' sampler-based sounds (both 'kits' and 'instruments'). I tried to use 'sampler' to be more generic but it's definitely not consistent, so that's something we can clean up later as well. Let me know if anything reads confusingly though.

**Loading new instruments** (caching is off for this example)

https://github.com/code-dot-org/code-dot-org/assets/85528507/c4a887df-6f93-46dd-8b90-e3b71b71e853

**Loading instruments with reduced samples**: compare the load time of Piano/Pluck to Rhodes (caching also off here)

https://github.com/code-dot-org/code-dot-org/assets/85528507/e42f03fd-1b1d-48ad-9ca1-9bc3fb8886c2

 
## Links

https://codedotorg.atlassian.net/browse/LABS-531

## Testing story

Tested this on a standalone project and intro progression with & without ToneJS. 

## Follow-up work

I'd love to go back in and consolidate/clean up some of the types (between fields.js, FieldChord/Pattern, and Chord/PatternPanel) since there's a lot of repetition, but that'll likely require some JS-TS conversions so I held off for now.