### PR TITLE
feat(lms): exclude lti_v1 from CPA age gating rules

### DIFF
--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -52,7 +52,7 @@ class Policies::ChildAccount
 
   # Authentication option types which we consider to be "owned" by the school
   # the student attends because the school has admin control of the account.
-  SCHOOL_OWNED_TYPES = [AuthenticationOption::CLEVER].freeze
+  SCHOOL_OWNED_TYPES = [AuthenticationOption::CLEVER, AuthenticationOption::LTI_V1].freeze
 
   # Does the user login using credentials they personally control?
   # For example, some accounts are created and owned by schools (Clever).

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -11,6 +11,7 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       [[:non_compliant_child, :unknown_us_region], true],
       [[:non_compliant_child, :not_U13], true],
       [[:non_compliant_child, :migrated_imported_from_clever], true],
+      [[:non_compliant_child, :with_lti_auth], true],
     ]
     test_matrix.each do |traits, compliance|
       user = create(*traits)


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-830)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. Set DCDO flag to enforce new user and all user lockout
2. Created new student in Colorado and age 10
3. SSO logged in from LMS

Expected: No lock out screen observed

Tested this with and without these changes. Without changes, a lockout screen was observed.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
