### PR TITLE
[JIMT][CT-482] - fixed editor jumping

### DIFF
--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -72,14 +72,13 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   // When we have a new channelId and/or start code, reset the editor with the start code.
   // A new channelId means we are loading a new project, and we need to reset the editor.
   useEffect(() => {
-    if (editorView) {
+    if (editorView && editorView.state.doc.toString() !== startCode) {
       editorView.dispatch({
         changes: {
           from: 0,
           to: editorView.state.doc.length,
           insert: startCode,
         },
-        selection: editorView.state.selection,
       });
     }
   }, [startCode, editorView, channelId]);

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -79,6 +79,7 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
           to: editorView.state.doc.length,
           insert: startCode,
         },
+        selection: editorView.state.selection,
       });
     }
   }, [startCode, editorView, channelId]);

--- a/apps/src/weblab2/Editor.tsx
+++ b/apps/src/weblab2/Editor.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useMemo} from 'react';
 
 import {editableFileType} from '@cdoide/utils';
 import {useCDOIDEContext} from '@cdoide/cdoIDEContext';
@@ -26,7 +26,12 @@ const Editor = () => {
     (value: string) => {
       saveFile(file.id, value);
     },
-    [file, saveFile]
+    [file.id, saveFile]
+  );
+
+  const editorConfigExtensions = useMemo(
+    () => [codeMirrorLangMapping[file.language]],
+    [file.language]
   );
 
   if (!editableFileType(file.language)) {
@@ -41,7 +46,7 @@ const Editor = () => {
           darkMode={true}
           onCodeChange={onChange}
           startCode={file.contents}
-          editorConfigExtensions={[codeMirrorLangMapping[file.language]]}
+          editorConfigExtensions={editorConfigExtensions}
         />
       )}
     </div>


### PR DESCRIPTION
CodeBridge has an issue where any typing would jump the position of the cursor back to the start.

I traced it back to the `lab2/CodeEditor` component itself, and specifically the second `useEffect` hook. What's happening is that the `startCode` value is changing because something new is handed in (this is part of the external loop where the editor caused a change, which fires off an action, which updates state, which eventually circles back to the component itself with a "new" file that's only what the user had just typed.

Fix is easy - in the effect, just compare the current value of the editor's doc and only set it to the new one if it's something different.

Side note - the original version of this fix operated differently. Instead of checking to see if the values had changed, it would just set the new string and reset the selection to what it was previously. That worked, but was concerning because if the file itself actually changed (e.g., we have the same editor open and were working with File A, and have now switched to File B), we could end up with the cursor in a random position in the new file. The way the code exists now, an external file change would always reset the cursor position back to the start, which is probably what we want.

One odd minor edge case could be if the file contents change, but it's still the same one. For example, if we format the file. We'll still reset the cursor position back to the beginning of the file, even though that may not be what the user would like. Ideally, the cursor would stay in the same position in the modified file. AFAIK, fixing that edge case would not be trivial in the general case and I think we should ignore it. This potential edge case is much smaller surface area than the original one with preserving the selection.

- jira ticket: [CT-482](https://codedotorg.atlassian.net/browse/CT-482)
