### PR TITLE
LTI sync summary updates v2

### DIFF
--- a/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
+++ b/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
@@ -171,6 +171,7 @@ class SyncOmniAuthSectionControl extends React.Component {
             isOpen={isLtiDialogOpen}
             syncResult={ltiSyncResult}
             onClose={this.onLtiDialogClose}
+            lmsName={sectionProviderName}
           />
         )}
         <BaseDialog

--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.story.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.story.tsx
@@ -28,10 +28,11 @@ SuccessfulSync.args = {
         name: 'CSD - Period 1',
         short_name: 'Period 1',
         size: 34,
+        lti_section_id: 1,
         instructors: [
           {
             name: 'Teacher 1',
-            id: '0',
+            id: 0,
             isOwner: true,
           },
         ],
@@ -40,10 +41,11 @@ SuccessfulSync.args = {
         name: 'CSD - Period 2',
         short_name: 'Period 2',
         size: 27,
+        lti_section_id: 2,
         instructors: [
           {
             name: 'Teacher 1',
-            id: '0',
+            id: 0,
             isOwner: true,
           },
         ],
@@ -52,10 +54,11 @@ SuccessfulSync.args = {
         name: 'CSD - Period 3',
         short_name: 'Period 3',
         size: 32,
+        lti_section_id: 3,
         instructors: [
           {
             name: 'Teacher 1',
-            id: '0',
+            id: 0,
             isOwner: true,
           },
         ],
@@ -66,10 +69,11 @@ SuccessfulSync.args = {
         name: 'CSD - Period 2',
         short_name: 'Period 2',
         size: 27,
+        lti_section_id: 2,
         instructors: [
           {
             name: 'Teacher 1',
-            id: '0',
+            id: 0,
             isOwner: true,
           },
         ],
@@ -78,10 +82,11 @@ SuccessfulSync.args = {
         name: 'CSD - Period 3',
         short_name: 'Period 3',
         size: 32,
+        lti_section_id: 3,
         instructors: [
           {
             name: 'Teacher 1',
-            id: '0',
+            id: 0,
             isOwner: true,
           },
         ],

--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
@@ -138,6 +138,9 @@ export default function LtiSectionSyncDialog({
   };
 
   const handleUpdateSectionOwners = () => {
+    if (!syncResult.changed || Object.keys(syncResult.changed).length === 0) {
+      return handleClose();
+    }
     return $.ajax({
       url: '/lti/v1/sections/bulk_update_owners',
       type: 'PATCH',

--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
@@ -247,12 +247,16 @@ export default function LtiSectionSyncDialog({
             labelText={i18n.ltiSectionSyncDialogHeaderPrimaryInstructor()}
             isLabelVisible={false}
             size={'xs'}
-            onChange={e =>
+            onChange={e => {
+              e.persist();
               setSectionOwners(owners => ({
                 ...owners,
-                [section.lti_section_id]: parseInt(e.target.value, 10),
-              }))
-            }
+                [section.lti_section_id.toString()]: parseInt(
+                  e.target.value,
+                  10
+                ),
+              }));
+            }}
           />
         </td>
         <td style={styles.tableCellNumber}>{section.size}</td>

--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
@@ -6,11 +6,13 @@ import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {LmsLinks} from '@cdo/apps/util/sharedConstants';
 import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
+import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
 import {
   LtiSection,
   LtiSectionMap,
   LtiSectionSyncDialogProps,
   LtiSectionSyncResult,
+  LtiSectionOwnerMap,
   SubView,
 } from './types';
 import PropTypes from 'prop-types';
@@ -29,6 +31,20 @@ export default function LtiSectionSyncDialog({
 }: LtiSectionSyncDialogProps) {
   const initialView = syncResult.error ? SubView.ERROR : SubView.SYNC_RESULT;
   const [currentView, setCurrentView] = useState<SubView>(initialView);
+  const [sectionOwners, setSectionOwners] = useState<LtiSectionOwnerMap>(() => {
+    const sectionOwners: LtiSectionOwnerMap = {};
+    if (syncResult.changed) {
+      Object.values(syncResult.changed).forEach(section => {
+        const sectionOwner = section.instructors.find(
+          instructor => instructor.isOwner
+        );
+        if (sectionOwner) {
+          sectionOwners[section.lti_section_id] = sectionOwner.id;
+        }
+      });
+    }
+    return sectionOwners;
+  });
 
   const handleClose = () => {
     setCurrentView(SubView.SPINNER);
@@ -120,6 +136,19 @@ export default function LtiSectionSyncDialog({
       PLATFORMS.STATSIG
     );
   };
+
+  const handleUpdateSectionOwners = () => {
+    return $.ajax({
+      url: '/lti/v1/sections/bulk_update_owners',
+      type: 'PATCH',
+      data: {
+        section_owners: sectionOwners,
+      },
+      success: () => {
+        handleClose();
+      },
+    });
+  };
   /**
    * Displays a summary of the changes after a successful sync with the LMS
    * @param syncResult
@@ -174,7 +203,7 @@ export default function LtiSectionSyncDialog({
               onClick={() => setCurrentView(SubView.DISABLE_ROSTER_SYNC)}
             />
           )}
-          <Button text={i18n.continue()} onClick={handleClose} />
+          <Button text={i18n.continue()} onClick={handleUpdateSectionOwners} />
         </DialogFooter>
       </div>
     );
@@ -198,13 +227,31 @@ export default function LtiSectionSyncDialog({
   const hideCloseButton = currentView === SubView.SPINNER;
 
   const SectionRow = (id: string, section: LtiSection) => {
-    const sectionOwnerName = section.instructors.find(
-      instructor => instructor.isOwner
-    )?.name;
+    const instructorOptions = section.instructors.map(instructor => ({
+      value: instructor.id.toString(),
+      text: instructor.name,
+    }));
     return (
       <tr key={id} role={'gridcell'}>
         <td style={styles.tableCellText}>{section.short_name}</td>
-        <td style={styles.tableCellText}>{sectionOwnerName}</td>
+        <td style={styles.tableCellText}>
+          <SimpleDropdown
+            name={`instructor-dropdown-${id}`}
+            items={instructorOptions}
+            selectedValue={
+              sectionOwners[section.lti_section_id]?.toString() ?? undefined
+            }
+            labelText={i18n.ltiSectionSyncDialogHeaderPrimaryInstructor()}
+            isLabelVisible={false}
+            size={'xs'}
+            onChange={e =>
+              setSectionOwners(owners => ({
+                ...owners,
+                [section.lti_section_id]: parseInt(e.target.value, 10),
+              }))
+            }
+          />
+        </td>
         <td style={styles.tableCellNumber}>{section.size}</td>
         <td style={styles.tableCellNumber}>{section.instructors.length}</td>
       </tr>

--- a/apps/src/lib/ui/lti/sync/types.ts
+++ b/apps/src/lib/ui/lti/sync/types.ts
@@ -2,12 +2,13 @@ export type LtiSection = {
   name: string;
   short_name: string;
   size: number;
+  lti_section_id: number;
   instructors: LtiInstructor[];
 };
 
 export interface LtiInstructor {
   name: string;
-  id: string;
+  id: number;
   isOwner: boolean;
 }
 
@@ -35,3 +36,5 @@ export enum SubView {
   ERROR = 'error',
   DISABLE_ROSTER_SYNC = 'disableRosterSync',
 }
+
+export type LtiSectionOwnerMap = {[sectionId: string]: number};

--- a/apps/test/unit/lib/ui/lti/sync/LtiSectionSyncDialogTest.tsx
+++ b/apps/test/unit/lib/ui/lti/sync/LtiSectionSyncDialogTest.tsx
@@ -15,10 +15,11 @@ const MOCK_ALL_SECTION_MAP: LtiSectionMap = {
     name: 'Section 1',
     short_name: 'Section 1',
     size: 100,
+    lti_section_id: 1,
     instructors: [
       {
         name: 'Teacher 1',
-        id: '0',
+        id: 0,
         isOwner: true,
       },
     ],
@@ -27,15 +28,16 @@ const MOCK_ALL_SECTION_MAP: LtiSectionMap = {
     name: 'Section 2',
     short_name: 'Section 2',
     size: 10,
+    lti_section_id: 2,
     instructors: [
       {
         name: 'Teacher 1',
-        id: '0',
+        id: 0,
         isOwner: true,
       },
       {
         name: 'Teacher 2',
-        id: '1',
+        id: 0,
         isOwner: false,
       },
     ],
@@ -47,10 +49,11 @@ const MOCK_UPDATED_SECTION_MAP: LtiSectionMap = {
     name: 'Section 2: Code.org fundamentals',
     short_name: 'Section 2',
     size: 15,
+    lti_section_id: 2,
     instructors: [
       {
         name: 'Teacher 1',
-        id: '0',
+        id: 0,
         isOwner: true,
       },
     ],

--- a/dashboard/app/controllers/lti/v1/sections_controller.rb
+++ b/dashboard/app/controllers/lti/v1/sections_controller.rb
@@ -1,0 +1,36 @@
+require 'metrics/events'
+
+module Lti
+  module V1
+    class SectionsController < ApplicationController
+      before_action :authenticate_user!
+
+      def bulk_update_owners
+        section_owners = params.require(:section_owners)
+        ActiveRecord::Base.transaction do
+          section_owners.each do |lti_section_id, owner_id|
+            section = LtiSection.find_by(id: lti_section_id)&.section
+            unless section
+              render :not_found
+              raise ActiveRecord::Rollback
+            end
+            authorize! :manage, section
+            next if section.user_id == owner_id
+            metadata = {
+              section_id: section.id,
+              previous_owner_id: section.user_id,
+              new_owner_id: owner_id,
+            }
+            section.update!(user_id: owner_id)
+            Metrics::Events.log_event(
+              user: current_user,
+              event_name: 'lti_section_owner_changed',
+              metadata: metadata
+            )
+          end
+        end
+        head :ok
+      end
+    end
+  end
+end

--- a/dashboard/app/views/lti/v1/sync_course.html.haml
+++ b/dashboard/app/views/lti/v1/sync_course.html.haml
@@ -1,6 +1,8 @@
 - script_data = {}
 - script_data[:lti_section_sync_result] = @lti_section_sync_result
 - script_data[:lms_name] = @lms_name
+- script_data[:current_user_id] = current_user.id
+- script_data[:current_username] = current_user.username
 
 - content_for(:head) do
   %script{src: webpack_asset_path('js/lti/v1/sync_course.js'), data: {ltiSectionSyncDialog: script_data.to_json}}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -612,6 +612,11 @@ Dashboard::Application.routes.draw do
     namespace :lti do
       namespace :v1 do
         resource :feedback, controller: :feedback, only: %i[create show]
+        resources :sections, only: [] do
+          collection do
+            patch :bulk_update_owners
+          end
+        end
       end
     end
 

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -234,6 +234,7 @@ module Services
         name: lti_section.section.name,
         short_name: nrps_section[:short_name],
         instructors: instructor_list,
+        lti_section_id: lti_section.id,
       }
     end
 

--- a/dashboard/test/controllers/lti/v1/lti_sections_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/lti_sections_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class Lti::V1::SectionsControllerTest < ActionController::TestCase
+  setup do
+    @user = create(:teacher)
+    sign_in @user
+  end
+  test 'updates section owners' do
+    new_owner = create :teacher
+    section_one = create :section, user: @user
+    section_two = create :section, user: @user
+    lti_section_one = create :lti_section, section: section_one
+    lti_section_two = create :lti_section, section: section_two
+    create :section_instructor, section: section_one, instructor: new_owner
+    create :section_instructor, section: section_two, instructor: new_owner
+
+    patch :bulk_update_owners, params: {section_owners: {lti_section_one.id => new_owner.id, lti_section_two.id => new_owner.id}}, format: :json
+    assert_response :ok
+    assert_equal new_owner.id, section_one.reload.user_id
+    assert_equal new_owner.id, section_two.reload.user_id
+  end
+
+  test 'does not update section owners if user is not an instructor' do
+    other_teacher = create :teacher
+    section = create :section, user: other_teacher
+    lti_section = create :lti_section, section: section
+    patch :bulk_update_owners, params: {section_owners: {lti_section.id => @user.id}}, format: :json
+    assert_response :forbidden
+    assert_equal other_teacher.id, section.reload.user_id
+  end
+
+  test 'if the owner is changed, the previous owner remains an instructor' do
+    new_owner = create :teacher
+    section = create :section, user: @user
+    lti_section = create :lti_section, section: section
+    create :section_instructor, section: section, instructor: new_owner
+
+    patch :bulk_update_owners, params: {section_owners: {lti_section.id => new_owner.id}}, format: :json
+    assert_response :ok
+    refute section.reload.user_id == @user.id
+    assert section.instructors.include? @user
+  end
+
+  test 'returns a 404 if a section is not found' do
+    patch :bulk_update_owners, params: {section_owners: {'foo' => @user.id}}, format: :json
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
Pt. 2 of the teacher-related updates for the sync confirmation modal. The [previous PR](https://github.com/code-dot-org/code-dot-org/pull/57695) updated the format to be a table instead of a list of sections. This one adds the following:

- Changes the Primary Teacher column from just the name of the teacher to a dropdown that includes all instructors for that section. This allows the user to solve situations where the section owner is ambiguous. Canvas sections can have multiple instructors, but none are considered "primary" in the LMS.
- Adds a new route to the LTI controller to update sections. I wasn't sure where to put this route, but I ended up putting into an Lti::V1::LtiSectionsController. This avoids adding to one of the two existing Sections controllers and contains this LTI-specific route to an LTI controller. Let me know if you have ideas for a better location for this route.
- Changes the `Continue` button in the modal to post to the new route, which will update the section owners.

Example screenshots:

Section B here has two teachers:
(The width on the dropdowns is uneven. A [PR](https://github.com/code-dot-org/code-dot-org/pull/57808) was merged to make them 100% width, but it had to be reverted. Assuming a fixed PR will eventually be merged, so I'm leaving the dropdowns as-is for now)
<img width="765" alt="Screenshot 2024-04-08 at 3 49 12 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/0fbac713-642e-43e6-8c29-6ce280ae2b6e">

Here I change the teacher and submit:
<img width="774" alt="Screenshot 2024-04-08 at 3 49 28 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/5a8edb32-9f69-455a-98a7-78f6f4f8783e">

Now `Carl Teacher2` is the primary teacher, and the old section owner has been "demoted" to a co-teacher:
<img width="1018" alt="Screenshot 2024-04-08 at 3 50 45 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/61713cfb-b718-44ae-aff3-bab3ec459355">



## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-804)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
