### PR TITLE
Revert "Revert "Full width by default in `SimpleDropdown`""

### DIFF
--- a/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [0.4.0](https://github.com/code-dot-org/code-dot-org/pull/57105)
-* use `width: 100%` instead of `width: auto` as default when styling `select` element. 
+* use `width: 100%` instead of `width: auto` as default when styling `select` element.
+* style select element with the use of `select` css selector instead of `.dropdown`
 
 ## [0.3.0](https://github.com/code-dot-org/code-dot-org/pull/57105)
 * moved `SimpleDropdown` to dropdown folder

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0](https://github.com/code-dot-org/code-dot-org/pull/57105)
+* use `width: 100%` instead of `width: auto` as default when styling `select` element. 
+
 ## [0.3.0](https://github.com/code-dot-org/code-dot-org/pull/57105)
 * moved `SimpleDropdown` to dropdown folder
 

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/SimpleDropdown.tsx
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/SimpleDropdown.tsx
@@ -82,7 +82,6 @@ const SimpleDropdown: React.FunctionComponent<SimpleDropdownProps> = ({
           onChange={onChange}
           value={selectedValue}
           id={id}
-          className={moduleStyles.dropdown}
           disabled={disabled}
         >
           {itemGroups.length > 0

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
@@ -60,8 +60,8 @@
     color: $light_black;
   }
 
-  &:has(.dropdown:hover) {
-    .dropdown:not(:disabled) {
+  &:has(select:hover) {
+    select:not(:disabled) {
       color: $light_black;
       background-color: $light_gray_100;
     }
@@ -71,8 +71,8 @@
     }
   }
 
-  &:has(.dropdown:active) {
-    .dropdown:not(:disabled) {
+  &:has(select:active) {
+    select:not(:disabled) {
       color: $light_black;
       background-color: unset;
     }
@@ -82,7 +82,7 @@
     }
   }
 
-  &:has(.dropdown:disabled) {
+  &:has(select:disabled) {
     select {
       color: $light_gray_200;
       border-color: $light_gray_200;
@@ -104,8 +104,8 @@
     border-color: $light_white;
   }
 
-  &:has(.dropdown:hover) {
-    .dropdown:not(:disabled) {
+  &:has(select:hover) {
+    select:not(:disabled) {
       color: $light_white;
       background-color: $light_gray_900;
     }
@@ -115,8 +115,8 @@
     }
   }
 
-  &:has(.dropdown:active) {
-    .dropdown:not(:disabled) {
+  &:has(select:active) {
+    select:not(:disabled) {
       color: $light_white;
       background-color: unset;
     }
@@ -126,7 +126,7 @@
     }
   }
 
-  &:has(.dropdown:disabled) {
+  &:has(select:disabled) {
     select {
       color: $light_gray_900;
       border-color: $light_gray_900;

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
@@ -11,11 +11,11 @@
     display: block;
   }
 
-  .dropdown {
+  select {
     display: inline-flex;
     align-items: center;
     align-self: stretch;
-    width: auto;
+    width: 100%;
     background-color: unset;
     border-radius: 0.25rem;
     border: 1px solid;
@@ -51,7 +51,7 @@
     color: $light_black;
   }
 
-  .dropdown {
+  select {
     color: $light_black;
     border-color: $light_black;
   }
@@ -83,7 +83,7 @@
   }
 
   &:has(.dropdown:disabled) {
-    .dropdown {
+    select {
       color: $light_gray_200;
       border-color: $light_gray_200;
     }
@@ -99,7 +99,7 @@
     color: $light_white;
   }
 
-  .dropdown {
+  select {
     color: $light_white;
     border-color: $light_white;
   }
@@ -127,7 +127,7 @@
   }
 
   &:has(.dropdown:disabled) {
-    .dropdown {
+    select {
       color: $light_gray_900;
       border-color: $light_gray_900;
     }
@@ -149,7 +149,7 @@
     margin-bottom: 0.37rem;
   }
 
-  .dropdown {
+  select {
     @include button-one-text;
     height: 3rem;
     padding: 0.625rem 1rem;
@@ -172,7 +172,7 @@
     margin-bottom: 0.37rem;
   }
 
-  .dropdown {
+  select {
     @include button-two-text;
     height: 2.5rem;
     padding: 0.5rem 1rem;
@@ -195,7 +195,7 @@
     margin-bottom: 0.37rem;
   }
 
-  .dropdown {
+  select {
     @include button-three-text;
     height: 2rem;
     padding: 0.3125rem 1rem;
@@ -218,7 +218,7 @@
     margin-bottom: 0.37rem;
   }
 
-  .dropdown {
+  select {
     @include button-four-text;
     height: 1.5rem;
     padding: 0.125rem 0.5rem;

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -27,7 +27,6 @@ import {
 } from './sectionProgressRedux';
 import UnitSelector from './UnitSelector';
 
-import styleConstants from './progressTables/progress-table-constants.module.scss';
 import dashboardStyles from '@cdo/apps/templates/teacherDashboard/teacher-dashboard.module.scss';
 
 const SECTION_PROGRESS = 'SectionProgress';
@@ -270,7 +269,6 @@ const styles = {
   },
   sortOrderSelect: {
     marginRight: sortOrderMargin,
-    width: parseInt(styleConstants.STUDENT_LIST_WIDTH) - sortOrderMargin,
   },
 };
 

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -27,6 +27,7 @@ import {
 } from './sectionProgressRedux';
 import UnitSelector from './UnitSelector';
 
+import styleConstants from './progressTables/progress-table-constants.module.scss';
 import dashboardStyles from '@cdo/apps/templates/teacherDashboard/teacher-dashboard.module.scss';
 
 const SECTION_PROGRESS = 'SectionProgress';
@@ -234,7 +235,7 @@ class SectionProgress extends Component {
   }
 }
 
-const sortOrderMargin = 22;
+const sortOrderMargin = 15;
 
 const styles = {
   heading: {
@@ -269,6 +270,7 @@ const styles = {
   },
   sortOrderSelect: {
     marginRight: sortOrderMargin,
+    width: parseInt(styleConstants.STUDENT_LIST_WIDTH) - sortOrderMargin,
   },
 };
 

--- a/apps/src/templates/sectionProgress/progressTables/progress-table-constants.module.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progress-table-constants.module.scss
@@ -13,6 +13,7 @@ $content-view-width: $table-width - $student-list-width;
 :export {
   MAX_BODY_HEIGHT: math.div($max-height, 1px);
   TABLE_WIDTH: math.div($table-width, 1px);
+  STUDENT_LIST_WIDTH: math.div($student-list-width, 1px);
   CONTENT_VIEW_WIDTH: math.div($content-view-width, 1px);
   ROW_HEIGHT: math.div($row-height, 1px);
   MAX_ROWS: $max-rows;

--- a/apps/src/templates/sectionProgress/progressTables/progress-table-constants.module.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progress-table-constants.module.scss
@@ -13,7 +13,6 @@ $content-view-width: $table-width - $student-list-width;
 :export {
   MAX_BODY_HEIGHT: math.div($max-height, 1px);
   TABLE_WIDTH: math.div($table-width, 1px);
-  STUDENT_LIST_WIDTH: math.div($student-list-width, 1px);
   CONTENT_VIEW_WIDTH: math.div($content-view-width, 1px);
   ROW_HEIGHT: math.div($row-height, 1px);
   MAX_ROWS: $max-rows;


### PR DESCRIPTION
Resuscitates https://github.com/code-dot-org/code-dot-org/pull/57808, which was reverted [here](https://github.com/code-dot-org/code-dot-org/pull/57808) due to an eyes failure -- details in [this Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1712600463000159). The text in a dropdown (family name vs. display name) on the Progress tab of the Teacher Dashboard was being slightly cut off :

<img width="330" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/339672e2-1f36-4567-923c-2d691e95f5e1">

New change in [ea7dd64](https://github.com/code-dot-org/code-dot-org/pull/57877/commits/ea7dd6498a93054ca835b4203636984a4b18f396) removes a hard coded width on the container div.

~~@etaderhold looks like you added this logic originally, any recollections on why the hard coded width is set? The dropdown will now expand to hold a long bit of text as one of the options, whereas it would have been cut off previously, not sure if that's a bad idea:~~

<img width="734" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/f677d907-5432-4d10-9bc6-8b8db8643f1f">

Alternatively, I could just make the hard coded width a bit larger, so LMK if that's preferable.

**Update:** I ended up going with this approach ^^^ -- looks like it still aligns properly (ie, takes 15px for the margin, then the rest of the space for the dropdown) 🤷 

<img width="573" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/698807be-0681-46b9-9d3e-c038c2a91d16">
