### PR TITLE
Add New Project string

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -372,6 +372,7 @@ en:
       my_dashboard: "My Dashboard"
       course_catalog: "Course Catalog"
       project_gallery: "Projects"
+      new_product: "New Project"
       schools: "Schools"
       districts: "Districts"
       sections: "Sections"

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -439,7 +439,7 @@ en:
       driver: 'Logged in'
       navigator: 'Partner'
       create: 'Create'
-      new_product: "New Project"
+      new_project: "New Project"
       algebra_game: 'Algebra'
       applab: 'App Lab'
       artist: 'Artist'

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -372,7 +372,6 @@ en:
       my_dashboard: "My Dashboard"
       course_catalog: "Course Catalog"
       project_gallery: "Projects"
-      new_product: "New Project"
       schools: "Schools"
       districts: "Districts"
       sections: "Sections"
@@ -440,6 +439,7 @@ en:
       driver: 'Logged in'
       navigator: 'Partner'
       create: 'Create'
+      new_product: "New Project"
       algebra_game: 'Algebra'
       applab: 'App Lab'
       artist: 'Artist'


### PR DESCRIPTION
Adds a `New Project` string ahead of the Create Account Button A/B test. Also added to the [i18n gsheet](https://docs.google.com/spreadsheets/d/1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU/edit#gid=0&range=1555:1555). 

The related `Create Account` string already exists on both the [en.yml](https://github.com/code-dot-org/code-dot-org/blob/a527f63f09cedcf87480ad39b63a701cd37acda7/dashboard/config/locales/en.yml#L435) file and the [i18n gsheet](https://docs.google.com/spreadsheets/d/1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU/edit#gid=0&range=1553:1553), but these don't appear to have been translated yet.

**Jira ticket:** [ACQ-1722](https://codedotorg.atlassian.net/browse/ACQ-1722)