### PR TITLE
Fix error handling for getColumn when table does not exist

### DIFF
--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -1241,9 +1241,13 @@ FirebaseStorage.getColumn = function (
     tableName,
     {},
     records => {
-      let columnValues = [];
-      records.forEach(row => columnValues.push(row[columnName]));
-      onSuccess(columnValues);
+      if (records === null) {
+        onSuccess(null);
+      } else {
+        let columnValues = [];
+        records.forEach(row => columnValues.push(row[columnName]));
+        onSuccess(columnValues);
+      }
     },
     onError
   );

--- a/apps/test/integration/levelSolutions/applab1/ec_data_blocks.js
+++ b/apps/test/integration/levelSolutions/applab1/ec_data_blocks.js
@@ -70,6 +70,81 @@ export default {
     },
 
     {
+      description:
+        'Data getColumn returns correct console message for nonexistant table',
+      editCode: true,
+      xml: `var names = getColumn('nonexistant table', 'name');`,
+
+      runBeforeClick(assert) {
+        // add a completion on timeout since this is a freeplay level
+        tickWrapper.runOnAppTick(Applab, 200, () => {
+          Applab.onPuzzleComplete();
+        });
+      },
+      customValidator(assert) {
+        // Error text includes correct info
+        const debugOutput = document.getElementById('debug-output');
+        assert.equal(
+          String(debugOutput.textContent).startsWith('ERROR'),
+          true,
+          `log message contains error: ${debugOutput.textContent}`
+        );
+        assert.equal(
+          String(debugOutput.textContent).endsWith(
+            "but that table doesn't exist in this app"
+          ),
+          true,
+          `log message contains correct info about nonexistant table: ${debugOutput.textContent}`
+        );
+        return true;
+      },
+      expected: {
+        result: true,
+        testResult: TestResults.FREE_PLAY,
+      },
+    },
+
+    {
+      description:
+        'Data getColumn returns correct console message for nonexistant column',
+      editCode: true,
+      xml: `
+        createRecord("mytable", {name:'Alice'}, function(record) {
+          createRecord("mytable", {name: 'Bob'}, function (record) {
+            var names = getColumn('mytable', 'nonexistant column');
+          });
+        });`,
+
+      runBeforeClick(assert) {
+        // add a completion on timeout since this is a freeplay level
+        tickWrapper.runOnAppTick(Applab, 200, () => {
+          Applab.onPuzzleComplete();
+        });
+      },
+      customValidator(assert) {
+        // Error text includes correct info
+        const debugOutput = document.getElementById('debug-output');
+        assert.equal(
+          String(debugOutput.textContent).startsWith('ERROR'),
+          true,
+          `log message contains error: ${debugOutput.textContent}`
+        );
+        assert.equal(
+          String(debugOutput.textContent).endsWith(
+            "but that column doesn't exist. "
+          ),
+          true,
+          `log message contains correct info about nonexistant column: ${debugOutput.textContent}`
+        );
+        return true;
+      },
+      expected: {
+        result: true,
+        testResult: TestResults.FREE_PLAY,
+      },
+    },
+
+    {
       description: 'Data createRecord again to confirm mock is reset',
       editCode: true,
       xml: `

--- a/apps/test/unit/storage/FirebaseStorageTest.js
+++ b/apps/test/unit/storage/FirebaseStorageTest.js
@@ -1172,6 +1172,97 @@ describe('FirebaseStorage', () => {
     });
   });
 
+  describe('getColumn', () => {
+    it('can get column when the column exists', done => {
+      const csvData =
+        'id,name,age,male\n' +
+        '4,alice,7,false\n' +
+        '5,bob,8,true\n' +
+        '6,charlie,9,true\n';
+      const expectedColumnValues = ['alice', 'bob', 'charlie'];
+
+      FirebaseStorage.importCsv(
+        'mytable',
+        csvData,
+        () => {
+          FirebaseStorage.getColumn('mytable', 'name', onSuccess, error => {
+            throw error;
+          });
+        },
+        error => {
+          throw error;
+        }
+      );
+      function onSuccess(columnValues) {
+        expect(columnValues).to.deep.equal(expectedColumnValues);
+        done();
+      }
+    });
+
+    it('can read cols from a current table', done => {
+      const tableData = {
+        1: '{"id":1,"name":"alice","age":7,"male":false}',
+        2: '{"id":2,"name":"bob","age":8,"male":true}',
+        3: '{"id":3,"name":"charlie","age":9,"male":true}',
+      };
+      getSharedDatabase()
+        .child('counters/tables/mytable')
+        .set({lastId: 3, rowCount: 3});
+      getSharedDatabase()
+        .child('storage/tables/mytable/records')
+        .set(tableData);
+
+      getProjectDatabase().child('current_tables/mytable').set(true);
+
+      const expectedColumnValues = ['alice', 'bob', 'charlie'];
+
+      FirebaseStorage.getColumn(
+        'mytable',
+        'name',
+        colValues => {
+          expect(colValues).to.deep.equal(expectedColumnValues);
+          done();
+        },
+        err => {
+          throw 'error';
+        }
+      );
+    });
+
+    it('returns [] for a table with no rows', done => {
+      FirebaseStorage.createTable(
+        'emptytable',
+        () => {
+          FirebaseStorage.getColumn(
+            'emptytable',
+            'column',
+            onSuccess,
+            error => {
+              throw error;
+            }
+          );
+        },
+        error => {
+          throw error;
+        }
+      );
+      function onSuccess(colValues) {
+        expect(colValues).to.deep.equal([]);
+        done();
+      }
+    });
+
+    it('returns null for a non-existent table', done => {
+      FirebaseStorage.getColumn('notATable', 'column', onSuccess, error => {
+        throw error;
+      });
+      function onSuccess(colValues) {
+        expect(colValues).to.equal(null);
+        done();
+      }
+    });
+  });
+
   describe('readRecords', () => {
     it('can read a table with rows', done => {
       const csvData =


### PR DESCRIPTION
There was a recent regression in getColumn where there's an uncaught exception when the table does not exist, which results in the student's program halting execution, and no error appearing that points to the problem line in their code. This makes it difficult for students to diagnose the issue if they forget to import the table they're referencing, and is a common occurrence with remixing projects since data tables do not get copied over into the remixed project (by design, but it's still a common gotcha). 

I think we should get this in ASAP to mitigate the impact that the regression is causing AP CSP students. I've scoped it down as much as possible to avoid any side-effects, and added test coverage for the code path.

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

We've seen a few zendesk tickets lately where users were complaining about their OnEvent callbacks not working, where the culprit seemed to be that they had a getColumn call stopping execution of the script. 

[slack discussions with links](https://codedotorg.slack.com/archives/C03DBDN67B7/p1712612383059099)

## Testing story

I added some test coverage that was previously missing and would have caught this regression, and tested the success case and error cases for nonexistent table and nonexistent column.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
