### PR TITLE
Update Curriculum Recommender fake curricula time stamps

### DIFF
--- a/apps/test/unit/util/curriculumRecommenderTestCurricula.js
+++ b/apps/test/unit/util/curriculumRecommenderTestCurricula.js
@@ -229,7 +229,7 @@ const FULL_TEST_COURSES = [
     school_subject: 'math',
     published_date: moment
       .utc()
-      .subtract(6, 'months')
+      .subtract(7, 'months')
       .format(UTC_PUBLISHED_DATE_FORMAT),
     device_compatibility:
       '{"computer":"ideal","chromebook":"ideal","tablet":"ideal","mobile":"ideal","no_device":"ideal"}',
@@ -249,7 +249,7 @@ const FULL_TEST_COURSES = [
     school_subject: 'math',
     published_date: moment
       .utc()
-      .subtract(1, 'years')
+      .subtract(13, 'months')
       .format(UTC_PUBLISHED_DATE_FORMAT),
     device_compatibility:
       '{"computer":"ideal","chromebook":"ideal","tablet":"ideal","mobile":"ideal","no_device":"ideal"}',
@@ -269,7 +269,7 @@ const FULL_TEST_COURSES = [
     school_subject: 'math',
     published_date: moment
       .utc()
-      .subtract(18, 'months')
+      .subtract(19, 'months')
       .format(UTC_PUBLISHED_DATE_FORMAT),
     device_compatibility:
       '{"computer":"ideal","chromebook":"ideal","tablet":"ideal","mobile":"ideal","no_device":"ideal"}',
@@ -289,7 +289,7 @@ const FULL_TEST_COURSES = [
     school_subject: 'science',
     published_date: moment
       .utc()
-      .subtract(2, 'years')
+      .subtract(25, 'months')
       .format(UTC_PUBLISHED_DATE_FORMAT),
     device_compatibility:
       '{"computer":"ideal","chromebook":"ideal","tablet":"ideal","mobile":"ideal","no_device":"ideal"}',
@@ -309,7 +309,7 @@ const FULL_TEST_COURSES = [
     school_subject: 'science',
     published_date: moment
       .utc()
-      .subtract(30, 'months')
+      .subtract(31, 'months')
       .format(UTC_PUBLISHED_DATE_FORMAT),
     device_compatibility:
       '{"computer":"ideal","chromebook":"ideal","tablet":"ideal","mobile":"ideal","no_device":"ideal"}',
@@ -329,7 +329,7 @@ const FULL_TEST_COURSES = [
     school_subject: null,
     published_date: moment
       .utc()
-      .subtract(3, 'years')
+      .subtract(37, 'months')
       .format(UTC_PUBLISHED_DATE_FORMAT),
     device_compatibility:
       '{"computer":"ideal","chromebook":"ideal","tablet":"ideal","mobile":"ideal","no_device":"ideal"}',


### PR DESCRIPTION
Yesterday, there were [flaky Curriculum Recommender unit tests](https://codedotorg.slack.com/archives/C0T0PNTM3/p1712624576741659). Nearly all the values are hard-coded to test the recommenders so my guess is that the flakiness came from setting the published dates and comparing them. If a curriculum was published within 1 or 2 years ago, [it gains a certain number of points when being scored](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/util/curriculumRecommender/curriculumRecommender.js#L252-L258). Since the test curricula had hard-coded published dates that were right on the cusps (e.g. Today minus one year exactly), I think sometimes the test would run and a given curriculum would have been considered published within one year ago, and sometimes not (thus, why the failing test showed the curricula scores in the wrong order).

This PR increases each published date by one month so that there are no dates right on the cusp of scoring points or not.

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1712624576741659)

## Testing story
Tested locally and it's still passing.
