### PR TITLE
[Google Blockly] strip user code

### DIFF
--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -12,17 +12,13 @@ import {
   setHasIncompatibleSources,
 } from '@cdo/apps/redux/blockly';
 import * as blockUtils from '../block_utils';
-import {handleCodeGenerationFailure} from './utils';
+import {
+  INFINITE_LOOP_TRAP,
+  LOOP_HIGHLIGHT,
+  handleCodeGenerationFailure,
+  strip,
+} from './utils';
 import {MetricEvent} from '@cdo/apps/lib/metrics/events';
-
-const INFINITE_LOOP_TRAP =
-  '  executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}\n';
-
-const LOOP_HIGHLIGHT = 'loopHighlight();\n';
-const LOOP_HIGHLIGHT_RE = new RegExp(
-  LOOP_HIGHLIGHT.replace(/\(.*\)/, '\\(.*\\)') + '\\s*',
-  'g'
-);
 
 /**
  * Wrapper class for https://github.com/code-dot-org/blockly
@@ -52,35 +48,6 @@ const BlocklyWrapper = function (blocklyInstance) {
     };
   };
 };
-
-function escapeRegExp(str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/**
- * Extract the user's code as raw JavaScript.
- * @param {string} code Generated code.
- * @return {string} The code without serial numbers and timeout checks.
- */
-function strip(code) {
-  return (
-    code
-      // Strip out serial numbers.
-      .replace(/(,\s*)?'block_id_\d+'\)/g, ')')
-      // Remove timeouts.
-      .replace(new RegExp(escapeRegExp(INFINITE_LOOP_TRAP), 'g'), '')
-      // Strip out loop highlight
-      .replace(LOOP_HIGHLIGHT_RE, '')
-      // Strip out class namespaces.
-      .replace(/(StudioApp|Maze|Turtle)\./g, '')
-      // Strip out particular helper functions.
-      .replace(/^function (colour_random)[\s\S]*?^}/gm, '')
-      // Collapse consecutive blank lines.
-      .replace(/\n\n+/gm, '\n\n')
-      // Trim.
-      .replace(/^\s+|\s+$/g, '')
-  );
-}
 
 /**
  * Given a type string for a field input, returns an appropriate change handler function

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -80,7 +80,12 @@ import {
 import {initializeScrollbarPair} from './addons/cdoScrollbar';
 import {getStore} from '@cdo/apps/redux';
 import {setFailedToGenerateCode} from '@cdo/apps/redux/blockly';
-import {handleCodeGenerationFailure} from './utils';
+import {
+  INFINITE_LOOP_TRAP,
+  LOOP_HIGHLIGHT,
+  handleCodeGenerationFailure,
+  strip,
+} from './utils';
 import {MetricEvent} from '@cdo/apps/lib/metrics/events';
 import {
   BlocklyWrapperType,
@@ -104,11 +109,8 @@ const options = {
 const plugin = new CrossTabCopyPaste();
 plugin.init(options);
 
-const INFINITE_LOOP_TRAP =
-  '  executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}\n';
 const MAX_GET_CODE_RETRIES = 2;
 const RETRY_GET_CODE_INTERVAL_MS = 500;
-const LOOP_HIGHLIGHT = 'loopHighlight();\n';
 
 /**
  * Wrapper class for https://github.com/google/blockly
@@ -224,6 +226,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       if (hiddenWorkspace) {
         workspaceCode += Blockly.JavaScript.workspaceToCode(hiddenWorkspace);
       }
+      workspaceCode = strip(workspaceCode);
       getStore().dispatch(setFailedToGenerateCode(false));
     } catch (e) {
       if (retryCount < MAX_GET_CODE_RETRIES) {

--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -153,3 +153,40 @@ export function getBaseName(themeName: Themes) {
     return themeName.replace(DARK_THEME_SUFFIX, '');
   }
 }
+export const INFINITE_LOOP_TRAP =
+  '  executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}\n';
+
+export const LOOP_HIGHLIGHT = 'loopHighlight();\n';
+const LOOP_HIGHLIGHT_RE = new RegExp(
+  LOOP_HIGHLIGHT.replace(/\(.*\)/, '\\(.*\\)') + '\\s*',
+  'g'
+);
+
+function escapeRegExp(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Extract the user's code as raw JavaScript.
+ * @param {string} code Generated code.
+ * @return {string} The code without serial numbers and timeout checks.
+ */
+export function strip(code: string) {
+  return (
+    code
+      // Strip out serial numbers.
+      .replace(/(,\s*)?'block_id_[^']+'\)/g, ')')
+      // Remove timeouts.
+      .replace(new RegExp(escapeRegExp(INFINITE_LOOP_TRAP), 'g'), '')
+      // Strip out loop highlight
+      .replace(LOOP_HIGHLIGHT_RE, '')
+      // Strip out class namespaces.
+      .replace(/(StudioApp|Maze|Turtle)\./g, '')
+      // Strip out particular helper functions.
+      .replace(/^function (colour_random)[\s\S]*?^}/gm, '')
+      // Collapse consecutive blank lines.
+      .replace(/\n\n+/gm, '\n\n')
+      // Trim.
+      .replace(/^\s+|\s+$/g, '')
+  );
+}

--- a/apps/src/craft/agent/craft.js
+++ b/apps/src/craft/agent/craft.js
@@ -712,7 +712,13 @@ export default class Craft {
     });
 
     // Run user generated code, calling appCodeOrgAPI
-    const code = Blockly.getWorkspaceCode();
+    let code = '';
+    let codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true);
+    if (studioApp().initializationBlocks) {
+      codeBlocks = studioApp().initializationBlocks.concat(codeBlocks);
+    }
+
+    code = Blockly.Generator.blocksToCode('JavaScript', codeBlocks);
     CustomMarshalingInterpreter.evalWith(code, {
       moveForward: function (blockID) {
         appCodeOrgAPI.moveForward(

--- a/apps/src/craft/aquatic/craft.js
+++ b/apps/src/craft/aquatic/craft.js
@@ -579,7 +579,8 @@ Craft.executeUserCode = function () {
   };
 
   // Run user code.
-  code += Blockly.getWorkspaceCode();
+  let codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true);
+  code += Blockly.Generator.blocksToCode('JavaScript', codeBlocks);
   interpreter = CustomMarshalingInterpreter.evalWith(
     code,
     {

--- a/apps/src/craft/designer/craft.js
+++ b/apps/src/craft/designer/craft.js
@@ -764,7 +764,11 @@ Craft.executeUserCode = function () {
   var appCodeOrgAPI = Craft.gameController.codeOrgAPI;
   appCodeOrgAPI.startCommandCollection();
   // Run user generated code, calling appCodeOrgAPI
-  const code = Blockly.getWorkspaceCode();
+  let codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true);
+  if (studioApp().initializationBlocks) {
+    codeBlocks = studioApp().initializationBlocks.concat(codeBlocks);
+  }
+  const code = Blockly.Generator.blocksToCode('JavaScript', codeBlocks);
 
   const evalApiMethods = {
     moveForward: function (blockID) {

--- a/apps/src/craft/simple/craft.js
+++ b/apps/src/craft/simple/craft.js
@@ -769,7 +769,13 @@ Craft.executeUserCode = function () {
   });
 
   // Run user generated code, calling appCodeOrgAPI
-  const code = Blockly.getWorkspaceCode();
+  let code = '';
+  let codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true);
+  if (studioApp().initializationBlocks) {
+    codeBlocks = studioApp().initializationBlocks.concat(codeBlocks);
+  }
+
+  code = Blockly.Generator.blocksToCode('JavaScript', codeBlocks);
 
   CustomMarshalingInterpreter.evalWith(
     code,


### PR DESCRIPTION
In older Blockly labs (Maze, Artist, Play Lab), there are some differences between the raw generated code that we feed into the JS interpreter and that which we show the student. For example, in these labs, additional code is used to prevent us from attempting to execute infinite loops. The generated code can also include block ids and lab-specific namespaces. Here is an example program on CDO Blockly and the associated "Show Code" modal:
|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/54069430-1a20-48f6-94e3-690090f589c0)|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/b0c9ecd7-ad6f-438f-b487-2401328c40dd)|
|-|-|

Here is the same program on Google Blockly:
|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/f85a81e3-1f2f-4f79-a6a7-21cbb33dc68b)|![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/5043f78f-f805-413c-8a0b-874360685df7)|
|-|-|


Note that the more complicated-looking code is still what we actually execute. CDO Blockly was accomplishing this cleanup with a call to a custom `strip` function which removes or modifies some stuff through regular expressions. We can actually use the same `strip` function to process code that Google Blockly generates, so I moved it (and some related constants) into our utils file. Some of the constants were actually already defined in both wrappers which felt a bit redundant.

The only functional change relates to differences in how block ids are generated.

Previously, it was sufficient to remove block ids by looking for a series of numbers:

`.replace(/(,\s*)?'block_id_\d+'\)/g, ')')`

The `'block_id_\d+'` part above matches the literal string `'block_id_'` followed by `\d+`, which matches one or more digits. To make it match any characters (except quotes), I replaced the latter with `[^']+`. 

With the changes in this branch, the code we show matches the CDO Blockly baseline. (Nit: there's a slight indentation difference inside the loop, but I think that's fine.)
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/5b6a7477-deac-4467-be4b-e963a28fb94c)

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

In addition to testing the indented behavior with the change, I also made sure I was still able to execute my code in this Maze level (with both versions of Blockly), as well as a couple random projects of other labs. No regressions found. The changes to the code is only for some very specific matched expressions, so this doesn't feel overly risky.


Making this change also required reverting a migration-related Minecraft change: https://github.com/code-dot-org/code-dot-org/pull/55993/commits/3c8902bd93dd86fc183976d7abf178ed19987f91

In order to get Minecraft migrated, I switched from using `Generator.blocksToCode` to `getWorkspaceCode()`. This change worked because there was no difference in the two, and was "needed" because `blocksToCode` wasn't defined yet. However, the generated code here is passed to the interpreter, so it needs to be the raw, un-stripped code. If we remove the infinite loop logic from the generated code given to the interpreter, then it's easy for students to get into frozen state (see pics). For this reason, it makes sense to go back to using the generator function, now that it has been defined.
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/be08aa08-bc19-4aae-a692-5403ab68299d)

<img width="709" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/612c70b8-9a48-46ec-a7e6-d24ade55be14">


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
