### PR TITLE
Make project template workspace icon tab navigable

### DIFF
--- a/apps/src/templates/ProjectTemplateWorkspaceIcon.jsx
+++ b/apps/src/templates/ProjectTemplateWorkspaceIcon.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import ReactTooltip from 'react-tooltip';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
+import moduleStyles from './project-template-workspace-icon.module.scss';
+import classNames from 'classnames';
+
 var msg = require('@cdo/locale');
 
 const IMAGE_BASE_URL = '/blockly/media/';
@@ -18,16 +21,24 @@ export default class ProjectTemplateWorkspaceIcon extends React.Component {
 
   render() {
     return (
-      <div style={styles.container}>
-        <img
-          style={styles.projectTemplateIcon}
-          className="projectTemplateWorkspaceIcon"
-          src={IMAGE_BASE_URL + 'connect.svg'}
+      <div className={moduleStyles.container}>
+        <button
+          type="button"
           data-tip
           data-for={this.tooltipId}
           aria-describedby={this.tooltipId}
-          alt={msg.workspaceProjectTemplateLevel()}
-        />
+          data-event="mouseenter mouseleave click"
+          className={moduleStyles.projectTemplateButton}
+        >
+          <img
+            className={classNames(
+              'projectTemplateWorkspaceIcon',
+              moduleStyles.projectTemplateIcon
+            )}
+            src={IMAGE_BASE_URL + 'connect.svg'}
+            alt={msg.workspaceProjectTemplateLevel()}
+          />
+        </button>
         <ReactTooltip
           id={this.tooltipId}
           role="tooltip"
@@ -35,7 +46,7 @@ export default class ProjectTemplateWorkspaceIcon extends React.Component {
           effect="solid"
           place={this.props.tooltipPlace}
         >
-          <div style={styles.tooltip}>
+          <div className={moduleStyles.tooltip}>
             {msg.workspaceProjectTemplateLevel()}
           </div>
         </ReactTooltip>
@@ -43,18 +54,3 @@ export default class ProjectTemplateWorkspaceIcon extends React.Component {
     );
   }
 }
-
-const styles = {
-  container: {
-    display: 'inline-block',
-  },
-  tooltip: {
-    maxWidth: 200,
-    lineHeight: '20px',
-    whiteSpace: 'normal',
-  },
-  projectTemplateIcon: {
-    marginRight: 5,
-    marginTop: -1,
-  },
-};

--- a/apps/src/templates/project-template-workspace-icon.module.scss
+++ b/apps/src/templates/project-template-workspace-icon.module.scss
@@ -1,0 +1,24 @@
+@import '@cdo/apps/mixins.scss';
+@import 'color.scss';
+
+.container {
+  display: inline-block;
+}
+
+.tooltip {
+  max-width: 200px;
+  line-height: 20px;
+  white-space: normal;
+}
+
+.projectTemplateIcon {
+  padding-top: 9px;
+  padding-bottom: 10px;
+  opacity: 1;
+}
+
+.projectTemplateButton {
+  @include remove-button-styles;
+  margin-right: 5px;
+  margin-bottom: -1px;
+}


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Description

Quick follow-up from https://github.com/code-dot-org/code-dot-org/pull/57886 to make the ProjectTemplateWorkspaceIcon tab navigable. Thanks to @fisher-alice for [writing up this code](https://github.com/code-dot-org/code-dot-org/commit/fa62bd24c24efc9b80ace5b25118986c4b90f35d)! Most of it is the same, with some additional work to move inline styles to module styles.

Icon in AI Chat:
<img width="1512" alt="Screenshot 2024-04-09 at 1 00 52 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/077888a4-bcd1-4db3-99f5-819a5658e947">

Icon in App Lab (non-Lab2):
<img width="1512" alt="Screenshot 2024-04-09 at 1 05 05 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/edc848ee-5d67-4f51-8744-bcb2455df65a">

Compared to current state:
<img width="1512" alt="Screenshot 2024-04-09 at 12 58 21 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/016aa39a-5319-4605-b351-8b9680c109c2">



## Testing story

Tested with a couple different level types.