### PR TITLE
Fix Facebook icon not loading in Eyes tests - V2

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -153,7 +153,7 @@ Scenario: congrats certificate pages
   Given I am on "http://studio.code.org/congrats"
   And I wait until element "#uitest-certificate" is visible
   And element "#uitest-certificate" is visible
-  And I wait for 2 seconds
+  And I wait for 5 seconds
   And I open my eyes to test "congrats certificate pages"
 
   When I am on "http://code.org/api/hour/finish/flappy"
@@ -161,13 +161,13 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait for 2 seconds
+  And I wait for 5 seconds
   And I see no difference for "uncustomized flappy certificate"
 
   When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
-  And I wait for 2 seconds
+  And I wait for 5 seconds
   And I see no difference for "customized flappy certificate"
 
   When I am on "http://code.org/api/hour/finish/oceans"
@@ -175,13 +175,13 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait for 2 seconds
+  And I wait for 5 seconds
   And I see no difference for "uncustomized oceans certificate"
 
   When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
-  And I wait for 2 seconds
+  And I wait for 5 seconds
   And I see no difference for "customized oceans certificate"
 
   When I am on "http://code.org/congrats/accelerated"
@@ -189,13 +189,13 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait for 2 seconds
+  And I wait for 5 seconds
   And I see no difference for "uncustomized 20-hour certificate"
 
   When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
-  And I wait for 2 seconds
+  And I wait for 5 seconds
   And I see no difference for "customized 20-hour certificate"
 
   Given I create a student named "Student1"
@@ -206,13 +206,13 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait for 2 seconds
+  And I wait for 5 seconds
   And I see no difference for "uncustomized Course A 2017 certificate"
 
   When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
-  And I wait for 2 seconds
+  And I wait for 5 seconds
   And I see no difference for "customized Course A 2017 certificate"
 
   And I close my eyes


### PR DESCRIPTION
This PR is a continuation of https://github.com/code-dot-org/code-dot-org/pull/56321 to try and fix a flaky eyes test on the certificates page Facebook icon. Increases the wait time from 2 seconds to 5 seconds.

💬 [Slack convo](https://codedotorg.slack.com/archives/C04540KNGDQ/p1712694021852239)