### PR TITLE
Add strings for new K-5 PL page

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -1776,7 +1776,7 @@
       csf:
         overline: "K-5 Teachers"
         title: "Computer Science Fundamentals"
-        desc: "Introduce students to the foundational concepts of computer science and challenges them to explore how computing and technology can impact the world."
+        desc: "Introduce students to the foundational concepts of computer science and challenge them to explore how computing and technology can impact the world."
         button: "Explore CS Fundamentals"
       csc:
         overline: "3-5 Teachers"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -1742,6 +1742,55 @@
         desc: "Our customer support team is ready to answer your questions. Email us at [support@code.org](%{email_url}) or check out our support center, which offers useful guides and answers!"
         button: "Visit our support center"
 
+  pl_page_k5:
+    heading: "K-5 professional learning workshops"
+    desc_01: "Our engaging workshops are for new and experienced computer science teachers!"
+    desc_02: "During these in-person or virtual facilitator-led workshops you will:"
+    top_list_01: "Explore the curriculum and learning tools"
+    top_list_02: "Experience the course as a teacher and a learner"
+    top_list_03: "Collaborate with fellow teachers"
+    top_list_04: "Earn a certificate of completion"
+    button: "Find a workshop near you"
+    workshops:
+      heading: "Choose the workshop that meets your needs"
+      desc: "Embark on a journey to master computer science education with our tailored workshops, whether you're starting fresh or looking to deepen your expertise."
+      intro:
+        overline: "The Intro Workshop"
+        title: "I've Never Taught Computer Science Fundamentals"
+        desc: "Dive into CS teaching fundamentals with our Intro Workshop, tailored for new educators in computer science. Join over 85,000 peers to develop actionable plans for implementing CS lessons, connect with a supportive teaching community, and leave equipped with strategies, certification, and exclusive Code.org swag."
+      deep_dive:
+        overline: "Deep-Dive Workshop"
+        title: "I've Already Taught Computer Science Fundamentals"
+        desc: "Enhance your CS teaching with our Deep Dive Workshop, ideal for educators already teaching CS Fundamentals who seek a richer understanding and advanced strategies. Collaborate in problem-solving sessions, address specific classroom challenges, and strengthen your teaching network, culminating in a deeper sense of community and ongoing support."
+    quote:
+      text: "It was great to put myself in situations that my students might face. Talking with others about our lessons was super helpful because we could bounce ideas off of one another."
+      byline: "Music Teacher"
+    workshops_map:
+      heading: "Register for a nearby workshop"
+      desc: "Use the map below to find the next upcoming CS Fundamentals workshop in your region. Because CS Fundamentals courses can be implemented at any point in the school year, workshops are available year round!"
+      deep_dive: "Deep Dive Workshop Available"
+    curriculum:
+      heading: "Curriculum associated with K-5 workshops"
+      desc: "Check out the curriculum offerings which you will explore in a K-5 workshop."
+      button: "See all K-5 curriculum options"
+      csf:
+        overline: "K-5 Teachers"
+        title: "Computer Science Fundamentals"
+        desc: "Introduce students to the foundational concepts of computer science and challenges them to explore how computing and technology can impact the world."
+        button: "Explore CS Fundamentals"
+      csc:
+        overline: "3-5 Teachers"
+        title: "Computer Science Connections"
+        desc: "Make connections between computer science (CS) and other subjects like math, language arts, science, and social studies."
+        button: "Explore CS Connections"
+    additional_offerings:
+      heading: "Additional professional learning offerings"
+      desc: "In addition to our facilitator led options for elementary teachers we have several other programs to meet the diverse needs of our teachers."
+      workshop_6_12:
+        title: "6-12 Workshops"
+        desc: "Do you teach middle or high school grades? Check out the link below to learn more about our 6-12 workshops."
+        button: "Explore 6-12 workshops"
+
   intl_pl_page:
     page_title: "International Professional Learning Resources"
     heading: "Global professional learning opportunities"


### PR DESCRIPTION
Adds strings for the new K-5 Professional Learning page.

**Note:** There's an opportunity to refactor some sections into views that can be shared between this new page and the existing Middle-High page (https://code.org/educate/professional-learning/middle-high). I'll reuse strings that already exist for these two sections: _Additional professional learning offerings_ and _Have questions?_. `workshop_6_12` is the only new string namespace needed for this.

**Jira ticket:** [ACQ-1748](https://codedotorg.atlassian.net/browse/ACQ-1748) • Parent ticket: [ACQ-1412](https://codedotorg.atlassian.net/browse/ACQ-1412)
**Figma mock:** [K-5 Workshops](https://www.figma.com/file/sZ6d1uhJWFksJ6j3Fnmbnc/PL-Flow-Improvements?type=design&node-id=1429%3A5232&mode=design&t=Qak8nYhT4n5lru6T-1)