### PR TITLE
Gen AI: add example topics and prompts

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -93,17 +93,37 @@ export const updateAiCustomization = createAsyncThunk(
     const {currentAiCustomizations, previouslySavedAiCustomizations} =
       state.aichat;
 
+    // Remove any empty example topics on save
+    const trimmedExampleTopics =
+      currentAiCustomizations.modelCardInfo.exampleTopics.filter(
+        topic => topic.length
+      );
+    thunkAPI.dispatch(
+      setModelCardProperty({
+        property: 'exampleTopics',
+        value: trimmedExampleTopics,
+      })
+    );
+
+    const trimmedCurrentAiCustomizations = {
+      ...currentAiCustomizations,
+      modelCardInfo: {
+        ...currentAiCustomizations.modelCardInfo,
+        exampleTopics: trimmedExampleTopics,
+      },
+    };
+
     await Lab2Registry.getInstance()
       .getProjectManager()
-      ?.save({source: JSON.stringify(currentAiCustomizations)}, true);
+      ?.save({source: JSON.stringify(trimmedCurrentAiCustomizations)}, true);
 
     thunkAPI.dispatch(
-      setPreviouslySavedAiCustomizations(currentAiCustomizations)
+      setPreviouslySavedAiCustomizations(trimmedCurrentAiCustomizations)
     );
 
     const changedProperties = findChangedProperties(
       previouslySavedAiCustomizations,
-      currentAiCustomizations
+      trimmedCurrentAiCustomizations
     );
     changedProperties.forEach(property => {
       thunkAPI.dispatch(

--- a/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
+++ b/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
@@ -13,7 +13,6 @@ const ExampleTopicsInputs: React.FunctionComponent<{
 
   return (
     <MultiItemInput
-      key="exampleTopics"
       items={topics}
       onAdd={() =>
         dispatch(

--- a/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
+++ b/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import MultiItemInput from '@cdo/apps/templates/MultiItemInput';
+
+import {setModelCardProperty} from '../../redux/aichatRedux';
+
+const ExampleTopicsInputs: React.FunctionComponent<{
+  topics: string[];
+  readOnly: boolean;
+}> = ({topics, readOnly}) => {
+  const dispatch = useAppDispatch();
+
+  return (
+    <MultiItemInput
+      key="exampleTopics"
+      items={topics}
+      onAdd={() =>
+        dispatch(
+          setModelCardProperty({
+            property: 'exampleTopics',
+            value: [...topics].concat(''),
+          })
+        )
+      }
+      onRemove={() => {
+        dispatch(
+          setModelCardProperty({
+            property: 'exampleTopics',
+            value: [...topics].slice(0, -1),
+          })
+        );
+      }}
+      onChange={(index, value) => {
+        const updatedTopics = topics.slice();
+        updatedTopics[index] = value;
+        dispatch(
+          setModelCardProperty({
+            property: 'exampleTopics',
+            value: updatedTopics,
+          })
+        );
+      }}
+      readOnly={readOnly}
+    />
+  );
+};
+
+export default ExampleTopicsInputs;

--- a/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
+++ b/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
@@ -1,5 +1,4 @@
 import React, {useCallback} from 'react';
-import {AnyAction, ThunkDispatch} from '@reduxjs/toolkit';
 
 import {
   setModelCardProperty,
@@ -8,52 +7,12 @@ import {
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
 import Button from '@cdo/apps/componentLibrary/button/Button';
-import MultiItemInput from '@cdo/apps/lab2/levelEditors/aichatSettings/MultiItemInput';
 
 import {MODEL_CARD_FIELDS_LABELS_ICONS} from './constants';
 import {isVisible, isDisabled} from './utils';
+import ExampleTopicsInputs from './ExampleTopicsInputs';
 import styles from '../model-customization-workspace.module.scss';
-import {ModelCardInfo} from '@cdo/apps/aichat/types';
-
-const renderExampleTopicsInputs = (
-  topics: string[],
-  dispatch: ThunkDispatch<unknown, unknown, AnyAction>,
-  readOnly: boolean
-) => {
-  return (
-    <MultiItemInput
-      key="exampleTopics"
-      items={topics}
-      onAdd={() =>
-        dispatch(
-          setModelCardProperty({
-            property: 'exampleTopics',
-            value: [...topics].concat(''),
-          })
-        )
-      }
-      onRemove={() => {
-        dispatch(
-          setModelCardProperty({
-            property: 'exampleTopics',
-            value: [...topics].slice(0, -1),
-          })
-        );
-      }}
-      onChange={(index, value) => {
-        const updatedTopics = topics.slice();
-        updatedTopics[index] = value;
-        dispatch(
-          setModelCardProperty({
-            property: 'exampleTopics',
-            value: updatedTopics,
-          })
-        );
-      }}
-      readOnly={readOnly}
-    />
-  );
-};
+import {ModelCardInfo} from '../../types';
 
 const PublishNotes: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
@@ -86,12 +45,12 @@ const PublishNotes: React.FunctionComponent = () => {
                 <label htmlFor={property}>
                   <StrongText>{label}</StrongText>
                 </label>
-                {property === 'exampleTopics' &&
-                  renderExampleTopicsInputs(
-                    modelCardInfo.exampleTopics,
-                    dispatch,
-                    isDisabled(visibility)
-                  )}
+                {property === 'exampleTopics' && (
+                  <ExampleTopicsInputs
+                    topics={modelCardInfo.exampleTopics}
+                    readOnly={isDisabled(visibility)}
+                  />
+                )}
                 {property !== 'exampleTopics' && (
                   <InputTag
                     id={property}

--- a/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
+++ b/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
@@ -1,16 +1,59 @@
 import React, {useCallback} from 'react';
+import {AnyAction, ThunkDispatch} from '@reduxjs/toolkit';
 
-import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
-import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
-import Button from '@cdo/apps/componentLibrary/button/Button';
-import {MODEL_CARD_FIELDS_LABELS_ICONS} from './constants';
-import {isVisible, isDisabled} from './utils';
 import {
   setModelCardProperty,
   updateAiCustomization,
 } from '@cdo/apps/aichat/redux/aichatRedux';
+import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
+import Button from '@cdo/apps/componentLibrary/button/Button';
+import MultiItemInput from '@cdo/apps/lab2/levelEditors/aichatSettings/MultiItemInput';
+
+import {MODEL_CARD_FIELDS_LABELS_ICONS} from './constants';
+import {isVisible, isDisabled} from './utils';
 import styles from '../model-customization-workspace.module.scss';
 import {ModelCardInfo} from '@cdo/apps/aichat/types';
+
+const renderExampleTopicsInputs = (
+  topics: string[],
+  dispatch: ThunkDispatch<unknown, unknown, AnyAction>,
+  readOnly: boolean
+) => {
+  return (
+    <MultiItemInput
+      key="exampleTopics"
+      items={topics}
+      onAdd={() =>
+        dispatch(
+          setModelCardProperty({
+            property: 'exampleTopics',
+            value: [...topics].concat(''),
+          })
+        )
+      }
+      onRemove={() => {
+        dispatch(
+          setModelCardProperty({
+            property: 'exampleTopics',
+            value: [...topics].slice(0, -1),
+          })
+        );
+      }}
+      onChange={(index, value) => {
+        const updatedTopics = topics.slice();
+        updatedTopics[index] = value;
+        dispatch(
+          setModelCardProperty({
+            property: 'exampleTopics',
+            value: updatedTopics,
+          })
+        );
+      }}
+      readOnly={readOnly}
+    />
+  );
+};
 
 const PublishNotes: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
@@ -35,26 +78,35 @@ const PublishNotes: React.FunctionComponent = () => {
     <div className={styles.verticalFlexContainer}>
       {isVisible(visibility) && (
         <div className={styles.customizationContainer}>
-          {MODEL_CARD_FIELDS_LABELS_ICONS.map(([property, label]) => {
+          {MODEL_CARD_FIELDS_LABELS_ICONS.map(([property, label, _]) => {
             const InputTag = getInputTag(property);
+
             return (
               <div className={styles.inputContainer} key={property}>
                 <label htmlFor={property}>
                   <StrongText>{label}</StrongText>
                 </label>
-                <InputTag
-                  id={property}
-                  disabled={isDisabled(visibility)}
-                  value={modelCardInfo[property]}
-                  onChange={event =>
-                    dispatch(
-                      setModelCardProperty({
-                        property: property,
-                        value: event.target.value,
-                      })
-                    )
-                  }
-                />
+                {property === 'exampleTopics' &&
+                  renderExampleTopicsInputs(
+                    modelCardInfo.exampleTopics,
+                    dispatch,
+                    isDisabled(visibility)
+                  )}
+                {property !== 'exampleTopics' && (
+                  <InputTag
+                    id={property}
+                    disabled={isDisabled(visibility)}
+                    value={modelCardInfo[property]}
+                    onChange={event =>
+                      dispatch(
+                        setModelCardProperty({
+                          property: property,
+                          value: event.target.value,
+                        })
+                      )
+                    }
+                  />
+                )}
               </div>
             );
           })}

--- a/apps/src/lab2/levelEditors/aichatSettings/EditAichatSettings.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/EditAichatSettings.tsx
@@ -1,15 +1,16 @@
+import React, {useCallback, useState} from 'react';
+
+import {
+  BodyFourText,
+  BodyThreeText,
+} from '@cdo/apps/componentLibrary/typography';
 import {
   AiCustomizations,
   LevelAichatSettings,
   ModelCardInfo,
   Visibility,
 } from '@cdo/apps/aichat/types';
-import React, {useCallback, useState} from 'react';
-import {
-  BodyFourText,
-  BodyThreeText,
-} from '@cdo/apps/componentLibrary/typography';
-import moduleStyles from './edit-aichat-settings.module.scss';
+import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
 import {
   MAX_RETRIEVAL_CONTEXTS,
   MAX_TEMPERATURE,
@@ -17,13 +18,14 @@ import {
   SET_TEMPERATURE_STEP,
   DEFAULT_LEVEL_AICHAT_SETTINGS,
 } from '@cdo/apps/aichat/views/modelCustomization/constants';
-import MultiItemInput from './MultiItemInput';
+import MultiItemInput from '@cdo/apps/templates/MultiItemInput';
+import CollapsibleSection from '@cdo/apps/templates/CollapsibleSection';
+
 import FieldSection from './FieldSection';
 import ModelCardFields from './ModelCardFields';
 import VisibilityDropdown from './VisibilityDropdown';
-import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
 import {UpdateContext} from './UpdateContext';
-import CollapsibleSection from '@cdo/apps/templates/CollapsibleSection';
+import moduleStyles from './edit-aichat-settings.module.scss';
 
 /**
  * Editor for the AI Customizations on the level edit page.

--- a/apps/src/lab2/levelEditors/aichatSettings/ModelCardFields.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/ModelCardFields.tsx
@@ -1,10 +1,12 @@
 import React, {useContext} from 'react';
-import MultiItemInput from './MultiItemInput';
-import moduleStyles from './edit-aichat-settings.module.scss';
+
+import MultiItemInput from '@cdo/apps/templates/MultiItemInput';
 import {
   MAX_ASK_ABOUT_TOPICS,
   MODEL_CARD_FIELDS_LABELS_ICONS,
 } from '@cdo/apps/aichat/views/modelCustomization/constants';
+
+import moduleStyles from './edit-aichat-settings.module.scss';
 import {UpdateContext} from './UpdateContext';
 
 const ModelCardFields: React.FunctionComponent = () => {
@@ -13,7 +15,7 @@ const ModelCardFields: React.FunctionComponent = () => {
   const exampleTopics = modelCardInfo.exampleTopics;
   return (
     <div className={moduleStyles['model-card-fields']}>
-      {MODEL_CARD_FIELDS_LABELS_ICONS.map(([property, label]) => {
+      {MODEL_CARD_FIELDS_LABELS_ICONS.map(([property, label, _]) => {
         if (property === 'exampleTopics') {
           return null;
         }

--- a/apps/src/lab2/levelEditors/aichatSettings/MultiItemInput.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/MultiItemInput.tsx
@@ -10,7 +10,16 @@ export const MultiItemInput: React.FunctionComponent<{
   onChange: (index: number, value: string) => void;
   multiline?: boolean;
   max?: number;
-}> = ({items, onAdd, onRemove, onChange, max, multiline = false}) => {
+  readOnly?: boolean;
+}> = ({
+  items,
+  onAdd,
+  onRemove,
+  onChange,
+  max,
+  multiline = false,
+  readOnly = false,
+}) => {
   const Tag = multiline ? 'textarea' : 'input';
   const showPlus = max === undefined || items.length < max;
   return (
@@ -31,28 +40,31 @@ export const MultiItemInput: React.FunctionComponent<{
                 multiline ? moduleStyles.textarea : moduleStyles.inlineLabel
               )}
               onChange={e => onChange(index, e.target.value)}
+              disabled={readOnly}
             />
           );
         })}
       </div>
-      <div className={moduleStyles.buttonsRow}>
-        {showPlus && (
+      {!readOnly && (
+        <div className={moduleStyles.buttonsRow}>
+          {showPlus && (
+            <button
+              type="button"
+              className={moduleStyles.plusMinusButton}
+              onClick={onAdd}
+            >
+              <FontAwesomeV6Icon iconName="plus" iconStyle="solid" />
+            </button>
+          )}
           <button
             type="button"
             className={moduleStyles.plusMinusButton}
-            onClick={onAdd}
+            onClick={onRemove}
           >
-            <FontAwesomeV6Icon iconName="plus" iconStyle="solid" />
+            <FontAwesomeV6Icon iconName="minus" iconStyle="solid" />
           </button>
-        )}
-        <button
-          type="button"
-          className={moduleStyles.plusMinusButton}
-          onClick={onRemove}
-        >
-          <FontAwesomeV6Icon iconName="minus" iconStyle="solid" />
-        </button>
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/src/lab2/levelEditors/aichatSettings/edit-aichat-settings.module.scss
+++ b/apps/src/lab2/levelEditors/aichatSettings/edit-aichat-settings.module.scss
@@ -1,5 +1,4 @@
 @import 'color.scss';
-@import '@cdo/apps/mixins.scss';
 
 .fieldSection {
   display: flex;
@@ -34,33 +33,4 @@
 .textarea {
   width: 100%;
   box-sizing: border-box;
-}
-
-.multiItemContainer {
-  display: flex;
-  flex-direction: column;
-}
-
-.multiItemInput {
-  display: flex;
-  flex-wrap: wrap;
-
-  &Multiline {
-    flex-direction: column;
-    flex-wrap: nowrap;
-  }
-}
-
-.buttonsRow {
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-}
-
-.plusMinusButton {
-  @include remove-button-styles;
-  border: 1px solid $neutral_dark;
-  border-radius: 5px;
-  padding: 5px;
-  margin-right: 10px;
 }

--- a/apps/src/templates/MultiItemInput.tsx
+++ b/apps/src/templates/MultiItemInput.tsx
@@ -1,7 +1,8 @@
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import classNames from 'classnames';
 import React from 'react';
-import moduleStyles from './edit-aichat-settings.module.scss';
+
+import moduleStyles from './multi-item-input.module.scss';
 
 export const MultiItemInput: React.FunctionComponent<{
   items: string[];

--- a/apps/src/templates/MultiItemInput.tsx
+++ b/apps/src/templates/MultiItemInput.tsx
@@ -1,6 +1,7 @@
-import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import classNames from 'classnames';
 import React from 'react';
+
+import Button from '@cdo/apps/componentLibrary/button/Button';
 
 import moduleStyles from './multi-item-input.module.scss';
 
@@ -49,21 +50,23 @@ export const MultiItemInput: React.FunctionComponent<{
       {!readOnly && (
         <div className={moduleStyles.buttonsRow}>
           {showPlus && (
-            <button
-              type="button"
+            <Button
               className={moduleStyles.plusMinusButton}
               onClick={onAdd}
-            >
-              <FontAwesomeV6Icon iconName="plus" iconStyle="solid" />
-            </button>
+              isIconOnly
+              size="s"
+              type="secondary"
+              icon={{iconName: 'plus'}}
+            />
           )}
-          <button
-            type="button"
+          <Button
             className={moduleStyles.plusMinusButton}
             onClick={onRemove}
-          >
-            <FontAwesomeV6Icon iconName="minus" iconStyle="solid" />
-          </button>
+            isIconOnly
+            size="s"
+            type="secondary"
+            icon={{iconName: 'minus'}}
+          />
         </div>
       )}
     </div>

--- a/apps/src/templates/multi-item-input.module.scss
+++ b/apps/src/templates/multi-item-input.module.scss
@@ -1,0 +1,40 @@
+@import 'color.scss';
+@import '@cdo/apps/mixins.scss';
+
+.multiItemContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.multiItemInput {
+  display: flex;
+  flex-wrap: wrap;
+
+  &Multiline {
+    flex-direction: column;
+    flex-wrap: nowrap;
+  }
+}
+
+.textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.inlineLabel {
+  margin-right: 10px;
+}
+
+.plusMinusButton {
+  @include remove-button-styles;
+  border: 1px solid $neutral_dark;
+  border-radius: 5px;
+  padding: 5px;
+  margin-right: 10px;
+}
+
+.buttonsRow {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+}


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

## Description

Adds support for the "Example Prompts and Topics" list that can already be customized in levelbuilder. Reuses the component built on the levelbuilder side for adding/removing example topics and prompts.

| Edit View | User View |
| - | - |
| ![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/22e450d2-acee-48b0-b668-432504d95afe) | ![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/623f7683-53e4-473d-9c9a-fd842fc7ded0) |


## Testing story

Tested manually that a levelbuilder configured change appeared in the level, and that I could add/remove entries and see them on page reload. I also checked that blank entries disappeared on save.