### PR TITLE
added CAP Notification to SectionSetUpContainer

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -407,6 +407,8 @@
   "childAccountConsentValidPermission": "Permission:",
   "childAccountConsentValidPermissionGranted": "Granted on {date}",
   "childAccountConsentValidMessage": "Thank you for approving your child’s Code.org account! You will receive a confirmation email within 24–48 hours. Please let your child know you’ve approved their account so they can get started learning and coding today!",
+  "childAccountPolicy_CreateSectionsWarning": "If you have students under 13, they may require parental consent to use a personal login. Please go back and use picture password, secret word, or school-managed sections to avoid any interruptions for students under 13.",
+  "childAccountPolicy_LearnMore": "Learn more about parental consent",
   "choiceLevel": "Choice level",
   "choose": "Choose",
   "chooseActivity": "Choose from the following activities:",

--- a/apps/src/sites/studio/pages/sections/new.js
+++ b/apps/src/sites/studio/pages/sections/new.js
@@ -6,13 +6,13 @@ import SectionsSetUpContainer from '@cdo/apps/templates/sectionsRefresh/Sections
 $(document).ready(() => {
   const isUsersFirstSection = getScriptData('isUsersFirstSection');
   const canEnableAITutor = getScriptData('canEnableAITutor');
-  const showChildAccountPolicy = getScriptData('showChildAccountPolicy');
+  const userCountry = getScriptData('userCountry');
 
   ReactDOM.render(
     <SectionsSetUpContainer
       isUsersFirstSection={isUsersFirstSection}
       canEnableAITutor={canEnableAITutor}
-      showChildAccountPolicy={showChildAccountPolicy}
+      userCountry={userCountry}
     />,
     document.getElementById('form')
   );

--- a/apps/src/sites/studio/pages/sections/new.js
+++ b/apps/src/sites/studio/pages/sections/new.js
@@ -6,11 +6,13 @@ import SectionsSetUpContainer from '@cdo/apps/templates/sectionsRefresh/Sections
 $(document).ready(() => {
   const isUsersFirstSection = getScriptData('isUsersFirstSection');
   const canEnableAITutor = getScriptData('canEnableAITutor');
+  const showChildAccountPolicy = getScriptData('showChildAccountPolicy');
 
   ReactDOM.render(
     <SectionsSetUpContainer
       isUsersFirstSection={isUsersFirstSection}
       canEnableAITutor={canEnableAITutor}
+      showChildAccountPolicy={showChildAccountPolicy}
     />,
     document.getElementById('form')
   );

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useState, useCallback, useRef} from 'react';
+import {Provider} from 'react-redux';
 
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {showVideoDialog} from '@cdo/apps/code-studio/videos';
@@ -12,7 +13,9 @@ import {
 import InfoHelpTip from '@cdo/apps/lib/ui/InfoHelpTip';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {getStore} from '@cdo/apps/redux';
 import Button from '@cdo/apps/templates/Button';
+import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
 import CoteacherSettings from '@cdo/apps/templates/sectionsRefresh/coteacherSettings/CoteacherSettings';
 import {navigateToHref} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
@@ -80,6 +83,7 @@ export default function SectionsSetUpContainer({
   isUsersFirstSection,
   sectionToBeEdited,
   canEnableAITutor,
+  showChildAccountPolicy,
 }) {
   const [sections, updateSection] = useSections(sectionToBeEdited);
   const [isCoteacherOpen, setIsCoteacherOpen] = useState(false);
@@ -361,7 +365,19 @@ export default function SectionsSetUpContainer({
           </>
         )}
       </div>
-
+      {showChildAccountPolicy && (
+        <Provider store={getStore()}>
+          <Notification
+            type={NotificationType.warning}
+            notice=""
+            details={i18n.childAccountPolicy_CreateSectionsWarning()}
+            detailsLink="https://support.code.org/hc/en-us/articles/15465423491085-How-do-I-obtain-parent-or-guardian-permission-for-student-accounts"
+            detailsLinkNewWindow={true}
+            detailsLinkText={i18n.childAccountPolicy_LearnMore()}
+            dismissible={false}
+          />
+        </Provider>
+      )}
       <SingleSectionSetUp
         sectionNum={1}
         section={sections[0]}
@@ -431,4 +447,5 @@ SectionsSetUpContainer.propTypes = {
   isUsersFirstSection: PropTypes.bool,
   sectionToBeEdited: PropTypes.object,
   canEnableAITutor: PropTypes.bool,
+  showChildAccountPolicy: PropTypes.bool,
 };

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -264,10 +264,10 @@ export default function SectionsSetUpContainer({
 
   const renderChildAccountPolicyNotification = () => {
     const isEmailLoggin = queryParams('loginType') === 'email';
-
+    const isStudentSection = queryParams('participantType') === 'student';
     // We want to display a Child Account Policy warning notification for US
     // teachers who are creating a new section with email logins.
-    if (showChildAccountPolicy && isEmailLoggin)
+    if (showChildAccountPolicy && isStudentSection && isEmailLoggin) {
       return (
         <Provider store={getStore()}>
           <Notification
@@ -281,7 +281,9 @@ export default function SectionsSetUpContainer({
           />
         </Provider>
       );
-    else return;
+    } else {
+      return null;
+    }
   };
 
   const renderExpandableSection = (

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -262,6 +262,28 @@ export default function SectionsSetUpContainer({
     );
   };
 
+  const renderChildAccountPolicyNotification = () => {
+    const isEmailLoggin = queryParams('loginType') === 'email';
+
+    // We want to display a Child Account Policy warning notification for US
+    // teachers who are creating a new section with email logins.
+    if (showChildAccountPolicy && isEmailLoggin)
+      return (
+        <Provider store={getStore()}>
+          <Notification
+            type={NotificationType.warning}
+            notice=""
+            details={i18n.childAccountPolicy_CreateSectionsWarning()}
+            detailsLink="https://support.code.org/hc/en-us/articles/15465423491085-How-do-I-obtain-parent-or-guardian-permission-for-student-accounts"
+            detailsLinkNewWindow={true}
+            detailsLinkText={i18n.childAccountPolicy_LearnMore()}
+            dismissible={false}
+          />
+        </Provider>
+      );
+    else return;
+  };
+
   const renderExpandableSection = (
     sectionId,
     sectionTitle,
@@ -365,19 +387,9 @@ export default function SectionsSetUpContainer({
           </>
         )}
       </div>
-      {showChildAccountPolicy && (
-        <Provider store={getStore()}>
-          <Notification
-            type={NotificationType.warning}
-            notice=""
-            details={i18n.childAccountPolicy_CreateSectionsWarning()}
-            detailsLink="https://support.code.org/hc/en-us/articles/15465423491085-How-do-I-obtain-parent-or-guardian-permission-for-student-accounts"
-            detailsLinkNewWindow={true}
-            detailsLinkText={i18n.childAccountPolicy_LearnMore()}
-            dismissible={false}
-          />
-        </Provider>
-      )}
+
+      {renderChildAccountPolicyNotification()}
+
       <SingleSectionSetUp
         sectionNum={1}
         section={sections[0]}

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -83,7 +83,7 @@ export default function SectionsSetUpContainer({
   isUsersFirstSection,
   sectionToBeEdited,
   canEnableAITutor,
-  showChildAccountPolicy,
+  userCountry,
 }) {
   const [sections, updateSection] = useSections(sectionToBeEdited);
   const [isCoteacherOpen, setIsCoteacherOpen] = useState(false);
@@ -265,9 +265,10 @@ export default function SectionsSetUpContainer({
   const renderChildAccountPolicyNotification = () => {
     const isEmailLoggin = queryParams('loginType') === 'email';
     const isStudentSection = queryParams('participantType') === 'student';
+    const isCapCountry = ['US', 'RD'].includes(userCountry);
     // We want to display a Child Account Policy warning notification for US
     // teachers who are creating a new section with email logins.
-    if (showChildAccountPolicy && isStudentSection && isEmailLoggin) {
+    if (isCapCountry && isStudentSection && isEmailLoggin) {
       return (
         <Provider store={getStore()}>
           <Notification
@@ -461,5 +462,5 @@ SectionsSetUpContainer.propTypes = {
   isUsersFirstSection: PropTypes.bool,
   sectionToBeEdited: PropTypes.object,
   canEnableAITutor: PropTypes.bool,
-  showChildAccountPolicy: PropTypes.bool,
+  userCountry: PropTypes.string,
 };

--- a/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
@@ -42,7 +42,7 @@ describe('SectionsSetUpContainer', () => {
     expect(wrapper.find('CurriculumQuickAssign').length).to.equal(1);
   });
 
-  it('renders Child Account Policy Notice if showChildAccountPolicy is true for student and email sections', () => {
+  it('renders Child Account Policy Notice for US, student and email sections', () => {
     sinon
       .stub(utils, 'queryParams')
       .withArgs('loginType')
@@ -50,13 +50,11 @@ describe('SectionsSetUpContainer', () => {
       .withArgs('participantType')
       .returns('student');
 
-    const wrapper = shallow(
-      <SectionsSetUpContainer showChildAccountPolicy={true} />
-    );
+    const wrapper = shallow(<SectionsSetUpContainer userCountry={'US'} />);
     expect(wrapper.find('Connect(Notification)').exists()).to.equal(true);
   });
 
-  it('does not render Child Account Policy Notice if showChildAccountPolicy is true for students and not email', () => {
+  it('does not render Child Account Policy Notice when sections are not email', () => {
     sinon
       .stub(utils, 'queryParams')
       .withArgs('loginType')
@@ -64,9 +62,19 @@ describe('SectionsSetUpContainer', () => {
       .withArgs('participantType')
       .returns('student');
 
-    const wrapper = shallow(
-      <SectionsSetUpContainer showChildAccountPolicy={true} />
-    );
+    const wrapper = shallow(<SectionsSetUpContainer userCountry={'US'} />);
+    expect(wrapper.find('Connect(Notification)').exists()).to.equal(false);
+  });
+
+  it('does not render Child Account Policy Notice for country different that US', () => {
+    sinon
+      .stub(utils, 'queryParams')
+      .withArgs('loginType')
+      .returns('email')
+      .withArgs('participantType')
+      .returns('student');
+
+    const wrapper = shallow(<SectionsSetUpContainer userCountry={'ES'} />);
     expect(wrapper.find('Connect(Notification)').exists()).to.equal(false);
   });
 

--- a/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
@@ -9,6 +9,9 @@ import * as windowUtils from '@cdo/apps/utils';
 import {expect} from '../../../util/reconfiguredChai';
 
 describe('SectionsSetUpContainer', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
   it('renders an initial set up section form', () => {
     const wrapper = shallow(<SectionsSetUpContainer />);
 
@@ -37,6 +40,34 @@ describe('SectionsSetUpContainer', () => {
     const wrapper = shallow(<SectionsSetUpContainer />);
 
     expect(wrapper.find('CurriculumQuickAssign').length).to.equal(1);
+  });
+
+  it('renders Child Account Policy Notice if showChildAccountPolicy is true for student and email sections', () => {
+    sinon
+      .stub(utils, 'queryParams')
+      .withArgs('loginType')
+      .returns('email')
+      .withArgs('participantType')
+      .returns('student');
+
+    const wrapper = shallow(
+      <SectionsSetUpContainer showChildAccountPolicy={true} />
+    );
+    expect(wrapper.find('Connect(Notification)').exists()).to.equal(true);
+  });
+
+  it('does not render Child Account Policy Notice if showChildAccountPolicy is true for students and not email', () => {
+    sinon
+      .stub(utils, 'queryParams')
+      .withArgs('loginType')
+      .returns('word')
+      .withArgs('participantType')
+      .returns('student');
+
+    const wrapper = shallow(
+      <SectionsSetUpContainer showChildAccountPolicy={true} />
+    );
+    expect(wrapper.find('Connect(Notification)').exists()).to.equal(false);
   });
 
   it('renders coteacher settings', () => {
@@ -96,8 +127,6 @@ describe('SectionsSetUpContainer', () => {
       .simulate('click', {preventDefault: () => {}});
 
     expect(reportSpy).to.have.been.called.once;
-
-    sinon.restore();
   });
 
   it('makes an ajax request when save is clicked', async () => {
@@ -127,8 +156,6 @@ describe('SectionsSetUpContainer', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(navigateToHrefSpy).to.have.been.called.once;
     expect(navigateToHrefSpy.getCall(0).args[0]).to.include('/home');
-
-    sinon.restore();
   });
 
   it('appends showSectionCreationDialog to url if isUsersFirstSection is true', async () => {
@@ -160,8 +187,6 @@ describe('SectionsSetUpContainer', () => {
     expect(navigateToHrefSpy.getCall(0).args[0]).to.include(
       '/home?showSectionCreationDialog=true'
     );
-
-    sinon.restore();
   });
 
   it('passes participantType and loginType to ajax request when save is clicked', () => {
@@ -194,8 +219,6 @@ describe('SectionsSetUpContainer', () => {
     const fetchBody = JSON.parse(fetchSpy.getCall(0).args[1].body);
     expect(fetchBody.login_type).to.equal('word');
     expect(fetchBody.participant_type).to.equal('student');
-
-    sinon.restore();
   });
 
   it('passes url attribute to make a new section if save and create new is clicked', () => {
@@ -223,7 +246,5 @@ describe('SectionsSetUpContainer', () => {
       .simulate('click', {preventDefault: () => {}});
 
     expect(fetchSpy).to.have.been.called.once;
-
-    sinon.restore();
   });
 });

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -6,7 +6,7 @@ class SectionsController < ApplicationController
 
   def new
     redirect_to '/home' unless params[:loginType] && params[:participantType]
-
+    @user_country = request.country.to_s.upcase
     @is_users_first_section = current_user.sections_instructed.empty?
   end
 

--- a/dashboard/app/views/sections/new.html.haml
+++ b/dashboard/app/views/sections/new.html.haml
@@ -1,4 +1,4 @@
-%script{src: webpack_asset_path('js/sections/new.js'), data: {isUsersFirstSection: @is_users_first_section.to_json, canEnableAITutor: current_user.can_enable_ai_tutor?.to_json, showChildAccountPolicy: %w[US RD].include?(@user_country).to_json}}
+%script{src: webpack_asset_path('js/sections/new.js'), data: {isUsersFirstSection: @is_users_first_section.to_json, canEnableAITutor: current_user.can_enable_ai_tutor?.to_json, userCountry: @user_country.to_json}}
 
 #form
 

--- a/dashboard/app/views/sections/new.html.haml
+++ b/dashboard/app/views/sections/new.html.haml
@@ -1,4 +1,4 @@
-%script{src: webpack_asset_path('js/sections/new.js'), data: {isUsersFirstSection: @is_users_first_section.to_json, canEnableAITutor: current_user.can_enable_ai_tutor?.to_json}}
+%script{src: webpack_asset_path('js/sections/new.js'), data: {isUsersFirstSection: @is_users_first_section.to_json, canEnableAITutor: current_user.can_enable_ai_tutor?.to_json, showChildAccountPolicy: %w[US RD].include?(@user_country).to_json}}
 
 #form
 


### PR DESCRIPTION
As part of the Colorado Privacy Act requirements, we want to show all US teachers, that create a new section using student personal logins, a warning message. This warning message intends to persuade teachers to use other student authentication methods (secret words, picture passwords, or school-managed accounts SSO) if any of their students are under 13.
The Notification also links to the parental permission support article.

This PR adds a warning banner on the Create New Section page. The banner shows when teachers try to create new sections that are set up using students' personal emails and are in the USA.

Unit tests have been added to cover the use of the newly added Notice.

## Links

- spec: [Colorado Privacy Act Part Two](https://docs.google.com/document/d/1eDd8ow0kp7Ganv6aJ6GjiynPQSxB2XO21OxWuhm1Z1c/edit#heading=h.qi8xxyq72bct)
- jira ticket: [P20-816](https://codedotorg.atlassian.net/browse/P20-816)

## Testing story
Teacher creates a new section using **personal email**:
![Screenshot 2024-04-10 at 09 19 38](https://github.com/code-dot-org/code-dot-org/assets/66776217/b8798f55-d633-4787-84be-f0e6bde78f51)

Teacher creates a new section using **secret words**:
![Screenshot 2024-04-10 at 09 23 16](https://github.com/code-dot-org/code-dot-org/assets/66776217/26b13e55-c782-47d7-8557-ecfe2c92b646)


Teacher creates a new section using **picture password**:
![Screenshot 2024-04-10 at 09 23 44](https://github.com/code-dot-org/code-dot-org/assets/66776217/7f582b39-166b-4cd8-b769-d0b69eef0ad3)

The banner renders in RTL languages:
![Screenshot 2024-04-10 at 09 33 34](https://github.com/code-dot-org/code-dot-org/assets/66776217/666ccf98-cc7c-4ed8-9ca2-069504588e65)

## Follow-up work

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
