### PR TITLE
Revert "Revert "Make project template workspace icon tab navigable""

### DIFF
--- a/apps/src/templates/ProjectTemplateWorkspaceIcon.jsx
+++ b/apps/src/templates/ProjectTemplateWorkspaceIcon.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import ReactTooltip from 'react-tooltip';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
+import moduleStyles from './project-template-workspace-icon.module.scss';
+import classNames from 'classnames';
+
 var msg = require('@cdo/locale');
 
 const IMAGE_BASE_URL = '/blockly/media/';
@@ -18,16 +21,24 @@ export default class ProjectTemplateWorkspaceIcon extends React.Component {
 
   render() {
     return (
-      <div style={styles.container}>
-        <img
-          style={styles.projectTemplateIcon}
-          className="projectTemplateWorkspaceIcon"
-          src={IMAGE_BASE_URL + 'connect.svg'}
+      <div className={moduleStyles.container}>
+        <button
+          type="button"
           data-tip
           data-for={this.tooltipId}
           aria-describedby={this.tooltipId}
-          alt={msg.workspaceProjectTemplateLevel()}
-        />
+          data-event="mouseenter mouseleave click"
+          className={moduleStyles.projectTemplateButton}
+        >
+          <img
+            className={classNames(
+              'projectTemplateWorkspaceIcon',
+              moduleStyles.projectTemplateIcon
+            )}
+            src={IMAGE_BASE_URL + 'connect.svg'}
+            alt={msg.workspaceProjectTemplateLevel()}
+          />
+        </button>
         <ReactTooltip
           id={this.tooltipId}
           role="tooltip"
@@ -35,7 +46,7 @@ export default class ProjectTemplateWorkspaceIcon extends React.Component {
           effect="solid"
           place={this.props.tooltipPlace}
         >
-          <div style={styles.tooltip}>
+          <div className={moduleStyles.tooltip}>
             {msg.workspaceProjectTemplateLevel()}
           </div>
         </ReactTooltip>
@@ -43,18 +54,3 @@ export default class ProjectTemplateWorkspaceIcon extends React.Component {
     );
   }
 }
-
-const styles = {
-  container: {
-    display: 'inline-block',
-  },
-  tooltip: {
-    maxWidth: 200,
-    lineHeight: '20px',
-    whiteSpace: 'normal',
-  },
-  projectTemplateIcon: {
-    marginRight: 5,
-    marginTop: -1,
-  },
-};

--- a/apps/src/templates/project-template-workspace-icon.module.scss
+++ b/apps/src/templates/project-template-workspace-icon.module.scss
@@ -1,0 +1,24 @@
+@import '@cdo/apps/mixins.scss';
+@import 'color.scss';
+
+.container {
+  display: inline-block;
+}
+
+.tooltip {
+  max-width: 200px;
+  line-height: 20px;
+  white-space: normal;
+}
+
+.projectTemplateIcon {
+  padding-top: 9px;
+  padding-bottom: 10px;
+  opacity: 1;
+}
+
+.projectTemplateButton {
+  @include remove-button-styles;
+  margin-right: 5px;
+  margin-bottom: -1px;
+}

--- a/apps/src/templates/project-template-workspace-icon.module.scss
+++ b/apps/src/templates/project-template-workspace-icon.module.scss
@@ -12,13 +12,11 @@
 }
 
 .projectTemplateIcon {
-  padding-top: 9px;
-  padding-bottom: 10px;
+  padding-bottom: 3px;
   opacity: 1;
 }
 
 .projectTemplateButton {
   @include remove-button-styles;
   margin-right: 5px;
-  margin-bottom: -1px;
 }


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#57924

Redo of https://github.com/code-dot-org/code-dot-org/pull/57908. The original CSS was somehow causing the height of the button to be larger than its container, forcing scrollbars to appear. Here instead I removed the excess padding and tried to get it to the same position with bottom padding only. It seems to work fine and doesn't produce scrollbars (at least on my machine) across various browsers and screen sizes.

Chrome, small screen (side-by-side with prod)
<img width="2044" alt="Screenshot 2024-04-10 at 10 14 51 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/8ae9996b-5aa7-4292-ada6-b6e820ae72a3">

Chrome, laptop screen (side-by-side with prod)
<img width="1314" alt="Screenshot 2024-04-10 at 10 15 58 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/637baf50-2cb9-41a4-a493-47a9082bdde0">

Chrome, large desktop screen
<img width="2560" alt="Screenshot 2024-04-10 at 10 28 15 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/5b854e58-5e32-41c6-a425-df85aa2b5b70">

Firefox
<img width="1388" alt="Screenshot 2024-04-10 at 10 21 00 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/f166dd42-0255-4f09-8729-f04961dae10d">

Safari
<img width="1511" alt="Screenshot 2024-04-10 at 10 24 20 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/dae8043d-bdfa-46bc-a1d1-6c2d6ab35126">

