### PR TITLE
Fix uncaught nil error during LTI auth

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -101,14 +101,14 @@ class LtiV1Controller < ApplicationController
       Honeybadger.notify(exception, context: {message: 'Error reading state and nonce from cache'})
       return render status: :internal_server_error
     end
-    if (params[:state] != cached_state_and_nonce[:state]) || (decoded_jwt_no_auth[:nonce] != cached_state_and_nonce[:nonce])
+    if cached_state_and_nonce.nil? || (params[:state] != cached_state_and_nonce[:state]) || (decoded_jwt_no_auth[:nonce] != cached_state_and_nonce[:nonce])
       return log_unauthorized(
         'State or nonce mismatch in LTI JWT auth',
         {
           state: params[:state],
           nonce: decoded_jwt_no_auth[:nonce],
-          cached_state: cached_state_and_nonce[:state],
-          cached_nonce: cached_state_and_nonce[:nonce],
+          cached_state: cached_state_and_nonce&.[](:state),
+          cached_nonce: cached_state_and_nonce&.[](:nonce),
         }
       )
     end

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -464,6 +464,14 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
+  test 'auth - if cached value is nil during the state/nonce check, return unauthorized' do
+    aud_is_array = false
+    jwt = create_valid_jwt(aud_is_array)
+    LtiV1Controller.any_instance.stubs(:read_cache).with(@state)
+    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
+    assert_response :unauthorized
+  end
+
   test 'auth - given a valid jwt with the audience as an array, redirect to target_link_url' do
     aud_is_array = true
     jwt = create_valid_jwt(aud_is_array)


### PR DESCRIPTION
During login, users have hit a `NoMethodError: undefined method '[]' for nil:NilClass` error trying to authenticate via LTI. This handles a nil value for the cached state and nonce with a 401 instead of throwing an unhandled error resulting in a 500/"sad bee".

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-866)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
