### PR TITLE
Add amplitude event for moving rubric window

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -155,6 +155,8 @@ const EVENTS = {
   TA_RUBRIC_STUDENT_AI_SUBMITTED: 'TA Rubric Student AI Level Submitted',
   TA_RUBRIC_AI_EVAL_FROM_SECTION:
     'TA Rubric AI Eval started from section request',
+  TA_RUBRIC_WINDOW_MOVE_START: 'TA Rubric window move start',
+  TA_RUBRIC_WINDOW_MOVE_END: 'TA Rubric window move end',
 
   // AI Tutor
   AI_TUTOR_PANEL_OPENED: 'AI Tutor Panel Opened',

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -19,6 +19,8 @@ import Draggable from 'react-draggable';
 import {TAB_NAMES} from './rubricHelpers';
 import aiBotOutlineIcon from '@cdo/static/ai-bot-outline.png';
 import HttpClient from '@cdo/apps/util/HttpClient';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 // product Tour
 import './introjs.scss';
@@ -108,6 +110,19 @@ export default function RubricContainer({
   const onStopHandler = (event, dragElement) => {
     setPositionX(dragElement.x);
     setPositionY(dragElement.y);
+    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_WINDOW_MOVE_END, {
+      ...(reportingData || {}),
+      window_x_end: dragElement.x,
+      window_y_end: dragElement.y,
+    });
+  };
+
+  const onStartHandler = (event, dragElement) => {
+    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_WINDOW_MOVE_START, {
+      ...(reportingData || {}),
+      window_x_start: dragElement.x,
+      window_y_start: dragElement.y,
+    });
   };
 
   // Currently the settings tab only provides a way to manually run AI.
@@ -175,6 +190,7 @@ export default function RubricContainer({
   return (
     <Draggable
       defaultPosition={{x: positionX, y: positionY}}
+      onStart={onStartHandler}
       onStop={onStopHandler}
     >
       <div

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -771,7 +771,7 @@ describe('RubricContainer', () => {
     stubFetchTeacherEvaluations(noEvals);
     stubFetchTourStatus({seen: true});
 
-    const {queryByText, getByTestId} = render(
+    const {getByTestId} = render(
       <Provider store={store}>
         <RubricContainer
           rubric={defaultRubric}

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -762,4 +762,47 @@ describe('RubricContainer', () => {
     expect(queryByText('Getting Started with AI Teaching Assistant')).to.not
       .exist;
   });
+
+  it('sends event when window is dragged', async function () {
+    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
+    stubFetchEvalStatusForUser(readyJson);
+    stubFetchEvalStatusForAll(readyJsonAll);
+    stubFetchAiEvaluations(mockAiEvaluations);
+    stubFetchTeacherEvaluations(noEvals);
+    stubFetchTourStatus({seen: true});
+
+    const {queryByText, getByTestId} = render(
+      <Provider store={store}>
+        <RubricContainer
+          rubric={defaultRubric}
+          studentLevelInfo={defaultStudentInfo}
+          teacherHasEnabledAi={true}
+          currentLevelName={'test_level'}
+          reportingData={{}}
+          open
+        />
+      </Provider>
+    );
+
+    await wait();
+
+    const element = getByTestId('draggable-test-id');
+
+    // simulate dragging
+    fireEvent.mouseDown(element, {clientX: 0, clientY: 0});
+    fireEvent.mouseMove(element, {clientX: 100, clientY: 100});
+
+    expect(sendEventSpy).to.have.been.calledWith(
+      EVENTS.TA_RUBRIC_WINDOW_MOVE_START,
+      {window_x_start: 0, window_y_start: 0}
+    );
+
+    fireEvent.mouseUp(element);
+
+    expect(sendEventSpy).to.have.been.calledWith(
+      EVENTS.TA_RUBRIC_WINDOW_MOVE_END,
+      {window_x_end: 0, window_y_end: 0}
+    );
+    sendEventSpy.restore();
+  });
 });


### PR DESCRIPTION
Added Amplitude analytics event for reporting when the rubric window is moved. Reports movement start and end positions in two separate events.

Jira Ticket: [AITT-554](https://codedotorg.atlassian.net/browse/AITT-554?atlOrigin=eyJpIjoiYjFmMmI5MmFmMDA0NGIzNWIyMTIyMDlkYTdkMTM4NWQiLCJwIjoiaiJ9)