### PR TITLE
Use more reliable restart strategy for ActiveJob

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -264,7 +264,7 @@ gem 'pusher', '~> 1.3.1', require: false
 
 gem 'youtube-dl.rb', group: [:development, :staging, :levelbuilder]
 
-gem 'daemons'
+gem 'daemons', '1.1.9'
 gem 'httparty'
 gem 'net-scp'
 gem 'net-ssh'

--- a/Gemfile
+++ b/Gemfile
@@ -264,7 +264,7 @@ gem 'pusher', '~> 1.3.1', require: false
 
 gem 'youtube-dl.rb', group: [:development, :staging, :levelbuilder]
 
-gem 'daemons', '1.1.9'
+gem 'daemons', '1.1.9' # Pinned to old version, see PR 57938
 gem 'httparty'
 gem 'net-scp'
 gem 'net-ssh'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,7 +320,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    daemons (1.4.1)
+    daemons (1.1.9)
     dalli (2.7.6)
     dalli-elasticache (1.0.1)
       dalli (>= 2.0.0)
@@ -997,7 +997,7 @@ DEPENDENCIES
   composite_primary_keys (~> 13.0)
   crowdin-api (~> 1.8.1)
   cucumber
-  daemons
+  daemons (= 1.1.9)
   dalli
   dalli-elasticache
   database_cleaner-active_record (~> 2.1.0)

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -113,7 +113,7 @@ namespace :build do
         ChatClient.log 'Restarting <b>dashboard</b> Active Job worker(s).'
         # Issue a stop command to all workers. Will kill if not stopped within ~20 seconds.
         RakeUtils.system 'bin/delayed_job', 'stop'
-        # Start new workers in non-development environments
+        # Start new workers
         if rack_env?(:production)
           RakeUtils.system 'bin/delayed_job', '-n', '10', 'start'
         elsif !rack_env?(:development)

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -111,17 +111,13 @@ namespace :build do
         # The sequencing described here is the best for mitigating any issues
         # that may arise when that best practice is not followed.
         ChatClient.log 'Restarting <b>dashboard</b> Active Job worker(s).'
+        # Issue a stop command to all workers. Will kill if not stopped within ~20 seconds.
+        RakeUtils.system 'bin/delayed_job', 'stop'
+        # Start new workers in non-development environments
         if rack_env?(:production)
-          # WARNING: the number of workers in production is safe to increase,
-          # but is not safe to lower without additional steps. specifically, if
-          # you lower the number of jobs from 10 to 8 (for example), you'll need
-          # to manually kill workers 8 and 9 (zero-based). otherwise, those
-          # workers will continue to run jobs using older code indefinitely.
-          RakeUtils.system 'bin/delayed_job', '-n', '10', 'restart'
+          RakeUtils.system 'bin/delayed_job', '-n', '10', 'start'
         elsif !rack_env?(:development)
-          # development environment does not use delayed_job by default.
-          # all other non-production daemons should run one worker.
-          RakeUtils.system 'bin/delayed_job', 'restart'
+          RakeUtils.system 'bin/delayed_job', 'start'
         end
 
         # Commit dsls.en.yml changes on staging


### PR DESCRIPTION
Slack Discussion: https://codedotorg.slack.com/archives/C051P2V2RN0/p1712167298464339

We have been experiencing issues with the `restart` command leaving old workers that don't have the latest code. This PR rolls back to an older version of the `daemons` gem and switches us to use an explicit `stop` and `start`.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
