### PR TITLE
[Google Blockly] Support block limits

### DIFF
--- a/apps/src/blockly/addons/blockSvgLimit.ts
+++ b/apps/src/blockly/addons/blockSvgLimit.ts
@@ -108,9 +108,6 @@ export default class BlockSvgLimit {
       return;
     }
 
-    const svgGroup = this.blockSvg.getSvgRoot();
-    svgGroup.append(this.limitGroup);
-
     const textBBox = (this.limitText as SVGGraphicsElement).getBBox();
     const rectWidth = Math.max(
       textBBox.width + this.halfBubbleSize,

--- a/apps/src/blockly/addons/blockSvgLimit.ts
+++ b/apps/src/blockly/addons/blockSvgLimit.ts
@@ -130,9 +130,6 @@ export default class BlockSvgLimit {
     // Stretch the bubble to to fit longer numbers as text.
     this.limitRect_.setAttribute('width', `${rectWidth}`);
     // Center the text in the bubble.
-    this.limitText_.setAttribute(
-      'x',
-      `${Math.round(rectWidth * 0.5) - HALF_BUBBLE_SIZE}`
-    );
+    this.limitText_.setAttribute('x', `${rectWidth * 0.5 - HALF_BUBBLE_SIZE}`);
   }
 }

--- a/apps/src/blockly/addons/blockSvgLimit.ts
+++ b/apps/src/blockly/addons/blockSvgLimit.ts
@@ -126,10 +126,19 @@ export default class BlockSvgLimit {
 
     const textBBox = (this.limitText_ as SVGGraphicsElement).getBBox();
     const rectWidth = Math.max(textBBox.width + HALF_BUBBLE_SIZE, BUBBLE_SIZE);
+    const rectHeight = Math.max(
+      textBBox.height + HALF_BUBBLE_SIZE / 2,
+      BUBBLE_SIZE
+    );
 
     // Stretch the bubble to to fit longer numbers as text.
     this.limitRect_.setAttribute('width', `${rectWidth}`);
+    this.limitRect_.setAttribute('height', `${rectHeight}`);
     // Center the text in the bubble.
     this.limitText_.setAttribute('x', `${rectWidth * 0.5 - HALF_BUBBLE_SIZE}`);
+    this.limitText_.setAttribute(
+      'y',
+      `${Math.ceil(rectHeight * 0.5) - HALF_BUBBLE_SIZE}`
+    );
   }
 }

--- a/apps/src/blockly/addons/blockSvgLimit.ts
+++ b/apps/src/blockly/addons/blockSvgLimit.ts
@@ -1,0 +1,148 @@
+import color from '@cdo/apps/util/color';
+import {BlockSvg} from 'blockly';
+
+const BUBBLE_SIZE = 18;
+const HALF_BUBBLE_SIZE = BUBBLE_SIZE / 2;
+/**
+ * Represents a bubble on a Blockly block, displaying the count of blocks remaining
+ * based on a limit initially stated in the toolbox XML.
+ */
+export default class BlockSvgLimit {
+  protected element_: BlockSvg;
+  protected count: number;
+  protected className: string;
+  protected limitGroup_: SVGElement | undefined;
+  protected limitRect_: SVGElement | undefined;
+  protected limitText_: SVGElement | undefined;
+
+  /**
+   * Constructs an SVG group to track a block limit.
+   * @param {Element} element - The block associated with the limit.
+   * @param {string} [count] - The initial count to display.
+   */
+  constructor(element: BlockSvg, count: number) {
+    this.element_ = element;
+    this.count = count;
+    this.className = 'blocklyLimit';
+
+    this.limitGroup_ = undefined;
+    this.limitRect_ = undefined;
+    this.limitText_ = undefined;
+    this.element_;
+    this.initChildren();
+  }
+
+  /**
+   * Updates the displayed count within the limit bubble and adjusts styling based
+   * on the count.
+   * @param {number} newCount The new count to display.
+   */
+  updateCount(newCount: number) {
+    // Update the count and text content
+    this.count = newCount;
+    this.updateTextAndClass();
+  }
+
+  /**
+   * Updates the text and class of the limit bubble depending on whether the student
+   * has blocks remaining. If over the limit, displays an exclamation mark and changes
+   * the bubble and text color.
+   */
+  updateTextAndClass() {
+    if (!this.limitText_ || !this.limitGroup_) {
+      return;
+    }
+    if (this.count >= 0) {
+      this.limitText_.textContent = `${this.count}`;
+      Blockly.utils.dom.removeClass(this.limitGroup_, 'overLimit');
+      Blockly.utils.dom.removeClass(this.limitText_, 'overLimit');
+    } else {
+      this.limitText_.textContent = '!';
+      Blockly.utils.dom.addClass(this.limitGroup_, 'overLimit');
+      Blockly.utils.dom.addClass(this.limitText_, 'overLimit');
+    }
+    this.render();
+  }
+
+  /**
+   * Disposes of the limit group and its children, cleaning up all references.
+   */
+  dispose() {
+    this.limitGroup_?.remove();
+    this.limitGroup_ = undefined;
+    this.limitRect_ = undefined;
+    this.limitText_ = undefined;
+  }
+
+  /**
+   * Initializes the SVG elements that make up the limit bubble.
+   */
+  initChildren() {
+    const position = this.element_.getRelativeToSurfaceXY();
+    // Google Blockly's block ids are randomly generated and can
+    // include invalid characters for element ids. Remove everything
+    // except alphanumeric characters and whitespace, then collapse
+    // multiple adjacent whitespace to single spaces.
+    const safeCharBlockId = this.element_.id
+      .replace(/[^\w\s\']|_/g, '')
+      .replace(/\s+/g, ' ');
+
+    this.limitGroup_ = Blockly.utils.dom.createSvgElement(
+      'g',
+      {
+        class: this.className,
+      },
+      this.element_.getSvgRoot()
+    );
+
+    this.limitRect_ = Blockly.utils.dom.createSvgElement(
+      'rect',
+      {
+        height: BUBBLE_SIZE,
+        width: BUBBLE_SIZE,
+        x: -HALF_BUBBLE_SIZE,
+        y: -HALF_BUBBLE_SIZE,
+        rx: HALF_BUBBLE_SIZE,
+        ry: HALF_BUBBLE_SIZE,
+      },
+      this.limitGroup_
+    );
+
+    this.limitText_ = Blockly.utils.dom.createSvgElement(
+      'text',
+      {
+        class: 'blocklyText blocklyLimit',
+        'dominant-baseline': 'central',
+        'text-anchor': 'middle',
+      },
+      this.limitGroup_
+    );
+    this.updateTextAndClass();
+  }
+
+  /**
+   * Renders the limit bubble, adjusting its size and position based on the
+   * current count text. Called automatically when the instance is created or
+   * updated.
+   */
+  render() {
+    if (!this.limitGroup_ || !this.limitRect_ || !this.limitText_) {
+      // If we haven't initialized the children yet, do nothing.
+      return;
+    }
+
+    const svgGroup = this.element_.getSvgRoot();
+    svgGroup.append(this.limitGroup_);
+
+    const textBBox = (this.limitText_ as SVGGraphicsElement).getBBox();
+    const rectWidth = Math.max(textBBox.width + HALF_BUBBLE_SIZE, BUBBLE_SIZE);
+
+    // Stretch the bubble to to fit longer numbers as text.
+    this.limitRect_.setAttribute('width', `${rectWidth}`);
+    // Center the text in the bubble.
+    this.limitText_.setAttribute(
+      'x',
+      `${Math.round(rectWidth * 0.5) - HALF_BUBBLE_SIZE}`
+    );
+  }
+}

--- a/apps/src/blockly/addons/blockSvgLimit.ts
+++ b/apps/src/blockly/addons/blockSvgLimit.ts
@@ -1,4 +1,3 @@
-import color from '@cdo/apps/util/color';
 import {BlockSvg} from 'blockly';
 
 const BUBBLE_SIZE = 18;
@@ -78,15 +77,6 @@ export default class BlockSvgLimit {
    * Initializes the SVG elements that make up the limit bubble.
    */
   initChildren() {
-    const position = this.element_.getRelativeToSurfaceXY();
-    // Google Blockly's block ids are randomly generated and can
-    // include invalid characters for element ids. Remove everything
-    // except alphanumeric characters and whitespace, then collapse
-    // multiple adjacent whitespace to single spaces.
-    const safeCharBlockId = this.element_.id
-      .replace(/[^\w\s\']|_/g, '')
-      .replace(/\s+/g, ' ');
-
     this.limitGroup_ = Blockly.utils.dom.createSvgElement(
       'g',
       {

--- a/apps/src/blockly/addons/blockSvgLimitIndicator.ts
+++ b/apps/src/blockly/addons/blockSvgLimitIndicator.ts
@@ -1,5 +1,8 @@
 import {BlockSvg} from 'blockly';
 
+const BUBBLE_SIZE = 18;
+const HALF_BUBBLE_SIZE = BUBBLE_SIZE / 2;
+
 /**
  * Represents a bubble on a Blockly block, displaying the count of blocks remaining
  * based on a limit initially stated in the toolbox XML.
@@ -7,26 +10,49 @@ import {BlockSvg} from 'blockly';
 export default class BlockSvgLimitIndicator {
   private readonly blockSvg: BlockSvg;
   private count: number;
-  private readonly bubbleSize: number = 18;
-  private readonly halfBubbleSize: number;
-  private limitGroup: SVGElement | undefined;
-  private limitRect: SVGElement | undefined;
-  private limitText: SVGElement | undefined;
+  private readonly limitGroup: SVGElement;
+  private readonly limitRect: SVGElement;
+  private readonly limitText: SVGElement;
 
   /**
    * Constructs an SVG group to track a block limit.
-   * @param {Element} element - The block associated with the limit.
-   * @param {string} [count] - The initial count to display.
+   * @param {BlockSvg} element - The block associated with the limit.
+   * @param {number} count - The initial count to display.
    */
   constructor(element: BlockSvg, count: number) {
     this.blockSvg = element;
     this.count = count;
-    this.halfBubbleSize = this.bubbleSize / 2;
 
-    this.limitGroup = undefined;
-    this.limitRect = undefined;
-    this.limitText = undefined;
-    this.initializeSvgElements();
+    // Initialize the SVG elements within the constructor
+    this.limitGroup = Blockly.utils.dom.createSvgElement(
+      'g',
+      {class: 'blocklyLimit'},
+      this.blockSvg.getSvgRoot()
+    );
+
+    this.limitRect = Blockly.utils.dom.createSvgElement(
+      'rect',
+      {
+        height: BUBBLE_SIZE,
+        width: BUBBLE_SIZE,
+        x: -HALF_BUBBLE_SIZE,
+        y: -HALF_BUBBLE_SIZE,
+        rx: HALF_BUBBLE_SIZE,
+        ry: HALF_BUBBLE_SIZE,
+      },
+      this.limitGroup
+    );
+
+    this.limitText = Blockly.utils.dom.createSvgElement(
+      'text',
+      {
+        class: 'blocklyText blocklyLimit',
+        'dominant-baseline': 'central',
+        'text-anchor': 'middle',
+      },
+      this.limitGroup
+    );
+    this.updateTextAndClass();
   }
 
   /**
@@ -45,9 +71,6 @@ export default class BlockSvgLimitIndicator {
    * the bubble and text color.
    */
   private updateTextAndClass() {
-    if (!this.limitText || !this.limitGroup) {
-      return;
-    }
     if (this.count >= 0) {
       this.limitText.textContent = `${this.count}`;
       Blockly.utils.dom.removeClass(this.limitGroup, 'overLimit');
@@ -61,71 +84,26 @@ export default class BlockSvgLimitIndicator {
   }
 
   /**
-   * Initializes the SVG elements that make up the limit bubble.
-   */
-  private initializeSvgElements() {
-    this.limitGroup = Blockly.utils.dom.createSvgElement(
-      'g',
-      {
-        class: 'blocklyLimit',
-      },
-      this.blockSvg.getSvgRoot()
-    );
-
-    this.limitRect = Blockly.utils.dom.createSvgElement(
-      'rect',
-      {
-        height: this.bubbleSize,
-        width: this.bubbleSize,
-        x: -this.halfBubbleSize,
-        y: -this.halfBubbleSize,
-        rx: this.halfBubbleSize,
-        ry: this.halfBubbleSize,
-      },
-      this.limitGroup
-    );
-
-    this.limitText = Blockly.utils.dom.createSvgElement(
-      'text',
-      {
-        class: 'blocklyText blocklyLimit',
-        'dominant-baseline': 'central',
-        'text-anchor': 'middle',
-      },
-      this.limitGroup
-    );
-    this.updateTextAndClass();
-  }
-
-  /**
    * Renders the limit bubble, adjusting its size and position based on the
    * current count text. Called automatically when the instance is created or
    * updated.
    */
   private render() {
-    if (!this.limitGroup || !this.limitRect || !this.limitText) {
-      // If we haven't initialized the children yet, do nothing.
-      return;
-    }
-
     const textBBox = (this.limitText as SVGGraphicsElement).getBBox();
-    const rectWidth = Math.max(
-      textBBox.width + this.halfBubbleSize,
-      this.bubbleSize
-    );
+    const rectWidth = Math.max(textBBox.width + HALF_BUBBLE_SIZE, BUBBLE_SIZE);
     const rectHeight = Math.max(
-      textBBox.height + this.halfBubbleSize / 2,
-      this.bubbleSize
+      textBBox.height + HALF_BUBBLE_SIZE / 2,
+      BUBBLE_SIZE
     );
 
     // Stretch the bubble to to fit longer numbers as text.
     this.limitRect.setAttribute('width', `${rectWidth}`);
     this.limitRect.setAttribute('height', `${rectHeight}`);
     // Center the text in the bubble.
-    this.limitText.setAttribute('x', `${rectWidth / 2 - this.halfBubbleSize}`);
+    this.limitText.setAttribute('x', `${rectWidth / 2 - HALF_BUBBLE_SIZE}`);
     this.limitText.setAttribute(
       'y',
-      `${Math.ceil(rectHeight / 2) - this.halfBubbleSize}`
+      `${Math.ceil(rectHeight / 2) - HALF_BUBBLE_SIZE}`
     );
   }
 }

--- a/apps/src/blockly/addons/blockSvgLimitIndicator.ts
+++ b/apps/src/blockly/addons/blockSvgLimitIndicator.ts
@@ -4,7 +4,7 @@ import {BlockSvg} from 'blockly';
  * Represents a bubble on a Blockly block, displaying the count of blocks remaining
  * based on a limit initially stated in the toolbox XML.
  */
-export default class BlockSvgLimit {
+export default class BlockSvgLimitIndicator {
   private readonly blockSvg: BlockSvg;
   private count: number;
   private readonly bubbleSize: number = 18;

--- a/apps/src/blockly/addons/cdoCss.ts
+++ b/apps/src/blockly/addons/cdoCss.ts
@@ -43,6 +43,15 @@ export default function initializeCss(blocklyWrapper: BlocklyWrapperType) {
       stroke: ${color.brand_secondary_dark};
       stroke-width: 3;
     }
+    .blocklyLimit rect {
+      fill: ${color.brand_accent_default};
+    }
+    .blocklyLimit.overLimit rect {
+      fill: ${color.product_caution_default};
+    }
+    .blocklyLimit.overLimit text {
+      fill: ${color.neutral_dark} !important;
+    }
     `
   );
 }

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -552,15 +552,15 @@ export function createBlockLimitMap() {
   blocks.forEach(block => {
     // Check if the block has a limit attribute
     const limitAttribute = block.getAttribute('limit');
-    if (limitAttribute !== null) {
-      // Check if the limit attribute is a valid number
-      const limit = parseInt(limitAttribute);
-      if (!isNaN(limit)) {
-        // Extract type and add to blockLimitMap
-        const type = block.getAttribute('type');
-        if (type !== null) {
-          blockLimitMap.set(type, limit);
-        }
+
+    // Directly parse the attribute. Template string is used to handle null values.
+    const limit = parseInt(`${limitAttribute}`);
+
+    if (!isNaN(limit)) {
+      // Extract type and add to blockLimitMap
+      const type = block.getAttribute('type');
+      if (type !== null) {
+        blockLimitMap.set(type, limit);
       }
     }
   });

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -349,15 +349,7 @@ export function blockLimitExceeded(): string | null {
  * @returns {number} The limit for the specified block type, or 0 if not found.
  */
 export function getBlockLimit(type: string): number {
-  const blockLimitMap = Blockly.blockLimitMap;
-
-  // Check if the block limit map is defined and has the requested type
-  if (blockLimitMap && blockLimitMap.has(type)) {
-    return blockLimitMap.get(type) || 0;
-  }
-
-  // Return undefined if the map is not defined or the type is not found
-  return 0;
+  return Blockly.blockLimitMap?.get(type) ?? 0;
 }
 
 /**

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -317,33 +317,30 @@ export function bindBrowserEvent(
 export function isWorkspaceReadOnly() {
   return false; // TODO - used for feedback
 }
-
 /**
  * Checks if any block type's usage count exceeds its defined limit and returns
  * the type of the first block found to exceed.
- * @returns {string | undefined} The type of the first block that exceeds its limit,
- * or undefined if no block exceeds the limit.
+ * @returns {string | null} The type of the first block that exceeds its limit,
+ * or null if no block exceeds the limit.
  */
-export function blockLimitExceeded(): string | undefined {
-  const blockLimitMap = Blockly.blockLimitMap;
-  const blockCountMap = Blockly.blockCountMap;
+export function blockLimitExceeded(): string | null {
+  const {blockLimitMap, blockCountMap} = Blockly;
 
   // Ensure both maps are defined
   if (!blockLimitMap || !blockCountMap) {
-    return undefined;
+    return null;
   }
 
-  // Iterate over the block count map
+  // Find the first instance where the limit is exceeded for a block type.
   for (const [type, count] of blockCountMap) {
     const limit = blockLimitMap.get(type);
-    // If a limit is defined and the count exceeds this limit, return the type
     if (limit !== undefined && count > limit) {
       return type;
     }
   }
 
-  // If no count exceeds the limit, return undefined
-  return undefined;
+  // If no count exceeds the limit, return null.
+  return null;
 }
 
 /**
@@ -541,9 +538,9 @@ export function getLevelToolboxBlocks(customCategory: string) {
 }
 
 /**
- * Creates a map of block types and limits, based on limit attribtues found
+ * Creates a map of block types and limits, based on limit attributes found
  * in the block XML for the current toolbox.
- * @returns {Map} A map of block limits
+ * @returns {Map<string, number>} A map of block limits
  */
 export function createBlockLimitMap() {
   const parser = new DOMParser();

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -346,10 +346,11 @@ export function blockLimitExceeded(): string | null {
 /**
  * Retrieves the block limit for a given block type from the block limit map.
  * @param {string} type The type of the block to check the limit for.
- * @returns {number} The limit for the specified block type, or 0 if not found.
+ * @returns {number | null} The limit for the specified block type, or null if not found.
  */
-export function getBlockLimit(type: string): number {
-  return Blockly.blockLimitMap?.get(type) ?? 0;
+export function getBlockLimit(type: string): number | null {
+  const limit = Blockly.blockLimitMap?.get(type);
+  return limit !== undefined ? limit : null;
 }
 
 /**
@@ -546,19 +547,15 @@ export function createBlockLimitMap() {
   const blockLimitMap = new Map<string, number>();
 
   // Select all block elements and convert NodeList to array
-  const blocks = Array.from(xmlDoc.querySelectorAll('block'));
+  const toolboxBlockElements = Array.from(xmlDoc.querySelectorAll('block'));
 
   // Iterate over each block element using forEach
-  blocks.forEach(block => {
-    // Check if the block has a limit attribute
-    const limitAttribute = block.getAttribute('limit');
-
-    // Directly parse the attribute. Template string is used to handle null values.
-    const limit = parseInt(`${limitAttribute}`);
+  toolboxBlockElements.forEach(blockElement => {
+    const limit = parseInt(blockElement.getAttribute('limit') ?? '');
 
     if (!isNaN(limit)) {
       // Extract type and add to blockLimitMap
-      const type = block.getAttribute('type');
+      const type = blockElement.getAttribute('type');
       if (type !== null) {
         blockLimitMap.set(type, limit);
       }

--- a/apps/src/blockly/eventHandlers.ts
+++ b/apps/src/blockly/eventHandlers.ts
@@ -3,13 +3,15 @@
 import {handleWorkspaceResizeOrScroll} from '@cdo/apps/code-studio/callouts';
 import {BLOCK_TYPES} from './constants';
 import {Abstract} from 'blockly/core/events/events_abstract';
-import {BlockChange} from 'blockly/core/events/events_block_change';
-import {BlockMove} from 'blockly/core/events/events_block_move';
-import {BlockCreate} from 'blockly/core/events/events_block_create';
 import {Block, WorkspaceSvg} from 'blockly';
 import {ExtendedBlockSvg, ExtendedWorkspaceSvg} from './types';
 import BlockSvgLimitIndicator from './addons/blockSvgLimitIndicator';
-import {ThemeChange} from 'blockly/core/events/events_theme_change';
+import type {
+  BlockChange,
+  BlockMove,
+  BlockCreate,
+  ThemeChange,
+} from 'blockly/core/events/events';
 
 // A custom version of Blockly's Events.disableOrphans. This makes a couple
 // changes to the original function.

--- a/apps/src/blockly/eventHandlers.ts
+++ b/apps/src/blockly/eventHandlers.ts
@@ -9,6 +9,7 @@ import {BlockCreate} from 'blockly/core/events/events_block_create';
 import {Block, WorkspaceSvg} from 'blockly';
 import {ExtendedBlockSvg, ExtendedWorkspaceSvg} from './types';
 import BlockSvgLimit from './addons/blockSvgLimit';
+import {ThemeChange} from 'blockly/core/events/events_theme_change';
 
 // A custom version of Blockly's Events.disableOrphans. This makes a couple
 // changes to the original function.
@@ -125,19 +126,19 @@ export function updateBlockLimits(event: Abstract) {
   if (
     event.type !== Blockly.Events.BLOCK_CHANGE &&
     event.type !== Blockly.Events.BLOCK_MOVE &&
-    event.type !== Blockly.Events.BLOCK_CREATE
+    event.type !== Blockly.Events.BLOCK_CREATE &&
+    event.type !== Blockly.Events.THEME_CHANGE
   ) {
     return;
   }
-  const blockEvent = event as BlockChange | BlockMove | BlockCreate;
+  const blockEvent = event as
+    | BlockChange
+    | BlockMove
+    | BlockCreate
+    | ThemeChange;
   const blockLimitMap = Blockly.blockLimitMap;
 
-  if (
-    !blockEvent.blockId ||
-    !blockEvent.workspaceId ||
-    !blockLimitMap ||
-    !(blockLimitMap?.size > 0)
-  ) {
+  if (!blockEvent.workspaceId || !blockLimitMap || !(blockLimitMap?.size > 0)) {
     return;
   }
   const eventWorkspace = Blockly.Workspace.getById(

--- a/apps/src/blockly/eventHandlers.ts
+++ b/apps/src/blockly/eventHandlers.ts
@@ -6,7 +6,7 @@ import {Abstract} from 'blockly/core/events/events_abstract';
 import {BlockChange} from 'blockly/core/events/events_block_change';
 import {BlockMove} from 'blockly/core/events/events_block_move';
 import {BlockCreate} from 'blockly/core/events/events_block_create';
-import {Block, Flyout, WorkspaceSvg} from 'blockly';
+import {Block, WorkspaceSvg} from 'blockly';
 import {ExtendedBlockSvg, ExtendedWorkspaceSvg} from './types';
 import BlockSvgLimit from './addons/blockSvgLimit';
 

--- a/apps/src/blockly/eventHandlers.ts
+++ b/apps/src/blockly/eventHandlers.ts
@@ -8,7 +8,7 @@ import {BlockMove} from 'blockly/core/events/events_block_move';
 import {BlockCreate} from 'blockly/core/events/events_block_create';
 import {Block, WorkspaceSvg} from 'blockly';
 import {ExtendedBlockSvg, ExtendedWorkspaceSvg} from './types';
-import BlockSvgLimit from './addons/blockSvgLimit';
+import BlockSvgLimitIndicator from './addons/blockSvgLimitIndicator';
 import {ThemeChange} from 'blockly/core/events/events_theme_change';
 
 // A custom version of Blockly's Events.disableOrphans. This makes a couple
@@ -185,10 +185,13 @@ export function updateBlockLimits(event: Abstract) {
     const blockLimitCount = blockLimitMap.get(flyoutBlock.type) as number;
     const blockUsedCount = blockCountMap.get(flyoutBlock.type) || 0;
     const remainingCount = blockLimitCount - blockUsedCount;
-    if (flyoutBlock.blockLimit_) {
-      flyoutBlock.blockLimit_.updateCount(remainingCount);
+    if (flyoutBlock.blockSvgLimitIndicator) {
+      flyoutBlock.blockSvgLimitIndicator.updateCount(remainingCount);
     } else {
-      flyoutBlock.blockLimit_ = new BlockSvgLimit(flyoutBlock, remainingCount);
+      flyoutBlock.blockSvgLimitIndicator = new BlockSvgLimitIndicator(
+        flyoutBlock,
+        remainingCount
+      );
     }
   });
 }

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -76,6 +76,7 @@ import {
   adjustCalloutsOnViewportChange,
   disableOrphans,
   reflowToolbox,
+  updateBlockLimits,
 } from './eventHandlers';
 import {initializeScrollbarPair} from './addons/cdoScrollbar';
 import {getStore} from '@cdo/apps/redux';
@@ -683,6 +684,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.isToolboxMode =
       optOptionsExtended.editBlocks === 'toolbox_blocks';
     blocklyWrapper.toolboxBlocks = options.toolbox;
+    blocklyWrapper.blockLimitMap = cdoUtils.createBlockLimitMap();
     const workspace = blocklyWrapper.blockly_.inject(
       container,
       options
@@ -714,6 +716,9 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
 
     if (!blocklyWrapper.isStartMode && !optOptionsExtended.isBlockEditMode) {
       workspace.addChangeListener(disableOrphans);
+    }
+    if (blocklyWrapper.blockLimitMap && blocklyWrapper.blockLimitMap.size > 0) {
+      workspace.addChangeListener(updateBlockLimits);
     }
 
     // When either the main workspace or the toolbox workspace viewport

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -43,7 +43,7 @@ import CdoFieldVariable from './addons/cdoFieldVariable';
 import CdoFieldBehaviorPicker from './addons/cdoFieldBehaviorPicker';
 import CdoFieldAngleDropdown from './addons/cdoFieldAngleDropdown';
 import CdoFieldAngleTextInput from './addons/cdoFieldAngleTextInput';
-import BlockSvgLimit from './addons/blockSvgLimit';
+import BlockSvgLimitIndicator from './addons/blockSvgLimitIndicator';
 
 export interface BlockDefinition {
   category: string;
@@ -188,7 +188,7 @@ export interface ExtendedBlockSvg extends BlockSvg {
   thumbnailSize?: number;
   // used for function blocks
   functionalSvg_?: BlockSvgFrame;
-  blockLimit_?: BlockSvgLimit;
+  blockSvgLimitIndicator?: BlockSvgLimitIndicator;
   workspace: ExtendedWorkspaceSvg;
 }
 

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -43,6 +43,7 @@ import CdoFieldVariable from './addons/cdoFieldVariable';
 import CdoFieldBehaviorPicker from './addons/cdoFieldBehaviorPicker';
 import CdoFieldAngleDropdown from './addons/cdoFieldAngleDropdown';
 import CdoFieldAngleTextInput from './addons/cdoFieldAngleTextInput';
+import BlockSvgLimit from './addons/blockSvgLimit';
 
 export interface BlockDefinition {
   category: string;
@@ -76,6 +77,8 @@ type GoogleBlocklyType = typeof GoogleBlockly;
 
 // Type for the Blockly instance created and modified by googleBlocklyWrapper.
 export interface BlocklyWrapperType extends GoogleBlocklyType {
+  blockCountMap: Map<string, number> | undefined;
+  blockLimitMap: Map<string, number> | undefined;
   readOnly: boolean;
   grayOutUndeletableBlocks: boolean;
   topLevelProcedureAutopopulate: boolean;
@@ -185,6 +188,7 @@ export interface ExtendedBlockSvg extends BlockSvg {
   thumbnailSize?: number;
   // used for function blocks
   functionalSvg_?: BlockSvgFrame;
+  blockLimit_?: BlockSvgLimit;
   workspace: ExtendedWorkspaceSvg;
 }
 


### PR DESCRIPTION
## About Block Limits

In 2016, we built a custom CDO Blockly feature for Maze, Artist, and Play Lab called block limits. This feature was designed to encourage students to think about their programming solutions in more efficient ways. Originally, this feature prevented students from using more than a set limit of a particular type of block. Google Blockly supports this with a `maxInstances` option ([documentation](https://developers.google.com/blockly/guides/configure/web/configuration_struct), [example](https://blockly.games/maze?lang=en&level=3&&skin=0)). However, our feature was later relaxed so that students could still drag out as many blocks as they wanted, but their pass/fail feedback would still reflect the limits. This was intended to allow students to start with an inefficient solution and then refactor (e.g. using a loop).

<img width="1261" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/5b5750a3-e017-4506-b6f3-cb84bdfb2fc7">

How it works:
- To set a block limit of 1, a `limit="1"` attribute is added to the block element of the toolbox XML. 
- In the student view of the level, an SVG element is rendered at the top left of the block initially showing the limit.
- As students drag out blocks (and enable them by connecting to stack), the counter over the block counts down.
- If the student has used more than the limit, the SVG counter shows `!` and changes color.
- If the student otherwise passes the level but with block than the limit of any available block, they get fail the level with a generated feedback string. The feedback includes a restatement of the limit and a rendering of the block.

This branch makes all of the above work with Google Blockly:
<img width="1260" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/bb8dd763-2a2c-4e36-a07f-9e7afc93ac12">


## Technical Details

**Storing Limits**
The first challenge was to find a way to be able to read and store the block limits. Blockly doesn't expect extra state to be serialized as attributes in the block element, instead preferring the use of mutators. Since we were already storing the toolbox xml string on the wrapper, I created a util `createBlockLimitMap()` that parses the xml to find these values. They are added to a map (`<string, number>`. This map is placed directly on the wrapper so that it can accessed as `Blockly.blockLimitMap` in other files.

**Event Handler**
Because the SVG will need to be updated, I registered a workspace change listener for blocks. This handler creates or updates a `blockCountMap` that also put on the wrapper instance. This is populated with the current workspace count of blocks whose types are represented in the limit map. (If a block type doesn't have a limit, we don't bother to count the instances of that block.)
Once we have the counts, we then create (or update) an SVG for each flyout block with a corresponding type. The SVG is given the number of blocks "remaining" (subtracting the count from the limit).

**Limit SVG**
In CDO Blockly, the limit is managed directly by the `BlockSvg` class.  Since this mainline doesn't support extending this class for purposes like this, I created a new `BlockSvgLimit` class that does pretty much the same thing. When needed, we will create an instance of this class and append it to the block. The actual SVG drawing is the same as the original with the exception of two minor changes:

- The colors have been updated in accordance with guidance from the Design team (@markabarrett). The new colors are listed in `cdoCss`.
- Bubble height and text position have been tweaked for better centering and to account for changing themes.

Original code for reference: https://github.com/code-dot-org/blockly/blob/v4.1.0/core/ui/block_svg/block_svg.js#L879-L951

## Validation

Again, this feature doesn't prevent students from using too many blocks, but it does prevent that from passing if they have. The functions `blockLimitExceeded` and `getBlockLimit` are used to make this determination. These functions were already defined in `cdoUtils` but not fully implemented. They now work by reading from the needed map(s) to determine if a block type and limit needs to be added to the failure feedback string.
The CDO Blockly versions of these functions are here: https://github.com/code-dot-org/code-dot-org/blob/mike/block-limits/apps/src/blockly/cdoBlocklyWrapper.js#L253-L267
The `BlockLimits` functions referenced at the link above are part of the CDO Blockly wrapper and available here: https://github.com/code-dot-org/blockly/blob/v4.1.0/core/ui/block_space/block_limits.js


## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

Jira: https://codedotorg.atlassian.net/browse/CT-495
Slack #Design thread: https://codedotorg.slack.com/archives/C0SUN2SSF/p1712781058747139

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I manually tested that the new SVG works as expected and is resized appropriately for a variety of numeric values. Students can pass or a fail a level as expected based whether they've exceeded a block limit. The feedback string renders the correct block and limit. I also made sure that the bubbles update in real time if the theme is changed.

We already have integration tests for block limits that use maze, so once Maze is migrated our coverage of this feature will pivot to cover the new implementation for Google Blockly. 

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

This work does not cover levelbuilder's ability to set block limits and save them when editing toolbox blocks.. If that feature is still desired we would need to:
* show the new svg on workspace blocks if we are in toolbox edit mode
* register a new block context menu option to update values in the block limit map
* save values from the map into the xml when saving toolbox blocks

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
