### PR TITLE
Full width by default in `SimpleDropdown`, third try

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/StudentTable.jsx
@@ -116,7 +116,7 @@ class StudentTable extends React.Component {
 const styles = {
   table: {
     width: '90%',
-    margin: 'auto',
+    margin: '8px auto auto',
   },
   tr: {
     height: 41,

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0](https://github.com/code-dot-org/code-dot-org/pull/57105)
+* use `width: 100%` instead of `width: auto` as default when styling `select` element.
+* style select element with the use of `select` css selector instead of `.dropdown`
+
 ## [0.3.0](https://github.com/code-dot-org/code-dot-org/pull/57105)
 * moved `SimpleDropdown` to dropdown folder
 

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/SimpleDropdown.tsx
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/SimpleDropdown.tsx
@@ -82,7 +82,6 @@ const SimpleDropdown: React.FunctionComponent<SimpleDropdownProps> = ({
           onChange={onChange}
           value={selectedValue}
           id={id}
-          className={moduleStyles.dropdown}
           disabled={disabled}
         >
           {itemGroups.length > 0

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
@@ -11,11 +11,11 @@
     display: block;
   }
 
-  .dropdown {
+  select {
     display: inline-flex;
     align-items: center;
     align-self: stretch;
-    width: auto;
+    width: 100%;
     background-color: unset;
     border-radius: 0.25rem;
     border: 1px solid;
@@ -51,7 +51,7 @@
     color: $light_black;
   }
 
-  .dropdown {
+  select {
     color: $light_black;
     border-color: $light_black;
   }
@@ -60,8 +60,8 @@
     color: $light_black;
   }
 
-  &:has(.dropdown:hover) {
-    .dropdown:not(:disabled) {
+  &:has(select:hover) {
+    select:not(:disabled) {
       color: $light_black;
       background-color: $light_gray_100;
     }
@@ -71,8 +71,8 @@
     }
   }
 
-  &:has(.dropdown:active) {
-    .dropdown:not(:disabled) {
+  &:has(select:active) {
+    select:not(:disabled) {
       color: $light_black;
       background-color: unset;
     }
@@ -82,8 +82,8 @@
     }
   }
 
-  &:has(.dropdown:disabled) {
-    .dropdown {
+  &:has(select:disabled) {
+    select {
       color: $light_gray_200;
       border-color: $light_gray_200;
     }
@@ -99,13 +99,13 @@
     color: $light_white;
   }
 
-  .dropdown {
+  select {
     color: $light_white;
     border-color: $light_white;
   }
 
-  &:has(.dropdown:hover) {
-    .dropdown:not(:disabled) {
+  &:has(select:hover) {
+    select:not(:disabled) {
       color: $light_white;
       background-color: $light_gray_900;
     }
@@ -115,8 +115,8 @@
     }
   }
 
-  &:has(.dropdown:active) {
-    .dropdown:not(:disabled) {
+  &:has(select:active) {
+    select:not(:disabled) {
       color: $light_white;
       background-color: unset;
     }
@@ -126,8 +126,8 @@
     }
   }
 
-  &:has(.dropdown:disabled) {
-    .dropdown {
+  &:has(select:disabled) {
+    select {
       color: $light_gray_900;
       border-color: $light_gray_900;
     }
@@ -149,7 +149,7 @@
     margin-bottom: 0.37rem;
   }
 
-  .dropdown {
+  select {
     @include button-one-text;
     height: 3rem;
     padding: 0.625rem 1rem;
@@ -172,7 +172,7 @@
     margin-bottom: 0.37rem;
   }
 
-  .dropdown {
+  select {
     @include button-two-text;
     height: 2.5rem;
     padding: 0.5rem 1rem;
@@ -195,7 +195,7 @@
     margin-bottom: 0.37rem;
   }
 
-  .dropdown {
+  select {
     @include button-three-text;
     height: 2rem;
     padding: 0.3125rem 1rem;
@@ -218,7 +218,7 @@
     margin-bottom: 0.37rem;
   }
 
-  .dropdown {
+  select {
     @include button-four-text;
     height: 1.5rem;
     padding: 0.125rem 0.5rem;

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -235,7 +235,7 @@ class SectionProgress extends Component {
   }
 }
 
-const sortOrderMargin = 22;
+const sortOrderMargin = 15;
 
 const styles = {
   heading: {


### PR DESCRIPTION
Third try for https://github.com/code-dot-org/code-dot-org/pull/57808 -- setting full width for our design system dropdown component.

New commit is [here](https://github.com/code-dot-org/code-dot-org/pull/57959/commits/26d1b6fe14a122fca4c11e206881615d2ed2ebd4), which adds some margin to the student table in the teacher panel. The margin was previously provided by the dropdown itself.

Slack discussion [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1712751803196409?thread_ts=1712600463.000159&cid=C0T0PNTM3).

**After this change (no diff from what is currently in production)**

![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/d39f8a3d-c9a0-41e4-bcf4-ae340099a749)

## Testing story

Tested manually on a Javalab level -- I also looked through [the failing eyes tests](https://eyes.applitools.com/app/test-results/00000251689582722449/?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110) when we last merged this, and I _think_ this was the only issue.