### PR TITLE
fix(lms): do not add observers or mentors as students

### DIFF
--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -28,6 +28,7 @@ class Policies::Lti
     ]
 ).freeze
   CONTEXT_LEARNER_ROLE = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner'.freeze
+  CONTEXT_MENTOR_ROLE = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor'.freeze
   LTI_ROLES_KEY = 'https://purl.imsglobal.org/spec/lti/claim/roles'.freeze
   LTI_CUSTOM_CLAIMS = "https://purl.imsglobal.org/spec/lti/claim/custom".freeze
   LTI_CONTEXT_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/context".freeze

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -131,7 +131,7 @@ module Services
       members = nrps_response[:members]
       context_title = nrps_response.dig(:context, :title)
       members.each do |member|
-        next if member[:status] == 'Inactive'
+        next if member[:status] == 'Inactive' || member[:roles].include?(Policies::Lti::CONTEXT_MENTOR_ROLE)
         # TODO: handle multiple messages. Shouldn't be needed until we support Deep Linking.
 
         # If the LMS hasn't implemented the resource link level membership service, we don't get the message property in the member object

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -16,6 +16,7 @@ class Services::LtiTest < ActiveSupport::TestCase
     ]
     @lti_integration = create :lti_integration
     @student_role = Policies::Lti::CONTEXT_LEARNER_ROLE
+    @observer_role = Policies::Lti::CONTEXT_MENTOR_ROLE
     @teacher_role = Policies::Lti::TEACHER_ROLES.first
 
     @id_token = {
@@ -54,6 +55,19 @@ class Services::LtiTest < ActiveSupport::TestCase
           display_name: 'teacher',
           full_name: 'Test Teacher',
           email: 'test-teacher@code.org'
+        }
+      }],
+    }.deep_symbolize_keys
+
+    @nrps_observer = {
+      status: 'Active',
+      user_id: SecureRandom.uuid,
+      roles: [@observer_role],
+      message: [{
+        @custom_claims_key => {
+          display_name: 'parent',
+          full_name: 'Test Parent',
+          email: 'test-parent@code.org'
         }
       }],
     }.deep_symbolize_keys
@@ -124,6 +138,27 @@ class Services::LtiTest < ActiveSupport::TestCase
                 email: "student0@code.org",
                 course_id: "115",
                 full_name: "Test Zero",
+                given_name: "Test",
+                family_name: "Zero",
+                section_ids: @lms_section_ids.join(','),
+                display_name: "Test Zero",
+                section_names: @lms_section_names.to_s
+              },
+            }
+          ]
+        },
+        {
+          status: "Active",
+          user_id: "observer-0",
+          roles: [Policies::Lti::CONTEXT_MENTOR_ROLE],
+          message: [
+            {
+              'https://purl.imsglobal.org/spec/lti/claim/message_type': "LtiResourceLinkRequest",
+              locale: "en",
+              'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                email: "parent-0@code.org",
+                course_id: "115",
+                full_name: "Parent Zero",
                 given_name: "Test",
                 family_name: "Zero",
                 section_ids: @lms_section_ids.join(','),


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

Previously, we added all non-teachers to the student roster. However, this includes observers or mentors which are typically parents observing their child's progress. Observers should not be added as students in the roster.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Added observers to the sync mock object and ensured followers do not increment. Prior to the fix, the unit test fails with:

```
Minitest::Assertion: Expected: 4
  Actual: 3
test/lib/services/lti_test.rb:458:in `block in <class:LtiTest>'
test/testing/setup_all_and_teardown_all.rb:36:in `run'

Minitest::Assertion: Expected: 2
  Actual: 3
test/lib/services/lti_test.rb:495:in `block in <class:LtiTest>'
test/testing/setup_all_and_teardown_all.rb:36:in `run'

Minitest::Assertion: Expected: 3
  Actual: 4
test/lib/services/lti_test.rb:521:in `block in <class:LtiTest>'
test/testing/setup_all_and_teardown_all.rb:36:in `run'

Minitest::Assertion: Expected: 6
  Actual: 5
test/lib/services/lti_test.rb:384:in `block (2 levels) in <class:LtiTest>'
test/lib/services/lti_test.rb:382:in `each'
test/lib/services/lti_test.rb:382:in `block in <class:LtiTest>'
test/testing/setup_all_and_teardown_all.rb:36:in `run'


```

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
