### PR TITLE
Fix-forward for failing Curriculum Catalog UI test with new redirect

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -172,7 +172,7 @@ Feature: Curriculum Catalog Page
     Then I wait until element "a:contains(Facilitator led workshops)" is visible
     And I click selector "a:contains(Facilitator led workshops)"
     Then I wait for jquery to load
-    And I wait until current URL contains "/professional-development-workshops"
+    And I wait until current URL contains "/professional-learning/elementary"
 
   @no_mobile
   Scenario: On expanded card, Signed-in teacher sees professional learning section


### PR DESCRIPTION
[This PR](https://github.com/code-dot-org/code-dot-org/pull/57904) updated [code.org/professional-development-workshops](https://code.org/professional-development-workshops) to redirect to [code.org/professional-learning/elementary](https://code.org/professional-learning/elementary). This then caused the Curriculum Catalog UI test file to fail since it was searching for a match to a URL that was being redirected away from. This PR updates the expected URL to reflect this now.

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1712877284145369?thread_ts=1712877091.471779&cid=C0T0PNTM3)
PR this builds on: [here](https://github.com/code-dot-org/code-dot-org/pull/57904)
