### PR TITLE
[AI Tutor] Reenable warning modal

### DIFF
--- a/apps/src/aiTutor/views/AITutorContainer.tsx
+++ b/apps/src/aiTutor/views/AITutorContainer.tsx
@@ -9,6 +9,7 @@ import aiBotOutlineIcon from '@cdo/static/ai-bot-outline.png';
 import AITutorChatWorkspace from './AITutorChatWorkspace';
 import AITutorFooter from './AITutorFooter';
 import style from './ai-tutor.module.scss';
+import WarningModal from './WarningModal';
 
 interface AITutorContainerProps {
   closeTutor?: () => void;
@@ -71,6 +72,7 @@ const AITutorContainer: React.FC<AITutorContainerProps> = ({
           )}
         </div>
         <AITutorFooter renderAITutor={renderAITutor} />
+        <WarningModal />
       </div>
     </Draggable>
   );

--- a/apps/src/aiTutor/views/WarningModal.tsx
+++ b/apps/src/aiTutor/views/WarningModal.tsx
@@ -19,7 +19,6 @@ const WarningModal = () => {
     return (
       <AccessibleDialog onClose={onClose} className={style.chatWarningModal}>
         <Heading2>Remember to chat responsibly!</Heading2>
-
         <button type="button" onClick={onClose} className={style.xCloseButton}>
           <i id="x-close" className="fa-solid fa-xmark" />
         </button>


### PR DESCRIPTION
When I did the UI refactor for AI Tutor, I intended to move where this renders, but I forgot to put it back! This readds the `<WarningModal>` component in its new spot. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
