### PR TITLE
fix(lms): allow list the lti iframe buster page from frame policies

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -128,9 +128,9 @@ class LtiV1Controller < ApplicationController
       auth_url_base = CDO.studio_url('/lti/v1/authenticate', CDO.default_scheme)
 
       query_params = {
-        id_token: ERB::Util.url_encode(params[:id_token]),
-        state: ERB::Util.url_encode(params[:state]),
-        new_tab: ERB::Util.url_encode("true"),
+        id_token: params[:id_token],
+        state: params[:state],
+        new_tab: "true",
       }
 
       @auth_url = "#{auth_url_base}?#{query_params.to_query}"

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -125,11 +125,16 @@ class LtiV1Controller < ApplicationController
     # in a new tab. This flow appends a 'new_tab=true' query param, so it will
     # pass this block once the iframe "jail break" has happened.
     if Policies::Lti.force_iframe_launch?(decoded_jwt[:iss]) && !params[:new_tab]
-      id_token = params[:id_token]
-      state = params[:state]
-      token_hash = {id_token: id_token, state: state}
-      redirect_to "#{lti_v1_iframe_url}?#{token_hash.to_query}"
-      return
+      auth_url_base = CDO.studio_url('/lti/v1/authenticate', CDO.default_scheme)
+
+      query_params = {
+        id_token: ERB::Util.url_encode(params[:id_token]),
+        state: ERB::Util.url_encode(params[:state]),
+        new_tab: ERB::Util.url_encode("true"),
+      }
+
+      @auth_url = "#{auth_url_base}?#{query_params.to_query}"
+      render 'lti/v1/iframe', layout: false and return
     end
 
     jwt_verifier = JwtVerifier.new(decoded_jwt, integration)
@@ -221,22 +226,6 @@ class LtiV1Controller < ApplicationController
       end
       format.json {render json: @lti_section_sync_result, status: status}
     end
-  end
-
-  # GET /lti/v1/iframe
-  # Detects if an LMS is trying open Code.org in an iframe and prompts user to
-  # open in new tab. The experience is unchanged to non-iframe users.
-  def iframe
-    auth_url_base = CDO.studio_url('/lti/v1/authenticate', CDO.default_scheme)
-
-    query_params = {
-      id_token: ERB::Util.url_encode(params[:id_token]),
-      state: ERB::Util.url_encode(params[:state]),
-      new_tab: ERB::Util.url_encode("true"),
-    }
-
-    @auth_url = "#{auth_url_base}?#{query_params.to_query}"
-    render 'lti/v1/iframe', layout: false
   end
 
   # GET /lti/v1/sync_course

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -604,7 +604,6 @@ Dashboard::Application.routes.draw do
     # LTI API endpoints
     match '/lti/v1/login(/:platform_id)', to: 'lti_v1#login', via: [:get, :post]
     match '/lti/v1/authenticate', to: 'lti_v1#authenticate', via: [:get, :post]
-    get '/lti/v1/iframe', to: 'lti_v1#iframe'
     match '/lti/v1/sync_course', to: 'lti_v1#sync_course', via: [:get, :post]
     post '/lti/v1/integrations', to: 'lti_v1#create_integration'
     get '/lti/v1/integrations', to: 'lti_v1#new_integration'

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -558,8 +558,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     payload = {**get_valid_payload, iss: issuer, aud: integration.client_id}
     jwt = create_jwt_and_stub(payload)
     post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
-    assert_response :redirect
-    assert_redirected_to '/lti/v1/iframe' + "?id_token=#{jwt}&state=#{@state}"
+    assert_template 'lti/v1/iframe'
   end
 
   test 'auth - should NOT redirect to iframe route if LMS caller is Schoology AND new_tab=true param is present' do

--- a/lib/cdo/rack/upgrade_insecure_requests.rb
+++ b/lib/cdo/rack/upgrade_insecure_requests.rb
@@ -64,7 +64,9 @@ module Rack
         # content.
 
         # If the request path is an allow listed, the frame-ancestors policy is made permissive.
-        # Warning: Only very specific paths can be on the allow list. Contact security for more information.
+        # Warning: Our default policy is to deny iframes for security concerns.  Allow list entries are only to be
+        # added when absolutely necessary, when the scope is reduced to bare minimum to meet the objectives, and once
+        # security has reviewed and signed off on the specific changed.  Please contact security for more information.
         iframe_path_allowlist = Set.new(["/lti/v1/authenticate"])
         cdo_allowed_iframe_ancestors = DCDO.get('allowed_iframe_ancestors', nil) || CDO.allowed_iframe_ancestors
         allowed_iframe_ancestors = iframe_path_allowlist.include?(env['REQUEST_PATH']) ? '*' : cdo_allowed_iframe_ancestors


### PR DESCRIPTION
LMS providers iframe sandbox apps such as Code.org. Due to Code.org's anti-clickjacking CSP, Code.org cannot be executed within an iframe. To get around this, an iframe buster was created that informs the user to click a button to launch Code.org in a new window. 

However, the frame content security policies still applied to the iframe buster path. The initial implementation allowlisted schoology specifically, however schoology allows for districts to have their own custom domains resulting in an unbounded allowlist.

Instead of applying frame CSPs to the iframe buster path, allow that specific page to load in an iframe. The frame buster page does not render the normal dashboard/rails and only a minimal page to have a button to launch Code.org. 

Another security consideration is that you can clickjack the iframe buster page. However, this route, `/lti/v1/iframe` is only accessible from a LMS logged in user path which implies that the user is originating from one of our onboarded LMS platforms. The iframe buster page is also of minimal content (just the launch Code.org button) and the user would not be entering keystrokes on this page.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. Validate that the Code.org iframe buster page can be rendered on Schoology
2. Validate that the CSP headers continue to be returned for other paths

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  3.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
