### PR TITLE
Localize long instructions for Lab2 levels

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -453,18 +453,6 @@ class Blockly < Level
     options.freeze
   end
 
-  # FND-985 Create shared API to get localized level properties.
-  def get_localized_property(property_name)
-    if should_localize? && try(property_name)
-      I18n.t(
-        name,
-        scope: [:data, property_name],
-        default: nil,
-        smart: true
-      )
-    end
-  end
-
   def localized_failure_message_override
     get_localized_property('failure_message_override')
   end

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -765,6 +765,18 @@ class Level < ApplicationRecord
     end
   end
 
+  # FND-985 Create shared API to get localized level properties.
+  def get_localized_property(property_name)
+    if should_localize? && try(property_name)
+      I18n.t(
+        name,
+        scope: [:data, property_name],
+        default: nil,
+        smart: true
+      )
+    end
+  end
+
   # There's a bit of trickery here. We consider a level to be
   # hint_prompt_enabled for the sake of the level editing experience if any of
   # the scripts associated with the level are hint_prompt_enabled.
@@ -834,6 +846,7 @@ class Level < ApplicationRecord
     # Localized properties
     properties_camelized["validations"] = localized_validations if properties_camelized["validations"]
     properties_camelized["panels"] = localized_panels if properties_camelized["panels"]
+    properties_camelized["longInstructions"] = (get_localized_property("long_instructions") || long_instructions) if properties_camelized["longInstructions"]
     properties_camelized
   end
 


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Description

Adds localized long instructions to Lab2 labs' level properties. This will be needed for localizing the Music Lab onboarding script.

<img width="1511" alt="Screenshot 2024-04-12 at 12 00 42 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/f80a4f13-be99-4992-9f68-47a07e5b1cdb">
<img width="1510" alt="Screenshot 2024-04-12 at 12 01 26 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/13716afb-8241-4cc4-ac5d-28c03937da30">


## Links

https://codedotorg.atlassian.net/browse/LABS-681

## Testing story

Tested with Music Lab and other Lab2 labs.