### PR TITLE
Enable 2024 diversity survey

### DIFF
--- a/dashboard/app/helpers/survey_results_helper.rb
+++ b/dashboard/app/helpers/survey_results_helper.rb
@@ -1,5 +1,5 @@
 module SurveyResultsHelper
-  DIVERSITY_SURVEY_ENABLED = false
+  DIVERSITY_SURVEY_ENABLED = true
 
   def show_diversity_survey?(kind)
     return false unless SurveyResultsHelper::DIVERSITY_SURVEY_ENABLED

--- a/dashboard/app/models/survey_result.rb
+++ b/dashboard/app/models/survey_result.rb
@@ -63,6 +63,7 @@ class SurveyResult < ApplicationRecord
     DIVERSITY_2021 = 'Diversity2021'.freeze,
     DIVERSITY_2022 = 'Diversity2022'.freeze,
     DIVERSITY_2023 = 'Diversity2023'.freeze,
+    DIVERSITY_2024 = 'Diversity2024'.freeze,
     NET_PROMOTER_SCORE_2015 = 'NetPromoterScore2015'.freeze,
     NET_PROMOTER_SCORE_2017 = 'NetPromoterScore2017'.freeze,
     NET_PROMOTER_SCORE_2019 = 'NetPromoterScore2019'.freeze,

--- a/dashboard/app/views/home/_homepage.html.haml
+++ b/dashboard/app/views/home/_homepage.html.haml
@@ -17,7 +17,7 @@
     #teacher_reminders
       - unless current_user.accepted_latest_terms?
         = render partial: 'layouts/implicit_new_user_terms_interstitial'
-      - if show_diversity_survey? SurveyResult::DIVERSITY_2023
+      - if show_diversity_survey? SurveyResult::DIVERSITY_2024
         = render partial: 'home/survey_diversity'
 
 #homepage-container

--- a/dashboard/app/views/home/_survey_diversity.haml
+++ b/dashboard/app/views/home/_survey_diversity.haml
@@ -22,7 +22,7 @@
             = value
             %br/
 
-      %input{type: "hidden", name: "survey[kind]", value: SurveyResult::DIVERSITY_2023}
+      %input{type: "hidden", name: "survey[kind]", value: SurveyResult::DIVERSITY_2024}
 
       #submit
         %button.btn-primary#submitSurvey{type: "submit"} Submit

--- a/dashboard/test/helpers/survey_results_helper_test.rb
+++ b/dashboard/test/helpers/survey_results_helper_test.rb
@@ -48,7 +48,7 @@ class SurveyResultsHelperTest < ActionView::TestCase
     stubs(:request).returns(stub(location: stub(try: "RD")))
     follower = create :follower, user: @teacher
     follower.student_user.update(age: 10)
-    refute show_diversity_survey? SurveyResult::DIVERSITY_2023
+    assert show_diversity_survey? SurveyResult::DIVERSITY_2024
   end
 
   test 'show nps survey' do


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

Modeled after #51060.

## Testing story
Tested locally
![image](https://github.com/code-dot-org/code-dot-org/assets/2933346/a61b10a8-3244-4b7a-8c15-5acc0b547911)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
