### PR TITLE
P20-870: Auto-verify LTI teachers on sign-up

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -285,6 +285,8 @@ class User < ApplicationRecord
     Services::Lti.create_lti_user_identity(self)
   end
 
+  after_create :verify_teacher!, if: -> {teacher? && Policies::Lti.lti?(self)}
+
   before_destroy :soft_delete_channels
 
   before_validation on: :create, if: -> {gender.present?} do
@@ -1490,6 +1492,10 @@ class User < ApplicationRecord
 
   def teacher?
     user_type == TYPE_TEACHER
+  end
+
+  def verify_teacher!
+    self.permission = UserPermission::AUTHORIZED_TEACHER
   end
 
   # This method just checks if a user has the authorized teacher permission

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -781,7 +781,7 @@ class UserTest < ActiveSupport::TestCase
     assert lti_teacher.verified_teacher?
   end
 
-  test 'LTI student should be verified after creation' do
+  test 'LTI student should not be verified after creation' do
     lti_integration = create(:lti_integration)
     auth_id = "#{lti_integration[:issuer]}|#{lti_integration[:client_id]}|#{SecureRandom.alphanumeric}"
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -770,6 +770,28 @@ class UserTest < ActiveSupport::TestCase
     assert_empty user.lti_user_identities
   end
 
+  test 'LTI teacher should be verified after creation' do
+    lti_integration = create(:lti_integration)
+    auth_id = "#{lti_integration[:issuer]}|#{lti_integration[:client_id]}|#{SecureRandom.alphanumeric}"
+
+    lti_teacher = build(:teacher)
+    lti_teacher.authentication_options << build(:lti_authentication_option, user: lti_teacher, authentication_id: auth_id)
+    lti_teacher.save!
+
+    assert lti_teacher.verified_teacher?
+  end
+
+  test 'LTI student should be verified after creation' do
+    lti_integration = create(:lti_integration)
+    auth_id = "#{lti_integration[:issuer]}|#{lti_integration[:client_id]}|#{SecureRandom.alphanumeric}"
+
+    lti_student = build(:student)
+    lti_student.authentication_options << build(:lti_authentication_option, user: lti_student, authentication_id: auth_id)
+    lti_student.save!
+
+    refute lti_student.verified_teacher?
+  end
+
   # FND-1130: This test will no longer be required
   test "teacher with no email created after 2016-06-14 should be invalid" do
     user = create :teacher, :without_email


### PR DESCRIPTION
## After Deploy Action
We need to run this query on prod to verify already created LTI teachers:
```ruby
lti_user_ids = AuthenticationOption.where(credential_type: AuthenticationOption::LTI_V1).select(:user_id)

User.where(id: lti_user_ids, user_type: User::TYPE_TEACHER).find_each do |lti_teacher|
  lti_teacher.verify_teacher!
end
```

## Links
- JIRA ticket: [P20-870](https://codedotorg.atlassian.net/browse/P20-870)