### PR TITLE
fix(lms): do not create a duplicative authentication option for teachers

### DIFF
--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -105,7 +105,6 @@ module Services
 
       if account_type == ::User::TYPE_TEACHER && email_address.present?
         user.user_type = ::User::TYPE_TEACHER
-        user.update_primary_contact_info(new_email: email_address, new_hashed_email: ::User.hash_email(email_address))
       else
         user.user_type = ::User::TYPE_STUDENT
         user.family_name = get_claim(nrps_member_message, :family_name)
@@ -122,6 +121,7 @@ module Services
         email: email_address,
         )
       user.authentication_options = [ao]
+      user.primary_contact_info = ao
       # TODO As final step of the LTI user creation, create LtiUserIdentity for the new user. https://codedotorg.atlassian.net/browse/P20-788
       user
     end


### PR DESCRIPTION
Previously during LMS new user initialization for teachers via NRPS, the email address of the teacher was added using `User.update_primary_contact_info`. This function will look up the user and check for an existing auth option, for which none will be found for a new user. As a fallback, this function will create a new auth option using credential type `EMAIL` and return.

Subsequently, the `initialize_lti_user_from_nrps` function will add the LTI authentication option with the same email. This results in a two authentication options with the same email which fails the `AuthenticationOption` `email_must_be_unique` validation causing a 422 error to be thrown back to the user.

In the SSO user creation flow, `PartialRegistration` updates the primary contact info to the first authentication option, causing the subsequent call to `update_primary_contact_info` to select the LTI auth option.

This PR updates the logic to set the primary contact info to the LTI authentication option directly bypassing the second auth option that was created.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. Added test to emulate duplicate user condition
2. Reproduced issue on Canvas and was able to sync successfully with teacher created

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  3.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
