### PR TITLE
Return Nil if there is no translation for palette_ params

### DIFF
--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -305,10 +305,10 @@ class ProgrammingExpression < ApplicationRecord
     i18n_params = I18n.t(
       :palette_params,
       scope: expression_scope,
-      default: palette_params,
+      default: nil,
       smart: true
     )
-    if i18n_params != localized_params
+    unless i18n_params.nil?
       localized_params&.each do |param|
         param_key = param['name'].to_sym
         unless i18n_params[param_key].nil?


### PR DESCRIPTION
In PR #49395 I added a method to localize the parameters in programming expressions.

In that implementation, I assumed the default value returned when the I18n API did not find any localized content, was the same as the original content (an Array of Hashes).

However, after a [regression in the content](https://codedotorg.slack.com/archives/C0T0PNTM3/p1712964952362009?thread_ts=1712934698.712219&cid=C0T0PNTM3), we analyzed more in-depth what the `I18n.t` method was returning and found out only the first element of the array was return when defaulting.

```
palette_params: [{"name"=>"[id]", "type"=>"string", "required"=>true, "description"=>"The unique identifier for the canvas screen element. The id is used for referencing the canvas functions or other UI element modification functions. Must begin with a letter, contain no spaces, and may contain letters, digits, - and _."}, {"name"=>"[width]", "type"=>"number", "description"=>"The horizontal width in pixels of the canvas. If not specified the app window width is used."}, {"name"=>"[height]", "type"=>"number", "description"=>"The vertical height in pixels of the canvas. If not specified the app window height is used."}]

i18n_params: {"name"=>"[id]", "type"=>"string", "required"=>true, "description"=>"The unique identifier for the canvas screen element. The id is used for referencing the canvas functions or other UI element modification functions. Must begin with a letter, contain no spaces, and may contain letters, digits, - and _."}
```

Instead, I decided to return `Nil Value` by default (when no localized content is found) and then, when the localized content is not `Nil`, merge the localized parameters with the non-localized ones.

Localized params look like this: `{:"[height]"=>{:type=>"número"}, :"[width]"=>{:type=>"número"}}`


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
