### PR TITLE
Add method to destroy a MailJet contact

### DIFF
--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -99,27 +99,6 @@ module MailJet
     end
   end
 
-  def self.delete_contact(email)
-    return unless enabled?
-
-    Mailjet.configure do |config|
-      config.api_key = API_KEY
-      config.secret_key = SECRET_KEY
-      config.api_version = "v3"
-    end
-
-    contact = Mailjet::Contact.find(email)
-    return unless contact
-
-    delete_uri = URI.parse("https://api.mailjet.com/v4/contacts/#{contact.id}")
-    delete_http_request = Net::HTTP::Delete.new(delete_uri)
-    delete_http_request.basic_auth(API_KEY, SECRET_KEY)
-
-    Net::HTTP.start(delete_uri.hostname, delete_uri.port, use_ssl: true) do |http|
-      http.request(delete_http_request)
-    end
-  end
-
   def self.send_template_email(to_email, to_name, email_config)
     return unless enabled?
 

--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -78,6 +78,48 @@ module MailJet
     )
   end
 
+  def self.delete_contact(email)
+    return unless enabled?
+
+    Mailjet.configure do |config|
+      config.api_key = API_KEY
+      config.secret_key = SECRET_KEY
+      config.api_version = "v3"
+    end
+
+    contact = Mailjet::Contact.find(email)
+    return unless contact
+
+    delete_uri = URI.parse("https://api.mailjet.com/v4/contacts/#{contact.id}")
+    delete_http_request = Net::HTTP::Delete.new(delete_uri)
+    delete_http_request.basic_auth(API_KEY, SECRET_KEY)
+
+    Net::HTTP.start(delete_uri.hostname, delete_uri.port, use_ssl: true) do |http|
+      http.request(delete_http_request)
+    end
+  end
+
+  def self.delete_contact(email)
+    return unless enabled?
+
+    Mailjet.configure do |config|
+      config.api_key = API_KEY
+      config.secret_key = SECRET_KEY
+      config.api_version = "v3"
+    end
+
+    contact = Mailjet::Contact.find(email)
+    return unless contact
+
+    delete_uri = URI.parse("https://api.mailjet.com/v4/contacts/#{contact.id}")
+    delete_http_request = Net::HTTP::Delete.new(delete_uri)
+    delete_http_request.basic_auth(API_KEY, SECRET_KEY)
+
+    Net::HTTP.start(delete_uri.hostname, delete_uri.port, use_ssl: true) do |http|
+      http.request(delete_http_request)
+    end
+  end
+
   def self.send_template_email(to_email, to_name, email_config)
     return unless enabled?
 

--- a/lib/test/cdo/test_mailjet.rb
+++ b/lib/test/cdo/test_mailjet.rb
@@ -7,7 +7,7 @@ class MailJetTest < Minitest::Test
   end
 
   def test_create_contact
-    email = 'fake.email@email.com'
+    email = 'fake.email@test.xx'
     name = 'Fake Name'
 
     Mailjet::Contact.expects(:create).with(is_excluded_from_campaigns: true, email: email, name: name)
@@ -22,7 +22,7 @@ class MailJetTest < Minitest::Test
   end
 
   def test_create_contact_with_existing_contact
-    email = 'fake.email@email.com'
+    email = 'fake.email@test.xx'
     name = 'Fake Name'
 
     mock_existing_contact = mock('Mailjet::Contactdata')
@@ -38,7 +38,7 @@ class MailJetTest < Minitest::Test
   end
 
   def test_send_template_email
-    to_email = 'fake.email@email.com'
+    to_email = 'fake.email@test.xx'
     to_name = 'Fake Name'
     from_address = 'test@code.org'
     from_name = 'Test Name'
@@ -66,5 +66,32 @@ class MailJetTest < Minitest::Test
     end
 
     MailJet.send_template_email(to_email, to_name, email_config)
+  end
+
+  def test_deletes_contact
+    email = 'fake.email@test.xx'
+
+    mock_contact = mock('Mailjet::Contact')
+    mock_contact.stubs(:id).returns(123)
+    Mailjet::Contact.expects(:find).with(email).returns(mock_contact)
+
+    mock_http_request = mock('Net::HTTP::Delete')
+    Net::HTTP::Delete.expects(:new).with(URI.parse("https://api.mailjet.com/v4/contacts/#{mock_contact.id}")).returns(mock_http_request)
+    mock_http_request.expects(:basic_auth).once
+
+    Net::HTTP.any_instance.expects(:request).with(mock_http_request)
+
+    MailJet.delete_contact(email)
+  end
+
+  def test_deletes_handles_nonexistent_contact
+    email = 'fake.email@test.xx'
+
+    Mailjet::Contact.expects(:find).with(email).returns(nil)
+
+    Net::HTTP::Delete.expects(:new).never
+    Net::HTTP.any_instance.expects(:request).never
+
+    MailJet.delete_contact(email)
   end
 end


### PR DESCRIPTION
Adds a method to destroy a MailJet contact. In a follow-up, I'll call this as part of the account purger.

Note that, for some reason, the API to delete a contact is only [available through cURL](https://dev.mailjet.com/email/guides/contact-management/#gdpr-delete-contacts). 