### PR TITLE
fix(lms): url encode for iframe passthrough

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -224,10 +224,14 @@ class LtiV1Controller < ApplicationController
   # open in new tab. The experience is unchanged to non-iframe users.
   def iframe
     auth_url_base = CDO.studio_url('/lti/v1/authenticate', CDO.default_scheme)
-    id_token_param = params[:id_token]
-    state_param = params[:state]
-    new_tab_param = 'new_tab=true'
-    @auth_url = "#{auth_url_base}?id_token=#{id_token_param}&state=#{state_param}&#{new_tab_param}"
+
+    query_params = {
+      id_token: ERB::Util.url_encode(params[:id_token]),
+      state: ERB::Util.url_encode(params[:state]),
+      new_tab: ERB::Util.url_encode("true"),
+    }
+
+    @auth_url = "#{auth_url_base}?#{query_params.to_query}"
     render 'lti/v1/iframe', layout: false
   end
 


### PR DESCRIPTION
This change URL encodes the `state` and `nonce` parameters. Since these parameters are used for redirects or window opens, the encoding is appropriate to ensure the values are passed through to the next page correctly.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. Ran adhoc schoology instance
2. Tested launching schoology to Code.org

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
