### PR TITLE
Pass lmsName to sync dialog via button

### DIFF
--- a/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
+++ b/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
@@ -171,6 +171,7 @@ class SyncOmniAuthSectionControl extends React.Component {
             isOpen={isLtiDialogOpen}
             syncResult={ltiSyncResult}
             onClose={this.onLtiDialogClose}
+            lmsName={sectionProviderName}
           />
         )}
         <BaseDialog


### PR DESCRIPTION
During the LMS sync meeting, we ran into an issue where the sync dialog wouldn't close after using the sync button from the Manage Students tab, if the sync result was empty. This was because the required `lmsName` prop was not being passed into the `LtiSectionSyncDialog` component from the `SyncOmniAuthSectionControl` component

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-875)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
