### PR TITLE
Restrict aichat controller to pilot

### DIFF
--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -7,7 +7,9 @@ class AichatController < ApplicationController
   # chatContext: {userId: number; currentLevelId: string; scriptId: number; channelId: string;}
   # POST /aichat/chat_completion
   def chat_completion
-    params.require([:newMessage, :storedMessages, :aichatParameters, :chatContext])
+    unless has_required_params?
+      return render status: :bad_request, json: {}
+    end
 
     # Check for PII / Profanity
     # Copied from ai_tutor_interactions_controller.rb - not sure if filtering is working.
@@ -29,5 +31,14 @@ class AichatController < ApplicationController
     response_body = {role: "assistant", content: "This is an assistant response from Sagemaker"}
     response_code = 200
     return {status: response_code, json: response_body}
+  end
+
+  private def has_required_params?
+    begin
+      params.require([:newMessage, :storedMessages, :aichatParameters, :chatContext])
+    rescue ActionController::ParameterMissing
+      return false
+    end
+    true
   end
 end

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -1,4 +1,5 @@
 class AichatController < ApplicationController
+  authorize_resource class: false
   # params are
   # newMessage: string
   # storedMessages: Array of {role: <'user', 'system', or 'assistant'>; content: string} - does not include user's new message

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -466,8 +466,8 @@ class Ability
       end
 
       if user.has_pilot_experiment?(GENAI_PILOT) ||
-        (!user.teachers.empty? && 
-        user.teachers.any? {|teacher| teacher.has_pilot_experiment?(GENAI_PILOT)})
+          (!user.teachers.empty? &&
+          user.teachers.any? {|teacher| teacher.has_pilot_experiment?(GENAI_PILOT)})
         can :chat_completion, :aichat
       end
     end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -2,8 +2,7 @@ class Ability
   include CanCan::Ability
   include Pd::Application::ActiveApplicationModels
 
-  CSA_PILOT = 'csa-pilot'
-  CSA_PILOT_FACILITATORS = 'csa-pilot-facilitators'
+  GENAI_PILOT = 'genai-pilot'
 
   # Define abilities for the passed in user here. For more information, see the
   # wiki at https://github.com/ryanb/cancan/wiki/Defining-Abilities.
@@ -464,6 +463,12 @@ class Ability
 
       can :use_unrestricted_javabuilder, :javabuilder_session do
         user.verified_instructor? || user.sections_as_student.any? {|s| s.assigned_csa? && s.teacher&.verified_instructor?}
+      end
+
+      if user.has_pilot_experiment?(GENAI_PILOT) ||
+        (!user.teachers.empty? && 
+        user.teachers.any? {|teacher| teacher.has_pilot_experiment?(GENAI_PILOT)})
+        can :chat_completion, :aichat
       end
     end
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -2,7 +2,7 @@ class Ability
   include CanCan::Ability
   include Pd::Application::ActiveApplicationModels
 
-  GENAI_PILOT = 'genai-pilot'
+  GENAI_PILOT = 'gen-ai-customizing-llms'
 
   # Define abilities for the passed in user here. For more information, see the
   # wiki at https://github.com/ryanb/cancan/wiki/Defining-Abilities.

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class AichatControllerTest < ActionController::TestCase
-  self.use_transactional_test_case = true
   GENAI_PILOT = "gen-ai-customizing-llms"
 
   setup_all do
@@ -20,6 +19,10 @@ class AichatControllerTest < ActionController::TestCase
     @valid_params = @common_params.merge(newMessage: valid_message)
     @pii_violation_params = @common_params.merge(newMessage: pii_violation_message)
     @profanity_violation_params = @common_params.merge(newMessage: profanity_violation_message)
+  end
+
+  teardown_all do
+    @genai_pilot.delete
   end
 
   test_user_gets_response_for :chat_completion,

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -9,7 +9,6 @@ class AichatControllerTest < ActionController::TestCase
     @pilot_teacher = create :teacher, pilot_experiment: GENAI_PILOT
     @section = create(:section, user: @pilot_teacher)
     @pilot_student = create(:follower, section: @section).student_user
-    ShareFiltering.stubs(:find_failure).returns(nil)
     @params = {
       storedMessages: [{role: "user", content: "this is a test!"}],
       aichatParameters: {temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test"},

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class AichatControllerTest < ActionController::TestCase
+  self.use_transactional_test_case = true
   GENAI_PILOT = "gen-ai-customizing-llms"
 
   setup_all do
@@ -19,10 +20,6 @@ class AichatControllerTest < ActionController::TestCase
     @valid_params = @common_params.merge(newMessage: valid_message)
     @pii_violation_params = @common_params.merge(newMessage: pii_violation_message)
     @profanity_violation_params = @common_params.merge(newMessage: profanity_violation_message)
-  end
-
-  teardown_all do
-    @genai_pilot.delete
   end
 
   test_user_gets_response_for :chat_completion,

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class AichatControllerTest < ActionController::TestCase
-  GENAI_PILOT = "genai-pilot"
+  GENAI_PILOT = "gen-ai-customizing-llms"
 
   setup_all do
     @genai_pilot = create :pilot

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -4,12 +4,12 @@ class AichatControllerTest < ActionController::TestCase
   GENAI_PILOT = "gen-ai-customizing-llms"
 
   setup_all do
-    @genai_pilot = create :pilot
-    @genai_pilot.name = GENAI_PILOT
-    @pilot_teacher = create :teacher, pilot_experiment: GENAI_PILOT
-    @section = create(:section, user: @pilot_teacher)
-    @pilot_student = create(:follower, section: @section).student_user
-    @params = {
+    genai_pilot = create :pilot
+    genai_pilot.name = GENAI_PILOT
+    @genai_pilot_teacher = create :teacher, pilot_experiment: GENAI_PILOT
+    pilot_section = create(:section, user: @genai_pilot_teacher)
+    @genai_pilot_student = create(:follower, section: pilot_section).student_user
+    @common_params = {
       storedMessages: [{role: "user", content: "this is a test!"}],
       aichatParameters: {temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test"},
       chatContext: {userId: 1, currentLevelId: "test", scriptId: 1, channelId: "test"}
@@ -17,9 +17,9 @@ class AichatControllerTest < ActionController::TestCase
     valid_message = "hello"
     pii_violation_message = "my email is l.lovepadel@sports.edu"
     profanity_violation_message = "Damn you, robot"
-    @valid_params = @params.merge(newMessage: valid_message)
-    @pii_violation_params = @params.merge(newMessage: pii_violation_message)
-    @profanity_violation_params = @params.merge(newMessage: profanity_violation_message)
+    @valid_params = @common_params.merge(newMessage: valid_message)
+    @pii_violation_params = @common_params.merge(newMessage: pii_violation_message)
+    @profanity_violation_params = @common_params.merge(newMessage: profanity_violation_message)
   end
 
   test_user_gets_response_for :chat_completion,
@@ -35,26 +35,26 @@ class AichatControllerTest < ActionController::TestCase
     response: :forbidden
 
   test 'pilot teacher has access test' do
-    sign_in(@pilot_teacher)
+    sign_in(@genai_pilot_teacher)
     post :chat_completion, params: @valid_params
     assert_response :success
   end
 
   test 'pilot student has access test' do
-    sign_in(@pilot_student)
+    sign_in(@genai_pilot_student)
     post :chat_completion, params: @valid_params
     assert_response :success
   end
 
   test 'Bad request if required params are not included' do
-    sign_in(@pilot_teacher)
+    sign_in(@genai_pilot_teacher)
     post :chat_completion, params: {newMessage: "hello"}
     assert_response :bad_request
   end
 
   # Post request with a profane messages param returns a failure
   test 'returns failure when chat message contains profanity' do
-    sign_in(@pilot_student)
+    sign_in(@genai_pilot_student)
     ShareFiltering.stubs(:find_failure).returns(ShareFailure.new(ShareFiltering::FailureType::PROFANITY, 'damn'))
     post :chat_completion, params: @profanity_violation_params
     assert_equal json_response["status"], ShareFiltering::FailureType::PROFANITY
@@ -63,7 +63,7 @@ class AichatControllerTest < ActionController::TestCase
 
   # Post request with a messages param containing PII returns a failure
   test 'returns failure when chat message contains PII' do
-    sign_in(@pilot_student)
+    sign_in(@genai_pilot_student)
     ShareFiltering.stubs(:find_failure).returns(ShareFailure.new(ShareFiltering::FailureType::EMAIL, 'l.lovepadel@sports.edu'))
     post :chat_completion, params: @pii_violation_params
     assert_equal json_response["status"], ShareFiltering::FailureType::EMAIL

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -4,8 +4,6 @@ class AichatControllerTest < ActionController::TestCase
   GENAI_PILOT = "gen-ai-customizing-llms"
 
   setup_all do
-    @genai_pilot = create :pilot
-    @genai_pilot.name = GENAI_PILOT
     @genai_pilot_teacher = create :teacher, pilot_experiment: GENAI_PILOT
     pilot_section = create(:section, user: @genai_pilot_teacher)
     @genai_pilot_student = create(:follower, section: pilot_section).student_user
@@ -20,12 +18,6 @@ class AichatControllerTest < ActionController::TestCase
     @valid_params = @common_params.merge(newMessage: valid_message)
     @pii_violation_params = @common_params.merge(newMessage: pii_violation_message)
     @profanity_violation_params = @common_params.merge(newMessage: profanity_violation_message)
-  end
-
-  teardown_all do
-    @genai_pilot_student.delete
-    @genai_pilot_teacher.delete
-    @genai_pilot.delete
   end
 
   test_user_gets_response_for :chat_completion,

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -4,8 +4,8 @@ class AichatControllerTest < ActionController::TestCase
   GENAI_PILOT = "gen-ai-customizing-llms"
 
   setup_all do
-    genai_pilot = create :pilot
-    genai_pilot.name = GENAI_PILOT
+    @genai_pilot = create :pilot
+    @genai_pilot.name = GENAI_PILOT
     @genai_pilot_teacher = create :teacher, pilot_experiment: GENAI_PILOT
     pilot_section = create(:section, user: @genai_pilot_teacher)
     @genai_pilot_student = create(:follower, section: pilot_section).student_user
@@ -20,6 +20,12 @@ class AichatControllerTest < ActionController::TestCase
     @valid_params = @common_params.merge(newMessage: valid_message)
     @pii_violation_params = @common_params.merge(newMessage: pii_violation_message)
     @profanity_violation_params = @common_params.merge(newMessage: profanity_violation_message)
+  end
+
+  teardown_all do
+    @genai_pilot_student.delete
+    @genai_pilot_teacher.delete
+    @genai_pilot.delete
   end
 
   test_user_gets_response_for :chat_completion,

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -1,10 +1,12 @@
 require 'test_helper'
 
 class AichatControllerTest < ActionController::TestCase
+  self.use_transactional_test_case = true
   GENAI_PILOT = "gen-ai-customizing-llms"
 
   setup_all do
-    @genai_pilot_teacher = create :teacher, pilot_experiment: GENAI_PILOT
+    @genai_pilot = create :pilot, name: GENAI_PILOT
+    @genai_pilot_teacher = create :teacher, pilot_experiment: @genai_pilot.name
     pilot_section = create(:section, user: @genai_pilot_teacher)
     @genai_pilot_student = create(:follower, section: pilot_section).student_user
     @common_params = {

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -4,10 +4,11 @@ class AichatControllerTest < ActionController::TestCase
   GENAI_PILOT = "genai-pilot"
 
   setup_all do
-    @teacher = create :teacher
     @genai_pilot = create :pilot
     @genai_pilot.name = GENAI_PILOT
     @pilot_teacher = create :teacher, pilot_experiment: GENAI_PILOT
+    @section = create(:section, user: @pilot_teacher)
+    @pilot_student = create(:follower, section: @section).student_user
   end
 
   test_user_gets_response_for :chat_completion,
@@ -15,6 +16,7 @@ class AichatControllerTest < ActionController::TestCase
     user: :student,
     method: :post,
     response: :forbidden
+
   test_user_gets_response_for :chat_completion,
     name: "teacher_no_access_test",
     user: :teacher,
@@ -24,11 +26,22 @@ class AichatControllerTest < ActionController::TestCase
   test 'pilot teacher has access test' do
     sign_in(@pilot_teacher)
     post :chat_completion, params: {
-                newMessage: "hello",
-                storedMessages: [{role: "user", content: "this is a test!"}],
-                aichatParameters: {temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test"},
-                chatContext: {userId: 1, currentLevelId: "test", scriptId: 1, channelId: "test"}
-            }
+      newMessage: "hello",
+      storedMessages: [{role: "user", content: "this is a test!"}],
+      aichatParameters: {temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test"},
+      chatContext: {userId: 1, currentLevelId: "test", scriptId: 1, channelId: "test"}
+    }
+    assert_response :success
+  end
+
+  test 'pilot student has access test' do
+    sign_in(@pilot_student)
+    post :chat_completion, params: {
+      newMessage: "hello",
+      storedMessages: [{role: "user", content: "this is a test!"}],
+      aichatParameters: {temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test"},
+      chatContext: {userId: 1, currentLevelId: "test", scriptId: 1, channelId: "test"}
+    }
     assert_response :success
   end
 

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class AichatControllerTest < ActionController::TestCase
+  GENAI_PILOT = "genai-pilot"
+
+  setup_all do
+    @teacher = create :teacher
+    @genai_pilot = create :pilot
+    @genai_pilot.name = GENAI_PILOT
+    @pilot_teacher = create :teacher, pilot_experiment: GENAI_PILOT
+  end
+
+  test_user_gets_response_for :chat_completion,
+    name: "student_no_access_test",
+    user: :student,
+    method: :post,
+    response: :forbidden
+  test_user_gets_response_for :chat_completion,
+    name: "teacher_no_access_test",
+    user: :teacher,
+    method: :post,
+    response: :forbidden
+
+  test 'pilot teacher has access test' do
+    sign_in(@pilot_teacher)
+    post :chat_completion, params: {
+                newMessage: "hello",
+                storedMessages: [{role: "user", content: "this is a test!"}],
+                aichatParameters: {temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test"},
+                chatContext: {userId: 1, currentLevelId: "test", scriptId: 1, channelId: "test"}
+            }
+    assert_response :success
+  end
+
+  test 'Bad request if required params are not included' do
+    sign_in(@pilot_teacher)
+    post :chat_completion, params: {newMessage: "hello"}
+    assert_response :bad_request
+  end
+end

--- a/dashboard/test/controllers/experiments_controller_test.rb
+++ b/dashboard/test/controllers/experiments_controller_test.rb
@@ -4,6 +4,9 @@ class ExperimentsControllerTest < ActionController::TestCase
   setup_all do
     @pilot = create :pilot, allow_joining_via_url: true
     @pilot_name = @pilot.name
+  end
+
+  setup do
     @teacher = create :teacher
     unit_group = create :unit_group, name: 'my-course'
     default_script = create(:script, name: 'default-script')

--- a/dashboard/test/controllers/experiments_controller_test.rb
+++ b/dashboard/test/controllers/experiments_controller_test.rb
@@ -4,9 +4,6 @@ class ExperimentsControllerTest < ActionController::TestCase
   setup_all do
     @pilot = create :pilot, allow_joining_via_url: true
     @pilot_name = @pilot.name
-  end
-
-  setup do
     @teacher = create :teacher
     unit_group = create :unit_group, name: 'my-course'
     default_script = create(:script, name: 'default-script')


### PR DESCRIPTION

This PR restricts the access to `chat_completion` of `aichat_controller` to users in the `SingleUserExperiment` with pilot name`gen-ai-customizing-llm` and students of teachers in the pilot.

Note that I added `has_required_params` to `aichiat_controller` so that a `bad_request` response would be returned to the client instead of just erroring out. I also included dashboard unit tests.

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
