### PR TITLE
chore(ejs): enable ejs javascript strict mode to remove `with` syntax

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -85,7 +85,7 @@
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.2.0",
     "dedent": "^1.5.1",
-    "ejs": "^2.6.1",
+    "ejs": "^3.1.10",
     "ejs-webpack-loader": "^2.2.2",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.15.6",

--- a/apps/src/blockTooltips/DropletParameterTooltip.html.ejs
+++ b/apps/src/blockTooltips/DropletParameterTooltip.html.ejs
@@ -1,4 +1,18 @@
 <% var i18n = require('@cdo/locale'); %>
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var funcName = locals.funcName;
+var functionName = locals.functionName;
+var isProperty = locals.isProperty;
+var tipPrefix = locals.tipPrefix;
+var functionShortDescription = locals.functionShortDescription;
+var parameters = locals.parameters;
+var signatureOverride = locals.signatureOverride;
+var showExamplesLink = locals.showExamplesLink;
+var currentParameterIndex = locals.currentParameterIndex;
+%>
 <div class="function-name">
   <% if (signatureOverride) { -%>
     <%= signatureOverride %>

--- a/apps/src/craft/code-connection/dialogs/connectToCodeConnection.html.ejs
+++ b/apps/src/craft/code-connection/dialogs/connectToCodeConnection.html.ejs
@@ -1,4 +1,10 @@
 <% var i18n = require('../../locale'); %>
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var image = locals.image;
+%>
 <h1 class="minecraft-big-yellow-header" id="getting-started-header"><%= i18n.minecraftNotConnected() %></h1>
 
 <h2 id="download-text"><%= i18n.connectToCodeConnection() %></h2>

--- a/apps/src/craft/code-connection/dialogs/errorMessage.html.ejs
+++ b/apps/src/craft/code-connection/dialogs/errorMessage.html.ejs
@@ -1,3 +1,10 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var title = locals.title;
+var message = locals.message;
+%>
 <h1 class="minecraft-big-yellow-header" id="error-message"><%= title %></h1>
 
 <h2><%= message %></h2>

--- a/apps/src/craft/simple/dialogs/houseSelection.html.ejs
+++ b/apps/src/craft/simple/dialogs/houseSelection.html.ejs
@@ -1,4 +1,10 @@
 <% var i18n = require('../../locale'); %>
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var image = locals.image;
+%>
 <h1 class="minecraft-big-yellow-header" id="getting-started-header"><%= i18n.houseSelectLetsBuild() %></h1>
 
 <h2 id="select-house-text"><%= i18n.houseSelectChooseFloorPlan() %></h2>

--- a/apps/src/maze/karelStartBlocks.xml.ejs
+++ b/apps/src/maze/karelStartBlocks.xml.ejs
@@ -3,6 +3,12 @@
 var msg = require('./locale');
 
 /**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var page = locals.page;
+var level = locals.level;
+
+/**
  * Template to create function for filling in shovels.
  */
 var fillShovelfuls = function(n) { -%>

--- a/apps/src/maze/startBlocks.xml.ejs
+++ b/apps/src/maze/startBlocks.xml.ejs
@@ -1,3 +1,10 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var level = locals.level;
+var page = locals.page;
+%>
 <% if (page === 2) { -%>
   <% if (level < 4) { -%>
     <block type="maze_moveForward" x="70" y="70"></block>

--- a/apps/src/maze/toolboxes/karel1.xml.ejs
+++ b/apps/src/maze/toolboxes/karel1.xml.ejs
@@ -1,3 +1,9 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var level = locals.level;
+%>
 <xml id="toolbox" style="display: none;">
   <block type="maze_moveForward"></block>
   <block type="maze_turn"><title name="DIR">turnLeft</title></block>

--- a/apps/src/maze/toolboxes/karel2.xml.ejs
+++ b/apps/src/maze/toolboxes/karel2.xml.ejs
@@ -3,6 +3,11 @@
 var commonMsg = require('@cdo/locale');
 var mazeMsg = require('.././locale');
 
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var level = locals.level;
+
 var addProcedures = function() { -%>
   <% if (level > 3) { -%>
     <category name="<%= commonMsg.catProcedures() %>" custom="PROCEDURE"></category>

--- a/apps/src/maze/toolboxes/karel3.xml.ejs
+++ b/apps/src/maze/toolboxes/karel3.xml.ejs
@@ -3,6 +3,11 @@
 var msg = require('@cdo/locale');
 
 /**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var level = locals.level;
+
+/**
  * Add the procedures category to the toolbox.
  */
 var addProcedures = function() { -%>

--- a/apps/src/maze/toolboxes/maze.xml.ejs
+++ b/apps/src/maze/toolboxes/maze.xml.ejs
@@ -1,3 +1,10 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var level = locals.level;
+var page = locals.page;
+%>
 <xml id="toolbox" style="display: none;">
   <block type="maze_moveForward"></block>
   <block type="maze_turn"><title name="DIR">turnLeft</title></block>

--- a/apps/src/netsim/NetSimAlert.html.ejs
+++ b/apps/src/netsim/NetSimAlert.html.ejs
@@ -14,6 +14,14 @@
    * @type {string}
    */
 %>
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var flavor = locals.flavor;
+var body = locals.body;
+var title = locals.title;
+%>
 <div class="alert netsim-alert <%= flavor %> fade in">
   <button type="button" class="netsim-alert-button close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
   <% if (title) { %><strong><%= title %></strong><% } %>

--- a/apps/src/netsim/NetSimBitLogPanel.html.ejs
+++ b/apps/src/netsim/NetSimBitLogPanel.html.ejs
@@ -1,4 +1,14 @@
 <%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+  var functionName = locals.functionName;
+  var binary = locals.binary;
+  var enabledEncodings = locals.enabledEncodings;
+  var chunkSize = locals.chunkSize;
+  var showReadWireButton = locals.showReadWireButton;
+%>
+<%
   var i18n = require('@cdo/netsim/locale');
   var NetSimConstants = require('./NetSimConstants');
   var DataConverters = require('./DataConverters');

--- a/apps/src/netsim/NetSimDnsTable.html.ejs
+++ b/apps/src/netsim/NetSimDnsTable.html.ejs
@@ -1,6 +1,13 @@
 <%
 var DnsMode = require('./NetSimConstants').DnsMode;
 %>
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var dnsMode = locals.dnsMode;
+var tableData = locals.tableData;
+%>
 <div class="netsim-dns-table">
   <h1>My Network</h1>
   <table>

--- a/apps/src/netsim/NetSimMetronome.html.ejs
+++ b/apps/src/netsim/NetSimMetronome.html.ejs
@@ -1,4 +1,11 @@
 <%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var progress = locals.progress;
+var pulseAge = locals.pulseAge;
+%>
+<%
   function moveCommand(x, y) {
     return 'M' + x + ' ' + y;
   }

--- a/apps/src/netsim/NetSimPanel.html.ejs
+++ b/apps/src/netsim/NetSimPanel.html.ejs
@@ -1,3 +1,12 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var instanceID = locals.instanceID;
+var className = locals.className;
+var panelTitle = locals.panelTitle;
+var userToggleable = locals.userToggleable;
+%>
 <div id="netsim-panel-<%= instanceID %>"
      class="netsim-panel <%= className %>">
   <h1>

--- a/apps/src/netsim/NetSimRemoteNodeSelectionPanel.html.ejs
+++ b/apps/src/netsim/NetSimRemoteNodeSelectionPanel.html.ejs
@@ -5,6 +5,16 @@ var i18n = require('@cdo/netsim/locale');
 var NetSimGlobals = require('./NetSimGlobals');
 var NodeType = require('./NetSimConstants').NodeType;
 
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var controller = locals.controller;
+var shardDisplayName = locals.shardDisplayName;
+var nodesOnShard = locals.nodesOnShard;
+var incomingConnectionNodes = locals.incomingConnectionNodes;
+var remoteNode = locals.remoteNode;
+var canSeeTeacherLog = locals.canSeeTeacherLog;
+
 /** @type {function} */
 var getAssetUrl = NetSimGlobals.getAssetUrlFunction();
 

--- a/apps/src/netsim/NetSimRouterStatsTable.html.ejs
+++ b/apps/src/netsim/NetSimRouterStatsTable.html.ejs
@@ -3,6 +3,20 @@
   var NetSimUtils = require('./NetSimUtils');
 
   /**
+  * This block destructures the local variables for use within this ejs template.
+  */
+  var uptime = locals.uptime;
+  var queuedPackets = locals.queuedPackets;
+  var totalPackets = locals.totalPackets;
+  var successfulPackets = locals.successfulPackets;
+  var totalData = locals.totalData;
+  var successfulData = locals.successfulData;
+  var bandwidthLimit = locals.bandwidthLimit;
+  var dataRate = locals.dataRate;
+  var totalMemory = locals.totalMemory;
+  var usedMemory = locals.usedMemory;
+
+  /**
    * Write a stats row with the given title and value.
    * @param {string} title - localized name of the statistic (the header column contents)
    * @param {*} statValue - the value of the statistic

--- a/apps/src/netsim/NetSimShardSelectionPanel.html.ejs
+++ b/apps/src/netsim/NetSimShardSelectionPanel.html.ejs
@@ -1,6 +1,15 @@
 <%
   var i18n = require('@cdo/netsim/locale');
 %>
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var displayName = locals.displayName;
+var selectedShardID = locals.selectedShardID;
+var shardChoices = locals.shardChoices;
+var SELECTOR_NONE_VALUE = locals.SELECTOR_NONE_VALUE;
+%>
 <div class="content-wrap">
   <div class="field-box display-name-control">
     <label for="netsim-lobby-name"><%= i18n.myName() %></label>

--- a/apps/src/netsim/NetSimSlider.html.ejs
+++ b/apps/src/netsim/NetSimSlider.html.ejs
@@ -1,3 +1,11 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var instanceID = locals.instanceID;
+var minValue = locals.minValue;
+var maxValue = locals.maxValue;
+%>
 <div id="netsim_slider_<%= instanceID %>" class="netsim-slider">
   <div class="slider-inline-wrap">
     <div class="slider"></div>

--- a/apps/src/netsim/NetSimStatusPanel.html.ejs
+++ b/apps/src/netsim/NetSimStatusPanel.html.ejs
@@ -1,6 +1,14 @@
 <%
 var i18n = require('@cdo/netsim/locale');
 %>
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var myHostname = locals.myHostname;
+var myAddress = locals.myAddress;
+var shareLink = locals.shareLink;
+%>
 <div class="content-wrap">
   <% if (myHostname) { %>
   <p>My hostname: <%= myHostname %></p>

--- a/apps/src/netsim/NetSimTabsComponent.html.ejs
+++ b/apps/src/netsim/NetSimTabsComponent.html.ejs
@@ -4,6 +4,11 @@
   var shouldShowTab = require('./NetSimUtils').shouldShowTab;
   var NetSimTabType = require('./NetSimConstants').NetSimTabType;
 
+  /**
+   * This block destructures the local variables for use within this ejs template.
+   */
+  var level = locals.level;
+
   var showInstructions = shouldShowTab(level, NetSimTabType.INSTRUCTIONS);
   var showMyDevice = shouldShowTab(level, NetSimTabType.MY_DEVICE);
   var showRouter = shouldShowTab(level, NetSimTabType.ROUTER);

--- a/apps/src/netsim/NetSimVisualization.html.ejs
+++ b/apps/src/netsim/NetSimVisualization.html.ejs
@@ -5,6 +5,12 @@
  * @type {boolean}
  */
 %>
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var showBackground = locals.showBackground;
+%>
 <svg version="1.1" width="298" height="298" xmlns="http://www.w3.org/2000/svg">
 
   <% if (showBackground) { %>

--- a/apps/src/netsim/page.html.ejs
+++ b/apps/src/netsim/page.html.ejs
@@ -1,3 +1,9 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var data = locals.data;
+%>
 <% var instructions = function() { -%>
   <div id="bubble" class="clearfix netsim-bubble">
     <table id="prompt-table">

--- a/apps/src/templates/export/fontAwesome.css.ejs
+++ b/apps/src/templates/export/fontAwesome.css.ejs
@@ -1,3 +1,13 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var fontBrandsPath = locals.fontBrandsPath;
+var fontSolidPath = locals.fontSolidPath;
+var fontRegularPath = locals.fontRegularPath;
+var fontV4CompatibilityPath = locals.fontV4CompatibilityPath;
+%>
+
 @font-face {
   font-family: 'FontAwesome';
   font-display: block;

--- a/apps/src/templates/export/gamelabCode.js.ejs
+++ b/apps/src/templates/export/gamelabCode.js.ejs
@@ -1,3 +1,12 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var code = locals.code;
+var animationOpts = locals.animationOpts;
+var animationListJSON = locals.animationListJSON;
+%>
+
 var p5Inst = new p5(null, 'sketch');
 
 window.preload = function () {

--- a/apps/src/templates/export/gamelabIndex.html.ejs
+++ b/apps/src/templates/export/gamelabIndex.html.ejs
@@ -1,3 +1,20 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var appName = locals.appName;
+var appHeight = locals.appHeight;
+var appWidth = locals.appWidth;
+var jQueryPath = locals.jQueryPath;
+var gamelabApiPath = locals.gamelabApiPath;
+var gamelabCssPath = locals.gamelabCssPath;
+var p5Path = locals.p5Path;
+var p5playPath = locals.p5playPath;
+var codePath = locals.codePath;
+var webExport = locals.webExport;
+var exportClass = locals.exportClass;
+var webpackRuntimePath = locals.webpackRuntimePath;
+%>
 <html>
   <head>
     <title><%- appName %></title>

--- a/apps/src/templates/export/project.html.ejs
+++ b/apps/src/templates/export/project.html.ejs
@@ -1,3 +1,15 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var appName = locals.appName;
+var exportConfigPath = locals.exportConfigPath;
+var htmlBody = locals.htmlBody;
+var faBrandsPath = locals.faBrandsPath;
+var faSolidPath = locals.faSolidPath;
+var faRegularPath = locals.faRegularPath;
+var faV4CompatibilityPath = locals.faV4CompatibilityPath;
+%>
 <html>
   <head>
     <title><%- appName %></title>

--- a/apps/src/templates/export/projectReadme.md.ejs
+++ b/apps/src/templates/export/projectReadme.md.ejs
@@ -1,3 +1,9 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var appName = locals.appName;
+%>
 # README for <%- appName %> #
 
 This is the README file for the <%- appName %> app. It's a great place to write

--- a/apps/src/templates/learn.html.ejs
+++ b/apps/src/templates/learn.html.ejs
@@ -1,4 +1,10 @@
 <% var msg = require('@cdo/locale') %>
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var assetUrl = locals.assetUrl;
+%>
 
 <% var root = location.protocol + '//' + location.host.replace('learn\.', '').replace('studio\.', ''); %>
 

--- a/apps/src/templates/makeYourOwn.html.ejs
+++ b/apps/src/templates/makeYourOwn.html.ejs
@@ -1,4 +1,10 @@
 <% var msg = require('@cdo/locale') %>
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var data = locals.data;
+%>
 
 <div id="make-your-own">
 

--- a/apps/src/templates/puzzleRating.html.ejs
+++ b/apps/src/templates/puzzleRating.html.ejs
@@ -1,3 +1,9 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var label = locals.label;
+%>
 <hr>
 <p><%= label %></p>
 

--- a/apps/src/templates/shareFailure.html.ejs
+++ b/apps/src/templates/shareFailure.html.ejs
@@ -1,3 +1,9 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var shareFailure = locals.shareFailure;
+%>
 <p id="share-fail-explanation"><%= shareFailure.message %></p>
 
 <% if (shareFailure.contents) { %>

--- a/apps/src/templates/sharing.html.ejs
+++ b/apps/src/templates/sharing.html.ejs
@@ -1,3 +1,9 @@
+<%
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var options = locals.options;
+%>
 <% var msg = require('@cdo/locale'); %>
 <% if (options.feedbackImage) { %>
   <img class="feedback-image" src="<%= options.feedbackImage %>"/>

--- a/apps/src/turtle/startBlocks.xml.ejs
+++ b/apps/src/turtle/startBlocks.xml.ejs
@@ -3,6 +3,12 @@
 var msg = require('./locale');
 
 /**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var level = locals.level;
+var page = locals.page;
+
+/**
  * Common code for creating procedures drawing different regular polygons.
  * options:
  *   title Title of procedure.

--- a/apps/src/turtle/toolbox.xml.ejs
+++ b/apps/src/turtle/toolbox.xml.ejs
@@ -1,6 +1,13 @@
 <%
 
 var msg = require('./locale');
+
+/**
+ * This block destructures the local variables for use within this ejs template.
+ */
+var level = locals.level;
+var page = locals.page;
+
 // An early hack introduced some levelbuilder levels as page 5, level 7. Long
 // term we can probably do something much cleaner, but for now I'm calling
 // out that this level is special (on page 5).

--- a/apps/test/unit/empty-data.ejs
+++ b/apps/test/unit/empty-data.ejs
@@ -1,1 +1,1 @@
-<%- data.test %>
+<%- locals.data.test %>

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -224,6 +224,9 @@ const WEBPACK_BASE_CONFIG = {
         test: /\.ejs$/,
         include: [p('src'), p('test')],
         loader: 'ejs-webpack-loader',
+        options: {
+          strict: true,
+        },
       },
       {test: /\.css$/, use: [{loader: 'style-loader'}, {loader: 'css-loader'}]},
 

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8130,7 +8130,7 @@ __metadata:
     dapjs: ^2.3.0
     dedent: ^1.5.1
     details-element-polyfill: "https://github.com/javan/details-element-polyfill"
-    ejs: ^2.6.1
+    ejs: ^3.1.10
     ejs-webpack-loader: ^2.2.2
     enzyme: ^3.9.0
     enzyme-adapter-react-16: ^1.15.6
@@ -10992,10 +10992,21 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
-"ejs@npm:^2.0.0, ejs@npm:^2.6.1":
+"ejs@npm:^2.0.0":
   version: 2.6.1
   resolution: "ejs@npm:2.6.1"
   checksum: 7bf366d8690160a773519fdf985eff07d541a243c2facc9244705bb75a73812969aae29afd3d8ae22581284d0f3a8ad9db6f0599f252996adba9685a76945f67
+  languageName: node
+  linkType: hard
+
+"ejs@npm:^3.1.10":
+  version: 3.1.10
+  resolution: "ejs@npm:3.1.10"
+  dependencies:
+    jake: ^10.8.5
+  bin:
+    ejs: bin/cli.js
+  checksum: ce90637e9c7538663ae023b8a7a380b2ef7cc4096de70be85abf5a3b9641912dde65353211d05e24d56b1f242d71185c6d00e02cb8860701d571786d92c71f05
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Note: This change is required for the jest migration as jest enables strict mode during babel transpilation.

Currently, Code.org uses EJS to templatize files. EJS, by default, utilizes the `with` keyword which is deprecated and per MDN, "this feature may cease to work at any time.". To remove this keyword, the EJS strict mode option is enabled (`with` is prohibited in strict).

To replace the functionality previously provided by `with` (add variables within a given block scope), the variables are destructured from the `locals` variable (which is provided by EJS). In strict mode, variables are not scoped globally by default and therefore assigning the variables within the EJS strict mode provides the same functionality as `with` but with extra syntax needed to use an EJS template.

Previously, the code would be able to function:

```
<% hello %>
```

Now with strict mode enabled, the same code would need to become:

```
<% locals.hello %>
```

To avoid mistakes, a variable reassignment block was created to existing EJS files. This will enable the variables to continue to be used as if the with block was available.

To identify the locals, all EJS exported default functions were inspected, for example:

```
 return DropletFunctionTooltipMarkup({
    funcName: tooltipInfo.functionName,
    functionName: tooltipInfo.functionName,
    isProperty: tooltipInfo.isProperty,
    tipPrefix: tooltipInfo.tipPrefix,
    functionShortDescription: tooltipInfo.description,
    parameters: tooltipInfo.parameterInfos,
    signatureOverride: tooltipInfo.signatureOverride,
    showExamplesLink: this.showExamplesLink,
    currentParameterIndex: currentParameterIndex,
  });
```

The object was extracted and converted from key/value ES6 object pairs to

```
var funcName = locals.funcName;
var functionName = locals.functionName;
...
```

This enables the local variable to be used in the same way it was expected with the “with” keyword.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [with deprecation and removal notice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with)
- [with in strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#simplifying_scope_management)
- [ejs documentation](https://ejs.co/#docs)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

These files are primarily used in the labs and exporter functionality. I ran through each lab and was able to progress in levels and export the labs as well.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

To minimize risk to AP CSP, this change will only be merged after April 30th.

## Follow-up work

1. Jest Migration

## Privacy

N/A

## Security

N/A

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
