### PR TITLE
[Python Lab] Add csv and txt as file options

### DIFF
--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -38,12 +38,9 @@ const defaultProject: MultiFileSource = {
 };
 
 const defaultConfig: ConfigType = {
-  //showSideBar: true,
-  // showLeftNav: false,
-  // showEditor: false,
   showPreview: false,
   activeLeftNav: 'Files',
-  EditorComponent: () => Editor(pythonlabLangMapping, ['py']),
+  EditorComponent: () => Editor(pythonlabLangMapping, ['py', 'csv', 'txt']),
   leftNav: [
     {
       icon: 'fa-square-check',

--- a/apps/src/weblab2/CDOIDE/CenterPane/Editor.tsx
+++ b/apps/src/weblab2/CDOIDE/CenterPane/Editor.tsx
@@ -26,10 +26,13 @@ const Editor = (
     [file?.id, saveFile]
   );
 
-  const editorConfigExtensions = useMemo(
-    () => (file?.language ? [langMapping[file.language]] : []),
-    [file?.language, langMapping]
-  );
+  const editorConfigExtensions = useMemo(() => {
+    if (file?.language && langMapping[file.language]) {
+      return [langMapping[file.language]];
+    } else {
+      return [];
+    }
+  }, [file?.language, langMapping]);
 
   if (file && !editableFileType(file.language, editableFileTypes)) {
     return <div>Cannot currently edit files of type {file.language}</div>;

--- a/apps/src/weblab2/CDOIDE/styles/cdoIDE.css
+++ b/apps/src/weblab2/CDOIDE/styles/cdoIDE.css
@@ -14,4 +14,5 @@
 .cdo-ide-area {
   width: 100%;
   border: 1px solid lightgray;
+  color: white;
 }


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Summary
Allow csv and txt files in Python Lab. Both csv and txt files have no language mapping, so I also updated the Editor component to support that behavior. In addition, if you try to create an unsupported file the text saying the file was unsupported was black on a black background, so I updated the css for that section of the UI.

## Links

- jira ticket: [CT-457](https://codedotorg.atlassian.net/browse/CT-457)


## Testing story
Tested locally that you can create and edit csv and txt files.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
