### PR TITLE
Add poster attribute to video fallback player

### DIFF
--- a/apps/src/util/loadVideos.js
+++ b/apps/src/util/loadVideos.js
@@ -41,6 +41,7 @@ function setupVideos(player) {
 
   $('.insert_video_player').each(function () {
     const downloadPath = $(this).data('download-path');
+    const posterPath = $(this).data('poster-path');
 
     // Use fallback player if that's the preference.
     // It requires a downloadPath, and it doesn't seem to work on IE8 because
@@ -49,17 +50,17 @@ function setupVideos(player) {
       $(this)
         .parent()
         .append(
-          '<video ' +
-            'style="position:absolute; top: 0; left: 0; width: 100%; height: 100%" ' +
-            'width="100%" height="100%" ' +
-            'class="video-js lazyload vjs-big-play-centered" ' +
-            'preload="none" ' +
-            'data-setup=\'{"nativeControlsForTouch": true}\' ' +
-            'controls>' +
-            '  <source src="' +
-            downloadPath +
-            '" type="video/mp4"/>' +
-            '</video>'
+          `<video
+            style="position:absolute; top: 0; left: 0; width: 100%; height: 100%"
+            width="100%"
+            height="100%"
+            class="video-js lazyload vjs-big-play-centered"
+            preload="none"
+            poster="${posterPath ? posterPath : ''}"
+            data-setup='{"nativeControlsForTouch": true}'
+            controls>
+            <source src="${downloadPath}" type="video/mp4"/>
+          </video>`
         );
     } else {
       // Always default to YouTube player.

--- a/apps/src/util/loadVideos.js
+++ b/apps/src/util/loadVideos.js
@@ -56,7 +56,7 @@ function setupVideos(player) {
             height="100%"
             class="video-js lazyload vjs-big-play-centered"
             preload="none"
-            poster="${posterPath ? posterPath : ''}"
+            ${posterPath ? `poster="${posterPath}"` : ''}
             data-setup='{"nativeControlsForTouch": true}'
             controls>
             <source src="${downloadPath}" type="video/mp4"/>

--- a/pegasus/sites.v3/code.org/views/display_video_lightbox.haml
+++ b/pegasus/sites.v3/code.org/views/display_video_lightbox.haml
@@ -2,7 +2,6 @@
 - twitter ||= nil
 - download_filename ||= nil
 - download_path ||= nil
-- poster_path ||= nil
 
 .modal.fade{id: "showVideo_#{id}"}
   .modal-dialog.modal-lg
@@ -13,7 +12,7 @@
           %span{:class=>"sr-only"} Close
         %div{style: "clear:both"}
       .modal-body{style: "padding-top: 0px"}
-        =view :index_video_reveal, video_code: video_code, facebook: facebook, twitter: twitter, download_filename: download_filename, download_path: download_path, poster_path: poster_path
+        =view :index_video_reveal, video_code: video_code, facebook: facebook, twitter: twitter, download_filename: download_filename, download_path: download_path
 
 :css
   .modal{

--- a/pegasus/sites.v3/code.org/views/display_video_lightbox.haml
+++ b/pegasus/sites.v3/code.org/views/display_video_lightbox.haml
@@ -2,6 +2,7 @@
 - twitter ||= nil
 - download_filename ||= nil
 - download_path ||= nil
+- poster_path ||= nil
 
 .modal.fade{id: "showVideo_#{id}"}
   .modal-dialog.modal-lg
@@ -12,7 +13,7 @@
           %span{:class=>"sr-only"} Close
         %div{style: "clear:both"}
       .modal-body{style: "padding-top: 0px"}
-        =view :index_video_reveal, video_code: video_code, facebook: facebook, twitter: twitter, download_filename: download_filename, download_path: download_path
+        =view :index_video_reveal, video_code: video_code, facebook: facebook, twitter: twitter, download_filename: download_filename, download_path: download_path, poster_path: poster_path
 
 :css
   .modal{

--- a/pegasus/sites.v3/code.org/views/display_video_thumbnail.haml
+++ b/pegasus/sites.v3/code.org/views/display_video_thumbnail.haml
@@ -2,6 +2,7 @@
 - twitter ||= nil
 - download_filename ||= nil
 - download_path ||= nil
+- poster_path ||= nil
 - caption ||= nil
 - width ||= '100%'
 - play_button ||= 'center' # 'center' or 'caption' or 'none'
@@ -115,4 +116,4 @@
     .video_caption_link= caption
 
 - unless thumbnail_only
-  = view :display_video_lightbox, id: id, video_code: video_code, facebook: facebook, twitter: twitter, download_filename: download_filename, download_path: download_path
+  = view :display_video_lightbox, id: id, video_code: video_code, facebook: facebook, twitter: twitter, download_filename: download_filename, download_path: download_path, poster_path: poster_path

--- a/pegasus/sites.v3/code.org/views/display_video_thumbnail.haml
+++ b/pegasus/sites.v3/code.org/views/display_video_thumbnail.haml
@@ -2,7 +2,6 @@
 - twitter ||= nil
 - download_filename ||= nil
 - download_path ||= nil
-- poster_path ||= nil
 - caption ||= nil
 - width ||= '100%'
 - play_button ||= 'center' # 'center' or 'caption' or 'none'
@@ -116,4 +115,4 @@
     .video_caption_link= caption
 
 - unless thumbnail_only
-  = view :display_video_lightbox, id: id, video_code: video_code, facebook: facebook, twitter: twitter, download_filename: download_filename, download_path: download_path, poster_path: poster_path
+  = view :display_video_lightbox, id: id, video_code: video_code, facebook: facebook, twitter: twitter, download_filename: download_filename, download_path: download_path

--- a/pegasus/sites.v3/code.org/views/index_video_reveal.haml
+++ b/pegasus/sites.v3/code.org/views/index_video_reveal.haml
@@ -16,7 +16,7 @@
 - icon_download = "fa-solid fa-download"
 
 %div{style: "text-align:right;"}
-  =view :video_with_fallback, video_code: video_code, download_path: download_path, poster_path: poster_path
+  =view :video_with_fallback, video_code: video_code, download_path: download_path
 
   %div{style: "float:left"}
     =view :share_buttons, facebook: facebook, twitter: twitter

--- a/pegasus/sites.v3/code.org/views/index_video_reveal.haml
+++ b/pegasus/sites.v3/code.org/views/index_video_reveal.haml
@@ -16,7 +16,7 @@
 - icon_download = "fa-solid fa-download"
 
 %div{style: "text-align:right;"}
-  =view :video_with_fallback, video_code: video_code, download_path: download_path
+  =view :video_with_fallback, video_code: video_code, download_path: download_path, poster_path: poster_path
 
   %div{style: "float:left"}
     =view :share_buttons, facebook: facebook, twitter: twitter

--- a/pegasus/sites.v3/code.org/views/video_with_fallback.haml
+++ b/pegasus/sites.v3/code.org/views/video_with_fallback.haml
@@ -1,4 +1,4 @@
-- poster_path ||= nil
+- poster_path ||= "//i.ytimg.com/vi/#{video_code}/mqdefault.jpg"
 
 %figure{style: "width:100%; height: 100%; margin: 0 auto;"}
   .videodiv{style: "position:relative;"}

--- a/pegasus/sites.v3/code.org/views/video_with_fallback.haml
+++ b/pegasus/sites.v3/code.org/views/video_with_fallback.haml
@@ -1,3 +1,4 @@
+- download_path ||= nil
 - poster_path ||= "//i.ytimg.com/vi/#{video_code}/mqdefault.jpg"
 
 %figure{style: "width:100%; height: 100%; margin: 0 auto;"}

--- a/pegasus/sites.v3/code.org/views/video_with_fallback.haml
+++ b/pegasus/sites.v3/code.org/views/video_with_fallback.haml
@@ -1,5 +1,7 @@
+- poster_path ||= nil
+
 %figure{style: "width:100%; height: 100%; margin: 0 auto;"}
   .videodiv{style: "position:relative;"}
     %img{style: "display:block; width:100%; height:auto", src: "/images/16x9.png"}/
     -# either youtube or fallback video player inserted here
-    .insert_video_player{:data=>{:video_code=>video_code, :download_path=>download_path}}
+    .insert_video_player{:data=>{:video_code=>video_code, :download_path=>download_path, :poster_path=>poster_path}}


### PR DESCRIPTION
Adds a `poster` attribute to videos using the fallback player (`video_with_fallback.haml` view) on https://code.org. The thumbnail is pulled from the YouTube video similar to how the `display_video_thumbnail` view works as seen [here](https://github.com/code-dot-org/code-dot-org/blob/12e028b4adf8c263038bde9009e6af3251ba74c5/pegasus/sites.v3/code.org/views/display_video_thumbnail.haml#L13). 

The work in this PR is done in preparation for adding Swiper video carousels ([see Jira ticket](https://codedotorg.atlassian.net/browse/ACQ-1359)). There's a bug between our code and Swiper that prevents the video lightbox from working properly, so this a workaround for that, but this improves the UX/UI for the fallback video player in general, yay! Standalone videos (not in a carousel) will still use the `dsplay_video_thumbnail` view, so this isn't as relevant for them.

_Note:_ for cases where YouTube is blocked, this works best on videos that have downloadable backups hosted in S3 — all of our newer videos have these, but some legacy videos may not in which case the video won't show up. This is not a new issue, but may become more visible with this change if a video carousel is used that has older videos without backups.

**Jira ticket:** [ACQ-1787](https://codedotorg.atlassian.net/browse/ACQ-1787)

----

## Fallback player (when YouTube is blocked)

https://github.com/code-dot-org/code-dot-org/assets/9256643/df0a3ca4-b9bb-40e9-ac71-97ae13595c4f

## YouTube player (YT is not blocked)

https://github.com/code-dot-org/code-dot-org/assets/9256643/c354af16-3624-4291-9a27-de54dee4113d


