### PR TITLE
Revert "[AI Tutor] Reenable warning modal"

### DIFF
--- a/apps/src/aiTutor/views/AITutorContainer.tsx
+++ b/apps/src/aiTutor/views/AITutorContainer.tsx
@@ -9,7 +9,6 @@ import aiBotOutlineIcon from '@cdo/static/ai-bot-outline.png';
 import AITutorChatWorkspace from './AITutorChatWorkspace';
 import AITutorFooter from './AITutorFooter';
 import style from './ai-tutor.module.scss';
-import WarningModal from './WarningModal';
 
 interface AITutorContainerProps {
   closeTutor?: () => void;
@@ -72,7 +71,6 @@ const AITutorContainer: React.FC<AITutorContainerProps> = ({
           )}
         </div>
         <AITutorFooter renderAITutor={renderAITutor} />
-        <WarningModal />
       </div>
     </Draggable>
   );

--- a/apps/src/aiTutor/views/WarningModal.tsx
+++ b/apps/src/aiTutor/views/WarningModal.tsx
@@ -19,6 +19,7 @@ const WarningModal = () => {
     return (
       <AccessibleDialog onClose={onClose} className={style.chatWarningModal}>
         <Heading2>Remember to chat responsibly!</Heading2>
+
         <button type="button" onClick={onClose} className={style.xCloseButton}>
           <i id="x-close" className="fa-solid fa-xmark" />
         </button>


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#57989

This is causing the following bug locally on pages with the AI Tutor rendered.

<img width="998" alt="Screenshot 2024-04-16 at 2 48 11 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/a9176b8c-7712-4996-adfc-a495abc21cda">

Java Lab appears to "fail gracefully" on production and not render the AI Tutor when this occurs, see Slack thread: https://codedotorg.slack.com/archives/C06KYAJDB24/p1713302545132099?thread_ts=1712853684.304749&cid=C06KYAJDB24. I have verified that running code and switching between tabs/adding files/viewing version history is all working in Java Lab. 

I'm not 100% sure how this got missed because I have a screenshot with this working before I posted this PR (see below), but I will continue to investigate. 

<img width="839" alt="Screenshot 2024-04-11 at 9 01 11 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/4d93747f-afb0-486c-a11e-273619f7ee1e">

