### PR TITLE
Stop Provisioning FakeDashboard Database Schema Within a Transaction

### DIFF
--- a/pegasus/test/fixtures/fake_dashboard.rb
+++ b/pegasus/test/fixtures/fake_dashboard.rb
@@ -315,11 +315,9 @@ module FakeDashboard
     ActiveRecord::Base.configurations = database
     ActiveRecord::Base.establish_connection
     ActiveRecord::Schema.verbose = false
-    ActiveRecord::Base.transaction do
-      # rubocop:disable CustomCops/DashboardRequires
-      require_relative('../../../dashboard/db/schema')
-      # rubocop:enable CustomCops/DashboardRequires
-    end
+    # rubocop:disable CustomCops/DashboardRequires
+    require_relative('../../../dashboard/db/schema')
+    # rubocop:enable CustomCops/DashboardRequires
 
     # Reuse the same connection in Sequel to share access to the temporary tables.
     connection = ActiveRecord::Base.connection.instance_variable_get(:@connection)


### PR DESCRIPTION
Enabling MySQL binary logging (in conjunction with having Global Transaction IDentifier mode ON) causes two Pegasus tests that utilize our `FakeDashboard` module to fail because they create temporary tables within transactions. In MySQL 5.7, Data Definition Language (DDL) statements are not atomic or transactional (MySQL 8.x supports atomic, but not transactional DDL). Try provisioning the FakeDashboard schema without using a transaction.


We need to enable binary logging to support a production cutover to MySQL 8 with minimal downtime and we'd like to enable binary logging on all environments, particularly so that we can test the production cutover on our managed test server.

## Testing story

I manually enabled binary logging with Global Transaction IDentifiers (GTID) on the test system, reproduced the error with the test Pegasus tests that use FakeDashboard, applied the code change in this feature branch, and verified that the two Pegasus tests now pass.

### 1) Enabled binary logging & GTID mode

```
mysql> SELECT @@gtid_mode;
+-------------+
| @@gtid_mode |
+-------------+
| ON          |
+-------------+
1 row in set (0.00 sec)

mysql> SHOW BINARY LOGS;
+----------------------------+-----------+
| Log_name                   | File_size |
+----------------------------+-----------+
| mysql-bin-changelog.000001 |       154 |
+----------------------------+-----------+
1 row in set (0.00 sec)

mysql> SELECT @@binlog_format;
+-----------------+
| @@binlog_format |
+-----------------+
| ROW             |
+-----------------+
1 row in set (0.00 sec)

mysql> SELECT @@enforce_gtid_consistency;
+----------------------------+
| @@enforce_gtid_consistency |
+----------------------------+
| ON                         |
+----------------------------+
1 row in set (0.01 sec)
```

### 2) Reproduced the errors

I can reproduce the issue:

`ubuntu@test:~/test/pegasus$ rake test TEST=test/test_poste_routes.rb`
`ubuntu@test:~/test/pegasus$ rake test TEST=test/test_dashboard.rb`

both fail with this error:
```
ActiveRecord::StatementInvalid: Mysql2::Error: Statement violates GTID consistency: CREATE TEMPORARY TABLE and DROP TEMPORARY TABLE can only be executed outside transactional context.
```

### 3) Deploy the fix in this feature branch to the test server and the tests pass

`git checkout origin/infrastructure/improve-fake-dashboard-db -- pegasus/test/fixtures/fake_dashboard.rb`

```
ubuntu@test:~/test/pegasus$ rake test TEST=test/test_dashboard.rb
GetSecretValue: test/cdo/slack_token
GetSecretValue: test/cdo/slack_bot_token
GetSecretValue: test/cdo/mapbox_access_token
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Started with run options --seed 37146

Dashboard::User::to_hash
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
  test_0001_returns dashboard row.to_hash                         PASS (0.41s)

Dashboard::User::get
  test_0001_does return students                                  PASS (0.00s)
  test_0002_does not return deleted students                      PASS (0.00s)

Finished in 0.47923s
3 tests, 4 assertions, 0 failures, 0 errors, 0 skips
ubuntu@test:~/test/pegasus$ rake test TEST=test/test_poste_routes.rb
GetSecretValue: test/cdo/slack_token
GetSecretValue: test/cdo/slack_bot_token
GetSecretValue: test/cdo/mapbox_access_token
GetSecretValue: test/cdo/mapbox_access_token
GetSecretValue: test/cdo/slack_token
GetSecretValue: test/cdo/slack_bot_token
GetSecretValue: test/cdo/pegasus_honeybadger_api_key
Run options: --seed 25451

# Running:

WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
GetSecretValue: test/cdo/poste_secret
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
......inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
GetSecretValue: test/cdo/dashboard_secret_key_base
.inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
.inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
.inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
..inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
.inline template:81: warning: string literal in condition
inline template:95: warning: string literal in condition
.

Finished in 9.195784s, 1.4137 runs/s, 3.0449 assertions/s.

13 runs, 28 assertions, 0 failures, 0 errors, 0 skips
```


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
