### PR TITLE
Music: localize scripts

### DIFF
--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -256,6 +256,8 @@ module ScriptConstants
     HELLO_WORLD_EMOJI = 'hello-world-emoji'.freeze,
     HELLO_WORLD_RETRO = 'hello-world-retro'.freeze,
     K1HOC_2017 = 'k1hoc2017'.freeze,
+    MUSIC_INTRO_2024 = 'music-intro-2024'.freeze,
+    MUSIC_ONBOARD = 'music-onboard'.freeze,
     NETSIM = 'netsim'.freeze,
     ODOMETER = 'odometer'.freeze,
     OUTBREAK = 'outbreak'.freeze,


### PR DESCRIPTION
Localize the `music-intro-2024` script, and also a `music-onboard` script which contains new versions of some Panels levels that we'll swap into `music-intro-2024` for launch.
