### PR TITLE
Music: default pack

### DIFF
--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -72,6 +72,8 @@ export const MIN_NUM_MEASURES = 30;
 export const LEGACY_DEFAULT_LIBRARY = 'default';
 export const DEFAULT_LIBRARY = 'intro2024';
 
+export const DEFAULT_PACK = 'default';
+
 export const DEFAULT_BPM = 120;
 export const DEFAULT_BEATS_PER_MEASURE = 4;
 export const DEFAULT_KEY = Key.C;

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -1,6 +1,6 @@
 import {ResponseValidator} from '@cdo/apps/util/HttpClient';
 import {Key} from '../utils/Notes';
-import {baseAssetUrlRestricted} from '../constants';
+import {baseAssetUrlRestricted, DEFAULT_PACK} from '../constants';
 import {getBaseAssetUrl} from '../appConfig';
 
 export default class MusicLibrary {
@@ -175,7 +175,9 @@ export default class MusicLibrary {
 
   getAvailableSounds() {
     return this.getAllowedSounds().filter(
-      folder => !folder.restricted || this.currentPackId === folder.id
+      folder =>
+        (!folder.restricted || this.currentPackId === folder.id) &&
+        folder.id !== DEFAULT_PACK
     );
   }
 


### PR DESCRIPTION
This adds support for selecting the default pack of sounds, which allows the user to use the non-restricted sound packs without selecting a restricted one.

It's listed alongside the restricted packs in the pack selection UI.  It's not listed as a pack in the sound selection UI, since the non-restricted packs are already enumerated there.

In the project, the pack will be saved as `"default"`.

In the library, the pack can be set up like so:

```
    {
      "name": "Code.org sounds",
      "artist": "Code.org",
      "id": "default",
      "path": "packs/default",
      "imageSrc": "default.png",
      "restricted": true,
      "sounds": [
        { "name": "Preview", "src": "preview", "length": 2, "type": "preview" }
      ]
    }
```

### Pack selection UI

<img width="1512" alt="music-default-pack-0" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/29ba083a-ddc6-4c31-adfe-448b6379b1df">

### Header

<img width="400" alt="Screenshot 2024-04-17 at 1 57 24 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/a4999c9c-351a-4557-9d36-d044cae902b1">

