### PR TITLE
Alice/genai dcdo

### DIFF
--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -7,7 +7,7 @@ class AichatController < ApplicationController
   # chatContext: {userId: number; currentLevelId: string; scriptId: number; channelId: string;}
   # POST /aichat/chat_completion
   def chat_completion
-    return render status: :forbidden, json: {} unless can_request_aichat_chat_completion? 
+    return render status: :forbidden, json: {} unless can_request_aichat_chat_completion?
     unless has_required_params?
       return render status: :bad_request, json: {}
     end

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -7,10 +7,11 @@ class AichatController < ApplicationController
   # chatContext: {userId: number; currentLevelId: string; scriptId: number; channelId: string;}
   # POST /aichat/chat_completion
   def chat_completion
+    return render status: :forbidden, json: {} unless can_request_aichat_chat_completion? 
     unless has_required_params?
       return render status: :bad_request, json: {}
     end
-
+    # return render status: :forbidden, json: {} unless can_request_aichat_chat_completion?
     # Check for PII / Profanity
     # Copied from ai_tutor_interactions_controller.rb - not sure if filtering is working.
     locale = params[:locale] || "en"
@@ -25,6 +26,10 @@ class AichatController < ApplicationController
     }
     response = request_chat_completion(payload)
     render(status: response[:status], json: response[:json])
+  end
+
+  def can_request_aichat_chat_completion?
+    DCDO.get('aichat_chat_completion', true)
   end
 
   def request_chat_completion(payload)

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -75,4 +75,10 @@ class AichatControllerTest < ActionController::TestCase
     assert_equal json_response["status"], ShareFiltering::FailureType::EMAIL
     assert_equal json_response["flagged_content"], "l.lovepadel@sports.edu"
   end
+
+  test 'Forbidden if DCDO flag is set to false' do
+    DCDO.stubs(:get).with('aichat_chat_completion', true).returns(false)
+    post :chat_completion, params: @valid_params
+    assert_equal json_response["status"], :forbidden
+  end
 end

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -4,8 +4,6 @@ class AichatControllerTest < ActionController::TestCase
   GENAI_PILOT = "gen-ai-customizing-llms"
 
   setup_all do
-    @genai_pilot = create :pilot
-    @genai_pilot.name = GENAI_PILOT
     @genai_pilot_teacher = create :teacher, pilot_experiment: GENAI_PILOT
     pilot_section = create(:section, user: @genai_pilot_teacher)
     @genai_pilot_student = create(:follower, section: pilot_section).student_user
@@ -20,12 +18,6 @@ class AichatControllerTest < ActionController::TestCase
     @valid_params = @common_params.merge(newMessage: valid_message)
     @pii_violation_params = @common_params.merge(newMessage: pii_violation_message)
     @profanity_violation_params = @common_params.merge(newMessage: profanity_violation_message)
-  end
-
-  teardown_all do
-    @genai_pilot_student.delete
-    @genai_pilot_teacher.delete
-    @genai_pilot.delete
   end
 
   test_user_gets_response_for :chat_completion,


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
