### PR TITLE
Prevent i18n sync from getting stuck

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -349,7 +349,7 @@ gem 'pry', '~> 0.14.0'
 # Google's Compact Language Detector
 gem 'cld'
 
-gem 'crowdin-api', '~> 1.8.1'
+gem 'crowdin-api', '~> 1.10.0'
 
 gem "delayed_job_active_record", "~> 4.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,7 +299,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    crowdin-api (1.8.1)
+    crowdin-api (1.10.0)
       open-uri (>= 0.1.0, < 0.2.0)
       rest-client (>= 2.0.0, < 2.2.0)
     css_parser (1.10.0)
@@ -995,7 +995,7 @@ DEPENDENCIES
   cld
   colorize
   composite_primary_keys (~> 13.0)
-  crowdin-api (~> 1.8.1)
+  crowdin-api (~> 1.10.0)
   cucumber
   daemons
   dalli

--- a/bin/i18n/utils/crowdin_client.rb
+++ b/bin/i18n/utils/crowdin_client.rb
@@ -13,6 +13,7 @@ module I18n
       MAX_CONCURRENT_REQUESTS = 10 # https://developer.crowdin.com/api/v2/#section/Introduction/Rate-Limits
 
       MAX_ITEMS_COUNT = Crowdin::Web::FetchAllExtensions::MAX_ITEMS_COUNT_PER_REQUEST.freeze
+      REQUEST_TIMEOUT = 60 # Number of seconds to wait for a request to complete
       REQUEST_RETRY_ATTEMPTS = 2 # Number of retries for a failed request
       REQUEST_RETRY_DELAY = 2 # Number of seconds to wait before retrying a failed request
       RETRIABLE_ERRORS = [
@@ -21,6 +22,7 @@ module I18n
         '500 Internal Server Error',
         '503 Service Unavailable',
         'Failed to open TCP connection',
+        'Timed out connecting to server',
       ].freeze # Request errors to retry
 
       # @param project [String] the Crowdin project name, one of the `CDO.crowdin_projects` keys
@@ -32,6 +34,7 @@ module I18n
         @client = ::Crowdin::Client.new do |config|
           config.api_token = I18nScriptUtils.crowdin_creds['api_token']
           config.project_id = CDO.crowdin_projects.dig(project, 'id')
+          config.request_timeout = REQUEST_TIMEOUT
         end
       end
 

--- a/bin/test/i18n/utils/test_crowdin_client.rb
+++ b/bin/test/i18n/utils/test_crowdin_client.rb
@@ -31,6 +31,7 @@ describe I18n::Utils::CrowdinClient do
 
       client_config.expects(:api_token=).with(api_token).once
       client_config.expects(:project_id=).with(project_id).once
+      client_config.expects(:request_timeout=).with(60).once
 
       assert_equal client, described_instance.send(:client)
     end


### PR DESCRIPTION
Sets the Crowdin API request timeout to 1 minute to prevent i18n sync from getting stuck

## Links
- Related PR: https://github.com/crowdin/crowdin-api-client-ruby/pull/87