### PR TITLE
modified text size

### DIFF
--- a/apps/src/lib/ui/feedback/FeedbackBanner.scss
+++ b/apps/src/lib/ui/feedback/FeedbackBanner.scss
@@ -10,6 +10,11 @@
   color: $dark_charcoal;
   line-height: 2rem;
 
+  & .share-more,
+  & .feedback-title {
+    font-size: 16px;
+  }
+
   & .feedback-banner-greeting {
     display: inline-block;
     margin-right: $indent;
@@ -28,7 +33,7 @@
   }
 
   & i {
-    color: #0F0F0F;
+    color: #0f0f0f;
     font-size: 1.3rem;
   }
 

--- a/apps/src/lib/ui/feedback/FeedbackBanner.tsx
+++ b/apps/src/lib/ui/feedback/FeedbackBanner.tsx
@@ -74,7 +74,11 @@ const FeedbackBanner: React.FC<FeedbackBannerProps> = ({
         <Fade in={!isLoading}>
           {answerStatus === BANNER_STATUS.UNANSWERED ? (
             <span>
-              <span id="feedback-banner-title" aria-hidden="true">
+              <span
+                id="feedback-banner-title"
+                className="feedback-title"
+                aria-hidden="true"
+              >
                 {question}
               </span>
 
@@ -107,7 +111,7 @@ const FeedbackBanner: React.FC<FeedbackBannerProps> = ({
               </span>
             </span>
           ) : (
-            <span>
+            <span className="share-more">
               <span id="feedback-banner-title" aria-hidden="true">
                 {shareMore}
               </span>


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

Modified font size of text in feedback bar.

- This should have no impact to the LTI Feedback Bar since the font size was already 16px.  
- The ProgressFeedbackBar went from font size of 13 to font size of 16.  
- I checked with Molly on this as well.
- The "Share More" bar will have the same font size (16) as well. 

Screenshots from the ProgressFeedbackBar
<img width="838" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/bcec8b0f-7aca-4bc9-8cb0-adbcd71c720d">


Screenshots from the LTI bar
<img width="1210" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/b08c3f3a-8d60-4ea4-b9de-9c65d01e9a01">

Note: The icons are not showing up for me in either the "old" or "new" view - I think that might have to be with how I am forcing that bar to show up.  I am modifying the state of the component in the browser.  I think the icons aren't showing up because it isn't loading them initially... 


## Follow-up work
 - Look into icons not showing up in LTI bar...
