### PR TITLE
P20-299: Delay "Thank You" email to be sent 24 hrs after approval

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -646,3 +646,8 @@ statsig_api_client_key: 'client-fake-key'
 # MailJet API keys
 mailjet_api_key:
 mailjet_secret_key:
+
+# ActiveJob queues
+active_job_queues:
+  :default: :default
+  :mailers: :mailers

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -186,6 +186,7 @@ module Dashboard
 
     # use https://(*-)studio.code.org urls in mails
     config.action_mailer.default_url_options = {host: CDO.canonical_hostname('studio.code.org'), protocol: 'https'}
+    config.action_mailer.deliver_later_queue_name = CDO.active_job_queues[:mailers]
 
     # Rails.cache is a fast memory store, cleared every time the application reloads.
     config.cache_store = :memory_store, {
@@ -214,5 +215,6 @@ module Dashboard
     config.exceptions_app = routes
 
     config.active_job.queue_adapter = :delayed_job
+    config.active_job.default_queue_name = CDO.active_job_queues[:default]
   end
 end

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -25,6 +25,10 @@ class Policies::ChildAccount
     }
   }.freeze
 
+  # The delay is intended to provide notice to a parent
+  # when a student may no longer be monitoring the "parent's email."
+  PERMISSION_GRANTED_MAIL_DELAY = 24.hours
+
   # Is this user compliant with our Child Account Policy(cap)?
   # For students under-13, in Colorado, with a personal email login: we require
   # parent permission before the student can start using their account.

--- a/dashboard/lib/services/child_account.rb
+++ b/dashboard/lib/services/child_account.rb
@@ -32,7 +32,9 @@ class Services::ChildAccount
       update_compliance(user, Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED)
       user.save!
       parent_email = permission_request.parent_email
-      ParentMailer.parent_permission_confirmation(parent_email).deliver_now
+      ParentMailer.
+        parent_permission_confirmation(parent_email).
+        deliver_later(wait: Policies::ChildAccount::PERMISSION_GRANTED_MAIL_DELAY.seconds)
     end
   end
 


### PR DESCRIPTION
## Summary
The delay is intended to provide notice to a parent when a student may no longer be monitoring the "parent's email."   

## Links
- JIRA ticket: [P20-299](https://codedotorg.atlassian.net/browse/P20-299)