### PR TITLE
Rearrange the My PL Page section order

### DIFF
--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
@@ -157,13 +157,15 @@ export default function LandingPage({
       <main className={style.wrapper}>
         {showGettingStartedBanner && RenderGettingStartedBanner()}
         {lastWorkshopSurveyUrl && RenderLastWorkshopSurveyBanner()}
-        <EnrolledWorkshops />
         {plCoursesStarted?.length >= 1 && (
           <section id={'self-paced-pl'}>
             <Heading2>{i18n.plLandingSelfPacedProgressHeading()}</Heading2>
             {RenderSelfPacedProgressTable()}
           </section>
         )}
+        <section>
+          <EnrolledWorkshops />
+        </section>
         {deeperLearningCourseData?.length >= 1 && (
           <section>
             <Heading2>Online Professional Learning Courses</Heading2>


### PR DESCRIPTION
Moves the Self-paced section on top of the My Workshops section on https://studio.code.org/my-professional-learning. I also wrapped the My Workshops section in a `<section>` element for margin purposes. There's still some extra space under the Survey banner, but I can clean that up as work continues on this page. 

**Jira ticket:** [ACQ-1793](https://codedotorg.atlassian.net/browse/ACQ-1793)

----

## Before
![Before](https://github.com/code-dot-org/code-dot-org/assets/9256643/876b076a-dcbd-4f93-b826-72017cd61719)

## After
![After](https://github.com/code-dot-org/code-dot-org/assets/9256643/9c741ebd-352e-4fc1-a8ec-d546ba5be0cb)
