### PR TITLE
fix(CoteacherTable): remove orphaned style

### DIFF
--- a/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherTable.jsx
+++ b/apps/src/templates/sectionsRefresh/coteacherSettings/CoteacherTable.jsx
@@ -11,7 +11,7 @@ import styles from './coteacher-settings.module.scss';
 
 const getPendingPill = () => {
   return (
-    <span style={styles.toolTipBox}>
+    <span>
       <div
         className={classNames(styles.tablePending, styles.tablePill)}
         data-tip


### PR DESCRIPTION
This span references a class name does not appear to exist in the included scss file. This resulst in an undefined class to be set to the span resulting in an error in more strict parsing libraries. Since the tag does not appear to reference anything, removing the style to avoid injecting an undefined into the DOM.

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [Slack Discussion](https://codedotorg.slack.com/archives/C045UAX4WKH/p1713308258059729)

## Testing story

1. Verified that the CoTeacherTable renders normally

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

N/A

## Privacy

N/A

## Security

N/A
## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
