### PR TITLE
Fix for flaky curriculum catalog quick view test.

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -160,7 +160,7 @@ Feature: Curriculum Catalog Page
 
     And I click selector "[aria-label='View details about AI for Oceans']"
 
-    And I click selector "a:contains(See curriculum details)"
+    And I click selector "a:contains(See curriculum details)" to load a new page
     And I wait until element "h1:contains(AI for Oceans)" is visible
 
   @no_mobile


### PR DESCRIPTION
Flaky test failing due to error ReferenceError: $ is not defined. The screen shots in sauce labs suggest the issue is happening during a page navigation, but the failure is happening on the old page.

Fix: waiting for the page to load in the step where page navigation is triggered.

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

Sauce lab link https://saucelabs.com/tests/53fd65fe9eb848d2a4b66e4e6e8f9483

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Drone 

## Deployment strategy

Regular DTP

## Follow-up work

N/A

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
