### PR TITLE
Music: tweak "start over" button

### DIFF
--- a/apps/src/music/views/HeaderButtons.module.scss
+++ b/apps/src/music/views/HeaderButtons.module.scss
@@ -43,12 +43,16 @@
     }
 
     &Content {
-      padding: 0 14px 0 9px;
+      padding: 0 16px 0 8px;
 
       &NoRightPadding {
         padding-right: 0;
       }
     }
+  }
+
+  .currentPack {
+    display: contents;
   }
 
   &Skip {

--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -39,7 +39,7 @@ const CurrentPack: React.FunctionComponent<CurrentPackProps> = ({
   }
 
   return (
-    <span>
+    <span className={moduleStyles.currentPack}>
       {packImageSrc && (
         <img
           src={packImageSrc}


### PR DESCRIPTION
Tiny adjustments to the "start over" button in Music Lab.

<img width="1512" alt="Screenshot 2024-04-18 at 3 09 20 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/58ab1362-85d8-4433-bca7-4f3122d14a99">
