### PR TITLE
Adds analytics event for evidence tooltip hover and link click.

### DIFF
--- a/apps/src/EditorAnnotator.js
+++ b/apps/src/EditorAnnotator.js
@@ -184,7 +184,8 @@ export class Annotator {
     logLevel = 'INFO',
     color = null,
     icon = null,
-    tipStyle = {}
+    tipStyle = {},
+    hoverCallback = null
   ) {}
 
   /**
@@ -551,7 +552,8 @@ export class DropletAnnotator extends Annotator {
     logLevel = 'INFO',
     color = null,
     icon = null,
-    tipStyle = {}
+    tipStyle = {},
+    hoverCallback = null
   ) {
     const hash = md5((color || '') + (icon || ''));
     if (color || icon) {
@@ -609,6 +611,7 @@ export class DropletAnnotator extends Annotator {
       message: message,
       hash: hash,
       tipStyle: tipStyle,
+      hoverCallback: hoverCallback,
     });
     this.annotationList_().addRuntimeAnnotation(logLevel, lineNumber, message);
 
@@ -639,9 +642,11 @@ export class DropletAnnotator extends Annotator {
               // See if it is one of our known annotations
               for (const annotation of this.knownAnnotations_) {
                 if (el.textContent.trim() === annotation.message.trim()) {
-                  el.classList.add(
-                    `editor-annotator-tooltip-${annotation.hash}`
-                  );
+                  const annotationClass = `editor-annotator-tooltip-${annotation.hash}`;
+                  el.classList.add(annotationClass);
+                  if (annotation.hoverCallback) {
+                    annotation.hoverCallback(annotation);
+                  }
                   Object.keys(annotation.tipStyle || {}).forEach(k => {
                     el.style[k] = annotation.tipStyle[k];
                   });
@@ -1110,7 +1115,8 @@ export default class EditorAnnotator {
     logLevel = 'INFO',
     color = null,
     icon = null,
-    tipStyle = {}
+    tipStyle = {},
+    hoverCallback = null
   ) {
     EditorAnnotator.annotator()?.annotateLine(
       lineNumber,

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -173,6 +173,8 @@ const EVENTS = {
   TA_RUBRIC_TOUR_BACK: 'TA Rubric product tour back button clicked',
   TA_RUBRIC_TOUR_CLOSED: 'TA Rubric product tour closed',
   TA_RUBRIC_TOUR_COMPLETE: 'User viewed all of TA Rubric product tour',
+  TA_RUBRIC_EVIDENCE_TOOLTIP_HOVERED: 'TA Rubric Evidence Tooltip Hovered',
+  TA_RUBRIC_EVIDENCE_GOTO_CLICKED: 'TA Rubric Evidence Line Number Clicked',
 
   // AI Tutor
   AI_TUTOR_PANEL_OPENED: 'AI Tutor Panel Opened',

--- a/apps/src/templates/rubrics/AiAssessment.jsx
+++ b/apps/src/templates/rubrics/AiAssessment.jsx
@@ -5,14 +5,24 @@ import {Heading6, StrongText} from '@cdo/apps/componentLibrary/typography';
 import i18n from '@cdo/locale';
 
 import AiAssessmentBox from './AiAssessmentBox';
+import {
+  aiEvaluationShape,
+  aiEvidenceShape,
+  learningGoalShape,
+  reportingDataShape,
+  studentLevelInfoShape,
+} from './rubricShapes';
 import aiBotImage from './images/AiBot_2x.png';
-import {aiEvaluationShape, aiEvidenceShape} from './rubricShapes';
 
 import style from './rubrics.module.scss';
 
 export default function AiAssessment({
   isAiAssessed,
+  learningGoals,
+  currentLearningGoal,
+  reportingData,
   studentName,
+  studentLevelInfo,
   aiUnderstandingLevel,
   aiConfidence,
   aiEvidence,
@@ -29,7 +39,11 @@ export default function AiAssessment({
           isAiAssessed={isAiAssessed}
           aiEvidence={aiEvidence}
           aiUnderstandingLevel={aiUnderstandingLevel}
+          currentLearningGoal={currentLearningGoal}
+          learningGoals={learningGoals}
+          reportingData={reportingData}
           studentName={studentName}
+          studentLevelInfo={studentLevelInfo}
           aiEvalInfo={aiEvalInfo}
           aiConfidence={aiConfidence}
         />
@@ -40,7 +54,11 @@ export default function AiAssessment({
 
 AiAssessment.propTypes = {
   isAiAssessed: PropTypes.bool.isRequired,
+  learningGoals: PropTypes.arrayOf(learningGoalShape),
+  currentLearningGoal: PropTypes.number,
+  reportingData: reportingDataShape,
   studentName: PropTypes.string,
+  studentLevelInfo: studentLevelInfoShape,
   aiUnderstandingLevel: PropTypes.number,
   aiConfidence: PropTypes.number,
   aiEvidence: PropTypes.arrayOf(aiEvidenceShape),

--- a/apps/src/templates/rubrics/AiAssessment.jsx
+++ b/apps/src/templates/rubrics/AiAssessment.jsx
@@ -5,6 +5,7 @@ import {Heading6, StrongText} from '@cdo/apps/componentLibrary/typography';
 import i18n from '@cdo/locale';
 
 import AiAssessmentBox from './AiAssessmentBox';
+import aiBotImage from './images/AiBot_2x.png';
 import {
   aiEvaluationShape,
   aiEvidenceShape,
@@ -12,7 +13,6 @@ import {
   reportingDataShape,
   studentLevelInfoShape,
 } from './rubricShapes';
-import aiBotImage from './images/AiBot_2x.png';
 
 import style from './rubrics.module.scss';
 

--- a/apps/src/templates/rubrics/AiAssessmentBox.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentBox.jsx
@@ -7,11 +7,16 @@ import {
   BodyFourText,
 } from '@cdo/apps/componentLibrary/typography';
 import EditorAnnotator from '@cdo/apps/EditorAnnotator';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {RubricUnderstandingLevels} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 import AiAssessmentFeedback from './AiAssessmentFeedback';
-import {RubricUnderstandingLevels} from '@cdo/apps/util/sharedConstants';
+import AiAssessmentFeedbackContext from './AiAssessmentFeedbackContext';
+import AiAssessmentFeedbackRadio from './AiAssessmentFeedbackRadio';
+import AiConfidenceBox from './AiConfidenceBox';
+import {UNDERSTANDING_LEVEL_STRINGS} from './rubricHelpers';
 import {
   aiEvaluationShape,
   aiEvidenceShape,
@@ -19,13 +24,8 @@ import {
   reportingDataShape,
   studentLevelInfoShape,
 } from './rubricShapes';
-import AiAssessmentFeedbackContext from './AiAssessmentFeedbackContext';
-import AiAssessmentFeedbackRadio from './AiAssessmentFeedbackRadio';
-import AiConfidenceBox from './AiConfidenceBox';
-import {UNDERSTANDING_LEVEL_STRINGS} from './rubricHelpers';
+
 import style from './rubrics.module.scss';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 export default function AiAssessmentBox({
   isAiAssessed,

--- a/apps/src/templates/rubrics/AiAssessmentBox.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentBox.jsx
@@ -11,17 +11,29 @@ import {RubricUnderstandingLevels} from '@cdo/generated-scripts/sharedConstants'
 import i18n from '@cdo/locale';
 
 import AiAssessmentFeedback from './AiAssessmentFeedback';
+import {RubricUnderstandingLevels} from '@cdo/apps/util/sharedConstants';
+import {
+  aiEvaluationShape,
+  aiEvidenceShape,
+  learningGoalShape,
+  reportingDataShape,
+  studentLevelInfoShape,
+} from './rubricShapes';
 import AiAssessmentFeedbackContext from './AiAssessmentFeedbackContext';
 import AiAssessmentFeedbackRadio from './AiAssessmentFeedbackRadio';
 import AiConfidenceBox from './AiConfidenceBox';
 import {UNDERSTANDING_LEVEL_STRINGS} from './rubricHelpers';
-import {aiEvaluationShape, aiEvidenceShape} from './rubricShapes';
-
 import style from './rubrics.module.scss';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 export default function AiAssessmentBox({
   isAiAssessed,
+  learningGoals,
+  currentLearningGoal,
+  reportingData,
   studentName,
+  studentLevelInfo,
   aiUnderstandingLevel,
   aiConfidence,
   aiEvalInfo,
@@ -49,9 +61,22 @@ export default function AiAssessmentBox({
       : i18n.aiAssessmentDoesNotMeet();
   };
 
+  const onEvidenceLineNumberClick = () => {
+    // When somebody clicks on the line number embedded in the evidence line,
+    // record that event alongside information about the learning goal.
+    const eventName = EVENTS.TA_RUBRIC_EVIDENCE_GOTO_CLICKED;
+    analyticsReporter.sendEvent(eventName, {
+      ...(reportingData || {}),
+      learningGoalKey: learningGoals[currentLearningGoal].key,
+      learningGoal: learningGoals[currentLearningGoal].learningGoal,
+      studentId: !!studentLevelInfo ? studentLevelInfo.user_id : '',
+    });
+  };
+
   // When a line number is clicked in the evidence listing
   const lineNumberClickHandler = (lineNumber, e) => {
     e.preventDefault();
+    onEvidenceLineNumberClick();
     EditorAnnotator.scrollToLine(lineNumber);
   };
 
@@ -152,7 +177,11 @@ export default function AiAssessmentBox({
 
 AiAssessmentBox.propTypes = {
   isAiAssessed: PropTypes.bool.isRequired,
+  learningGoals: PropTypes.arrayOf(learningGoalShape),
+  currentLearningGoal: PropTypes.number,
+  reportingData: reportingDataShape,
   studentName: PropTypes.string,
+  studentLevelInfo: studentLevelInfoShape,
   aiUnderstandingLevel: PropTypes.number,
   aiConfidence: PropTypes.number,
   aiEvalInfo: aiEvaluationShape,

--- a/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
+++ b/apps/test/unit/templates/rubrics/AiAssessmentBoxTest.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import sinon from 'sinon';
 
 import EditorAnnotator from '@cdo/apps/EditorAnnotator';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import AiAssessmentBox from '@cdo/apps/templates/rubrics/AiAssessmentBox';
 import AiAssessmentFeedbackContext from '@cdo/apps/templates/rubrics/AiAssessmentFeedbackContext';
 import {RubricUnderstandingLevels} from '@cdo/generated-scripts/sharedConstants';
@@ -11,6 +13,11 @@ import i18n from '@cdo/locale';
 import {expect} from '../../../util/reconfiguredChai';
 
 describe('AiAssessmentBox', () => {
+  const reportingData = {
+    unitName: 'test-2023',
+    courseName: 'course-2023',
+    levelName: 'Test Blah Blah Blah',
+  };
   const mockAiInfo = {
     id: 2,
     learning_goal_id: 2,
@@ -43,10 +50,14 @@ describe('AiAssessmentBox', () => {
   const props = {
     isAiAssessed: true,
     studentName: 'Jane Doe',
+    learningGoals: [{key: 'key', learningGoal: 'goal'}],
+    currentLearningGoal: 0,
+    reportingData: reportingData,
     aiUnderstandingLevel: RubricUnderstandingLevels.CONVINCING,
     aiConfidence: 70,
     aiEvalInfo: mockAiInfo,
     aiEvidence: mockEvidence,
+    studentLevelInfo: {name: 'student', user_id: 42},
   };
 
   it('renders AiAssessmentBox with student information if it is assessed by AI', () => {
@@ -203,5 +214,35 @@ describe('AiAssessmentBox', () => {
 
     // Restore stubs
     scrollToLineStub.restore();
+  });
+
+  it('should send an event when the evidence link is clicked', () => {
+    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
+    const eventName = EVENTS.TA_RUBRIC_EVIDENCE_GOTO_CLICKED;
+    const scrollToLineStub = sinon.stub(EditorAnnotator, 'scrollToLine');
+
+    const wrapper = mount(
+      <AiAssessmentFeedbackContext.Provider value={[-1, () => {}]}>
+        <AiAssessmentBox {...props} />
+      </AiAssessmentFeedbackContext.Provider>
+    );
+
+    // Find the links and expect clicking on them actives scrolling
+    const link = wrapper.find('ul li p a').first();
+
+    // Click on it
+    link.simulate('click');
+
+    // Check that we sent the event
+    expect(sendEventSpy).to.have.been.calledWith(eventName, {
+      ...reportingData,
+      learningGoalKey: props.learningGoals[props.currentLearningGoal].key,
+      learningGoal: props.learningGoals[props.currentLearningGoal].learningGoal,
+      studentId: 42,
+    });
+
+    // Restore stubs
+    scrollToLineStub.restore();
+    sendEventSpy.restore();
   });
 });

--- a/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
@@ -104,6 +104,12 @@ const studentLevelInfo = {
   lastAttempt: '2024-03-02',
 };
 
+const reportingData = {
+  unitName: 'test-2023',
+  courseName: 'course-2023',
+  levelName: 'Test Blah Blah Blah',
+};
+
 describe('LearningGoals - React Testing Library', () => {
   let annotatorStub,
     annotateLineStub,
@@ -293,6 +299,49 @@ describe('LearningGoals - React Testing Library', () => {
       );
       screen.getByText('AI Confidence: medium');
     });
+  });
+
+  it('should send an event if the annotation tooltip is hovered', () => {
+    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
+
+    // We need to check that the callback we give to the annotator would create
+    // the event report.
+    let hoverCallback = undefined;
+    annotateLineStub.callsFake((a, b, c, d, e, f, callback) => {
+      hoverCallback = callback;
+    });
+
+    render(
+      <LearningGoals
+        learningGoals={learningGoals}
+        aiEvaluations={aiEvaluations}
+        reportingData={reportingData}
+        studentLevelInfo={studentLevelInfo}
+        teacherHasEnabledAi
+        canProvideFeedback
+      />
+    );
+
+    const evidence = /The sprite is defined here/;
+    screen.getByText(evidence);
+
+    // There should be /some/ kind of callback registered
+    expect(hoverCallback).to.not.be.undefined;
+
+    // Call the callback ourselves
+    hoverCallback({});
+
+    // We should have triggered the sending of the event with the given data.
+    const eventName = EVENTS.TA_RUBRIC_EVIDENCE_TOOLTIP_HOVERED;
+    expect(sendEventSpy).to.have.been.calledWith(eventName, {
+      ...reportingData,
+      learningGoalKey: learningGoals[0].key,
+      learningGoal: learningGoals[0].learningGoal,
+      studentId: studentLevelInfo.user_id,
+    });
+
+    // Restore stubs
+    sendEventSpy.restore();
   });
 });
 


### PR DESCRIPTION
This adds analytics events for two actions:

* Teacher clicks on the line number link that is part of the evidence listing to scroll to the evidence in the editor.
* Teacher hovers over the tooltip indicator within the editor to reveal the evidence text.

These events also record:

* The level metadata to identify the lesson
* Learning goal identification
* The student id

This adds some extra ability to the `EditorAnnotator` to provide a callback when the tooltip is opened to facilitate this type of recordkeeping.

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Links

- jira ticket: [AITT-542](https://codedotorg.atlassian.net/browse/AITT-542)

## Testing story

Added basic tests to note that the records are being created when those user interactions occur.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
