### PR TITLE
Add deleting MailJet contacts to deleted_accounts_helper

### DIFF
--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -55,6 +55,9 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     FirebaseHelper.stubs(:delete_channel)
     FirebaseHelper.stubs(:delete_channels)
 
+    # Skip MailJet calls
+    MailJet.stubs(:delete_contact)
+
     # Global log used to check expected log output
     @log = StringIO.new
   end

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -1,5 +1,6 @@
 require_relative '../../shared/middleware/helpers/storage_id'
 require 'cdo/aws/s3'
+require 'cdo/mailjet'
 require 'cdo/db'
 
 # rubocop:disable CustomCops/PegasusDbUsage
@@ -250,6 +251,10 @@ class DeleteAccountsHelper
     ContactRollupsPardotMemory.find_or_create_by(email: email).update(marked_for_deletion_at: Time.now.utc)
   end
 
+  def remove_mailjet_contact(email)
+    MailJet.delete_contact(email)
+  end
+
   # Removes the StudioPerson record associated with the user IF it is not
   # associated with any other users.
   # @param [User] user The user whose studio person we will delete if it's not shared
@@ -441,6 +446,7 @@ class DeleteAccountsHelper
     clean_user_sections(user.id)
     remove_user_from_sections_as_student(user)
     remove_poste_data(user_email) if user_email&.present?
+    remove_mailjet_contact(user_email) if user_email&.present?
     purge_contact_rollups(user_email)
     purge_unshared_studio_person(user)
     anonymize_user(user)


### PR DESCRIPTION
The delete method for MailJet was written in a [previous PR](https://github.com/code-dot-org/code-dot-org/pull/58012) so this is just hooking it up! Before deleting a MailJet contact, we do check if one actually exists, so this shouldn't affect existing users.

