### PR TITLE
P20-881: Unlock existing CPA students who have requested parental permission

### DIFF
--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -13,6 +13,15 @@ class Policies::ChildAccount
 
     # The student's account has been approved by their parent.
     PERMISSION_GRANTED = SharedConstants::CHILD_ACCOUNT_COMPLIANCE_STATES.PERMISSION_GRANTED
+
+    # def self.locked_out?(student)
+    # def self.request_sent?(student)
+    # def self.permission_granted?(student)
+    SharedConstants::CHILD_ACCOUNT_COMPLIANCE_STATES.to_h.each do |key, value|
+      define_singleton_method("#{key.downcase}?") do |student|
+        student.child_account_compliance_state == value
+      end
+    end
   end
 
   # The individual US State child account policy configuration
@@ -30,7 +39,11 @@ class Policies::ChildAccount
   # parent permission before the student can start using their account.
   def self.compliant?(user)
     return true unless parent_permission_required?(user)
-    user.child_account_compliance_state == ComplianceState::PERMISSION_GRANTED
+    # CPA Part 2: unlock students created before the policy went into effect
+    # who have requested parental permission but have not yet received approval.
+    return true if ComplianceState.request_sent?(user) && user_predates_policy?(user)
+
+    ComplianceState.permission_granted?(user)
   end
 
   # Checks if a user is affected by a state policy but was created prior to the

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -1,6 +1,30 @@
 require 'test_helper'
 
 class Policies::ChildAccountTest < ActiveSupport::TestCase
+  class ComplianceStateTest < ActiveSupport::TestCase
+    setup do
+      @student = build(:student)
+    end
+
+    test 'locked_out?' do
+      assert_changes -> {Policies::ChildAccount::ComplianceState.locked_out?(@student)}, from: false, to: true do
+        @student.child_account_compliance_state = Policies::ChildAccount::ComplianceState::LOCKED_OUT
+      end
+    end
+
+    test 'request_sent?' do
+      assert_changes -> {Policies::ChildAccount::ComplianceState.request_sent?(@student)}, from: false, to: true do
+        @student.child_account_compliance_state = Policies::ChildAccount::ComplianceState::REQUEST_SENT
+      end
+    end
+
+    test 'permission_granted?' do
+      assert_changes -> {Policies::ChildAccount::ComplianceState.permission_granted?(@student)}, from: false, to: true do
+        @student.child_account_compliance_state = Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED
+      end
+    end
+  end
+
   test 'compliant?' do
     # [User traits, Expected result from compliant?]
     test_matrix = [
@@ -12,6 +36,8 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       [[:non_compliant_child, :not_U13], true],
       [[:non_compliant_child, :migrated_imported_from_clever], true],
       [[:non_compliant_child, :with_lti_auth], true],
+      [[:non_compliant_child, :with_pending_parent_permission, {created_at: '2023-06-30T23:59:59Z'}], true],
+      [[:non_compliant_child, :with_pending_parent_permission, {created_at: '2023-07-01T00:00:00Z'}], false],
     ]
     test_matrix.each do |traits, compliance|
       user = create(*traits)


### PR DESCRIPTION
## Summary
Unlocks CPA students created before the policy went into effect who have requested parental permission but have not yet received approval

## Links
- JIRA ticket: [P20-823](https://codedotorg.atlassian.net/browse/P20-823)