### PR TITLE
Fix flaky test Teacher Application Detail View.

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pd/application_detail_view.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/application_detail_view.feature
@@ -15,7 +15,7 @@ Feature: Teacher Application Detail View
     # Access the Detail View by navigating to the first row's "view application" button href
     # rather than clicking so it does not open in a new tab.
     Then I wait until element "table#quick-view a.btn:contains(View Application)" is visible
-    Then execute JavaScript expression "window.location = $('table#quick-view a.btn:contains(View Application):first()').prop('href')"
+    Then execute JavaScript expression "window.location = $('table#quick-view a.btn:contains(View Application):first()').prop('href')" to load a new page
     Then I wait until element "#detail-view" is visible
     Then I scroll the "#change-principal-approval-requirement" element into view
     Then I click selector "button:contains('Make required')"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -610,8 +610,10 @@ Then /^evaluate JavaScript expression "([^"]*)"$/ do |expression|
   expect(@browser.execute_script("return #{expression}")).to eq(true)
 end
 
-Then /^execute JavaScript expression "([^"]*)"$/ do |expression|
-  @browser.execute_script("return #{expression}")
+Then /^execute JavaScript expression "([^"]*)"( to load a new page)?$/ do |expression, load|
+  page_load(load) do
+    @browser.execute_script("return #{expression}")
+  end
 end
 
 Then /^I navigate to the course page for "([^"]*)"$/ do |course|


### PR DESCRIPTION
Flaky test failing due to error `ReferenceError: $ is not defined`. The screen shots in sauce labs suggest the issue is happening during a page navigation, but the failure is happening on the old page.

Fix: waiting for the page to load in the step where page navigation is triggered.

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

Sauce lab link https://saucelabs.com/tests/89109b66a7444ab29bdda6357fe3fc84

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Drone 

## Deployment strategy

Regular DTP

## Follow-up work

N/A

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
