### PR TITLE
Fix i18n sync error "Timed out reading data from server"

### DIFF
--- a/bin/i18n/utils/crowdin_client.rb
+++ b/bin/i18n/utils/crowdin_client.rb
@@ -13,7 +13,7 @@ module I18n
       MAX_CONCURRENT_REQUESTS = 10 # https://developer.crowdin.com/api/v2/#section/Introduction/Rate-Limits
 
       MAX_ITEMS_COUNT = Crowdin::Web::FetchAllExtensions::MAX_ITEMS_COUNT_PER_REQUEST.freeze
-      REQUEST_TIMEOUT = 60 # Number of seconds to wait for a request to complete
+      REQUEST_TIMEOUT = 120 # Number of seconds to wait for a request to complete
       REQUEST_RETRY_ATTEMPTS = 2 # Number of retries for a failed request
       REQUEST_RETRY_DELAY = 2 # Number of seconds to wait before retrying a failed request
       RETRIABLE_ERRORS = [
@@ -23,6 +23,7 @@ module I18n
         '503 Service Unavailable',
         'Failed to open TCP connection',
         'Timed out connecting to server',
+        'Timed out reading data from server',
       ].freeze # Request errors to retry
 
       # @param project [String] the Crowdin project name, one of the `CDO.crowdin_projects` keys

--- a/bin/test/i18n/utils/test_crowdin_client.rb
+++ b/bin/test/i18n/utils/test_crowdin_client.rb
@@ -31,7 +31,7 @@ describe I18n::Utils::CrowdinClient do
 
       client_config.expects(:api_token=).with(api_token).once
       client_config.expects(:project_id=).with(project_id).once
-      client_config.expects(:request_timeout=).with(60).once
+      client_config.expects(:request_timeout=).with(120).once
 
       assert_equal client, described_instance.send(:client)
     end


### PR DESCRIPTION
## Issue

> bundler: failed to load command: ./bin/i18n/sync-all.rb (./bin/i18n/sync-all.rb)
/home/ubuntu/code-dot-org/bin/i18n/utils/crowdin_client.rb:270:in `request': Something went wrong while request processing. Details - Timed out reading data from server (I18n::Utils::CrowdinClient::RequestError)

>Project:  hour-of-code
Endpoint: update_or_restore_file
Params:   [595, {:storageId=>2110631276}]
Attempt:  1

## Links
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/58066