### PR TITLE
Unit tests for ProgressFeedbackBanner

### DIFF
--- a/apps/src/templates/sectionProgressV2/ProgressFeedbackBanner.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressFeedbackBanner.jsx
@@ -112,6 +112,8 @@ ProgressFeedbackBanner.propTypes = {
   errorWhenCreatingOrLoading: PropTypes.string,
 };
 
+export const UnconnectedProgressFeedbackBanner = ProgressFeedbackBanner;
+
 export default connect(
   state => ({
     currentUser: state.currentUser,

--- a/apps/src/templates/sectionProgressV2/ProgressFeedbackBanner.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressFeedbackBanner.jsx
@@ -48,10 +48,6 @@ const ProgressFeedbackBanner = ({
       return;
     }
 
-    console.log(progressV2Feedback);
-    console.log(answered);
-    console.log(bannerStatus);
-
     // If feedback has been loaded and empty and the user hasn't answered, it is unanswered.
     // If we have feedback and the user did not just submit feedback, close the banner.
     if (progressV2Feedback && !answered) {

--- a/apps/src/templates/sectionProgressV2/ProgressFeedbackBanner.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressFeedbackBanner.jsx
@@ -48,6 +48,10 @@ const ProgressFeedbackBanner = ({
       return;
     }
 
+    console.log(progressV2Feedback);
+    console.log(answered);
+    console.log(bannerStatus);
+
     // If feedback has been loaded and empty and the user hasn't answered, it is unanswered.
     // If we have feedback and the user did not just submit feedback, close the banner.
     if (progressV2Feedback && !answered) {

--- a/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
@@ -1,4 +1,4 @@
-import {fireEvent, render, screen} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import React from 'react';
 import sinon from 'sinon';
 
@@ -61,25 +61,25 @@ describe('UnconnectedProgressFeedbackBanner', () => {
     expect(shareMoreText).to.not.exist;
   });
 
-  it('clicking thumbs up attempts to send feedback and asks for more detailed feedback', () => {
-    render(
-      <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
-    );
-    const thumbsUpButton = screen.getByTitle(
-      i18n.progressV2_feedback_thumbsUp()
-    );
-    expect(thumbsUpButton).to.be.visible;
-    fireEvent.click(thumbsUpButton);
-    expect(fakeCreate).to.have.been.calledOnce;
-    const shareMoreText = screen.getByText(
-      i18n.progressV2_feedback_shareMore()
-    );
-    const shareMoreLink = screen.getByRole('link', {
-      name: i18n.progressV2_feedback_shareMoreLinkText(),
-    });
-    expect(shareMoreLink).to.be.visible;
-    expect(shareMoreText).to.be.visible;
-  });
+  //   it('clicking thumbs up attempts to send feedback and asks for more detailed feedback', () => {
+  //     render(
+  //       <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
+  //     );
+  //     const thumbsUpButton = screen.getByTitle(
+  //       i18n.progressV2_feedback_thumbsUp()
+  //     );
+  //     expect(thumbsUpButton).to.be.visible;
+  //     fireEvent.click(thumbsUpButton);
+  //     expect(fakeCreate).to.have.been.calledOnce;
+  //     const shareMoreText = screen.getByText(
+  //       i18n.progressV2_feedback_shareMore()
+  //     );
+  //     const shareMoreLink = screen.getByRole('link', {
+  //       name: i18n.progressV2_feedback_shareMoreLinkText(),
+  //     });
+  //     expect(shareMoreLink).to.be.visible;
+  //     expect(shareMoreText).to.be.visible;
+  //   });
 
   //   it('clicking thumbs down attempts to send feedback and asks for more detailed feedback', () => {
   //     render(
@@ -93,36 +93,35 @@ describe('UnconnectedProgressFeedbackBanner', () => {
   //     expect(fakeCreate).to.have.been.calledOnce;
   //   });
 
-  //   it('user is able to close the banner', () => {
-  //     const fakeFetch = sinon.spy();
-  //     const fakeCreate = sinon.spy();
-  //     const props = {
-  //       currentUser: {isAdmin: false},
-  //       canShow: true,
-  //       isLoading: false,
-  //       progressV2Feedback: {empty: true},
-  //       fetchProgressV2Feedback: fakeFetch,
-  //       createProgressV2Feedback: fakeCreate,
-  //       errorWhenCreatingOrLoading: null,
-  //     };
+  it('user is able to close the banner', async () => {
+    render(
+      <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
+    );
 
-  //     render(<UnconnectedProgressFeedbackBanner {...props} />);
-  //     const thumbsUpButton = screen.getByTitle(
-  //       i18n.progressV2_feedback_thumbsUp()
-  //     );
-  //     expect(thumbsUpButton).to.be.visible;
-  //     fireEvent.click(thumbsUpButton);
-  //     expect(fakeCreate).to.have.been.calledOnce;
-  //     const closeButton = screen.getByText('×');
-  //     expect(closeButton).to.be.visible;
-  //     fireEvent.click(closeButton);
-  //     const questionText = screen.queryByText(
-  //       i18n.progressV2_feedback_question()
-  //     );
-  //     const shareMoreText = screen.queryByText(
-  //       i18n.progressV2_feedback_shareMore()
-  //     );
-  //     expect(questionText).to.not.exist;
-  //     expect(shareMoreText).to.not.exist;
-  //   });
+    // Give feedback
+    const thumbsUpButton = screen.getByTitle(
+      i18n.progressV2_feedback_thumbsUp()
+    );
+    expect(thumbsUpButton).to.be.visible;
+    fireEvent.click(thumbsUpButton);
+    await waitFor(() => {
+      expect(fakeCreate).to.have.been.calledOnce;
+    });
+    screen.debug();
+
+    // Close the banner
+    const closeButton = screen.getByText('×');
+    expect(closeButton).to.be.visible;
+    fireEvent.click(closeButton);
+    await waitFor(() => {
+      const questionText = screen.queryByText(
+        i18n.progressV2_feedback_question()
+      );
+      const shareMoreText = screen.queryByText(
+        i18n.progressV2_feedback_shareMore()
+      );
+      expect(questionText).to.not.exist;
+      expect(shareMoreText).to.not.exist;
+    });
+  });
 });

--- a/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
@@ -2,44 +2,49 @@ import {render, screen} from '@testing-library/react';
 import React from 'react';
 import sinon from 'sinon';
 
-import UnconnectedProgressFeedbackBanner from '@cdo/apps/templates/sectionProgressV2/ProgressFeedbackBanner';
+import {UnconnectedProgressFeedbackBanner} from '@cdo/apps/templates/sectionProgressV2/ProgressFeedbackBanner';
 import i18n from '@cdo/locale';
 
 import {expect} from '../../../util/reconfiguredChai';
 
 describe('UnconnectedProgressFeedbackBanner', () => {
-  it('renders correctly with initial state', () => {
+  it('renders correctly when user has not answered survey question', () => {
     const fakeFetch = sinon.spy();
     const fakeCreate = sinon.spy();
     const props = {
-      canShow: false,
+      currentUser: {isAdmin: false},
+      canShow: true,
       isLoading: false,
-      progressV2Feedback: null,
+      progressV2Feedback: {empty: true},
       fetchProgressV2Feedback: fakeFetch,
       createProgressV2Feedback: fakeCreate,
       errorWhenCreatingOrLoading: null,
     };
 
     render(<UnconnectedProgressFeedbackBanner {...props} />);
-    expect(screen.getByText(i18n.progressV2_feedback_question())).not.be
+    expect(screen.getByText(i18n.progressV2_feedback_question())).to.be.visible;
+    expect(screen.getByTitle(i18n.progressV2_feedback_thumbsUp())).to.be
+      .visible;
+    expect(screen.getByTitle(i18n.progressV2_feedback_thumbsDown())).to.be
       .visible;
   });
 
-  //   it('handles answer function when thumbs up is clicked', () => {
-  //     const createFeedbackMock = jest.fn();
+  //   it('renders correctly with initial state', () => {
+  //     const fakeFetch = sinon.spy();
+  //     const fakeCreate = sinon.spy();
   //     const props = {
+  //       currentUser: {isAdmin: false},
+  //       bannerStatus: 'unanswered',
   //       canShow: true,
   //       isLoading: false,
   //       progressV2Feedback: {empty: true},
-  //       fetchProgressV2Feedback: jest.fn(),
-  //       createProgressV2Feedback: createFeedbackMock,
+  //       fetchProgressV2Feedback: fakeFetch,
+  //       createProgressV2Feedback: fakeCreate,
   //       errorWhenCreatingOrLoading: null,
   //     };
 
-  //     const {getByText} = render(
-  //       <UnconnectedProgressFeedbackBanner {...props} />
-  //     );
-  //     fireEvent.click(getByText(/Thumbs Up/i));
-  //     expect(createFeedbackMock).toHaveBeenCalled();
+  //     render(<UnconnectedProgressFeedbackBanner {...props} />);
+  //     screen.debug();
+  //     expect(screen.getByText(i18n.progressV2_feedback_question())).to.be.visible;
   //   });
 });

--- a/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
@@ -172,50 +172,51 @@ describe('UnconnectedProgressFeedbackBanner', () => {
     });
   });
 
-  it('attempts reset and reload if error from createFeedback', async () => {
-    console.log('---------------');
-    const {rerender} = render(
-      <UnconnectedProgressFeedbackBanner {...defaultProps} />
-    );
-    rerender(
-      <UnconnectedProgressFeedbackBanner
-        {...defaultProps}
-        errorWhenCreatingOrLoading={'This produced an error.'}
-      />
-    );
-    const questionText = screen.queryByText(
-      i18n.progressV2_feedback_question()
-    );
-    const shareMoreText = screen.queryByText(
-      i18n.progressV2_feedback_shareMore()
-    );
-    expect(questionText).to.not.exist;
-    expect(shareMoreText).to.not.exist;
-    // console.log('before first await');
-    // await waitFor(() => {
-    //   const questionText = screen.queryByText(
-    //     i18n.progressV2_feedback_question()
-    //   );
-    //   const shareMoreText = screen.queryByText(
-    //     i18n.progressV2_feedback_shareMore()
-    //   );
-    //   expect(questionText).to.not.exist;
-    //   expect(shareMoreText).to.not.exist;
-    // });
-    console.log('before second await');
-    await waitFor(
-      expect(screen.getByText(i18n.progressV2_feedback_question())).to.be
-        .visible
-    );
-    console.log('after last await');
-    screen.debug();
-    // await waitFor(() => {
-    //   expect(screen.getByText(i18n.progressV2_feedback_question())).to.be
-    //     .visible;
-    //   expect(screen.getByTitle(i18n.progressV2_feedback_thumbsUp())).to.be
-    //     .visible;
-    //   expect(screen.getByTitle(i18n.progressV2_feedback_thumbsDown())).to.be
-    //     .visible;
-    // });
-  });
+  // TODO: Fix test after Liam updates component
+  // it('attempts reset and reload if error from createFeedback', async () => {
+  //   console.log('---------------');
+  //   const {rerender} = render(
+  //     <UnconnectedProgressFeedbackBanner {...defaultProps} />
+  //   );
+  //   rerender(
+  //     <UnconnectedProgressFeedbackBanner
+  //       {...defaultProps}
+  //       errorWhenCreatingOrLoading={'This produced an error.'}
+  //     />
+  //   );
+  //   const questionText = screen.queryByText(
+  //     i18n.progressV2_feedback_question()
+  //   );
+  //   const shareMoreText = screen.queryByText(
+  //     i18n.progressV2_feedback_shareMore()
+  //   );
+  //   expect(questionText).to.not.exist;
+  //   expect(shareMoreText).to.not.exist;
+  //   // console.log('before first await');
+  //   // await waitFor(() => {
+  //   //   const questionText = screen.queryByText(
+  //   //     i18n.progressV2_feedback_question()
+  //   //   );
+  //   //   const shareMoreText = screen.queryByText(
+  //   //     i18n.progressV2_feedback_shareMore()
+  //   //   );
+  //   //   expect(questionText).to.not.exist;
+  //   //   expect(shareMoreText).to.not.exist;
+  //   // });
+  //   console.log('before second await');
+  //   await waitFor(
+  //     expect(screen.getByText(i18n.progressV2_feedback_question())).to.be
+  //       .visible
+  //   );
+  //   console.log('after last await');
+  //   screen.debug();
+  //   // await waitFor(() => {
+  //   //   expect(screen.getByText(i18n.progressV2_feedback_question())).to.be
+  //   //     .visible;
+  //   //   expect(screen.getByTitle(i18n.progressV2_feedback_thumbsUp())).to.be
+  //   //     .visible;
+  //   //   expect(screen.getByTitle(i18n.progressV2_feedback_thumbsDown())).to.be
+  //   //     .visible;
+  //   // });
+  // });
 });

--- a/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
@@ -20,6 +20,11 @@ describe('UnconnectedProgressFeedbackBanner', () => {
     errorWhenCreatingOrLoading: null,
   };
 
+  afterEach(() => {
+    // Reset the spy's history after each test
+    fakeCreate.resetHistory();
+  });
+
   it('renders correctly with initial state', () => {
     render(<UnconnectedProgressFeedbackBanner {...defaultProps} />);
     const questionText = screen.queryByText(
@@ -61,37 +66,51 @@ describe('UnconnectedProgressFeedbackBanner', () => {
     expect(shareMoreText).to.not.exist;
   });
 
-  //   it('clicking thumbs up attempts to send feedback and asks for more detailed feedback', () => {
-  //     render(
-  //       <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
-  //     );
-  //     const thumbsUpButton = screen.getByTitle(
-  //       i18n.progressV2_feedback_thumbsUp()
-  //     );
-  //     expect(thumbsUpButton).to.be.visible;
-  //     fireEvent.click(thumbsUpButton);
-  //     expect(fakeCreate).to.have.been.calledOnce;
-  //     const shareMoreText = screen.getByText(
-  //       i18n.progressV2_feedback_shareMore()
-  //     );
-  //     const shareMoreLink = screen.getByRole('link', {
-  //       name: i18n.progressV2_feedback_shareMoreLinkText(),
-  //     });
-  //     expect(shareMoreLink).to.be.visible;
-  //     expect(shareMoreText).to.be.visible;
-  //   });
+  it('clicking thumbs up attempts to send feedback and asks for more detailed feedback', async () => {
+    render(
+      <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
+    );
+    const thumbsUpButton = screen.getByTitle(
+      i18n.progressV2_feedback_thumbsUp()
+    );
+    expect(thumbsUpButton).to.be.visible;
+    fireEvent.click(thumbsUpButton);
 
-  //   it('clicking thumbs down attempts to send feedback and asks for more detailed feedback', () => {
-  //     render(
-  //       <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
-  //     );
-  //     const thumbsDownButton = screen.getByTitle(
-  //       i18n.progressV2_feedback_thumbsDown()
-  //     );
-  //     expect(thumbsDownButton).to.be.visible;
-  //     fireEvent.click(thumbsDownButton);
-  //     expect(fakeCreate).to.have.been.calledOnce;
-  //   });
+    await waitFor(() => {
+      expect(fakeCreate).to.have.been.calledOnce;
+    });
+    const shareMoreText = screen.getByText(
+      i18n.progressV2_feedback_shareMore()
+    );
+    const shareMoreLink = screen.getByRole('link', {
+      name: i18n.progressV2_feedback_shareMoreLinkText(),
+    });
+    expect(shareMoreLink).to.be.visible;
+    expect(shareMoreText).to.be.visible;
+  });
+
+  it('clicking thumbs down attempts to send feedback and asks for more detailed feedback', async () => {
+    render(
+      <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
+    );
+    const thumbsDownButton = screen.getByTitle(
+      i18n.progressV2_feedback_thumbsDown()
+    );
+    expect(thumbsDownButton).to.be.visible;
+    fireEvent.click(thumbsDownButton);
+    await waitFor(() => {
+      expect(fakeCreate).to.have.been.calledOnce;
+    });
+
+    const shareMoreText = screen.getByText(
+      i18n.progressV2_feedback_shareMore()
+    );
+    const shareMoreLink = screen.getByRole('link', {
+      name: i18n.progressV2_feedback_shareMoreLinkText(),
+    });
+    expect(shareMoreLink).to.be.visible;
+    expect(shareMoreText).to.be.visible;
+  });
 
   it('user is able to close the banner', async () => {
     render(
@@ -107,7 +126,6 @@ describe('UnconnectedProgressFeedbackBanner', () => {
     await waitFor(() => {
       expect(fakeCreate).to.have.been.calledOnce;
     });
-    screen.debug();
 
     // Close the banner
     const closeButton = screen.getByText('×');

--- a/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
@@ -12,20 +12,47 @@ describe('UnconnectedProgressFeedbackBanner', () => {
   const fakeCreate = sinon.spy();
   const defaultProps = {
     currentUser: {isAdmin: false},
-    canShow: false,
+    canShow: true,
     isLoading: false,
     progressV2Feedback: {empty: true},
-    fetchProgressV2Feedback: fakeFetch,
-    createProgressV2Feedback: fakeCreate,
+    fetchProgressV2Feedback: () => {},
+    createProgressV2Feedback: () => {},
     errorWhenCreatingOrLoading: null,
   };
 
   afterEach(() => {
     fakeCreate.resetHistory();
+    fakeFetch.resetHistory();
   });
 
-  it('renders correctly with initial state', () => {
-    render(<UnconnectedProgressFeedbackBanner {...defaultProps} />);
+  it('renders empty if it can not show', () => {
+    render(
+      <UnconnectedProgressFeedbackBanner
+        {...defaultProps}
+        canShow={false}
+        fetchProgressV2Feedback={fakeFetch}
+      />
+    );
+    expect(fakeFetch).to.have.been.calledOnce;
+    const questionText = screen.queryByText(
+      i18n.progressV2_feedback_question()
+    );
+    const shareMoreText = screen.queryByText(
+      i18n.progressV2_feedback_shareMore()
+    );
+    expect(questionText).to.not.exist;
+    expect(shareMoreText).to.not.exist;
+  });
+
+  it('renders empty if user already answered the feedback question', () => {
+    render(
+      <UnconnectedProgressFeedbackBanner
+        {...defaultProps}
+        progressV2Feedback={{empty: false}}
+        fetchProgressV2Feedback={fakeFetch}
+      />
+    );
+    expect(fakeFetch).to.have.been.calledOnce;
     const questionText = screen.queryByText(
       i18n.progressV2_feedback_question()
     );
@@ -37,9 +64,7 @@ describe('UnconnectedProgressFeedbackBanner', () => {
   });
 
   it('renders correctly when user has not answered survey question', () => {
-    render(
-      <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
-    );
+    render(<UnconnectedProgressFeedbackBanner {...defaultProps} />);
     expect(screen.getByText(i18n.progressV2_feedback_question())).to.be.visible;
     expect(screen.getByTitle(i18n.progressV2_feedback_thumbsUp())).to.be
       .visible;
@@ -49,11 +74,7 @@ describe('UnconnectedProgressFeedbackBanner', () => {
 
   it('renders correctly when the data is loading', () => {
     render(
-      <UnconnectedProgressFeedbackBanner
-        {...defaultProps}
-        canShow={true}
-        isLoading={true}
-      />
+      <UnconnectedProgressFeedbackBanner {...defaultProps} isLoading={true} />
     );
     const questionText = screen.queryByText(
       i18n.progressV2_feedback_question()
@@ -67,7 +88,10 @@ describe('UnconnectedProgressFeedbackBanner', () => {
 
   it('clicking thumbs up attempts to send feedback and asks for more detailed feedback', async () => {
     render(
-      <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
+      <UnconnectedProgressFeedbackBanner
+        {...defaultProps}
+        createProgressV2Feedback={fakeCreate}
+      />
     );
     const thumbsUpButton = screen.getByTitle(
       i18n.progressV2_feedback_thumbsUp()
@@ -90,7 +114,10 @@ describe('UnconnectedProgressFeedbackBanner', () => {
 
   it('clicking thumbs down attempts to send feedback and asks for more detailed feedback', async () => {
     render(
-      <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
+      <UnconnectedProgressFeedbackBanner
+        {...defaultProps}
+        createProgressV2Feedback={fakeCreate}
+      />
     );
     const thumbsDownButton = screen.getByTitle(
       i18n.progressV2_feedback_thumbsDown()
@@ -113,7 +140,10 @@ describe('UnconnectedProgressFeedbackBanner', () => {
 
   it('user is able to close the banner', async () => {
     render(
-      <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
+      <UnconnectedProgressFeedbackBanner
+        {...defaultProps}
+        createProgressV2Feedback={fakeCreate}
+      />
     );
 
     // Give feedback
@@ -140,5 +170,52 @@ describe('UnconnectedProgressFeedbackBanner', () => {
       expect(questionText).to.not.exist;
       expect(shareMoreText).to.not.exist;
     });
+  });
+
+  it('attempts reset and reload if error from createFeedback', async () => {
+    console.log('---------------');
+    const {rerender} = render(
+      <UnconnectedProgressFeedbackBanner {...defaultProps} />
+    );
+    rerender(
+      <UnconnectedProgressFeedbackBanner
+        {...defaultProps}
+        errorWhenCreatingOrLoading={'This produced an error.'}
+      />
+    );
+    const questionText = screen.queryByText(
+      i18n.progressV2_feedback_question()
+    );
+    const shareMoreText = screen.queryByText(
+      i18n.progressV2_feedback_shareMore()
+    );
+    expect(questionText).to.not.exist;
+    expect(shareMoreText).to.not.exist;
+    // console.log('before first await');
+    // await waitFor(() => {
+    //   const questionText = screen.queryByText(
+    //     i18n.progressV2_feedback_question()
+    //   );
+    //   const shareMoreText = screen.queryByText(
+    //     i18n.progressV2_feedback_shareMore()
+    //   );
+    //   expect(questionText).to.not.exist;
+    //   expect(shareMoreText).to.not.exist;
+    // });
+    console.log('before second await');
+    await waitFor(
+      expect(screen.getByText(i18n.progressV2_feedback_question())).to.be
+        .visible
+    );
+    console.log('after last await');
+    screen.debug();
+    // await waitFor(() => {
+    //   expect(screen.getByText(i18n.progressV2_feedback_question())).to.be
+    //     .visible;
+    //   expect(screen.getByTitle(i18n.progressV2_feedback_thumbsUp())).to.be
+    //     .visible;
+    //   expect(screen.getByTitle(i18n.progressV2_feedback_thumbsDown())).to.be
+    //     .visible;
+    // });
   });
 });

--- a/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
@@ -173,8 +173,7 @@ describe('UnconnectedProgressFeedbackBanner', () => {
   });
 
   // TODO: Fix test after Liam updates component
-  // it('attempts reset and reload if error from createFeedback', async () => {
-  //   console.log('---------------');
+  // it('attempts reset and reload if error from createFeedback', () => {
   //   const {rerender} = render(
   //     <UnconnectedProgressFeedbackBanner {...defaultProps} />
   //   );
@@ -192,31 +191,5 @@ describe('UnconnectedProgressFeedbackBanner', () => {
   //   );
   //   expect(questionText).to.not.exist;
   //   expect(shareMoreText).to.not.exist;
-  //   // console.log('before first await');
-  //   // await waitFor(() => {
-  //   //   const questionText = screen.queryByText(
-  //   //     i18n.progressV2_feedback_question()
-  //   //   );
-  //   //   const shareMoreText = screen.queryByText(
-  //   //     i18n.progressV2_feedback_shareMore()
-  //   //   );
-  //   //   expect(questionText).to.not.exist;
-  //   //   expect(shareMoreText).to.not.exist;
-  //   // });
-  //   console.log('before second await');
-  //   await waitFor(
-  //     expect(screen.getByText(i18n.progressV2_feedback_question())).to.be
-  //       .visible
-  //   );
-  //   console.log('after last await');
-  //   screen.debug();
-  //   // await waitFor(() => {
-  //   //   expect(screen.getByText(i18n.progressV2_feedback_question())).to.be
-  //   //     .visible;
-  //   //   expect(screen.getByTitle(i18n.progressV2_feedback_thumbsUp())).to.be
-  //   //     .visible;
-  //   //   expect(screen.getByTitle(i18n.progressV2_feedback_thumbsDown())).to.be
-  //   //     .visible;
-  //   // });
   // });
 });

--- a/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
@@ -21,7 +21,6 @@ describe('UnconnectedProgressFeedbackBanner', () => {
   };
 
   afterEach(() => {
-    // Reset the spy's history after each test
     fakeCreate.resetHistory();
   });
 

--- a/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import React from 'react';
 import sinon from 'sinon';
 
@@ -8,6 +8,30 @@ import i18n from '@cdo/locale';
 import {expect} from '../../../util/reconfiguredChai';
 
 describe('UnconnectedProgressFeedbackBanner', () => {
+  it('renders correctly with initial state', () => {
+    const fakeFetch = sinon.spy();
+    const fakeCreate = sinon.spy();
+    const props = {
+      currentUser: {isAdmin: false},
+      canShow: false,
+      isLoading: false,
+      progressV2Feedback: {empty: true},
+      fetchProgressV2Feedback: fakeFetch,
+      createProgressV2Feedback: fakeCreate,
+      errorWhenCreatingOrLoading: null,
+    };
+
+    render(<UnconnectedProgressFeedbackBanner {...props} />);
+    const questionText = screen.queryByText(
+      i18n.progressV2_feedback_question()
+    );
+    const shareMoreText = screen.queryByText(
+      i18n.progressV2_feedback_shareMore()
+    );
+    expect(questionText).to.not.exist;
+    expect(shareMoreText).to.not.exist;
+  });
+
   it('renders correctly when user has not answered survey question', () => {
     const fakeFetch = sinon.spy();
     const fakeCreate = sinon.spy();
@@ -29,12 +53,65 @@ describe('UnconnectedProgressFeedbackBanner', () => {
       .visible;
   });
 
-  //   it('renders correctly with initial state', () => {
+  it('renders correctly when the data is loading', () => {
+    const fakeFetch = sinon.spy();
+    const fakeCreate = sinon.spy();
+    const props = {
+      currentUser: {isAdmin: false},
+      canShow: true,
+      isLoading: true,
+      progressV2Feedback: {empty: true},
+      fetchProgressV2Feedback: fakeFetch,
+      createProgressV2Feedback: fakeCreate,
+      errorWhenCreatingOrLoading: null,
+    };
+
+    render(<UnconnectedProgressFeedbackBanner {...props} />);
+    const questionText = screen.queryByText(
+      i18n.progressV2_feedback_question()
+    );
+    const shareMoreText = screen.queryByText(
+      i18n.progressV2_feedback_shareMore()
+    );
+    expect(questionText).to.not.exist;
+    expect(shareMoreText).to.not.exist;
+  });
+
+  it('clicking thumbs up attempts to send feedback', () => {
+    const fakeFetch = sinon.spy();
+    const fakeCreate = sinon.spy();
+    const props = {
+      currentUser: {isAdmin: false},
+      canShow: true,
+      isLoading: false,
+      progressV2Feedback: {empty: true},
+      fetchProgressV2Feedback: fakeFetch,
+      createProgressV2Feedback: fakeCreate,
+      errorWhenCreatingOrLoading: null,
+    };
+
+    render(<UnconnectedProgressFeedbackBanner {...props} />);
+    const thumbsUpButton = screen.getByTitle(
+      i18n.progressV2_feedback_thumbsUp()
+    );
+    expect(thumbsUpButton).to.be.visible;
+    fireEvent.click(thumbsUpButton);
+    expect(fakeCreate).to.have.been.calledOnce;
+    const shareMoreText = screen.getByText(
+      i18n.progressV2_feedback_shareMore()
+    );
+    const shareMoreLink = screen.getByRole('link', {
+      name: i18n.progressV2_feedback_shareMoreLinkText(),
+    });
+    expect(shareMoreLink).to.be.visible;
+    expect(shareMoreText).to.be.visible;
+  });
+
+  //   it('clicking thumbs down attempts to send feedback', () => {
   //     const fakeFetch = sinon.spy();
   //     const fakeCreate = sinon.spy();
   //     const props = {
   //       currentUser: {isAdmin: false},
-  //       bannerStatus: 'unanswered',
   //       canShow: true,
   //       isLoading: false,
   //       progressV2Feedback: {empty: true},
@@ -44,7 +121,37 @@ describe('UnconnectedProgressFeedbackBanner', () => {
   //     };
 
   //     render(<UnconnectedProgressFeedbackBanner {...props} />);
-  //     screen.debug();
-  //     expect(screen.getByText(i18n.progressV2_feedback_question())).to.be.visible;
+  //     const thumbsDownButton = screen.getByTitle(
+  //       i18n.progressV2_feedback_thumbsDown()
+  //     );
+  //     expect(thumbsDownButton).to.be.visible;
+  //     fireEvent.click(thumbsDownButton);
+  //     expect(fakeCreate).to.have.been.calledOnce;
+  //   });
+
+  //   it('user is able to close the banner', () => {
+  //     const fakeFetch = sinon.spy();
+  //     const fakeCreate = sinon.spy();
+  //     const props = {
+  //       currentUser: {isAdmin: false},
+  //       canShow: true,
+  //       isLoading: false,
+  //       progressV2Feedback: {empty: true},
+  //       fetchProgressV2Feedback: fakeFetch,
+  //       createProgressV2Feedback: fakeCreate,
+  //       errorWhenCreatingOrLoading: null,
+  //     };
+
+  //     render(<UnconnectedProgressFeedbackBanner {...props} />);
+  //     const thumbsUpButton = screen.getByTitle(
+  //       i18n.progressV2_feedback_thumbsUp()
+  //     );
+  //     expect(thumbsUpButton).to.be.visible;
+  //     fireEvent.click(thumbsUpButton);
+  //     expect(fakeCreate).to.have.been.calledOnce;
+  //     const closeButton = screen.getByText('HEHEHEHE');
+  //     expect(closeButton).to.be.visible;
+  //     fireEvent.click(closeButton);
+  // expect close function to be called
   //   });
 });

--- a/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
@@ -8,20 +8,20 @@ import i18n from '@cdo/locale';
 import {expect} from '../../../util/reconfiguredChai';
 
 describe('UnconnectedProgressFeedbackBanner', () => {
-  it('renders correctly with initial state', () => {
-    const fakeFetch = sinon.spy();
-    const fakeCreate = sinon.spy();
-    const props = {
-      currentUser: {isAdmin: false},
-      canShow: false,
-      isLoading: false,
-      progressV2Feedback: {empty: true},
-      fetchProgressV2Feedback: fakeFetch,
-      createProgressV2Feedback: fakeCreate,
-      errorWhenCreatingOrLoading: null,
-    };
+  const fakeFetch = sinon.spy();
+  const fakeCreate = sinon.spy();
+  const defaultProps = {
+    currentUser: {isAdmin: false},
+    canShow: false,
+    isLoading: false,
+    progressV2Feedback: {empty: true},
+    fetchProgressV2Feedback: fakeFetch,
+    createProgressV2Feedback: fakeCreate,
+    errorWhenCreatingOrLoading: null,
+  };
 
-    render(<UnconnectedProgressFeedbackBanner {...props} />);
+  it('renders correctly with initial state', () => {
+    render(<UnconnectedProgressFeedbackBanner {...defaultProps} />);
     const questionText = screen.queryByText(
       i18n.progressV2_feedback_question()
     );
@@ -33,19 +33,9 @@ describe('UnconnectedProgressFeedbackBanner', () => {
   });
 
   it('renders correctly when user has not answered survey question', () => {
-    const fakeFetch = sinon.spy();
-    const fakeCreate = sinon.spy();
-    const props = {
-      currentUser: {isAdmin: false},
-      canShow: true,
-      isLoading: false,
-      progressV2Feedback: {empty: true},
-      fetchProgressV2Feedback: fakeFetch,
-      createProgressV2Feedback: fakeCreate,
-      errorWhenCreatingOrLoading: null,
-    };
-
-    render(<UnconnectedProgressFeedbackBanner {...props} />);
+    render(
+      <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
+    );
     expect(screen.getByText(i18n.progressV2_feedback_question())).to.be.visible;
     expect(screen.getByTitle(i18n.progressV2_feedback_thumbsUp())).to.be
       .visible;
@@ -54,19 +44,13 @@ describe('UnconnectedProgressFeedbackBanner', () => {
   });
 
   it('renders correctly when the data is loading', () => {
-    const fakeFetch = sinon.spy();
-    const fakeCreate = sinon.spy();
-    const props = {
-      currentUser: {isAdmin: false},
-      canShow: true,
-      isLoading: true,
-      progressV2Feedback: {empty: true},
-      fetchProgressV2Feedback: fakeFetch,
-      createProgressV2Feedback: fakeCreate,
-      errorWhenCreatingOrLoading: null,
-    };
-
-    render(<UnconnectedProgressFeedbackBanner {...props} />);
+    render(
+      <UnconnectedProgressFeedbackBanner
+        {...defaultProps}
+        canShow={true}
+        isLoading={true}
+      />
+    );
     const questionText = screen.queryByText(
       i18n.progressV2_feedback_question()
     );
@@ -77,20 +61,10 @@ describe('UnconnectedProgressFeedbackBanner', () => {
     expect(shareMoreText).to.not.exist;
   });
 
-  it('clicking thumbs up attempts to send feedback', () => {
-    const fakeFetch = sinon.spy();
-    const fakeCreate = sinon.spy();
-    const props = {
-      currentUser: {isAdmin: false},
-      canShow: true,
-      isLoading: false,
-      progressV2Feedback: {empty: true},
-      fetchProgressV2Feedback: fakeFetch,
-      createProgressV2Feedback: fakeCreate,
-      errorWhenCreatingOrLoading: null,
-    };
-
-    render(<UnconnectedProgressFeedbackBanner {...props} />);
+  it('clicking thumbs up attempts to send feedback and asks for more detailed feedback', () => {
+    render(
+      <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
+    );
     const thumbsUpButton = screen.getByTitle(
       i18n.progressV2_feedback_thumbsUp()
     );
@@ -107,20 +81,10 @@ describe('UnconnectedProgressFeedbackBanner', () => {
     expect(shareMoreText).to.be.visible;
   });
 
-  //   it('clicking thumbs down attempts to send feedback', () => {
-  //     const fakeFetch = sinon.spy();
-  //     const fakeCreate = sinon.spy();
-  //     const props = {
-  //       currentUser: {isAdmin: false},
-  //       canShow: true,
-  //       isLoading: false,
-  //       progressV2Feedback: {empty: true},
-  //       fetchProgressV2Feedback: fakeFetch,
-  //       createProgressV2Feedback: fakeCreate,
-  //       errorWhenCreatingOrLoading: null,
-  //     };
-
-  //     render(<UnconnectedProgressFeedbackBanner {...props} />);
+  //   it('clicking thumbs down attempts to send feedback and asks for more detailed feedback', () => {
+  //     render(
+  //       <UnconnectedProgressFeedbackBanner {...defaultProps} canShow={true} />
+  //     );
   //     const thumbsDownButton = screen.getByTitle(
   //       i18n.progressV2_feedback_thumbsDown()
   //     );
@@ -149,9 +113,16 @@ describe('UnconnectedProgressFeedbackBanner', () => {
   //     expect(thumbsUpButton).to.be.visible;
   //     fireEvent.click(thumbsUpButton);
   //     expect(fakeCreate).to.have.been.calledOnce;
-  //     const closeButton = screen.getByText('HEHEHEHE');
+  //     const closeButton = screen.getByText('×');
   //     expect(closeButton).to.be.visible;
   //     fireEvent.click(closeButton);
-  // expect close function to be called
+  //     const questionText = screen.queryByText(
+  //       i18n.progressV2_feedback_question()
+  //     );
+  //     const shareMoreText = screen.queryByText(
+  //       i18n.progressV2_feedback_shareMore()
+  //     );
+  //     expect(questionText).to.not.exist;
+  //     expect(shareMoreText).to.not.exist;
   //   });
 });

--- a/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
@@ -1,0 +1,45 @@
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+import sinon from 'sinon';
+
+import UnconnectedProgressFeedbackBanner from '@cdo/apps/templates/sectionProgressV2/ProgressFeedbackBanner';
+import i18n from '@cdo/locale';
+
+import {expect} from '../../../util/reconfiguredChai';
+
+describe('UnconnectedProgressFeedbackBanner', () => {
+  it('renders correctly with initial state', () => {
+    const fakeFetch = sinon.spy();
+    const fakeCreate = sinon.spy();
+    const props = {
+      canShow: false,
+      isLoading: false,
+      progressV2Feedback: null,
+      fetchProgressV2Feedback: fakeFetch,
+      createProgressV2Feedback: fakeCreate,
+      errorWhenCreatingOrLoading: null,
+    };
+
+    render(<UnconnectedProgressFeedbackBanner {...props} />);
+    expect(screen.getByText(i18n.progressV2_feedback_question())).not.be
+      .visible;
+  });
+
+  //   it('handles answer function when thumbs up is clicked', () => {
+  //     const createFeedbackMock = jest.fn();
+  //     const props = {
+  //       canShow: true,
+  //       isLoading: false,
+  //       progressV2Feedback: {empty: true},
+  //       fetchProgressV2Feedback: jest.fn(),
+  //       createProgressV2Feedback: createFeedbackMock,
+  //       errorWhenCreatingOrLoading: null,
+  //     };
+
+  //     const {getByText} = render(
+  //       <UnconnectedProgressFeedbackBanner {...props} />
+  //     );
+  //     fireEvent.click(getByText(/Thumbs Up/i));
+  //     expect(createFeedbackMock).toHaveBeenCalled();
+  //   });
+});


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<hr>

Added tests for the `ProgressFeedbackBannerTest` component

## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1028)

## Testing story

It is all tests!