### PR TITLE
Add Music Lab landing page tutorial section strings

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -2053,6 +2053,10 @@
     teachers_guide:
       heading: "Get the teacher's guide to Music Lab"
       desc: "Grab your copy of the teacher's guide to Music Lab to learn how to get started, explore activity ideas, and get answers to frequently asked questions."
+    tutorial:
+      heading: "Teach Music Lab in your Classroom"
+      desc: "Use our Music Lab tutorial to unleash your students' musical creativity, combining the joy of music with the principles of coding."
+      button: "Start tutorial"
     additional_resources:
       heading: "Additional resources"
       catalog:


### PR DESCRIPTION
Adds strings for a new tutorial section on the as-yet-to-be-created Music Lab landing page

**Jira ticket:** [ACQ-1800](https://codedotorg.atlassian.net/browse/ACQ-1800)
**Figma comment:** [here](https://www.figma.com/file/2WMErkWkUqY8DNxPCa5hXB?type=design&node-id=2390-1392&mode=design#775332984)