### PR TITLE
[Python lab] Load pyodide from cdn

### DIFF
--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -1,10 +1,12 @@
 import {deleteSourceFiles, writeSource} from './patches/pythonScriptUtils';
 import {DEFAULT_FOLDER_ID} from '../weblab2/CDOIDE/constants';
-import {loadPyodide, version} from 'pyodide';
+import {loadPyodide /*, version*/} from 'pyodide';
 
 async function loadPyodideAndPackages() {
   self.pyodide = await loadPyodide({
-    indexURL: `/assets/js/pyodide/${version}/`,
+    indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.24.1/full',
+    // This URL is not working on prod, so we will use the CDN for now.
+    // indexURL: `/assets/js/pyodide/${version}/`,
     // pre-load numpy as it will frequently be used, and matplotlib as we patch it.
     packages: ['numpy', 'matplotlib'],
   });


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Summary
Loading pyodide from our code.org endpoint is not currently working on non-local environments. While we figure out what went wrong, go back to loading it from the cdn instead.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
