### PR TITLE
Gen AI lab: persist model card publish state, fix model list bug

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -99,7 +99,7 @@ const initialState: AichatState = {
 export const updateAiCustomization = createAsyncThunk(
   'aichat/updateAiCustomization',
   async (_, thunkAPI) => {
-    const rootState = (await thunkAPI.getState()) as RootState;
+    const rootState = thunkAPI.getState() as RootState;
     const {currentAiCustomizations, savedAiCustomizations} = rootState.aichat;
     const {dispatch} = thunkAPI;
 
@@ -120,7 +120,7 @@ export const publishModel = createAsyncThunk(
     const {dispatch} = thunkAPI;
     dispatch(setModelCardProperty({property: 'isPublished', value: true}));
 
-    const rootState = (await thunkAPI.getState()) as RootState;
+    const rootState = thunkAPI.getState() as RootState;
     const {currentAiCustomizations, savedAiCustomizations} = rootState.aichat;
     await saveAiCustomization(
       currentAiCustomizations,
@@ -137,13 +137,13 @@ export const saveModelCard = createAsyncThunk(
   'aichat/saveModelCard',
   async (_, thunkAPI) => {
     const {dispatch} = thunkAPI;
-    const modelCardInfo = await (thunkAPI.getState() as RootState).aichat
+    const modelCardInfo = (thunkAPI.getState() as RootState).aichat
       .currentAiCustomizations.modelCardInfo;
     if (!hasFilledOutModelCard(modelCardInfo)) {
       dispatch(setModelCardProperty({property: 'isPublished', value: false}));
     }
 
-    const {currentAiCustomizations, savedAiCustomizations} = await (
+    const {currentAiCustomizations, savedAiCustomizations} = (
       thunkAPI.getState() as RootState
     ).aichat;
     await saveAiCustomization(
@@ -333,10 +333,6 @@ const aichatSlice = createSlice({
             [customization]: studentAiCustomizations[customization],
           };
         }
-      }
-
-      if (studentAiCustomizations.modelCardInfo.isPublished) {
-        reconciledAiCustomizations.modelCardInfo.isPublished = true;
       }
 
       state.savedAiCustomizations = reconciledAiCustomizations;

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -75,6 +75,7 @@ export interface ModelCardInfo {
   limitationsAndWarnings: string;
   testingAndEvaluation: string;
   exampleTopics: string[];
+  isPublished: boolean;
 }
 
 /** Metadata about a given model, common across all aichat levels */

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -47,10 +47,10 @@ const AichatView: React.FunctionComponent = () => {
 
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
 
-  const {currentAiCustomizations, viewMode, hasPublished} = useAppSelector(
+  const {currentAiCustomizations, viewMode} = useAppSelector(
     state => state.aichat
   );
-  const {botName} = currentAiCustomizations.modelCardInfo;
+  const {botName, isPublished} = currentAiCustomizations.modelCardInfo;
 
   useEffect(() => {
     const studentAiCustomizations = JSON.parse(initialSources);
@@ -68,7 +68,7 @@ const AichatView: React.FunctionComponent = () => {
   const showPresentationToggle = () => {
     return (
       !levelAichatSettings?.hidePresentationPanel &&
-      (hasPublished ||
+      (isPublished ||
         (levelAichatSettings?.visibilities &&
           isDisabled(levelAichatSettings.visibilities.modelCardInfo)))
     );

--- a/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
+++ b/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
@@ -64,7 +64,7 @@ const PublishNotes: React.FunctionComponent = () => {
                     readOnly={isDisabled(visibility)}
                   />
                 )}
-                {property !== 'exampleTopics' && (
+                {property !== 'exampleTopics' && property !== 'isPublished' && (
                   <InputTag
                     id={property}
                     type="text"

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -34,12 +34,13 @@ const SetupCustomization: React.FunctionComponent = () => {
   );
 
   /** defaults to all models if not set in levelProperties */
-  const availableModelIds = useAppSelector(
-    state =>
-      (state.lab.levelProperties as AichatLevelProperties | undefined)
-        ?.aichatSettings?.availableModelIds
-  );
-  const availableModels = availableModelIds
+  const availableModelIds =
+    useAppSelector(
+      state =>
+        (state.lab.levelProperties as AichatLevelProperties | undefined)
+          ?.aichatSettings?.availableModelIds
+    ) || [];
+  const availableModels = availableModelIds.length
     ? modelDescriptions.filter(model => availableModelIds.includes(model.id))
     : modelDescriptions;
 

--- a/apps/src/aichat/views/modelCustomization/constants.ts
+++ b/apps/src/aichat/views/modelCustomization/constants.ts
@@ -32,13 +32,14 @@ export const TECHNICAL_INFO_FIELDS = [
   'Retrieval Used',
 ] as const;
 
-export const EMPTY_MODEL_CARD_INFO: ModelCardInfo = {
+const EMPTY_MODEL_CARD_INFO: ModelCardInfo = {
   botName: '',
   description: '',
   intendedUse: '',
   limitationsAndWarnings: '',
   testingAndEvaluation: '',
   exampleTopics: [],
+  isPublished: false,
 };
 
 export const EMPTY_AI_CUSTOMIZATIONS: AiCustomizations = {

--- a/apps/src/aichat/views/presentation/PresentationView.tsx
+++ b/apps/src/aichat/views/presentation/PresentationView.tsx
@@ -49,7 +49,7 @@ const PresentationView: React.FunctionComponent = () => {
           {modelCardInfo['botName']}
         </Heading4>
         {MODEL_CARD_FIELDS_LABELS_ICONS.map(([property, label, iconName]) => {
-          if (property === 'botName') {
+          if (property === 'botName' || property === 'isPublished') {
             return null;
           }
           return (

--- a/apps/src/lab2/levelEditors/aichatSettings/ModelCardFields.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/ModelCardFields.tsx
@@ -16,7 +16,7 @@ const ModelCardFields: React.FunctionComponent = () => {
   return (
     <div className={moduleStyles['model-card-fields']}>
       {MODEL_CARD_FIELDS_LABELS_ICONS.map(([property, label, _]) => {
-        if (property === 'exampleTopics') {
+        if (property === 'exampleTopics' || property === 'isPublished') {
           return null;
         }
         return (


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

## Description

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/57949 -- persist whether a student has published their model in S3.

We discussed a couple of options in [this comment thread](https://github.com/code-dot-org/code-dot-org/pull/57949#discussion_r1561663697) - I think either approach (putting this flag separate from `ModelCardInfo`, or inside of it) would result in some ugliness / special casing. Since we're already special casing within `ModelCardInfo` for the list of examples and topics, I felt like adding another special case wasn't too bad.

This keeps our read/write to S3 logic simple (ie, write something with the `AiCustomization` type).

## Testing story

Tested manually that loading/reloading the page once a model is published/unpublished, that state is retained. Also tested that I was able to make levelbuilder changes to model card info successfully.